### PR TITLE
Login: Add 2FA support for social login

### DIFF
--- a/WordPress/Classes/Services/LoginFacade.h
+++ b/WordPress/Classes/Services/LoginFacade.h
@@ -52,6 +52,17 @@
 - (void)loginToWordPressDotComWithGoogleIDToken:(NSString *)googleIDToken;
 
 /**
+ * Social login via a social account with 2FA using a nonce.
+ *
+ * @param googleIDToken A Google id_token.
+ */
+- (void)loginToWordPressDotComWithUser:(NSInteger)userID
+                              authType:(NSString *)authType
+                           twoStepCode:(NSString *)twoStepCode
+                          twoStepNonce:(NSString *)twoStepNonce;
+
+
+/**
  *  A delegate with a few methods that indicate various aspects of the login process
  */
 @property (nonatomic, weak) id<LoginFacadeDelegate> delegate;
@@ -137,6 +148,15 @@
  *  @param authToken                authToken to be used to access the site
  */
 - (void)finishedLoginWithGoogleIDToken:(NSString *)googleIDToken authToken:(NSString *)authToken;
+
+
+/**
+ *  Called when finished logging in to a WordPress.com site via a 2FA Nonce.
+ *
+ *  @param googleIDToken            the token used
+ *  @param authToken                authToken to be used to access the site
+ */
+- (void)finishedLoginWithNonceAuthToken:(NSString *)authToken;
 
 
 /**

--- a/WordPress/Classes/Services/LoginFacade.m
+++ b/WordPress/Classes/Services/LoginFacade.m
@@ -87,6 +87,31 @@
     }];
 }
 
+- (void)loginToWordPressDotComWithUser:(NSInteger)userID
+                              authType:(NSString *)authType
+                           twoStepCode:(NSString *)twoStepCode
+                          twoStepNonce:(NSString *)twoStepNonce
+{
+    if ([self.delegate respondsToSelector:@selector(displayLoginMessage:)]) {
+        [self.delegate displayLoginMessage:NSLocalizedString(@"Connecting to WordPress.com", nil)];
+    }
+
+    [self.wordpressComOAuthClientFacade authenticateSocialLoginUser:userID
+                                                           authType:authType
+                                                        twoStepCode:twoStepCode
+                                                       twoStepNonce:twoStepNonce
+                                                            success:^(NSString *authToken) {
+                                                                if ([self.delegate respondsToSelector:@selector(finishedLoginWithNonceAuthToken:)]) {
+                                                                    [self.delegate finishedLoginWithNonceAuthToken:authToken];
+                                                                }
+                                                            } failure:^(NSError *error) {
+                                                                [WPAppAnalytics track:WPAnalyticsStatLoginFailed error:error];
+                                                                if ([self.delegate respondsToSelector:@selector(displayRemoteError:)]) {
+                                                                    [self.delegate displayRemoteError:error];
+                                                                }
+                                                            }];
+}
+
 - (void)signInToWordpressDotCom:(LoginFields *)loginFields
 {
     if ([self.delegate respondsToSelector:@selector(displayLoginMessage:)]) {

--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -29,6 +29,7 @@ class Login2FAViewController: LoginViewController, SigninKeyboardResponder {
         localizeControls()
         configureTextFields()
         configureSubmitButton(animating: false)
+        configureSendCodeButton()
     }
 
 
@@ -84,14 +85,20 @@ class Login2FAViewController: LoginViewController, SigninKeyboardResponder {
         sendCodeButton.titleLabel?.numberOfLines = 0
     }
 
-
+    /// configures the text fields
+    ///
     func configureTextFields() {
         verificationCodeField.textInsets = WPStyleGuide.edgeInsetForLoginTextFields()
+    }
 
+    /// Hides the send code button when appropriate
+    ///
+    func configureSendCodeButton() {
         guard let _ = loginFields.nonceInfo else {
             return
         }
-        sendCodeButton.isHidden = true
+        sendCodeButton.isEnabled = false
+        sendCodeButton.setTitle("", for: .normal)
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -245,17 +245,16 @@ extension Login2FAViewController {
 
         configureViewLoading(false)
         let err = error as NSError
+        let bad2FAMessage = NSLocalizedString("Whoops, that's not a valid two-factor verification code. Double-check your code and try again!", comment: "Error message shown when an incorrect two factor code is provided.")
         if err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidOneTimePassword.rawValue {
             // Invalid verification code.
-            displayError(message: NSLocalizedString("Whoops, that's not a valid two-factor verification code. Double-check your code and try again!",
-                                                    comment: "Error message shown when an incorrect two factor code is provided."))
+            displayError(message: bad2FAMessage)
         } else if err.domain == "WordPressComOAuthError" && err.code == WordPressComOAuthError.invalidTwoStepCode.rawValue {
             // Invalid 2FA during social login
             if let newNonce = (error as NSError).userInfo[WordPressComOAuthClient.WordPressComOAuthErrorNewNonceKey] as? String {
                 loginFields.nonceInfo?.updateNonce(with: newNonce)
             }
-            displayError(message: NSLocalizedString("Whoops, that's not a valid two-factor verification code. Double-check your code and try again!",
-                                                    comment: "Error message shown when an incorrect two factor code is provided."))
+            displayError(message: bad2FAMessage)
         } else {
             displayError(error as NSError, sourceTag: sourceTag)
         }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -443,7 +443,10 @@ extension LoginEmailViewController {
 
 
     func needsMultifactorCode(forUserID userID: Int, andNonceInfo nonceInfo: SocialLogin2FANonceInfo!) {
-        // TODO: to be implemented.
+        loginFields.nonceInfo = nonceInfo
+        loginFields.nonceUserID = userID
+
+        performSegue(withIdentifier: NUXAbstractViewController.SegueIdentifier.show2FA, sender: self)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginFields.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginFields.swift
@@ -21,6 +21,12 @@ class LoginFields: NSObject {
     /// The two factor code entered by a user.
     var multifactorCode = "" // 2fa code
 
+    /// Nonce info in the event of a social login with 2fa
+    var nonceInfo: SocialLogin2FANonceInfo?
+
+    /// User ID for use with the nonce for social login
+    var nonceUserID: Int = 0
+
     /// Used by the SignupViewController. Signup currently asks for both a
     /// username and an email address.  This can be factored away when we revamp
     /// the signup flow.

--- a/WordPressKit/WordPressKit/SocialLogin2FANonceInfo.swift
+++ b/WordPressKit/WordPressKit/SocialLogin2FANonceInfo.swift
@@ -13,6 +13,7 @@ public class SocialLogin2FANonceInfo: NSObject {
         static let lastUsedPlaceholder = "last_used_placeholder"
     }
 
+    /// These constants match the server-side authentication code
     private enum AuthTypeLengths {
         static let authenticator = 6
         static let sms = 7

--- a/WordPressKit/WordPressKit/SocialLogin2FANonceInfo.swift
+++ b/WordPressKit/WordPressKit/SocialLogin2FANonceInfo.swift
@@ -8,4 +8,45 @@ public class SocialLogin2FANonceInfo: NSObject {
     var supportedAuthTypes = [String]() // backup|authenticator|sms
     var notificationSent = "" // none|sms
     var phoneNumber = "" // The last two digits of the phone number to which an SMS was sent.
+
+    private enum Constants {
+        static let lastUsedPlaceholder = "last_used_placeholder"
+    }
+
+    private enum AuthTypeLengths {
+        static let authenticator = 6
+        static let sms = 7
+        static let backup = 8
+    }
+
+    public func authTypeAndNonce(for code: String) -> (String, String) {
+        let typeNoncePair: (String, String)
+        switch code.count {
+        case AuthTypeLengths.sms:
+            typeNoncePair = ("sms", nonceSMS)
+            nonceSMS = Constants.lastUsedPlaceholder
+        case AuthTypeLengths.backup:
+            typeNoncePair = ("backup", nonceBackup)
+            nonceBackup = Constants.lastUsedPlaceholder
+        case AuthTypeLengths.authenticator:
+            fallthrough
+        default:
+            typeNoncePair = ("authenticator", nonceAuthenticator)
+            nonceAuthenticator = Constants.lastUsedPlaceholder
+        }
+        return typeNoncePair
+    }
+
+    public func updateNonce(with newNonce: String) {
+        switch Constants.lastUsedPlaceholder {
+        case nonceSMS:
+            nonceSMS = newNonce
+        case nonceBackup:
+            nonceBackup = newNonce
+        case nonceAuthenticator:
+            fallthrough
+        default:
+            nonceAuthenticator = newNonce
+        }
+    }
 }


### PR DESCRIPTION
Refs #7675

This covers the scenario in which the user's account is already associated with Google, and their WordPress.com account requires 2FA.

To test:
- Setup a wpcom account to be associated with Google, and require 2FA
- Attempt to login to the app using Google
- When prompted for a 2FA token cover these scenarios:
  - using app/generator token
  - using SMS token
  - using backup token
  - using an incorrect of the above, then the real one
  - using an incorrect of another sort, then a real one of a different kind (sms first, backup second, etc)

Needs review: @aerych 
