### PR TITLE
Fixes web authenticator problem with some URLs

### DIFF
--- a/WordPress/Classes/Utility/WebViewAuthenticator.swift
+++ b/WordPress/Classes/Utility/WebViewAuthenticator.swift
@@ -144,10 +144,12 @@ private extension WebViewAuthenticator {
     }
 
     func redirectUrl(url: String) -> String? {
-        guard case .dotCom = credentials else {
+        guard case .dotCom = credentials,
+            let escapedUrl = url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) else {
             return url
         }
-        return self.url(string: "https://wordpress.com/", parameters: [WebViewAuthenticator.redirectParameter: url])?.absoluteString
+
+        return self.url(string: "https://wordpress.com/", parameters: [WebViewAuthenticator.redirectParameter: escapedUrl])?.absoluteString
     }
 
     func url(string: String, parameters: [String: String]) -> URL? {


### PR DESCRIPTION
Ensure the redirect URL is properly encoded, so the original URL is retrieved
when the redirect is intercepted

Fixes #8149 

To test:

Find a reader post with a link to Twitter and verify it works
