### PR TITLE
Login: improve validation during 2fa entry

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import SVProgressHUD
 import WordPressShared
 import GoogleSignIn
-import WordPressComKit
 
 /// Provides a form and functionality for entering a two factor auth code and
 /// signing into WordPress.com
@@ -178,8 +177,7 @@ class Login2FAViewController: LoginViewController, SigninKeyboardResponder, UITe
     }
 
     /// Only allow digits in the 2FA text field
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool
-    {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let allowedCharacters = CharacterSet.decimalDigits
         let characterSet = CharacterSet(charactersIn: string)
         let isOnlyNumbers = allowedCharacters.isSuperset(of: characterSet)

--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -112,7 +112,6 @@ class Login2FAViewController: LoginViewController, SigninKeyboardResponder, UITe
 
         submitButton?.isEnabled = (
             !animating &&
-            !loginFields.multifactorCode.isEmpty &&
             isNumeric &&
             isValidLength
         )

--- a/WordPressKit/WordPressKit/SocialLogin2FANonceInfo.swift
+++ b/WordPressKit/WordPressKit/SocialLogin2FANonceInfo.swift
@@ -14,22 +14,22 @@ public class SocialLogin2FANonceInfo: NSObject {
     }
 
     /// These constants match the server-side authentication code
-    private enum AuthTypeLengths {
-        static let authenticator = 6
-        static let sms = 7
-        static let backup = 8
+    public enum TwoFactorTypeLengths: Int {
+        case authenticator = 6
+        case sms = 7
+        case backup = 8
     }
 
     public func authTypeAndNonce(for code: String) -> (String, String) {
         let typeNoncePair: (String, String)
         switch code.count {
-        case AuthTypeLengths.sms:
+        case TwoFactorTypeLengths.sms.rawValue:
             typeNoncePair = ("sms", nonceSMS)
             nonceSMS = Constants.lastUsedPlaceholder
-        case AuthTypeLengths.backup:
+        case TwoFactorTypeLengths.backup.rawValue:
             typeNoncePair = ("backup", nonceBackup)
             nonceBackup = Constants.lastUsedPlaceholder
-        case AuthTypeLengths.authenticator:
+        case TwoFactorTypeLengths.authenticator.rawValue:
             fallthrough
         default:
             typeNoncePair = ("authenticator", nonceAuthenticator)


### PR DESCRIPTION
Fixes #8037

To test:
- Ensure you can still enter valid 2FA codes 😉
  - Make sure to test normal wpcom accounts as well as Google-based login
- Test entering invalid codes: letters, codes longer than 8, etc
- The submit button should only be active for valid-looking 2FA codes

Needs review: @aerych 