### PR TITLE
Update hybrid editor to 1.9.7

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'Gridicons', '0.10'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.23'
-  pod 'WordPress-iOS-Editor', '1.9.5'
+  pod 'WordPress-iOS-Editor', '1.9.7'
   pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS', :commit => 'fb6a19233cad8462b6816f4c32876a8d41144067'
 
   target 'WordPressTest' do

--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'Gridicons', '0.10'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.23'
-  pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => '6cfb190136bdf3f58ce852e1c4e4538a7f62f193'
+  pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => 'b71e878366691029c766c2bb6460efb8d0fc4559'
   pod 'WordPress-Aztec-iOS', '=1.0.0-beta.12'
 
   target 'WordPressTest' do

--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'Gridicons', '0.10'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.23'
-  pod 'WordPress-iOS-Editor', '1.9.5'
+  pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :branch => 'release/1.9.6'
   pod 'WordPress-Aztec-iOS', '=1.0.0-beta.12'
 
   target 'WordPressTest' do

--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'Gridicons', '0.10'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.23'
-  pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :branch => 'release/1.9.6'
+  pod 'WordPress-iOS-Editor', :git => 'https://github.com/wordpress-mobile/WordPress-Editor-iOS.git', :commit => '6cfb190136bdf3f58ce852e1c4e4538a7f62f193'
   pod 'WordPress-Aztec-iOS', '=1.0.0-beta.12'
 
   target 'WordPressTest' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -114,7 +114,7 @@ PODS:
   - SVProgressHUD (2.2.1)
   - UIDeviceIdentifier (0.5.0)
   - WordPress-Aztec-iOS (1.0.0-beta.12)
-  - WordPress-iOS-Editor (1.9.5):
+  - WordPress-iOS-Editor (1.9.6):
     - CocoaLumberjack (~> 3.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
   - WordPressComKit (0.0.6):
@@ -150,7 +150,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.1)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (= 1.0.0-beta.12)
-  - WordPress-iOS-Editor (= 1.9.5)
+  - WordPress-iOS-Editor (from `https://github.com/wordpress-mobile/WordPress-Editor-iOS.git`, branch `release/1.9.6`)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.23)
   - wpxmlrpc (= 0.8.3)
@@ -159,6 +159,9 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
+  WordPress-iOS-Editor:
+    :branch: release/1.9.6
+    :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -167,6 +170,9 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
+  WordPress-iOS-Editor:
+    :commit: 029267bf3baf99659f96dfccd3e74aeb091d3fae
+    :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
     :tag: 0.0.6
@@ -203,11 +209,11 @@ SPEC CHECKSUMS:
   SVProgressHUD: db27c54e6e18bc903341661fc9feb55e04905cc4
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-Aztec-iOS: d472d3af74219e0bd4e01d49500d1e32c3a8cbf4
-  WordPress-iOS-Editor: be1de639b28b894789366b8380f26df30a8bb571
+  WordPress-iOS-Editor: 589d1762e01f5599e42f6dff680a78778d150892
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 51dff88157706419e000169b37c3abe0d3017b5f
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 973818f8b72e7edc83724c63027be2c4e312ac01
+PODFILE CHECKSUM: 605c33f6041a950257fd419222cec10915b93f5c
 
 COCOAPODS: 1.3.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -114,7 +114,7 @@ PODS:
   - SVProgressHUD (2.2.1)
   - UIDeviceIdentifier (0.5.0)
   - WordPress-Aztec-iOS (1.0.0-beta.12)
-  - WordPress-iOS-Editor (1.9.5):
+  - WordPress-iOS-Editor (1.9.7):
     - CocoaLumberjack (~> 3.2.0)
     - NSObject-SafeExpectations (~> 0.0.2)
   - WordPressComKit (0.0.6):
