### PR TITLE
WordPressKit: Swift 4.0 Support

### DIFF
--- a/WordPressKit/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit/WordPressKit.xcodeproj/project.pbxproj
@@ -1509,12 +1509,12 @@
 				TargetAttributes = {
 					9368C77A1EC5EF1B0092CE8E = {
 						CreatedOnToolsVersion = 8.3.2;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
 					9368C7831EC5EF1B0092CE8E = {
 						CreatedOnToolsVersion = 8.3.2;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0910;
 						ProvisioningStyle = Automatic;
 					};
 				};

--- a/WordPressKit/WordPressKit/AccountSettingsRemote.swift
+++ b/WordPressKit/WordPressKit/AccountSettingsRemote.swift
@@ -3,11 +3,11 @@ import WordPressShared
 import CocoaLumberjack
 
 public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
-    public static let remotes = NSMapTable<AnyObject, AnyObject>(keyOptions: NSPointerFunctions.Options(), valueOptions: NSPointerFunctions.Options.weakMemory)
+    @objc public static let remotes = NSMapTable<AnyObject, AnyObject>(keyOptions: NSPointerFunctions.Options(), valueOptions: NSPointerFunctions.Options.weakMemory)
 
     /// Returns an AccountSettingsRemote with the given api, reusing a previous
     /// remote if it exists.
-    public static func remoteWithApi(_ api: WordPressComRestApi) -> AccountSettingsRemote {
+    @objc public static func remoteWithApi(_ api: WordPressComRestApi) -> AccountSettingsRemote {
         // We're hashing on the authToken because we don't want duplicate api
         // objects for the same account.
         //

--- a/WordPressKit/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/WordPressKit/ActivityServiceRemote.swift
@@ -62,7 +62,7 @@ public class ActivityServiceRemote: ServiceRemoteWordPressComREST {
     ///
     /// - Returns: A restoreID to check the status of the rewind request.
     ///
-    public func restoreSite(_ siteID: Int,
+    @objc public func restoreSite(_ siteID: Int,
                             rewindID: String,
                             success: @escaping (_ restoreID: String) -> Void,
                             failure: @escaping (Error) -> Void) {

--- a/WordPressKit/WordPressKit/BlogJetpackSettingsServiceRemote.swift
+++ b/WordPressKit/WordPressKit/BlogJetpackSettingsServiceRemote.swift
@@ -75,7 +75,7 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.POST(path!,
                                  parameters: parameters,
                                  success: {
-                                    _ in
+                                    _,_  in
                                     success()
                                  }, failure: {
                                     error, _ in
@@ -94,7 +94,7 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.POST(path!,
                                  parameters: parameters,
                                  success: {
-                                    _ in
+                                    _,_  in
                                     success()
                                  }, failure: {
                                     error, _ in
@@ -104,14 +104,14 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
 
     /// Disconnects Jetpack from a site
     ///
-    public func disconnectJetpackFromSite(_ siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    @objc public func disconnectJetpackFromSite(_ siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         let endpoint = "jetpack-blogs/\(siteID)/mine/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
         wordPressComRestApi.POST(path!,
                                  parameters: nil,
                                  success: {
-                                     _ in
+                                     _,_  in
                                      success()
                                  }, failure: {
                                      error, _ in

--- a/WordPressKit/WordPressKit/KeyringConnection.swift
+++ b/WordPressKit/WordPressKit/KeyringConnection.swift
@@ -7,18 +7,18 @@ import Foundation
 /// but also treated like it is a Remote Object.
 ///
 open class KeyringConnection: NSObject {
-    open var additionalExternalUsers = [KeyringConnectionExternalUser]()
-    open var dateIssued = Date()
-    open var dateExpires: Date? = nil
-    open var externalID = "" // Some services uses strings for their IDs
-    open var externalName = ""
-    open var externalDisplay = ""
-    open var externalProfilePicture = ""
-    open var label = ""
-    open var keyringID: NSNumber = 0
-    open var refreshURL = ""
-    open var service = ""
-    open var status = ""
-    open var type = ""
-    open var userID: NSNumber = 0
+    @objc open var additionalExternalUsers = [KeyringConnectionExternalUser]()
+    @objc open var dateIssued = Date()
+    @objc open var dateExpires: Date? = nil
+    @objc open var externalID = "" // Some services uses strings for their IDs
+    @objc open var externalName = ""
+    @objc open var externalDisplay = ""
+    @objc open var externalProfilePicture = ""
+    @objc open var label = ""
+    @objc open var keyringID: NSNumber = 0
+    @objc open var refreshURL = ""
+    @objc open var service = ""
+    @objc open var status = ""
+    @objc open var type = ""
+    @objc open var userID: NSNumber = 0
 }

--- a/WordPressKit/WordPressKit/KeyringConnectionExternalUser.swift
+++ b/WordPressKit/WordPressKit/KeyringConnectionExternalUser.swift
@@ -5,8 +5,8 @@ import Foundation
 /// external service that could be used other than the default account.
 ///
 open class KeyringConnectionExternalUser: NSObject {
-    open var externalID = ""
-    open var externalName = ""
-    open var externalCategory = ""
-    open var externalProfilePicture = ""
+    @objc open var externalID = ""
+    @objc open var externalName = ""
+    @objc open var externalCategory = ""
+    @objc open var externalProfilePicture = ""
 }

--- a/WordPressKit/WordPressKit/NotificationSettingsServiceRemote.swift
+++ b/WordPressKit/WordPressKit/NotificationSettingsServiceRemote.swift
@@ -48,7 +48,7 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: Optional closure to be called on success.
     ///     - failure: Optional closure to be called on failure.
     ///
-    open func updateSettings(_ settings: [String: AnyObject], success: (() -> ())?, failure: ((NSError?) -> Void)?) {
+    @objc open func updateSettings(_ settings: [String: AnyObject], success: (() -> ())?, failure: ((NSError?) -> Void)?) {
         let path = String(format: "me/notifications/settings/")
         let requestUrl = self.path(forEndpoint: path, withVersion: ._1_1)
 
@@ -73,7 +73,7 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: Optional closure to be called on success.
     ///     - failure: Optional closure to be called on failure.
     ///
-    open func registerDeviceForPushNotifications(_ token: String, pushNotificationAppId: String, success: ((_ deviceId: String) -> ())?, failure: ((NSError) -> Void)?) {
+    @objc open func registerDeviceForPushNotifications(_ token: String, pushNotificationAppId: String, success: ((_ deviceId: String) -> ())?, failure: ((NSError) -> Void)?) {
         let endpoint = "devices/new"
         let requestUrl = path(forEndpoint: endpoint, withVersion: ._1_1)
 
@@ -117,7 +117,7 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: Optional closure to be called on success.
     ///     - failure: Optional closure to be called on failure.
     ///
-    open func unregisterDeviceForPushNotifications(_ deviceId: String, success: (() -> ())?, failure: ((NSError) -> Void)?) {
+    @objc open func unregisterDeviceForPushNotifications(_ deviceId: String, success: (() -> ())?, failure: ((NSError) -> Void)?) {
         let endpoint = String(format: "devices/%@/delete", deviceId)
         let requestUrl = path(forEndpoint: endpoint, withVersion: ._1_1)
 

--- a/WordPressKit/WordPressKit/NotificationSyncServiceRemote.swift
+++ b/WordPressKit/WordPressKit/NotificationSyncServiceRemote.swift
@@ -58,7 +58,7 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
     ///     - read: The new Read Status to set.
     ///     - completion: Closure to be executed on completion, indicating whether the OP was successful or not.
     ///
-    public func updateReadStatus(_ notificationID: String, read: Bool, completion: @escaping ((Error?) -> Void)) {
+    @objc public func updateReadStatus(_ notificationID: String, read: Bool, completion: @escaping ((Error?) -> Void)) {
         let path = "notifications/read"
         let requestUrl = self.path(forEndpoint: path, withVersion: ._1_1)
 
@@ -85,7 +85,7 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
     ///     - timestamp: Timestamp of the last seen notification.
     ///     - completion: Closure to be executed on completion, indicating whether the OP was successful or not.
     ///
-    public func updateLastSeen(_ timestamp: String, completion: @escaping ((Error?) -> Void)) {
+    @objc public func updateLastSeen(_ timestamp: String, completion: @escaping ((Error?) -> Void)) {
         let path = "notifications/seen"
         let requestUrl = self.path(forEndpoint: path, withVersion: ._1_1)
 

--- a/WordPressKit/WordPressKit/PeopleServiceRemote.swift
+++ b/WordPressKit/WordPressKit/PeopleServiceRemote.swift
@@ -214,7 +214,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: Optional closure to be executed on success
     ///     - failure: Optional closure to be executed on error.
     ///
-    public func deleteFollower(_ siteID: Int,
+    @objc public func deleteFollower(_ siteID: Int,
                         userID: Int,
                         success: (() -> Void)? = nil,
                         failure: ((Error) -> Void)? = nil) {
@@ -237,7 +237,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: Optional closure to be executed on success
     ///     - failure: Optional closure to be executed on error.
     ///
-    public func deleteViewer(_ siteID: Int,
+    @objc public func deleteViewer(_ siteID: Int,
                       userID: Int,
                       success: (() -> Void)? = nil,
                       failure: ((Error) -> Void)? = nil) {
@@ -290,7 +290,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: Closure to be executed on success.
     ///     - failure: Closure to be executed on failure. The remote error will be passed on.
     ///
-    public func validateInvitation(_ siteID: Int,
+    @objc public func validateInvitation(_ siteID: Int,
                             usernameOrEmail: String,
                             role: String,
                             success: @escaping (() -> Void),
@@ -332,7 +332,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: Closure to be executed on success.
     ///     - failure: Closure to be executed on failure. The remote error will be passed on.
     ///
-    public func sendInvitation(_ siteID: Int,
+    @objc public func sendInvitation(_ siteID: Int,
                         usernameOrEmail: String,
                         role: String,
                         message: String,

--- a/WordPressKit/WordPressKit/PluginServiceRemote.swift
+++ b/WordPressKit/WordPressKit/PluginServiceRemote.swift
@@ -30,35 +30,35 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         })
     }
 
-    public func activatePlugin(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    @objc public func activatePlugin(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         let parameters = [
             "active": "true"
             ] as [String: AnyObject]
         updatePlugin(parameters: parameters, pluginID: pluginID, siteID: siteID, success: success, failure: failure)
     }
 
-    public func deactivatePlugin(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    @objc public func deactivatePlugin(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         let parameters = [
             "active": "false"
             ] as [String: AnyObject]
         updatePlugin(parameters: parameters, pluginID: pluginID, siteID: siteID, success: success, failure: failure)
     }
 
-    public func enableAutoupdates(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    @objc public func enableAutoupdates(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         let parameters = [
             "autoupdate": "true"
             ] as [String: AnyObject]
         updatePlugin(parameters: parameters, pluginID: pluginID, siteID: siteID, success: success, failure: failure)
     }
 
-    public func disableAutoupdates(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    @objc public func disableAutoupdates(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         let parameters = [
             "autoupdate": "false"
             ] as [String: AnyObject]
         updatePlugin(parameters: parameters, pluginID: pluginID, siteID: siteID, success: success, failure: failure)
     }
 
-    public func remove(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    @objc public func remove(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         guard let escapedPluginID = encoded(pluginID: pluginID) else {
             return
         }
@@ -68,7 +68,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.POST(
             path,
             parameters: nil,
-            success: { _ in
+            success: { _,_  in
                 success()
             }, failure: { (error, _) in
                 failure(error)
@@ -86,7 +86,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.POST(
             path,
             parameters: parameters,
-            success: { _ in
+            success: { _,_  in
                 success()
             },
             failure: { (error, _) in

--- a/WordPressKit/WordPressKit/PushAuthenticationServiceRemote.swift
+++ b/WordPressKit/WordPressKit/PushAuthenticationServiceRemote.swift
@@ -11,7 +11,7 @@ import Foundation
     ///     - success: Closure to be executed on success. Can be nil.
     ///     - failure: Closure to be executed on failure. Can be nil.
     ///
-    open func authorizeLogin(_ token: String, success: (() -> ())?, failure: (() -> ())?) {
+    @objc open func authorizeLogin(_ token: String, success: (() -> ())?, failure: (() -> ())?) {
         let path = "me/two-step/push-authentication"
         let requestUrl = self.path(forEndpoint: path, withVersion: ._1_1)
 

--- a/WordPressKit/WordPressKit/RemoteBlogSettings.swift
+++ b/WordPressKit/WordPressKit/RemoteBlogSettings.swift
@@ -8,33 +8,33 @@ public class RemoteBlogSettings: NSObject {
 
     /// Represents the Blog Name.
     ///
-    public var name: String?
+    @objc public var name: String?
 
     /// Stores the Blog's Tagline setting.
     ///
-    public var tagline: String?
+    @objc public var tagline: String?
 
     /// Stores the Blog's Privacy Preferences Settings
     ///
-    public var privacy: NSNumber?
+    @objc public var privacy: NSNumber?
 
     /// Stores the Blog's Language ID Setting
     ///
-    public var languageID: NSNumber?
+    @objc public var languageID: NSNumber?
 
     /// Stores the Blog's Icon Media ID
     ///
-    public var iconMediaID: NSNumber?
+    @objc public var iconMediaID: NSNumber?
 
     // MARK: - Writing
 
     /// Contains the Default Category ID. Used when creating new posts.
     ///
-    public var defaultCategoryID: NSNumber?
+    @objc public var defaultCategoryID: NSNumber?
 
     /// Contains the Default Post Format. Used when creating new posts.
     ///
-    public var defaultPostFormat: String?
+    @objc public var defaultPostFormat: String?
 
 
 
@@ -42,74 +42,74 @@ public class RemoteBlogSettings: NSObject {
 
     /// Represents whether comments are allowed, or not.
     ///
-    public var commentsAllowed: NSNumber?
+    @objc public var commentsAllowed: NSNumber?
 
     /// Contains a list of words that would automatically blacklist a comment.
     ///
-    public var commentsBlacklistKeys: String?
+    @objc public var commentsBlacklistKeys: String?
 
     /// If true, comments will be automatically closed after the number of days, specified by `commentsCloseAutomaticallyAfterDays`.
     ///
-    public var commentsCloseAutomatically: NSNumber?
+    @objc public var commentsCloseAutomatically: NSNumber?
 
     /// Represents the number of days comments will be enabled, granted that the `commentsCloseAutomatically`
     /// property is set to true.
     ///
-    public var commentsCloseAutomaticallyAfterDays: NSNumber?
+    @objc public var commentsCloseAutomaticallyAfterDays: NSNumber?
 
     /// When enabled, comments from known users will be whitelisted.
     ///
-    public var commentsFromKnownUsersWhitelisted: NSNumber?
+    @objc public var commentsFromKnownUsersWhitelisted: NSNumber?
 
     /// Indicates the maximum number of links allowed per comment. When a new comment exceeds this number,
     /// it'll be held in queue for moderation.
     ///
-    public var commentsMaximumLinks: NSNumber?
+    @objc public var commentsMaximumLinks: NSNumber?
 
     /// Contains a list of words that cause a comment to require moderation.
     ///
-    public var commentsModerationKeys: String?
+    @objc public var commentsModerationKeys: String?
 
     /// If true, comment pagination will be enabled.
     ///
-    public var commentsPagingEnabled: NSNumber?
+    @objc public var commentsPagingEnabled: NSNumber?
 
     /// Specifies the number of comments per page. This will be used only if the property `commentsPagingEnabled`
     /// is set to true.
     ///
-    public var commentsPageSize: NSNumber?
+    @objc public var commentsPageSize: NSNumber?
 
     /// When enabled, new comments will require Manual Moderation, before showing up.
     ///
-    public var commentsRequireManualModeration: NSNumber?
+    @objc public var commentsRequireManualModeration: NSNumber?
 
     /// If set to true, commenters will be required to enter their name and email.
     ///
-    public var commentsRequireNameAndEmail: NSNumber?
+    @objc public var commentsRequireNameAndEmail: NSNumber?
 
     /// Specifies whether commenters should be registered or not.
     ///
-    public var commentsRequireRegistration: NSNumber?
+    @objc public var commentsRequireRegistration: NSNumber?
 
     /// Indicates the sorting order of the comments. Ascending / Descending, based on the date.
     ///
-    public var commentsSortOrder: String?
+    @objc public var commentsSortOrder: String?
 
     /// Indicates the number of levels allowed per comment.
     ///
-    public var commentsThreadingDepth: NSNumber?
+    @objc public var commentsThreadingDepth: NSNumber?
 
     /// When enabled, comment threading will be supported.
     ///
-    public var commentsThreadingEnabled: NSNumber?
+    @objc public var commentsThreadingEnabled: NSNumber?
 
     /// If set to true, 3rd party sites will be allowed to post pingbacks.
     ///
-    public var pingbackInboundEnabled: NSNumber?
+    @objc public var pingbackInboundEnabled: NSNumber?
 
     /// When Outbound Pingbacks are enabled, 3rd party sites that get linked will be notified.
     ///
-    public var pingbackOutboundEnabled: NSNumber?
+    @objc public var pingbackOutboundEnabled: NSNumber?
 
 
 
@@ -117,46 +117,46 @@ public class RemoteBlogSettings: NSObject {
 
     /// When set to true, Related Posts will be allowed.
     ///
-    public var relatedPostsAllowed: NSNumber?
+    @objc public var relatedPostsAllowed: NSNumber?
 
     /// When set to true, Related Posts will be enabled.
     ///
-    public var relatedPostsEnabled: NSNumber?
+    @objc public var relatedPostsEnabled: NSNumber?
 
     /// Indicates whether related posts should show a headline.
     ///
-    public var relatedPostsShowHeadline: NSNumber?
+    @objc public var relatedPostsShowHeadline: NSNumber?
 
     /// Indicates whether related posts should show thumbnails.
     ///
-    public var relatedPostsShowThumbnails: NSNumber?
+    @objc public var relatedPostsShowThumbnails: NSNumber?
 
 
     // MARK: - Sharing
 
     /// Indicates the style to use for the sharing buttons on a particular blog..
     ///
-    public var sharingButtonStyle: String?
+    @objc public var sharingButtonStyle: String?
 
     /// The title of the sharing label on the user's blog.
     ///
-    public var sharingLabel: String?
+    @objc public var sharingLabel: String?
 
     /// Indicates the twitter username to use when sharing via Twitter
     ///
-    public var sharingTwitterName: String?
+    @objc public var sharingTwitterName: String?
 
     /// Indicates whether related posts should show thumbnails.
     ///
-    public var sharingCommentLikesEnabled: NSNumber?
+    @objc public var sharingCommentLikesEnabled: NSNumber?
 
     /// Indicates whether sharing via post likes has been disabled
     ///
-    public var sharingDisabledLikes: NSNumber?
+    @objc public var sharingDisabledLikes: NSNumber?
 
     /// Indicates whether sharing by reblogging has been disabled
     ///
-    public var sharingDisabledReblogs: NSNumber?
+    @objc public var sharingDisabledReblogs: NSNumber?
 
 
 
@@ -164,7 +164,7 @@ public class RemoteBlogSettings: NSObject {
 
     /// Computed property, meant to help conversion from Remote / String-Based values, into their Integer counterparts
     ///
-    public var commentsSortOrderAscending: Bool {
+    @objc public var commentsSortOrderAscending: Bool {
         set {
             commentsSortOrder = newValue ? RemoteBlogSettings.AscendingStringValue :  RemoteBlogSettings.DescendingStringValue
         }

--- a/WordPressKit/WordPressKit/RemotePublicizeConnection.swift
+++ b/WordPressKit/WordPressKit/RemotePublicizeConnection.swift
@@ -1,22 +1,22 @@
 import Foundation
 
 @objc open class RemotePublicizeConnection: NSObject {
-    open var connectionID: NSNumber = 0
-    open var dateIssued = Date()
-    open var dateExpires: Date? = nil
-    open var externalID = ""
-    open var externalName = ""
-    open var externalDisplay = ""
-    open var externalProfilePicture = ""
-    open var externalProfileURL = ""
-    open var externalFollowerCount: NSNumber = 0
-    open var keyringConnectionID: NSNumber = 0
-    open var keyringConnectionUserID: NSNumber = 0
-    open var label = ""
-    open var refreshURL = ""
-    open var service = ""
-    open var shared = false
-    open var status = ""
-    open var siteID: NSNumber = 0
-    open var userID: NSNumber = 0
+    @objc open var connectionID: NSNumber = 0
+    @objc open var dateIssued = Date()
+    @objc open var dateExpires: Date? = nil
+    @objc open var externalID = ""
+    @objc open var externalName = ""
+    @objc open var externalDisplay = ""
+    @objc open var externalProfilePicture = ""
+    @objc open var externalProfileURL = ""
+    @objc open var externalFollowerCount: NSNumber = 0
+    @objc open var keyringConnectionID: NSNumber = 0
+    @objc open var keyringConnectionUserID: NSNumber = 0
+    @objc open var label = ""
+    @objc open var refreshURL = ""
+    @objc open var service = ""
+    @objc open var shared = false
+    @objc open var status = ""
+    @objc open var siteID: NSNumber = 0
+    @objc open var userID: NSNumber = 0
 }

--- a/WordPressKit/WordPressKit/RemotePublicizeService.swift
+++ b/WordPressKit/WordPressKit/RemotePublicizeService.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 @objc open class RemotePublicizeService: NSObject {
-    open var connectURL = ""
-    open var detail = ""
-    open var icon = ""
-    open var jetpackSupport = false
-    open var jetpackModuleRequired = ""
-    open var label = ""
-    open var multipleExternalUserIDSupport = false
-    open var order: NSNumber = 0
-    open var serviceID = ""
-    open var type = ""
+    @objc open var connectURL = ""
+    @objc open var detail = ""
+    @objc open var icon = ""
+    @objc open var jetpackSupport = false
+    @objc open var jetpackModuleRequired = ""
+    @objc open var label = ""
+    @objc open var multipleExternalUserIDSupport = false
+    @objc open var order: NSNumber = 0
+    @objc open var serviceID = ""
+    @objc open var type = ""
 }

--- a/WordPressKit/WordPressKit/RemoteReaderCrossPostMeta.swift
+++ b/WordPressKit/WordPressKit/RemoteReaderCrossPostMeta.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 open class RemoteReaderCrossPostMeta: NSObject {
-    open var postID: NSNumber = 0
-    open var siteID: NSNumber = 0
-    open var siteURL = ""
-    open var postURL = ""
-    open var commentURL = ""
+    @objc open var postID: NSNumber = 0
+    @objc open var siteID: NSNumber = 0
+    @objc open var siteURL = ""
+    @objc open var postURL = ""
+    @objc open var commentURL = ""
 }

--- a/WordPressKit/WordPressKit/RemoteSharingButton.swift
+++ b/WordPressKit/WordPressKit/RemoteSharingButton.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 @objc open class RemoteSharingButton: NSObject {
-    open var buttonID = ""
-    open var name = ""
-    open var shortname = ""
-    open var custom = false
-    open var enabled = false
-    open var visibility: String?
-    open var order: NSNumber = 0
+    @objc open var buttonID = ""
+    @objc open var name = ""
+    @objc open var shortname = ""
+    @objc open var custom = false
+    @objc open var enabled = false
+    @objc open var visibility: String?
+    @objc open var order: NSNumber = 0
 }

--- a/WordPressKit/WordPressKit/SharingServiceRemote.swift
+++ b/WordPressKit/WordPressKit/SharingServiceRemote.swift
@@ -16,7 +16,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///
     /// - Returns: An `NSError` object.
     ///
-    func errorForUnexpectedResponse(_ httpResponse: HTTPURLResponse?) -> NSError {
+    @objc func errorForUnexpectedResponse(_ httpResponse: HTTPURLResponse?) -> NSError {
         let failureReason = "The request returned an unexpected type."
         let domain = "org.wordpress.sharing-management"
         let code = 0
@@ -41,7 +41,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: An optional success block accepting an array of `RemotePublicizeService` objects.
     ///     - failure: An optional failure block accepting an `NSError` argument.
     ///
-    open func getPublicizeServices(_ success: (([RemotePublicizeService]) -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc open func getPublicizeServices(_ success: (([RemotePublicizeService]) -> Void)?, failure: ((NSError?) -> Void)?) {
         let endpoint = "meta/external-services"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let params = ["type": "publicize"]
@@ -98,7 +98,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: An optional success block accepting an array of `KeyringConnection` objects.
     ///     - failure: An optional failure block accepting an `NSError` argument.
     ///
-    open func getKeyringConnections(_ success: (([KeyringConnection]) -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc open func getKeyringConnections(_ success: (([KeyringConnection]) -> Void)?, failure: ((NSError?) -> Void)?) {
         let endpoint = "me/keyring-connections"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
@@ -174,7 +174,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: An optional success block accepting an array of `RemotePublicizeConnection` objects.
     ///     - failure: An optional failure block accepting an `NSError` argument.
     ///
-    open func getPublicizeConnections(_ siteID: NSNumber, success: (([RemotePublicizeConnection]) -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc open func getPublicizeConnections(_ siteID: NSNumber, success: (([RemotePublicizeConnection]) -> Void)?, failure: ((NSError?) -> Void)?) {
         let endpoint = "sites/\(siteID)/publicize-connections"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
@@ -213,7 +213,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: An optional success block accepting a `RemotePublicizeConnection` object.
     ///     - failure: An optional failure block accepting an `NSError` argument.
     ///
-    open func createPublicizeConnection(_ siteID: NSNumber,
+    @objc open func createPublicizeConnection(_ siteID: NSNumber,
         keyringConnectionID: NSNumber,
         externalUserID: String?,
         success: ((RemotePublicizeConnection) -> Void)?,
@@ -259,7 +259,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: An optional success block accepting no arguments.
     ///     - failure: An optional failure block accepting an `NSError` argument.
     ///
-    open func updatePublicizeConnectionWithID(_ connectionID: NSNumber,
+    @objc open func updatePublicizeConnectionWithID(_ connectionID: NSNumber,
         externalID: String?,
         forSite siteID: NSNumber,
         success: ((RemotePublicizeConnection) -> Void)?,
@@ -302,7 +302,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: An optional success block accepting no arguments.
     ///     - failure: An optional failure block accepting an `NSError` argument.
     ///
-    open func updatePublicizeConnectionWithID(_ connectionID: NSNumber,
+    @objc open func updatePublicizeConnectionWithID(_ connectionID: NSNumber,
         shared: Bool,
         forSite siteID: NSNumber,
         success: ((RemotePublicizeConnection) -> Void)?,
@@ -342,7 +342,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: An optional success block accepting no arguments.
     ///     - failure: An optional failure block accepting an `NSError` argument.
     ///
-    open func deletePublicizeConnection(_ siteID: NSNumber, connectionID: NSNumber, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc open func deletePublicizeConnection(_ siteID: NSNumber, connectionID: NSNumber, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         let endpoint = "sites/\(siteID)/publicize-connections/\(connectionID)/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
@@ -415,7 +415,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: An optional success block accepting an array of `RemoteSharingButton` objects.
     ///     - failure: An optional failure block accepting an `NSError` argument.
     ///
-    open func getSharingButtonsForSite(_ siteID: NSNumber, success: (([RemoteSharingButton]) -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc open func getSharingButtonsForSite(_ siteID: NSNumber, success: (([RemoteSharingButton]) -> Void)?, failure: ((NSError?) -> Void)?) {
         let endpoint = "sites/\(siteID)/sharing-buttons"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
@@ -450,7 +450,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: An optional success block accepting an array of `RemoteSharingButton` objects.
     ///     - failure: An optional failure block accepting an `NSError` argument.
     ///
-    open func updateSharingButtonsForSite(_ siteID: NSNumber, sharingButtons: [RemoteSharingButton], success: (([RemoteSharingButton]) -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc open func updateSharingButtonsForSite(_ siteID: NSNumber, sharingButtons: [RemoteSharingButton], success: (([RemoteSharingButton]) -> Void)?, failure: ((NSError?) -> Void)?) {
         let endpoint = "sites/\(siteID)/sharing-buttons"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let buttons = dictionariesFromRemoteSharingButtons(sharingButtons)

--- a/WordPressKit/WordPressKit/SiteManagementServiceRemote.swift
+++ b/WordPressKit/WordPressKit/SiteManagementServiceRemote.swift
@@ -11,7 +11,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
     ///    - success: Optional success block with no parameters
     ///    - failure: Optional failure block with NSError
     ///
-    open func deleteSite(_ siteID: NSNumber, success: (() -> Void)?, failure: ((NSError) -> Void)?) {
+    @objc open func deleteSite(_ siteID: NSNumber, success: (() -> Void)?, failure: ((NSError) -> Void)?) {
         let endpoint = "sites/\(siteID)/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
@@ -48,7 +48,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
     ///    - success: Optional success block with no parameters
     ///    - failure: Optional failure block with NSError
     ///
-    open func exportContent(_ siteID: NSNumber, success: (() -> Void)?, failure: ((NSError) -> Void)?) {
+    @objc open func exportContent(_ siteID: NSNumber, success: (() -> Void)?, failure: ((NSError) -> Void)?) {
         let endpoint = "sites/\(siteID)/exports/start"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
@@ -82,7 +82,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: Optional success block with array of purchases (if any)
     ///     - failure: Optional failure block with NSError
     ///
-    open func getActivePurchases(_ siteID: NSNumber, success: (([SitePurchase]) -> Void)?, failure: ((NSError) -> Void)?) {
+    @objc open func getActivePurchases(_ siteID: NSNumber, success: (([SitePurchase]) -> Void)?, failure: ((NSError) -> Void)?) {
         let endpoint = "sites/\(siteID)/purchases"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 

--- a/WordPressKit/WordPressKit/SocialLogin2FANonceInfo.swift
+++ b/WordPressKit/WordPressKit/SocialLogin2FANonceInfo.swift
@@ -2,12 +2,12 @@ import Foundation
 
 @objc
 public class SocialLogin2FANonceInfo: NSObject {
-    var nonceSMS = ""
-    var nonceBackup = ""
-    var nonceAuthenticator = ""
-    var supportedAuthTypes = [String]() // backup|authenticator|sms
-    var notificationSent = "" // none|sms
-    var phoneNumber = "" // The last two digits of the phone number to which an SMS was sent.
+    @objc var nonceSMS = ""
+    @objc var nonceBackup = ""
+    @objc var nonceAuthenticator = ""
+    @objc var supportedAuthTypes = [String]() // backup|authenticator|sms
+    @objc var notificationSent = "" // none|sms
+    @objc var phoneNumber = "" // The last two digits of the phone number to which an SMS was sent.
 
     private enum Constants {
         static let lastUsedPlaceholder = "last_used_placeholder"
@@ -38,7 +38,7 @@ public class SocialLogin2FANonceInfo: NSObject {
         return typeNoncePair
     }
 
-    public func updateNonce(with newNonce: String) {
+    @objc public func updateNonce(with newNonce: String) {
         switch Constants.lastUsedPlaceholder {
         case nonceSMS:
             nonceSMS = newNonce

--- a/WordPressKit/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressKit/WordPressComOAuthClient.swift
@@ -20,14 +20,14 @@ import CocoaLumberjack
 ///
 public final class WordPressComOAuthClient: NSObject {
 
-    public static let WordPressComOAuthErrorResponseObjectKey = "WordPressComOAuthErrorResponseObjectKey"
-    public static let WordPressComOAuthErrorNewNonceKey = "WordPressComOAuthErrorNewNonceKey"
-    public static let WordPressComOAuthErrorDomain = "WordPressComOAuthError"
-    public static let WordPressComOAuthBaseUrl = "https://public-api.wordpress.com/oauth2"
-    public static let WordPressComSocialLoginUrl = "https://wordpress.com/wp-login.php?action=social-login-endpoint&version=1.0"
-    public static let WordPressComSocialLogin2FAUrl = "https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint&version=1.0"
-    public static let WordPressComOAuthRedirectUrl = "https://wordpress.com/"
-    public static let WordPressComSocialLoginEndpointVersion = 1.0
+    @objc public static let WordPressComOAuthErrorResponseObjectKey = "WordPressComOAuthErrorResponseObjectKey"
+    @objc public static let WordPressComOAuthErrorNewNonceKey = "WordPressComOAuthErrorNewNonceKey"
+    @objc public static let WordPressComOAuthErrorDomain = "WordPressComOAuthError"
+    @objc public static let WordPressComOAuthBaseUrl = "https://public-api.wordpress.com/oauth2"
+    @objc public static let WordPressComSocialLoginUrl = "https://wordpress.com/wp-login.php?action=social-login-endpoint&version=1.0"
+    @objc public static let WordPressComSocialLogin2FAUrl = "https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint&version=1.0"
+    @objc public static let WordPressComOAuthRedirectUrl = "https://wordpress.com/"
+    @objc public static let WordPressComSocialLoginEndpointVersion = 1.0
 
     fileprivate let clientID: String
     fileprivate let secret: String
@@ -55,7 +55,7 @@ public final class WordPressComOAuthClient: NSObject {
     /// Creates a WordPresComOAuthClient initialized with the clientID and secret constants defined in the
     /// ApiCredentials singleton
     ///
-    public class func client(clientID: String, secret: String) -> WordPressComOAuthClient {
+    @objc public class func client(clientID: String, secret: String) -> WordPressComOAuthClient {
         let client = WordPressComOAuthClient(clientID: clientID, secret: secret)
         return client
     }
@@ -66,7 +66,7 @@ public final class WordPressComOAuthClient: NSObject {
     ///     - clientID: the app oauth clientID
     ///     - secret: the app secret
     ///
-    public init(clientID: String, secret: String) {
+    @objc public init(clientID: String, secret: String) {
         self.clientID = clientID
         self.secret = secret
     }
@@ -80,7 +80,7 @@ public final class WordPressComOAuthClient: NSObject {
     ///     - success: block to be called if authentication was successful. The OAuth2 token is passed as a parameter.
     ///     - failure: block to be called if authentication failed. The error object is passed as a parameter.
     ///
-    public func authenticateWithUsername(_ username: String,
+    @objc public func authenticateWithUsername(_ username: String,
                                   password: String,
                                   multifactorCode: String?,
                                   success: @escaping (_ authToken: String?) -> (),
@@ -122,7 +122,7 @@ public final class WordPressComOAuthClient: NSObject {
     ///     - success: block to be called if authentication was successful.
     ///     - failure: block to be called if authentication failed. The error object is passed as a parameter.
     ///
-    public func requestOneTimeCodeWithUsername(_ username: String, password: String,
+    @objc public func requestOneTimeCodeWithUsername(_ username: String, password: String,
                                         success: @escaping () -> (), failure: @escaping (_ error: NSError) -> ()) {
         let parameters = [
             "username": username,
@@ -151,7 +151,7 @@ public final class WordPressComOAuthClient: NSObject {
     ///     - needsMultifactor: block to be called if a 2fa token is needed to complete the auth process.
     ///     - failure: block to be called if authentication failed. The error object is passed as a parameter.
     ///
-    public func authenticateWithIDToken(_ token: String,
+    @objc public func authenticateWithIDToken(_ token: String,
                                         success: @escaping (_ authToken: String?) -> Void,
                                         needsMultifactor: @escaping (_ userID: Int, _ nonceInfo: SocialLogin2FANonceInfo) -> Void,
                                         existingUserNeedsConnection: @escaping (_ email: String) -> Void,
@@ -264,7 +264,7 @@ public final class WordPressComOAuthClient: NSObject {
     ///     - success: block to be called if authentication was successful. The OAuth2 token is passed as a parameter.
     ///     - failure: block to be called if authentication failed. The error object is passed as a parameter.
     ///
-    public func authenticateSocialLoginUser(_ userID: Int,
+    @objc public func authenticateSocialLoginUser(_ userID: Int,
                                             authType: String,
                                             twoStepCode: String,
                                             twoStepNonce: String,
@@ -405,7 +405,7 @@ final class WordPressComOAuthResponseSerializer: AFJSONResponseSerializer {
     ///   - responseObject: The responseObject (if any) that was passed with the error.
     ///   - newNonce: *optional* The new nonce provided when a 2FA fails
     /// - Returns: An NSError.
-    func errorFor(errorCode: String, errorDescription: String, responseObject: Any?, newNonce: String? = nil) -> NSError {
+    @objc func errorFor(errorCode: String, errorDescription: String, responseObject: Any?, newNonce: String? = nil) -> NSError {
         var userInfo:[String: AnyObject] = [NSLocalizedDescriptionKey: errorDescription as AnyObject]
         if let responseObject = responseObject {
             userInfo[WordPressComOAuthClient.WordPressComOAuthErrorResponseObjectKey] = responseObject as AnyObject

--- a/WordPressKit/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressKit/WordPressComRestApi.swift
@@ -24,21 +24,21 @@ import WordPressShared
 }
 
 open class WordPressComRestApi: NSObject {
-    open static let ErrorKeyResponseData: String = AFNetworkingOperationFailingURLResponseDataErrorKey
-    open static let ErrorKeyErrorCode: String = "WordPressComRestApiErrorCodeKey"
-    open static let ErrorKeyErrorMessage: String = "WordPressComRestApiErrorMessageKey"
+    @objc open static let ErrorKeyResponseData: String = AFNetworkingOperationFailingURLResponseDataErrorKey
+    @objc open static let ErrorKeyErrorCode: String = "WordPressComRestApiErrorCodeKey"
+    @objc open static let ErrorKeyErrorMessage: String = "WordPressComRestApiErrorMessageKey"
 
     public typealias RequestEnqueuedBlock = () -> Void
     public typealias SuccessResponseBlock = (_ responseObject: AnyObject, _ httpResponse: HTTPURLResponse?) -> ()
     public typealias FailureReponseBlock = (_ error: NSError, _ httpResponse: HTTPURLResponse?) -> ()
 
-    open static let apiBaseURLString: String = "https://public-api.wordpress.com/"
+    @objc open static let apiBaseURLString: String = "https://public-api.wordpress.com/"
     
-    open static let defaultBackgroundSessionIdentifier = "org.wordpress.wpcomrestapi"
+    @objc open static let defaultBackgroundSessionIdentifier = "org.wordpress.wpcomrestapi"
     
-    open let backgroundSessionIdentifier: String
+    @objc open let backgroundSessionIdentifier: String
 
-    open let sharedContainerIdentifier: String?
+    @objc open let sharedContainerIdentifier: String?
     
     fileprivate let backgroundUploads: Bool
 
@@ -50,7 +50,7 @@ open class WordPressComRestApi: NSObject {
     /**
      Configure whether or not the user's preferred language locale should be appended. Defaults to true.
      */
-    open var appendsPreferredLanguageLocale = true
+    @objc open var appendsPreferredLanguageLocale = true
 
     fileprivate lazy var sessionManager: AFHTTPSessionManager = {
         let sessionConfiguration = URLSessionConfiguration.default
@@ -85,7 +85,7 @@ open class WordPressComRestApi: NSObject {
         return sessionManager
     }
     
-    convenience public init(oAuthToken: String? = nil, userAgent: String? = nil) {
+    @objc convenience public init(oAuthToken: String? = nil, userAgent: String? = nil) {
         self.init(oAuthToken: oAuthToken, userAgent: userAgent, backgroundUploads: false, backgroundSessionIdentifier: WordPressComRestApi.defaultBackgroundSessionIdentifier)
     }
     
@@ -103,7 +103,7 @@ open class WordPressComRestApi: NSObject {
     ///   after the app is killed by the system and the system will retried them until they are done. If the background session is initiated from an app extension, you *must* provide a value
     ///   for the sharedContainerIdentifier.
     ///
-    public init(oAuthToken: String? = nil, userAgent: String? = nil,
+    @objc public init(oAuthToken: String? = nil, userAgent: String? = nil,
                 backgroundUploads: Bool = false,
                 backgroundSessionIdentifier: String = WordPressComRestApi.defaultBackgroundSessionIdentifier,
                 sharedContainerIdentifier: String? = nil) {
@@ -123,7 +123,7 @@ open class WordPressComRestApi: NSObject {
     /**
      Cancels all ongoing taks and makes the session invalid so the object will not fullfil any more request
      */
-    open func invalidateAndCancelTasks() {
+    @objc open func invalidateAndCancelTasks() {
         sessionManager.invalidateSessionCancelingTasks(true)
         uploadSessionManager.invalidateSessionCancelingTasks(true)
     }
@@ -142,7 +142,7 @@ open class WordPressComRestApi: NSObject {
      returns nil it's because something happened on the request serialization and the network request was not started, but the failure callback
      will be invoked with the error specificing the serialization issues.
      */
-    @discardableResult open func GET(_ URLString: String,
+    @objc @discardableResult open func GET(_ URLString: String,
                      parameters: [String: AnyObject]?,
                      success: @escaping SuccessResponseBlock,
                      failure: @escaping FailureReponseBlock) -> Progress? {
@@ -186,7 +186,7 @@ open class WordPressComRestApi: NSObject {
      returns nil it's because something happened on the request serialization and the network request was not started, but the failure callback
      will be invoked with the error specificing the serialization issues.
      */
-    @discardableResult open func POST(_ URLString: String,
+    @objc @discardableResult open func POST(_ URLString: String,
                      parameters: [String: AnyObject]?,
                      success: @escaping SuccessResponseBlock,
                      failure: @escaping FailureReponseBlock) -> Progress? {
@@ -232,7 +232,7 @@ open class WordPressComRestApi: NSObject {
      returns nil it's because something happened on the request serialization and the network request was not started, but the failure callback
      will be invoked with the error specificing the serialization issues.
      */
-    @discardableResult open func multipartPOST(_ URLString: String,
+    @objc @discardableResult open func multipartPOST(_ URLString: String,
                               parameters: [String: AnyObject]?,
                               fileParts: [FilePart],
                               requestEnqueued: RequestEnqueuedBlock? = nil,
@@ -326,7 +326,7 @@ open class WordPressComRestApi: NSObject {
         }
     }
 
-    open func hasCredentials() -> Bool {
+    @objc open func hasCredentials() -> Bool {
         guard let authToken = oAuthToken else {
             return false
         }
@@ -344,9 +344,9 @@ open class WordPressComRestApi: NSObject {
         return WordPressComRestApi.pathByAppendingPreferredLanguageLocale(path)
     }
 
-    open static let WordPressComRestCApiErrorKeyData = "WordPressOrgXMLRPCApiErrorKeyData"
+    @objc open static let WordPressComRestCApiErrorKeyData = "WordPressOrgXMLRPCApiErrorKeyData"
 
-    public func temporaryFileURL(withExtension fileExtension: String) -> URL {
+    @objc public func temporaryFileURL(withExtension fileExtension: String) -> URL {
         assert(!fileExtension.isEmpty, "file Extension cannot be empty")
         let fileName = "\(ProcessInfo.processInfo.globallyUniqueString)_file.\(fileExtension)"
         let fileURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
@@ -356,12 +356,12 @@ open class WordPressComRestApi: NSObject {
 
 /// FilePart represents the infomartion needed to encode a file on a multipart form request
 public final class FilePart: NSObject {
-    let parameterName: String
-    let url: URL
-    let filename: String
-    let mimeType: String
+    @objc let parameterName: String
+    @objc let url: URL
+    @objc let filename: String
+    @objc let mimeType: String
 
-    public init(parameterName: String, url: URL, filename: String, mimeType: String) {
+    @objc public init(parameterName: String, url: URL, filename: String, mimeType: String) {
         self.parameterName = parameterName
         self.url = url
         self.filename = filename
@@ -424,7 +424,7 @@ final class WordPressComRestAPIResponseSerializer: AFJSONResponseSerializer {
         userInfo[NSLocalizedDescriptionKey] =  errorDescription
         error?.pointee = NSError(domain: nserror.domain,
                                code: nserror.code,
-                               userInfo: userInfo
+                               userInfo: userInfo as? [String : Any]
             )
         return responseObject as AnyObject?
     }
@@ -432,7 +432,7 @@ final class WordPressComRestAPIResponseSerializer: AFJSONResponseSerializer {
 
 extension WordPressComRestApi {
     /// Returns an Api object without an oAuthtoken defined and with the userAgent set for the WordPress App user agent
-    class public func anonymousApi(userAgent: String) -> WordPressComRestApi {
+    @objc class public func anonymousApi(userAgent: String) -> WordPressComRestApi {
         return WordPressComRestApi(oAuthToken: nil, userAgent: userAgent)
     }
 
@@ -444,7 +444,7 @@ extension WordPressComRestApi {
     ///
     /// - Returns: The path with the locale appended, or the original path if it already had a locale param.
     ///
-    class public func pathByAppendingPreferredLanguageLocale(_ path: String) -> String {
+    @objc class public func pathByAppendingPreferredLanguageLocale(_ path: String) -> String {
         let localeKey = WordPressComRestApi.localeKey
         if path.isEmpty || path.contains("\(localeKey)=") {
             return path

--- a/WordPressKit/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -11,7 +11,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
     fileprivate let userAgent: String?
     fileprivate var backgroundUploads: Bool
     fileprivate var backgroundSessionIdentifier: String
-    open static let defaultBackgroundSessionIdentifier = "org.wordpress.wporgxmlrpcapi"
+    @objc open static let defaultBackgroundSessionIdentifier = "org.wordpress.wporgxmlrpcapi"
 
     fileprivate lazy var sessionManager: Alamofire.SessionManager = {
         let sessionConfiguration = URLSessionConfiguration.default
@@ -56,7 +56,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
     ///   - userAgent: the user agent to use on the connection.
     ///   - backgroundUploads:  If this value is true the API object will use a background session to execute uploads requests when using the `multipartPOST` function. The default value is false.
     ///   - backgroundSessionIdentifier: The session identifier to use for the background session. This must be unique in the system.
-    public init(endpoint: URL, userAgent: String? = nil, backgroundUploads: Bool = false, backgroundSessionIdentifier: String) {
+    @objc public init(endpoint: URL, userAgent: String? = nil, backgroundUploads: Bool = false, backgroundSessionIdentifier: String) {
         self.endpoint = endpoint
         self.userAgent = userAgent
         self.backgroundUploads = backgroundUploads
@@ -69,7 +69,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
     /// - Parameters:
     ///   - endpoint:  the endpoint to connect to the xmlrpc api interface.
     ///   - userAgent: the user agent to use on the connection.
-    convenience public init(endpoint: URL, userAgent: String? = nil) {
+    @objc convenience public init(endpoint: URL, userAgent: String? = nil) {
         self.init(endpoint: endpoint, userAgent: userAgent, backgroundUploads: false, backgroundSessionIdentifier: WordPressOrgXMLRPCApi.defaultBackgroundSessionIdentifier + "." + endpoint.absoluteString)
     }
 
@@ -81,7 +81,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
     /**
      Cancels all ongoing and makes the session so the object will not fullfil any more request
      */
-    open func invalidateAndCancelTasks() {
+    @objc open func invalidateAndCancelTasks() {
         sessionManager.session.invalidateAndCancel()
         uploadSessionManager.session.invalidateAndCancel()
     }
@@ -95,7 +95,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
      - parameter success:  callback block to be invoked if credentials are valid, the object returned in the block is the options dictionary for the site.
      - parameter failure:  callback block to be invoked is credentials fail
      */
-    open func checkCredentials(_ username: String,
+    @objc open func checkCredentials(_ username: String,
                                  password: String,
                                  success: @escaping SuccessResponseBlock,
                                  failure: @escaping FailureReponseBlock) {
@@ -114,7 +114,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
      returns nil it's because something happened on the request serialization and the network request was not started, but the failure callback
      will be invoked with the error specificing the serialization issues.
      */
-    @discardableResult open func callMethod(_ method: String,
+    @objc @discardableResult open func callMethod(_ method: String,
                            parameters: [AnyObject]?,
                            success: @escaping SuccessResponseBlock,
                            failure: @escaping FailureReponseBlock) -> Progress? {
@@ -162,7 +162,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
      returns nil it's because something happened on the request serialization and the network request was not started, but the failure callback
      will be invoked with the error specificing the serialization issues.
      */
-    @discardableResult open func streamCallMethod(_ method: String,
+    @objc @discardableResult open func streamCallMethod(_ method: String,
                                  parameters: [AnyObject]?,
                                  success: @escaping SuccessResponseBlock,
                                  failure: @escaping FailureReponseBlock) -> Progress? {
@@ -265,15 +265,15 @@ open class WordPressOrgXMLRPCApi: NSObject {
         return responseXML as AnyObject
     }
 
-    open static let WordPressOrgXMLRPCApiErrorKeyData = "WordPressOrgXMLRPCApiErrorKeyData"
-    open static let WordPressOrgXMLRPCApiErrorKeyDataString = "WordPressOrgXMLRPCApiErrorKeyDataString"
+    @objc open static let WordPressOrgXMLRPCApiErrorKeyData = "WordPressOrgXMLRPCApiErrorKeyData"
+    @objc open static let WordPressOrgXMLRPCApiErrorKeyDataString = "WordPressOrgXMLRPCApiErrorKeyDataString"
 
     fileprivate func convertError(_ error: NSError, data: Data?) -> NSError {
         if let data = data {
             var userInfo: [AnyHashable: Any] = error.userInfo
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyDataString] = NSString(data: data, encoding: String.Encoding.utf8.rawValue)
-            return NSError(domain: error.domain, code: error.code, userInfo: userInfo)
+            return NSError(domain: error.domain, code: error.code, userInfo: userInfo as? [String : Any])
         }
         return error
     }
@@ -281,7 +281,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
 
 extension WordPressOrgXMLRPCApi {
 
-    public func urlSession(_ session: URLSession,
+    @objc public func urlSession(_ session: URLSession,
                            didReceive challenge: URLAuthenticationChallenge,
                            completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         switch challenge.protectionSpace.authenticationMethod {
@@ -306,7 +306,7 @@ extension WordPressOrgXMLRPCApi {
         }
     }
 
-    public func urlSession(_ session: URLSession,
+    @objc public func urlSession(_ session: URLSession,
                            task: URLSessionTask,
                            didReceive challenge: URLAuthenticationChallenge,
                                        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {

--- a/WordPressKit/WordPressKit/WordPressOrgXMLRPCValidator.swift
+++ b/WordPressKit/WordPressKit/WordPressOrgXMLRPCValidator.swift
@@ -37,7 +37,7 @@ import CocoaLumberjack
 /// WordPress XMLRPC sites.
 open class WordPressOrgXMLRPCValidator: NSObject {
 
-    open static let UserInfoHasJetpackKey = "UserInfoHasJetpackKey"
+    @objc open static let UserInfoHasJetpackKey = "UserInfoHasJetpackKey"
 
     // The documentation for NSURLErrorHTTPTooManyRedirects says that 16
     // is the default threshold for allowable redirects.
@@ -57,7 +57,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
      - parameter failure: completion handler that is invoked when the site is considered invalid,
      the error object provides details why the endpoint is invalid
      */
-    open func guessXMLRPCURLForSite(_ site: String,
+    @objc open func guessXMLRPCURLForSite(_ site: String,
                                     userAgent: String,
                                       success: @escaping (_ xmlrpcURL: URL) -> (),
                                       failure: @escaping (_ error: NSError) -> ()) {
@@ -247,7 +247,13 @@ open class WordPressOrgXMLRPCValidator: NSObject {
         if matches.count <= 0 {
             return nil
         }
+
+#if swift(>=4.0)
+        let rsdURLRange = matches[0].range(at: 1)
+#else
         let rsdURLRange = matches[0].rangeAt(1)
+#endif
+
         if rsdURLRange.location == NSNotFound {
             return nil
         }

--- a/WordPressKit/WordPressKit/WordPressRSDParser.swift
+++ b/WordPressKit/WordPressKit/WordPressRSDParser.swift
@@ -7,7 +7,7 @@ open class WordPressRSDParser: NSObject, XMLParserDelegate {
     fileprivate let parser: XMLParser
     fileprivate var endpoint: String?
 
-    init?(xmlString: String) {
+    @objc init?(xmlString: String) {
         guard let data = xmlString.data(using: String.Encoding.utf8) else {
             return nil
         }

--- a/WordPressKit/WordPressKitTests/AccountSettingsRemoteTests.swift
+++ b/WordPressKit/WordPressKitTests/AccountSettingsRemoteTests.swift
@@ -129,7 +129,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(meSettingsEndpoint, filename: updateSettingsChangeEmailSuccessMockFilename, contentType: .ApplicationJSON)
         let change = AccountSettingsChange.email(changedEmail)
-        remote.updateSetting(change, success: { something in
+        remote.updateSetting(change, success: { () in
             expect.fulfill()
         }, failure: { error in
             XCTFail("This callback shouldn't get called")
@@ -143,7 +143,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Revert account email success")
 
         stubRemoteResponse(meSettingsEndpoint, filename: updateSettingsRevertEmailSuccessMockFilename, contentType: .ApplicationJSON)
-        remote.updateSetting(.emailRevertPendingChange, success: { something in
+        remote.updateSetting(.emailRevertPendingChange, success: { () in
             expect.fulfill()
         }, failure: { error in
             XCTFail("This callback shouldn't get called")
@@ -158,7 +158,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(meSettingsEndpoint, filename: updateSettingsChangeSiteSuccessMockFilename, contentType: .ApplicationJSON)
         let change = AccountSettingsChange.primarySite(changedSiteID)
-        remote.updateSetting(change, success: { something in
+        remote.updateSetting(change, success: { () in
             expect.fulfill()
         }, failure: { error in
             XCTFail("This callback shouldn't get called")
@@ -173,7 +173,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(meSettingsEndpoint, filename: updateSettingsChangeWebAddressSuccessMockFilename, contentType: .ApplicationJSON)
         let change = AccountSettingsChange.webAddress(changedUserURL)
-        remote.updateSetting(change, success: { something in
+        remote.updateSetting(change, success: { () in
             expect.fulfill()
         }, failure: { error in
             XCTFail("This callback shouldn't get called")
@@ -188,7 +188,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(meSettingsEndpoint, filename: updateSettingsChangeAboutMeSuccessMockFilename, contentType: .ApplicationJSON)
         let change = AccountSettingsChange.aboutMe(changedAboutMe)
-        remote.updateSetting(change, success: { something in
+        remote.updateSetting(change, success: { () in
             expect.fulfill()
         }, failure: { error in
             XCTFail("This callback shouldn't get called")
@@ -203,7 +203,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(meSettingsEndpoint, filename: updateSettingsChangeFirstNameSuccessMockFilename, contentType: .ApplicationJSON)
         let change = AccountSettingsChange.firstName(changedFirstName)
-        remote.updateSetting(change, success: { something in
+        remote.updateSetting(change, success: { () in
             expect.fulfill()
         }, failure: { error in
             XCTFail("This callback shouldn't get called")
@@ -218,7 +218,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(meSettingsEndpoint, filename: updateSettingsChangeLastNameSuccessMockFilename, contentType: .ApplicationJSON)
         let change = AccountSettingsChange.lastName(changedLastName)
-        remote.updateSetting(change, success: { something in
+        remote.updateSetting(change, success: { () in
             expect.fulfill()
         }, failure: { error in
             XCTFail("This callback shouldn't get called")
@@ -233,7 +233,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(meSettingsEndpoint, filename: updateSettingsChangeDisplayNameSuccessMockFilename, contentType: .ApplicationJSON)
         let change = AccountSettingsChange.displayName(changedDisplayName)
-        remote.updateSetting(change, success: { something in
+        remote.updateSetting(change, success: { () in
             expect.fulfill()
         }, failure: { error in
             XCTFail("This callback shouldn't get called")
@@ -248,7 +248,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(meSettingsEndpoint, data: Data(), contentType: .NoContentType, status: 500)
         let change = AccountSettingsChange.displayName(changedDisplayName)
-        remote.updateSetting(change, success: { something in
+        remote.updateSetting(change, success: { () in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -266,7 +266,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(meSettingsEndpoint, filename: updateSettingsChangeDisplayNameBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
         let change = AccountSettingsChange.displayName(changedDisplayName)
-        remote.updateSetting(change, success: { something in
+        remote.updateSetting(change, success: { () in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -281,7 +281,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(meSettingsEndpoint, filename: updateSettingsInvalidInputFailureMockFilename, contentType: .ApplicationJSON, status: 400)
         let change = AccountSettingsChange.displayName(changedDisplayName)
-        remote.updateSetting(change, success: { something in
+        remote.updateSetting(change, success: { () in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in

--- a/WordPressKit/WordPressKitTests/JSONLoader.swift
+++ b/WordPressKit/WordPressKitTests/JSONLoader.swift
@@ -11,9 +11,9 @@ import Foundation
     *
     *  @returns    A dictionary representing the contents of the json file.
     */
-    open func loadFile(_ name: String, type: String) -> JSONDictionary? {
+    @objc open func loadFile(_ name: String, type: String) -> JSONDictionary? {
 
-        let path = Bundle(for: type(of: self)).path(forResource: name, ofType: type)
+        let path = Bundle(for: Swift.type(of: self)).path(forResource: name, ofType: type)
 
         if let unwrappedPath = path {
             return loadFile(unwrappedPath)
@@ -29,7 +29,7 @@ import Foundation
      *
      *  @returns    A dictionary representing the contents of the json file.
      */
-    open func loadFile(_ path: String) -> JSONDictionary? {
+    @objc open func loadFile(_ path: String) -> JSONDictionary? {
 
         if let contents = try? Data(contentsOf: URL(fileURLWithPath: path)) {
             return parseData(contents)

--- a/WordPressKit/WordPressKitTests/MockWordPressComRestApi.swift
+++ b/WordPressKit/WordPressKitTests/MockWordPressComRestApi.swift
@@ -2,12 +2,12 @@ import Foundation
 @testable import WordPressKit
 
 class MockWordPressComRestApi: WordPressComRestApi {
-    var getMethodCalled = false
-    var postMethodCalled = false
-    var URLStringPassedIn: String?
-    var parametersPassedIn: AnyObject?
-    var successBlockPassedIn: ((AnyObject, HTTPURLResponse?) -> Void)?
-    var failureBlockPassedIn: ((NSError, HTTPURLResponse?) -> Void)?
+    @objc var getMethodCalled = false
+    @objc var postMethodCalled = false
+    @objc var URLStringPassedIn: String?
+    @objc var parametersPassedIn: AnyObject?
+    @objc var successBlockPassedIn: ((AnyObject, HTTPURLResponse?) -> Void)?
+    @objc var failureBlockPassedIn: ((NSError, HTTPURLResponse?) -> Void)?
 
     override func GET(_ URLString: String?, parameters: [String: AnyObject]?, success: @escaping ((AnyObject, HTTPURLResponse?) -> Void), failure: @escaping ((NSError, HTTPURLResponse?) -> Void)) -> Progress? {
         getMethodCalled = true
@@ -44,7 +44,7 @@ class MockWordPressComRestApi: WordPressComRestApi {
         return Progress()
     }
 
-    func methodCalled() -> String {
+    @objc func methodCalled() -> String {
 
         var method = "Unknown"
         if getMethodCalled {

--- a/WordPressKit/WordPressKitTests/PeopleServiceRemoteTests.swift
+++ b/WordPressKit/WordPressKitTests/PeopleServiceRemoteTests.swift
@@ -81,7 +81,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Delete user with bad auth failure")
 
         stubRemoteResponse(siteUserDeleteEndpoint, filename: deleteUserAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.deleteUser(siteID, userID: userID, success: { roles in
+        remote.deleteUser(siteID, userID: userID, success: { () in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -98,7 +98,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Delete user with site owner failure")
 
         stubRemoteResponse(siteUserDeleteEndpoint, filename: deleteUserSiteOwnerFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.deleteUser(siteID, userID: userID, success: { roles in
+        remote.deleteUser(siteID, userID: userID, success: { () in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -115,7 +115,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Delete user with non site member failure")
 
         stubRemoteResponse(siteUserDeleteEndpoint, filename: deleteUserNonMemberFailureMockFilename, contentType: .ApplicationJSON, status: 400)
-        remote.deleteUser(siteID, userID: userID, success: { roles in
+        remote.deleteUser(siteID, userID: userID, success: { () in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in

--- a/WordPressKit/WordPressKitTests/PluginServiceRemoteTests.swift
+++ b/WordPressKit/WordPressKitTests/PluginServiceRemoteTests.swift
@@ -53,7 +53,7 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(sitePluginsEndpoint,
                            filename: getPluginsErrorMockFilename,
                            contentType: .ApplicationJSON)
-        remote.getPlugins(siteID: siteID, success: { (plugins) in
+        remote.getPlugins(siteID: siteID, success: { (_, _)  in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { (error) in


### PR DESCRIPTION
### Details:
This PR is a follow up to #8159 (and should be reviewed after the former is merged). We'll introduce a few changes that make the WordPressKit Target Swift 4.0 friendly.

Needs Review: @diegoreymendez 
Thanks in advance!

### To test:
1. Verify that the app builds as usual
2. Toggle WordPressShared an WordPressKit to Swift 4.0
3. Verify that the app builds!
4. Verify that the WordPressKit Unit Tests are green
