### PR TITLE
Fix authenticated WordPress.com previews

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
@@ -9,9 +9,11 @@ protocol PostPreviewGeneratorDelegate {
 class PostPreviewGenerator: NSObject {
     let post: AbstractPost
     weak var delegate: PostPreviewGeneratorDelegate?
+    fileprivate let authenticator: WebViewAuthenticator?
 
     init(post: AbstractPost) {
         self.post = post
+        authenticator = WebViewAuthenticator(blog: post.blog)
         super.init()
     }
 
@@ -40,6 +42,10 @@ class PostPreviewGenerator: NSObject {
                 " " +
                 NSLocalizedString("A simple preview is shown below.", comment: "")
         )
+    }
+
+    func interceptRedirect(request: URLRequest) -> URLRequest? {
+        return authenticator?.interceptRedirect(request: request)
     }
 }
 
@@ -104,7 +110,7 @@ private extension PostPreviewGenerator {
     }
 
     func attemptCookieAuthenticatedRequest(url: URL) {
-        guard let authenticator = WebViewAuthenticator(blog: post.blog) else {
+        guard let authenticator = authenticator else {
             showFakePreview()
             return
         }


### PR DESCRIPTION
With the migration to WebViewAuthenticator and WebKit, we use a special
redirect system for WordPress.com, that needs some additional handling of the
authentication response.

In an oversight, this code wasn't added to PostPreviewViewController, which
uses its own UIWebView instead of subclassing the existing Web View Controllers.

Fixes #8117 

To test:

- Test from a fresh install to ensure there are no previous cookies
- Preview a post on a private site (or a draft)
- The preview should load the post correctly and authenticated

Needs review: @bummytime 
