### PR TITLE
WordPressShared: Swift 4.0 Support

### DIFF
--- a/WordPressShared/CocoaLumberjack.swift
+++ b/WordPressShared/CocoaLumberjack.swift
@@ -93,10 +93,19 @@ public func DDLogError(_ message: @autoclosure () -> String, level: DDLogLevel =
 public func CurrentFileName(_ fileName: StaticString = #file) -> String {
     var str = String(describing: fileName)
     if let idx = str.range(of: "/", options: .backwards)?.upperBound {
+#if swift(>=4.0)
+        str = String(str[idx...])
+#else
         str = str.substring(from: idx)
+#endif
     }
     if let idx = str.range(of: ".", options: .backwards)?.lowerBound {
+#if swift(>=4.0)
+        str = String(str.prefix(upTo: idx))
+#else
         str = str.substring(to: idx)
+#endif
     }
+
     return str
 }

--- a/WordPressShared/WordPressShared.xcodeproj/project.pbxproj
+++ b/WordPressShared/WordPressShared.xcodeproj/project.pbxproj
@@ -505,12 +505,12 @@
 				TargetAttributes = {
 					829DD13D1EC9EED200AB8C12 = {
 						CreatedOnToolsVersion = 8.3;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
 					829DD1461EC9EED200AB8C12 = {
 						CreatedOnToolsVersion = 8.3;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
 				};

--- a/WordPressShared/WordPressShared/Core/Utility/NSMutableData+Helpers.swift
+++ b/WordPressShared/WordPressShared/Core/Utility/NSMutableData+Helpers.swift
@@ -9,7 +9,7 @@ extension NSMutableData {
     ///
     /// - Parameter string: The raw String to be UTF8-Encoded, and appended
     ///
-    public func appendString(_ string: String) {
+    @objc public func appendString(_ string: String) {
         if let data = string.data(using: String.Encoding.utf8) {
             append(data)
         }

--- a/WordPressShared/WordPressShared/Core/Utility/RichContentFormatter.swift
+++ b/WordPressShared/WordPressShared/Core/Utility/RichContentFormatter.swift
@@ -40,7 +40,7 @@ import Foundation
     ///
     /// - Returns: The formatted string.
     ///
-    public class func formatContentString(_ string: String, isPrivateSite isPrivate: Bool) -> String {
+    @objc public class func formatContentString(_ string: String, isPrivateSite isPrivate: Bool) -> String {
         guard string.count > 0 else {
             return string
         }
@@ -63,7 +63,7 @@ import Foundation
     ///
     /// - Returns: The formatted string.
     ///
-    public class func removeForbiddenTags(_ string: String) -> String {
+    @objc public class func removeForbiddenTags(_ string: String) -> String {
         guard string.count > 0 else {
             return string
         }
@@ -95,7 +95,7 @@ import Foundation
     ///
     /// - Returns: The formatted string.
     ///
-    public class func normalizeParagraphs(_ string: String) -> String {
+    @objc public class func normalizeParagraphs(_ string: String) -> String {
         guard string.count > 0 else {
             return string
         }
@@ -131,7 +131,7 @@ import Foundation
     }
 
 
-    public class func filterNewLines(_ string: String) -> String {
+    @objc public class func filterNewLines(_ string: String) -> String {
         var content = string
 
         var ranges = [NSRange]()
@@ -181,7 +181,7 @@ import Foundation
     ///
     /// - Returns: The formatted string.
     ///
-    public class func removeInlineStyles(_ string: String) -> String {
+    @objc public class func removeInlineStyles(_ string: String) -> String {
         guard string.count > 0 else {
             return string
         }
@@ -204,7 +204,7 @@ import Foundation
     ///
     /// - Returns: The formatted string.
     ///
-    public class func resizeGalleryImageURL(_ string: String, isPrivateSite isPrivate: Bool) -> String {
+    @objc public class func resizeGalleryImageURL(_ string: String, isPrivateSite isPrivate: Bool) -> String {
         guard string.count > 0 else {
             return string
         }
@@ -258,7 +258,7 @@ import Foundation
     ///
     /// - Returns: The value for the attribute or an empty string..
     ///
-    public class func parseValueForAttribute(_ attribute: String, inElement element: String) -> String {
+    @objc public class func parseValueForAttribute(_ attribute: String, inElement element: String) -> String {
         let elementStr = element as NSString
         var value = ""
         let attrStr = "\(attribute)=\""
@@ -282,15 +282,20 @@ import Foundation
     ///
     /// - Returns: The formatted string.
     ///
-    public class func removeTrailingBreakTags(_ string: String) -> String {
+    @objc public class func removeTrailingBreakTags(_ string: String) -> String {
         guard string.count > 0 else {
             return string
         }
+
         var content = string.trim()
         let matches = RegEx.trailingBRTags.matches(in: content, options: .reportCompletion, range: NSRange(location: 0, length: content.count))
         if let match = matches.first {
             let index = content.index(content.startIndex, offsetBy: match.range.location)
+#if swift(>=4.0)
+            content = String(content.prefix(upTo: index))
+#else
             content = content.substring(to: index)
+#endif
         }
 
         return content

--- a/WordPressShared/WordPressShared/Core/Utility/WPImageURLHelper.swift
+++ b/WordPressShared/WordPressShared/Core/Utility/WPImageURLHelper.swift
@@ -13,7 +13,7 @@ open class WPImageURLHelper: NSObject {
 
      - note: If there is any problem with the original URL parsing, the original URL is returned with no changes.
      */
-    open class func imageURLWithSize(_ size: CGSize, forImageURL url: URL) -> URL {
+    @objc open class func imageURLWithSize(_ size: CGSize, forImageURL url: URL) -> URL {
         guard var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
             return url
         }

--- a/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
+++ b/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
@@ -1,14 +1,14 @@
 /// Extension on WPStyleGuide to use Dynamic Type fonts.
 ///
 extension WPStyleGuide {
-    static let defaultTableViewRowHeight: CGFloat = 44.0
+    @objc static let defaultTableViewRowHeight: CGFloat = 44.0
 
     /// Configures a table to automatically resize its rows according to their content.
     ///
     /// - Parameters:
     ///     - tableView: The tableView to configure.
     ///
-    public class func configureAutomaticHeightRows(for tableView: UITableView) {
+    @objc public class func configureAutomaticHeightRows(for tableView: UITableView) {
         tableView.rowHeight = UITableViewAutomaticDimension
         tableView.estimatedRowHeight = defaultTableViewRowHeight
     }
@@ -19,7 +19,7 @@ extension WPStyleGuide {
     ///     - label: The label to configure.
     ///     - style: The desired UIFontTextStyle.
     ///
-    public class func configureLabel(_ label: UILabel, textStyle style: UIFontTextStyle) {
+    @objc public class func configureLabel(_ label: UILabel, textStyle style: UIFontTextStyle) {
         label.font = UIFont.preferredFont(forTextStyle: style)
         label.adjustsFontForContentSizeCategory = true
     }
@@ -31,7 +31,7 @@ extension WPStyleGuide {
     ///     - style: The desired UIFontTextStyle.
     ///     - traits: The desired UIFontDescriptorSymbolicTraits.
     ///
-    public class func configureLabel(_ label: UILabel, textStyle style: UIFontTextStyle, symbolicTraits traits: UIFontDescriptorSymbolicTraits) {
+    @objc public class func configureLabel(_ label: UILabel, textStyle style: UIFontTextStyle, symbolicTraits traits: UIFontDescriptorSymbolicTraits) {
         label.font = fontForTextStyle(style, symbolicTraits: traits)
         label.adjustsFontForContentSizeCategory = true
     }
@@ -45,7 +45,7 @@ extension WPStyleGuide {
     ///       UIFontWeightRegular, UIFontWeightMedium, UIFontWeightSemibold, UIFontWeightBold,
     ///       UIFontWeightHeavy, UIFontWeightBlack).
     ///
-    public class func configureLabel(_ label: UILabel, textStyle style: UIFontTextStyle, fontWeight weight: CGFloat) {
+    @objc public class func configureLabel(_ label: UILabel, textStyle style: UIFontTextStyle, fontWeight weight: CGFloat) {
         label.font = fontForTextStyle(style, fontWeight: weight)
         label.adjustsFontForContentSizeCategory = true
     }
@@ -56,7 +56,7 @@ extension WPStyleGuide {
     ///     - label: The label to configure.
     ///     - style: The desired UIFontTextStyle.
     ///
-    public class func configureLabelForNotoFont(_ label: UILabel, textStyle style: UIFontTextStyle) {
+    @objc public class func configureLabelForNotoFont(_ label: UILabel, textStyle style: UIFontTextStyle) {
         label.font = notoFontForTextStyle(style)
         label.adjustsFontForContentSizeCategory = true
     }
@@ -68,7 +68,7 @@ extension WPStyleGuide {
     ///
     /// - Returns: The created font.
     ///
-    public class func fontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
+    @objc public class func fontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
         let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
         return UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
     }
@@ -81,7 +81,7 @@ extension WPStyleGuide {
     ///
     /// - Returns: The created font.
     ///
-    public class func fontForTextStyle(_ style: UIFontTextStyle, symbolicTraits traits: UIFontDescriptorSymbolicTraits) -> UIFont {
+    @objc public class func fontForTextStyle(_ style: UIFontTextStyle, symbolicTraits traits: UIFontDescriptorSymbolicTraits) -> UIFont {
         var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
         fontDescriptor = fontDescriptor.withSymbolicTraits(traits) ?? fontDescriptor
         return UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
@@ -97,10 +97,10 @@ extension WPStyleGuide {
     ///
     /// - Returns: The created font.
     ///
-    public class func fontForTextStyle(_ style: UIFontTextStyle, fontWeight weight: CGFloat) -> UIFont {
+    @objc public class func fontForTextStyle(_ style: UIFontTextStyle, fontWeight weight: CGFloat) -> UIFont {
         var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
-        let traits = [UIFontWeightTrait: weight]
-        fontDescriptor = fontDescriptor.addingAttributes([UIFontDescriptorTraitsAttribute: traits])
+        let traits = [UIFontDescriptor.TraitKey.weight: weight]
+        fontDescriptor = fontDescriptor.addingAttributes([UIFontDescriptor.AttributeName.traits: traits])
         return UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
     }
 
@@ -111,7 +111,7 @@ extension WPStyleGuide {
     ///
     /// - Returns: The created font point size.
     ///
-    public class func fontSizeForTextStyle(_ style: UIFontTextStyle) -> CGFloat {
+    @objc public class func fontSizeForTextStyle(_ style: UIFontTextStyle) -> CGFloat {
         let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
         let font = UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
         return font.pointSize
@@ -124,7 +124,7 @@ extension WPStyleGuide {
     ///
     /// - Returns: The created font.
     ///
-    public class func notoFontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
+    @objc public class func notoFontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
         return customNotoFontNamed("NotoSerif", forTextStyle: style)
     }
 
@@ -135,7 +135,7 @@ extension WPStyleGuide {
     ///
     /// - Returns: The created font.
     ///
-    public class func notoBoldFontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
+    @objc public class func notoBoldFontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
         return customNotoFontNamed("NotoSerif-Bold", forTextStyle: style)
     }
 
@@ -146,7 +146,7 @@ extension WPStyleGuide {
     ///
     /// - Returns: The created font.
     ///
-    public class func notoItalicFontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
+    @objc public class func notoItalicFontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
         return customNotoFontNamed("NotoSerif-Italic", forTextStyle: style)
     }
 
@@ -157,7 +157,7 @@ extension WPStyleGuide {
     ///
     /// - Returns: The created font.
     ///
-    public class func notoBoldItalicFontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
+    @objc public class func notoBoldItalicFontForTextStyle(_ style: UIFontTextStyle) -> UIFont {
         return customNotoFontNamed("NotoSerif-BoldItalic", forTextStyle: style)
     }
 

--- a/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
+++ b/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
@@ -99,8 +99,15 @@ extension WPStyleGuide {
     ///
     @objc public class func fontForTextStyle(_ style: UIFontTextStyle, fontWeight weight: CGFloat) -> UIFont {
         var fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
+
+#if swift(>=4.0)
         let traits = [UIFontDescriptor.TraitKey.weight: weight]
-        fontDescriptor = fontDescriptor.addingAttributes([UIFontDescriptor.AttributeName.traits: traits])
+        fontDescriptor = fontDescriptor.addingAttributes([.traits: traits])
+#else
+        let traits = [UIFontWeightTrait: weight]
+        fontDescriptor = fontDescriptor.addingAttributes([UIFontDescriptorTraitsAttribute: traits])
+#endif
+
         return UIFont(descriptor: fontDescriptor, size: CGFloat(0.0))
     }
 

--- a/WordPressShared/WordPressShared/Languages.swift
+++ b/WordPressShared/WordPressShared/Languages.swift
@@ -47,7 +47,7 @@ public class WordPressComLanguageDatabase: NSObject {
     ///
     /// - Returns: A string containing the language name, or an empty string, in case it wasn't found.
     ///
-    public func nameForLanguageWithId(_ languageId: Int) -> String {
+    @objc public func nameForLanguageWithId(_ languageId: Int) -> String {
         return find(id: languageId)?.name ?? ""
     }
 
@@ -105,7 +105,7 @@ public class WordPressComLanguageDatabase: NSObject {
 
     /// Overrides the device language. For testing purposes only.
     ///
-    func _overrideDeviceLanguageCode(_ code: String) {
+    @objc func _overrideDeviceLanguageCode(_ code: String) {
         deviceLanguageCode = code.lowercased()
     }
 

--- a/WordPressShared/WordPressShared/NSDate+Helpers.swift
+++ b/WordPressShared/WordPressShared/NSDate+Helpers.swift
@@ -144,7 +144,7 @@ extension Date {
 }
 
 extension NSDate {
-    public static func dateWithISO8601String(_ string: String) -> NSDate? {
+    @objc public static func dateWithISO8601String(_ string: String) -> NSDate? {
         return Date.DateFormatters.iso8601.date(from: string) as NSDate?
     }
 
@@ -157,7 +157,7 @@ extension NSDate {
     /// - Example: 2 days ago
     /// - Example: Jan 22, 2017
     ///
-    public func mediumString() -> String {
+    @objc public func mediumString() -> String {
         return (self as Date).mediumString()
     }
 
@@ -169,7 +169,7 @@ extension NSDate {
     /// - Example: Jan 28, 2017, 1:51 PM
     /// - Example: Jan 22, 2017, 2:18 AM
     ///
-    public func mediumStringWithTime() -> String {
+    @objc public func mediumStringWithTime() -> String {
         return (self as Date).mediumStringWithTime()
     }
 
@@ -181,11 +181,11 @@ extension NSDate {
     /// - Example: 1/28/17, 1:51 PM
     /// - Example: 1/22/17, 2:18 AM
     ///
-    public func shortStringWithTime() -> String {
+    @objc public func shortStringWithTime() -> String {
         return (self as Date).shortStringWithTime()
     }
 
-    public func toStringForPageSections() -> String {
+    @objc public func toStringForPageSections() -> String {
         return (self as Date).toStringForPageSections()
     }
 }

--- a/WordPressShared/WordPressShared/UIAlertController+Helpers.swift
+++ b/WordPressShared/WordPressShared/UIAlertController+Helpers.swift
@@ -2,26 +2,26 @@ import Foundation
 
 
 extension UIAlertController {
-    @discardableResult public func addCancelActionWithTitle(_ title: String?, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+    @objc @discardableResult public func addCancelActionWithTitle(_ title: String?, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         return addActionWithTitle(title, style: .cancel, handler: handler)
     }
 
-    @discardableResult public func addDestructiveActionWithTitle(_ title: String?, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+    @objc @discardableResult public func addDestructiveActionWithTitle(_ title: String?, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         return addActionWithTitle(title, style: .destructive, handler: handler)
     }
 
-    @discardableResult public func addDefaultActionWithTitle(_ title: String?, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+    @objc @discardableResult public func addDefaultActionWithTitle(_ title: String?, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         return addActionWithTitle(title, style: .default, handler: handler)
     }
 
-    @discardableResult public func addActionWithTitle(_ title: String?, style: UIAlertActionStyle, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
+    @objc @discardableResult public func addActionWithTitle(_ title: String?, style: UIAlertActionStyle, handler: ((UIAlertAction) -> Void)? = nil) -> UIAlertAction {
         let action = UIAlertAction(title: title, style: style, handler: handler)
         addAction(action)
 
         return action
     }
 
-    public func presentFromRootViewController() {
+    @objc public func presentFromRootViewController() {
         // Note:
         // This method is required because the presenter ViewController must be visible, and we've got several
         // flows in which the VC that triggers the alert, might not be visible anymore.


### PR DESCRIPTION
### Details:
Okay. Let's do this!. In this PR we're adding Swift 4.0 support to both, WordPressShared and WordPressSharedTests Targets.

Needs Review: @diegoreymendez 
Thanks in advance!

### To test:
1. Run the Unit Tests. Verify they stay green!
2. Click over the WordPressShared target 
3. Toggle the Language Picker to Swift 4
4. Verify that WPiOS still builds correctly
