### PR TITLE
Login: Clarifies why error is not handled.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
@@ -199,7 +199,7 @@ extension LoginViewController: SigninWPComSyncHandler, LoginFacadeDelegate {
             // be gained by displaying an error that can not currently be resolved
             // in the app and doing so might tarnish an otherwise satisfying login
             // experience.
-            // If / when we add support for manually connecting/disconnecting services
+            // If/when we add support for manually connecting/disconnecting services
             // we can revisit.
         })
     }

--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
@@ -193,6 +193,14 @@ extension LoginViewController: SigninWPComSyncHandler, LoginFacadeDelegate {
             // noop
         }, failure: { error in
             DDLogError(error.description)
+            // We're opting to let this call fail silently.
+            // Our user has already successfully authenticated and can use the app --
+            // connecting the social service isn't critical.  There's little to
+            // be gained by displaying an error that can not currently be resolved
+            // in the app and doing so might tarnish an otherwise satisfying login
+            // experience.
+            // If / when we add support for manually connecting/disconnecting services
+            // we can revisit.
         })
     }
 


### PR DESCRIPTION
Refs #7675 
Adding a comment to clarify why we're not informing a user of a failure connecting a social account.

Needs review: @nheagy 
cc @theck13 