### PR TITLE
Add attribution to internal icon generation script

### DIFF
--- a/Scripts/BuildPhases/AddVersionToIcons.sh
+++ b/Scripts/BuildPhases/AddVersionToIcons.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+# Based on Eric Krzysztof Zablocki Boostrap library - https://github.com/krzysztofzablocki/Bootstrap
+
 convertPath=`which convert`
 echo ${convertPath}
 if [[ ! -f ${convertPath} || -z ${convertPath} ]]; then

--- a/Scripts/BuildPhases/AddVersionToIcons.sh
+++ b/Scripts/BuildPhases/AddVersionToIcons.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Based on Eric Krzysztof Zablocki Boostrap library - https://github.com/krzysztofzablocki/Bootstrap
+# Based on Krzysztof Zablocki Boostrap library - https://github.com/krzysztofzablocki/Bootstrap
 
 convertPath=`which convert`
 echo ${convertPath}


### PR DESCRIPTION
We should have the correct attribution in the icon generation script. This PR fixes that.

**To test:**
Check that the script still works correctly when generating the internal build.

