### PR TITLE
Avoid media duplicates on Media Library

### DIFF
--- a/WordPress/Classes/Services/MediaSyncCoordinator.swift
+++ b/WordPress/Classes/Services/MediaSyncCoordinator.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// MediaSyncCoordinator is responsible for syncing media
+/// items from the server, independently of a specific view controller. It should be accessed
+/// via the `shared` singleton.
+///
+public class MediaSyncCoordinator: NSObject {
+
+    static let shared = MediaSyncCoordinator()
+    private let context = ContextManager.sharedInstance().newDerivedContext()
+
+    // Init marked private to ensure use of shared singleton.
+    private override init() {}
+
+    /// Sync the specified blog media library.
+    ///
+    /// - parameter blog: The blog from where to sync the media library from.
+    ///
+    func syncMedia(of blog: Blog, success: (() -> ())?, failure: ((Error) -> ())? ) {
+        let service = MediaService(managedObjectContext: context)
+        service.syncMediaLibrary(for: blog, success: success, failure: failure)
+    }
+}

--- a/WordPress/Classes/Services/MediaSyncCoordinator.swift
+++ b/WordPress/Classes/Services/MediaSyncCoordinator.swift
@@ -16,7 +16,7 @@ public class MediaSyncCoordinator: NSObject {
     ///
     /// - parameter blog: The blog from where to sync the media library from.
     ///
-    func syncMedia(of blog: Blog, success: (() -> ())?, failure: ((Error) -> ())? ) {
+    func syncMedia(for blog: Blog, success: (() -> Void)? = nil, failure: ((Error) ->Void)? = nil) {
         let service = MediaService(managedObjectContext: context)
         service.syncMediaLibrary(for: blog, success: success, failure: failure)
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -134,9 +134,8 @@
         }
     }
     // try to sync from the server
-    NSManagedObjectContext *backgroundContext = [[ContextManager sharedInstance] newDerivedContext];
-    MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:backgroundContext];
-    [mediaService syncMediaLibraryForBlog:self.blog success:^{
+    MediaSyncCoordinator *mediaSyncCoordinator = [MediaSyncCoordinator shared];
+    [mediaSyncCoordinator syncMediaOf:self.blog success:^{
         if (!localResultsAvailable && successBlock) {
             successBlock();
         }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -135,7 +135,7 @@
     }
     // try to sync from the server
     MediaSyncCoordinator *mediaSyncCoordinator = [MediaSyncCoordinator shared];
-    [mediaSyncCoordinator syncMediaOf:self.blog success:^{
+    [mediaSyncCoordinator syncMediaFor:self.blog success:^{
         if (!localResultsAvailable && successBlock) {
             successBlock();
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -965,6 +965,7 @@
 		FF0A4FEA1F16C9BD00D6CC69 /* ImageAttachment+WordPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0A4FE91F16C9BD00D6CC69 /* ImageAttachment+WordPress.swift */; };
 		FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF0AAE091A150A560089841D /* WPProgressTableViewCell.m */; };
 		FF0AAE0D1A16550D0089841D /* WPMediaProgressTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FF0AAE0C1A16550D0089841D /* WPMediaProgressTableViewController.m */; };
+		FF161DA11FB1C6C20050373F /* MediaSyncCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF161DA01FB1C6C20050373F /* MediaSyncCoordinator.swift */; };
 		FF1933FF1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1933FE1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m */; };
 		FF2716921CAAC87B0006E2D4 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2716911CAAC87B0006E2D4 /* LoginTests.swift */; };
 		FF27169F1CAAF5060006E2D4 /* WordPressTestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF27169E1CAAF5060006E2D4 /* WordPressTestCredentials.swift */; };
@@ -2420,6 +2421,7 @@
 		FF0AAE091A150A560089841D /* WPProgressTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPProgressTableViewCell.m; sourceTree = "<group>"; };
 		FF0AAE0B1A16550D0089841D /* WPMediaProgressTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPMediaProgressTableViewController.h; sourceTree = "<group>"; };
 		FF0AAE0C1A16550D0089841D /* WPMediaProgressTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPMediaProgressTableViewController.m; sourceTree = "<group>"; };
+		FF161DA01FB1C6C20050373F /* MediaSyncCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaSyncCoordinator.swift; sourceTree = "<group>"; };
 		FF1933FD1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RelatedPostsPreviewTableViewCell.h; sourceTree = "<group>"; };
 		FF1933FE1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RelatedPostsPreviewTableViewCell.m; sourceTree = "<group>"; };
 		FF27168F1CAAC87A0006E2D4 /* WordPressUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WordPressUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3836,6 +3838,7 @@
 				93DEB88119E5BF7100F9546D /* TodayExtensionService.m */,
 				E6311C401EC9FF4A00122529 /* UsersService.swift */,
 				17876B1C1F9A131200F774C7 /* MediaUploadCoordinator.swift */,
+				FF161DA01FB1C6C20050373F /* MediaSyncCoordinator.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -6661,6 +6664,7 @@
 				5D42A405175E76A7005CFF05 /* WPImageViewController.m in Sources */,
 				E61084C01B9B47BA008050C5 /* ReaderListTopic.swift in Sources */,
 				E6374DC11C444D8B00F24720 /* PublicizeService.swift in Sources */,
+				FF161DA11FB1C6C20050373F /* MediaSyncCoordinator.swift in Sources */,
 				931D26FE19EDA10D00114F17 /* ALIterativeMigrator.m in Sources */,
 				E1F8E1231B0B411E0073E628 /* JetpackService.m in Sources */,
 				436605E21ECE568800EE8882 /* LoginNavigationController.swift in Sources */,


### PR DESCRIPTION
Fixes #8018 

To test:
 - Open a blog that has a large media library (Meetomatic is a good example)
 - Go to the media library
 - Close
 - Open the site icon media picker
 - Close
 - Create a new post, tap to add media and select the media library
 - It should take a while to sync but no duplicates should show in the media library while the updates are going.


