### PR TITLE
Activity Log v0.001 with no storage

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -29,6 +29,8 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     BlogFeatureCommentLikes,
     /// Can we show stats for the blog?
     BlogFeatureStats,
+    /// Can we show activity for the blog?
+    BlogFeatureActivity,
     /// Does the blog support mentions?
     BlogFeatureMentions,
     /// Does the blog support push notifications?

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -462,7 +462,9 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
         case BlogFeaturePushNotifications:
             return [self supportsPushNotifications];
         case BlogFeatureThemeBrowsing:
-            return [self supportsRestApi] && [self isAdmin];
+        case BlogFeatureActivity:
+            // For now Activity is suported only on Jetpack sites for admin users
+            return [self supportsRestApi] && [self isAdmin] && ![self isHostedAtWPcom];
         case BlogFeatureCustomThemes:
             return [self supportsRestApi] && [self isAdmin] && ![self isHostedAtWPcom];
         case BlogFeaturePremiumThemes:

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -9,6 +9,7 @@ enum FeatureFlag: Int {
     case googleLogin
     case jetpackDisconnect
     case jetpackCommentsOnReader
+    case activity
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -27,6 +28,8 @@ enum FeatureFlag: Int {
             return BuildConfiguration.current == .localDeveloper
         case .jetpackCommentsOnReader:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
+        case .activity:
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListRow.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListRow.swift
@@ -1,0 +1,19 @@
+import Gridicons
+
+struct ActivityListRow: ImmuTableRow {
+    typealias CellType = ActivityTableViewCell
+
+    static let cell: ImmuTableCell = {
+        let nib = UINib(nibName: "ActivityTableViewCell", bundle: Bundle(for: CellType.self))
+        return ImmuTableCell.nib(nib, CellType.self)
+    }()
+
+    let activity: Activity
+    let action: ImmuTableAction?
+
+    func configureCell(_ cell: UITableViewCell) {
+        let cell = cell as! CellType
+        cell.configureCell(activity)
+        cell.selectionStyle = .none
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -1,0 +1,99 @@
+import Foundation
+import CocoaLumberjack
+import WordPressShared
+
+class ActivityListViewController: UITableViewController, ImmuTablePresenter {
+
+    let siteID: Int
+    let service: ActivityServiceRemote
+
+    fileprivate lazy var handler: ImmuTableViewHandler = {
+        return ImmuTableViewHandler(takeOver: self)
+    }()
+
+    fileprivate var viewModel: ActivityListViewModel = .loading {
+        didSet {
+            handler.viewModel = viewModel.tableViewModel()
+            updateNoResults()
+        }
+    }
+
+    // MARK: - GUI
+
+    fileprivate let noResultsView = WPNoResultsView()
+
+    // MARK: - Constructors
+
+    init(siteID: Int, service: ActivityServiceRemote) {
+        self.siteID = siteID
+        self.service = service
+        super.init(style: .grouped)
+        title = NSLocalizedString("Activity", comment: "Title for the activity list")
+        noResultsView.delegate = self
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    convenience init?(blog: Blog) {
+        precondition(blog.dotComID != nil)
+        guard let api = blog.wordPressComRestApi(),
+            let service = ActivityServiceRemote(wordPressComRestApi: api) else {
+                return nil
+        }
+
+        self.init(siteID: Int(blog.dotComID!), service: service)
+    }
+
+    // MARK: - View lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        WPStyleGuide.configureColors(for: view, andTableView: tableView)
+        ImmuTable.registerRows([ActivityListRow.self], tableView: tableView)
+        handler.viewModel = viewModel.tableViewModel()
+        updateNoResults()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        service.getActivityForSite(siteID, count: 100, success: { (activities, _) in
+            self.viewModel = .ready(activities)
+        }, failure: { error in
+            DDLogError("Error loading activities: \(error)")
+            self.viewModel = .error(String(describing: error))
+        })
+    }
+
+    func updateNoResults() {
+        if let noResultsViewModel = viewModel.noResultsViewModel {
+            showNoResults(noResultsViewModel)
+        } else {
+            hideNoResults()
+        }
+    }
+
+    func showNoResults(_ viewModel: WPNoResultsView.Model) {
+        noResultsView.bindViewModel(viewModel)
+        if noResultsView.isDescendant(of: tableView) {
+            noResultsView.centerInSuperview()
+        } else {
+            tableView.addSubview(withFadeAnimation: noResultsView)
+        }
+    }
+
+    func hideNoResults() {
+        noResultsView.removeFromSuperview()
+    }
+}
+
+// MARK: - WPNoResultsViewDelegate
+
+extension ActivityListViewController: WPNoResultsViewDelegate {
+    func didTap(_ noResultsView: WPNoResultsView!) {
+        let supportVC = SupportViewController()
+        supportVC.showFromTabBar()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -1,0 +1,48 @@
+enum ActivityListViewModel {
+    case loading
+    case ready([Activity])
+    case error(String)
+
+    var noResultsViewModel: WPNoResultsView.Model? {
+        switch self {
+        case .loading:
+            return WPNoResultsView.Model(
+                title: NSLocalizedString("Loading Activities...",
+                                         comment: "Text displayed while loading the activity feed for a site")
+            )
+        case .ready:
+            return nil
+        case .error:
+            let appDelegate = WordPressAppDelegate.sharedInstance()
+            if (appDelegate?.connectionAvailable)! {
+                return WPNoResultsView.Model(
+                    title: NSLocalizedString("Oops", comment: ""),
+                    message: NSLocalizedString("There was an error loading activities",
+                                               comment: "Text displayed when there is a failure loading the activity feed"),
+                    buttonTitle: NSLocalizedString("Contact support",
+                                                   comment: "Button label for contacting support")
+                )
+            } else {
+                return WPNoResultsView.Model(
+                    title: NSLocalizedString("No connection", comment: ""),
+                    message: NSLocalizedString("An active internet connection is required to view activities", comment: "")
+                )
+            }
+        }
+    }
+
+    func tableViewModel() -> ImmuTable {
+        switch self {
+        case .loading, .error:
+            return .Empty
+        case .ready(let activities):
+            let rows = activities.map({ activity in
+                return ActivityListRow(activity: activity,
+                                       action: nil)
+            })
+            return ImmuTable(sections: [
+                ImmuTableSection(rows: rows)
+            ])
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -1,0 +1,73 @@
+import Foundation
+import WordPressShared.WPTableViewCell
+
+open class ActivityTableViewCell: WPTableViewCell {
+
+    // MARK: - Overwritten Methods
+
+    open override func awakeFromNib() {
+        super.awakeFromNib()
+        assert(gravatarImageView != nil)
+        assert(summaryLabel != nil)
+        assert(timestampLabel != nil)
+    }
+
+    // MARK: - Public Methods
+
+    open func configureCell(_ activity: Activity) {
+        self.activity = activity
+        timestampLabel?.attributedText = NSAttributedString(string: activity.published.mediumStringWithTime(),
+                                                            attributes: Style.timestampStyle())
+        if activity.name == ActivityName.fullBackup {
+            gravatarImageView.isHidden = true
+            summaryLabel.attributedText = NSAttributedString(string: activity.summary,
+                                                             attributes: Style.summaryBoldStyle())
+
+        } else {
+            gravatarImageView.isHidden = false
+            if let actor = activity.actor,
+                let url = URL(string: actor.avatarURL) {
+                downloadGravatarWithURL(url)
+            } else {
+                gravatarImageView.image = placeholderImage
+            }
+            summaryLabel.attributedText = NSAttributedString(string: activity.summary,
+                                                             attributes: Style.summaryRegularStyle())
+        }
+        if activity.rewindable {
+            backgroundColor = Style.backgroundRewindableColor()
+        } else {
+            backgroundColor = Style.backgroundColor()
+        }
+    }
+
+    // MARK: - Private Methods
+
+    fileprivate func downloadGravatarWithURL(_ url: URL?) {
+        if url == gravatarURL {
+            return
+        }
+
+        let gravatar = url.flatMap { Gravatar($0) }
+        gravatarImageView.downloadGravatar(gravatar, placeholder: placeholderImage, animate: true)
+
+        gravatarURL = url
+    }
+
+    typealias Style = WPStyleGuide.Activity
+
+    // MARK: - Private Properties
+
+    fileprivate var activity: Activity?
+    fileprivate var gravatarURL: URL?
+
+    fileprivate var placeholderImage: UIImage {
+        return Style.gravatarPlaceholderImage()
+    }
+
+    // MARK: - IBOutlets
+
+    @IBOutlet fileprivate var gravatarImageView: CircularImageView!
+    @IBOutlet fileprivate var summaryLabel: UILabel!
+    @IBOutlet fileprivate var timestampLabel: UILabel!
+}

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.xib
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13174"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="Upg-EE-wRd" customClass="ActivityTableViewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="74"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="73.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="dsX-LD-1XZ">
+                        <rect key="frame" x="16" y="11" width="288" height="52"/>
+                        <subviews>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="0Gm-n3-CNm" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="46" height="46"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" priority="999" constant="46" id="h59-o3-ocT"/>
+                                    <constraint firstAttribute="width" constant="46" id="pBo-eH-W4J"/>
+                                </constraints>
+                            </imageView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="TCy-wp-wTe">
+                                <rect key="frame" x="56" y="0.0" width="232" height="39"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Summary" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wrp-Wr-ZBq">
+                                        <rect key="frame" x="0.0" y="-4" width="232" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="dIK-tl-nW4">
+                                        <rect key="frame" x="0.0" y="18.5" width="232" height="20.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Timestamp" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bDl-id-9M7">
+                                                <rect key="frame" x="0.0" y="0.0" width="232" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
+                                    </stackView>
+                                </subviews>
+                                <edgeInsets key="layoutMargins" top="-4" left="0.0" bottom="0.0" right="0.0"/>
+                            </stackView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="dsX-LD-1XZ" secondAttribute="top" id="9dw-Qk-yyT"/>
+                        </constraints>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="dsX-LD-1XZ" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leadingMargin" id="WVn-it-RvF"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="dsX-LD-1XZ" secondAttribute="bottom" id="YbA-Pd-ZGu"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="dsX-LD-1XZ" secondAttribute="trailing" id="mUy-WB-D5x"/>
+                    <constraint firstItem="dsX-LD-1XZ" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="topMargin" id="qkF-E2-4Jc"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="gravatarImageView" destination="0Gm-n3-CNm" id="GXM-xm-h6r"/>
+                <outlet property="summaryLabel" destination="Wrp-Wr-ZBq" id="avY-5i-4By"/>
+                <outlet property="timestampLabel" destination="bDl-id-9M7" id="sk9-hl-b6r"/>
+            </connections>
+            <point key="canvasLocation" x="34" y="56"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="gravatar" width="85" height="85"/>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Activity/WPStyleGuide+Activity.swift
+++ b/WordPress/Classes/ViewRelated/Activity/WPStyleGuide+Activity.swift
@@ -1,0 +1,67 @@
+import Foundation
+import WordPressShared
+
+/// This class groups all of the styles used by all of the ActivityListViewController.
+///
+extension WPStyleGuide {
+    public struct Activity {
+
+        // MARK: - Public Properties
+
+        public static func gravatarPlaceholderImage() -> UIImage {
+            return gravatar
+        }
+
+        public static func summaryRegularStyle() -> [String: AnyObject] {
+            return  [NSParagraphStyleAttributeName: summaryParagraph,
+                     NSFontAttributeName: summaryRegularFont,
+                     NSForegroundColorAttributeName: WPStyleGuide.littleEddieGrey()]
+        }
+
+        public static func summaryBoldStyle() -> [String: AnyObject] {
+            return [NSParagraphStyleAttributeName: summaryParagraph,
+                    NSFontAttributeName: summaryBoldFont,
+                    NSForegroundColorAttributeName: WPStyleGuide.littleEddieGrey()]
+        }
+
+        public static func timestampStyle() -> [String: AnyObject] {
+            return  [NSFontAttributeName: timestampFont,
+                     NSForegroundColorAttributeName: WPStyleGuide.allTAllShadeGrey()]
+        }
+
+        public static func backgroundColor() -> UIColor {
+            return UIColor.white
+        }
+
+        public static func backgroundRewindableColor() -> UIColor {
+            return WPStyleGuide.lightBlue()
+        }
+
+        // MARK: - Private Properties
+
+        fileprivate static let gravatar = UIImage(named: "gravatar")!
+
+        private static var timestampFont: UIFont {
+            return WPStyleGuide.fontForTextStyle(.caption1)
+        }
+
+        private static var summaryRegularFont: UIFont {
+            return WPStyleGuide.fontForTextStyle(.footnote)
+        }
+
+        private static var summaryBoldFont: UIFont {
+            return WPStyleGuide.fontForTextStyle(.footnote, fontWeight: UIFontWeightSemibold)
+        }
+
+        private static var summaryLineSize: CGFloat {
+            return WPStyleGuide.fontSizeForTextStyle(.footnote) * 1.3
+        }
+
+        private static var summaryParagraph: NSMutableParagraphStyle {
+            return NSMutableParagraphStyle(minLineHeight: summaryLineSize,
+                                           maxLineHeight: summaryLineSize,
+                                           lineBreakMode: .byTruncatingTail,
+                                           alignment: .natural)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -398,6 +398,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                      [weakSelf showStats];
                                                  }]];
 
+    if ([Feature enabled:FeatureFlagActivity] && [self.blog supports:BlogFeatureActivity]) {
+        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Activity", @"Noun. Links to a blog's Activity screen.")
+                                                        image:[Gridicon iconOfType:GridiconTypeStatsAlt]
+                                                     callback:^{
+                                                         [weakSelf showActivity];
+                                                     }]];
+    }
+
     if ([self.blog supports:BlogFeaturePlans]) {
         BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Plans", @"Action title. Noun. Links to a blog's Plans screen.")
                                                          identifier:BlogDetailsPlanCellIdentifier
@@ -977,6 +985,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     } else {
         [self showDetailViewController:statsView sender:self];
     }
+}
+
+- (void)showActivity
+{
+    ActivityListViewController *controller = [[ActivityListViewController alloc] initWithBlog:self.blog];
+    [self showDetailViewController:controller sender:self];
 }
 
 - (void)showThemes

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -352,6 +352,12 @@
 		8298F38F1EEF2B15008EB7F0 /* AppFeedbackPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8298F38E1EEF2B15008EB7F0 /* AppFeedbackPromptView.swift */; };
 		8298F3921EEF3BA7008EB7F0 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8298F3911EEF3BA7008EB7F0 /* StoreKit.framework */; };
 		82B85DF91EDDB807004FD510 /* SiteIconPickerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B85DF81EDDB807004FD510 /* SiteIconPickerPresenter.swift */; };
+		82FC61241FA8ADAD00A1757E /* ActivityTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FC611C1FA8ADAC00A1757E /* ActivityTableViewCell.swift */; };
+		82FC61251FA8ADAD00A1757E /* ActivityListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FC611D1FA8ADAC00A1757E /* ActivityListViewController.swift */; };
+		82FC61261FA8ADAD00A1757E /* ActivityTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 82FC611E1FA8ADAC00A1757E /* ActivityTableViewCell.xib */; };
+		82FC61271FA8ADAD00A1757E /* WPStyleGuide+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FC611F1FA8ADAC00A1757E /* WPStyleGuide+Activity.swift */; };
+		82FC612A1FA8B6F000A1757E /* ActivityListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FC61291FA8B6F000A1757E /* ActivityListViewModel.swift */; };
+		82FC612C1FA8B7FC00A1757E /* ActivityListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FC612B1FA8B7FC00A1757E /* ActivityListRow.swift */; };
 		82FFBF4D1F434BDA00F4573F /* ThemeIdHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FFBF4C1F434BDA00F4573F /* ThemeIdHelper.swift */; };
 		83043E55126FA31400EC9953 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83043E54126FA31400EC9953 /* MessageUI.framework */; };
 		83418AAA11C9FA6E00ACF00C /* Comment.m in Sources */ = {isa = PBXBuildFile; fileRef = 83418AA911C9FA6E00ACF00C /* Comment.m */; };
