### PR TITLE
Issue/7991 Media Item View Controller crash

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -448,7 +448,11 @@ private struct MediaMetadataPresenter {
 
     /// A String containing the uppercased file extension of the asset (.JPG, .PNG, etc)
     var fileType: String? {
-        return (media.filename! as NSString).pathExtension.uppercased()
+        guard let filename = media.filename else {
+            return nil
+        }
+
+        return (filename as NSString).pathExtension.uppercased()
     }
 }
 


### PR DESCRIPTION
Refs #7991.

It looks like our previous fix didn't resolve the issue. It's tricky because the crash report wasn't telling us exactly where the crash was. I found the same crash in Xcode's crashes, loaded it into the project, and it highlighted this line in `MediaMetadataPresenter`. This PR is just a small tweak to remove a force unwrap, which is all I can see potentially crashing there.

To test:

* Ensure you can still view details for media items in the Media section of the app.

Needs review: @elibud 
cc @catehstn 