### PR TITLE
Fixing SiteCreation.storyboard build warning.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SiteCreation.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreation.storyboard
@@ -35,7 +35,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="WqP-gn-21O">
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="siteTypeTableCell" id="WqP-gn-21O">
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="WqP-gn-21O" id="s7l-PK-2RA">


### PR DESCRIPTION
Adding 'siteTypeTableCell' reuseIdentifier to Site Type table prototype cell.

Fixes #8216 

To test: Open project. Build. The warning should no longer appear.

Needs Review: @nheagy 