@@ -1538,6 +1544,12 @@
 		8298F3911EEF3BA7008EB7F0 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		82B85DF81EDDB807004FD510 /* SiteIconPickerPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteIconPickerPresenter.swift; sourceTree = "<group>"; };
 		82FA39771EB132090058A2D0 /* WordPress 59.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 59.xcdatamodel"; sourceTree = "<group>"; };
+		82FC611C1FA8ADAC00A1757E /* ActivityTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityTableViewCell.swift; sourceTree = "<group>"; };
+		82FC611D1FA8ADAC00A1757E /* ActivityListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityListViewController.swift; sourceTree = "<group>"; };
+		82FC611E1FA8ADAC00A1757E /* ActivityTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ActivityTableViewCell.xib; sourceTree = "<group>"; };
+		82FC611F1FA8ADAC00A1757E /* WPStyleGuide+Activity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Activity.swift"; sourceTree = "<group>"; };
+		82FC61291FA8B6F000A1757E /* ActivityListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListViewModel.swift; sourceTree = "<group>"; };
+		82FC612B1FA8B7FC00A1757E /* ActivityListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListRow.swift; sourceTree = "<group>"; };
 		82FFBF4C1F434BDA00F4573F /* ThemeIdHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeIdHelper.swift; sourceTree = "<group>"; };
 		82FFBF4E1F45E03D00F4573F /* WordPress 66.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 66.xcdatamodel"; sourceTree = "<group>"; };
 		83043E54126FA31400EC9953 /* MessageUI.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
@@ -3401,6 +3413,19 @@
 			path = Ratings;
 			sourceTree = "<group>";
 		};
+		82FC61181FA8ADAC00A1757E /* Activity */ = {
+			isa = PBXGroup;
+			children = (
+				82FC612B1FA8B7FC00A1757E /* ActivityListRow.swift */,
+				82FC611D1FA8ADAC00A1757E /* ActivityListViewController.swift */,
+				82FC61291FA8B6F000A1757E /* ActivityListViewModel.swift */,
+				82FC611C1FA8ADAC00A1757E /* ActivityTableViewCell.swift */,
+				82FC611E1FA8ADAC00A1757E /* ActivityTableViewCell.xib */,
+				82FC611F1FA8ADAC00A1757E /* WPStyleGuide+Activity.swift */,
+			);
+			path = Activity;
+			sourceTree = "<group>";
+		};
 		8320B5CF11FCA3EA00607422 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
