### PR TITLE
Remove cookies from WebKit on sign out

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -105,7 +105,6 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     if (account == nil) {
         return;
     }
-    NSString *username = account.username;
     [self.managedObjectContext deleteObject:account];
 
     [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
@@ -122,9 +121,8 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
                        [NSHTTPCookieStorage sharedHTTPCookieStorage]
                        ];
     }
-    NSURL *url = [NSURL URLWithString:@"https://wordpress.com/"];
     for (id<CookieJar> cookieJar in cookieJars) {
-        [cookieJar removeCookiesWithUrl:url username:username completion:^{}];
+        [cookieJar removeWordPressComCookiesWithCompletion:^{}];
     }
 
     [[NSURLCache sharedURLCache] removeAllCachedResponses];

--- a/WordPress/Classes/Utility/CookieJar.swift
+++ b/WordPress/Classes/Utility/CookieJar.swift
@@ -15,7 +15,14 @@ import WebKit
 // extensions, as it needs to be accessible to Obj-C.
 // Whenever we migrate enough code so this doesn't need to be called from Swift,
 // a regular CookieJar protocol with shared implementation on an extension would suffice.
-private protocol CookieJarSharedImplementation: CookieJar {
+//
+// Also, although you're not supposed to use this outside this file, it can't be private
+// since we're subclassing HTTPCookieStorage (which conforms to this) in MockCookieJar in
+// the test target, and the swift compiler will crash when doing that ¯\_(ツ)_/¯
+//
+// https://bugs.swift.org/browse/SR-2370
+//
+protocol CookieJarSharedImplementation: CookieJar {
 }
 
 extension CookieJarSharedImplementation {

--- a/WordPress/Classes/Utility/CookieJar.swift
+++ b/WordPress/Classes/Utility/CookieJar.swift
@@ -5,32 +5,118 @@ import WebKit
 /// cookie storage systems, to aid with the transition from UIWebView to WebKit.
 ///
 @objc protocol CookieJar {
+    func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void)
     func hasCookie(url: URL, username: String, completion: @escaping (Bool) -> Void)
+    func removeCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void)
+    func removeCookies(url: URL, username: String, completion: @escaping () -> Void)
 }
 
-extension HTTPCookieStorage: CookieJar {
-    func hasCookie(url: URL, username: String, completion: @escaping (Bool) -> Void) {
-        let cookie = cookies(for: url)?
-            .first(where: { cookie in
-                return cookie.isWordPressLoggedIn(username: username)
-            })
+// As long as CookieJar is @objc, we can't have shared methods in protocol
+// extensions, as it needs to be accessible to Obj-C.
+// Whenever we migrate enough code so this doesn't need to be called from Swift,
+// a regular CookieJar protocol with shared implementation on an extension would suffice.
+private protocol CookieJarSharedImplementation: CookieJar {
+}
 
-        completion(cookie != nil)
+extension CookieJarSharedImplementation {
+    func _hasCookie(url: URL, username: String, completion: @escaping (Bool) -> Void) {
+        getCookies(url: url) { (cookies) in
+            let cookie = cookies
+                .first(where: { cookie in
+                    return cookie.isWordPressLoggedIn(username: username)
+                })
+
+            completion(cookie != nil)
+        }
+    }
+
+    func removeCookies(url: URL, matching: @escaping (HTTPCookie) -> Bool, completion: @escaping () -> Void) {
+        getCookies(url: url) { [unowned self] (cookies) in
+            self.removeCookies(cookies.filter(matching), completion: completion)
+        }
+    }
+
+    func _removeCookies(url: URL, username: String, completion: @escaping () -> Void) {
+        removeCookies(url: url, matching: { $0.isWordPressLoggedIn(username: username) }, completion: completion)
+    }
+
+    func removeCookies(url: URL, completion: @escaping () -> Void) {
+        removeCookies(url: url, matching: { _ in true }, completion: completion)
+    }
+}
+
+extension HTTPCookieStorage: CookieJarSharedImplementation {
+    func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void) {
+        completion(cookies(for: url) ?? [])
+    }
+
+    func hasCookie(url: URL, username: String, completion: @escaping (Bool) -> Void) {
+        _hasCookie(url: url, username: username, completion: completion)
+    }
+
+    func removeCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
+        cookies.forEach(deleteCookie(_:))
+        completion()
+    }
+
+    func removeCookies(url: URL, username: String, completion: @escaping () -> Void) {
+        _removeCookies(url: url, username: username, completion: completion)
     }
 }
 
 @available(iOS 11.0, *)
