### PR TITLE
Re-enable themes on WordPress.com sites

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -462,6 +462,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
         case BlogFeaturePushNotifications:
             return [self supportsPushNotifications];
         case BlogFeatureThemeBrowsing:
+            return [self supportsRestApi] && [self isAdmin];
         case BlogFeatureActivity:
             // For now Activity is suported only on Jetpack sites for admin users
             return [self supportsRestApi] && [self isAdmin] && ![self isHostedAtWPcom];


### PR DESCRIPTION
Fixes #8114 

To test:

- Make sure the Themes section is visible for both WordPress.com and Jetpack sites

Needs review: @diegoreymendez 