### PR TITLE
Add basic MediaUploadCoordinator

### DIFF
--- a/WordPress/Classes/Services/MediaUploadCoordinator.swift
+++ b/WordPress/Classes/Services/MediaUploadCoordinator.swift
@@ -113,7 +113,8 @@ class MediaUploadCoordinator {
     /// including any 'wildcard' observers that are observing _all_ media items.
     ///
     private func observersForMedia(_ media: Media) -> [MediaObserver] {
-        return mediaObservers.values.filter({ $0.media?.mediaID == media.mediaID }) + wildcardObservers
+        let values = mediaObservers.values.filter({ $0.media?.mediaID == media.mediaID })
+        return values + wildcardObservers
     }
 
     /// Utility method to return all 'wildcard' observers that are

--- a/WordPress/Classes/Services/MediaUploadCoordinator.swift
+++ b/WordPress/Classes/Services/MediaUploadCoordinator.swift
@@ -9,6 +9,9 @@ class MediaUploadCoordinator {
 
     private let queue = DispatchQueue(label: "org.wordpress.mediauploadcoordinator")
 
+    // Init marked private to ensure use of shared singleton.
+    private init() {}
+
     // MARK: - Adding Media
 
     /// Adds the specified media asset to the specified blog. The upload process
@@ -54,7 +57,8 @@ class MediaUploadCoordinator {
     /// Add an observer to receive updates when media items are updated.
     ///
     /// - parameter onUpdate: A block that will be called whenever media items
-    ///                       (or a specific media item) are updated.
+    ///                       (or a specific media item) are updated. The update
+    ///                       block will always be called on the main queue.
     /// - parameter media: An optional specific media item to receive updates for.
     ///                    If provided, the `onUpdate` block will only be called
     ///                    for updates to this media item, otherwise it will be

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -146,6 +146,7 @@
 		177CBE501DA3A3AC009F951E /* CollectionType+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177CBE4F1DA3A3AC009F951E /* CollectionType+Helpers.swift */; };
 		177E7DAD1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */; };
 		1782BE841E70063100A91E7D /* MediaItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1782BE831E70063100A91E7D /* MediaItemViewController.swift */; };
+		17876B1D1F9A131200F774C7 /* MediaUploadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17876B1C1F9A131200F774C7 /* MediaUploadCoordinator.swift */; };
 		178EDE701C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178EDE6F1C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift */; };
 		1790A4531E28F0ED00AE54C2 /* UINavigationController+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1790A4521E28F0ED00AE54C2 /* UINavigationController+Helpers.swift */; };
 		17AD36D51D36C1A60044B10D /* WPStyleGuide+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */; };
@@ -1220,6 +1221,7 @@
 		177CBE4F1DA3A3AC009F951E /* CollectionType+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CollectionType+Helpers.swift"; sourceTree = "<group>"; };
 		177E7DAC1DD0D1E600890467 /* UINavigationController+SplitViewFullscreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+SplitViewFullscreen.swift"; sourceTree = "<group>"; };
 		1782BE831E70063100A91E7D /* MediaItemViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaItemViewController.swift; sourceTree = "<group>"; };
+		17876B1C1F9A131200F774C7 /* MediaUploadCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaUploadCoordinator.swift; sourceTree = "<group>"; };
 		178EDE6F1C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = PlanPostPurchaseViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		1790A4521E28F0ED00AE54C2 /* UINavigationController+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Helpers.swift"; sourceTree = "<group>"; };
 		17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Search.swift"; sourceTree = "<group>"; };
@@ -3806,6 +3808,7 @@
 				93DEB88019E5BF7100F9546D /* TodayExtensionService.h */,
 				93DEB88119E5BF7100F9546D /* TodayExtensionService.m */,
 				E6311C401EC9FF4A00122529 /* UsersService.swift */,
+				17876B1C1F9A131200F774C7 /* MediaUploadCoordinator.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -6443,6 +6446,7 @@
 				0857C2791CE5375F0014AE99 /* MenuItemsVisualOrderingView.m in Sources */,
 				437542E31DD4E19E00D6B727 /* EditPostViewController.swift in Sources */,
 				595CB3761D2317D50082C7E9 /* PostListFilter.swift in Sources */,
+				17876B1D1F9A131200F774C7 /* MediaUploadCoordinator.swift in Sources */,
 				08E77F451EE87FCF006F9515 /* MediaThumbnailExporter.swift in Sources */,
 				E240859C183D82AE002EB0EF /* WPAnimatedBox.m in Sources */,
 				08472A201C727E020040769D /* PostServiceOptions.m in Sources */,


### PR DESCRIPTION
Fixes #7597 

This PR adds a skeleton implementation of a MediaUploadCoordinator. It supports creating and uploading media via a single method, and observing begin / end events for a single Media object or for all Media objects. We'll build on top of this as we go, adding additional functionality and tweaking the implementation.

To test:

* You can check out a branch that makes use of this in the Media Library: `feature/upload-coordinator-in-media-library`. You should be able to use it to add media to the media library, and see a message logged out when the media item is created and finishes uploading.

Needs review: @SergioEstevao 