-extension WKHTTPCookieStore: CookieJar {
-    func hasCookie(url: URL, username: String, completion: @escaping (Bool) -> Void) {
+extension WKHTTPCookieStore: CookieJarSharedImplementation {
+    func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void) {
         getAllCookies { (cookies) in
-            let cookie = cookies.first(where: { (cookie) -> Bool in
+            completion(cookies.filter({ (cookie) in
                 return cookie.matches(url: url)
-                    && cookie.isWordPressLoggedIn(username: username)
-            })
-            completion(cookie != nil)
+            }))
         }
     }
+
+    func hasCookie(url: URL, username: String, completion: @escaping (Bool) -> Void) {
+        _hasCookie(url: url, username: username, completion: completion)
+    }
+
+    func removeCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
+        let group = DispatchGroup()
+        cookies
+            .forEach({ [unowned self] (cookie) in
+                group.enter()
+                self.delete(cookie, completionHandler: {
+                    group.leave()
+                })
+            })
+        let result = group.wait(timeout: .now() + .seconds(2))
+        if result == .timedOut {
+            DDLogWarn("Time out waiting for WKHTTPCookieStore to remove cookies")
+        }
+        completion()
+    }
+
+    func removeCookies(url: URL, username: String, completion: @escaping () -> Void) {
+        _removeCookies(url: url, username: username, completion: completion)
+    }
 }
+
+#if DEBUG
+    func __removeAllWordPressComCookies() {
+        var jars = [CookieJarSharedImplementation]()
+        jars.append(HTTPCookieStorage.shared)
+        if #available(iOS 11.0, *) {
+            jars.append(WKWebsiteDataStore.default().httpCookieStore)
+        }
+        let url = URL(string: "https://wordpress.com/")!
+        let group = DispatchGroup()
+        jars.forEach({ jar in
+            group.enter()
+            jar.removeCookies(url: url, matching: { _ in true }, completion: {
+                group.leave()
+            })
+        })
+        _ = group.wait(timeout: .now() + .seconds(5))
+    }
+#endif
 
 private let loggedInCookieName = "wordpress_logged_in"
 private extension HTTPCookie {

--- a/WordPress/Classes/Utility/CookieJar.swift
+++ b/WordPress/Classes/Utility/CookieJar.swift
@@ -6,9 +6,10 @@ import WebKit
 ///
 @objc protocol CookieJar {
     func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void)
+    func getCookies(completion: @escaping ([HTTPCookie]) -> Void)
     func hasCookie(url: URL, username: String, completion: @escaping (Bool) -> Void)
     func removeCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void)
-    func removeCookies(url: URL, username: String, completion: @escaping () -> Void)
+    func removeWordPressComCookies(completion: @escaping () -> Void)
 }
 
 // As long as CookieJar is @objc, we can't have shared methods in protocol
@@ -37,24 +38,20 @@ extension CookieJarSharedImplementation {
         }
     }
 
