### PR TITLE
Notifications: Links in Comments are now actionable

### DIFF
--- a/WordPress/Classes/Models/Notifications/NotificationRange.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationRange.swift
@@ -41,17 +41,34 @@ class NotificationRange {
     /// Designated Initializer
     ///
     init?(dictionary: [String: AnyObject]) {
-        guard let type = dictionary[RangeKeys.RawType] as? String, let indices = dictionary[RangeKeys.Indices] as? [Int],
-            let start = indices.first, let end = indices.last else {
+        guard let indices = dictionary[RangeKeys.Indices] as? [Int],
+            let start = indices.first,
+            let end = indices.last
+        else {
             return nil
         }
 
-        kind = Kind(rawValue: type) ?? .Site
         range = NSMakeRange(start, end - start)
         siteID = dictionary[RangeKeys.SiteId] as? NSNumber
 
         if let rawURL = dictionary[RangeKeys.URL] as? String {
             url = URL(string: rawURL)
+        }
+
+        // The Duck is STILL ALIVE:
+        // ========================
+        // I truly hope the reviewer, and the Opensource Community can forgive this ongoing hack.
+        // Notifications can now carry URL's without specifying an explicit 'Type'. For that reason,
+        // surprise!... we're now also inferring the Notification Type.
+        //
+        if let type = dictionary[RangeKeys.RawType] as? String, let theKind = Kind(rawValue: type) {
+            kind = theKind
+        } else if siteID != nil {
+            kind = .Site
+        } else if url != nil {
+            kind = .Link
+        } else {
+            return nil
         }
 
         //  SORRY: << Let me stress this. Sorry, i'm 1000% against Duck Typing.

--- a/WordPress/Classes/Models/Notifications/NotificationRange.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationRange.swift
@@ -41,34 +41,20 @@ class NotificationRange {
     /// Designated Initializer
     ///
     init?(dictionary: [String: AnyObject]) {
-        guard let indices = dictionary[RangeKeys.Indices] as? [Int],
+        guard let theKind = NotificationRange.kind(for: dictionary),
+            let indices = dictionary[RangeKeys.Indices] as? [Int],
             let start = indices.first,
             let end = indices.last
         else {
             return nil
         }
 
+        kind = theKind
         range = NSMakeRange(start, end - start)
         siteID = dictionary[RangeKeys.SiteId] as? NSNumber
 
         if let rawURL = dictionary[RangeKeys.URL] as? String {
             url = URL(string: rawURL)
-        }
-
-        // The Duck is STILL ALIVE:
-        // ========================
-        // I truly hope the reviewer, and the Opensource Community can forgive this ongoing hack.
-        // Notifications can now carry URL's without specifying an explicit 'Type'. For that reason,
-        // surprise!... we're now also inferring the Notification Type.
-        //
-        if let type = dictionary[RangeKeys.RawType] as? String, let theKind = Kind(rawValue: type) {
-            kind = theKind
-        } else if siteID != nil {
-            kind = .Site
-        } else if url != nil {
-            kind = .Link
-        } else {
-            return nil
         }
 
         //  SORRY: << Let me stress this. Sorry, i'm 1000% against Duck Typing.
@@ -95,6 +81,30 @@ class NotificationRange {
         default:
             break
         }
+    }
+
+
+    /// Returns the NotificationRange Kind, for a given raw Notification Range.
+    ///
+    /// - Details:
+    ///     I truly hope the reviewer, and the Opensource Community can forgive this ongoing hack.
+    ///     Notifications can now carry URL's without specifying an explicit 'Type'. For that reason,
+    ///     surprise!... we're now also inferring the Notification Type.
+    ///
+    private static func kind(for dictionary: [String: AnyObject]) -> Kind? {
+        if let type = dictionary[RangeKeys.RawType] as? String, let kind = Kind(rawValue: type) {
+            return kind
+        }
+
+        if dictionary[RangeKeys.SiteId] != nil {
+            return .Site
+        }
+
+        if dictionary[RangeKeys.URL] != nil {
+            return .Link
+        }
+
+        return nil
     }
 }
 

--- a/WordPress/Classes/Models/Notifications/NotificationRange.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationRange.swift
@@ -93,9 +93,8 @@ class NotificationRange {
     ///
     private static func kind(for dictionary: [String: AnyObject]) -> Kind? {
         if let type = dictionary[RangeKeys.RawType] as? String,
-            let kind = Kind(rawValue: type)
-        {
-            return kind
+            let kind = Kind(rawValue: type) {
+                return kind
         }
 
         if let _ = dictionary[RangeKeys.SiteId] {

--- a/WordPress/Classes/Models/Notifications/NotificationRange.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationRange.swift
@@ -112,6 +112,7 @@ extension NotificationRange {
         case Noticon            = "noticon"
         case Site               = "site"
         case Match              = "match"
+        case Link = "link"
     }
 
     /// Parsing Keys

--- a/WordPress/Classes/Models/Notifications/NotificationRange.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationRange.swift
@@ -92,15 +92,17 @@ class NotificationRange {
     ///     surprise!... we're now also inferring the Notification Type.
     ///
     private static func kind(for dictionary: [String: AnyObject]) -> Kind? {
-        if let type = dictionary[RangeKeys.RawType] as? String, let kind = Kind(rawValue: type) {
+        if let type = dictionary[RangeKeys.RawType] as? String,
+            let kind = Kind(rawValue: type)
+        {
             return kind
         }
 
-        if dictionary[RangeKeys.SiteId] != nil {
+        if let _ = dictionary[RangeKeys.SiteId] {
             return .Site
         }
 
-        if dictionary[RangeKeys.URL] != nil {
+        if let _ = dictionary[RangeKeys.URL] {
             return .Link
         }
 

--- a/WordPress/Classes/Models/Notifications/NotificationRange.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationRange.swift
@@ -103,27 +103,27 @@ extension NotificationRange {
     /// Known kinds of Range
     ///
     enum Kind: String {
-        case User               = "user"
-        case Post               = "post"
-        case Comment            = "comment"
-        case Stats              = "stat"
-        case Follow             = "follow"
-        case Blockquote         = "blockquote"
-        case Noticon            = "noticon"
-        case Site               = "site"
-        case Match              = "match"
+        case User = "user"
+        case Post = "post"
+        case Comment = "comment"
+        case Stats = "stat"
+        case Follow = "follow"
+        case Blockquote = "blockquote"
+        case Noticon = "noticon"
+        case Site = "site"
+        case Match = "match"
         case Link = "link"
     }
 
     /// Parsing Keys
     ///
     fileprivate enum RangeKeys {
-        static let RawType      = "type"
-        static let URL          = "url"
-        static let Indices      = "indices"
-        static let Id           = "id"
-        static let Value        = "value"
-        static let SiteId       = "site_id"
-        static let PostId       = "post_id"
+        static let RawType = "type"
+        static let URL = "url"
+        static let Indices = "indices"
+        static let Id = "id"
+        static let Value = "value"
+        static let SiteId = "site_id"
+        static let PostId = "post_id"
     }
 }


### PR DESCRIPTION
### Details:
This PR patches the NotificationRange entity, so that whenever a plain link is present within a comment's body, it can be actioned upon.

Fixes #6056

### To test:
1. Receive a Comment Notification with a link in it's body
2. Open the Notifications tab and expand it's details
3. Press over the link

As a result, a WebView should be onscreen.

Needs review: @aerych 
Sir, may i bug you with a small fix?

cc @dmsnell because you've asked about the incoming comment-warning!!

