### PR TITLE
Make WebKitViewController toolbar respect safe areas

### DIFF
--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -6,7 +6,6 @@ import WebKit
 class WebKitViewController: UIViewController {
     let webView = WKWebView()
     let progressView = WebProgressView()
-    let toolbar = UIToolbar()
     let titleView = NavigationTitleView()
 
     var backButton: UIBarButtonItem?
@@ -51,9 +50,6 @@ class WebKitViewController: UIViewController {
             progressView,
             webView
             ])
-        if !secureInteraction {
-            stackView.addArrangedSubview(toolbar)
-        }
         stackView.axis = .vertical
         view = stackView
     }
@@ -132,7 +128,8 @@ class WebKitViewController: UIViewController {
     }
 
     func configureToolbar() {
-        toolbar.barTintColor = UIColor.white
+        navigationController?.isToolbarHidden = secureInteraction
+        navigationController?.toolbar.barTintColor = UIColor.white
 
         backButton = UIBarButtonItem(image: Gridicon.iconOfType(.chevronLeft).imageFlippedForRightToLeftLayoutDirection(),
                                      style: .plain,
@@ -156,7 +153,7 @@ class WebKitViewController: UIViewController {
 
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
 
-        toolbar.items = [
+        let items = [
             backButton!,
             space,
             forwardButton!,
@@ -166,9 +163,11 @@ class WebKitViewController: UIViewController {
             safariButton!
         ]
 
-        toolbar.items?.forEach({ (button) in
+        items.forEach({ (button) in
             button.tintColor = WPStyleGuide.greyLighten10()
         })
+
+        setToolbarItems(items, animated: false)
     }
 
     func close() {


### PR DESCRIPTION
Fixes #8155 

![web-iphone-x](https://user-images.githubusercontent.com/8739/32828654-08ab5832-c9f0-11e7-9ac5-e320c5cd4670.png)


To test:

Go to Site > View Site and make sure the web view looks good on an iPhone X

