### PR TITLE
Aztec: Drag + Drop Placeholder Fix

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -55,7 +55,7 @@ target 'WordPress' do
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.23'
   pod 'WordPress-iOS-Editor', '1.9.5'
-  pod 'WordPress-Aztec-iOS', '=1.0.0-beta.12'
+  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS', :commit => 'fb6a19233cad8462b6816f4c32876a8d41144067'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -149,7 +149,7 @@ DEPENDENCIES:
   - Starscream (= 2.1.1)
   - SVProgressHUD (= 2.2.1)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (= 1.0.0-beta.12)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS`, commit `fb6a19233cad8462b6816f4c32876a8d41144067`)
   - WordPress-iOS-Editor (= 1.9.5)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.23)
@@ -159,6 +159,9 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
+  WordPress-Aztec-iOS:
+    :commit: fb6a19233cad8462b6816f4c32876a8d41144067
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -167,6 +170,9 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
+  WordPress-Aztec-iOS:
+    :commit: fb6a19233cad8462b6816f4c32876a8d41144067
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -202,12 +208,12 @@ SPEC CHECKSUMS:
   Starscream: 142bd8ef24592d985daee9fa48c936070b85b15f
   SVProgressHUD: db27c54e6e18bc903341661fc9feb55e04905cc4
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: d472d3af74219e0bd4e01d49500d1e32c3a8cbf4
+  WordPress-Aztec-iOS: 69768334c8c7d4e7a28c9edd1bd7263262809d3d
   WordPress-iOS-Editor: be1de639b28b894789366b8380f26df30a8bb571
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 51dff88157706419e000169b37c3abe0d3017b5f
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 973818f8b72e7edc83724c63027be2c4e312ac01
+PODFILE CHECKSUM: e11371b981b270ed8547ce45b74ec80e95c8677d
 
 COCOAPODS: 1.3.1

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3089,9 +3089,9 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
         }
     }
 
-    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL {
+    func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL? {
         saveToMedia(attachment: imageAttachment)
-        return URL(string:"placeholder://")!
+        return nil
     }
 
     func cancelAllPendingMediaRequests() {


### PR DESCRIPTION
### Details:
Since we were providing an actual URL for the **ImageAttachment**, an entire chain of requests were being triggered, that resulted in AFNetworking being queried for the `placeholder://` URL.

This had the side effect of: placeholder image getting displayed, during the whole `Upload Media` OP.

We've patched [Aztec Here](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/772) so that **nil** URL's are allowed (and thus, we can safely neutralize the `placeholder://` workaround, which effectively fixes issue #7973.

I'm submitting this PR right away so everything is in place, we'll be updating the Aztec dependency ASAP.

Fixes #7973

### To test:
1. Launch Aztec
2. Add some new media
3. Verify that the actual asset immediately replaces the placeholder, while the Upload OP is going on
4. Verify that everything is okay once the upload completes.

Needs review: @diegoreymendez @SergioEstevao 
**Depends o [this Aztec PR](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/772)
