### PR TITLE
Fix tag loading for WordPress.org sites

### DIFF
--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -222,7 +222,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 {
     RemotePostTag *tag = [RemotePostTag new];
     tag.tagID = [xmlrpcDictionary numberForKey:TaxonomyXMLRPCIDParameter];
-    tag.name = [xmlrpcDictionary stringForKey:TaxonomyXMLRPCNumberParameter];
+    tag.name = [xmlrpcDictionary stringForKey:TaxonomyXMLRPCNameParameter];
     tag.slug = [xmlrpcDictionary stringForKey:TaxonomyXMLRPCSlugParameter];
     return tag;
 }


### PR DESCRIPTION
Fixes #8053 

To test:

Make sure tags show up in the tag picker for .org sites

Needs review: @bummytime 