### PR TITLE
Support for comment likes on Jetpack sites

### DIFF
--- a/WordPressKit/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/CommentServiceRemoteREST.m
@@ -30,6 +30,7 @@
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
                                  @"status": @"all",
                                  @"context": @"edit",
+                                 @"force": @"wpcom", // Force fetching data from shadow site on Jetpack sites
                                  @"number": @(maximumComments)
                                  }];
     if (options) {
@@ -173,7 +174,12 @@
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [self.wordPressComRestApi GET:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    NSDictionary *parameters = @{
+        @"force": @"wpcom" // Force fetching data from shadow site on Jetpack sites
+    };
+    [self.wordPressComRestApi GET:requestUrl
+                       parameters:parameters
+                          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
             NSDictionary *dict = (NSDictionary *)responseObject;
             NSArray *comments = [self remoteCommentsFromJSONArray:[dict arrayForKey:@"comments"]];


### PR DESCRIPTION
**Fixes** #7389 

**To test:**

1 - Like a comment on one of your Jetpack sites
2 - Fetch that comment via Reader and via Blog->Comments
3 - Check that the like is present

Needs review: @koke 
