### PR TITLE
Aztec: Title + Body Constraints Out of Sync

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -754,14 +754,14 @@ class AztecPostViewController: UIViewController, PostEditor {
     func startListeningToNotifications() {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(keyboardWillShow), name: .UIKeyboardWillShow, object: nil)
-        nc.addObserver(self, selector: #selector(keyboardWillHide), name: .UIKeyboardWillHide, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardDidHide), name: .UIKeyboardDidHide, object: nil)
         nc.addObserver(self, selector: #selector(applicationWillResignActive(_:)), name: .UIApplicationWillResignActive, object: nil)
     }
 
     func stopListeningToNotifications() {
         let nc = NotificationCenter.default
         nc.removeObserver(self, name: .UIKeyboardWillShow, object: nil)
-        nc.removeObserver(self, name: .UIKeyboardWillHide, object: nil)
+        nc.removeObserver(self, name: .UIKeyboardDidHide, object: nil)
         nc.removeObserver(self, name: .UIApplicationWillResignActive, object: nil)
     }
 
@@ -895,7 +895,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         refreshInsets(forKeyboardFrame: keyboardFrame)
     }
 
-    func keyboardWillHide(_ notification: Foundation.Notification) {
+    func keyboardDidHide(_ notification: Foundation.Notification) {
         guard
             let userInfo = notification.userInfo as? [String: AnyObject],
             let keyboardFrame = (userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue


### PR DESCRIPTION
### Details:
This PR fixes an annoying UX bug, in which the Body + Title are rendered with a gap in between (temporarily!).

Needs review: @diegoreymendez 

Fixes #8043

### Steps:
1. Enable Aztec
2. Edit a document that has Vertical Scroll
3. Press the body to display the keyboard
4. Swipe all the way down
5. Release your finger!

Verify that the Document's body doesn't loose "Vertical Sync" with the title. Sample video of the actual bug [available here.](https://cloudup.com/c02u4ci4Pqg).
