### PR TITLE
 Activity Log Remote Feed initial implementation and tests

### DIFF
--- a/WordPressKit/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit/WordPressKit.xcodeproj/project.pbxproj
@@ -202,6 +202,14 @@
 		74FC6F411F191C1D00112505 /* notifications-last-seen.json in Resources */ = {isa = PBXBuildFile; fileRef = 74FC6F3D1F191C1D00112505 /* notifications-last-seen.json */; };
 		74FC6F421F191C1D00112505 /* notifications-load-hash.json in Resources */ = {isa = PBXBuildFile; fileRef = 74FC6F3E1F191C1D00112505 /* notifications-load-hash.json */; };
 		74FC6F431F191C1D00112505 /* notifications-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 74FC6F3F1F191C1D00112505 /* notifications-load-all.json */; };
+		826016F11F9FA13A00533B6C /* ActivityServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826016F01F9FA13A00533B6C /* ActivityServiceRemote.swift */; };
+		826016F31F9FA17B00533B6C /* RemoteActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826016F21F9FA17B00533B6C /* RemoteActivity.swift */; };
+		826016F91F9FAF6300533B6C /* activity-log-success-3.json in Resources */ = {isa = PBXBuildFile; fileRef = 826016F41F9FAF6300533B6C /* activity-log-success-3.json */; };
+		826016FA1F9FAF6300533B6C /* activity-log-success-1.json in Resources */ = {isa = PBXBuildFile; fileRef = 826016F51F9FAF6300533B6C /* activity-log-success-1.json */; };
+		826016FB1F9FAF6300533B6C /* activity-log-auth-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 826016F61F9FAF6300533B6C /* activity-log-auth-failure.json */; };
+		826016FC1F9FAF6300533B6C /* activity-log-success-2.json in Resources */ = {isa = PBXBuildFile; fileRef = 826016F71F9FAF6300533B6C /* activity-log-success-2.json */; };
+		826016FD1F9FAF6300533B6C /* activity-log-bad-json-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 826016F81F9FAF6300533B6C /* activity-log-bad-json-failure.json */; };
+		826017001F9FD60A00533B6C /* ActivityServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826016FF1F9FD60A00533B6C /* ActivityServiceRemoteTests.swift */; };
 		82FFBF501F45EFD100F4573F /* RemoteBlogJetpackSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FFBF4F1F45EFD100F4573F /* RemoteBlogJetpackSettings.swift */; };
 		82FFBF521F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FFBF511F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift */; };
 		82FFBF561F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FFBF551F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift */; };
@@ -554,6 +562,14 @@
 		74FC6F3D1F191C1D00112505 /* notifications-last-seen.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "notifications-last-seen.json"; sourceTree = "<group>"; };
 		74FC6F3E1F191C1D00112505 /* notifications-load-hash.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "notifications-load-hash.json"; sourceTree = "<group>"; };
 		74FC6F3F1F191C1D00112505 /* notifications-load-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "notifications-load-all.json"; sourceTree = "<group>"; };
+		826016F01F9FA13A00533B6C /* ActivityServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityServiceRemote.swift; sourceTree = "<group>"; };
+		826016F21F9FA17B00533B6C /* RemoteActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteActivity.swift; sourceTree = "<group>"; };
+		826016F41F9FAF6300533B6C /* activity-log-success-3.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "activity-log-success-3.json"; sourceTree = "<group>"; };
+		826016F51F9FAF6300533B6C /* activity-log-success-1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "activity-log-success-1.json"; sourceTree = "<group>"; };
+		826016F61F9FAF6300533B6C /* activity-log-auth-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "activity-log-auth-failure.json"; sourceTree = "<group>"; };
+		826016F71F9FAF6300533B6C /* activity-log-success-2.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "activity-log-success-2.json"; sourceTree = "<group>"; };
+		826016F81F9FAF6300533B6C /* activity-log-bad-json-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "activity-log-bad-json-failure.json"; sourceTree = "<group>"; };
+		826016FF1F9FD60A00533B6C /* ActivityServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityServiceRemoteTests.swift; sourceTree = "<group>"; };
 		82FFBF4F1F45EFD100F4573F /* RemoteBlogJetpackSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteBlogJetpackSettings.swift; sourceTree = "<group>"; };
 		82FFBF511F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteBlogJetpackMonitorSettings.swift; sourceTree = "<group>"; };
 		82FFBF551F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlogJetpackSettingsServiceRemote.swift; sourceTree = "<group>"; };
@@ -832,6 +848,14 @@
 			name = Media;
 			sourceTree = "<group>";
 		};
+		826016FE1F9FD59400533B6C /* Activity */ = {
+			isa = PBXGroup;
+			children = (
+				826016FF1F9FD60A00533B6C /* ActivityServiceRemoteTests.swift */,
+			);
+			name = Activity;
+			sourceTree = "<group>";
+		};
 		85FE0F09B4E9702893D675A4 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -886,6 +910,7 @@
 				74B335D91F06F3D60053A184 /* WordPressComRestApiTests.swift */,
 				74B335DB1F06F4180053A184 /* WordPressOrgXMLRPCApiTests.swift */,
 				93BD273E1EE732CC002BB00B /* Accounts */,
+				826016FE1F9FD59400533B6C /* Activity */,
 				74B5F0DF1EF82AAB00B411E7 /* Blog */,
 				74585B911F0D520700E7E667 /* Domains */,
 				74FA25F81F1FDA240044BC54 /* Media */,
@@ -980,6 +1005,7 @@
 				93BD273A1EE73282002BB00B /* AccountServiceRemoteREST.m */,
 				E6D0EE611F7EF9CE0064D3FC /* AccountServiceRemoteREST+SocialService.swift */,
 				7403A2E31EF06ED500DED7DC /* AccountSettingsRemote.swift */,
+				826016F01F9FA13A00533B6C /* ActivityServiceRemote.swift */,
 				82FFBF551F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift */,
 				74B5F0DB1EF829B800B411E7 /* BlogServiceRemote.h */,
 				74B5F0D31EF8299B00B411E7 /* BlogServiceRemoteREST.h */,
