### PR TITLE
Implement version 1.2 of the plugins endpoint

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
@@ -51,9 +51,10 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        service.getPlugins(siteID: siteID, success: { result in
-            self.viewModel = .ready(result)
+        service.getPlugins(siteID: siteID, success: { (plugins, _) in
+            self.viewModel = .ready(plugins)
         }, failure: { error in
+            DDLogError("Error loading plugins: \(error)")
             self.viewModel = .error(String(describing: error))
         })
     }

--- a/WordPressKit/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit/WordPressKit.xcodeproj/project.pbxproj
@@ -338,6 +338,7 @@
 		E13EE1491F332B8500C15787 /* site-plugins-success.json in Resources */ = {isa = PBXBuildFile; fileRef = E13EE1481F332B8500C15787 /* site-plugins-success.json */; };
 		E13EE14C1F332C4400C15787 /* PluginServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E13EE14B1F332C4400C15787 /* PluginServiceRemoteTests.swift */; };
 		E14694031F344F71004052C8 /* site-plugins-error.json in Resources */ = {isa = PBXBuildFile; fileRef = E14694021F344F71004052C8 /* site-plugins-error.json */; };
+		E1EF5D5D1F9F329900B6D53E /* SitePluginCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EF5D5C1F9F329900B6D53E /* SitePluginCapabilities.swift */; };
 		E632D7781F6E047400297F6D /* SocialLogin2FANonceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E632D7771F6E047400297F6D /* SocialLogin2FANonceInfo.swift */; };
 		E6C1E8491EF21FC100D139D9 /* is-passwordless-account-no-account-found.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C1E8471EF21FC100D139D9 /* is-passwordless-account-no-account-found.json */; };
 		E6C1E84A1EF21FC100D139D9 /* is-passwordless-account-success.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C1E8481EF21FC100D139D9 /* is-passwordless-account-success.json */; };
@@ -698,6 +699,7 @@
 		E13EE1481F332B8500C15787 /* site-plugins-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-plugins-success.json"; sourceTree = "<group>"; };
 		E13EE14B1F332C4400C15787 /* PluginServiceRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PluginServiceRemoteTests.swift; sourceTree = "<group>"; };
 		E14694021F344F71004052C8 /* site-plugins-error.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-plugins-error.json"; sourceTree = "<group>"; };
+		E1EF5D5C1F9F329900B6D53E /* SitePluginCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginCapabilities.swift; sourceTree = "<group>"; };
 		E5273E8FA8F6117F941D6CC1 /* Pods-WordPressKit.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKit.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressKit/Pods-WordPressKit.release-internal.xcconfig"; sourceTree = "<group>"; };
 		E632D7771F6E047400297F6D /* SocialLogin2FANonceInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocialLogin2FANonceInfo.swift; sourceTree = "<group>"; };
 		E6C1E8471EF21FC100D139D9 /* is-passwordless-account-no-account-found.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "is-passwordless-account-no-account-found.json"; sourceTree = "<group>"; };
@@ -1050,17 +1052,18 @@
 		9368C79C1EC62EBD0092CE8E /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				E1EF5D5E1F9F3CA700B6D53E /* Plugins */,
+				930F52B91ECF8A44002F921B /* Stats */,
 				7403A3011EF0726E00DED7DC /* AccountSettings.swift */,
 				74E229591F1E77290085F7F2 /* KeyringConnection.swift */,
 				74E2295A1F1E77290085F7F2 /* KeyringConnectionExternalUser.swift */,
-				E13EE1441F3323C300C15787 /* PluginState.swift */,
 				93C674E51EE8345300BFAF05 /* RemoteBlog.h */,
 				93C674E61EE8345300BFAF05 /* RemoteBlog.m */,
+				82FFBF511F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift */,
+				82FFBF4F1F45EFD100F4573F /* RemoteBlogJetpackSettings.swift */,
 				93C674E91EE8348F00BFAF05 /* RemoteBlogOptionsHelper.h */,
 				93C674EA1EE8348F00BFAF05 /* RemoteBlogOptionsHelper.m */,
 				93C674ED1EE834B700BFAF05 /* RemoteBlogSettings.swift */,
-				82FFBF4F1F45EFD100F4573F /* RemoteBlogJetpackSettings.swift */,
-				82FFBF511F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift */,
 				74BA04F71F06DC3900ED5CD8 /* RemoteComment.h */,
 				74BA04F81F06DC3900ED5CD8 /* RemoteComment.m */,
 				74585B961F0D54B400E7E667 /* RemoteDomain.swift */,