@@ -3491,6 +3516,7 @@
 		8584FDB31923EF4F0019C02E /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				82FC61181FA8ADAC00A1757E /* Activity */,
 				B50C0C441EF429D500372C65 /* Aztec */,
 				AC34397B0E11443300E5D79B /* Blog */,
 				8320B5CF11FCA3EA00607422 /* Cells */,
@@ -5634,6 +5660,7 @@
 				E1D91456134A853D0089019C /* Localizable.strings in Resources */,
 				B5EEB19F1CA96D19004B6540 /* ImageCropViewController.xib in Resources */,
 				5D1D04751B7A50B100CDE646 /* Reader.storyboard in Resources */,
+				82FC61261FA8ADAD00A1757E /* ActivityTableViewCell.xib in Resources */,
 				B5E23BDF19AD0D00000D6879 /* NoteTableViewCell.xib in Resources */,
 				4645AFC51961E1FB005F7509 /* AppImages.xcassets in Resources */,
 				B5C66B761ACF072C00F68370 /* NoteBlockCommentTableViewCell.xib in Resources */,
@@ -6138,6 +6165,7 @@
 				E102B7901E714F24007928E8 /* RecentSitesService.swift in Sources */,
 				E1D7FF381C74EB0E00E7E5E5 /* PlanService.swift in Sources */,
 				5D7DEA2919D488DD0032EE77 /* WPStyleGuide+ReaderComments.swift in Sources */,
