### PR TITLE
We no longer need this because Github now support reviewers.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,3 @@ Fixes #
 To test:
 
 
-
-Needs review: @


### PR DESCRIPTION
Title has it.