-    func removeCookies(url: URL, matching: @escaping (HTTPCookie) -> Bool, completion: @escaping () -> Void) {
-        getCookies(url: url) { [unowned self] (cookies) in
-            self.removeCookies(cookies.filter(matching), completion: completion)
+    func _removeWordPressComCookies(completion: @escaping () -> Void) {
+        getCookies { [unowned self] (cookies) in
+            self.removeCookies(cookies.filter({ $0.domain.hasSuffix(".wordpress.com") }), completion: completion)
         }
-    }
-
-    func _removeCookies(url: URL, username: String, completion: @escaping () -> Void) {
-        removeCookies(url: url, matching: { $0.isWordPressLoggedIn(username: username) }, completion: completion)
-    }
-
-    func removeCookies(url: URL, completion: @escaping () -> Void) {
-        removeCookies(url: url, matching: { _ in true }, completion: completion)
     }
 }
 
 extension HTTPCookieStorage: CookieJarSharedImplementation {
     func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void) {
         completion(cookies(for: url) ?? [])
+    }
+
+    func getCookies(completion: @escaping ([HTTPCookie]) -> Void) {
+        completion(cookies ?? [])
     }
 
     func hasCookie(url: URL, username: String, completion: @escaping (Bool) -> Void) {
@@ -66,8 +63,8 @@ extension HTTPCookieStorage: CookieJarSharedImplementation {
         completion()
     }
 
-    func removeCookies(url: URL, username: String, completion: @escaping () -> Void) {
-        _removeCookies(url: url, username: username, completion: completion)
+    func removeWordPressComCookies(completion: @escaping () -> Void) {
+        _removeWordPressComCookies(completion: completion)
     }
 }
 
@@ -79,6 +76,10 @@ extension WKHTTPCookieStore: CookieJarSharedImplementation {
                 return cookie.matches(url: url)
             }))
         }
+    }
+
+    func getCookies(completion: @escaping ([HTTPCookie]) -> Void) {
+        getAllCookies(completion)
     }
 
     func hasCookie(url: URL, username: String, completion: @escaping (Bool) -> Void) {
@@ -101,8 +102,8 @@ extension WKHTTPCookieStore: CookieJarSharedImplementation {
         completion()
     }
 
-    func removeCookies(url: URL, username: String, completion: @escaping () -> Void) {
-        _removeCookies(url: url, username: username, completion: completion)
+    func removeWordPressComCookies(completion: @escaping () -> Void) {
+        _removeWordPressComCookies(completion: completion)
     }
 }
 
@@ -113,13 +114,12 @@ extension WKHTTPCookieStore: CookieJarSharedImplementation {
         if #available(iOS 11.0, *) {
             jars.append(WKWebsiteDataStore.default().httpCookieStore)
         }
-        let url = URL(string: "https://wordpress.com/")!
         let group = DispatchGroup()
         jars.forEach({ jar in
             group.enter()
-            jar.removeCookies(url: url, matching: { _ in true }, completion: {
+            jar.removeWordPressComCookies {
                 group.leave()
-            })
+            }
         })
         _ = group.wait(timeout: .now() + .seconds(5))
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -748,6 +748,8 @@
 		E174F6E6172A73960004F23A /* WPAccount.m in Sources */ = {isa = PBXBuildFile; fileRef = E105E9CE1726955600C0D9E7 /* WPAccount.m */; };
 		E17780801C97FA9500FA7E14 /* StoreKit+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = E177807F1C97FA9500FA7E14 /* StoreKit+Debug.swift */; };
 		E17E67031FA22C93009BDC9A /* PluginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E17E67021FA22C93009BDC9A /* PluginViewModel.swift */; };
+		E180BD4C1FB462FF00D0D781 /* CookieJarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E180BD4B1FB462FF00D0D781 /* CookieJarTests.swift */; };
+		E180BD4E1FB4681E00D0D781 /* MockCookieJar.swift in Sources */ = {isa = PBXBuildFile; fileRef = E180BD4D1FB4681E00D0D781 /* MockCookieJar.swift */; };
 		E18165FD14E4428B006CE885 /* loader.html in Resources */ = {isa = PBXBuildFile; fileRef = E18165FC14E4428B006CE885 /* loader.html */; };
 		E1823E6C1E42231C00C19F53 /* UIEdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1823E6B1E42231C00C19F53 /* UIEdgeInsets.swift */; };
 		E183EC9C16B215FE00C2EB11 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A01C542D0E24E88400D411F2 /* SystemConfiguration.framework */; };
