### PR TITLE
Refactor MediaExportService to MediaImportService

### DIFF
--- a/WordPress/Classes/Services/MediaImportService.swift
+++ b/WordPress/Classes/Services/MediaImportService.swift
@@ -94,7 +94,7 @@ open class MediaImportService: LocalCoreDataService {
     /// - parameter onCompletion: Called if the Media was successfully created and the file's data exported to an absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
-    public func `import`(url: URL, to media: Media,onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
+    public func `import`(url: URL, to media: Media, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
         exportQueue.async {
 
             let exporter = MediaURLExporter()
@@ -102,7 +102,7 @@ open class MediaImportService: LocalCoreDataService {
             exporter.videoOptions = self.exporterVideoOptions
 
             exporter.exportURL(fileURL: url, onCompletion: { (urlExport) in
-                self.managedObjectContext.perform {                    
+                self.managedObjectContext.perform {
                     self.configureMedia(media, withExport: urlExport)
                     ContextManager.sharedInstance().save(self.managedObjectContext, withCompletionBlock: {
                         onCompletion(media)

--- a/WordPress/Classes/Services/MediaImportService.swift
+++ b/WordPress/Classes/Services/MediaImportService.swift
@@ -8,10 +8,10 @@ import CocoaLumberjack
 ///
 open class MediaImportService: LocalCoreDataService {
 
-    private static let defaultExportQueue: DispatchQueue = DispatchQueue(label: "org.wordpress.mediaImportService", autoreleaseFrequency: .workItem)
+    private static let defaultImportQueue: DispatchQueue = DispatchQueue(label: "org.wordpress.mediaImportService", autoreleaseFrequency: .workItem)
 
-    public lazy var exportQueue: DispatchQueue = {
-        return MediaImportService.defaultExportQueue
+    public lazy var importQueue: DispatchQueue = {
+        return MediaImportService.defaultImportQueue
     }()
 
     /// Constant for the ideal compression quality used when images are added to the Media Library.
@@ -39,7 +39,7 @@ open class MediaImportService: LocalCoreDataService {
     ///
     @objc(importAsset:toMedia:onCompletion:onError:)
     public func `import`(_ asset: PHAsset, to media: Media, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
-        exportQueue.async {
+        importQueue.async {
 
             let exporter = MediaAssetExporter()
             exporter.imageOptions = self.exporterImageOptions
@@ -69,7 +69,7 @@ open class MediaImportService: LocalCoreDataService {
     ///
     @objc(importImage:toMedia:onCompletion:onError:)
     public func `import`(_ image: UIImage, to media: Media, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
-        exportQueue.async {
+        importQueue.async {
 
             let exporter = MediaImageExporter()
             exporter.options = self.exporterImageOptions
@@ -98,7 +98,7 @@ open class MediaImportService: LocalCoreDataService {
     ///
     @objc(importURL:toMedia:onCompletion:onError:)
     public func `import`(_ url: URL, to media: Media, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
-        exportQueue.async {
+        importQueue.async {
 
             let exporter = MediaURLExporter()
             exporter.imageOptions = self.exporterImageOptions

--- a/WordPress/Classes/Services/MediaImportService.swift
+++ b/WordPress/Classes/Services/MediaImportService.swift
@@ -34,7 +34,7 @@ open class MediaImportService: LocalCoreDataService {
     ///
     /// - paramater asset: the PHAsset media where data will be read from.
     /// - paramater media: the media object to where media will be imported to.
-    /// - parameter onCompletion: Called if the Media was successfully created and the asset's data exported to an absoluteLocalURL.
+    /// - parameter onCompletion: Called if the Media was successfully created and the asset's data imported to the absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
     @objc(importAsset:toMedia:onCompletion:onError:)
@@ -64,7 +64,7 @@ open class MediaImportService: LocalCoreDataService {
     ///
     /// - paramater image: the UIImage where data will be read from.
     /// - paramater media: the media object to where media will be imported to.
-    /// - parameter onCompletion: Called if the Media was successfully created and the image's data exported to an absoluteLocalURL.
+    /// - parameter onCompletion: Called if the Media was successfully created and the image's data imported to the absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
     @objc(importImage:toMedia:onCompletion:onError:)
@@ -93,7 +93,7 @@ open class MediaImportService: LocalCoreDataService {
     ///
     /// - paramater url: the URL from where data will be read from.
     /// - paramater media: the media object to where media will be imported to.
-    /// - parameter onCompletion: Called if the Media was successfully created and the file's data exported to an absoluteLocalURL.
+    /// - parameter onCompletion: Called if the Media was successfully created and the file's data imported to the absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
     @objc(importURL:toMedia:onCompletion:onError:)

--- a/WordPress/Classes/Services/MediaImportService.swift
+++ b/WordPress/Classes/Services/MediaImportService.swift
@@ -6,12 +6,12 @@ import CocoaLumberjack
 /// - Note: Methods with escaping closures will call back via the configured managedObjectContext
 ///   method and its corresponding thread.
 ///
-open class MediaExportService: LocalCoreDataService {
+open class MediaImportService: LocalCoreDataService {
 
     private static let defaultExportQueue: DispatchQueue = DispatchQueue(label: "org.wordpress.mediaExportService", autoreleaseFrequency: .workItem)
 
     public lazy var exportQueue: DispatchQueue = {
-        return MediaExportService.defaultExportQueue
+        return MediaImportService.defaultExportQueue
     }()
 
     /// Constant for the ideal compression quality used when images are added to the Media Library.
@@ -157,7 +157,7 @@ open class MediaExportService: LocalCoreDataService {
     /// Handle the OnError callback and logging any errors encountered.
     ///
     fileprivate func handleExportError(_ error: MediaExportError, errorHandler: OnError?) {
-        MediaExportService.logExportError(error)
+        MediaImportService.logExportError(error)
         // Return the error via the context's queue, and as an NSError to ensure it carries over the right code/message.
         if let errorHandler = errorHandler {
             self.managedObjectContext.perform {
@@ -172,7 +172,7 @@ open class MediaExportService: LocalCoreDataService {
         var options = MediaImageExporter.Options()
         options.maximumImageSize = self.exporterMaximumImageSize()
         options.stripsGeoLocationIfNeeded = MediaSettings().removeLocationSetting
-        options.imageCompressionQuality = MediaExportService.preferredImageCompressionQuality
+        options.imageCompressionQuality = MediaImportService.preferredImageCompressionQuality
         return options
     }
 

--- a/WordPress/Classes/Services/MediaImportService.swift
+++ b/WordPress/Classes/Services/MediaImportService.swift
@@ -32,8 +32,8 @@ open class MediaImportService: LocalCoreDataService {
 
     /// Imports media from a PHAsset to the Media object, asynchronously.
     ///
-    /// - paramater asset: the PHAsset media where data will be read from.
-    /// - paramater media: the media object to where media will be imported to.
+    /// - parameter asset: the PHAsset media where data will be read from.
+    /// - parameter media: the media object to where media will be imported to.
     /// - parameter onCompletion: Called if the Media was successfully created and the asset's data imported to the absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
@@ -62,8 +62,8 @@ open class MediaImportService: LocalCoreDataService {
     ///
     /// The UIImage is expected to be a JPEG, PNG, or other 'normal' image.
     ///
-    /// - paramater image: the UIImage where data will be read from.
-    /// - paramater media: the media object to where media will be imported to.
+    /// - parameter image: the UIImage where data will be read from.
+    /// - parameter media: the media object to where media will be imported to.
     /// - parameter onCompletion: Called if the Media was successfully created and the image's data imported to the absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
@@ -91,8 +91,8 @@ open class MediaImportService: LocalCoreDataService {
     ///
     /// The file URL is expected to be a JPEG, PNG, GIF, other 'normal' image, or video.
     ///
-    /// - paramater url: the URL from where data will be read from.
-    /// - paramater media: the media object to where media will be imported to.
+    /// - parameter url: the URL from where data will be read from.
+    /// - parameter media: the media object to where media will be imported to.
     /// - parameter onCompletion: Called if the Media was successfully created and the file's data imported to the absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///

--- a/WordPress/Classes/Services/MediaImportService.swift
+++ b/WordPress/Classes/Services/MediaImportService.swift
@@ -37,7 +37,8 @@ open class MediaImportService: LocalCoreDataService {
     /// - parameter onCompletion: Called if the Media was successfully created and the asset's data exported to an absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
-    public func `import`(asset: PHAsset, to media: Media, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
+    @objc(importAsset:toMedia:onCompletion:onError:)
+    public func `import`(_ asset: PHAsset, to media: Media, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
         exportQueue.async {
 
             let exporter = MediaAssetExporter()
@@ -66,7 +67,8 @@ open class MediaImportService: LocalCoreDataService {
     /// - parameter onCompletion: Called if the Media was successfully created and the image's data exported to an absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
-    public func `import`(image: UIImage, to media: Media, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
+    @objc(importImage:toMedia:onCompletion:onError:)
+    public func `import`(_ image: UIImage, to media: Media, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
         exportQueue.async {
 
             let exporter = MediaImageExporter()
@@ -94,7 +96,8 @@ open class MediaImportService: LocalCoreDataService {
     /// - parameter onCompletion: Called if the Media was successfully created and the file's data exported to an absoluteLocalURL.
     /// - parameter onError: Called if an error was encountered during creation, error convertible to NSError with a localized description.
     ///
-    public func `import`(url: URL, to media: Media, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
+    @objc(importURL:toMedia:onCompletion:onError:)
+    public func `import`(_ url: URL, to media: Media, onCompletion: @escaping MediaCompletion, onError: @escaping OnError) {
         exportQueue.async {
 
             let exporter = MediaURLExporter()

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -176,20 +176,20 @@
     // Export based on the type of the exportable.
     MediaImportService *importService = [[MediaImportService alloc] initWithManagedObjectContext:self.managedObjectContext];
     if ([exportable isKindOfClass:[PHAsset class]]) {
-        [importService importWithAsset:(PHAsset *)exportable
-                                    to:media
-                          onCompletion:completionWithMedia
-                               onError:completionWithError];
+        [importService importAsset:(PHAsset *)exportable
+                           toMedia:media
+                      onCompletion:completionWithMedia
+                           onError:completionWithError];
     } else if ([exportable isKindOfClass:[UIImage class]]) {
-        [importService importWithImage:(UIImage *)exportable
-                                    to:media
-                          onCompletion:completionWithMedia
-                               onError:completionWithError];
+        [importService importImage:(UIImage *)exportable
+                           toMedia:media
+                      onCompletion:completionWithMedia
+                           onError:completionWithError];
     } else if ([exportable isKindOfClass:[NSURL class]]) {
-        [importService importWithUrl:(NSURL *)exportable
-                                  to:media
-                        onCompletion:completionWithMedia
-                             onError:completionWithError];
+        [importService importURL:(NSURL *)exportable
+                         toMedia:media
+                    onCompletion:completionWithMedia
+                         onError:completionWithError];
     } else {
         completionWithError(nil);
     }

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -39,7 +39,7 @@
                 completion:(void (^)(Media *media, NSError *error))completion
 {
     NSString *mediaName = [[url pathComponents] lastObject];
-    [self exportMediaWith:url
+    [self createMediaWith:url
                  objectID:postObjectID
                 mediaName:mediaName
         thumbnailCallback:thumbnailCallback
@@ -53,7 +53,7 @@
                 completion:(void (^)(Media *media, NSError *error))completion
 {
     NSString *mediaName = [[url pathComponents] lastObject];
-    [self exportMediaWith:url
+    [self createMediaWith:url
                  objectID:blogObjectID
                 mediaName:mediaName
         thumbnailCallback:thumbnailCallback
@@ -67,7 +67,7 @@
            thumbnailCallback:(void (^)(NSURL *thumbnailURL))thumbnailCallback
                   completion:(void (^)(Media *media, NSError *error))completion
 {
-    [self exportMediaWith:image
+    [self createMediaWith:image
                  objectID:postObjectID
                 mediaName:mediaID
         thumbnailCallback:thumbnailCallback
@@ -81,7 +81,7 @@
                     completion:(void (^)(Media *media, NSError *error))completion
 {
     NSString *mediaName = [asset originalFilename];
-    [self exportMediaWith:asset
+    [self createMediaWith:asset
                  objectID:postObjectID
                 mediaName:mediaName
         thumbnailCallback:thumbnailCallback
@@ -95,7 +95,7 @@
                     completion:(void (^)(Media *media, NSError *error))completion
 {
     NSString *mediaName = [asset originalFilename];
-    [self exportMediaWith:asset
+    [self createMediaWith:asset
                  objectID:blogObjectID
                 mediaName:mediaName
         thumbnailCallback:thumbnailCallback
@@ -108,7 +108,7 @@
            thumbnailCallback:(void (^)(NSURL *thumbnailURL))thumbnailCallback
                   completion:(void (^)(Media *media, NSError *error))completion
 {
-    [self exportMediaWith:image
+    [self createMediaWith:image
                  objectID:blogObjectID
                 mediaName:[[NSUUID UUID] UUIDString]
         thumbnailCallback:thumbnailCallback
@@ -117,7 +117,7 @@
 
 #pragma mark - Private exporting
 
-- (void)exportMediaWith:(id<ExportableAsset>)exportable
+- (void)createMediaWith:(id<ExportableAsset>)exportable
                objectID:(NSManagedObjectID *)objectID
               mediaName:(NSString *)mediaName
       thumbnailCallback:(void (^)(NSURL *thumbnailURL))thumbnailCallback
@@ -151,6 +151,13 @@
         return;
     }
 
+    Media *media;
+    if (post != nil) {
+        media = [Media makeMediaWithPost:post];
+    } else {
+        media = [Media makeMediaWithBlog:blog];
+    }
+
     // Setup completion handlers
     void(^completionWithMedia)(Media *) = ^(Media *media) {
         // Pre-generate a thumbnail image, see the method notes.
@@ -167,25 +174,22 @@
     };
 
     // Export based on the type of the exportable.
-    MediaImportService *exportService = [[MediaImportService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    MediaImportService *importService = [[MediaImportService alloc] initWithManagedObjectContext:self.managedObjectContext];
     if ([exportable isKindOfClass:[PHAsset class]]) {
-        [exportService exportMediaWithBlog:blog
-                                      post:post
-                                     asset:(PHAsset *)exportable
-                              onCompletion:completionWithMedia
-                                   onError:completionWithError];
+        [importService importWithAsset:(PHAsset *)exportable
+                                    to:media
+                          onCompletion:completionWithMedia
+                               onError:completionWithError];
     } else if ([exportable isKindOfClass:[UIImage class]]) {
-        [exportService exportMediaWithBlog:blog
-                                      post:post
-                                     image:(UIImage *)exportable
-                              onCompletion:completionWithMedia
-                                   onError:completionWithError];
+        [importService importWithImage:(UIImage *)exportable
+                                    to:media
+                          onCompletion:completionWithMedia
+                               onError:completionWithError];
     } else if ([exportable isKindOfClass:[NSURL class]]) {
-        [exportService exportMediaWithBlog:blog
-                                      post:post
-                                       url:(NSURL *)exportable
-                              onCompletion:completionWithMedia
-                                   onError:completionWithError];
+        [importService importWithUrl:(NSURL *)exportable
+                                  to:media
+                        onCompletion:completionWithMedia
+                             onError:completionWithError];
     } else {
         completionWithError(nil);
     }

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -167,7 +167,7 @@
     };
 
     // Export based on the type of the exportable.
-    MediaExportService *exportService = [[MediaExportService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    MediaImportService *exportService = [[MediaImportService alloc] initWithManagedObjectContext:self.managedObjectContext];
     if ([exportable isKindOfClass:[PHAsset class]]) {
         [exportService exportMediaWithBlog:blog
                                       post:post

--- a/WordPress/Classes/Services/MediaThumbnailService.swift
+++ b/WordPress/Classes/Services/MediaThumbnailService.swift
@@ -200,7 +200,7 @@ class MediaThumbnailService: LocalCoreDataService {
     /// Handle the OnError callback and logging any errors encountered.
     ///
     fileprivate func handleExportError(_ error: MediaExportError, errorHandler: OnError?) {
-        MediaExportService.logExportError(error)
+        MediaImportService.logExportError(error)
         if let errorHandler = errorHandler {
             self.managedObjectContext.perform {
                 errorHandler(error.toNSError())

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -174,7 +174,7 @@
             NSString *fileName = [NSString stringWithFormat:@"%@_%@", [[NSProcessInfo processInfo] globallyUniqueString], @".jpg"];
             NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
             NSError *error;
-            if ([image writeToURL:fileURL type:(__bridge NSString *)kUTTypeJPEG compressionQuality:MediaExportService.preferredImageCompressionQuality metadata:metadata error:&error]){
+            if ([image writeToURL:fileURL type:(__bridge NSString *)kUTTypeJPEG compressionQuality:MediaImportService.preferredImageCompressionQuality metadata:metadata error:&error]){
                 return [PHAssetChangeRequest creationRequestForAssetFromImageAtFileURL:fileURL];
             }
             return nil;
@@ -183,7 +183,7 @@
         NSString *fileName = [NSString stringWithFormat:@"%@_%@", [[NSProcessInfo processInfo] globallyUniqueString], @".jpg"];        
         NSURL *fileURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:fileName]];
         NSError *error;
-        if ([image writeToURL:fileURL type:(__bridge NSString *)kUTTypeJPEG compressionQuality:MediaExportService.preferredImageCompressionQuality metadata:metadata error:&error]){
+        if ([image writeToURL:fileURL type:(__bridge NSString *)kUTTypeJPEG compressionQuality:MediaImportService.preferredImageCompressionQuality metadata:metadata error:&error]){
             [self addMediaFromURL:fileURL completionBlock:completionBlock];
         } else {
             if (completionBlock) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -49,7 +49,7 @@
 		0807CB721CE670A800CDBDAC /* WPContentSearchHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0807CB711CE670A800CDBDAC /* WPContentSearchHelper.swift */; };
 		080AAA691E7C63C3004DCD11 /* Media+HTML.m in Sources */ = {isa = PBXBuildFile; fileRef = 080AAA681E7C63C3004DCD11 /* Media+HTML.m */; };
 		080C44A91CE14A9F00B3A02F /* MenuDetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 080C449E1CE14A9F00B3A02F /* MenuDetailsViewController.m */; };
-		0815CF461E96F22600069916 /* MediaExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0815CF451E96F22600069916 /* MediaExportService.swift */; };
+		0815CF461E96F22600069916 /* MediaImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0815CF451E96F22600069916 /* MediaImportService.swift */; };
 		08216FAA1CDBF95100304BA7 /* MenuItemEditing.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08216FA71CDBF95100304BA7 /* MenuItemEditing.storyboard */; };
 		08216FAB1CDBF95100304BA7 /* MenuItemEditingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 08216FA91CDBF95100304BA7 /* MenuItemEditingViewController.m */; };
 		08216FC81CDBF96000304BA7 /* MenuItemAbstractPostsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 08216FAD1CDBF96000304BA7 /* MenuItemAbstractPostsViewController.m */; };
@@ -936,9 +936,9 @@
 		F1049F331F39FCF9004DF0BB /* CalypsoProcessorOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */; };
 		F128C31C1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */; };
 		F1564E5B18946087009F8F97 /* NSStringHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */; };
+		F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B43771F849F580089B817 /* PostAttachmentTests.swift */; };
 		F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
 		F1D690171F82914200200E30 /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
-		F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B43771F849F580089B817 /* PostAttachmentTests.swift */; };
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
@@ -1073,7 +1073,7 @@
 		080AAA681E7C63C3004DCD11 /* Media+HTML.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Media+HTML.m"; sourceTree = "<group>"; };
 		080C449D1CE14A9F00B3A02F /* MenuDetailsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuDetailsViewController.h; sourceTree = "<group>"; };
 		080C449E1CE14A9F00B3A02F /* MenuDetailsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuDetailsViewController.m; sourceTree = "<group>"; };
-		0815CF451E96F22600069916 /* MediaExportService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaExportService.swift; sourceTree = "<group>"; };
+		0815CF451E96F22600069916 /* MediaImportService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaImportService.swift; sourceTree = "<group>"; };
 		08216FA71CDBF95100304BA7 /* MenuItemEditing.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MenuItemEditing.storyboard; sourceTree = "<group>"; };
 		08216FA81CDBF95100304BA7 /* MenuItemEditingViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemEditingViewController.h; sourceTree = "<group>"; };
 		08216FA91CDBF95100304BA7 /* MenuItemEditingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemEditingViewController.m; sourceTree = "<group>"; };
@@ -2374,9 +2374,9 @@
 		F128C31A1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPNavigationMediaPickerViewController+StatusBarStyle.h"; sourceTree = "<group>"; };
 		F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WPNavigationMediaPickerViewController+StatusBarStyle.m"; sourceTree = "<group>"; };
 		F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringHelpersTests.m; sourceTree = "<group>"; };
+		F18B43771F849F580089B817 /* PostAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostAttachmentTests.swift; path = Posts/PostAttachmentTests.swift; sourceTree = "<group>"; };
 		F1D690141F828FF000200E30 /* BuildConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfiguration.swift; sourceTree = "<group>"; };
 		F1D690151F828FF000200E30 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
-		F18B43771F849F580089B817 /* PostAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostAttachmentTests.swift; path = Posts/PostAttachmentTests.swift; sourceTree = "<group>"; };
 		F373612EEEEF10E500093FF3 /* Pods-WordPress.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressShareExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Themes.swift"; sourceTree = "<group>"; };
@@ -3749,7 +3749,7 @@
 				1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */,
 				930284B618EAF7B600CB0BF4 /* LocalCoreDataService.h */,
 				FFC6ADD91B56F366002F3C84 /* LocalCoreDataService.m */,
-				0815CF451E96F22600069916 /* MediaExportService.swift */,
+				0815CF451E96F22600069916 /* MediaImportService.swift */,
 				087EBFA71F02313E001F7ACE /* MediaThumbnailService.swift */,
 				5DA3EE141925090A00294E0B /* MediaService.h */,
 				5DA3EE151925090A00294E0B /* MediaService.m */,
@@ -6660,7 +6660,7 @@
 				5D6C4B121B604190005E3C43 /* RichTextView.swift in Sources */,
 				E1CECE021E6EC7A8009C6695 /* FakePreviewBuilder.swift in Sources */,
 				171963401D378D5100898E8B /* SearchWrapperView.swift in Sources */,
-				0815CF461E96F22600069916 /* MediaExportService.swift in Sources */,
+				0815CF461E96F22600069916 /* MediaImportService.swift in Sources */,
 				E148362F1C6DF7D8005ACF53 /* Product.swift in Sources */,
 				082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */,
 				5D119DA3176FBE040073D83A /* UIImageView+AFNetworkingExtra.m in Sources */,


### PR DESCRIPTION
This PR renames the MediaExportService to be MediaImportService and also renames the export methods to be import method.

The rational for this change is that we are no exporting media but importing media from different source (PHAsset, URL, image) to our Media object.

It also moves the creation of the Media object to be done before the importing is done. This way it will be easier in the future to track progress of the import process.

To test:
 - Open app
 - Create new media by using the Media Library or creating a new post
 - Check that data is created correctly.
