### PR TITLE
Configure comments sync helper for Jetpack sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -476,7 +476,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
     _post = post;
 
-    if (_post.isWPCom) {
+    if (_post.isWPCom || _post.isJetpack) {
         self.syncHelper = [[WPContentSyncHelper alloc] init];
         self.syncHelper.delegate = self;
     }


### PR DESCRIPTION
**Fixes** #8219 

**To test:**
Follow the steps on the original ticket and check that comments load correctly.

