### PR TITLE
Remove feature flag for Jetpack comments on Reader

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -7,7 +7,6 @@ enum FeatureFlag: Int {
     case pluginManagement
     case googleLogin
     case jetpackDisconnect
-    case jetpackCommentsOnReader
     case asyncUploadsInMediaLibrary
     case activity
 
@@ -24,8 +23,6 @@ enum FeatureFlag: Int {
             return true
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
-        case .jetpackCommentsOnReader:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .asyncUploadsInMediaLibrary:
             return BuildConfiguration.current == .localDeveloper
         case .activity:

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -438,7 +438,7 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         // Show comments if logged in and comments are enabled, or if comments exist.
         // But only if it is from wpcom or jetpack (external is not yet supported).
         // Nesting this conditional cos it seems clearer that way
-        if contentProvider!.isWPCom() || (contentProvider!.isJetpack() && FeatureFlag.jetpackCommentsOnReader.enabled) {
+        if contentProvider!.isWPCom() || contentProvider!.isJetpack() {
             if (enableLoggedInFeatures && contentProvider!.commentsOpen()) || contentProvider!.commentCount().intValue > 0 {
 
                 commentActionButton.tag = CardAction.comment.rawValue


### PR DESCRIPTION
**Fixes** #7662 
I have checked with the Reader team and we are ready to flip the switch on this one.

**To test:**
Check that comments are enabled for Jetpack sites on Reader for a production build.

