### PR TITLE
Fix XCode 9.1 warnings

### DIFF
--- a/WordPress/Classes/Extensions/NSAttributedString+StyledHTML.swift
+++ b/WordPress/Classes/Extensions/NSAttributedString+StyledHTML.swift
@@ -45,7 +45,7 @@ extension NSAttributedString {
 
         attributedString.addAttribute(NSParagraphStyleAttributeName,
                                    value: paragraphStyle,
-                                   range: NSMakeRange(0, attributedString.string.characters.count - 1))
+                                   range: NSMakeRange(0, attributedString.string.count - 1))
 
         return NSAttributedString(attributedString: attributedString)
     }

--- a/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
+++ b/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
@@ -191,8 +191,8 @@ extension NotificationBlock {
             if range.kind == .Noticon {
                 let noticon         = (range.value ?? String()) + " "
                 theString.replaceCharacters(in: shiftedRange, with: noticon)
-                lengthShift         += noticon.characters.count
-                shiftedRange.length += noticon.characters.count
+                lengthShift         += noticon.count
+                shiftedRange.length += noticon.count
             }
 
             if let rangeStyle = rangeStylesMap?[range.kind] {

--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -15,7 +15,7 @@ extension String {
     ///
     func matches(regex: String, options: NSRegularExpression.Options = []) -> [NSTextCheckingResult] {
         let regex = try! NSRegularExpression(pattern: regex, options: options)
-        let fullRange = NSRange(location: 0, length: characters.count)
+        let fullRange = NSRange(location: 0, length: count)
 
         return regex.matches(in: self, options: [], range: fullRange)
     }
@@ -32,7 +32,7 @@ extension String {
     func replacingMatches(of regex: String, with template: String, options: NSRegularExpression.Options = []) -> String {
 
         let regex = try! NSRegularExpression(pattern: regex, options: options)
-        let fullRange = NSRange(location: 0, length: characters.count)
+        let fullRange = NSRange(location: 0, length: count)
 
         return regex.stringByReplacingMatches(in: self,
                                               options: [],
@@ -52,7 +52,7 @@ extension String {
     func replacingMatches(of regex: String, options: NSRegularExpression.Options = [], using block: (String, [String]) -> String) -> String {
 
         let regex = try! NSRegularExpression(pattern: regex, options: options)
-        let fullRange = NSRange(location: 0, length: characters.count)
+        let fullRange = NSRange(location: 0, length: count)
         let matches = regex.matches(in: self, options: [], range: fullRange)
         var newString = self
 

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -66,7 +66,7 @@ class Post: AbstractPost {
     // MARK: - Content Preview
 
     fileprivate func buildContentPreview() {
-        if let excerpt = mt_excerpt, excerpt.characters.count > 0 {
+        if let excerpt = mt_excerpt, excerpt.count > 0 {
             storedContentPreviewForDisplay = String.makePlainText(excerpt)
         } else if let content = content {
             storedContentPreviewForDisplay = NSString.summary(fromContent: content)
@@ -221,13 +221,13 @@ class Post: AbstractPost {
     }
 
     override func hasTags() -> Bool {
-        return (tags?.trim().characters.count > 0)
+        return (tags?.trim().count > 0)
     }
 
     // MARK: - BasePost
 
     override func contentPreviewForDisplay() -> String {
-        if storedContentPreviewForDisplay.characters.count == 0 {
+        if storedContentPreviewForDisplay.count == 0 {
             buildContentPreview()
         }
 
@@ -290,7 +290,7 @@ class Post: AbstractPost {
         var title = postTitle?.trimmingCharacters(in: CharacterSet.whitespaces) ?? ""
         title = title.stringByDecodingXMLCharacters()
 
-        if title.characters.count == 0 && contentPreviewForDisplay().characters.count == 0 && !hasRemote() {
+        if title.count == 0 && contentPreviewForDisplay().count == 0 && !hasRemote() {
             title = NSLocalizedString("(no title)", comment: "Lets a user know that a local draft does not have a title.")
         }
 

--- a/WordPress/Classes/Models/ThemeIdHelper.swift
+++ b/WordPress/Classes/Models/ThemeIdHelper.swift
@@ -13,7 +13,7 @@ class ThemeIdHelper: NSObject {
         if blog.supports(.customThemes) && themeIdHasWPComSuffix(themeId) {
             // When a WP.com theme is used on a JP site, its themeId is modified to themeId-wpcom,
             // we need to remove this to be able to match it on the theme list
-            return String(themeId.characters.dropLast(WPComThemesIDSuffix.characters.count))
+            return String(themeId.dropLast(WPComThemesIDSuffix.count))
         }
 
         return themeId

--- a/WordPress/Classes/Utility/EmailTypoChecker.swift
+++ b/WordPress/Classes/Utility/EmailTypoChecker.swift
@@ -66,7 +66,7 @@ open class EmailTypoChecker: NSObject {
         }
 
         // If the domain name is too long, don't try suggestion (resource consuming and useless)
-        guard domain.characters.count < lengthOfLongestKnownDomain() + 1 else {
+        guard domain.count < lengthOfLongestKnownDomain() + 1 else {
             return email
         }
 
@@ -88,22 +88,22 @@ private func edits(_ word: String) -> [String] {
     // deletes
     let deleted = deletes(word)
     let transposed = transposes(word)
-    let replaced = alphabet.characters.flatMap({ character in
-        return replaces(character, ys: word.characters)
+    let replaced = alphabet.flatMap({ character in
+        return replaces(character, ys: word)
     })
-    let inserted = alphabet.characters.flatMap({ character in
-        return between(character, ys: word.characters)
+    let inserted = alphabet.flatMap({ character in
+        return between(character, ys: word)
     })
 
     return deleted + transposed + replaced + inserted
 }
 
 private func deletes(_ word: String) -> [String] {
-    return word.characters.indices.map({ word.removing(at: $0) })
+    return word.indices.map({ word.removing(at: $0) })
 }
 
 private func transposes(_ word: String) -> [String] {
-    return word.characters.indices.flatMap({ index in
+    return word.indices.flatMap({ index in
         let (i, j) = (index, word.index(after: index))
         guard j < word.endIndex else {
             return nil
@@ -114,24 +114,24 @@ private func transposes(_ word: String) -> [String] {
     })
 }
 
-private func replaces(_ x: Character, ys: String.CharacterView) -> [String] {
+private func replaces(_ x: Character, ys: String) -> [String] {
     guard let head = ys.first else {
         return [String(x)]
     }
     let tail = ys.dropFirst()
-    return [String(x) + String(tail)] + replaces(x, ys: tail).map({ String(head) + $0 })
+    return [String(x) + String(tail)] + replaces(x, ys: String(tail)).map({ String(head) + $0 })
 }
 
-private func between(_ x: Character, ys: String.CharacterView) -> [String] {
+private func between(_ x: Character, ys: String) -> [String] {
     guard let head = ys.first else {
         return [String(x)]
     }
     let tail = ys.dropFirst()
-    return [String(x) + String(ys)] + between(x, ys: tail).map({ String(head) + $0 })
+    return [String(x) + String(ys)] + between(x, ys: String(tail)).map({ String(head) + $0 })
 }
 
 private let alphabet = "abcdefghijklmnopqrstuvwxyz"
 
 private func lengthOfLongestKnownDomain() -> Int {
-    return knownDomains.map({ $0.characters.count }).max() ?? 0
+    return knownDomains.map({ $0.count }).max() ?? 0
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -15,7 +15,7 @@ class CalypsoProcessorOut: Processor {
     ///
     func process(_ text: String) -> String {
 
-        guard text.characters.count > 0 else {
+        guard text.count > 0 else {
             return ""
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Renderers/CommentAttachmentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Renderers/CommentAttachmentRenderer.swift
@@ -108,7 +108,7 @@ private extension CommentAttachmentRenderer {
 
     func verify(_ text: String, startsWith string: String) -> Bool {
 
-        guard let endIndex = text.index(text.startIndex, offsetBy: string.characters.count, limitedBy: text.endIndex) else {
+        guard let endIndex = text.index(text.startIndex, offsetBy: string.count, limitedBy: text.endIndex) else {
             return false
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1422,7 +1422,7 @@ extension AztecPostViewController: UITextViewDelegate {
     ///
     private func shouldChangeTitleText(in range: NSRange, replacementText text: String) -> Bool {
 
-        guard text.characters.count > 1 else {
+        guard text.count > 1 else {
             guard text.rangeOfCharacter(from: CharacterSet.newlines, options: [], range: nil) == nil else {
                 richTextView.becomeFirstResponder()
                 richTextView.selectedRange = NSRange(location: 0, length: 0)

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -283,7 +283,7 @@ import WordPressShared
             cell.textLabel?.text = self.twitterUsernameTitle
 
             var name = self.blog.settings!.sharingTwitterName
-            if name.characters.count > 0 {
+            if name.count > 0 {
                 name = "@\(name)"
             }
             cell.detailTextLabel?.text = name

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -383,7 +383,7 @@ class MediaLibraryViewController: UIViewController {
     }
 
     private var hasSearchQuery: Bool {
-        return (pickerDataSource.searchQuery ?? "").characters.count > 0
+        return (pickerDataSource.searchQuery ?? "").count > 0
     }
 
     // MARK: - Actions

--- a/WordPress/Classes/ViewRelated/NUX/FancyAlertViewController+LoginError.swift
+++ b/WordPress/Classes/ViewRelated/NUX/FancyAlertViewController+LoginError.swift
@@ -91,7 +91,7 @@ extension FancyAlertViewController {
             message = NSLocalizedString("Incorrect username or password. Please try entering your login details again.", comment: "An error message shown when a user signed in with incorrect credentials.")
         }
 
-        if message.trim().characters.count == 0 {
+        if message.trim().count == 0 {
             message = NSLocalizedString("Log in failed. Please try again.", comment: "A generic error message for a failed log in.")
         }
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -192,7 +192,7 @@ import WordPressShared
     /// - Returns: The base URL or an empty string.
     ///
     class func baseSiteURL(string: String) -> String {
-        guard let siteURL = NSURL(string: NSURL.idnEncodedURL(string)), string.characters.count > 0 else {
+        guard let siteURL = NSURL(string: NSURL.idnEncodedURL(string)), string.count > 0 else {
             return ""
         }
 
@@ -330,7 +330,7 @@ import WordPressShared
     /// - Returns: True if the username is 50 characters or less.
     ///
     class func validateUsernameMaxLength(_ username: String) -> Bool {
-        return username.characters.count <= 50
+        return username.count <= 50
     }
 
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -199,7 +199,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
         // If we have recently trashed posts, create an OR predicate to find posts matching the filter,
         // or posts that were recently deleted.
-        if searchText?.characters.count == 0 && recentlyTrashedPostObjectIDs.count > 0 {
+        if searchText?.count == 0 && recentlyTrashedPostObjectIDs.count > 0 {
 
             let trashedPredicate = NSPredicate(format: "SELF IN %@", recentlyTrashedPostObjectIDs)
 
@@ -208,7 +208,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             predicates.append(filterPredicate)
         }
 
-        if let searchText = searchText, searchText.characters.count > 0 {
+        if let searchText = searchText, searchText.count > 0 {
             let searchPredicate = NSPredicate(format: "postTitle CONTAINS[cd] %@", searchText)
             predicates.append(searchPredicate)
         }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -752,7 +752,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
     // MARK: - Searching
 
     func isSearching() -> Bool {
-        return searchController.isActive && currentSearchTerm()?.characters.count > 0
+        return searchController.isActive && currentSearchTerm()?.count > 0
     }
 
     func currentSearchTerm() -> String? {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -306,7 +306,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
         // If we have recently trashed posts, create an OR predicate to find posts matching the filter,
         // or posts that were recently deleted.
-        if searchText?.characters.count == 0 && recentlyTrashedPostObjectIDs.count > 0 {
+        if searchText?.count == 0 && recentlyTrashedPostObjectIDs.count > 0 {
             let trashedPredicate = NSPredicate(format: "SELF IN %@", recentlyTrashedPostObjectIDs)
 
             predicates.append(NSCompoundPredicate(orPredicateWithSubpredicates: [filterPredicate, trashedPredicate]))
@@ -322,7 +322,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             predicates.append(authorPredicate)
         }
 
-        if let searchText = searchText, searchText.characters.count > 0 {
+        if let searchText = searchText, searchText.count > 0 {
             let searchPredicate = NSPredicate(format: "postTitle CONTAINS[cd] %@", searchText)
             predicates.append(searchPredicate)
         }
@@ -387,7 +387,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
         if recentlyTrashedPostObjectIDs.contains(post.objectID) == true && filterSettings.currentPostListFilter().filterType != .trashed {
             identifier = type(of: self).postCardRestoreCellIdentifier
-        } else if post.pathForDisplayImage?.characters.count > 0 {
+        } else if post.pathForDisplayImage?.count > 0 {
             identifier = type(of: self).postCardImageCellIdentifier
         } else {
             identifier = type(of: self).postCardTextCellIdentifier

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -628,11 +628,11 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     fileprivate func configureTag() {
         var tag = ""
         if let rawTag = post?.primaryTag {
-            if rawTag.characters.count > 0 {
+            if rawTag.count > 0 {
                 tag = "#\(rawTag)"
             }
         }
-        tagButton.isHidden = tag.characters.count == 0
+        tagButton.isHidden = tag.count == 0
         tagButton.setTitle(tag, for: UIControlState())
         tagButton.setTitle(tag, for: .highlighted)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -299,7 +299,7 @@ import WordPressShared
         let controller = SettingsTextViewController(text: nil, placeholder: placeholder, hint: nil)
         controller.title = NSLocalizedString("Add a Tag", comment: "Title of a feature to add a new tag to the tags subscribed by the user.")
         controller.onValueChanged = { value in
-            if value.trim().characters.count > 0 {
+            if value.trim().count > 0 {
                 self.followTagNamed(value.trim())
             }
         }

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
@@ -95,7 +95,7 @@ class WPRichTextFormatter {
 
         let str = attrString.string
         let regex = try! NSRegularExpression(pattern: HRTagProcessor.horizontalRuleIdentifier, options: .caseInsensitive)
-        let matches = regex.matches(in: str, options: NSRegularExpression.MatchingOptions.reportCompletion, range: NSMakeRange(0, str.characters.count))
+        let matches = regex.matches(in: str, options: NSRegularExpression.MatchingOptions.reportCompletion, range: NSMakeRange(0, str.count))
 
         for match: NSTextCheckingResult in matches.reversed() {
             let range = match.range
@@ -140,7 +140,7 @@ class WPRichTextFormatter {
 
         let str = attrString.string
         let regex = try! NSRegularExpression(pattern: type(of: self).blockquoteIdentifier, options: .caseInsensitive)
-        let matches = regex.matches(in: str, options: NSRegularExpression.MatchingOptions.reportCompletion, range: NSMakeRange(0, str.characters.count))
+        let matches = regex.matches(in: str, options: NSRegularExpression.MatchingOptions.reportCompletion, range: NSMakeRange(0, str.count))
 
         for match: NSTextCheckingResult in matches.reversed() {
 
@@ -180,7 +180,7 @@ class WPRichTextFormatter {
     func processAndExtractTags(_ string: String) -> ParsedSource {
         var attachments = [WPTextAttachment]()
 
-        guard string.characters.count > 0 else {
+        guard string.count > 0 else {
             return (string, attachments)
         }
 
@@ -291,7 +291,7 @@ class HtmlTagProcessor {
             parsedString += endTag
 
             // Advance the scanner to account for the closing tag.
-            scanner.scanLocation += endTag.characters.count
+            scanner.scanLocation += endTag.count
         }
 
         return (success, parsedString)
@@ -337,7 +337,7 @@ class BlockquoteTagProcessor: HtmlTagProcessor {
         // the tag.
         if !parsedString.contains("<p>") {
             var str = parsedString as NSString
-            let location = "<\(tagName)>".characters.count
+            let location = "<\(tagName)>".count
             str = str.replacingCharacters(in: NSRange(location: location, length: 0), with: WPRichTextFormatter.blockquoteIdentifier) as NSString
             parsedString = str as String
             return (parsedString, nil)

--- a/WordPress/WordPressScreenshotGeneration/SnapshotHelper.swift
+++ b/WordPress/WordPressScreenshotGeneration/SnapshotHelper.swift
@@ -112,7 +112,7 @@ open class Snapshot: NSObject {
         do {
             let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
             let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
-            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.characters.count))
+            let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.count))
             let results = matches.map { result -> String in
                 (launchArguments as NSString).substring(with: result.range)
             }

--- a/WordPress/WordPressShareExtension/SitePickerViewController.swift
+++ b/WordPress/WordPressShareExtension/SitePickerViewController.swift
@@ -41,7 +41,7 @@ class SitePickerViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let site = sites[indexPath.row]
-        onChange?(site.blogID.intValue, (site.name?.characters.count)! > 0 ? site.name : URL(string: site.url)?.host)
+        onChange?(site.blogID.intValue, (site.name?.count)! > 0 ? site.name : URL(string: site.url)?.host)
         _ = navigationController?.popViewController(animated: true)
     }
 

--- a/WordPress/WordPressShareExtension/String+Extensions.swift
+++ b/WordPress/WordPressShareExtension/String+Extensions.swift
@@ -12,7 +12,7 @@ extension String {
             return self
         }
 
-        let range   = NSMakeRange(0, characters.count)
+        let range   = NSMakeRange(0, count)
         var offset  = 0
 
         detector.enumerateMatches(in: self, options: [], range: range) { (result, flags, stop) in
@@ -25,7 +25,7 @@ extension String {
             let anchoredURL     = "<a href=\"\(rawURL)\">\(rawURL)</a>"
 
             output.replaceCharacters(in: rangeWithOffset, with: anchoredURL)
-            offset += anchoredURL.characters.count - rawURL.characters.count
+            offset += anchoredURL.count - rawURL.count
         }
 
         return output as String

--- a/WordPress/WordPressUITests/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/XCTest+Extensions.swift
@@ -43,7 +43,7 @@ extension XCUIElement {
     func clearAndEnterText(text: String) -> Void {
         let app = XCUIApplication()
 
-        if (self.value as! String).characters.count > 0 {
+        if (self.value as! String).count > 0 {
             self.press(forDuration: 1.2)
             app.menuItems["Select All"].tap()
         } else {

--- a/WordPressKit/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressKit/WordPressComOAuthClient.swift
@@ -94,7 +94,7 @@ public final class WordPressComOAuthClient: NSObject {
             "wpcom_supports_2fa": true as AnyObject
         ]
 
-        if let multifactorCode = multifactorCode, multifactorCode.characters.count > 0 {
+        if let multifactorCode = multifactorCode, multifactorCode.count > 0 {
             parameters["wpcom_otp"] = multifactorCode as AnyObject?
         }
 

--- a/WordPressKit/WordPressKit/WordPressOrgXMLRPCValidator.swift
+++ b/WordPressKit/WordPressKit/WordPressOrgXMLRPCValidator.swift
@@ -243,7 +243,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
 
         let matches = rsdURLRegExp.matches(in: html,
                                                    options: NSRegularExpression.MatchingOptions(),
-                                                   range: NSMakeRange(0, html.characters.count))
+                                                   range: NSMakeRange(0, html.count))
         if matches.count <= 0 {
             return nil
         }

--- a/WordPressShared/WordPressShared/Core/Utility/RichContentFormatter.swift
+++ b/WordPressShared/WordPressShared/Core/Utility/RichContentFormatter.swift
@@ -41,7 +41,7 @@ import Foundation
     /// - Returns: The formatted string.
     ///
     public class func formatContentString(_ string: String, isPrivateSite isPrivate: Bool) -> String {
-        guard string.characters.count > 0 else {
+        guard string.count > 0 else {
             return string
         }
 
@@ -64,24 +64,24 @@ import Foundation
     /// - Returns: The formatted string.
     ///
     public class func removeForbiddenTags(_ string: String) -> String {
-        guard string.characters.count > 0 else {
+        guard string.count > 0 else {
             return string
         }
         var content = string
 
         content = RegEx.styleTags.stringByReplacingMatches(in: content,
                                                                    options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.characters.count),
+                                                                   range: NSRange(location: 0, length: content.count),
                                                                    withTemplate: "")
 
         content = RegEx.scriptTags.stringByReplacingMatches(in: content,
                                                                     options: .reportCompletion,
-                                                                    range: NSRange(location: 0, length: content.characters.count),
+                                                                    range: NSRange(location: 0, length: content.count),
                                                                     withTemplate: "")
 
         content = RegEx.tableTags.stringByReplacingMatches(in: content,
                                                                    options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.characters.count),
+                                                                   range: NSRange(location: 0, length: content.count),
                                                                    withTemplate: "")
 
         return content
@@ -96,7 +96,7 @@ import Foundation
     /// - Returns: The formatted string.
     ///
     public class func normalizeParagraphs(_ string: String) -> String {
-        guard string.characters.count > 0 else {
+        guard string.count > 0 else {
             return string
         }
         var content = string
@@ -106,23 +106,23 @@ import Foundation
          // Convert div tags to p tags
         content = RegEx.divTagsStart.stringByReplacingMatches(in: content,
                                                                    options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.characters.count),
+                                                                   range: NSRange(location: 0, length: content.count),
                                                                    withTemplate: openPTag)
 
         content = RegEx.divTagsEnd.stringByReplacingMatches(in: content,
                                                                     options: .reportCompletion,
-                                                                    range: NSRange(location: 0, length: content.characters.count),
+                                                                    range: NSRange(location: 0, length: content.count),
                                                                     withTemplate: closePTag)
 
         // Remove duplicate/redundant p tags.
         content = RegEx.pTagsStart.stringByReplacingMatches(in: content,
                                                                    options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.characters.count),
+                                                                   range: NSRange(location: 0, length: content.count),
                                                                    withTemplate: openPTag)
 
         content = RegEx.pTagsEnd.stringByReplacingMatches(in: content,
                                                                    options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.characters.count),
+                                                                   range: NSRange(location: 0, length: content.count),
                                                                    withTemplate: closePTag)
 
         content = filterNewLines(content)
@@ -137,11 +137,11 @@ import Foundation
         var ranges = [NSRange]()
         // We don't want to remove new lines from preformatted tag blocks,
         // so get the ranges of such blocks.
-        let matches = RegEx.preTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.characters.count))
+        let matches = RegEx.preTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.count))
         if matches.count == 0 {
 
             // No blocks found, so we'll parse the whole string.
-            ranges.append(NSRange(location: 0, length: content.characters.count))
+            ranges.append(NSRange(location: 0, length: content.count))
 
         } else {
 
@@ -157,7 +157,7 @@ import Foundation
                 location = match.range.location + match.range.length
             }
 
-            length = content.characters.count - location
+            length = content.count - location
             ranges.append(NSRange(location: location, length: length))
         }
 
@@ -182,14 +182,14 @@ import Foundation
     /// - Returns: The formatted string.
     ///
     public class func removeInlineStyles(_ string: String) -> String {
-        guard string.characters.count > 0 else {
+        guard string.count > 0 else {
             return string
         }
         var content = string
 
         content = RegEx.styleAttr.stringByReplacingMatches(in: content,
                                                                    options: .reportCompletion,
-                                                                   range: NSRange(location: 0, length: content.characters.count),
+                                                                   range: NSRange(location: 0, length: content.count),
                                                                    withTemplate: "")
 
         return content
@@ -205,7 +205,7 @@ import Foundation
     /// - Returns: The formatted string.
     ///
     public class func resizeGalleryImageURL(_ string: String, isPrivateSite isPrivate: Bool) -> String {
-        guard string.characters.count > 0 else {
+        guard string.count > 0 else {
             return string
         }
 
@@ -241,7 +241,7 @@ import Foundation
             mImageStr.replaceOccurrences(of: srcImgURLStr,
                                          with: modifiedURL.absoluteString,
                                          options: .literal,
-                                         range: NSRange(location: 0, length: imgElementStr.characters.count))
+                                         range: NSRange(location: 0, length: imgElementStr.count))
 
             mContent.replaceCharacters(in: match.range, with: mImageStr as String)
         }
@@ -283,13 +283,13 @@ import Foundation
     /// - Returns: The formatted string.
     ///
     public class func removeTrailingBreakTags(_ string: String) -> String {
-        guard string.characters.count > 0 else {
+        guard string.count > 0 else {
             return string
         }
         var content = string.trim()
-        let matches = RegEx.trailingBRTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.characters.count))
+        let matches = RegEx.trailingBRTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.count))
         if let match = matches.first {
-            let index = content.characters.index(content.startIndex, offsetBy: match.range.location)
+            let index = content.index(content.startIndex, offsetBy: match.range.location)
             content = content.substring(to: index)
         }
 

--- a/WordPressShared/WordPressSharedTests/LanguagesTests.swift
+++ b/WordPressShared/WordPressSharedTests/LanguagesTests.swift
@@ -16,8 +16,8 @@ class LanguagesTests: XCTestCase {
         let sum = languages.all + languages.popular
 
         for language in sum {
-            XCTAssert(language.slug.characters.count > 0)
-            XCTAssert(language.name.characters.count > 0)
+            XCTAssert(language.slug.count > 0)
+            XCTAssert(language.name.count > 0)
         }
     }
 


### PR DESCRIPTION
**Fixes** #8084 

**To test:**
- Clean + Build, check that we only have our usual 3 warnings (Update to Swift 4, Pods project settings, incompatible Objective-C category)
- Check that `EmailTypoChecker.swift` is working as expected (correcting emails for known domains on signups)
- Check that the rest of the app works fine

Needs review: @frosty 