### PR TITLE
Add error analytics to share extension

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1116,6 +1116,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatLoginMagicLinkSucceeded:
             eventName = @"login_magic_link_succeeded";
             break;
+        case WPAnalyticsStatShareExtensionError:
+            eventName = @"share_extension_error";
+            break;
 
             // to be implemented
         case WPAnalyticsStatDefaultAccountChanged:

--- a/WordPress/Tracks+ShareExtension.swift
+++ b/WordPress/Tracks+ShareExtension.swift
@@ -15,6 +15,11 @@ extension Tracks {
         trackExtensionEvent(.Posted, properties: properties as [String: AnyObject]?)
     }
 
+    public func trackExtensionError(_ error: NSError) {
+        let properties = ["error": error.localizedDescription]
+        trackExtensionEvent(.Error, properties: properties as [String: AnyObject]?)
+    }
+
     public func trackExtensionCancelled() {
         trackExtensionEvent(.Canceled)
     }
@@ -31,5 +36,6 @@ extension Tracks {
         case Launched   = "wpios_share_extension_launched"
         case Posted     = "wpios_share_extension_posted"
         case Canceled   = "wpios_share_extension_canceled"
+        case Error      = "wpios_share_extension_error"
     }
 }

--- a/WordPress/Tracks+ShareExtension.swift
+++ b/WordPress/Tracks+ShareExtension.swift
@@ -16,7 +16,7 @@ extension Tracks {
     }
 
     public func trackExtensionError(_ error: NSError) {
-        let properties = ["error": error.localizedDescription]
+        let properties = ["error_code": String(error.code), "error_domain": error.domain, "error_description": error.description]
         trackExtensionEvent(.Error, properties: properties as [String: AnyObject]?)
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -337,7 +337,6 @@
 		7492F78E1F9BD94500B5A04A /* ShareMediaFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7430C4481F97F23600E2673E /* ShareMediaFileManager.swift */; };
 		74B335EC1F06F9520053A184 /* MockWordPressComRestApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B335EB1F06F9520053A184 /* MockWordPressComRestApi.swift */; };
 		74BB6F1A19AE7B9400FB7829 /* WPLegacyEditPageViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 74BB6F1919AE7B9400FB7829 /* WPLegacyEditPageViewController.m */; };
-		74CEF0771F9AA0F700B729CA /* ShareExtensionSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74CEF0761F9AA0F700B729CA /* ShareExtensionSessionManager.swift */; };
 		74CEF0781F9AA10100B729CA /* ShareExtensionSessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74CEF0761F9AA0F700B729CA /* ShareExtensionSessionManager.swift */; };
 		74D5FFD619ACDF6700389E8F /* WPLegacyEditPostViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 74D5FFD519ACDF6700389E8F /* WPLegacyEditPostViewController.m */; };
 		74F24F671EE8729700E8BFE8 /* xmlrpc-bad-username-password-error.xml in Resources */ = {isa = PBXBuildFile; fileRef = 74F24F621EE8729700E8BFE8 /* xmlrpc-bad-username-password-error.xml */; };
@@ -6748,7 +6747,6 @@
 				B50248C21C96FFCC00AFBDED /* WordPressShare-Lumberjack.m in Sources */,
 				B52937E01C94A2B100940C1C /* WPReusableTableViewCells.swift in Sources */,
 				B50248B61C96FF8400AFBDED /* SitePickerViewController.swift in Sources */,
-				74CEF0771F9AA0F700B729CA /* ShareExtensionSessionManager.swift in Sources */,
 				E125F1E51E8E596200320B67 /* SharePost.swift in Sources */,
 				B5D7A0EC1CCFD1FC003C375D /* UIImage+RoundedCorner.m in Sources */,
 				B5D7A0EB1CCFD1F6003C375D /* UIImage+Alpha.m in Sources */,

--- a/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
@@ -62,4 +62,11 @@ extension ShareExtensionSessionManager: URLSessionTaskDelegate {
 
         backgroundSessionCompletionBlock?()
     }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let error = error else {
+            return
+        }
+        DDLogError("Error recieved for share extension media uploading. Session:\(session) Task:\(task) Error:\(error).")
+    }
 }

--- a/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
@@ -64,9 +64,10 @@ extension ShareExtensionSessionManager: URLSessionTaskDelegate {
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        guard let error = error else {
+        guard let error = error as NSError? else {
             return
         }
+        WPAppAnalytics.track(.shareExtensionError, error: error)
         DDLogError("Error recieved for share extension media uploading. Session:\(session) Task:\(task) Error:\(error).")
     }
 }

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -255,7 +255,7 @@ private extension ShareViewController {
         do {
             try attachedImageData.write(to: fullPath, options: [.atomic])
         } catch {
-            NSLog("Error saving \(fullPath) to shared container: \(String(describing: error))")
+            DDLogError("Error saving \(fullPath) to shared container: \(String(describing: error))")
             return
         }
 
@@ -286,7 +286,7 @@ private extension ShareViewController {
             guard let error = error as NSError? else {
                 return
             }
-            NSLog("Error creating post in share extension: \(error.localizedDescription)")
+            DDLogError("Error creating post in share extension: \(error.localizedDescription)")
             self.tracks.trackExtensionError(error)
             ShareMediaFileManager.shared.purgeUploadDirectory()
         }

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -283,7 +283,11 @@ private extension ShareViewController {
         }, success: {_ in
             ShareMediaFileManager.shared.purgeUploadDirectory()
         }) { error in
-            NSLog("Error creating post in share extension: \(String(describing: error))")
+            guard let error = error as NSError? else {
+                return
+            }
+            NSLog("Error creating post in share extension: \(error.localizedDescription)")
+            self.tracks.trackExtensionError(error)
             ShareMediaFileManager.shared.purgeUploadDirectory()
         }
     }

--- a/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -291,6 +291,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatTrainTracksInteract,
     WPAnalyticsStatTwoFactorCodeRequested,
     WPAnalyticsStatTwoFactorSentSMS,
+    WPAnalyticsStatShareExtensionError,
     WPAnalyticsStatMaxValue
 };
 


### PR DESCRIPTION
Fixes #8046 

This PR attempts to add analytics for error capture in the share extension. Unfortunately there still is a chance the error tracking call in `ShareViewController.swift` will not be fired. However by also adding a similar call to `ShareExtensionSessionManager.swift` we can attempt to track when something goes catastrophically wrong with the background URLSession when creating a new post. 

To test:
Try using the share extension and make sure everything still works as expected. Note: simply turning off the network will not cause the queued background upload task to fail.

Needs review: @SergioEstevao would you mind?
