### PR TITLE
Enable Aztec for all users by default.

### DIFF
--- a/WordPress/Classes/Services/EditorSettings.swift
+++ b/WordPress/Classes/Services/EditorSettings.swift
@@ -9,10 +9,10 @@ class EditorSettings: NSObject {
     }
 
     // MARK: - Enabled Editors Keys
-    
+
     fileprivate let hybridEditorEnabledKey = "kUserDefaultsNewEditorEnabled"
     fileprivate let aztecEditorEnabledKey = "kUserDefaultsNativeEditorEnabled"
-    
+
     // MARK: - Forcing Aztec Keys
 
     fileprivate let lastVersionWhereAztecWasForced = "lastVersionWhereAztecWasForced"
@@ -24,29 +24,29 @@ class EditorSettings: NSObject {
     init(database: KeyValueDatabase) {
         self.database = database
         super.init()
-        
+
         setDefaultsForVersionFirstLaunch()
     }
 
     convenience override init() {
         self.init(database: UserDefaults() as KeyValueDatabase)
     }
-    
+
     // MARK: - Native Editor By Default
-    
+
     fileprivate let aztecEditorMadeDefault = "aztecEditorMadeDefault"
-    
+
     /// Contains the logic for setting the defaults the first time a version is launched.
     ///
     func setDefaultsForVersionFirstLaunch() {
         let bundleVersion = Bundle.main.bundleVersion()
-        
+
         let lastInternalForcedVersion = database.object(forKey: lastVersionWhereAztecWasForced) as? String ?? ""
-        
+
         guard lastInternalForcedVersion != bundleVersion else {
             return
         }
-        
+
         enable(.aztec)
         database.set(bundleVersion, forKey: lastVersionWhereAztecWasForced)
     }
@@ -56,7 +56,7 @@ class EditorSettings: NSObject {
     private var current: Editor {
         let hybridEditorEnabled = database.object(forKey: hybridEditorEnabledKey) as? Bool ?? false
         let nativeEditorEnabled = database.object(forKey: aztecEditorEnabledKey) as? Bool ?? false
-        
+
         if nativeEditorEnabled {
             return .aztec
         } else if hybridEditorEnabled {
@@ -65,22 +65,22 @@ class EditorSettings: NSObject {
             return .legacy
         }
     }
-    
+
     func isEnabled(_ editor: Editor) -> Bool {
         return current == editor
     }
-    
+
     /// Enables the specified editor.
     ///
     func enable(_ editor: Editor) {
-        
+
         // Tracking ON and OFF for Aztec specifically.
         if editor == .aztec && !isEnabled(.aztec) {
             WPAnalytics.track(.editorToggledOn)
         } else if editor != .aztec && isEnabled(.aztec) {
             WPAnalytics.track(.editorToggledOff)
         }
-        
+
         switch editor {
         case .legacy:
             database.set(false, forKey: hybridEditorEnabledKey)

--- a/WordPress/Classes/Services/EditorSettings.swift
+++ b/WordPress/Classes/Services/EditorSettings.swift
@@ -16,7 +16,7 @@ class EditorSettings: NSObject {
     // MARK: - Forcing Aztec Keys
 
     fileprivate let lastVersionWhereAztecWasForced = "lastVersionWhereAztecWasForced"
-
+    
     // MARK: - Internal variables
     fileprivate let database: KeyValueDatabase
 

--- a/WordPress/Classes/Services/EditorSettings.swift
+++ b/WordPress/Classes/Services/EditorSettings.swift
@@ -16,7 +16,7 @@ class EditorSettings: NSObject {
     // MARK: - Forcing Aztec Keys
 
     fileprivate let lastVersionWhereAztecWasForced = "lastVersionWhereAztecWasForced"
-    
+
     // MARK: - Internal variables
     fileprivate let database: KeyValueDatabase
 

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -111,22 +111,6 @@ int ddLogLevel = DDLogLevelInfo;
 
     self.shouldRestoreApplicationState = !isFixingAuthTokenIssue;
 
-    // Temporary force of Aztec to "on" for all internal users
-#ifdef INTERNAL_BUILD
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSString *defaultsKey = @"AztecInternalForcedOnVersion";
-    NSString *lastBuildAztecForcedOn = [defaults stringForKey:defaultsKey];
-    NSString *currentVersion = [[NSBundle mainBundle] bundleVersion];
-    if (![currentVersion isEqualToString:lastBuildAztecForcedOn]) {
-        [defaults setObject:currentVersion forKey:defaultsKey];
-        [defaults synchronize];
-
-        EditorSettings *settings = [EditorSettings new];
-        [settings setVisualEditorEnabled:TRUE];
-        [settings setNativeEditorEnabled:TRUE];
-    }
-#endif
-
     return YES;
 }
 

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -90,26 +90,24 @@ class AppSettingsViewController: UITableViewController {
         let editorHeader = NSLocalizedString("Editor", comment: "Title label for the editor settings section in the app settings")
         var editorRows = [ImmuTableRow]()
 
-        let editor = editorSettings.editor
-
         let textEditor = CheckmarkRow(
             title: NSLocalizedString("Plain Text", comment: "Option to enable the plain text (legacy) editor"),
-            checked: (editor == .legacy),
-            action: visualEditorChanged(editor: .legacy)
+            checked: editorSettings.isEnabled(.legacy),
+            action: enableEditor(.legacy)
         )
         editorRows.append(textEditor)
 
         let visualEditor = CheckmarkRow(
             title: NSLocalizedString("Visual", comment: "Option to enable the hybrid visual editor"),
-            checked: (editor == .hybrid),
-            action: visualEditorChanged(editor: .hybrid)
+            checked: editorSettings.isEnabled(.hybrid),
+            action: enableEditor(.hybrid)
         )
         editorRows.append(visualEditor)
 
         let nativeEditor = CheckmarkRow(
             title: NSLocalizedString("Visual 2.0", comment: "Option to enable the beta native editor (Aztec)"),
-            checked: (editor == .aztec),
-            action: visualEditorChanged(editor: .aztec)
+            checked: editorSettings.isEnabled(.aztec),
+            action: enableEditor(.aztec)
         )
         editorRows.append(nativeEditor)
 
@@ -191,7 +189,7 @@ class AppSettingsViewController: UITableViewController {
     }
 
     private func shouldShowEditorFooterForSection(_ section: Int) -> Bool {
-        return section == Sections.editor.rawValue && EditorSettings().editor == .aztec
+        return section == Sections.editor.rawValue && EditorSettings().isEnabled(.aztec)
     }
 
     @objc fileprivate func handleEditorFooterTap(_ sender: UITapGestureRecognizer) {
@@ -311,38 +309,10 @@ class AppSettingsViewController: UITableViewController {
         }
     }
 
-    func visualEditorChanged(editor: EditorSettings.Editor) -> ImmuTableAction {
-        return { [weak self] row in
-            let currentEditorIsAztec = EditorSettings().nativeEditorEnabled
-
-            switch editor {
-            case .legacy:
-                EditorSettings().nativeEditorEnabled = false
-                EditorSettings().visualEditorEnabled = false
-                if currentEditorIsAztec {
-                    WPAnalytics.track(.editorToggledOff)
-                }
-            case .hybrid:
-                EditorSettings().nativeEditorEnabled = false
-                EditorSettings().visualEditorEnabled = true
-                if currentEditorIsAztec {
-                    WPAnalytics.track(.editorToggledOff)
-                }
-            case .aztec:
-                EditorSettings().visualEditorEnabled = true
-                EditorSettings().nativeEditorEnabled = true
-                if !currentEditorIsAztec {
-                    WPAnalytics.track(.editorToggledOn)
-                }
-            }
-
+    func enableEditor(_ editor: EditorSettings.Editor) -> ImmuTableAction {
+        return { [weak self] _ in
+            EditorSettings().enable(editor)
             self?.reloadViewModel()
-        }
-    }
-
-    func nativeEditorChanged() -> (Bool) -> Void {
-        return { enabled in
-            EditorSettings().nativeEditorEnabled = enabled
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPLegacyEditPostViewController.m
@@ -61,7 +61,7 @@ NSString *const WPAppAnalyticsEditorSourceValueLegacy = @"legacy";
 
 + (UIViewController *)viewControllerWithRestorationIdentifierPath:(NSArray *)identifierComponents coder:(NSCoder *)coder
 {
-    BOOL dontRestoreIfNewEditorIsEnabled = [[EditorSettings new] visualEditorEnabled];
+    BOOL dontRestoreIfNewEditorIsEnabled = [[EditorSettings new] isEnabled:EditorHybrid];
     
     if (dontRestoreIfNewEditorIsEnabled) {
         return nil;

--- a/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/WPPostViewController.m
@@ -386,7 +386,7 @@ UIDocumentPickerDelegate
 {
     UIViewController* restoredViewController = nil;
     
-    BOOL restoreOnlyIfNewEditorIsEnabled = [[EditorSettings new] visualEditorEnabled];
+    BOOL restoreOnlyIfNewEditorIsEnabled = [[EditorSettings new] isEnabled:EditorHybrid];
     
     if (restoreOnlyIfNewEditorIsEnabled) {
         restoredViewController = [self restoreViewControllerWithIdentifierPath:identifierComponents

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -43,9 +43,9 @@ extension FancyAlertViewController {
 
         let enableEditor = {
             let settings = EditorSettings(database: UserDefaults.standard)
-            
+
             settings.enable(.aztec)
-            
+
             //settings.visualEditorEnabled = true
             //settings.nativeEditorEnabled = true
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -22,7 +22,7 @@ extension FancyAlertViewController {
     }
 
     static func aztecAnnouncementController() -> FancyAlertViewController {
-        if EditorSettings().nativeEditorEnabled {
+        if EditorSettings().isEnabled(.aztec) {
             return existingTesterAztecAnnouncementController()
         } else {
             return newTesterAztecAnnouncementController()
@@ -43,8 +43,11 @@ extension FancyAlertViewController {
 
         let enableEditor = {
             let settings = EditorSettings(database: UserDefaults.standard)
-            settings.visualEditorEnabled = true
-            settings.nativeEditorEnabled = true
+            
+            settings.enable(.aztec)
+            
+            //settings.visualEditorEnabled = true
+            //settings.nativeEditorEnabled = true
 
             WPAnalytics.track(.editorToggledOn)
         }

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+AztecAnnouncement.swift
@@ -46,9 +46,6 @@ extension FancyAlertViewController {
 
             settings.enable(.aztec)
 
-            //settings.visualEditorEnabled = true
-            //settings.nativeEditorEnabled = true
-
             WPAnalytics.track(.editorToggledOn)
         }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -935,9 +935,9 @@
 		F1049F331F39FCF9004DF0BB /* CalypsoProcessorOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */; };
 		F128C31C1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */; };
 		F1564E5B18946087009F8F97 /* NSStringHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */; };
+		F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B43771F849F580089B817 /* PostAttachmentTests.swift */; };
 		F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
 		F1D690171F82914200200E30 /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
-		F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B43771F849F580089B817 /* PostAttachmentTests.swift */; };
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
@@ -2372,9 +2372,9 @@
 		F128C31A1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPNavigationMediaPickerViewController+StatusBarStyle.h"; sourceTree = "<group>"; };
 		F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "WPNavigationMediaPickerViewController+StatusBarStyle.m"; sourceTree = "<group>"; };
 		F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringHelpersTests.m; sourceTree = "<group>"; };
+		F18B43771F849F580089B817 /* PostAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostAttachmentTests.swift; path = Posts/PostAttachmentTests.swift; sourceTree = "<group>"; };
 		F1D690141F828FF000200E30 /* BuildConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfiguration.swift; sourceTree = "<group>"; };
 		F1D690151F828FF000200E30 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
-		F18B43771F849F580089B817 /* PostAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostAttachmentTests.swift; path = Posts/PostAttachmentTests.swift; sourceTree = "<group>"; };
 		F373612EEEEF10E500093FF3 /* Pods-WordPress.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressShareExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Themes.swift"; sourceTree = "<group>"; };

--- a/WordPress/WordPressTest/EditorSettingsTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsTests.swift
@@ -13,29 +13,29 @@ class EditorSettingsTests: XCTestCase {
     func testAztecEnabledByDefaultButNotForcedAgain() {
         let testClosure: () -> () = { _ in
             let database = EphemeralKeyValueDatabase()
-            
+
             // This simulates the first launch
             let editorSettings = EditorSettings(database: database)
-            
+
             XCTAssertFalse(editorSettings.isEnabled(.legacy))
             XCTAssertFalse(editorSettings.isEnabled(.hybrid))
             XCTAssertTrue(editorSettings.isEnabled(.aztec))
-            
+
             // We pick another editor and try again
             editorSettings.enable(.hybrid)
-            
+
             XCTAssertFalse(editorSettings.isEnabled(.legacy))
             XCTAssertTrue(editorSettings.isEnabled(.hybrid))
             XCTAssertFalse(editorSettings.isEnabled(.aztec))
-            
+
             // This simulates a second launch
             let secondEditorSettings = EditorSettings(database: database)
-            
+
             XCTAssertFalse(secondEditorSettings.isEnabled(.legacy))
             XCTAssertTrue(secondEditorSettings.isEnabled(.hybrid))
             XCTAssertFalse(secondEditorSettings.isEnabled(.aztec))
         }
-        
+
         BuildConfiguration.localDeveloper.test(testClosure)
         BuildConfiguration.a8cBranchTest.test(testClosure)
         BuildConfiguration.a8cPrereleaseTesting.test(testClosure)


### PR DESCRIPTION
### Description:

Fixes #8032 

This PR:

- Enables [Aztec by default](https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/8032-enable-aztec-for-all-users?expand=1#diff-da0fecd820d59f1edb25a061a232a23bR41) for the first launch of all versions moving forward.
- Simplifies the interface of `EditorSettings`.  External classes [now need to do less](https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/8032-enable-aztec-for-all-users?expand=1#diff-fda23a7cb324124c3e6c17b7ac196d73R314).
- Editors [can no longer be turned OFF](https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/8032-enable-aztec-for-all-users?expand=1#diff-da0fecd820d59f1edb25a061a232a23bL52).  This was "dangerous" and had no logical meaning.  Now you can only [turn one ON](https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/8032-enable-aztec-for-all-users?expand=1#diff-da0fecd820d59f1edb25a061a232a23bR75) (thus disabling all others).
- Allows users to [pick another editor](https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/8032-enable-aztec-for-all-users?expand=1#diff-da0fecd820d59f1edb25a061a232a23bR47) until the next version is out.
- Removes code no longer in use: [the "available" keys](https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/8032-enable-aztec-for-all-users?expand=1#diff-da0fecd820d59f1edb25a061a232a23bL11), [Aztec as default for internal releases](https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/8032-enable-aztec-for-all-users?expand=1#diff-a7805d4caf5932b05c692a969604dcd3L114) and [an unused method](https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/8032-enable-aztec-for-all-users?expand=1#diff-fda23a7cb324124c3e6c17b7ac196d73L343).
- Replaced [some unit tests](https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/8032-enable-aztec-for-all-users?expand=1#diff-9c468091a95f0a1873041b59523a299cR13) that don't apply anymore due to #8032.
- Event [tracking is now handled](https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/8032-enable-aztec-for-all-users?expand=1#diff-da0fecd820d59f1edb25a061a232a23bR78) by `EditorSettings` for convenience.

### Testing:

**Test 1:**

Run the unit tests.

**Test 2:**

1. Reset your simulator.  Erase all content and settings.
2. Modify WPiOS's Info.plist version to 8.5
3. Launch the app
4. Make sure Aztec is ON by default.
5. Change the editor to something else.
6. Quit and relaunch the app.
7. Make sure your editor pick wasn't changed.
5. Kill the app
6. Modify WPiOS's Info.plist version to 8.6
3. Launch the app
4. Make sure Aztec is ON by default.