+				82FC61251FA8ADAD00A1757E /* ActivityListViewController.swift in Sources */,
 				E1222B671F878E4700D23173 /* WebViewControllerFactory.swift in Sources */,
 				E1D86E691B2B414300DD2192 /* WordPress-32-33.xcmappingmodel in Sources */,
 				5DB3BA0818D11D8D00F3F3E9 /* PublishDatePickerView.m in Sources */,
@@ -6214,6 +6242,7 @@
 				822D60B91F4CCC7A0016C46D /* BlogJetpackSettingsService.swift in Sources */,
 				08216FD51CDBF96000304BA7 /* MenuItemTypeViewController.m in Sources */,
 				B526DC291B1E47FC002A8C5F /* WPStyleGuide+WebView.m in Sources */,
+				82FC61271FA8ADAD00A1757E /* WPStyleGuide+Activity.swift in Sources */,
 				B532D4EC199D4357006E4DF6 /* NoteBlockTextTableViewCell.swift in Sources */,
 				B52F8CD81B43260C00D36025 /* NotificationSettingStreamsViewController.swift in Sources */,
 				E1AB5A071E0BF17500574B4E /* Array.swift in Sources */,
@@ -6277,6 +6306,7 @@
 				E6D3B1431D1C702600008D4B /* ReaderFollowedSitesViewController.swift in Sources */,
 				B5899ADE1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift in Sources */,
 				E6D0EE601F7EF9830064D3FC /* AccountService+SocialService.swift in Sources */,
