### PR TITLE
Login: Fix enter key causing validation problems in 2fa VC

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -196,6 +196,11 @@ class Login2FAViewController: LoginViewController, SigninKeyboardResponder, UITe
         return false
     }
 
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        validateForm()
+        return false
+    }
+
 
     // MARK: - Actions
 


### PR DESCRIPTION
Fixes #8087

To test:
 - begin login with an account that requires 2FA in simulator
 - when entering 2FA code type it in, then hit enter on laptop
 - no validation error should appear

Needs review: @aerych 
