### PR TITLE
Media Library: Show uploading progress in cells

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.1'
   pod 'Gridicons', '0.12'
   pod 'NSURL+IDN', '0.3'
-  pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'e7d7bfada8c73c4ab388f065d5025efd52352748'
+  pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '73bafc4236ece8e9d28aad8be1e2357caf8481da'
   pod 'WordPress-iOS-Editor', '1.9.7'
   pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '00c407e27164431759840d363ff6a61b2fd70ad6'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -150,7 +150,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `00c407e27164431759840d363ff6a61b2fd70ad6`)
   - WordPress-iOS-Editor (= 1.9.7)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `e7d7bfada8c73c4ab388f065d5025efd52352748`)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `73bafc4236ece8e9d28aad8be1e2357caf8481da`)
   - wpxmlrpc (= 0.8.3)
 
 EXTERNAL SOURCES:
@@ -161,7 +161,7 @@ EXTERNAL SOURCES:
     :commit: 00c407e27164431759840d363ff6a61b2fd70ad6
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WPMediaPicker:
-    :commit: e7d7bfada8c73c4ab388f065d5025efd52352748
+    :commit: 73bafc4236ece8e9d28aad8be1e2357caf8481da
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
@@ -172,7 +172,7 @@ CHECKOUT OPTIONS:
     :commit: 00c407e27164431759840d363ff6a61b2fd70ad6
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WPMediaPicker:
-    :commit: e7d7bfada8c73c4ab388f065d5025efd52352748
+    :commit: 73bafc4236ece8e9d28aad8be1e2357caf8481da
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
@@ -211,6 +211,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 5e2db7fd30d8ca497d91b26fbf61e94d6660f1c6
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 86ec32ebe5c9c746d7e67cf8944495fe53b12d25
+PODFILE CHECKSUM: 4df16359823b0040171b94827062ee4ec62e5cfc
 
 COCOAPODS: 1.3.1