@@ -1054,6 +1080,7 @@
 				74E229591F1E77290085F7F2 /* KeyringConnection.swift */,
 				74E2295A1F1E77290085F7F2 /* KeyringConnectionExternalUser.swift */,
 				E13EE1441F3323C300C15787 /* PluginState.swift */,
+				826016F21F9FA17B00533B6C /* RemoteActivity.swift */,
 				93C674E51EE8345300BFAF05 /* RemoteBlog.h */,
 				93C674E61EE8345300BFAF05 /* RemoteBlog.m */,
 				93C674E91EE8348F00BFAF05 /* RemoteBlogOptionsHelper.h */,
@@ -1158,6 +1185,11 @@
 		93BD27421EE73384002BB00B /* Mock Data */ = {
 			isa = PBXGroup;
 			children = (
+				826016F61F9FAF6300533B6C /* activity-log-auth-failure.json */,
+				826016F81F9FAF6300533B6C /* activity-log-bad-json-failure.json */,
+				826016F51F9FAF6300533B6C /* activity-log-success-1.json */,
+				826016F71F9FAF6300533B6C /* activity-log-success-2.json */,
+				826016F41F9FAF6300533B6C /* activity-log-success-3.json */,
 				40F88F611F85799A00AE3FAF /* auth-send-verification-email-success.json */,
 				40F88F5F1F85723400AE3FAF /* auth-send-verification-email-already-verified-failure.json */,
 				93BD27431EE73442002BB00B /* auth-send-login-email-invalid-client-failure.json */,
@@ -1549,7 +1581,9 @@
 				74C473B71EF3229B009918F2 /* site-delete-unexpected-json-failure.json in Resources */,
 				93AC8ECD1ED32FD000900F5A /* stats-v1.1-insights.json in Resources */,
 				740B23EE1F17FB7E00067A2A /* xmlrpc-malformed-request-xml-error.xml in Resources */,
+				826016F91F9FAF6300533B6C /* activity-log-success-3.json in Resources */,
 				93BD27551EE73442002BB00B /* auth-send-login-email-invalid-client-failure.json in Resources */,
+				826016FD1F9FAF6300533B6C /* activity-log-bad-json-failure.json in Resources */,
 				74C473CD1EF336BD009918F2 /* site-active-purchases-bad-json-failure.json in Resources */,
 				74D67F351F15C3740010C5ED /* site-users-delete-not-member-failure.json in Resources */,
 				74D67F201F15C3240010C5ED /* people-validate-invitation-failure.json in Resources */,
@@ -1589,6 +1623,7 @@
 				93BD27611EE73442002BB00B /* me-sites-empty-success.json in Resources */,
 				74FC6F431F191C1D00112505 /* notifications-load-all.json in Resources */,
 				74C473C11EF32C74009918F2 /* site-export-missing-status-failure.json in Resources */,
+				826016FC1F9FAF6300533B6C /* activity-log-success-2.json in Resources */,
 				74D67F1E1F15C3240010C5ED /* people-send-invitation-failure.json in Resources */,
 				7403A3001EF06FEB00DED7DC /* me-settings-success.json in Resources */,
 				74B335EA1F06F76B0053A184 /* xmlrpc-response-getpost.xml in Resources */,
@@ -1622,6 +1657,7 @@
 				74C473BB1EF328D8009918F2 /* site-export-success.json in Resources */,
 				7403A2FE1EF06FEB00DED7DC /* me-settings-change-web-address-success.json in Resources */,
 				93BD27621EE73442002BB00B /* me-sites-success.json in Resources */,
+				826016FB1F9FAF6300533B6C /* activity-log-auth-failure.json in Resources */,
 				7433BC161EFC45C7002D9E92 /* site-plans-success.json in Resources */,
 				7433BC141EFC45C7002D9E92 /* site-plans-empty-failure.json in Resources */,
 				7403A2F61EF06FEB00DED7DC /* me-settings-change-aboutme-success.json in Resources */,
@@ -1634,6 +1670,7 @@
 				74D67F361F15C3740010C5ED /* site-users-delete-site-owner-failure.json in Resources */,
 				74C473CB1EF33696009918F2 /* site-active-purchases-auth-failure.json in Resources */,
 				74D67F381F15C3740010C5ED /* site-viewers-delete-auth-failure.json in Resources */,
+				826016FA1F9FAF6300533B6C /* activity-log-success-1.json in Resources */,
 				93AC8EDB1ED32FD000900F5A /* stats-v1.1-visits-day-bad-date.json in Resources */,
 				93AC8ECB1ED32FD000900F5A /* stats-v1.1-followers-email-day.json in Resources */,
 				740B23E41F17FB4200067A2A /* xmlrpc-metaweblog-editpost-success.xml in Resources */,
@@ -1788,12 +1825,14 @@
 				7430C9B81F1927C50051B8E6 /* RemoteReaderTopic.m in Sources */,
 				7403A3021EF0726E00DED7DC /* AccountSettings.swift in Sources */,
 				9368C7C01EC630CE0092CE8E /* StatsStringUtilities.m in Sources */,
+				826016F11F9FA13A00533B6C /* ActivityServiceRemote.swift in Sources */,
 				74BA04FA1F06DC3900ED5CD8 /* RemoteComment.m in Sources */,
 				93C674EC1EE8348F00BFAF05 /* RemoteBlogOptionsHelper.m in Sources */,
 				E632D7781F6E047400297F6D /* SocialLogin2FANonceInfo.swift in Sources */,
 				7403A2E41EF06ED500DED7DC /* AccountSettingsRemote.swift in Sources */,
 				93C674E81EE8345300BFAF05 /* RemoteBlog.m in Sources */,
 				93BD27831EE73944002BB00B /* WordPressRSDParser.swift in Sources */,
+				826016F31F9FA17B00533B6C /* RemoteActivity.swift in Sources */,
 				742362E31F1025B400BD0A7F /* RemoteMenuLocation.m in Sources */,
 				82FFBF561F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift in Sources */,
 				9368C7B81EC630270092CE8E /* StatsStreakItem.m in Sources */,
@@ -1856,6 +1895,7 @@
 				74D67F0A1F15C24C0010C5ED /* PeopleServiceRemoteTests.swift in Sources */,
 				74585B901F0D51F900E7E667 /* DomainsServiceRemoteRESTTests.swift in Sources */,
 				7430C9BD1F192C0F0051B8E6 /* ReaderPostServiceRemoteTests.m in Sources */,
+				826017001F9FD60A00533B6C /* ActivityServiceRemoteTests.swift in Sources */,
 				93F50A3A1F226BB600B5BEBA /* WordPressComServiceRemoteRestTests.swift in Sources */,
 				93AC8EE01ED32FD000900F5A /* StatsStreakTests.m in Sources */,
 				E13EE14C1F332C4400C15787 /* PluginServiceRemoteTests.swift in Sources */,

--- a/WordPressKit/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/WordPressKit/ActivityServiceRemote.swift
@@ -67,8 +67,8 @@ private extension ActivityServiceRemote {
                 throw ActivityServiceRemote.ResponseError.decodingFailure
         }
 
-        let activities = orderedItems.map { activity -> RemoteActivity in
-            return RemoteActivity(dictionary: activity)
+        let activities = try orderedItems.map { activity -> RemoteActivity in
+            return try RemoteActivity(dictionary: activity)
         }
 
         return (activities, totalItems)

--- a/WordPressKit/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/WordPressKit/ActivityServiceRemote.swift
@@ -1,0 +1,77 @@
+import Foundation
+import WordPressShared
+import CocoaLumberjack
+
+public class ActivityServiceRemote: ServiceRemoteWordPressComREST {
+
+    public enum ResponseError: Error {
+        case decodingFailure
+    }
+
+    /// Retrieves activity events associated to a site.
+    ///
+    /// - Parameters:
+    ///     - siteID: The target site's ID.
+    ///     - offset: The first N activities to be skipped in the returned array.
+    ///     - count: Number of objects to retrieve.
+    ///     - success: Closure to be executed on success
+    ///     - failure: Closure to be executed on error.
+    ///
+    /// - Returns: An array of activities and a boolean indicating if there's more activities to fetch.
+    ///
+    public func getActivityForSite(_ siteID: Int,
+                                   offset: Int = 0,
+                                   count: Int,
+                                   success: @escaping (_ activities: [RemoteActivity], _ hasMore: Bool) -> Void,
+                                   failure: @escaping (Error) -> Void) {
+        let endpoint = "sites/\(siteID)/activity"
+        let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
+        let locale = WordPressComLanguageDatabase().deviceLanguage.slug
+        let pageNumber = (offset / count + 1)
+        let parameters: [String: AnyObject] = [
+            "locale": locale as AnyObject,
+            "number": count as AnyObject,
+            "page": pageNumber as AnyObject
+        ]
+
+        wordPressComRestApi.GET(path!,
+                                parameters: parameters as [String : AnyObject]?,
+                                success: {
+                                    response, _ in
+                                    do {
+                                        let (activities, totalItems) = try self.mapActivitiesResponse(response)
+                                        let hasMore = totalItems > pageNumber * (count + 1)
+                                        success(activities, hasMore)
+                                    } catch {
+                                        DDLogError("Error parsing activity response for site \(siteID)")
+                                        DDLogError("\(error)")
+                                        DDLogDebug("Full response: \(response)")
+                                        failure(error)
+                                    }
+        }, failure: {
+            error, _ in
+            failure(error)
+        })
+    }
+
+}
+
+private extension ActivityServiceRemote {
+
+    func mapActivitiesResponse(_ response: AnyObject) throws -> ([RemoteActivity], Int) {
+
+        guard let json = response as? [String: AnyObject],
+            let totalItems = json["totalItems"] as? Int,
+            let current = json["current"] as? [String: AnyObject],
+            let orderedItems = current["orderedItems"] as? [[String: AnyObject]] else {
+                throw ActivityServiceRemote.ResponseError.decodingFailure
+        }
+
+        let activities = orderedItems.map { activity -> RemoteActivity in
+            return RemoteActivity(dictionary: activity)
+        }
+
+        return (activities, totalItems)
+    }
+
+}

--- a/WordPressKit/WordPressKit/RemoteActivity.swift
+++ b/WordPressKit/WordPressKit/RemoteActivity.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-open class RemoteActivity {
+public struct RemoteActivity {
     public let activityID: String
     public let summary: String
     public let name: String
@@ -14,8 +14,11 @@ open class RemoteActivity {
     public let target: RemoteActivityObject?
     public let items: [RemoteActivityObject]?
 
-    init(dictionary: [String: AnyObject]) {
-        activityID = dictionary["activity_id"] as? String ?? ""
+    init(dictionary: [String: AnyObject]) throws {
+        guard let id = dictionary["activity_id"] as? String else {
+            throw RemoteActivityError.missingActivityId
+        }
+        activityID = id
         summary = dictionary["summary"] as? String ?? ""
         name = dictionary["name"] as? String ?? ""
         type = dictionary["type"] as? String ?? ""
@@ -53,7 +56,7 @@ open class RemoteActivity {
     }
 }
 
-open class RemoteActivityActor {
+public struct RemoteActivityActor {
     public let displayName: String
     public let type: String
     public let wpcomUserID: String
@@ -73,7 +76,7 @@ open class RemoteActivityActor {
     }
 }
 
-open class RemoteActivityObject {
+public struct RemoteActivityObject {
     public let name: String
     public let type: String
     public let attributes: [String: Any]
@@ -89,6 +92,10 @@ open class RemoteActivityObject {
             attributes = [:]
         }
     }
+}
+
+enum RemoteActivityError: Error {
+    case missingActivityId
 }
 
 extension RemoteActivity: CustomDebugStringConvertible {

--- a/WordPressKit/WordPressKit/RemoteActivity.swift
+++ b/WordPressKit/WordPressKit/RemoteActivity.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+open class RemoteActivity {
+    public let activityID: String
+    public let summary: String
+    public let name: String
+    public let type: String
+    public let gridicon: String
+    public let status: String
+    public let rewindable: Bool
+    public let published: Date?
+    public let actor: RemoteActivityActor?
+    public let object: RemoteActivityObject?
+    public let target: RemoteActivityObject?
+    public let items: [RemoteActivityObject]?
+
+    init(dictionary: [String: AnyObject]) {
+        activityID = dictionary["activity_id"] as? String ?? ""
+        summary = dictionary["summary"] as? String ?? ""
+        name = dictionary["name"] as? String ?? ""
+        type = dictionary["type"] as? String ?? ""
+        gridicon = dictionary["gridicon"] as? String ?? ""
+        status = dictionary["status"] as? String ?? ""
+        rewindable = dictionary["is_rewindable"] as? Bool ?? false
+        let dateFormatter = ISO8601DateFormatter()
+        if let publishedString = dictionary["published"] as? String {
+            published = dateFormatter.date(from: publishedString)
+        } else {
+            published = nil
+        }
+        if let actorData = dictionary["actor"] as? [String: AnyObject] {
+            actor = RemoteActivityActor.init(dictionary: actorData)
+        } else {
+            actor = nil
+        }
+        if let objectData = dictionary["object"] as? [String: AnyObject] {
+            object = RemoteActivityObject.init(dictionary: objectData)
+        } else {
+            object = nil
+        }
+        if let targetData = dictionary["actor"] as? [String: AnyObject] {
+            target = RemoteActivityObject.init(dictionary: targetData)
+        } else {
+            target = nil
+        }
+        if let orderedItems = dictionary["items"] as? [[String: AnyObject]] {
+            items = orderedItems.map { item -> RemoteActivityObject in
+                return RemoteActivityObject(dictionary: item)
+            }
+        } else {
+            items = nil
+        }
+    }
+}
+
+open class RemoteActivityActor {
+    public let displayName: String
+    public let type: String
+    public let wpcomUserID: String
+    public let avatarURL: String
+    public let role: String
+
+    init(dictionary: [String: AnyObject]) {
+        displayName = dictionary["name"] as? String ?? ""
+        type = dictionary["type"] as? String ?? ""
+        wpcomUserID = dictionary["wp_com_user_id"] as? String ?? ""
+        if let iconInfo = dictionary["icon"] as? [String: AnyObject] {
+            avatarURL = iconInfo["url"] as? String ?? ""
+        } else {
+            avatarURL = ""
+        }
+        role = dictionary["role"] as? String ?? ""
+    }
+}
+
+public struct RemoteActivityObject {
+    public let name: String
+    public let type: String
+    public let attributes: [String: Any]
+
+    init(dictionary: [String: AnyObject]) {
+        name = dictionary["name"] as? String ?? ""
+        type = dictionary["type"] as? String ?? ""
+        let mutableDictionary = NSMutableDictionary(dictionary: dictionary)
+        mutableDictionary.removeObjects(forKeys: ["name", "type"])
+        if let extraAttributes = mutableDictionary as? [String: Any] {
+            attributes = extraAttributes
+        } else {
+            attributes = [:]
+        }
+    }
+}

--- a/WordPressKit/WordPressKit/RemoteActivity.swift
+++ b/WordPressKit/WordPressKit/RemoteActivity.swift
@@ -73,7 +73,7 @@ open class RemoteActivityActor {
     }
 }
 
-public struct RemoteActivityObject {
+open class RemoteActivityObject {
     public let name: String
     public let type: String
     public let attributes: [String: Any]
@@ -88,5 +88,29 @@ public struct RemoteActivityObject {
         } else {
             attributes = [:]
         }
+    }
+}
+
+extension RemoteActivity: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        let dateFormatter = ISO8601DateFormatter()
+        let publishedDate = published != nil ? dateFormatter.string(from: published!) : ""
+        return "<RemoteActivity: (activityID: \(activityID), summary: \(summary), name: \(name), type: \(type) " +
+               "gridicon: \(gridicon), status: \(status), rewindable: \(rewindable), published: \(publishedDate) " +
+               "actor: \(actor.debugDescription), object: \(object.debugDescription), " +
+               "target: \(target.debugDescription), items: \(items != nil ? items.debugDescription : "[]")>";
+    }
+}
+
+extension RemoteActivityActor: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "<RemoteActivityActor(displayName: \(displayName), type: \(type), wpcomUserID: \(wpcomUserID) " +
+               "avatarURL: \(avatarURL), role: \(role)>"
+    }
+}
+
+extension RemoteActivityObject: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "<RemoteActivityObject(name: \(name), type: \(type), attributes: \(attributes.debugDescription)>"
     }
 }

--- a/WordPressKit/WordPressKit/ServiceRemoteWordPressComREST.m
+++ b/WordPressKit/WordPressKit/ServiceRemoteWordPressComREST.m
@@ -54,6 +54,10 @@ static NSString* const ServiceRemoteWordPressComRESTApiVersionString_2_0 = @"wpc
             result = ServiceRemoteWordPressComRESTApiVersionString_1_3;
             break;
 
+        case ServiceRemoteWordPressComRESTApiVersion_2_0:
+            result = ServiceRemoteWordPressComRESTApiVersionString_2_0;
+            break;
+
         default:
             NSAssert(NO, @"This should never by executed");
             result = ServiceRemoteWordPressComRESTApiVersionStringInvalid;

--- a/WordPressKit/WordPressKitTests/ActivityServiceRemoteTests.swift
+++ b/WordPressKit/WordPressKitTests/ActivityServiceRemoteTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import XCTest
+@testable import WordPressKit
+
+class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
+
+    /// MARK: - Constants
+
+    let siteID = 321
+
+    let getActivitySuccessOneMockFilename = "activity-log-success-1.json"
+    let getActivitySuccessTwoMockFilename = "activity-log-success-2.json"
+    let getActivitySuccessThreeMockFilename = "activity-log-success-3.json"
+    let getActivityBadJsonFailureMockFilename = "activity-log-bad-json-failure.json"
+    let getActivityAuthFailureMockFilename = "activity-log-auth-failure.json"
+
+    /// MARK: - Properties
+
+    var siteActivityEndpoint: String { return "sites/\(siteID)/activity" }
+    var remote: ActivityServiceRemote!
+
+    /// MARK: - Overridden Methods
+
+    override func setUp() {
+        super.setUp()
+
+        remote = ActivityServiceRemote(wordPressComRestApi: getRestApi())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        remote = nil
+    }
+
+    /// MARK: - Get Activity Tests
+
+    func testGetActivitySucceedsOne() {
+        let expect = expectation(description: "Get activity for site success one")
+
+        stubRemoteResponse(siteActivityEndpoint, filename: getActivitySuccessOneMockFilename, contentType: .ApplicationJSON)
+        remote.getActivityForSite(siteID,
+                                  offset: 0,
+                                  count: 20,
+                                  success: { (activities, hasMore) in
+                                      XCTAssertEqual(activities.count, 8, "The activity count should be 8")
+                                      XCTAssertEqual(hasMore, false, "The value of hasMore should be false")
+                                      expect.fulfill()
+                                  }, failure: { error in
+                                      XCTFail("This callback shouldn't get called")
+                                      expect.fulfill()
+                                  })
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testGetActivitySucceedsTwo() {
+        let expect = expectation(description: "Get activity for site success two")
+
+        stubRemoteResponse(siteActivityEndpoint, filename: getActivitySuccessTwoMockFilename, contentType: .ApplicationJSON)
+        remote.getActivityForSite(siteID,
+                                  offset: 0,
+                                  count: 20,
+                                  success: { (activities, hasMore) in
+                                      XCTAssertEqual(activities.count, 20, "The activity count should be 20")
+                                      XCTAssertEqual(hasMore, true, "The value of hasMore should be true")
+                                      expect.fulfill()
+                                  }, failure: { error in
+                                      XCTFail("This callback shouldn't get called")
+                                      expect.fulfill()
+                                  })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testGetActivitySucceedsThree() {
+        let expect = expectation(description: "Get activity for site success three")
+
+        stubRemoteResponse(siteActivityEndpoint, filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
+        remote.getActivityForSite(siteID,
+                                  offset: 100,
+                                  count: 20,
+                                  success: { (activities, hasMore) in
+                                      XCTAssertEqual(activities.count, 19, "The activity count should be 19")
+                                      XCTAssertEqual(hasMore, false, "The value of hasMore should be false")
+                                      expect.fulfill()
+                                  }, failure: { error in
+                                      XCTFail("This callback shouldn't get called")
+                                      expect.fulfill()
+                                  })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testGetActivityWithBadAuthFails() {
+        let expect = expectation(description: "Get plans with bad auth failure")
+
+        stubRemoteResponse(siteActivityEndpoint, filename: getActivityAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
+        remote.getActivityForSite(siteID,
+                                  count: 20,
+                                  success: { (activities, hasMore) in
+                                      XCTFail("This callback shouldn't get called")
+                                      expect.fulfill()
+                                  }, failure: { error in
+                                      let error = error as NSError
+                                      XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+                                      XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
+                                      expect.fulfill()
+                                  })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testGetActivityWithBadJsonFails() {
+        let expect = expectation(description: "Get plans with invalid json response failure")
+
+        stubRemoteResponse(siteActivityEndpoint, filename: getActivityBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
+        remote.getActivityForSite(siteID,
+                                  count: 20,
+                                  success: { (activities, hasMore) in
+                                      XCTFail("This callback shouldn't get called")
+                                      expect.fulfill()
+                                 }, failure: { error in
+                                      expect.fulfill()
+                                 })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+}
+

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-auth-failure.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-auth-failure.json
@@ -1,0 +1,4 @@
+{
+    "error": "authorization_required",
+    "message": "An active access token must be used to query information about the current user."
+}

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-bad-json-failure.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-bad-json-failure.json
@@ -1,0 +1,27 @@
+{
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "summary": "Activity log",
+    "type": "OrderedCollection",
+    "totalItems": 608,
+    "page": 1,
+    "totalPages": 31,
+    "itemsPerPage": 20,
+    "id": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20",
+    "first": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20&page=1",
+    "last": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20&page=31",
+    "current": {
+        "type": "OrderedCollectionPage",
+        "id": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20&page=1",
+        "next": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20&page=2",
+        "totalItems": 20,
+        "orderedItems": [
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-1.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-1.json
@@ -1,0 +1,289 @@
+{
+    "@context": "https:\\/\\/www.w3.org\\/ns\\/activitystreams",
+    "summary": "Activity log",
+    "type": "OrderedCollection",
+    "totalItems": 8,
+    "page": 1,
+    "totalPages": 1,
+    "itemsPerPage": 20,
+    "id": "https:\\/\\/public-api.wordpress.com\\/wpcom\\/v2\\/sites\\/activity002.mystagingwebsite.com\\/activity?number=20",
+    "first": "https:\\/\\/public-api.wordpress.com\\/wpcom\\/v2\\/sites\\/activity002.mystagingwebsite.com\\/activity?number=20&page=1",
+    "last": "https:\\/\\/public-api.wordpress.com\\/wpcom\\/v2\\/sites\\/activity002.mystagingwebsite.com\\/activity?number=20&page=31",
+    "current": {
+        "type": "OrderedCollectionPage",
+        "id": "https:\\/\\/public-api.wordpress.com\\/wpcom\\/v2\\/sites\\/activity002.mystagingwebsite.com\\/activity?number=20&page=1",
+        "next": "https:\\/\\/public-api.wordpress.com\\/wpcom\\/v2\\/sites\\/activity002.mystagingwebsite.com\\/activity?number=20&page=2",
+        "totalItems": 20,
+        "orderedItems": [
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 84973892,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Join",
+                         "published": "2017-10-24T15:16:38+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV9O9QdZjEqjFGbxaO_m",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 84973892
+                         }
+                         },
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Join",
+                         "published": "2017-10-11T17:10:02+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV8MajCujEqjFGbxwDy9",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367
+                         }
+                         },
+                         {
+                         "summary": "activity002 published Post scheduled from wp-admin",
+                         "name": "post__published",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:21:35+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": "success",
+                         "activity_id": "AV8Lz_qXjEqjFGbxuPdj",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled from wp-admin",
+                         "object_id": 721,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         },
+                         {
+                         "summary": "activity002 updated Post scheduled from wp-admin",
+                         "name": "post__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:19:24+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": null,
+                         "activity_id": "AV8Lze9njEqjFGbxuN7o",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled from wp-admin",
+                         "object_id": 721,
+                         "object_type": "post",
+                         "object_status": "future"
+                         }
+                         },
+                         {
+                         "summary": "activity002 published Post scheduled post",
+                         "name": "post__published",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:15:10+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": "success",
+                         "activity_id": "AV8Lyh49jEqjFGbxuLF9",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled post",
+                         "object_id": 719,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         },
+                         {
+                         "summary": "activity002 updated Post scheduled post",
+                         "name": "post__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:12:18+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": null,
+                         "activity_id": "AV8Lx3B3jEqjFGbxuI45",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled post",
+                         "object_id": 719,
+                         "object_type": "post",
+                         "object_status": "future"
+                         }
+                         },
+                         {
+                         "summary": "activity002 updated Post scheduled post",
+                         "name": "post__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:11:56+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": null,
+                         "activity_id": "AV8LxxvujEqjFGbxuIpT",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled post",
+                         "object_id": 719,
+                         "object_type": "post",
+                         "object_status": "draft"
+                         }
+                         },
+                         {
+                         "summary": "activity002 added user elibud to site.",
+                         "name": "user__registered",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Announce",
+                         "published": "2017-10-10T15:51:37+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "user",
+                         "status": "success",
+                         "activity_id": "AV8G_AvDjEqjFGbxhaGf",
+                         "object": {
+                         "type": "Person",
+                         "name": "elibud",
+                         "external_user_id": 11,
+                         "wpcom_user_id": 0
+                         }
+                         }
+                         ]
+    }
+}

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-2.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-2.json
@@ -1,0 +1,696 @@
+{
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "summary": "Activity log",
+    "type": "OrderedCollection",
+    "totalItems": 608,
+    "page": 5,
+    "totalPages": 31,
+    "itemsPerPage": 20,
+    "id": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20",
+    "first": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20&page=1",
+    "last": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20&page=31",
+    "current": {
+        "type": "OrderedCollectionPage",
+        "id": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20&page=1",
+        "next": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20&page=2",
+        "totalItems": 20,
+        "orderedItems": [
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 84973892,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Join",
+                         "published": "2017-10-24T15:16:38+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV9O9QdZjEqjFGbxaO_m",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 84973892
+                         }
+                         },
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Join",
+                         "published": "2017-10-11T17:10:02+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV8MajCujEqjFGbxwDy9",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367
+                         }
+                         },
+                         {
+                         "summary": "activity002 published Post scheduled from wp-admin",
+                         "name": "post__published",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:21:35+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": "success",
+                         "activity_id": "AV8Lz_qXjEqjFGbxuPdj",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled from wp-admin",
+                         "object_id": 721,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         },
+                         {
+                         "summary": "activity002 updated Post scheduled from wp-admin",
+                         "name": "post__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:19:24+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": null,
+                         "activity_id": "AV8Lze9njEqjFGbxuN7o",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled from wp-admin",
+                         "object_id": 721,
+                         "object_type": "post",
+                         "object_status": "future"
+                         }
+                         },
+                         {
+                         "summary": "activity002 published Post scheduled post",
+                         "name": "post__published",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:15:10+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": "success",
+                         "activity_id": "AV8Lyh49jEqjFGbxuLF9",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled post",
+                         "object_id": 719,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         },
+                         {
+                         "summary": "activity002 updated Post scheduled post",
+                         "name": "post__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:12:18+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": null,
+                         "activity_id": "AV8Lx3B3jEqjFGbxuI45",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled post",
+                         "object_id": 719,
+                         "object_type": "post",
+                         "object_status": "future"
+                         }
+                         },
+                         {
+                         "summary": "activity002 updated Post scheduled post",
+                         "name": "post__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:11:56+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": null,
+                         "activity_id": "AV8LxxvujEqjFGbxuIpT",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled post",
+                         "object_id": 719,
+                         "object_type": "post",
+                         "object_status": "draft"
+                         }
+                         },
+                         {
+                         "summary": "activity002 added user elibud to site.",
+                         "name": "user__registered",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Announce",
+                         "published": "2017-10-10T15:51:37+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "user",
+                         "status": "success",
+                         "activity_id": "AV8G_AvDjEqjFGbxhaGf",
+                         "object": {
+                         "type": "Person",
+                         "name": "elibud",
+                         "external_user_id": 11,
+                         "wpcom_user_id": 0
+                         }
+                         },
+                         {
+                         "summary": "activity002 removed Elisa from site and reassigned their content to .",
+                         "name": "user__deleted",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Move",
+                         "published": "2017-10-10T15:50:03+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "user",
+                         "status": "error",
+                         "activity_id": "AV8G-qN3jEqjFGbxhY-1",
+                         "object": {
+                         "type": "Tombstone",
+                         "name": "Elisa",
+                         "external_user_id": 10,
+                         "wpcom_user_id": 0,
+                         "formerType": "Person"
+                         },
+                         "target": {
+                         "type": "Person",
+                         "name": null,
+                         "external_user_id": null,
+                         "wpcom_user_id": null
+                         }
+                         },
+                         {
+                         "summary": "activity002 modified user Elisa",
+                         "name": "user__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Update",
+                         "published": "2017-10-10T15:50:03+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "user",
+                         "status": null,
+                         "activity_id": "AV8G-qN3jEqjFGbxhY-0",
+                         "object": {
+                         "type": "Person",
+                         "name": "Elisa",
+                         "external_user_id": 10,
+                         "wpcom_user_id": 0
+                         }
+                         },
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Join",
+                         "published": "2017-10-10T15:50:03+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV8G-qN3jEqjFGbxhY-z",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367
+                         }
+                         },
+                         {
+                         "summary": "activity002 logged out",
+                         "name": "user__logout",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Leave",
+                         "published": "2017-10-10T15:50:03+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV8G-qN3jEqjFGbxhY-y",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367
+                         }
+                         },
+                         {
+                         "summary": "activity002 added user  to site.",
+                         "name": "user__registered",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Announce",
+                         "published": "2017-10-10T15:50:03+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "user",
+                         "status": "success",
+                         "activity_id": "AV8G-qN3jEqjFGbxhY-x",
+                         "object": {
+                         "type": "Person",
+                         "name": null,
+                         "external_user_id": 10,
+                         "wpcom_user_id": 0
+                         }
+                         },
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Join",
+                         "published": "2017-10-10T15:50:03+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV8G-pRtjEqjFGbxhY8C",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367
+                         }
+                         },
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Join",
+                         "published": "2017-10-05T21:55:55+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV7uicvDjEqjFGbxlwGR",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367
+                         }
+                         },
+                         {
+                         "summary": " published post What would you do with\\u2026",
+                         "name": "post__published",
+                         "actor": {
+                         "type": "Person",
+                         "name": "",
+                         "external_user_id": 0,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-09-29T16:19:16+00:00",
+                         "generator": {
+                         "jetpack_version": 5.3,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": "success",
+                         "activity_id": "AV7Ob3apjEqjFGbxaq0F",
+                         "object": {
+                         "type": "Article",
+                         "name": "What would you do with\\u2026",
+                         "object_id": 700,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         },
+                         {
+                         "summary": "Jurewicz72 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "Jurewicz72",
+                         "external_user_id": 8,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/464e6b473313c1794b0442e8c8b16c9a?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "subscriber"
+                         },
+                         "type": "Join",
+                         "published": "2017-09-29T16:19:16+00:00",
+                         "generator": {
+                         "jetpack_version": 5.3,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV7Ob3apjEqjFGbxaq0E",
+                         "object": {
+                         "type": "Person",
+                         "name": "Jurewicz72",
+                         "external_user_id": 8,
+                         "wpcom_user_id": 0
+                         }
+                         },
+                         {
+                         "summary": " published post RT @photomatt: Upload Once, Blog\\u2026",
+                         "name": "post__published",
+                         "actor": {
+                         "type": "Person",
+                         "name": "",
+                         "external_user_id": 0,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-09-26T19:13:38+00:00",
+                         "generator": {
+                         "jetpack_version": 5.3,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": "success",
+                         "activity_id": "AV6_m_yYjEqjFGbx4P68",
+                         "object": {
+                         "type": "Article",
+                         "name": "RT @photomatt: Upload Once, Blog\\u2026",
+                         "object_id": 699,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         },
+                         {
+                         "summary": " updated post RT @Lunarbaboon: New comic about\\u2026",
+                         "name": "post__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "",
+                         "external_user_id": 0,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-09-26T16:19:40+00:00",
+                         "generator": {
+                         "jetpack_version": 5.3,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": null,
+                         "activity_id": "AV6-_K5-jEqjFGbx2r_3",
+                         "object": {
+                         "type": "Article",
+                         "name": "RT @Lunarbaboon: New comic about\\u2026",
+                         "object_id": 696,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         },
+                         {
+                         "summary": " published post RT @Lunarbaboon: New comic about\\u2026",
+                         "name": "post__published",
+                         "actor": {
+                         "type": "Person",
+                         "name": "",
+                         "external_user_id": 0,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-09-26T16:17:40+00:00",
+                         "generator": {
+                         "jetpack_version": 5.3,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": "success",
+                         "activity_id": "AV6--tiRjEqjFGbx2qxl",
+                         "object": {
+                         "type": "Article",
+                         "name": "RT @Lunarbaboon: New comic about\\u2026",
+                         "object_id": 696,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         }
+                         ]
+    }
+}

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-3.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-3.json
@@ -1,0 +1,662 @@
+{
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "summary": "Activity log",
+    "type": "OrderedCollection",
+    "totalItems": 119,
+    "page": 6,
+    "totalPages": 6,
+    "itemsPerPage": 20,
+    "id": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20",
+    "first": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20&page=1",
+    "last": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20&page=31",
+    "current": {
+        "type": "OrderedCollectionPage",
+        "id": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20&page=1",
+        "next": "https://public-api.wordpress.com/wpcom/v2/sites/activity002.mystagingwebsite.com/activity?number=20&page=2",
+        "totalItems": 19,
+        "orderedItems": [
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 84973892,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Join",
+                         "published": "2017-10-24T15:16:38+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV9O9QdZjEqjFGbxaO_m",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 84973892
+                         }
+                         },
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Join",
+                         "published": "2017-10-11T17:10:02+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV8MajCujEqjFGbxwDy9",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367
+                         }
+                         },
+                         {
+                         "summary": "activity002 published Post scheduled from wp-admin",
+                         "name": "post__published",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:21:35+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": "success",
+                         "activity_id": "AV8Lz_qXjEqjFGbxuPdj",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled from wp-admin",
+                         "object_id": 721,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         },
+                         {
+                         "summary": "activity002 updated Post scheduled from wp-admin",
+                         "name": "post__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:19:24+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": null,
+                         "activity_id": "AV8Lze9njEqjFGbxuN7o",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled from wp-admin",
+                         "object_id": 721,
+                         "object_type": "post",
+                         "object_status": "future"
+                         }
+                         },
+                         {
+                         "summary": "activity002 published Post scheduled post",
+                         "name": "post__published",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:15:10+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": "success",
+                         "activity_id": "AV8Lyh49jEqjFGbxuLF9",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled post",
+                         "object_id": 719,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         },
+                         {
+                         "summary": "activity002 updated Post scheduled post",
+                         "name": "post__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:12:18+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": null,
+                         "activity_id": "AV8Lx3B3jEqjFGbxuI45",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled post",
+                         "object_id": 719,
+                         "object_type": "post",
+                         "object_status": "future"
+                         }
+                         },
+                         {
+                         "summary": "activity002 updated Post scheduled post",
+                         "name": "post__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Update",
+                         "published": "2017-10-11T14:11:56+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": null,
+                         "activity_id": "AV8LxxvujEqjFGbxuIpT",
+                         "object": {
+                         "type": "Article",
+                         "name": "scheduled post",
+                         "object_id": 719,
+                         "object_type": "post",
+                         "object_status": "draft"
+                         }
+                         },
+                         {
+                         "summary": "activity002 added user elibud to site.",
+                         "name": "user__registered",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Announce",
+                         "published": "2017-10-10T15:51:37+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "user",
+                         "status": "success",
+                         "activity_id": "AV8G_AvDjEqjFGbxhaGf",
+                         "object": {
+                         "type": "Person",
+                         "name": "elibud",
+                         "external_user_id": 11,
+                         "wpcom_user_id": 0
+                         }
+                         },
+                         {
+                         "summary": "activity002 removed Elisa from site and reassigned their content to .",
+                         "name": "user__deleted",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Move",
+                         "published": "2017-10-10T15:50:03+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "user",
+                         "status": "error",
+                         "activity_id": "AV8G-qN3jEqjFGbxhY-1",
+                         "object": {
+                         "type": "Tombstone",
+                         "name": "Elisa",
+                         "external_user_id": 10,
+                         "wpcom_user_id": 0,
+                         "formerType": "Person"
+                         },
+                         "target": {
+                         "type": "Person",
+                         "name": null,
+                         "external_user_id": null,
+                         "wpcom_user_id": null
+                         }
+                         },
+                         {
+                         "summary": "activity002 modified user Elisa",
+                         "name": "user__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Update",
+                         "published": "2017-10-10T15:50:03+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "user",
+                         "status": null,
+                         "activity_id": "AV8G-qN3jEqjFGbxhY-0",
+                         "object": {
+                         "type": "Person",
+                         "name": "Elisa",
+                         "external_user_id": 10,
+                         "wpcom_user_id": 0
+                         }
+                         },
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Join",
+                         "published": "2017-10-10T15:50:03+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV8G-qN3jEqjFGbxhY-z",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367
+                         }
+                         },
+                         {
+                         "summary": "activity002 logged out",
+                         "name": "user__logout",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Leave",
+                         "published": "2017-10-10T15:50:03+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV8G-qN3jEqjFGbxhY-y",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367
+                         }
+                         },
+                         {
+                         "summary": "activity002 added user  to site.",
+                         "name": "user__registered",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Announce",
+                         "published": "2017-10-10T15:50:03+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "user",
+                         "status": "success",
+                         "activity_id": "AV8G-qN3jEqjFGbxhY-x",
+                         "object": {
+                         "type": "Person",
+                         "name": null,
+                         "external_user_id": 10,
+                         "wpcom_user_id": 0
+                         }
+                         },
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Join",
+                         "published": "2017-10-10T15:50:03+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV8G-pRtjEqjFGbxhY8C",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367
+                         }
+                         },
+                         {
+                         "summary": "activity002 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/a78c747ecc4e8d1936e8d33080ae1803?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "administrator"
+                         },
+                         "type": "Join",
+                         "published": "2017-10-05T21:55:55+00:00",
+                         "generator": {
+                         "jetpack_version": 5.4,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV7uicvDjEqjFGbxlwGR",
+                         "object": {
+                         "type": "Person",
+                         "name": "activity002",
+                         "external_user_id": 1,
+                         "wpcom_user_id": 60261367
+                         }
+                         },
+                         {
+                         "summary": " published post What would you do with\\u2026",
+                         "name": "post__published",
+                         "actor": {
+                         "type": "Person",
+                         "name": "",
+                         "external_user_id": 0,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-09-29T16:19:16+00:00",
+                         "generator": {
+                         "jetpack_version": 5.3,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": "success",
+                         "activity_id": "AV7Ob3apjEqjFGbxaq0F",
+                         "object": {
+                         "type": "Article",
+                         "name": "What would you do with\\u2026",
+                         "object_id": 700,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         },
+                         {
+                         "summary": "Jurewicz72 logged in successfully",
+                         "name": "user__login",
+                         "actor": {
+                         "type": "Person",
+                         "name": "Jurewicz72",
+                         "external_user_id": 8,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/464e6b473313c1794b0442e8c8b16c9a?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": "subscriber"
+                         },
+                         "type": "Join",
+                         "published": "2017-09-29T16:19:16+00:00",
+                         "generator": {
+                         "jetpack_version": 5.3,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "lock",
+                         "status": null,
+                         "activity_id": "AV7Ob3apjEqjFGbxaq0E",
+                         "object": {
+                         "type": "Person",
+                         "name": "Jurewicz72",
+                         "external_user_id": 8,
+                         "wpcom_user_id": 0
+                         }
+                         },
+                         {
+                         "summary": " published post RT @photomatt: Upload Once, Blog\\u2026",
+                         "name": "post__published",
+                         "actor": {
+                         "type": "Person",
+                         "name": "",
+                         "external_user_id": 0,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-09-26T19:13:38+00:00",
+                         "generator": {
+                         "jetpack_version": 5.3,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": "success",
+                         "activity_id": "AV6_m_yYjEqjFGbx4P68",
+                         "object": {
+                         "type": "Article",
+                         "name": "RT @photomatt: Upload Once, Blog\\u2026",
+                         "object_id": 699,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         },
+                         {
+                         "summary": " updated post RT @Lunarbaboon: New comic about\\u2026",
+                         "name": "post__updated",
+                         "actor": {
+                         "type": "Person",
+                         "name": "",
+                         "external_user_id": 0,
+                         "wpcom_user_id": 0,
+                         "icon": {
+                         "type": "Image",
+                         "url": "https:\\/\\/secure.gravatar.com\\/avatar\\/?s=96&d=mm&r=g",
+                         "width": 96,
+                         "height": 96
+                         },
+                         "role": ""
+                         },
+                         "type": "Update",
+                         "published": "2017-09-26T16:19:40+00:00",
+                         "generator": {
+                         "jetpack_version": 5.3,
+                         "blog_id": 135188029
+                         },
+                         "is_rewindable": false,
+                         "gridicon": "posts",
+                         "status": null,
+                         "activity_id": "AV6-_K5-jEqjFGbx2r_3",
+                         "object": {
+                         "type": "Article",
+                         "name": "RT @Lunarbaboon: New comic about\\u2026",
+                         "object_id": 696,
+                         "object_type": "post",
+                         "object_status": "publish"
+                         }
+                         }
+                         ]
+    }
+}


### PR DESCRIPTION
**First step in** #7832
Remote implementation of the activity log feed endpoint.

**To test:**
Execute the tests, see that all is green.
For a site that supports the Activity Log you can add the following code to invoke the remote fetch:
```
let activityServiceRemote = ActivityServiceRemote(wordPressComRestApi: blog.wordPressComRestApi())
  activityServiceRemote?.getActivityForSite((blog.dotComID?.intValue)!, count: 20, success: { (activities, hasMore) in
    print(activities.count, hasMore)
  }, failure: { (error) in
    print("Error \(error)")
})
```
Needs review: @koke 