### PR TITLE
MediaLibrary: Fix search bar size / content inset on iOS 11

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -22,7 +22,6 @@ class MediaLibraryViewController: UIViewController {
 
     fileprivate var capturePresenter: WPMediaCapturePresenter?
 
-    private let defaultSearchBarHeight: CGFloat = 44.0
     lazy fileprivate var searchBarContainer: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -186,24 +185,50 @@ class MediaLibraryViewController: UIViewController {
     }
 
     private func addSearchBarContainer() {
+        searchBarContainer.backgroundColor = searchBar.barTintColor
+
         stackView.insertArrangedSubview(searchBarContainer, at: 0)
 
         NSLayoutConstraint.activate([
             searchBarContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             searchBarContainer.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-        ])
+            ])
 
-        let heightConstraint = searchBarContainer.heightAnchor.constraint(equalToConstant: defaultSearchBarHeight)
+        wrapSearchBarInPaddingView()
+
+        let height = searchBar.intrinsicContentSize.height
+        let heightConstraint = searchBarContainer.heightAnchor.constraint(equalToConstant: height)
         heightConstraint.priority = UILayoutPriorityDefaultLow
         heightConstraint.isActive = true
 
-        let expandedHeightConstraint = searchBarContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: defaultSearchBarHeight)
+        let expandedHeightConstraint = searchBarContainer.heightAnchor.constraint(greaterThanOrEqualToConstant: height)
         expandedHeightConstraint.priority = UILayoutPriorityRequired
         expandedHeightConstraint.isActive = true
 
         searchBarContainer.layoutIfNeeded()
-        searchBarContainer.addSubview(searchBar)
         searchBar.sizeToFit()
+    }
+
+    private func wrapSearchBarInPaddingView() {
+        let paddingView = UIView()
+        paddingView.translatesAutoresizingMaskIntoConstraints = false
+        searchBarContainer.addSubview(paddingView)
+        paddingView.addSubview(searchBar)
+
+        var leading = searchBarContainer.leadingAnchor
+        var trailing = searchBarContainer.trailingAnchor
+
+        if #available(iOS 11.0, *) {
+            leading = searchBarContainer.safeAreaLayoutGuide.leadingAnchor
+            trailing = searchBarContainer.safeAreaLayoutGuide.trailingAnchor
+        }
+
+        NSLayoutConstraint.activate([
+            paddingView.leadingAnchor.constraint(equalTo: leading),
+            paddingView.trailingAnchor.constraint(equalTo: trailing),
+            paddingView.topAnchor.constraint(equalTo: searchBarContainer.topAnchor),
+            paddingView.bottomAnchor.constraint(equalTo: searchBarContainer.bottomAnchor),
+            ])
     }
 
     private func addNoResultsView() {


### PR DESCRIPTION
Fixes #7922 

On iOS 11, a section of the top row of media items in the collection view was cut off, due to the iOS 11 search bar being taller than the (previously hardcoded) 44pt.

This PR fixes that by using the search bar's intrinsic content size, and also respects the safe area insets on iPhone X.

![media-insets](https://user-images.githubusercontent.com/4780/31626626-633eb894-b2a2-11e7-84ed-fb47cd9121ec.png)

To test:

* Open the media library on iOS 10 and 11 and check the top of the scroll area looks correct.
* Check that the search bar displays correctly in both portrait and landscape on iPhone X (and isn't broken on other devices).
* Check that the search bar shows / hides correctly if you go from an empty media library to one that contains media items (and vice versa)

Needs review: @bummytime 