### PR TITLE
Turn on Google login for all builds

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -21,7 +21,7 @@ enum FeatureFlag: Int {
         case .pluginManagement:
             return BuildConfiguration.current == .localDeveloper
         case .googleLogin:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         }


### PR DESCRIPTION
Fixes #7675

To test:
- ensure Google login shows up for a non-debug build

Needs review: @aerych 
_Let's do this_
