### PR TITLE
Aztec media overlay icon fix

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2905,10 +2905,7 @@ extension AztecPostViewController {
                                            handler: { (action) in
                                             if attachment == self.currentSelectedAttachment {
                                                 self.currentSelectedAttachment = nil
-                                                if attachment is ImageAttachment {
-                                                    attachment.overlayImage = nil
-                                                }
-                                                attachment.message = nil
+                                                self.resetMediaAttachmentOverlay(attachment)
                                                 self.richTextView.refresh(attachment)
                                             }
         })
@@ -2946,10 +2943,7 @@ extension AztecPostViewController {
                                                     //retry upload
                                                     if let media = self.mediaProgressCoordinator.object(forMediaID: mediaID) as? Media,
                                                         let attachment = self.richTextView.attachment(withId: mediaID) {
-                                                        if attachment is ImageAttachment {
-                                                            attachment.overlayImage = nil
-                                                        }
-                                                        attachment.message = nil
+                                                        self.resetMediaAttachmentOverlay(attachment)
                                                         attachment.progress = 0
                                                         self.richTextView.refresh(attachment)
                                                         self.mediaProgressCoordinator.track(numberOfItems: 1)
@@ -3044,6 +3038,13 @@ extension AztecPostViewController {
         updateToolbar(formatBar, forMode: .text)
         restoreInputAssistantItems()
     }
+
+    fileprivate func resetMediaAttachmentOverlay(_ mediaAttachment: MediaAttachment) {
+        if mediaAttachment is ImageAttachment {
+            mediaAttachment.overlayImage = nil
+        }
+        mediaAttachment.message = nil
+    }
 }
 
 
@@ -3074,10 +3075,7 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
         } else {
             // if it's a new attachment tapped let's unmark the previous one
             if let selectedAttachment = currentSelectedAttachment {
-                if selectedAttachment is ImageAttachment {
-                    selectedAttachment.overlayImage = nil
-                }
-                selectedAttachment.message = nil
+                self.resetMediaAttachmentOverlay(selectedAttachment)
                 richTextView.refresh(selectedAttachment)
             }
             // and mark the newly tapped attachment
@@ -3134,10 +3132,7 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
     func deselected(textAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
         currentSelectedAttachment = nil
         if let mediaAttachment = attachment as? MediaAttachment {
-            mediaAttachment.message = nil
-            if mediaAttachment is ImageAttachment {
-                mediaAttachment.overlayImage = nil
-            }
+            self.resetMediaAttachmentOverlay(mediaAttachment)
             richTextView.refresh(mediaAttachment)
         }
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3074,6 +3074,9 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
         } else {
             // if it's a new attachment tapped let's unmark the previous one
             if let selectedAttachment = currentSelectedAttachment {
+                if selectedAttachment is ImageAttachment {
+                    selectedAttachment.overlayImage = nil
+                }
                 selectedAttachment.message = nil
                 richTextView.refresh(selectedAttachment)
             }


### PR DESCRIPTION
Fixes #8068 

This PR adds logic to remove the overlay image on a media attachment when another is selected. In addition, the overlay reset logic was refactored into its own method to make things more DRY.

### To test (on iOS 10 & 11):

* Open a post with multiple media attachments and select an image. Now select another image. Verify the overlay text + image are removed from the previously selected image.

* Open a test post with and select an image. Tap the image again and then select dismiss from the action sheet. Verify the overlay image + text is removed.

* Open a test post, turn off the network connectivity, and attempt to upload media. After it fails, turn the network connectivity back on and then tap the image and select "Retry" on the action sheet. Verify the overlay image + text is removed.

_Note: Merging this fix into 8.7._

Needs review: @SergioEstevao Thank you! 