@@ -150,7 +150,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.1)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS`, commit `fb6a19233cad8462b6816f4c32876a8d41144067`)
-  - WordPress-iOS-Editor (= 1.9.5)
+  - WordPress-iOS-Editor (= 1.9.7)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.23)
   - wpxmlrpc (= 0.8.3)
@@ -209,11 +209,11 @@ SPEC CHECKSUMS:
   SVProgressHUD: db27c54e6e18bc903341661fc9feb55e04905cc4
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-Aztec-iOS: 69768334c8c7d4e7a28c9edd1bd7263262809d3d
-  WordPress-iOS-Editor: be1de639b28b894789366b8380f26df30a8bb571
+  WordPress-iOS-Editor: 03b3bc631a31520ccf78e665548286c6d12c17f4
   WordPressComKit: 119ae1d20bfb090769274732b51e7bd186a96f7e
   WPMediaPicker: 51dff88157706419e000169b37c3abe0d3017b5f
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: e11371b981b270ed8547ce45b74ec80e95c8677d
+PODFILE CHECKSUM: 7502e76425ba5bb6851ac339ea44f653e845064d
 
 COCOAPODS: 1.3.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -150,7 +150,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.1)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (= 1.0.0-beta.12)
-  - WordPress-iOS-Editor (from `https://github.com/wordpress-mobile/WordPress-Editor-iOS.git`, branch `release/1.9.6`)
+  - WordPress-iOS-Editor (from `https://github.com/wordpress-mobile/WordPress-Editor-iOS.git`, commit `6cfb190136bdf3f58ce852e1c4e4538a7f62f193`)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.23)
   - wpxmlrpc (= 0.8.3)
@@ -160,7 +160,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
   WordPress-iOS-Editor:
-    :branch: release/1.9.6
+    :commit: 6cfb190136bdf3f58ce852e1c4e4538a7f62f193
     :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -171,7 +171,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
   WordPress-iOS-Editor:
-    :commit: 029267bf3baf99659f96dfccd3e74aeb091d3fae
+    :commit: 6cfb190136bdf3f58ce852e1c4e4538a7f62f193
     :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -214,6 +214,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 51dff88157706419e000169b37c3abe0d3017b5f
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 605c33f6041a950257fd419222cec10915b93f5c
+PODFILE CHECKSUM: ef84ceb8f7b68672613a9d71daa04b1dc25e261f
 
 COCOAPODS: 1.3.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -150,7 +150,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.1)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (= 1.0.0-beta.12)
-  - WordPress-iOS-Editor (from `https://github.com/wordpress-mobile/WordPress-Editor-iOS.git`, commit `6cfb190136bdf3f58ce852e1c4e4538a7f62f193`)
+  - WordPress-iOS-Editor (from `https://github.com/wordpress-mobile/WordPress-Editor-iOS.git`, commit `b71e878366691029c766c2bb6460efb8d0fc4559`)
   - WordPressComKit (from `https://github.com/Automattic/WordPressComKit.git`, tag `0.0.6`)
   - WPMediaPicker (= 0.23)
   - wpxmlrpc (= 0.8.3)
@@ -160,7 +160,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
   WordPress-iOS-Editor:
-    :commit: 6cfb190136bdf3f58ce852e1c4e4538a7f62f193
+    :commit: b71e878366691029c766c2bb6460efb8d0fc4559
     :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -171,7 +171,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
   WordPress-iOS-Editor:
-    :commit: 6cfb190136bdf3f58ce852e1c4e4538a7f62f193
+    :commit: b71e878366691029c766c2bb6460efb8d0fc4559
     :git: https://github.com/wordpress-mobile/WordPress-Editor-iOS.git
   WordPressComKit:
     :git: https://github.com/Automattic/WordPressComKit.git
@@ -214,6 +214,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 51dff88157706419e000169b37c3abe0d3017b5f
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: ef84ceb8f7b68672613a9d71daa04b1dc25e261f
+PODFILE CHECKSUM: ab96a4f1b05a27fbec71175c3f4a4e679fc6f913
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
This PR updates the WordPress-Editor pod to version 1.9.7.

This updates addresses the following issues:

- Problems with the icons on the format toolbar being resized or going missing.
- Substitution of quotes and dashes for special quotes and special dashes. Ticket here: https://github.com/wordpress-mobile/WordPress-Editor-iOS/issues/904
- It also prepare the editors for the iPhoneX

To test:
 - Launch the app
 - Activate the hybrid editor
 - Check if format toolbar works in the different orientations, devices, and iOS (10 and 11)
 - Test the same using the old legacy editor.