@@ -2133,6 +2135,8 @@
 		E17B98E7171FFB450073E30D /* WordPress 11.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 11.xcdatamodel"; sourceTree = "<group>"; };
 		E17BE7A9134DEC12007285FD /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E17E67021FA22C93009BDC9A /* PluginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginViewModel.swift; sourceTree = "<group>"; };
+		E180BD4B1FB462FF00D0D781 /* CookieJarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieJarTests.swift; sourceTree = "<group>"; };
+		E180BD4D1FB4681E00D0D781 /* MockCookieJar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCookieJar.swift; sourceTree = "<group>"; };
 		E18165FC14E4428B006CE885 /* loader.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = loader.html; path = Resources/HTML/loader.html; sourceTree = "<group>"; };
 		E1823E6B1E42231C00C19F53 /* UIEdgeInsets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIEdgeInsets.swift; sourceTree = "<group>"; };
 		E185042E1EE6ABD9005C234C /* Restorer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Restorer.swift; sourceTree = "<group>"; };
@@ -3499,6 +3503,7 @@
 				08F8CD2B1EBD243A0049D0C0 /* Media */,
 				82301B8E1E787420009C9C4E /* AppRatingUtilityTests.swift */,
 				17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */,
+				E180BD4B1FB462FF00D0D781 /* CookieJarTests.swift */,
 				E1C3C8541CE4684800D5DB36 /* EmailTypoCheckerTests.swift */,
 				E1EBC3721C118ED200F638E0 /* ImmuTableTest.swift */,
 				93A379EB19FFBF7900415023 /* KeychainTest.m */,
@@ -4799,6 +4804,7 @@
 			children = (
 				E150520D16CAC75A00D3DDDC /* CoreDataTestHelper.h */,
 				E150520E16CAC75A00D3DDDC /* CoreDataTestHelper.m */,
+				E180BD4D1FB4681E00D0D781 /* MockCookieJar.swift */,
 				E1B642121EFA5113001DC6D7 /* ModelTestHelper.swift */,
 				93E9050519E6F3D8005513C9 /* TestContextManager.h */,
 				93E9050619E6F3D8005513C9 /* TestContextManager.m */,
@@ -6873,6 +6879,7 @@
 				E6B9B8AF1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift in Sources */,
 				B5416CFE1C1756B900006DD8 /* PushNotificationsManagerTests.m in Sources */,
 				59B48B621B99E132008EBB84 /* JSONLoader.swift in Sources */,
+				E180BD4C1FB462FF00D0D781 /* CookieJarTests.swift in Sources */,
 				9363113F19FA996700B0C739 /* AccountServiceTests.swift in Sources */,
 				74585B991F0D58F300E7E667 /* DomainsServiceTests.swift in Sources */,
 				0879FC161E9301DD00E1EFC8 /* MediaTests.swift in Sources */,
@@ -6912,6 +6919,7 @@
 				E1B921BC1C0ED5A3003EA3CB /* MediaSizeSliderCellTest.swift in Sources */,
 				0885A3671E837AFE00619B4D /* URLIncrementalFilenameTests.swift in Sources */,
 				F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */,
+				E180BD4E1FB4681E00D0D781 /* MockCookieJar.swift in Sources */,
 				E1E4CE0D177439D100430844 /* WPAvatarSourceTest.m in Sources */,
 				B55F1AA21C107CE200FD04D4 /* BlogSettingsDiscussionTests.swift in Sources */,
 			);

--- a/WordPress/WordPressTest/CookieJarTests.swift
+++ b/WordPress/WordPressTest/CookieJarTests.swift
@@ -19,7 +19,7 @@ class CookieJarTests: XCTestCase {
 
         let expectation = self.expectation(description: "getCookies completion called")
         cookieJar.getCookies(url: wordPressComLoginURL) { (cookies) in
-            XCTAssertEqual(cookies.count, 1)
+            XCTAssertEqual(cookies.count, 2)
             expectation.fulfill()
         }
         waitForExpectations(timeout: 1, handler: nil)
@@ -47,22 +47,11 @@ class CookieJarTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
     }
 
