### PR TITLE
Increase timeout for domain tests.

### DIFF
--- a/WordPress/WordPressTest/DomainsServiceTests.swift
+++ b/WordPress/WordPressTest/DomainsServiceTests.swift
@@ -73,7 +73,7 @@ class DomainsServiceTests: XCTestCase {
             expect.fulfill()
         })
 
-        waitForExpectations(timeout: 0.2, handler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
     }
 
     func testDomainServiceHandlesTwoNewDomains() {


### PR DESCRIPTION
We found some issues with automated tests that were failing in BuddyBuild due to timeouts.

This PR increases the timeout to avoid these random failures.

**To test:**

1. Run the unit tests and make sure the domain tests are not failing.
2. Make sure BuddyBuild's build also succeeds.
