### PR TITLE
New prs.sh script

### DIFF
--- a/Scripts/prs.sh
+++ b/Scripts/prs.sh
@@ -1,2 +1,10 @@
+if [ $# -ne 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
+    echo "usage: prs.sh source_branch destination_branch"
+    echo "example: prs.sh release/8.7 release/8.8"
+    exit -1;
+fi
 
-for pr in `git log --pretty=oneline release/8.7..release/8.8 | grep -Eo '#\d+' | tr -d '#'`; do curl -s https://api.github.com/repos/wordpress-mobile/WordPress-iOS/pulls/$pr | jq -r '"#\(.number): \(.title) @\(.user.login) \(.html_url)"'; done
+source_branch="$1"
+destination_branch="$2"
+
+for pr in `git log --pretty=oneline $source_branch..$destination_branch | grep -Eo '#\d+' | tr -d '#'`; do curl -s https://api.github.com/repos/wordpress-mobile/WordPress-iOS/pulls/$pr | jq -r '"#\(.number): \(.title) @\(.user.login) \(.html_url)"'; done

--- a/Scripts/prs.sh
+++ b/Scripts/prs.sh
@@ -1,0 +1,2 @@
+
+for pr in `git log --pretty=oneline release/8.7..release/8.8 | grep -Eo '#\d+' | tr -d '#'`; do curl -s https://api.github.com/repos/wordpress-mobile/WordPress-iOS/pulls/$pr | jq -r '"#\(.number): \(.title) @\(.user.login) \(.html_url)"'; done


### PR DESCRIPTION
## Description

Adds a new and more generic version of the `prs.sh` script, that doesn't require auth tokens inside the script.

IMPORTANT: after merging this PR we need to decide where to start writing the documentation for the scripts we have.  The instructions below can be used as a starting point for that documentation.

## Testing

### Setup

Before testing this script you have to make sure your local git configuration is properly set up.

**Make sure you have a `~/.ssh/config` file**

Do: `ls ~/.ssh/config`

If the file exists, jump to the GitHub entry configuration below.

If the file does not exist, follow the steps below to create it.

1. Create the file using your preferred text editor.
2. Run: `chown 600 ~/.ssh/config`

**Configure a GitHub entry in `~/.ssh/config`**

Here's an example of what it should look like:

```
Host github.com
	Hostname github.com
	IdentityFile ~/.ssh/my_github_rsa_private_key
	UseKeychain yes
```

### Testing

Once your config file is set up, simply run the script:

```
./prs.sh release/8.7 release/8.8
```
