### PR TITLE
Change background color to white on FAQ search

### DIFF
--- a/WordPress/HelpshiftCustomConfig.plist
+++ b/WordPress/HelpshiftCustomConfig.plist
@@ -56,7 +56,7 @@
 		<key>Bar button font size</key>
 		<string></string>
 		<key>Background color</key>
-		<string></string>
+		<string>FFFFFF</string>
 		<key>Set Translucent</key>
 		<true/>
 	</dict>


### PR DESCRIPTION
**Fixes** #8153 

As part of iOS 11 changes, the background color of the search field in our FAQ section became dark blue, making it impossible to read what was being typed. Due to iOS 11 changes and the fact that this ViewController is presented entirely by Helpshift we can not fully control how it looks, so currently we are just setting the background color to white to improve readibility. Not a good looking solution but the best we can do without a Helpshift update (we have contacted them regarding this issue).

Before|After
-|-
![simulator screen shot - iphone 8 - 2017-11-15 at 11 54 54](https://user-images.githubusercontent.com/5558824/32842432-d2713226-c9fb-11e7-93a3-28179735c4c3.png)|![simulator screen shot - iphone 8 - 2017-11-15 at 11 08 47](https://user-images.githubusercontent.com/5558824/32841696-c9173f92-c9f9-11e7-9723-192e2eb924e7.png)

**To test:**

1. Me->WordPress Help Center, check that the background of the Search field is light gray.
2. Test that other Helpshift functionalities (like Contact Us) work and look as expected.

