### PR TITLE
Media: Make creationDate nullable to match optional type in model

### DIFF
--- a/WordPress/Classes/Models/Media.h
+++ b/WordPress/Classes/Models/Media.h
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSUInteger, MediaType) {
 
 @property (nonatomic, strong, nullable) NSString *alt;
 @property (nonatomic, strong, nullable) NSString *caption;
-@property (nonatomic, strong) NSDate *creationDate;
+@property (nonatomic, strong, nullable) NSDate *creationDate;
 @property (nonatomic, strong, nullable) NSString *desc;
 @property (nonatomic, strong, nullable) NSString *filename;
 @property (nonatomic, strong, nullable) NSNumber *filesize;

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -112,7 +112,7 @@ class MediaItemViewController: UITableViewController {
         default: break
         }
 
-        rows.append(TextRow(title: NSLocalizedString("Uploaded", comment: "Label for the date a media asset (image / video) was uploaded"), value: media.creationDate.mediumString()))
+        rows.append(TextRow(title: NSLocalizedString("Uploaded", comment: "Label for the date a media asset (image / video) was uploaded"), value: media.creationDate?.mediumString() ?? ""))
 
         return rows
     }


### PR DESCRIPTION
Hopefully fixes #7991.

I can't see anything else obvious that could cause the original crash, except that we use the media's `creationDate` when populating the metadata rows. `creationDate` is optional in the `Media` model, but the property in the `Media` class wasn't nullable.

To test:

* Ensure you can view the Media Item View Controller correctly (Site > Media > choose an item).
* Check that the Uploaded field still shows a date.

Needs review: @SergioEstevao 