@@ -1107,7 +1110,6 @@
 				93BD27671EE736A8002BB00B /* RemoteUser.h */,
 				93BD27681EE736A8002BB00B /* RemoteUser.m */,
 				E632D7771F6E047400297F6D /* SocialLogin2FANonceInfo.swift */,
-				930F52B91ECF8A44002F921B /* Stats */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -1326,6 +1328,15 @@
 			isa = PBXGroup;
 			children = (
 				E13EE14B1F332C4400C15787 /* PluginServiceRemoteTests.swift */,
+			);
+			name = Plugins;
+			sourceTree = "<group>";
+		};
+		E1EF5D5E1F9F3CA700B6D53E /* Plugins */ = {
+			isa = PBXGroup;
+			children = (
+				E13EE1441F3323C300C15787 /* PluginState.swift */,
+				E1EF5D5C1F9F329900B6D53E /* SitePluginCapabilities.swift */,
 			);
 			name = Plugins;
 			sourceTree = "<group>";
@@ -1835,6 +1846,7 @@
 				740B23C51F17EE8000067A2A /* RemotePost.m in Sources */,
 				74E2295B1F1E77290085F7F2 /* KeyringConnection.swift in Sources */,
 				74B5F0DA1EF8299B00B411E7 /* BlogServiceRemoteXMLRPC.m in Sources */,
+				E1EF5D5D1F9F329900B6D53E /* SitePluginCapabilities.swift in Sources */,
 				93F50A411F227C9700B5BEBA /* RemoteProfile.swift in Sources */,
 				93C674EE1EE834B700BFAF05 /* RemoteBlogSettings.swift in Sources */,
 				82FFBF521F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift in Sources */,

--- a/WordPressKit/WordPressKit/PluginServiceRemote.swift
+++ b/WordPressKit/WordPressKit/PluginServiceRemote.swift
@@ -43,16 +43,14 @@ fileprivate extension PluginServiceRemote {
     }
 
     func pluginState(response: [String: AnyObject]) throws -> PluginState {
-        guard let id = response["id"] as? String,
-            let slug = response["slug"] as? String,
+        guard let slug = response["slug"] as? String,
             let active = response["active"] as? Bool,
             let autoupdate = response["autoupdate"] as? Bool,
             let name = response["display_name"] as? String else {
                 throw ResponseError.decodingFailure
         }
         let version = response["version"] as? String
-        return PluginState(id: id,
-                           slug: slug,
+        return PluginState(slug: slug,
                            active: active,
                            name: name,
                            version: version,

--- a/WordPressKit/WordPressKit/PluginState.swift
+++ b/WordPressKit/WordPressKit/PluginState.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 public struct PluginState {
-    public let id: String
     public let slug: String
     public let active: Bool
     public let name: String

--- a/WordPressKit/WordPressKit/SitePluginCapabilities.swift
+++ b/WordPressKit/WordPressKit/SitePluginCapabilities.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct SitePluginCapabilities {
+    public let modify: Bool
+    public let autoupdate: Bool
+}

--- a/WordPressKit/WordPressKitTests/Mock Data/site-plugins-success.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/site-plugins-success.json
@@ -1,130 +1,103 @@
 {
-  "plugins": [
-    {
-      "id": "akismet/akismet",
-      "slug": "akismet",
-      "active": true,
-      "name": "Akismet Anti-Spam",
-      "plugin_url": "https://akismet.com/",
-      "version": "3.3.3",
-      "description": "Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam</strong>. It keeps your site protected even while you sleep. To get started: activate the Akismet plugin and then go to your Akismet Settings page to set up your API key.",
-      "author": "Automattic",
-      "author_url": "https://automattic.com/wordpress-plugins/",
-      "network": false,
-      "autoupdate": true,
-      "action_links": []
-    },
-    {
-      "id": "upload-fail.php_/upload-fail",
-      "slug": "upload-fail.php_",
-      "active": false,
-      "name": "Force Failed Uploads",
-      "plugin_url": "",
-      "version": "",
-      "description": "",
-      "author": "",
-      "author_url": "",
-      "network": false,
-      "autoupdate": false,
-      "action_links": []
-    },
-    {
-      "id": "jetpack/jetpack",
-      "slug": "jetpack",
-      "active": true,
-      "name": "Jetpack by WordPress.com",
-      "plugin_url": "https://jetpack.com",
-      "version": "5.2.1",
-      "description": "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.",
-      "author": "Automattic",
-      "author_url": "https://jetpack.com",
-      "network": false,
-      "autoupdate": true,
-      "action_links": {
-        "Jetpack": "https://example.com/wp-admin/admin.php?page=jetpack",
-        "Settings": "https://example.com/wp-admin/admin.php?page=jetpack#/settings",
-        "Support": "https://example.com/wp-admin/admin.php?page=jetpack-debugger"
-      }
-    },
-    {
-      "id": "koketest",
-      "slug": "koketest",
-      "active": false,
-      "name": "Koke Test",
-      "plugin_url": "",
-      "version": "",
-      "description": "",
-      "author": "",
-      "author_url": "",
-      "network": false,
-      "autoupdate": false,
-      "action_links": []
-    },
-    {
-      "id": "user-role-editor/user-role-editor",
-      "slug": "user-role-editor",
-      "active": true,
-      "name": "User Role Editor",
-      "plugin_url": "https://www.role-editor.com",
-      "version": "4.35.3",
-      "description": "Change/add/delete WordPress user roles and capabilities.",
-      "author": "Vladimir Garagulya",
-      "author_url": "https://www.role-editor.com",
-      "network": false,
-      "autoupdate": false,
-      "action_links": []
-    },
-    {
-      "id": "vaultpress/vaultpress",
-      "slug": "vaultpress",
-      "active": false,
-      "name": "VaultPress",
-      "plugin_url": "http://vaultpress.com/?utm_source=plugin-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0",
-      "version": "1.9.2",
-      "description": "Protect your content, themes, plugins, and settings with <strong>realtime backup</strong> and <strong>automated security scanning</strong> from <a href=\"http://vaultpress.com/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0\" rel=\"nofollow\">VaultPress</a>. Activate, enter your registration key, and never worry again. <a href=\"http://vaultpress.com/help/?utm_source=wp-admin&amp;utm_medium=plugin-description&amp;utm_campaign=1.0\" rel=\"nofollow\">Need some help?</a>",
-      "author": "Automattic",
-      "author_url": "http://vaultpress.com/?utm_source=author-uri&amp;utm_medium=plugin-description&amp;utm_campaign=1.0",
-      "network": false,
-      "autoupdate": false,
-      "action_links": []
-    },
-    {
-      "id": "wordpress-beta-tester/wp-beta-tester",
-      "slug": "wordpress-beta-tester",
-      "active": true,
-      "name": "WordPress Beta Tester",
-      "plugin_url": "https://wordpress.org/plugins/wordpress-beta-tester/",
-      "version": "1.1.2",
-      "description": "Allows you to easily upgrade to Beta releases.",
-      "author": "Peter Westwood",
-      "author_url": "http://blog.ftwr.co.uk/",
-      "network": true,
-      "autoupdate": true,
-      "action_links": []
-    },
-    {
-      "id": "wordpress-seo/wp-seo",
-      "slug": "wordpress-seo",
-      "active": true,
-      "update": {
-        "id": "w.org/plugins/wordpress-seo",
-        "slug": "wordpress-seo",
-        "plugin": "wordpress-seo/wp-seo.php",
-        "new_version": "5.1",
-        "url": "https://wordpress.org/plugins/wordpress-seo/",
-        "package": "https://downloads.wordpress.org/plugin/wordpress-seo.5.1.zip",
-        "tested": "4.8",
-        "compatibility": {}
-      },
-      "name": "Yoast SEO",
-      "plugin_url": "https://yoast.com/wordpress/plugins/seo/#utm_source=wpadmin&utm_medium=plugin&utm_campaign=wpseoplugin",
-      "version": "5.0",
-      "description": "The first true all-in-one SEO solution for WordPress, including on-page content analysis, XML sitemaps and much more.",
-      "author": "Team Yoast",
-      "author_url": "https://yoast.com/",
-      "network": false,
-      "autoupdate": false,
-      "action_links": []
+    "plugins": [
+                {
+                "slug": "akismet",
+                "active": false,
+                "name": "akismet\/akismet",
+                "display_name": "Akismet Anti-Spam",
+                "plugin_url": "https:\/\/akismet.com\/",
+                "version": "3.3.4",
+                "description": "Used by millions, Akismet is quite possibly the best way in the world to <strong>protect your blog from spam<\/strong>. It keeps your site protected even while you sleep. To get started: activate the Akismet plugin and then go to your Akismet Settings page to set up your API key.",
+                "author": "Automattic",
+                "author_url": "https:\/\/automattic.com\/wordpress-plugins\/",
+                "network": false,
+                "update": {
+                "id": "w.org\/plugins\/akismet",
+                "slug": "akismet",
+                "plugin": "akismet\/akismet.php",
+                "new_version": "4.0",
+                "url": "https:\/\/wordpress.org\/plugins\/akismet\/",
+                "package": "https:\/\/downloads.wordpress.org\/plugin\/akismet.4.0.zip",
+                "tested": "4.8.1"
+                },
+                "action_links": [],
+                "autoupdate": false,
+                "uninstallable": false
+                },
+                {
+                "slug": "hello",
+                "active": false,
+                "name": "hello",
+                "display_name": "Hello Dolly",
+                "plugin_url": "http:\/\/wordpress.org\/plugins\/hello-dolly\/",
+                "version": "1.6",
+                "description": "This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from <cite>Hello, Dolly<\/cite> in the upper right of your admin screen on every page.",
+                "author": "Matt Mullenweg",
+                "author_url": "http:\/\/ma.tt\/",
+                "network": false,
+                "update": [],
+                "action_links": [],
+                "autoupdate": false,
+                "uninstallable": false
+                },
+                {
+                "slug": "howdy",
+                "active": false,
+                "name": "howdy",
+                "display_name": "Howdy",
+                "plugin_url": "",
+                "version": "",
+                "description": "",
+                "author": "",
+                "author_url": "",
+                "network": false,
+                "update": [],
+                "action_links": [],
+                "autoupdate": false,
+                "uninstallable": false
+                },
+                {
+                "slug": "jetpack-beta",
+                "active": true,
+                "name": "jetpack-beta\/jetpack-beta",
+                "display_name": "Jetpack Beta Tester",
+                "plugin_url": "https:\/\/jetpack.com\/beta\/",
+                "version": "2.0.3",
+                "description": "Use the Beta plugin to get a sneak peek at new features and test them on your site.",
+                "author": "Automattic",
+                "author_url": "https:\/\/jetpack.com\/",
+                "network": false,
+                "update": [],
+                "action_links": {
+                "Settings": "https:\/\/example.com\/wp-admin\/admin.php?page=jetpack-beta"
+                },
+                "autoupdate": false,
+                "uninstallable": false
+                },
+                {
+                "slug": "jetpack-dev",
+                "active": true,
+                "name": "jetpack-dev\/jetpack",
+                "display_name": "Jetpack by WordPress.com",
+                "plugin_url": "https:\/\/jetpack.com",
+                "version": "5.4",
+                "description": "Bring the power of the WordPress.com cloud to your self-hosted WordPress. Jetpack enables you to connect your blog to a WordPress.com account to use the powerful features normally only available to WordPress.com users.",
+                "author": "Automattic",
+                "author_url": "https:\/\/jetpack.com",
+                "network": false,
+                "update": [],
+                "action_links": {
+                "Jetpack": "https:\/\/example.com\/wp-admin\/admin.php?page=jetpack",
+                "Settings": "https:\/\/example.com\/wp-admin\/admin.php?page=jetpack#\/settings",
+                "Support": "https:\/\/example.com\/wp-admin\/admin.php?page=jetpack-debugger"
+                },
+                "autoupdate": false,
+                "uninstallable": false
+                }
+                ],
+    "file_mod_capabilities": {
+        "modify_files": true,
+        "autoupdate_files": true
     }
-  ]
 }
+

--- a/WordPressKit/WordPressKitTests/PluginServiceRemoteTests.swift
+++ b/WordPressKit/WordPressKitTests/PluginServiceRemoteTests.swift
@@ -34,8 +34,10 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(sitePluginsEndpoint,
                            filename: getPluginsSuccessMockFilename,
                            contentType: .ApplicationJSON)
-        remote.getPlugins(siteID: siteID, success: { (plugins, _) in
+        remote.getPlugins(siteID: siteID, success: { (plugins, capabilities) in
             XCTAssertEqual(plugins.count, 5)
+            XCTAssertTrue(capabilities.autoupdate)
+            XCTAssertTrue(capabilities.modify)
             expect.fulfill()
         }, failure: { (error) in
             XCTFail("This callback shouldn't get called")

--- a/WordPressKit/WordPressKitTests/PluginServiceRemoteTests.swift
+++ b/WordPressKit/WordPressKitTests/PluginServiceRemoteTests.swift
@@ -34,8 +34,8 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(sitePluginsEndpoint,
                            filename: getPluginsSuccessMockFilename,
                            contentType: .ApplicationJSON)
-        remote.getPlugins(siteID: siteID, success: { (plugins) in
-            XCTAssertEqual(plugins.count, 8)
+        remote.getPlugins(siteID: siteID, success: { (plugins, _) in
+            XCTAssertEqual(plugins.count, 5)
             expect.fulfill()
         }, failure: { (error) in
             XCTFail("This callback shouldn't get called")


### PR DESCRIPTION
Switches the plugin remote to the 1.2 version of the endpoints.

This will only work for now on a site running Jetpack beta, but the changes will be included in the 5.5 release (Nov 7), which should be enough time since we'll release 8.8 two weeks later.

Needs review: @elibud 
