### PR TITLE
Social Login: request a new SMS code for 2FA

### DIFF
--- a/WordPress/Classes/Services/LoginFacade.h
+++ b/WordPress/Classes/Services/LoginFacade.h
@@ -45,6 +45,13 @@
 - (void)requestOneTimeCodeWithLoginFields:(LoginFields *)loginFields;
 
 /**
+ *  This method requests a one time code needed for 2fa when using social login
+ *
+ *  @param loginFields the fields representing the site we need a 2fa code for.
+ */
+- (void)requestSocial2FACodeWithLoginFields:(LoginFields *)loginFields;
+
+/**
  * Social login via google.
  *
  * @param googleIDToken A Google id_token.

--- a/WordPress/Classes/Services/LoginFacade.m
+++ b/WordPress/Classes/Services/LoginFacade.m
@@ -61,6 +61,23 @@
     }];
 }
 
+- (void)requestSocial2FACodeWithLoginFields:(LoginFields *)loginFields
+{
+    [self.wordpressComOAuthClientFacade requestSocial2FACodeWithUserID:loginFields.nonceUserID
+                                                                nonce:loginFields.nonceInfo.nonceSMS
+                                                                 success:^(NSString *newNonce) {
+                                                                     if (newNonce) {
+                                                                         loginFields.nonceInfo.nonceSMS = newNonce;
+                                                                     }
+                                                                     [WPAnalytics track:WPAnalyticsStatTwoFactorSentSMS];
+                                                                 } failure:^(NSError *error, NSString *newNonce) {
+                                                                     if (newNonce) {
+                                                                         loginFields.nonceInfo.nonceSMS = newNonce;
+                                                                     }
+                                                                     DDLogError(@"Failed to request one time code");
+                                                                 }];
+}
+
 - (void)loginToWordPressDotComWithGoogleIDToken:(NSString *)googleIDToken
 {
     if ([self.delegate respondsToSelector:@selector(displayLoginMessage:)]) {

--- a/WordPress/Classes/Services/WordPressComOAuthClientFacade.h
+++ b/WordPress/Classes/Services/WordPressComOAuthClientFacade.h
@@ -16,6 +16,11 @@
                                success:(void (^)(void))success
                                failure:(void (^)(NSError *error))failure;
 
+- (void)requestSocial2FACodeWithUserID:(NSInteger)userID
+                                 nonce:(NSString *)nonce
+                               success:(void (^)(NSString *newNonce))success
+                               failure:(void (^)(NSError *error, NSString *newNonce))failure;
+
 - (void)authenticateWithGoogleIDToken:(NSString *)token
                               success:(void (^)(NSString *authToken))success
                      needsMultiFactor:(void (^)(NSInteger userID, SocialLogin2FANonceInfo *nonceInfo))needsMultifactor

--- a/WordPress/Classes/Services/WordPressComOAuthClientFacade.m
+++ b/WordPress/Classes/Services/WordPressComOAuthClientFacade.m
@@ -33,6 +33,15 @@
     [client requestOneTimeCodeWithUsername:username password:password success:success failure:failure];
 }
 
+- (void)requestSocial2FACodeWithUserID:(NSInteger)userID
+                                nonce:(NSString *)nonce
+                                 success:(void (^)(NSString *newNonce))success
+                                 failure:(void (^)(NSError *error, NSString *newNonce))failure
+{
+    WordPressComOAuthClient *client = [WordPressComOAuthClient clientWithClientID:ApiCredentials.client secret:ApiCredentials.secret];
+    [client requestSocial2FACodeWithUserID:userID nonce:nonce success:success failure:failure];
+}
+
 - (void)authenticateWithGoogleIDToken:(NSString *)token
                               success:(void (^)(NSString *authToken))success
                      needsMultiFactor:(void (^)(NSInteger userID, SocialLogin2FANonceInfo *nonceInfo))needsMultifactor

--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -29,7 +29,6 @@ class Login2FAViewController: LoginViewController, SigninKeyboardResponder, UITe
         localizeControls()
         configureTextFields()
         configureSubmitButton(animating: false)
-        configureSendCodeButton()
     }
 
 
@@ -89,16 +88,6 @@ class Login2FAViewController: LoginViewController, SigninKeyboardResponder, UITe
     ///
     func configureTextFields() {
         verificationCodeField.textInsets = WPStyleGuide.edgeInsetForLoginTextFields()
-    }
-
-    /// Hides the send code button when appropriate
-    ///
-    func configureSendCodeButton() {
-        guard let _ = loginFields.nonceInfo else {
-            return
-        }
-        sendCodeButton.isEnabled = false
-        sendCodeButton.setTitle("", for: .normal)
     }
 
 
@@ -225,7 +214,12 @@ class Login2FAViewController: LoginViewController, SigninKeyboardResponder, UITe
         let message = NSLocalizedString("SMS Sent", comment: "One Time Code has been sent via SMS")
         SVProgressHUD.showDismissibleSuccess(withStatus: message)
 
-        loginFacade.requestOneTimeCode(with: loginFields)
+        if let _ = loginFields.nonceInfo {
+            // social login
+            loginFacade.requestSocial2FACode(with: loginFields)
+        } else {
+            loginFacade.requestOneTimeCode(with: loginFields)
+        }
     }
 
 

--- a/WordPressKit/WordPressKit/SocialLogin2FANonceInfo.swift
+++ b/WordPressKit/WordPressKit/SocialLogin2FANonceInfo.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @objc
 public class SocialLogin2FANonceInfo: NSObject {
-    @objc var nonceSMS = ""
+    @objc public var nonceSMS = ""
     @objc var nonceBackup = ""
     @objc var nonceAuthenticator = ""
     @objc var supportedAuthTypes = [String]() // backup|authenticator|sms

--- a/WordPressKit/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressKit/WordPressComOAuthClient.swift
@@ -183,8 +183,6 @@ public final class WordPressComOAuthClient: NSObject {
 
             success(nonceInfo.nonceSMS)
         }) { (task, error) in
-            let errDesc = (error as NSError).description
-            print("sms request failed \(errDesc)")
             if let newNonce = (error as NSError).userInfo[WordPressComOAuthClient.WordPressComOAuthErrorNewNonceKey] as? String {
                 failure(error as NSError, newNonce)
             } else {

--- a/WordPressKit/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressKit/WordPressComOAuthClient.swift
@@ -26,6 +26,7 @@ public final class WordPressComOAuthClient: NSObject {
     @objc public static let WordPressComOAuthBaseUrl = "https://public-api.wordpress.com/oauth2"
     @objc public static let WordPressComSocialLoginUrl = "https://wordpress.com/wp-login.php?action=social-login-endpoint&version=1.0"
     @objc public static let WordPressComSocialLogin2FAUrl = "https://wordpress.com/wp-login.php?action=two-step-authentication-endpoint&version=1.0"
+    @objc public static let WordPressComSocialLoginNewSMS2FAUrl = "https://wordpress.com/wp-login.php?action=send-sms-code-endpoint"
     @objc public static let WordPressComOAuthRedirectUrl = "https://wordpress.com/"
     @objc public static let WordPressComSocialLoginEndpointVersion = 1.0
 
@@ -42,6 +43,10 @@ public final class WordPressComOAuthClient: NSObject {
 
     fileprivate let social2FASessionManager: AFHTTPSessionManager = {
         return WordPressComOAuthClient.sessionManager(url: WordPressComOAuthClient.WordPressComSocialLogin2FAUrl)
+    }()
+
+    fileprivate let socialNewSMS2FASessionmanager: AFHTTPSessionManager = {
+        return WordPressComOAuthClient.sessionManager(url: WordPressComOAuthClient.WordPressComSocialLoginNewSMS2FAUrl)
     }()
 
     fileprivate class func sessionManager(url: String) -> AFHTTPSessionManager {
@@ -299,6 +304,24 @@ public final class WordPressComOAuthClient: NSObject {
         }
         )
     }
+
+    /// Request a new SMS code to be sent during social login
+    ///
+    public func requestNewSocialSMS2FACode(_ userID: Int,
+                                           success: @escaping () -> Void,
+                                           failure: @escaping (_ error: NSError) -> Void) {
+        let parameters = [
+            "user_id" : userID
+        ]
+
+        socialNewSMS2FASessionmanager.post("", parameters: parameters, progress: nil, success: { (task, responseObject) in
+            print("sms request succeeded")
+        }) { (task, error) in
+            let errDesc = (error as NSError).description
+            print("sms request failed \(errDesc)")
+        }
+    }
+
 
 
     fileprivate func cleanedUpResponseForLogging(_ response: AnyObject) -> AnyObject {


### PR DESCRIPTION
Fixes #8065

This turns on the button on the 2FA screen for requesting a new code via SMS.

To test:
- First, login with a Google-enabled wpcom account that requires 2FA
- You can only request a new 2FA code once a minute.
- You'll get a SMS code sent immediately. Wait over a minute and request a new code, it should appear.
- And if you mash the button, no new codes will be sent. However, each time you hit the button a request is made and the error creates a new nonce. So make sure you can hit the button a few times within a minute, and that it still works after a minute passes!

Needs Review: @aerych 
