### PR TITLE
Login: Several small UX fixes for Google login

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -331,10 +331,19 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
 
         if awaitingGoogle {
             awaitingGoogle = false
-            configureViewLoading(false)
             GIDSignIn.sharedInstance().disconnect()
 
-            let socialErrorVC = LoginSocialErrorViewController(title: NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com"), description: error.localizedDescription)
+            let errorTitle: String
+            let errorDescription: String
+            if (error as! NSError).code == WordPressComOAuthError.unknownUser.rawValue {
+                errorTitle = NSLocalizedString("Connected But…", comment:"Title shown when a user logs in with Google but no matching WordPress.com account is found")
+                errorDescription = NSLocalizedString("The Google account \"\(loginFields.username)\" doesn't match any account on WordPress.com", comment:"D shown when a user logs in with Google but no matching WordPress.com account is found")
+            } else {
+                errorTitle = NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com")
+                errorDescription = error.localizedDescription
+            }
+
+            let socialErrorVC = LoginSocialErrorViewController(title: errorTitle, description: errorDescription)
             let socialErrorNav = LoginNavigationController(rootViewController: socialErrorVC)
             socialErrorVC.delegate = self
             present(socialErrorNav, animated: true) {}

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -332,6 +332,7 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
         if awaitingGoogle {
             awaitingGoogle = false
             configureViewLoading(false)
+            GIDSignIn.sharedInstance().disconnect()
 
             let socialErrorVC = LoginSocialErrorViewController(title: NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com"), description: error.localizedDescription)
             let socialErrorNav = LoginNavigationController(rootViewController: socialErrorVC)

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -336,8 +336,8 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
             let errorTitle: String
             let errorDescription: String
             if (error as! NSError).code == WordPressComOAuthError.unknownUser.rawValue {
-                errorTitle = NSLocalizedString("Connected But…", comment:"Title shown when a user logs in with Google but no matching WordPress.com account is found")
-                errorDescription = NSLocalizedString("The Google account \"\(loginFields.username)\" doesn't match any account on WordPress.com", comment:"D shown when a user logs in with Google but no matching WordPress.com account is found")
+                errorTitle = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
+                errorDescription = NSLocalizedString("The Google account \"\(loginFields.username)\" doesn't match any account on WordPress.com", comment: "D shown when a user logs in with Google but no matching WordPress.com account is found")
             } else {
                 errorTitle = NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com")
                 errorDescription = error.localizedDescription

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -158,6 +158,8 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
 
     func googleLoginTapped() {
         awaitingGoogle = true
+        configureViewLoading(true)
+
         GIDSignIn.sharedInstance().disconnect()
 
         // Flag this as a social sign in.
@@ -329,6 +331,7 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
 
         if awaitingGoogle {
             awaitingGoogle = false
+            configureViewLoading(false)
 
             let socialErrorVC = LoginSocialErrorViewController(title: NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com"), description: error.localizedDescription)
             let socialErrorNav = LoginNavigationController(rootViewController: socialErrorVC)
@@ -458,6 +461,7 @@ extension LoginEmailViewController: GIDSignInDelegate {
               let email = user.profile.email else {
             // The Google SignIn for may have been canceled.
             //TODO: Add analytis
+            configureViewLoading(false)
             return
         }
 
@@ -465,8 +469,6 @@ extension LoginEmailViewController: GIDSignInDelegate {
         loginFields.emailAddress = email
         loginFields.username = email
         loginFields.meta.socialServiceIDToken = token
-
-        configureViewLoading(true)
 
         loginFacade.loginToWordPressDotCom(withGoogleIDToken: token)
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -335,7 +335,7 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
 
             let errorTitle: String
             let errorDescription: String
-            if (error as! NSError).code == WordPressComOAuthError.unknownUser.rawValue {
+            if (error as NSError).code == WordPressComOAuthError.unknownUser.rawValue {
                 errorTitle = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
                 errorDescription = NSLocalizedString("The Google account \"\(loginFields.username)\" doesn't match any account on WordPress.com", comment: "D shown when a user logs in with Google but no matching WordPress.com account is found")
             } else {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -337,7 +337,7 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
             let errorDescription: String
             if (error as NSError).code == WordPressComOAuthError.unknownUser.rawValue {
                 errorTitle = NSLocalizedString("Connected But…", comment: "Title shown when a user logs in with Google but no matching WordPress.com account is found")
-                errorDescription = NSLocalizedString("The Google account \"\(loginFields.username)\" doesn't match any account on WordPress.com", comment: "D shown when a user logs in with Google but no matching WordPress.com account is found")
+                errorDescription = NSLocalizedString("The Google account \"\(loginFields.username)\" doesn't match any account on WordPress.com", comment: "Description shown when a user logs in with Google but no matching WordPress.com account is found")
             } else {
                 errorTitle = NSLocalizedString("Unable To Connect", comment: "Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com")
                 errorDescription = error.localizedDescription

--- a/WordPressKit/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressKit/WordPressComOAuthClient.swift
@@ -393,7 +393,7 @@ final class WordPressComOAuthResponseSerializer: AFJSONResponseSerializer {
             newNonce = data["two_step_nonce"] as? String
         }
 
-        return errorFor(errorCode: errorCode, errorDescription: errorDescription, responseObject: responseObject, newNonce: newNonce)
+        return errorFor(errorCode: errorCode, errorDescription: errorDescription, responseObject: responseDict, newNonce: newNonce)
     }
 
     /// Creates an NSError from the supplied arguements. The response object is

--- a/WordPressKit/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressKit/WordPressComOAuthClient.swift
@@ -377,9 +377,9 @@ final class WordPressComOAuthResponseSerializer: AFJSONResponseSerializer {
 
     /// Create the NSError from the response dictionary
     private func parseError(from responseDict: [String: AnyObject]) -> NSError {
-        var errorCode: String = ""
-        var errorDescription: String = ""
-        var newNonce: String? = nil
+        var errorCode = ""
+        var errorDescription = ""
+        var newNonce: String?
 
         // there's either a data object, or an error.
         if  let errorStr = responseDict["error"] as? String {


### PR DESCRIPTION
Refs #7675

- Fixes next button spinning behaviour on email screen when using Google
- Improves error shown when Google login succeeds but then fails on wpcom

To test:
- Descriptions here: https://github.com/wordpress-mobile/WordPress-iOS/issues/7675#issuecomment-338247427
- Also, the error parsing for 400, 409, 403 responses has been refactored. Test it still works!

Needs review: @aerych 