+				82FC61241FA8ADAD00A1757E /* ActivityTableViewCell.swift in Sources */,
 				FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */,
 				B57B99D519A2C20200506504 /* NoteTableHeaderView.swift in Sources */,
 				1790A4531E28F0ED00AE54C2 /* UINavigationController+Helpers.swift in Sources */,
@@ -6566,6 +6596,7 @@
 				1751E5911CE0E552000CA08D /* KeyValueDatabase.swift in Sources */,
 				937F3E321AD6FDA7006BA498 /* WPAnalyticsTrackerAutomatticTracks.m in Sources */,
 				B55086211CC15CCB004EADB4 /* PromptViewController.swift in Sources */,
+				82FC612C1FA8B7FC00A1757E /* ActivityListRow.swift in Sources */,
 				B5DB8AF21C949DA90059196A /* WPReusableTableViewCells.swift in Sources */,
 				FF0A4FEA1F16C9BD00D6CC69 /* ImageAttachment+WordPress.swift in Sources */,
 				B5B68BD41C19AAED00EB59E0 /* InteractiveNotificationsManager.swift in Sources */,
@@ -6687,6 +6718,7 @@
 				0815CF461E96F22600069916 /* MediaImportService.swift in Sources */,
 				E148362F1C6DF7D8005ACF53 /* Product.swift in Sources */,
 				082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */,