--- a/WordPress/Classes/ViewRelated/Media/MediaCellProgressView.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaCellProgressView.swift
@@ -101,6 +101,7 @@ class ProgressIndicatorView: UIView {
         configureLayer(progressLayer)
         progressTrackLayer.addSublayer(progressLayer)
         progressLayer.isHidden = false
+        progressLayer.strokeEnd = 0.0
     }
 
     func configureLayer(_ layer: CAShapeLayer) {

--- a/WordPress/Classes/ViewRelated/Media/MediaCellProgressView.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaCellProgressView.swift
@@ -5,7 +5,15 @@ import WordPressShared
 /// asset is currently being processed, uploaded, or has failed to upload.
 ///
 class MediaCellProgressView: UIView {
-    fileprivate let progressIndicator = ProgressIndicatorView()
+    let progressIndicator = ProgressIndicatorView()
+
+    override var isHidden: Bool {
+        didSet {
+            if isHidden {
+                progressIndicator.state = .stopped
+            }
+        }
+    }
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -33,13 +41,16 @@ class MediaCellProgressView: UIView {
 /// Small circular progress indicator view, currently just used in media cells
 /// during the processing / upload flow.
 ///
-private class ProgressIndicatorView: UIView {
+class ProgressIndicatorView: UIView {
+    private let indeterminateLayer = CAShapeLayer()
+    private let progressTrackLayer = CAShapeLayer()
     private let progressLayer = CAShapeLayer()
 
     private enum Appearance {
         static let defaultSize: CGFloat = 25.0
         static let lineWidth: CGFloat = 3.0
         static let lineColor: UIColor = .white
+        static let trackColor: UIColor = WPStyleGuide.grey()
     }
 
     private enum Animations {
@@ -50,6 +61,29 @@ private class ProgressIndicatorView: UIView {
         static let strokeBeginTime: TimeInterval = 0.5
     }
 
+    enum State: Equatable {
+        case stopped
+        case indeterminate
+        case progress(Double)
+
+        static func ==(lhs: State, rhs: State) -> Bool {
+            switch (lhs, rhs) {
+            case (.stopped, .stopped): return true
+            case (.indeterminate, .indeterminate): return true
+            case let (.progress(l), .progress(r)): return l == r
+            default: return false
+            }
+        }
+    }
+
+    var state: State = .stopped {
+        didSet {
+            stateDidChange()
+        }
+    }
+
+    private var isAnimating = false
+
     convenience init() {
         self.init(frame: CGRect(x: 0, y: 0, width: Appearance.defaultSize, height: Appearance.defaultSize))
     }
@@ -57,13 +91,27 @@ private class ProgressIndicatorView: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
 
-        progressLayer.frame = bounds
-        layer.addSublayer(progressLayer)
+        configureLayer(indeterminateLayer)
+        layer.addSublayer(indeterminateLayer)
 
-        progressLayer.lineWidth = Appearance.lineWidth
-        progressLayer.strokeColor = Appearance.lineColor.cgColor
-        progressLayer.fillColor = UIColor.clear.cgColor
-        progressLayer.path = UIBezierPath(roundedRect: bounds, cornerRadius: bounds.width / 2.0).cgPath
+        configureLayer(progressTrackLayer)
+        progressTrackLayer.strokeColor = Appearance.trackColor.cgColor
+        layer.addSublayer(progressTrackLayer)
+
+        configureLayer(progressLayer)
+        progressTrackLayer.addSublayer(progressLayer)
+        progressLayer.isHidden = false
+    }
+
+    func configureLayer(_ layer: CAShapeLayer) {
+        layer.frame = bounds
+
+        layer.lineWidth = Appearance.lineWidth
+        layer.strokeColor = Appearance.lineColor.cgColor
+        layer.fillColor = UIColor.clear.cgColor
+        layer.path = UIBezierPath(roundedRect: bounds, cornerRadius: bounds.width / 2.0).cgPath
+
+        layer.isHidden = true
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -77,10 +125,41 @@ private class ProgressIndicatorView: UIView {
     override func didMoveToWindow() {
         super.didMoveToWindow()
 
-        startAnimating()
+        if state == .indeterminate {
+            startAnimating()
+        }
+    }
+
+    private func stateDidChange() {
+        switch state {
+        case .stopped:
+            stopAnimating()
+            updateProgressLayer(with: 0.0, hidden: true)
+        case .indeterminate:
+            startAnimating()
+        case .progress(let progress):
+            stopAnimating()
+            updateProgressLayer(with: progress)
+            break
+        }
+    }
+
+    func updateProgressLayer(with progress: Double, hidden: Bool = false) {
+        progressLayer.strokeEnd = CGFloat(progress)
+        progressTrackLayer.isHidden = hidden
     }
 
     func startAnimating() {
+        guard !isAnimating && window != nil else {
+            return
+        }
+
+        isAnimating = true
+
+        progressLayer.strokeEnd = 0
+        progressTrackLayer.isHidden = true
+        indeterminateLayer.isHidden = false
+
         let strokeEnd = CAKeyframeAnimation(keyPath: "strokeEnd")
         strokeEnd.duration = Animations.strokeDuration
         strokeEnd.values = [0.0, 1.0]
@@ -101,11 +180,18 @@ private class ProgressIndicatorView: UIView {
         animation.duration = Animations.rotationDuration
         animation.repeatCount = Float.infinity
 
-        progressLayer.add(animation, forKey: "rotation")
-        progressLayer.add(group, forKey: "rotationGroup")
+        indeterminateLayer.add(animation, forKey: "rotation")
+        indeterminateLayer.add(group, forKey: "rotationGroup")
     }
 
     func stopAnimating() {
-        progressLayer.removeAllAnimations()
+        guard isAnimating else {
+            return
+        }
+
+        indeterminateLayer.isHidden = true
+        indeterminateLayer.removeAllAnimations()
+
+        isAnimating = false
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -23,6 +23,10 @@ class MediaLibraryViewController: UIViewController {
 
     fileprivate var capturePresenter: WPMediaCapturePresenter?
 
+    // After 99% progress, we'll count a media item as being uploaded, and we'll
+    // show an indeterminate spinner as the server processes it.
+    fileprivate static let uploadCompleteProgress: Double = 0.99
+
     lazy fileprivate var searchBarContainer: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -401,17 +405,38 @@ class MediaLibraryViewController: UIViewController {
     }
 
     private func reloadCell(for media: Media) {
+        visibleCells(for: media).forEach { cell in
+            cell.overlayView = nil
+            cell.asset = media
+        }
+    }
+
+    private func updateCellProgress(_ progress: Double, for media: Media) {
+        visibleCells(for: media).forEach { cell in
+            if let overlayView = cell.overlayView as? MediaCellProgressView {
+                if progress < MediaLibraryViewController.uploadCompleteProgress {
+                    overlayView.progressIndicator.state = .progress(progress)
+                } else {
+                    overlayView.progressIndicator.state = .indeterminate
+                }
+            }
+        }
+    }
+
+    private func showUploadingStateForCell(for media: Media) {
+        visibleCells(for: media).forEach { cell in
+            if let overlayView = cell.overlayView as? MediaCellProgressView {
+                overlayView.progressIndicator.state = .indeterminate
+            }
+        }
+    }
+
+    private func visibleCells(for media: Media) -> [WPMediaCollectionViewCell] {
         guard let cells = pickerViewController.collectionView?.visibleCells as? [WPMediaCollectionViewCell] else {
-            return
+            return []
         }
 
-        cells.forEach({ cell in
-            if let asset = cell.asset as? Media,
-                asset == media {
-                cell.overlayView = nil
-                cell.asset = media
-            }
-        })
+        return cells.filter({ ($0.asset as? Media) == media })
     }
 
     private var hasSearchQuery: Bool {
@@ -586,11 +611,14 @@ class MediaLibraryViewController: UIViewController {
         }
 
         uploadObserverUUID = MediaUploadCoordinator.shared.addObserver({ [weak self] (media, state) in
-            print("Media \(String(describing: media.filename)) in state \(String(describing: state))")
             switch state {
+            case .progress(let progress) :
+                self?.updateCellProgress(progress, for: media)
+                break
+            case .uploading:
+                self?.showUploadingStateForCell(for: media)
             case .ended:
                 self?.reloadCell(for: media)
-            default: break
             }
             }, for: nil)
     }
@@ -801,6 +829,12 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, willShowOverlayView overlayView: UIView, forCellFor asset: WPMediaAsset) {
+        if let overlayView = overlayView as? MediaCellProgressView,
+            let media = asset as? Media {
+            if media.remoteStatus == .processing {
+                overlayView.progressIndicator.state = .indeterminate
+            }
+        }
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, shouldShowOverlayViewForCellFor asset: WPMediaAsset) -> Bool {


### PR DESCRIPTION
This PR adds progress updates to cells in the media library when content is being uploaded asynchronously:

![overlays-1](https://user-images.githubusercontent.com/4780/32960177-ef12cef0-cbbb-11e7-8e28-53eceefa1921.gif)

We show indeterminate spinners whilst the media items are being processed locally, then discrete progress during the upload, then indeterminate again once we hit 99% progress and the item is being processed on the remote end.

To test:

* Try uploading items using the async feature in the media library, and check the cells display correctly
* Try scrolling up and down the collectionview during an upload
* Try backing out of the media library and coming back in during an upload
* Check that normal uploads still work as expected
