### PR TITLE
WPImageViewController: Auto hide home indicator on iPhone X

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
@@ -195,6 +195,11 @@ static CGFloat const MinimumZoomScale = 0.1;
     [self centerImage];
 }
 
+- (BOOL)prefersHomeIndicatorAutoHidden
+{
+    return self.shouldHideStatusBar;
+}
+
 #pragma mark - Instance Methods
 
 - (void)hideBars:(BOOL)hide animated:(BOOL)animated
@@ -206,9 +211,17 @@ static CGFloat const MinimumZoomScale = 0.1;
         [UIView animateWithDuration:0.3
                          animations:^{
                              [self setNeedsStatusBarAppearanceUpdate];
+
+                             if (@available(iOS 11.0, *)) {
+                                 [self setNeedsUpdateOfHomeIndicatorAutoHidden];
+                             }
                          }];
     } else {
         [self setNeedsStatusBarAppearanceUpdate];
+
+        if (@available(iOS 11.0, *)) {
+            [self setNeedsUpdateOfHomeIndicatorAutoHidden];
+        }
     }
 }
 


### PR DESCRIPTION
This PR auto-hides the home indicator in `WPImageViewController` on iPhone X.

Before – the home indicator is always present at the bottom of the image view controller:

<img width="376" alt="screen shot 2017-11-10 at 11 21 10" src="https://user-images.githubusercontent.com/4780/32656336-54008b3a-c609-11e7-8db2-25bcb729d128.png">

After – the home indicator hides a few seconds after the image view controller appears:

![home-hide](https://user-images.githubusercontent.com/4780/32656340-56492f28-c609-11e7-86a1-983b0744ac12.gif)

To test:

* Build and run the app on an iPhone X or in the simulator, and navigate to a site's Media Library.
* Tap on an image, then tap on the larger preview to view it full screen.
* Check that the home indicator at the bottom is hidden.
