### PR TITLE
Configure comments sync helper for Jetpack sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -476,7 +476,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
     _post = post;
 
-    if (_post.isWPCom) {
+    if (_post.isWPCom || _post.isJetpack) {
         self.syncHelper = [[WPContentSyncHelper alloc] init];
         self.syncHelper.delegate = self;
     }


### PR DESCRIPTION
Fixes #8219 

Copy of https://github.com/wordpress-mobile/WordPress-iOS/pull/8220 targetting `release/8.9`. 
I made a mistake on https://github.com/wordpress-mobile/WordPress-iOS/pull/8220 and merged into `develop` instead of `release/8.9`
