### PR TITLE
Cleans up WPAnalyticsStatLogout tracking

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.h
+++ b/WordPress/Classes/System/WordPressAppDelegate.h
@@ -27,5 +27,6 @@
 ///-----------
 - (void)showWelcomeScreenIfNeededAnimated:(BOOL)animated;
 - (void)showWelcomeScreenAnimated:(BOOL)animated thenEditor:(BOOL)thenEditor;
+- (void)trackLogoutIfNeeded;
 
 @end

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -598,6 +598,13 @@ int ddLogLevel = DDLogLevelInfo;
     [SVProgressHUD setFont:[WPStyleGuide fontForTextStyle:UIFontTextStyleHeadline]];
 }
 
+- (void)trackLogoutIfNeeded
+{
+    if (![self isLoggedIn]) {
+        [WPAnalytics track:WPAnalyticsStatLogout];
+    }
+}
+
 #pragma mark - Analytics
 
 - (void)configureAnalytics
@@ -851,10 +858,7 @@ int ddLogLevel = DDLogLevelInfo;
     if (notification.object) {
         [self setupShareExtensionToken];
     } else {
-        if ([self noSelfHostedBlogs] && [self noWordPressDotComAccount]) {
-            [WPAnalytics track:WPAnalyticsStatLogout];
-        }
-
+        [self trackLogoutIfNeeded];
         [self removeTodayWidgetConfiguration];
         [self removeShareExtensionConfiguration];
         [self showWelcomeScreenIfNeededAnimated:NO];

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -272,8 +272,6 @@ static ContextManager *_override;
             DDLogError(@"Unresolved error %@, %@", error, [error userInfo]);
             abort();
         }
-        
-        [WPAnalytics track:WPAnalyticsStatLogout];
     }
 
     return _persistentStoreCoordinator;

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1075,6 +1075,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     [blogService removeBlog:self.blog];
+    [[WordPressAppDelegate sharedInstance] trackLogoutIfNeeded];
     [self.navigationController popToRootViewControllerAnimated:YES];
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -319,13 +319,6 @@ static NSInteger HideSearchMinSites = 3;
     }];
 }
 
-- (void)trackLogoutIfNeeded
-{
-    if (self.dataSource.allBlogsCount == 0 && ![self defaultWordPressComAccount]) {
-        [WPAnalytics track:WPAnalyticsStatLogout];
-    }
-}
-
 #pragma mark - Header methods
 
 - (UIView *)headerView
@@ -911,7 +904,7 @@ static NSInteger HideSearchMinSites = 3;
 {
     [self.tableView reloadData];
     [self updateEditButton];
-    [self trackLogoutIfNeeded];
+    [[WordPressAppDelegate sharedInstance] trackLogoutIfNeeded];
     [self maybeShowNUX];
     [self updateViewsForCurrentSiteCount];
     [self validateBlogDetailsViewController];

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -233,7 +233,6 @@ static NSInteger HideSearchMinSites = 3;
         return;
     }
     if (![self defaultWordPressComAccount]) {
-        [WPAnalytics track:WPAnalyticsStatLogout];
         [[WordPressAppDelegate sharedInstance] showWelcomeScreenIfNeededAnimated:YES];
     }
 }
@@ -318,6 +317,13 @@ static NSInteger HideSearchMinSites = 3;
             [blogService syncBlogsForAccount:defaultAccount success:nil failure:nil];
         }
     }];
+}
+
+- (void)trackLogoutIfNeeded
+{
+    if (self.dataSource.allBlogsCount == 0 && ![self defaultWordPressComAccount]) {
+        [WPAnalytics track:WPAnalyticsStatLogout];
+    }
 }
 
 #pragma mark - Header methods
@@ -905,6 +911,7 @@ static NSInteger HideSearchMinSites = 3;
 {
     [self.tableView reloadData];
     [self updateEditButton];
+    [self trackLogoutIfNeeded];
     [self maybeShowNUX];
     [self updateViewsForCurrentSiteCount];
     [self validateBlogDetailsViewController];


### PR DESCRIPTION
## Discussion

A small PR that attempts to cleanup the calls to `[WPAnalytics track:WPAnalyticsStatLogout]`to be more accurate:

* The `ContextManager` [#](https://github.com/wordpress-mobile/WordPress-iOS/blob/6.2/WordPress/Classes/Utility/ContextManager.m#L223) 
  -  I removed the call from here which, I realize, is debatable. My rationale is if there is a complete failure to spin up the `persistentStoreCoordinator`, the user is not actively "logging out". Perhaps another stat could be tracked here instead, but for now I removed it.
* The `BlogListViewController` [#](https://github.com/wordpress-mobile/WordPress-iOS/blob/6.2/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m#L233)
  - In this case, we were tracking the logout in `maybeShowNUX` which is called both from `dataChanged` and `viewWillAppear`. The problem here is that the tracking call was always called when the user restarted the app after removing the only .org site from the blog list (assuming she is not logged into .com) — thus resulting in `WPAnalyticsStatLogout` called multiple times.
* The `WordPressAppDelegate` [#](https://github.com/wordpress-mobile/WordPress-iOS/blob/6.2/WordPress/Classes/System/WordPressAppDelegate.m#L980)
  - I left this tracking call in place since it seems to be a reasonable spot to track this event.

Fixes #5615

## Testing

The primary thing to test is that we are not calling `WPAnalyticsStatLogout` more than needed on the site list screen. 

1. Put a breakpoint in [trackLogoutIfNeeded](https://github.com/wordpress-mobile/WordPress-iOS/blob/f87ec2091bac4874881def63abadff4fb5855b6c/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m#L325)
2. Sign into the app with .org site (sans Jetpack) and navigate to the Sites List screen. Make sure you are not logged into .com
3. Remove the .org site from the app
4. Verify the breakpoint is hit
5. Kill the app and restart it
6. Verify the breakpoint is **not** hit

@aerych would you mind reviewing this?



