### PR TITLE
Fix for issues sharing web pages from Safari

### DIFF
--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -130,6 +130,9 @@ private extension TypeBasedExtensionContentExtractor {
 
     func extract(context: NSExtensionContext, completion: @escaping (ExtractedItem?) -> Void) {
         guard let provider = context.itemProviders(ofType: acceptedType).first else {
+            DispatchQueue.main.async {
+                completion(nil)
+            }
             return
         }
         provider.loadItem(forTypeIdentifier: acceptedType, options: nil) { (payload, error) in

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -259,7 +259,11 @@ private extension ShareViewController {
 
     func uploadPost(subject: String, body: String, status: String, siteID: Int, requestEnqueued: @escaping () -> ()) {
         // 15-Nov-2017: Creating a post without media on the PostServiceRemoteREST does not use background uploads so set it false
-        let api = WordPressComRestApi(oAuthToken: oauth2Token, userAgent: nil, backgroundUploads: false, backgroundSessionIdentifier: backgroundSessionIdentifier, sharedContainerIdentifier: WPAppGroupName)
+        let api = WordPressComRestApi(oAuthToken: oauth2Token,
+                                      userAgent: nil,
+                                      backgroundUploads: false,
+                                      backgroundSessionIdentifier: backgroundSessionIdentifier,
+                                      sharedContainerIdentifier: WPAppGroupName)
         let remote = PostServiceRemoteREST.init(wordPressComRestApi: api, siteID: NSNumber(value: siteID))
         let remotePost: RemotePost = {
             let post = RemotePost()
@@ -291,7 +295,11 @@ private extension ShareViewController {
                 return
         }
 
-        let api = WordPressComRestApi(oAuthToken: oauth2Token, userAgent: nil, backgroundUploads: true, backgroundSessionIdentifier: backgroundSessionIdentifier, sharedContainerIdentifier: WPAppGroupName)
+        let api = WordPressComRestApi(oAuthToken: oauth2Token,
+                                      userAgent: nil,
+                                      backgroundUploads: true,
+                                      backgroundSessionIdentifier: backgroundSessionIdentifier,
+                                      sharedContainerIdentifier: WPAppGroupName)
         let remote = PostServiceRemoteREST.init(wordPressComRestApi: api, siteID: NSNumber(value: siteID))
         let remotePost: RemotePost = {
             let post = RemotePost()


### PR DESCRIPTION
![sharing_issue](https://user-images.githubusercontent.com/154014/32859280-a0db00a8-ca13-11e7-84fc-75ce83643577.gif)

## Discussion

Fixes #8166 

This PR provides a fix for sharing web pages from Safari. See the bug for more details. In addition, a small change to `ShareExtractor` was made so the post's content body is properly filled when sharing a web page (including highlighted text). Previously it was left blank because the [completion handler](https://github.com/wordpress-mobile/WordPress-iOS/blob/13026fb5972644e6d8f9962ceea77ae155d2e4fb/WordPress/WordPressShareExtension/ShareExtractor.swift#L55) was never called.

## To Test
1. Initiate sharing a web page to WPiOS in Safari. In the share UI, verify the post Title and Body are pre-filled and Safari doesn't hang when the post button is tapped. Check the destination site to make sure the post saved correctly.

2.  Initiate sharing a photo to WPiOS from Photos.  In the share UI, verify the correct image is staged. Check the destination site to make sure the post saved correctly.

@elibud Could you review this?