-    func testRemoveCookiesMatching() {
+    func testRemoveCookies() {
         addCookies()
 
         let expectation = self.expectation(description: "removeCookies completion called")
-        cookieJar.removeCookies(url: wordPressComLoginURL, username: "testuser") { [mockCookieJar] in
-            XCTAssertEqual(mockCookieJar.cookies?.count, 0)
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 1, handler: nil)
-    }
-
-    func testRemoveCookiesNotMatching() {
-        addCookies()
-
-        let expectation = self.expectation(description: "removeCookies completion called")
-        cookieJar.removeCookies(url: wordPressComLoginURL, username: "anotheruser") { [mockCookieJar] in
+        cookieJar.removeWordPressComCookies { [mockCookieJar] in
             XCTAssertEqual(mockCookieJar.cookies?.count, 1)
             expectation.fulfill()
         }
@@ -73,5 +62,6 @@ class CookieJarTests: XCTestCase {
 private extension CookieJarTests {
     func addCookies() {
         mockCookieJar.setWordPressComCookie(username: "testuser")
+        mockCookieJar.setWordPressCookie(username: "testuser", domain: "example.com")
     }
 }

--- a/WordPress/WordPressTest/CookieJarTests.swift
+++ b/WordPress/WordPressTest/CookieJarTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+import WebKit
+@testable import WordPress
+
+class CookieJarTests: XCTestCase {
+    var mockCookieJar = MockCookieJar()
+    var cookieJar: CookieJar {
+        return mockCookieJar
+    }
+    let wordPressComLoginURL = URL(string: "https://wordpress.com/wp-login.php")!
+
+    override func setUp() {
+        super.setUp()
+        mockCookieJar = MockCookieJar()
+    }
+
+    func testGetCookies() {
+        addCookies()
+
+        let expectation = self.expectation(description: "getCookies completion called")
+        cookieJar.getCookies(url: wordPressComLoginURL) { (cookies) in
+            XCTAssertEqual(cookies.count, 1)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testHasCookieMatching() {
+        addCookies()
+
+        let expectation = self.expectation(description: "hasCookie completion called")
+        cookieJar.hasCookie(url: wordPressComLoginURL, username: "testuser") { (matches) in
+            XCTAssertTrue(matches)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+
+    }
+    func testHasCookieNotMatching() {
+        addCookies()
+
+        let expectation = self.expectation(description: "hasCookie completion called")
+        cookieJar.hasCookie(url: wordPressComLoginURL, username: "anotheruser") { (matches) in
+            XCTAssertFalse(matches)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testRemoveCookiesMatching() {
+        addCookies()
+
+        let expectation = self.expectation(description: "removeCookies completion called")
+        cookieJar.removeCookies(url: wordPressComLoginURL, username: "testuser") { [mockCookieJar] in
+            XCTAssertEqual(mockCookieJar.cookies?.count, 0)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+
+    func testRemoveCookiesNotMatching() {
+        addCookies()
+
+        let expectation = self.expectation(description: "removeCookies completion called")
+        cookieJar.removeCookies(url: wordPressComLoginURL, username: "anotheruser") { [mockCookieJar] in
+            XCTAssertEqual(mockCookieJar.cookies?.count, 1)
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1, handler: nil)
+    }
+}
+
+private extension CookieJarTests {
+    func addCookies() {
+        mockCookieJar.setWordPressComCookie(username: "testuser")
+    }
+}

--- a/WordPress/WordPressTest/MockCookieJar.swift
+++ b/WordPress/WordPressTest/MockCookieJar.swift
@@ -1,0 +1,38 @@
+import Foundation
+import WordPress
+
+class MockCookieJar: HTTPCookieStorage {
+    var _cookies = [HTTPCookie]()
+
+    override func cookies(for URL: URL) -> [HTTPCookie]? {
+        return _cookies
+    }
+
+    override var cookies: [HTTPCookie]? {
+        return _cookies
+    }
+
+    override func deleteCookie(_ cookie: HTTPCookie) {
+        if let index = _cookies.index(of: cookie) {
+            _cookies.remove(at: index)
+        }
+    }
+
+    override func setCookie(_ cookie: HTTPCookie) {
+        guard !_cookies.contains(cookie) else {
+            return
+        }
+        _cookies.append(cookie)
+    }
+
+    func setWordPressComCookie(username: String) {
+        let cookie = HTTPCookie(properties: [
+            .domain: "wordpress.com",
+            .path: "/",
+            .secure: true,
+            .name: "wordpress_logged_in",
+            .value: "\(username)%00000"
+            ])!
+        setCookie(cookie)
+    }
+}

--- a/WordPress/WordPressTest/MockCookieJar.swift
+++ b/WordPress/WordPressTest/MockCookieJar.swift
@@ -25,14 +25,18 @@ class MockCookieJar: HTTPCookieStorage {
         _cookies.append(cookie)
     }
 
-    func setWordPressComCookie(username: String) {
+    func setWordPressCookie(username: String, domain: String) {
         let cookie = HTTPCookie(properties: [
-            .domain: "wordpress.com",
+            .domain: domain,
             .path: "/",
             .secure: true,
             .name: "wordpress_logged_in",
             .value: "\(username)%00000"
             ])!
         setCookie(cookie)
+    }
+
+    func setWordPressComCookie(username: String) {
+        setWordPressCookie(username: username, domain: ".wordpress.com")
     }
 }

--- a/WordPress/WordPressTest/WebViewAuthenticatorTests.swift
+++ b/WordPress/WordPressTest/WebViewAuthenticatorTests.swift
@@ -9,17 +9,6 @@ private extension URLRequest {
     }
 }
 
-private class MockCookieJar: CookieJar {
-    let implementation: (URL, String) -> Bool
-    init(_ implementation: @escaping (URL, String) -> Bool) {
-        self.implementation = implementation
-    }
-
-    func hasCookie(url: URL, username: String, completion: @escaping (Bool) -> Void) {
-        completion(implementation(url, username))
-    }
-}
-
 class WebViewAuthenticatorTests: XCTestCase {
     let dotComLoginURL = URL(string: "https://wordpress.com/wp-login.php")!
     let dotComUser = "comuser"
@@ -42,9 +31,7 @@ class WebViewAuthenticatorTests: XCTestCase {
         let url = URL(string: "http://example.com/some-page/?preview=true&preview_nonce=7ad6fc")!
         let authenticator = siteAuthenticator
 
-        let cookieJar = MockCookieJar({ (url, username) in
-            return false
-        })
+        let cookieJar = MockCookieJar()
         var authenticatedRequest: URLRequest? = nil
         authenticator.request(url: url, cookieJar: cookieJar) {
             authenticatedRequest = $0
@@ -65,9 +52,7 @@ class WebViewAuthenticatorTests: XCTestCase {
         let url = URL(string: "https://example.wordpress.com/some-page/")!
         let authenticator = dotComAuthenticator
 
-        let cookieJar = MockCookieJar({ (url, username) in
-            return false
-        })
+        let cookieJar = MockCookieJar()
         var authenticatedRequest: URLRequest? = nil
         authenticator.request(url: url, cookieJar: cookieJar) {
             authenticatedRequest = $0
@@ -86,9 +71,8 @@ class WebViewAuthenticatorTests: XCTestCase {
         let url = URL(string: "https://example.wordpress.com/some-page/")!
         let authenticator = dotComAuthenticator
 
-        let cookieJar = MockCookieJar({ (url, username) in
-            return url.host == "wordpress.com"
-        })
+        let cookieJar = MockCookieJar()
+        cookieJar.setWordPressComCookie(username: dotComUser)
         var authenticatedRequest: URLRequest? = nil
         authenticator.request(url: url, cookieJar: cookieJar) {
             authenticatedRequest = $0


### PR DESCRIPTION
While working on #8120, I noticed the AccountService was clearing cookies from NSHTTPCookieStorage on sign out, but hadn't been updated to clear WebKit cookies.

This extends CookieJar so it's easier to remove cookies from both stores, and adds a debugging helper to clear all WordPress.com cookies.

Also added unit tests for CookieJar.

To test:

- Make sure unit tests pass
- Sign out and make sure no WordPress.com cookies are retained

To help with this, you can pause the execution and run this from LLDB:

```
(lldb) expr -l swift -- import Foundation
expr -l swift -- import WebKit
expr -l swift -O -- HTTPCookieStorage.shared.cookies
expr -l swift -- WKWebsiteDataStore.default().httpCookieStore.getAllCookies({ print($0) })
continue

▿ Optional<Array<NSHTTPCookie>>
  - some : 0 elements

Process 71708 resuming
(lldb) error: Process is running.  Use 'process interrupt' to pause execution.
[]
```

Needs review: @frosty 