### PR TITLE
Fixes a crash on WPStatsServiceRemote

### DIFF
--- a/WordPressKit/WordPressKit/WPStatsServiceRemote.m
+++ b/WordPressKit/WordPressKit/WPStatsServiceRemote.m
@@ -280,15 +280,20 @@ typedef void (^TaskUpdateHandler)(NSURLSessionTask *, NSArray<NSURLSessionTask*>
         }
 
         for (NSArray *visit in visitsData) {
-            StatsSummary *statsSummary = [StatsSummary new];
-            statsSummary.periodUnit = StatsPeriodUnitDay;
-            statsSummary.date = [self deviceLocalDateForString:visit[0] withPeriodUnit:StatsPeriodUnitDay];
-            statsSummary.label = [self nicePointNameForDate:statsSummary.date forStatsPeriodUnit:statsSummary.periodUnit];
-            statsSummary.views = [self localizedStringForNumber:visit[1]];
-            statsSummary.viewsValue = visit[1];
-            
-            [visitsArray addObject:statsSummary];
-            visitsDictionary[statsSummary.date] = statsSummary;
+            // We can only save stats data that has a proper date on it
+            // Otherwise it will crash on the visitsDictionary insertion
+            NSDate *statDate = [self deviceLocalDateForString:visit[0] withPeriodUnit:StatsPeriodUnitDay];
+            if (statDate) {
+                StatsSummary *statsSummary = [StatsSummary new];
+                statsSummary.periodUnit = StatsPeriodUnitDay;
+                statsSummary.date = statDate;
+                statsSummary.label = [self nicePointNameForDate:statsSummary.date forStatsPeriodUnit:statsSummary.periodUnit];
+                statsSummary.views = [self localizedStringForNumber:visit[1]];
+                statsSummary.viewsValue = visit[1];
+
+                [visitsArray addObject:statsSummary];
+                visitsDictionary[statsSummary.date] = statsSummary;
+            }
         }
         
         NSMutableArray *yearsItems = [NSMutableArray new];


### PR DESCRIPTION
**Fixes** #7994 

**To test:**
We can't really test it unless we manipulate the incoming data, but is a pretty straight forward fix and the crash pointed exactly to it.

Needs review: @astralbodies 
