### PR TITLE
Fixing category warning

### DIFF
--- a/WordPress/Classes/Models/Domain.swift
+++ b/WordPress/Classes/Models/Domain.swift
@@ -16,7 +16,7 @@ class ManagedDomain: NSManagedObject {
 
     // MARK: - NSManagedObject
 
-    override class var entityName: String {
+    override class func entityName() -> String {
         return "Domain"
     }
 

--- a/WordPress/Classes/Models/ManagedAccountSettings.swift
+++ b/WordPress/Classes/Models/ManagedAccountSettings.swift
@@ -8,7 +8,7 @@ class ManagedAccountSettings: NSManagedObject {
 
     // MARK: - NSManagedObject
 
-    override class var entityName: String {
+    override class func entityName() -> String {
         return "AccountSettings"
     }
 

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -44,7 +44,7 @@ class Post: AbstractPost {
 
     // MARK: - NSManagedObject
 
-    override class var entityName: String {
+    override class func entityName() -> String {
         return "Post"
     }
 

--- a/WordPress/Classes/Services/AccountSettingsService.swift
+++ b/WordPress/Classes/Services/AccountSettingsService.swift
@@ -158,7 +158,7 @@ class AccountSettingsService {
     }
 
     fileprivate func managedAccountSettingsWithID(_ userID: Int) -> ManagedAccountSettings? {
-        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ManagedAccountSettings.entityName)
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ManagedAccountSettings.entityName())
         request.predicate = NSPredicate(format: "account.userID = %d", userID)
         request.fetchLimit = 1
         guard let results = (try? context.fetch(request)) as? [ManagedAccountSettings] else {
@@ -174,7 +174,7 @@ class AccountSettingsService {
             return
         }
 
-        if let managedSettings = NSEntityDescription.insertNewObject(forEntityName: ManagedAccountSettings.entityName, into: context) as? ManagedAccountSettings {
+        if let managedSettings = NSEntityDescription.insertNewObject(forEntityName: ManagedAccountSettings.entityName(), into: context) as? ManagedAccountSettings {
             managedSettings.updateWith(settings)
             managedSettings.account = account
         }

--- a/WordPress/Classes/Services/DomainsService.swift
+++ b/WordPress/Classes/Services/DomainsService.swift
@@ -65,7 +65,7 @@ struct DomainsService {
     fileprivate func managedDomainWithName(_ domainName: String, forSite siteID: Int) -> ManagedDomain? {
         guard let blog = blogForSiteID(siteID) else { return nil }
 
-        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ManagedDomain.entityName)
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ManagedDomain.entityName())
         request.predicate = NSPredicate(format: "%K = %@ AND %K = %@", ManagedDomain.Relationships.blog, blog, ManagedDomain.Attributes.domainName, domainName)
         request.fetchLimit = 1
         let results = (try? context.fetch(request) as! [ManagedDomain]) ?? []
@@ -75,7 +75,7 @@ struct DomainsService {
     fileprivate func createManagedDomain(_ domain: Domain, forSite siteID: Int) {
         guard let blog = blogForSiteID(siteID) else { return }
 
-        let managedDomain = NSEntityDescription.insertNewObject(forEntityName: ManagedDomain.entityName, into: context) as! ManagedDomain
+        let managedDomain = NSEntityDescription.insertNewObject(forEntityName: ManagedDomain.entityName(), into: context) as! ManagedDomain
         managedDomain.updateWith(domain, blog: blog)
         DDLogDebug("Created domain \(managedDomain)")
     }
@@ -83,7 +83,7 @@ struct DomainsService {
     fileprivate func domainsForSite(_ siteID: Int) -> [Domain] {
         guard let blog = blogForSiteID(siteID) else { return [] }
 
-        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ManagedDomain.entityName)
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ManagedDomain.entityName())
         request.predicate = NSPredicate(format: "%K == %@", ManagedDomain.Relationships.blog, blog)
 
         let domains: [ManagedDomain]
@@ -100,7 +100,7 @@ struct DomainsService {
     fileprivate func removeDomains(_ domainNames: Set<String>, fromSite siteID: Int) {
         guard let blog = blogForSiteID(siteID) else { return }
 
-        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ManagedDomain.entityName)
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ManagedDomain.entityName())
         request.predicate = NSPredicate(format: "%K = %@ AND %K IN %@", ManagedDomain.Relationships.blog, blog, ManagedDomain.Attributes.domainName, domainNames)
         let objects = (try? context.fetch(request) as! [NSManagedObject]) ?? []
         for object in objects {

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -10,7 +10,7 @@ extension NSManagedObject {
     ///
     /// Note: entity().name returns nil as per iOS 10, in Unit Testing Targets. Awesome.
     ///
-    @objc class var entityName: String {
+    @objc class func entityName() -> String {
         return entity().name ?? classNameWithoutNamespaces()
     }
 
@@ -23,7 +23,7 @@ extension NSManagedObject {
             return fetchRequest()
         }
 
-        return NSFetchRequest(entityName: entityName)
+        return NSFetchRequest(entityName: entityName())
     }
 }
 
@@ -100,7 +100,7 @@ extension NSManagedObjectContext {
     /// Inserts a new Entity. For performance reasons, this helper *DOES NOT* persists the context.
     ///
     func insertNewObject<T: NSManagedObject>(ofType type: T.Type) -> T {
-        return NSEntityDescription.insertNewObject(forEntityName: T.entityName, into: self) as! T
+        return NSEntityDescription.insertNewObject(forEntityName: T.entityName(), into: self) as! T
     }
 
     /// Loads a single NSManagedObject instance, given its ObjectID, if available.

--- a/WordPress/Classes/ViewRelated/Domains/DomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/DomainsListViewController.swift
@@ -50,7 +50,7 @@ class DomainsListViewController: UITableViewController, ImmuTablePresenter {
     fileprivate var viewModel: ImmuTable!
 
     fileprivate var fetchRequest: NSFetchRequest<NSFetchRequestResult> {
-        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ManagedDomain.entityName)
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: ManagedDomain.entityName())
         request.predicate = NSPredicate(format: "%K == %@", ManagedDomain.Relationships.blog, blog)
         request.sortDescriptors = [NSSortDescriptor(key: ManagedDomain.Attributes.isPrimary, ascending: false),
                                    NSSortDescriptor(key: ManagedDomain.Attributes.domainName, ascending: true)]

--- a/WordPress/WordPressTest/CoreDataHelperTests.swift
+++ b/WordPress/WordPressTest/CoreDataHelperTests.swift
@@ -24,7 +24,7 @@ class CoreDataHelperTests: XCTestCase {
     ///
     func testNewFetchRequestReturnsNewRequestWithGenericEntityName() {
         let request = DummyEntity.safeFetchRequest()
-        XCTAssert(request.entityName! == DummyEntity.entityName)
+        XCTAssert(request.entityName! == DummyEntity.entityName())
     }
 
     /// Verifies that allObjects returns all of the entities of the specialized kind.
@@ -217,7 +217,7 @@ class DummyStack {
 
         // Entity
         let entity = NSEntityDescription()
-        entity.name = DummyEntity.entityName
+        entity.name = DummyEntity.entityName()
         entity.managedObjectClassName = String(reflecting: DummyEntity.self)
         entity.properties = [keyAttribute, valueAttribute]
 

--- a/WordPress/WordPressTest/DomainsServiceTests.swift
+++ b/WordPress/WordPressTest/DomainsServiceTests.swift
@@ -54,7 +54,7 @@ class DomainsServiceTests: XCTestCase {
 
 
     fileprivate func findAllDomains() -> [ManagedDomain] {
-        let fetch = NSFetchRequest<NSFetchRequestResult>(entityName: ManagedDomain.entityName)
+        let fetch = NSFetchRequest<NSFetchRequestResult>(entityName: ManagedDomain.entityName())
         fetch.sortDescriptors = [ NSSortDescriptor(key: ManagedDomain.Attributes.domainName, ascending: true) ]
         fetch.predicate = NSPredicate(format: "%K == %@", ManagedDomain.Relationships.blog, testBlog)
 
@@ -115,7 +115,7 @@ class DomainsServiceTests: XCTestCase {
     }
 
     func testDomainServiceUpdatesExistingDomains() {
-        let existingDomain = NSEntityDescription.insertNewObject(forEntityName: ManagedDomain.entityName, into: context) as! ManagedDomain
+        let existingDomain = NSEntityDescription.insertNewObject(forEntityName: ManagedDomain.entityName(), into: context) as! ManagedDomain
         existingDomain.domainName = "example.com"
         existingDomain.isPrimary = false
         existingDomain.domainType = .wpCom

--- a/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
+++ b/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
@@ -17,7 +17,7 @@ class MediaLibraryPickerDataSourceTests: XCTestCase {
         blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: context) as! Blog
         blog.url = "http://wordpress.com"
         blog.xmlrpc = "http://wordpress.com"
-        post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName, into: context) as! Post
+        post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: context) as! Post
         post.blog = blog
         dataSource = MediaLibraryPickerDataSource(blog: blog)
     }

--- a/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
+++ b/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
@@ -155,7 +155,7 @@ class NotificationSyncMediatorTests: XCTestCase {
 
         // Inject Dummy Note
         let path = "notifications-like.json"
-        let note = manager.loadEntityNamed(Notification.entityName, withContentsOfFile: path) as! WordPress.Notification
+        let note = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path) as! WordPress.Notification
 
         XCTAssertNotNil(note)
         XCTAssertFalse(note.read)

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -13,7 +13,7 @@ class PostTests: XCTestCase {
     }
 
     fileprivate func newTestPost() -> Post {
-        return NSEntityDescription.insertNewObject(forEntityName: Post.entityName, into: context) as! Post
+        return NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: context) as! Post
     }
 
     fileprivate func newTestPostCategory() -> PostCategory {


### PR DESCRIPTION
### Description:
Building WPiOS produces the following warning:

```
ld: warning: Some object files have incompatible Objective-C category definitions. Some category metadata may be lost. All files containing Objective-C categories should be built using the same compiler.
```

<img width="297" alt="screen shot 2017-11-23 at 6 45 58 pm" src="https://user-images.githubusercontent.com/1195260/33189272-e9c7f786-d07f-11e7-88ec-56f719e33a86.png">

This is, reportedly, caused by `static var`properties, [declared in Class Extensions](https://stackoverflow.com/questions/39665979/xcode-8-objective-c-category-warning).


### Details:
Pinpointing the exact source of this warning took **a lifetime**. I've tracked it down to **CoreDataHelper**'s `static var entityName`.

In this PR we're converting this mechanism into an actual method, which neutralizes the warning.

### To test:
Verify that WordPress iOS builds correctly, without the ObjC Category Warning.

Needs Review: @koke 
Thanks in advance sir!

