### PR TITLE
Login: retain email address after failed Google login attempts

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -476,7 +476,6 @@ extension LoginEmailViewController: GIDSignInDelegate {
 
 extension LoginEmailViewController: LoginSocialErrorViewControllerDelegate {
     private func cleanupAfterSocialErrors() {
-        loginFields.username = ""
         dismiss(animated: true) {}
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -480,6 +480,7 @@ extension LoginEmailViewController: LoginSocialErrorViewControllerDelegate {
     }
 
     func retryWithEmail() {
+        loginFields.username = ""
         cleanupAfterSocialErrors()
     }
     func retryWithAddress() {
@@ -490,6 +491,7 @@ extension LoginEmailViewController: LoginSocialErrorViewControllerDelegate {
         cleanupAfterSocialErrors()
         let storyboard = UIStoryboard(name: "Login", bundle: nil)
         if let controller = storyboard.instantiateViewController(withIdentifier: "SignupViewController") as? NUXAbstractViewController {
+            controller.loginFields = loginFields
             navigationController?.pushViewController(controller, animated: true)
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -74,6 +74,7 @@ import WordPressShared
 
         // Update special case login fields.
         loginFields.meta.userIsDotCom = true
+        emailField.text = loginFields.emailAddress
 
         configureLayoutForSmallScreensIfNeeded()
         configureSubmitButton(animating: false)


### PR DESCRIPTION
Refs #7675

Small change so that we keep the Google email address of failed login attempts to prefill on subsequent login or signup screens.

To test:
- Use the Google button to login to a Google account with no associated WordPress.com account.
- On the error screen, pick an option and ensure that the Google email address is correctly prefilled
- Repeat for the other two options

Needs review: @aerych 
