### PR TITLE
Async: Allow manual testing of UploadCoordinator in Media Library

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -9,6 +9,7 @@ enum FeatureFlag: Int {
     case googleLogin
     case jetpackDisconnect
     case jetpackCommentsOnReader
+    case asyncUploadsInMediaLibrary
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -27,6 +28,8 @@ enum FeatureFlag: Int {
             return BuildConfiguration.current == .localDeveloper
         case .jetpackCommentsOnReader:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
+        case .asyncUploadsInMediaLibrary:
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 }


### PR DESCRIPTION
Fixes #8095.

This PR adds a feature flagged, local development only option to the Media Library when adding media, which uses the new in-development UploadCoordinator to perform uploads.

![simulator screen shot - iphone 8 - 2017-11-03 at 11 57 02](https://user-images.githubusercontent.com/4780/32380662-843b215e-c0a8-11e7-8857-ce20748bee46.png)

At the time of creating this PR, there's no UI indicating uploads in progress, but they do log out to the console.

To test:

* Build and run, and attempt to use the new upload option in the Media library. Check that the feature flag is for local development only.

Needs review: @SergioEstevao 