### PR TITLE
Make sure the media is attached to post.

### DIFF
--- a/WordPress/Classes/Extensions/Media+Blog.swift
+++ b/WordPress/Classes/Extensions/Media+Blog.swift
@@ -8,7 +8,7 @@ extension Media {
         let media = NSEntityDescription.insertNewObject(forEntityName: "Media", into: context) as! Media
         media.creationDate = Date()
         media.mediaID = 0
-        media.remoteStatus = .local;
+        media.remoteStatus = .local
         return media
     }
 

--- a/WordPress/Classes/Extensions/Media+Blog.swift
+++ b/WordPress/Classes/Extensions/Media+Blog.swift
@@ -8,6 +8,7 @@ extension Media {
         let media = NSEntityDescription.insertNewObject(forEntityName: "Media", into: context) as! Media
         media.creationDate = Date()
         media.mediaID = 0
+        media.remoteStatus = .local;
         return media
     }
 

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -162,15 +162,17 @@
 
 - (NSString *)remoteStatusText
 {
-    switch ([self.remoteStatusNumber intValue]) {
+    switch (self.remoteStatus) {
         case MediaRemoteStatusPushing:
-            return NSLocalizedString(@"Uploading", @"");
+            return NSLocalizedString(@"Uploading", @"Status for Media object that is being uploaded.");
         case MediaRemoteStatusFailed:
-            return NSLocalizedString(@"Failed", @"");
+            return NSLocalizedString(@"Failed", @"Status for Media object that is failed upload or export.");
         case MediaRemoteStatusSync:
-            return NSLocalizedString(@"Uploaded", @"");
-        default:
-            return NSLocalizedString(@"Pending", @"");
+            return NSLocalizedString(@"Uploaded", @"Status for Media object that is uploaded and sync with server.");
+        case MediaRemoteStatusProcessing:
+            return NSLocalizedString(@"Pending", @"Status for Media object that is being processed locally.");
+        case MediaRemoteStatusLocal:
+            return NSLocalizedString(@"Local", @"Status for Media object that is only exists locally.");
     }
 }
 

--- a/WordPress/Classes/Services/MediaExportService.swift
+++ b/WordPress/Classes/Services/MediaExportService.swift
@@ -198,8 +198,7 @@ open class MediaExportService: LocalCoreDataService {
 
     /// Configure Media with the AssetExport.
     ///
-    fileprivate func configureMedia(_ media: Media, withExport export: MediaAssetExporter.AssetExport) {
-        media.remoteStatusNumber = NSNumber(value: MediaRemoteStatus.local.rawValue)
+    fileprivate func configureMedia(_ media: Media, withExport export: MediaAssetExporter.AssetExport) {        
         switch export {
         case .exportedImage(let imageExport):
             configureMedia(media, withExport: imageExport)

--- a/WordPress/Classes/Services/MediaExportService.swift
+++ b/WordPress/Classes/Services/MediaExportService.swift
@@ -198,7 +198,7 @@ open class MediaExportService: LocalCoreDataService {
 
     /// Configure Media with the AssetExport.
     ///
-    fileprivate func configureMedia(_ media: Media, withExport export: MediaAssetExporter.AssetExport) {        
+    fileprivate func configureMedia(_ media: Media, withExport export: MediaAssetExporter.AssetExport) {
         switch export {
         case .exportedImage(let imageExport):
             configureMedia(media, withExport: imageExport)

--- a/WordPress/Classes/Services/MediaExportService.swift
+++ b/WordPress/Classes/Services/MediaExportService.swift
@@ -31,11 +31,12 @@ open class MediaExportService: LocalCoreDataService {
     // MARK: - Instance methods
 
     /// Creates a Media object with an absoluteLocalURL for a PHAsset's data, asynchronously.
-    ///
+    /// - paramater blog: a blog object to where the media object will be added to.
+    /// - paramater post: an optional post object to where the media object will be attached to.
     /// - parameter onCompletion: Called if the Media was successfully created and the asset's data exported to an absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
-    public func exportMediaWith(blog: Blog, asset: PHAsset, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
+    public func exportMediaWith(blog: Blog, post: AbstractPost?, asset: PHAsset, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
         exportQueue.async {
 
             let exporter = MediaAssetExporter()
@@ -44,8 +45,12 @@ open class MediaExportService: LocalCoreDataService {
 
             exporter.exportData(forAsset: asset, onCompletion: { (assetExport) in
                 self.managedObjectContext.perform {
-
-                    let media = Media.makeMedia(blog: blog)
+                    let media: Media
+                    if let post = post {
+                        media = Media.makeMedia(post: post)
+                    } else {
+                        media = Media.makeMedia(blog: blog)
+                    }
                     self.configureMedia(media, withExport: assetExport)
                     ContextManager.sharedInstance().save(self.managedObjectContext, withCompletionBlock: {
                         onCompletion(media)
@@ -61,10 +66,12 @@ open class MediaExportService: LocalCoreDataService {
     ///
     /// The UIImage is expected to be a JPEG, PNG, or other 'normal' image.
     ///
+    /// - paramater blog: a blog object to where the media object will be added to.
+    /// - paramater post: an optional post object to where the media object will be attached to.
     /// - parameter onCompletion: Called if the Media was successfully created and the image's data exported to an absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
-    public func exportMediaWith(blog: Blog, image: UIImage, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
+    public func exportMediaWith(blog: Blog, post: AbstractPost?, image: UIImage, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
         exportQueue.async {
 
             let exporter = MediaImageExporter()
@@ -72,8 +79,12 @@ open class MediaExportService: LocalCoreDataService {
 
             exporter.exportImage(image, fileName: nil, onCompletion: { (imageExport) in
                 self.managedObjectContext.perform {
-
-                    let media = Media.makeMedia(blog: blog)
+                    let media: Media
+                    if let post = post {
+                        media = Media.makeMedia(post: post)
+                    } else {
+                        media = Media.makeMedia(blog: blog)
+                    }
                     self.configureMedia(media, withExport: imageExport)
                     ContextManager.sharedInstance().save(self.managedObjectContext, withCompletionBlock: {
                         onCompletion(media)
@@ -89,10 +100,12 @@ open class MediaExportService: LocalCoreDataService {
     ///
     /// The file URL is expected to be a JPEG, PNG, GIF, other 'normal' image, or video.
     ///
+    /// - paramater blog: a blog object to where the media object will be added to.
+    /// - paramater post: an optional post object to where the media object will be attached to.
     /// - parameter onCompletion: Called if the Media was successfully created and the file's data exported to an absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
-    public func exportMediaWith(blog: Blog, url: URL, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
+    public func exportMediaWith(blog: Blog, post: AbstractPost?, url: URL, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
         exportQueue.async {
 
             let exporter = MediaURLExporter()
@@ -101,8 +114,12 @@ open class MediaExportService: LocalCoreDataService {
 
             exporter.exportURL(fileURL: url, onCompletion: { (urlExport) in
                 self.managedObjectContext.perform {
-
-                    let media = Media.makeMedia(blog: blog)
+                    let media: Media
+                    if let post = post {
+                        media = Media.makeMedia(post: post)
+                    } else {
+                        media = Media.makeMedia(blog: blog)
+                    }
                     self.configureMedia(media, withExport: urlExport)
                     ContextManager.sharedInstance().save(self.managedObjectContext, withCompletionBlock: {
                         onCompletion(media)
@@ -182,6 +199,7 @@ open class MediaExportService: LocalCoreDataService {
     /// Configure Media with the AssetExport.
     ///
     fileprivate func configureMedia(_ media: Media, withExport export: MediaAssetExporter.AssetExport) {
+        media.remoteStatusNumber = NSNumber(value: MediaRemoteStatus.local.rawValue)
         switch export {
         case .exportedImage(let imageExport):
             configureMedia(media, withExport: imageExport)

--- a/WordPress/Classes/Services/MediaService+Legacy.m
+++ b/WordPress/Classes/Services/MediaService+Legacy.m
@@ -168,7 +168,6 @@
         } else if ([object isKindOfClass:[Blog class]]) {
             Blog *blog = (Blog *)object;
             media = [Media makeMediaWithBlog:blog];
-            media.remoteStatusNumber = @(MediaRemoteStatusLocal);
         }
 
         if (media) {

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -170,16 +170,19 @@
     MediaExportService *exportService = [[MediaExportService alloc] initWithManagedObjectContext:self.managedObjectContext];
     if ([exportable isKindOfClass:[PHAsset class]]) {
         [exportService exportMediaWithBlog:blog
+                                      post:post
                                      asset:(PHAsset *)exportable
                               onCompletion:completionWithMedia
                                    onError:completionWithError];
     } else if ([exportable isKindOfClass:[UIImage class]]) {
         [exportService exportMediaWithBlog:blog
+                                      post:post
                                      image:(UIImage *)exportable
                               onCompletion:completionWithMedia
                                    onError:completionWithError];
     } else if ([exportable isKindOfClass:[NSURL class]]) {
         [exportService exportMediaWithBlog:blog
+                                      post:post
                                        url:(NSURL *)exportable
                               onCompletion:completionWithMedia
                                    onError:completionWithError];

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -262,7 +262,6 @@
             }
 
             [self updateMedia:mediaInContext withRemoteMedia:media];
-            mediaInContext.remoteStatus = MediaRemoteStatusSync;
             [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
                 if (success) {
                     success();
@@ -767,8 +766,7 @@
         @autoreleasepool {
             Media *local = [Media existingMediaWithMediaID:remote.mediaID inBlog:blog];
             if (!local) {
-                local = [Media makeMediaWithBlog:blog];
-                local.remoteStatus = MediaRemoteStatusSync;
+                local = [Media makeMediaWithBlog:blog];                
             }
             [self updateMedia:local withRemoteMedia:remote];
             [mediaToKeep addObject:local];
@@ -815,6 +813,8 @@
     media.length = remoteMedia.length;
     media.remoteThumbnailURL = remoteMedia.remoteThumbnailURL;
     media.postID = remoteMedia.postID;
+
+    media.remoteStatus = MediaRemoteStatusSync;
 }
 
 - (RemoteMedia *)remoteMediaFromMedia:(Media *)media


### PR DESCRIPTION
Fixes #8009 

So this PR restore the attachment of media to the posts on the new media code.
It also fix a status of the media object when the they are created.

To test:
 - Open the app
 - Start a new post
 - Insert a media object to the post
 - Publish the post
 - Go to the web and using the old WP-Admin check in the media library if your new media object is attached to the post.

