### PR TITLE
Login: fix crash when dismissing Google view

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -454,8 +454,8 @@ extension LoginEmailViewController: GIDSignInDelegate {
     func sign(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {
         // TODO: finish implementing wpcom login via Google code
         guard let user = user,
-            let token = user.authentication.idToken,
-                let email = user.profile.email else {
+              let token = user.authentication.idToken,
+              let email = user.profile.email else {
             // The Google SignIn for may have been canceled.
             //TODO: Add analytis
             return

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -451,9 +451,10 @@ extension LoginEmailViewController {
 }
 
 extension LoginEmailViewController: GIDSignInDelegate {
-    func sign(_ signIn: GIDSignIn!, didSignInFor user: GIDGoogleUser!, withError error: Error!) {
+    func sign(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {
         // TODO: finish implementing wpcom login via Google code
-        guard let token = user.authentication.idToken,
+        guard let user = user,
+            let token = user.authentication.idToken,
                 let email = user.profile.email else {
             // The Google SignIn for may have been canceled.
             //TODO: Add analytis


### PR DESCRIPTION
refs #7675

To test:
- Tap Log in with Google button
- Tap Cancel in the upper left
- _App should not crash_

Needs review: @aerych 

*Note*: this was branched from #8010 and will include its changes until merged.