+				82FC612A1FA8B6F000A1757E /* ActivityListViewModel.swift in Sources */,
 				5D119DA3176FBE040073D83A /* UIImageView+AFNetworkingExtra.m in Sources */,
 				E17780801C97FA9500FA7E14 /* StoreKit+Debug.swift in Sources */,
 				5DF59C0B1770AE3A00171208 /* UILabel+SuggestSize.m in Sources */,

--- a/WordPressKit/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit/WordPressKit.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 		74FC6F421F191C1D00112505 /* notifications-load-hash.json in Resources */ = {isa = PBXBuildFile; fileRef = 74FC6F3E1F191C1D00112505 /* notifications-load-hash.json */; };
 		74FC6F431F191C1D00112505 /* notifications-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 74FC6F3F1F191C1D00112505 /* notifications-load-all.json */; };
 		826016F11F9FA13A00533B6C /* ActivityServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826016F01F9FA13A00533B6C /* ActivityServiceRemote.swift */; };
-		826016F31F9FA17B00533B6C /* RemoteActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826016F21F9FA17B00533B6C /* RemoteActivity.swift */; };
+		826016F31F9FA17B00533B6C /* Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826016F21F9FA17B00533B6C /* Activity.swift */; };
 		826016F91F9FAF6300533B6C /* activity-log-success-3.json in Resources */ = {isa = PBXBuildFile; fileRef = 826016F41F9FAF6300533B6C /* activity-log-success-3.json */; };
 		826016FA1F9FAF6300533B6C /* activity-log-success-1.json in Resources */ = {isa = PBXBuildFile; fileRef = 826016F51F9FAF6300533B6C /* activity-log-success-1.json */; };
 		826016FB1F9FAF6300533B6C /* activity-log-auth-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 826016F61F9FAF6300533B6C /* activity-log-auth-failure.json */; };
@@ -564,7 +564,7 @@
 		74FC6F3E1F191C1D00112505 /* notifications-load-hash.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "notifications-load-hash.json"; sourceTree = "<group>"; };
 		74FC6F3F1F191C1D00112505 /* notifications-load-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "notifications-load-all.json"; sourceTree = "<group>"; };
 		826016F01F9FA13A00533B6C /* ActivityServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityServiceRemote.swift; sourceTree = "<group>"; };
-		826016F21F9FA17B00533B6C /* RemoteActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteActivity.swift; sourceTree = "<group>"; };
+		826016F21F9FA17B00533B6C /* Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Activity.swift; sourceTree = "<group>"; };
 		826016F41F9FAF6300533B6C /* activity-log-success-3.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "activity-log-success-3.json"; sourceTree = "<group>"; };
 		826016F51F9FAF6300533B6C /* activity-log-success-1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "activity-log-success-1.json"; sourceTree = "<group>"; };
 		826016F61F9FAF6300533B6C /* activity-log-auth-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "activity-log-auth-failure.json"; sourceTree = "<group>"; };
@@ -1084,7 +1084,7 @@
 				74E229591F1E77290085F7F2 /* KeyringConnection.swift */,
 				74E2295A1F1E77290085F7F2 /* KeyringConnectionExternalUser.swift */,
 				E13EE1441F3323C300C15787 /* PluginState.swift */,
-				826016F21F9FA17B00533B6C /* RemoteActivity.swift */,
+				826016F21F9FA17B00533B6C /* Activity.swift */,
 				93C674E51EE8345300BFAF05 /* RemoteBlog.h */,
 				93C674E61EE8345300BFAF05 /* RemoteBlog.m */,
 				82FFBF511F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift */,
