### PR TITLE
Aztec: Improve automatic link detection

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1697,7 +1697,8 @@ extension AztecPostViewController {
         var urlToUse = url
 
         if isInsertingNewLink {
-            if let pastedURL = UIPasteboard.general.value(forPasteboardType: String(kUTTypeURL)) as? URL {
+            if UIPasteboard.general.hasURLs,
+                let pastedURL = UIPasteboard.general.url {
                 urlToUse = pastedURL
             }
         }


### PR DESCRIPTION
This PR fixes an issue where the Insert Link dialog in Aztec was detecting plain text clipboard items as URLs, and auto-filling them. 

To test:

* Copy some text that is not a URL to your clipboard. For example: "Pickle Rick".
* In Aztec, tap the insert link button. The URL should not be auto-filled (if you test on `develop`, it will be).
* Now copy some text that is a URL. For example: "https://stabby.today".
* In Aztec, tap the insert link button. The URL should now be auto-filled.
