### PR TITLE
Fix alt field on .org sites.

### DIFF
--- a/WordPressKit/WordPressKit/MediaServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/MediaServiceRemoteXMLRPC.m
@@ -243,7 +243,8 @@
 
     remoteMedia.caption = [xmlRPC stringForKey:@"caption"];
     remoteMedia.descriptionText = [xmlRPC stringForKey:@"description"];
-    remoteMedia.alt = [xmlRPC stringForKey:@"alt"];
+    // Sergio (2017-10-26): This field isn't returned by the XMLRPC API so we assuming empty string
+    remoteMedia.alt = @"";
     remoteMedia.extension = [remoteMedia.file pathExtension];
     remoteMedia.length = [xmlRPC numberForKeyPath:@"metadata.length"];
 


### PR DESCRIPTION
Fixes #8052 

To test:
 - Open a self-hosted site not jetpack
 - Open Media Library
 - tap on a image
 - Check if navigation is working correctly.