@@ -1846,7 +1846,7 @@
 				7403A2E41EF06ED500DED7DC /* AccountSettingsRemote.swift in Sources */,
 				93C674E81EE8345300BFAF05 /* RemoteBlog.m in Sources */,
 				93BD27831EE73944002BB00B /* WordPressRSDParser.swift in Sources */,
-				826016F31F9FA17B00533B6C /* RemoteActivity.swift in Sources */,
+				826016F31F9FA17B00533B6C /* Activity.swift in Sources */,
 				742362E31F1025B400BD0A7F /* RemoteMenuLocation.m in Sources */,
 				82FFBF561F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift in Sources */,
 				9368C7B81EC630270092CE8E /* StatsStreakItem.m in Sources */,

--- a/WordPressKit/WordPressKit/Activity.swift
+++ b/WordPressKit/WordPressKit/Activity.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct RemoteActivity {
+public struct Activity {
     public let activityID: String
     public let summary: String
     public let name: String
@@ -8,47 +8,51 @@ public struct RemoteActivity {
     public let gridicon: String
     public let status: String
     public let rewindable: Bool
-    public let published: Date?
-    public let actor: RemoteActivityActor?
-    public let object: RemoteActivityObject?
-    public let target: RemoteActivityObject?
-    public let items: [RemoteActivityObject]?
+    public let rewindID: String?
+    public let published: Date
+    public let actor: ActivityActor?
+    public let object: ActivityObject?
+    public let target: ActivityObject?
+    public let items: [ActivityObject]?
 
     init(dictionary: [String: AnyObject]) throws {
         guard let id = dictionary["activity_id"] as? String else {
             throw RemoteActivityError.missingActivityId
         }
+        guard let publishedString = dictionary["published"] as? String else {
+            throw RemoteActivityError.missingPublishedDate
+        }
+        let dateFormatter = ISO8601DateFormatter()
+        guard let publishedDate = dateFormatter.date(from: publishedString) else {
+            throw RemoteActivityError.incorrectPusblishedDateFormat
+        }
         activityID = id
+        published = publishedDate
         summary = dictionary["summary"] as? String ?? ""
         name = dictionary["name"] as? String ?? ""
         type = dictionary["type"] as? String ?? ""
         gridicon = dictionary["gridicon"] as? String ?? ""
         status = dictionary["status"] as? String ?? ""
         rewindable = dictionary["is_rewindable"] as? Bool ?? false
-        let dateFormatter = ISO8601DateFormatter()
-        if let publishedString = dictionary["published"] as? String {
-            published = dateFormatter.date(from: publishedString)
-        } else {
-            published = nil
-        }
+        rewindID = dictionary["rewind_id"] as? String
         if let actorData = dictionary["actor"] as? [String: AnyObject] {
-            actor = RemoteActivityActor.init(dictionary: actorData)
+            actor = ActivityActor.init(dictionary: actorData)
         } else {
             actor = nil
         }
         if let objectData = dictionary["object"] as? [String: AnyObject] {
-            object = RemoteActivityObject.init(dictionary: objectData)
+            object = ActivityObject.init(dictionary: objectData)
         } else {
             object = nil
         }
         if let targetData = dictionary["actor"] as? [String: AnyObject] {
-            target = RemoteActivityObject.init(dictionary: targetData)
+            target = ActivityObject.init(dictionary: targetData)
         } else {
             target = nil
         }
         if let orderedItems = dictionary["items"] as? [[String: AnyObject]] {
-            items = orderedItems.map { item -> RemoteActivityObject in
-                return RemoteActivityObject(dictionary: item)
+            items = orderedItems.map { item -> ActivityObject in
+                return ActivityObject(dictionary: item)
             }
         } else {
             items = nil
@@ -56,7 +60,7 @@ public struct RemoteActivity {
     }
 }
 
-public struct RemoteActivityActor {
+public struct ActivityActor {
     public let displayName: String
     public let type: String
     public let wpcomUserID: String
@@ -76,7 +80,7 @@ public struct RemoteActivityActor {
     }
 }
 
-public struct RemoteActivityObject {
+public struct ActivityObject {
     public let name: String
     public let type: String
     public let attributes: [String: Any]
@@ -96,28 +100,34 @@ public struct RemoteActivityObject {
 
 enum RemoteActivityError: Error {
     case missingActivityId
+    case missingPublishedDate
+    case incorrectPusblishedDateFormat
 }
 
-extension RemoteActivity: CustomDebugStringConvertible {
+public struct ActivityName {
+    public static let fullBackup = "rewind__backup_complete_full"
+}
+
+extension Activity: CustomDebugStringConvertible {
     public var debugDescription: String {
         let dateFormatter = ISO8601DateFormatter()
-        let publishedDate = published != nil ? dateFormatter.string(from: published!) : ""
-        return "<RemoteActivity: (activityID: \(activityID), summary: \(summary), name: \(name), type: \(type) " +
-               "gridicon: \(gridicon), status: \(status), rewindable: \(rewindable), published: \(publishedDate) " +
-               "actor: \(actor.debugDescription), object: \(object.debugDescription), " +
-               "target: \(target.debugDescription), items: \(items != nil ? items.debugDescription : "[]")>";
+        return "<Activity: (activityID: \(activityID), summary: \(summary), name: \(name), type: \(type) " +
+               "gridicon: \(gridicon), status: \(status), rewindable: \(rewindable), " +
+               "published: \(dateFormatter.string(from: published)) actor: \(actor.debugDescription), " +
+               "object: \(object.debugDescription), target: \(target.debugDescription), " +
+               "items: \(items != nil ? items.debugDescription : "[]")>";
     }
 }
 
-extension RemoteActivityActor: CustomDebugStringConvertible {
+extension ActivityActor: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "<RemoteActivityActor(displayName: \(displayName), type: \(type), wpcomUserID: \(wpcomUserID) " +
+        return "<ActivityActor(displayName: \(displayName), type: \(type), wpcomUserID: \(wpcomUserID) " +
                "avatarURL: \(avatarURL), role: \(role)>"
     }
 }
 
-extension RemoteActivityObject: CustomDebugStringConvertible {
+extension ActivityObject: CustomDebugStringConvertible {
     public var debugDescription: String {
-        return "<RemoteActivityObject(name: \(name), type: \(type), attributes: \(attributes.debugDescription)>"
+        return "<ActivityObject(name: \(name), type: \(type), attributes: \(attributes.debugDescription)>"
     }
 }

--- a/WordPressKit/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/WordPressKit/ActivityServiceRemote.swift
@@ -22,7 +22,7 @@ public class ActivityServiceRemote: ServiceRemoteWordPressComREST {
     public func getActivityForSite(_ siteID: Int,
                                    offset: Int = 0,
                                    count: Int,
-                                   success: @escaping (_ activities: [RemoteActivity], _ hasMore: Bool) -> Void,
+                                   success: @escaping (_ activities: [Activity], _ hasMore: Bool) -> Void,
                                    failure: @escaping (Error) -> Void) {
         let endpoint = "sites/\(siteID)/activity"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
@@ -58,7 +58,7 @@ public class ActivityServiceRemote: ServiceRemoteWordPressComREST {
 
 private extension ActivityServiceRemote {
 
-    func mapActivitiesResponse(_ response: AnyObject) throws -> ([RemoteActivity], Int) {
+    func mapActivitiesResponse(_ response: AnyObject) throws -> ([Activity], Int) {
 
         guard let json = response as? [String: AnyObject],
             let totalItems = json["totalItems"] as? Int,
@@ -67,8 +67,8 @@ private extension ActivityServiceRemote {
                 throw ActivityServiceRemote.ResponseError.decodingFailure
         }
 
-        let activities = try orderedItems.map { activity -> RemoteActivity in
-            return try RemoteActivity(dictionary: activity)
+        let activities = try orderedItems.map { activity -> Activity in
+            return try Activity(dictionary: activity)
         }
 
         return (activities, totalItems)

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-1.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-1.json
@@ -70,7 +70,8 @@
                          "jetpack_version": 5.4,
                          "blog_id": 135188029
                          },
-                         "is_rewindable": false,
+                         "is_rewindable": true,
+                         "rewind_id": "35555666",
                          "gridicon": "lock",
                          "status": null,
                          "activity_id": "AV8MajCujEqjFGbxwDy9",


### PR DESCRIPTION
**Another step for** #7832 

This PR provides a simple fetch for a site last 100 activities and displays their summary, actor, timestamp and a varying background color: light blue for rewindable activities, white for non rewindable ones. In the future we will, instead of changing the background, add the Rewind button accordingly.
It is a very crude version 0.001 in anticipation to adding a store according to the new Flux pattern and support for Rewind.

**To test:**
Go to a Jetpack site -> Activity logged in as an admin for the site
Check that what you see matches the web

Needs review: @koke 
