### PR TITLE
Support for Portfolios - (OLD / being replaced)

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     /// Does the blog support editing media metadata?
     BlogFeatureMediaMetadataEditing,
     /// Does the blog support deleting media?
-    BlogFeatureMediaDeletion
+    BlogFeatureMediaDeletion,
 };
 
 typedef NS_ENUM(NSInteger, SiteVisibility) {

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -99,6 +99,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @property (nonatomic, assign, readwrite) BOOL isSyncingMedia;
 @property (nonatomic, strong, readwrite, nullable) NSDate *lastPostsSync;
 @property (nonatomic, strong, readwrite, nullable) NSDate *lastPagesSync;
+@property (nonatomic, strong, readwrite, nullable) NSDate *lastProjectsSync;
 @property (nonatomic, strong, readwrite, nullable) NSDate *lastCommentsSync;
 @property (nonatomic, strong, readwrite, nullable) NSDate *lastStatsSync;
 @property (nonatomic, strong, readwrite, nullable) NSString *lastUpdateWarning;

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -64,7 +64,7 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     /// Does the blog support editing media metadata?
     BlogFeatureMediaMetadataEditing,
     /// Does the blog support deleting media?
-    BlogFeatureMediaDeletion,
+    BlogFeatureMediaDeletion
 };
 
 typedef NS_ENUM(NSInteger, SiteVisibility) {

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -56,6 +56,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
 @dynamic lastPostsSync;
 @dynamic lastStatsSync;
 @dynamic lastPagesSync;
+@dynamic lastProjectsSync;
 @dynamic lastCommentsSync;
 @dynamic lastUpdateWarning;
 @dynamic options;

--- a/WordPress/Classes/Models/BlogSettings.swift
+++ b/WordPress/Classes/Models/BlogSettings.swift
@@ -44,7 +44,9 @@ open class BlogSettings: NSManagedObject {
     ///
     @NSManaged var defaultPostFormat: String?
 
-
+    /// Represents whether the Portfolio feature is enabled or not
+    ///
+    @NSManaged var portfolioEnabled: Bool
 
     // MARK: - Discussion
 

--- a/WordPress/Classes/Models/Project.swift
+++ b/WordPress/Classes/Models/Project.swift
@@ -1,0 +1,33 @@
+import Foundation
+import CoreData
+
+@objc (Project)
+class Project: AbstractPost {
+    /// Section identifier for the project, using the creation date.
+    ///
+    func sectionIdentifierWithDateCreated() -> String {
+        let date = date_created_gmt ?? Date()
+        return date.toStringForPageSections()
+    }
+    
+    /// Section identifier for the project, using the last modification date.
+    ///
+    func sectionIdentifierWithDateModified() -> String {
+        let date = dateModified ?? Date()
+        return date.toStringForPageSections()
+    }
+    
+    /// Returns the selector string to use as a sectionNameKeyPath, depending on the given keyPath.
+    ///
+    static func sectionIdentifier(dateKeyPath: String) -> String {
+        switch dateKeyPath {
+        case #keyPath(AbstractPost.date_created_gmt):
+            return NSStringFromSelector(#selector(Project.sectionIdentifierWithDateCreated))
+        case #keyPath(AbstractPost.dateModified):
+            return NSStringFromSelector(#selector(Project.sectionIdentifierWithDateModified))
+        default:
+            preconditionFailure("Invalid key path for a section identifier")
+        }
+    }
+}
+

--- a/WordPress/Classes/Models/Project.swift
+++ b/WordPress/Classes/Models/Project.swift
@@ -5,21 +5,21 @@ import CoreData
 class Project: AbstractPost {
     /// Section identifier for the project, using the creation date.
     ///
-    func sectionIdentifierWithDateCreated() -> String {
+    @objc func sectionIdentifierWithDateCreated() -> String {
         let date = date_created_gmt ?? Date()
         return date.toStringForPageSections()
     }
     
     /// Section identifier for the project, using the last modification date.
     ///
-    func sectionIdentifierWithDateModified() -> String {
+    @objc func sectionIdentifierWithDateModified() -> String {
         let date = dateModified ?? Date()
         return date.toStringForPageSections()
     }
     
     /// Returns the selector string to use as a sectionNameKeyPath, depending on the given keyPath.
     ///
-    static func sectionIdentifier(dateKeyPath: String) -> String {
+    @objc static func sectionIdentifier(dateKeyPath: String) -> String {
         switch dateKeyPath {
         case #keyPath(AbstractPost.date_created_gmt):
             return NSStringFromSelector(#selector(Project.sectionIdentifierWithDateCreated))

--- a/WordPress/Classes/Models/Project.swift
+++ b/WordPress/Classes/Models/Project.swift
@@ -9,14 +9,14 @@ class Project: AbstractPost {
         let date = date_created_gmt ?? Date()
         return date.toStringForPageSections()
     }
-    
+
     /// Section identifier for the project, using the last modification date.
     ///
     @objc func sectionIdentifierWithDateModified() -> String {
         let date = dateModified ?? Date()
         return date.toStringForPageSections()
     }
-    
+
     /// Returns the selector string to use as a sectionNameKeyPath, depending on the given keyPath.
     ///
     @objc static func sectionIdentifier(dateKeyPath: String) -> String {
@@ -30,4 +30,3 @@ class Project: AbstractPost {
         }
     }
 }
-

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -974,6 +974,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     // Writing
     settings.defaultCategoryID = remoteSettings.defaultCategoryID ?: settings.defaultCategoryID;
     settings.defaultPostFormat = remoteSettings.defaultPostFormat ?: settings.defaultPostFormat;
+    settings.portfolioEnabled = [remoteSettings.portfolioEnabled boolValue];
 
     // Discussion
     settings.commentsAllowed = [remoteSettings.commentsAllowed boolValue];
@@ -1034,6 +1035,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     // Writing
     remoteSettings.defaultCategoryID = settings.defaultCategoryID;
     remoteSettings.defaultPostFormat = settings.defaultPostFormat;
+    remoteSettings.portfolioEnabled = @(settings.portfolioEnabled);
 
     // Discussion
     remoteSettings.commentsAllowed = @(settings.commentsAllowed);

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -17,6 +17,7 @@ typedef void(^PostServiceSyncFailure)(NSError * _Nullable error);
 typedef NSString * PostServiceType NS_TYPED_ENUM;
 extern PostServiceType const PostServiceTypePost;
 extern PostServiceType const PostServiceTypePage;
+extern PostServiceType const PostServiceTypeProject;
 extern PostServiceType const PostServiceTypeAny;
 extern const NSUInteger PostServiceDefaultNumberToSync;
 
@@ -47,7 +48,7 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
  NSManagedObjectContext supplied when the PostService was initialized, and may not
  run on the main thread.
 
- @param postType The type (post or page) of post to sync
+ @param postType The type (post, page, or project) of post to sync
  @param blog The blog that has the posts.
  @param success A success block
  @param failure A failure block
@@ -63,7 +64,7 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
  NSManagedObjectContext supplied when the PostService was initialized, and may not
  run on the main thread.
  
- @param postType The type (post or page) of post to sync
+ @param postType The type (post, page, or project) of post to sync
  @param options Sync options for specific request parameters.
  @param blog The blog that has the posts.
  @param success A success block

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -12,6 +12,7 @@
 
 PostServiceType const PostServiceTypePost = @"post";
 PostServiceType const PostServiceTypePage = @"page";
+PostServiceType const PostServiceTypeProject = @"project";
 PostServiceType const PostServiceTypeAny = @"any";
 NSString * const PostServiceErrorDomain = @"PostServiceErrorDomain";
 
@@ -60,6 +61,21 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     Page *page = [self createPageForBlog:blog];
     [self initializeDraft:page];
     return page;
+}
+
+- (Project *)createProjectForBlog:(Blog *)blog {
+    NSAssert(self.managedObjectContext == blog.managedObjectContext, @"Blog's context should be the the same as the service's");
+    Project *project = [NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass([Project class]) inManagedObjectContext:self.managedObjectContext];
+    project.blog = blog;
+    project.date_created_gmt = [NSDate date];
+    project.remoteStatus = AbstractPostRemoteStatusSync;
+    return project;
+}
+
+- (Project *)createDraftProjectForBlog:(Blog *)blog {
+    Project *project = [self createProjectForBlog:blog];
+    [self initializeDraft:project];
+    return project;
 }
 
 - (void)getPostWithID:(NSNumber *)postID
@@ -437,6 +453,9 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
             if ([remotePost.type isEqualToString:PostServiceTypePage]) {
                 // Create a Page entity for posts with a remote type of "page"
                 post = [self createPageForBlog:blog];
+            } else if ([remotePost.type isEqualToString:PostServiceTypeProject]) {
+                // Create a Project entity for posts with a remote type of "project"
+                post = [self createProjectForBlog:blog];
             } else {
                 // Create a Post entity for any other posts that have a remote post type of "post" or a custom post type.
                 post = [self createPostForBlog:blog];
@@ -465,8 +484,11 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
         } else if ([syncPostType isEqualToString:PostServiceTypePage]) {
             // If syncing "page" posts, set up the fetch for any Page entities.
             request = [NSFetchRequest fetchRequestWithEntityName:NSStringFromClass([Page class])];
+        } else if ([syncPostType isEqualToString:PostServiceTypeProject]) {
+            // If syncing "project" posts, set up the fetch for any Project entities.
+            request = [NSFetchRequest fetchRequestWithEntityName:NSStringFromClass([Project class])];
         } else {
-            // If not syncing "page" or "any" post, use the Post entity.
+            // If not syncing "page", "project", or "any" post, use the Post entity.
             request = [NSFetchRequest fetchRequestWithEntityName:NSStringFromClass([Post class])];
             // Include the postType attribute in the predicate.
             NSPredicate *postTypePredicate = [NSPredicate predicateWithFormat:@"postType = %@", syncPostType];

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -12,7 +12,7 @@
 
 PostServiceType const PostServiceTypePost = @"post";
 PostServiceType const PostServiceTypePage = @"page";
-PostServiceType const PostServiceTypeProject = @"project";
+PostServiceType const PostServiceTypeProject = @"jetpack-portfolio";
 PostServiceType const PostServiceTypeAny = @"any";
 NSString * const PostServiceErrorDomain = @"PostServiceErrorDomain";
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -11,6 +11,7 @@ enum FeatureFlag: Int {
     case asyncUploadsInMediaLibrary
     case activity
     case siteCreation
+    case portfolio
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -32,6 +33,8 @@ enum FeatureFlag: Int {
         case .activity:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .siteCreation:
+            return BuildConfiguration.current == .localDeveloper
+        case .portfolio:
             return BuildConfiguration.current == .localDeveloper
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -451,7 +451,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Portfolio", @"Noun. Title. Links to the blog's Portfolio screen.")
                                                     image:[Gridicon iconOfType:GridiconTypeFolder]
                                                  callback:^{
-                                                     // TODO: show Portfolio
+                                                     [weakSelf showPortfolio];
                                                  }]];
 
     NSString *title = NSLocalizedString(@"Publish", @"Section title for the publish table section in the blog details screen");
@@ -909,6 +909,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatOpenedPosts withBlog:self.blog];
     PostListViewController *controller = [PostListViewController controllerWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
+}
+
+- (void)showPortfolio
+{
+    // TODO: Implement missing enum case
+    // [WPAppAnalytics track:WPAnalyticsStatOpenedPortfolio withBlog:self.blog];
+     PortfolioListViewController *controller = [PortfolioListViewController controllerWithBlog:self.blog];
+     [self showDetailViewController:controller sender:self];
 }
 
 - (void)showPageList

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -813,6 +813,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self preloadStats];
         [self preloadPosts];
         [self preloadPages];
+        [self preloadProjects];
         [self preloadComments];
     }
 }
@@ -837,6 +838,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self preloadPostsOfType:PostServiceTypePage];
 }
 
+- (void)preloadProjects
+{
+    [self preloadPostsOfType:PostServiceTypeProject];
+}
+
 // preloads posts or pages.
 - (void)preloadPostsOfType:(PostServiceType)postType
 {
@@ -851,6 +857,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     NSDate *lastSyncDate;
     if ([postType isEqual:PostServiceTypePage]) {
         lastSyncDate = self.blog.lastPagesSync;
+    } else if ([postType isEqualToString:PostServiceTypeProject]) {
+        lastSyncDate = self.blog.lastProjectsSync;
     } else {
         lastSyncDate = self.blog.lastPostsSync;
     }
@@ -869,6 +877,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
         if ([postType isEqual:PostServiceTypePage]) {
             self.blog.lastPagesSync = [NSDate date];
+        } else if ([postType isEqual:PostServiceTypeProject]) {
+            self.blog.lastProjectsSync = [NSDate date];
         } else {
             self.blog.lastPostsSync = [NSDate date];
         }
@@ -879,6 +889,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             NSDate *invalidatedDate = [NSDate dateWithTimeIntervalSince1970:0.0];
             if ([postType isEqual:PostServiceTypePage]) {
                 self.blog.lastPagesSync = invalidatedDate;
+            } else if ([postType isEqual:PostServiceTypeProject]) {
+                self.blog.lastProjectsSync = invalidatedDate;
             } else {
                 self.blog.lastPostsSync = invalidatedDate;
             }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -447,6 +447,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         row.detail = [NSString stringWithFormat:@"%d", numberOfPendingComments];
     }
     [rows addObject:row];
+    
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Portfolio", @"Noun. Title. Links to the blog's Portfolio screen.")
+                                                    image:[Gridicon iconOfType:GridiconTypeFolder]
+                                                 callback:^{
+                                                     // TODO: show Portfolio
+                                                 }]];
 
     NSString *title = NSLocalizedString(@"Publish", @"Section title for the publish table section in the blog details screen");
     return [[BlogDetailsSection alloc] initWithTitle:title andRows:rows];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -448,7 +448,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
     [rows addObject:row];
 
-    if ([self.blog.settings portfolioEnabled]) {
+    if ([Feature enabled:FeatureFlagPortfolio] && [self.blog.settings portfolioEnabled]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Portfolio", @"Noun. Title. Links to the blog's Portfolio screen.")
                                                         image:[Gridicon iconOfType:GridiconTypeFolder]
                                                      callback:^{

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -447,12 +447,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         row.detail = [NSString stringWithFormat:@"%d", numberOfPendingComments];
     }
     [rows addObject:row];
-    
-    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Portfolio", @"Noun. Title. Links to the blog's Portfolio screen.")
-                                                    image:[Gridicon iconOfType:GridiconTypeFolder]
-                                                 callback:^{
-                                                     [weakSelf showPortfolio];
-                                                 }]];
+
+    if ([self.blog.settings portfolioEnabled]) {
+        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Portfolio", @"Noun. Title. Links to the blog's Portfolio screen.")
+                                                        image:[Gridicon iconOfType:GridiconTypeFolder]
+                                                     callback:^{
+                                                         [weakSelf showPortfolio];
+                                                     }]];
+    }
 
     NSString *title = NSLocalizedString(@"Publish", @"Section title for the publish table section in the blog details screen");
     return [[BlogDetailsSection alloc] initWithTitle:title andRows:rows];

--- a/WordPress/Classes/ViewRelated/Portfolio/Controllers/PortfolioListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/Controllers/PortfolioListViewController.swift
@@ -6,6 +6,12 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
     
     fileprivate static let portfolioViewControllerRestorationKey = "PortfolioViewControllerRestorationKey"
     
+    fileprivate lazy var sectionFooterSeparatorView: UIView = {
+        let footer = UIView()
+        footer.backgroundColor = WPStyleGuide.greyLighten20()
+        return footer
+    }()
+    
     // MARK: - Convenience constructors
     
     class func controllerWithBlog(_ blog: Blog) -> PortfolioListViewController {
@@ -59,8 +65,8 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        // TODO:
-//        title = NSLocalizedString("Pages", comment: "Tile of the screen showing the list of pages for a blog.")
+
+        title = NSLocalizedString("Portfolio", comment: "Tile of the screen showing the list of projects (Portfolio) for a blog.")
     }
     
     // MARK: - Configuration
@@ -83,6 +89,49 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
 //        tableView.register(restorePageCellNib, forCellReuseIdentifier: type(of: self).restorePageCellIdentifier)
         
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
+    }
+    
+    override func configureSearchController() {
+        super.configureSearchController()
+        
+        tableView.tableHeaderView = searchController.searchBar
+        
+        tableView.scrollIndicatorInsets.top = searchController.searchBar.bounds.height
+    }
+    
+    fileprivate func noResultsTitles() -> [PostListFilter.Status: String] {
+        if isSearching() {
+            return noResultsTitlesWhenSearching()
+        } else {
+            return noResultsTitlesWhenFiltering()
+        }
+    }
+    
+    fileprivate func noResultsTitlesWhenSearching() -> [PostListFilter.Status: String] {
+        
+        let draftMessage = String(format: NSLocalizedString("No drafts match your search for %@", comment: "The '%@' is a placeholder for the search term."), currentSearchTerm()!)
+        let scheduledMessage = String(format: NSLocalizedString("No scheduled projects match your search for %@", comment: "The '%@' is a placeholder for the search term."), currentSearchTerm()!)
+        let trashedMessage = String(format: NSLocalizedString("No trashed projects match your search for %@", comment: "The '%@' is a placeholder for the search term."), currentSearchTerm()!)
+        let publishedMessage = String(format: NSLocalizedString("No projects match your search for %@", comment: "The '%@' is a placeholder for the search term."), currentSearchTerm()!)
+        
+        return noResultsTitles(draftMessage, scheduled: scheduledMessage, trashed: trashedMessage, published: publishedMessage)
+    }
+    
+    fileprivate func noResultsTitlesWhenFiltering() -> [PostListFilter.Status: String] {
+        
+        let draftMessage = NSLocalizedString("You don't have any drafts.", comment: "Displayed when the user views drafts in the portfolio list and there are no projects")
+        let scheduledMessage = NSLocalizedString("You don't have any scheduled projects.", comment: "Displayed when the user views scheduled projects in the portfolio list and there are no projects")
+        let trashedMessage = NSLocalizedString("You don't have any projects in your trash folder.", comment: "Displayed when the user views trashed in the portfolio list and there are no projects")
+        let publishedMessage = NSLocalizedString("You haven't published any projects yet.", comment: "Displayed when the user views published projects in the portfolio list and there are no projects")
+        
+        return noResultsTitles(draftMessage, scheduled: scheduledMessage, trashed: trashedMessage, published: publishedMessage)
+    }
+    
+    fileprivate func noResultsTitles(_ draft: String, scheduled: String, trashed: String, published: String) -> [PostListFilter.Status: String] {
+        return [.draft: draft,
+                .scheduled: scheduled,
+                .trashed: trashed,
+                .published: published]
     }
     
     override func configureAuthorFilter() {
@@ -129,6 +178,13 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
     }
     
     // MARK: - Table View Handling
+    
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView! {
+        if section == tableView.numberOfSections - 1 {
+            return sectionFooterSeparatorView
+        }
+        return UIView(frame: CGRect.zero)
+    }
     
     override func configureCell(_ cell: UITableViewCell, at indexPath: IndexPath) {
         // TODO:

--- a/WordPress/Classes/ViewRelated/Portfolio/Controllers/PortfolioListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/Controllers/PortfolioListViewController.swift
@@ -1,4 +1,4 @@
-import Foundation
+ import Foundation
 import CocoaLumberjack
 import WordPressShared
 
@@ -11,6 +11,10 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
         footer.backgroundColor = WPStyleGuide.greyLighten20()
         return footer
     }()
+    
+    // MARK: - GUI
+    
+    fileprivate let animatedBox = WPAnimatedBox()
     
     // MARK: - Convenience constructors
     
@@ -218,5 +222,79 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
     
     func createProject() {
         // TODO: implement this
+    }
+    
+    // MARK: - Refreshing noResultsView
+    
+    func handleRefreshNoResultsView(_ noResultsView: WPNoResultsView) {
+        noResultsView.titleText = noResultsTitle()
+        noResultsView.messageText = noResultsMessage()
+        noResultsView.accessoryView = noResultsAccessoryView()
+        noResultsView.buttonTitle = noResultsButtonTitle()
+    }
+    
+    // MARK: - NoResultsView Customizer helpers
+    
+    fileprivate func noResultsAccessoryView() -> UIView {
+        if syncHelper.isSyncing {
+            animatedBox.animate(afterDelay: 0.1)
+            return animatedBox
+        }
+        
+        return UIImageView(image: UIImage(named: "illustration-posts"))
+    }
+    
+    fileprivate func noResultsButtonTitle() -> String {
+        if syncHelper.isSyncing == true || isSearching() {
+            return ""
+        }
+        
+        let filterType = filterSettings.currentPostListFilter().filterType
+        
+        switch filterType {
+        case .trashed:
+            return ""
+        default:
+            return NSLocalizedString("Start a Project", comment: "Button title, encourages users to create their first project on their blog.")
+        }
+    }
+    
+    fileprivate func noResultsTitle() -> String {
+        if syncHelper.isSyncing == true {
+            return NSLocalizedString("Fetching projects...", comment: "A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new projects.")
+        }
+        
+        let filter = filterSettings.currentPostListFilter()
+        let titles = noResultsTitles()
+        let title = titles[filter.filterType]
+        return title ?? ""
+    }
+    
+    fileprivate func noResultsMessage() -> String {
+        if syncHelper.isSyncing == true || isSearching() {
+            return ""
+        }
+        
+        let filterType = filterSettings.currentPostListFilter().filterType
+        
+        switch filterType {
+        case .draft:
+            return NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views drafts in the portfolio and there are no projects")
+        case .scheduled:
+            return NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views scheduled projects in the portfolio and there are no projects")
+        case .trashed:
+            return NSLocalizedString("Everything you write is solid gold.", comment: "Displayed when the user views trashed projects in the portfolio and there are no projects")
+        default:
+            return NSLocalizedString("Would you like to publish your first project?", comment: "Displayed when the user views published projects in the portfolio and there are no projects")
+        }
+    }
+    
+    // MARK: - UISearchControllerDelegate
+    
+    func didPresentSearchController(_ searchController: UISearchController) {
+        if #available(iOS 11.0, *) {
+            tableView.scrollIndicatorInsets.top = searchController.searchBar.bounds.height + searchController.searchBar.frame.origin.y - topLayoutGuide.length
+            tableView.contentInset.top = 0
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Portfolio/Controllers/PortfolioListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/Controllers/PortfolioListViewController.swift
@@ -1,0 +1,166 @@
+import Foundation
+import CocoaLumberjack
+import WordPressShared
+
+class PortfolioListViewController: AbstractPostListViewController, UIViewControllerRestoration {
+    
+    fileprivate static let portfolioViewControllerRestorationKey = "PortfolioViewControllerRestorationKey"
+    
+    // MARK: - Convenience constructors
+    
+    class func controllerWithBlog(_ blog: Blog) -> PortfolioListViewController {
+        
+        let storyBoard = UIStoryboard(name: "Portfolio", bundle: Bundle.main)
+        let controller = storyBoard.instantiateViewController(withIdentifier: "PortfolioListViewController") as! PortfolioListViewController
+        
+        controller.blog = blog
+        controller.restorationClass = self
+        
+        return controller
+    }
+    
+    // MARK: - UIViewControllerRestoration
+    
+    class func viewController(withRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
+        
+        let context = ContextManager.sharedInstance().mainContext
+
+        guard let blogID = coder.decodeObject(forKey: portfolioViewControllerRestorationKey) as? String,
+            let objectURL = URL(string: blogID),
+            let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: objectURL),
+            let restoredBlog = try? context.existingObject(with: objectID) as! Blog else {
+
+                return nil
+        }
+
+        return self.controllerWithBlog(restoredBlog)
+    }
+    
+    // MARK: - UIStateRestoring
+    
+    override func encodeRestorableState(with coder: NSCoder) {
+        
+        let objectString = blog?.objectID.uriRepresentation().absoluteString
+        
+        coder.encode(objectString, forKey: type(of: self).portfolioViewControllerRestorationKey)
+        
+        super.encodeRestorableState(with: coder)
+    }
+    
+    // MARK: - UIViewController
+    
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        super.refreshNoResultsView = { [weak self] noResultsView in
+            // TODO:
+//            self?.handleRefreshNoResultsView(noResultsView)
+        }
+        super.tableViewController = (segue.destination as! UITableViewController)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // TODO:
+//        title = NSLocalizedString("Pages", comment: "Tile of the screen showing the list of pages for a blog.")
+    }
+    
+    // MARK: - Configuration
+    
+    override func configureTableView() {
+        tableView.accessibilityIdentifier = "PortfolioTable"
+        tableView.isAccessibilityElement = true
+        // TODO:
+//        tableView.estimatedRowHeight = type(of: self).pageCellEstimatedRowHeight
+        tableView.rowHeight = UITableViewAutomaticDimension
+        
+//        let bundle = Bundle.main
+        
+        // Register the cells
+        // TODO:
+//        let pageCellNib = UINib(nibName: type(of: self).pageCellNibName, bundle: bundle)
+//        tableView.register(pageCellNib, forCellReuseIdentifier: type(of: self).pageCellIdentifier)
+//
+//        let restorePageCellNib = UINib(nibName: type(of: self).restorePageCellNibName, bundle: bundle)
+//        tableView.register(restorePageCellNib, forCellReuseIdentifier: type(of: self).restorePageCellIdentifier)
+        
+        WPStyleGuide.configureColors(for: view, andTableView: tableView)
+    }
+    
+    override func configureAuthorFilter() {
+        // Noop
+    }
+    
+    // MARK: - TableView Handler Delegate Methods
+    
+    override func entityName() -> String {
+        // TODO: model for Project
+        return String(describing: Post.self)
+    }
+    
+    override func predicateForFetchRequest() -> NSPredicate {
+        var predicates = [NSPredicate]()
+        
+        if let blog = blog {
+            let basePredicate = NSPredicate(format: "blog = %@ && revision = nil", blog)
+            predicates.append(basePredicate)
+        }
+        
+        // TODO:
+//        let searchText = currentSearchTerm()
+//        let filterPredicate = filterSettings.currentPostListFilter().predicateForFetchRequest
+//
+//        // If we have recently trashed posts, create an OR predicate to find posts matching the filter,
+//        // or posts that were recently deleted.
+//        if searchText?.count == 0 && recentlyTrashedPostObjectIDs.count > 0 {
+//
+//            let trashedPredicate = NSPredicate(format: "SELF IN %@", recentlyTrashedPostObjectIDs)
+//
+//            predicates.append(NSCompoundPredicate(orPredicateWithSubpredicates: [filterPredicate, trashedPredicate]))
+//        } else {
+//            predicates.append(filterPredicate)
+//        }
+//
+//        if let searchText = searchText, searchText.count > 0 {
+//            let searchPredicate = NSPredicate(format: "postTitle CONTAINS[cd] %@", searchText)
+//            predicates.append(searchPredicate)
+//        }
+        
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+        return predicate
+    }
+    
+    // MARK: - Table View Handling
+    
+    override func configureCell(_ cell: UITableViewCell, at indexPath: IndexPath) {
+        // TODO:
+//        guard let cell = cell as? BasePageListCell else {
+//            preconditionFailure("The cell should be of class \(String(describing: BasePageListCell.self))")
+//        }
+//
+//        cell.accessoryType = .none
+//
+//        if cell.reuseIdentifier == type(of: self).pageCellIdentifier {
+//            cell.onAction = { [weak self] cell, button, page in
+//                self?.handleMenuAction(fromCell: cell, fromButton: button, forPage: page)
+//            }
+//        } else if cell.reuseIdentifier == type(of: self).restorePageCellIdentifier {
+//            cell.selectionStyle = .none
+//            cell.onAction = { [weak self] cell, _, page in
+//                self?.handleRestoreAction(fromCell: cell, forPage: page)
+//            }
+//        }
+//
+//        let page = pageAtIndexPath(indexPath)
+//
+//        cell.configureCell(page)
+    }
+    
+    // MARK: - Portfolio Actions
+    
+    override func createPost() {
+        self.createProject()
+    }
+    
+    func createProject() {
+        // TODO: implement this
+    }
+}

--- a/WordPress/Classes/ViewRelated/Portfolio/Portfolio.storyboard
+++ b/WordPress/Classes/ViewRelated/Portfolio/Portfolio.storyboard
@@ -91,7 +91,7 @@
         <scene sceneID="zmQ-gW-j5g">
             <objects>
                 <tableViewController id="UOf-UC-H8O" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="03w-qx-tGs">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="47" sectionHeaderHeight="24" sectionFooterHeight="1" id="03w-qx-tGs">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -102,6 +102,7 @@
                     </tableView>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="RVL-9n-voS">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </refreshControl>
                 </tableViewController>

--- a/WordPress/Classes/ViewRelated/Portfolio/Portfolio.storyboard
+++ b/WordPress/Classes/ViewRelated/Portfolio/Portfolio.storyboard
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Portfolio-->
+        <scene sceneID="5e3-9S-G4m">
+            <objects>
+                <viewController storyboardIdentifier="PortfolioListViewController" extendedLayoutIncludesOpaqueBars="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Iyh-Nw-rHr" userLabel="Portfolio" customClass="PortfolioListViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="QVt-iV-j25"/>
+                        <viewControllerLayoutGuide type="bottom" id="LNR-aQ-IpK"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="uWe-E5-Cdr">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <subviews>
+                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5hk-SY-SLb">
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
+                                <connections>
+                                    <segue destination="UOf-UC-H8O" kind="embed" id="h5t-39-QBl"/>
+                                </connections>
+                            </containerView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="bottomMargin" secondItem="5hk-SY-SLb" secondAttribute="bottom" id="BU1-f3-4Ke"/>
+                            <constraint firstItem="5hk-SY-SLb" firstAttribute="top" secondItem="uWe-E5-Cdr" secondAttribute="topMargin" id="E7P-zQ-Yc1"/>
+                            <constraint firstAttribute="trailing" secondItem="5hk-SY-SLb" secondAttribute="trailing" id="FHZ-ap-nEl"/>
+                            <constraint firstItem="5hk-SY-SLb" firstAttribute="leading" secondItem="uWe-E5-Cdr" secondAttribute="leading" id="MFS-UF-dfc"/>
+                        </constraints>
+                    </view>
+                    <extendedEdge key="edgesForExtendedLayout" top="YES"/>
+                    <navigationItem key="navigationItem" title="Portfolio" id="aNJ-I6-TXT"/>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <nil key="simulatedBottomBarMetrics"/>
+                    <connections>
+                        <outlet property="addButton" destination="sQ1-yR-sa6" id="H6o-ZV-xQJ"/>
+                        <outlet property="filterButton" destination="mdd-xs-dfC" id="z6X-7i-sKv"/>
+                        <outlet property="rightBarButtonView" destination="mze-5v-MXb" id="DzF-3k-sX1"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Pq2-te-AuG" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" id="mdd-xs-dfC" customClass="NavBarTitleDropdownButton">
+                    <rect key="frame" x="0.0" y="0.0" width="77" height="25"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <inset key="imageEdgeInsets" minX="4" minY="0.0" maxX="0.0" maxY="0.0"/>
+                    <state key="normal" title="Button" image="icon-nav-chevron">
+                        <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    </state>
+                    <connections>
+                        <action selector="didTapFilterButton:" destination="Iyh-Nw-rHr" eventType="touchUpInside" id="Xiw-S1-z1x"/>
+                    </connections>
+                </button>
+                <view clipsSubviews="YES" contentMode="scaleToFill" id="mze-5v-MXb" userLabel="Right Bar Button View">
+                    <rect key="frame" x="0.0" y="0.0" width="80" height="44"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sQ1-yR-sa6" userLabel="Add Button">
+                            <rect key="frame" x="40" y="0.0" width="40" height="44"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="40" id="ZJz-QB-OAq"/>
+                            </constraints>
+                            <state key="normal" image="icon-post-add">
+                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            </state>
+                            <state key="highlighted" image="icon-post-add-highlight"/>
+                            <connections>
+                                <action selector="handleAddButtonTapped:" destination="Iyh-Nw-rHr" eventType="touchUpInside" id="ViG-xp-Kaj"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="sQ1-yR-sa6" firstAttribute="top" secondItem="mze-5v-MXb" secondAttribute="top" id="6Yk-47-vEF"/>
+                        <constraint firstAttribute="bottom" secondItem="sQ1-yR-sa6" secondAttribute="bottom" id="CPK-qw-Nfs"/>
+                        <constraint firstAttribute="trailing" secondItem="sQ1-yR-sa6" secondAttribute="trailing" id="Zwq-WJ-DRX"/>
+                    </constraints>
+                </view>
+            </objects>
+            <point key="canvasLocation" x="-453" y="-623"/>
+        </scene>
+        <!--Table View Controller-->
+        <scene sceneID="zmQ-gW-j5g">
+            <objects>
+                <tableViewController id="UOf-UC-H8O" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="03w-qx-tGs">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <connections>
+                            <outlet property="dataSource" destination="UOf-UC-H8O" id="LFI-dh-GNQ"/>
+                            <outlet property="delegate" destination="UOf-UC-H8O" id="mYy-pD-y5i"/>
+                        </connections>
+                    </tableView>
+                    <extendedEdge key="edgesForExtendedLayout"/>
+                    <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="RVL-9n-voS">
+                        <autoresizingMask key="autoresizingMask"/>
+                    </refreshControl>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2Ks-Kj-O5c" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="319" y="-624"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="icon-nav-chevron" width="14" height="8"/>
+        <image name="icon-post-add" width="22" height="22"/>
+        <image name="icon-post-add-highlight" width="22" height="22"/>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Portfolio/PortfolioListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/PortfolioListViewController.swift
@@ -147,13 +147,11 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
     // MARK: - Sync Methods
     
     override internal func postTypeToSync() -> PostServiceType {
-        // TODO: return .project
-        return .page
+        return .project
     }
     
     override internal func lastSyncDate() -> Date? {
-        // TODO: return correct value
-        return blog?.lastPagesSync
+        return blog?.lastProjectsSync
     }
     
     // MARK: - Model Interaction

--- a/WordPress/Classes/ViewRelated/Portfolio/PortfolioListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/PortfolioListViewController.swift
@@ -116,7 +116,6 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
     }
     
     fileprivate func noResultsTitlesWhenSearching() -> [PostListFilter.Status: String] {
-        
         let draftMessage = String(format: NSLocalizedString("No drafts match your search for %@", comment: "The '%@' is a placeholder for the search term."), currentSearchTerm()!)
         let scheduledMessage = String(format: NSLocalizedString("No scheduled projects match your search for %@", comment: "The '%@' is a placeholder for the search term."), currentSearchTerm()!)
         let trashedMessage = String(format: NSLocalizedString("No trashed projects match your search for %@", comment: "The '%@' is a placeholder for the search term."), currentSearchTerm()!)
@@ -126,7 +125,6 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
     }
     
     fileprivate func noResultsTitlesWhenFiltering() -> [PostListFilter.Status: String] {
-        
         let draftMessage = NSLocalizedString("You don't have any drafts.", comment: "Displayed when the user views drafts in the portfolio list and there are no projects")
         let scheduledMessage = NSLocalizedString("You don't have any scheduled projects.", comment: "Displayed when the user views scheduled projects in the portfolio list and there are no projects")
         let trashedMessage = NSLocalizedString("You don't have any projects in your trash folder.", comment: "Displayed when the user views trashed in the portfolio list and there are no projects")
@@ -146,11 +144,32 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
         // Noop
     }
     
+    // MARK: - Sync Methods
+    
+    override internal func postTypeToSync() -> PostServiceType {
+        // TODO: return .project
+        return .page
+    }
+    
+    override internal func lastSyncDate() -> Date? {
+        // TODO: return correct value
+        return blog?.lastPagesSync
+    }
+    
+    // MARK: - Model Interaction
+
+    fileprivate func projectAtIndexPath(_ indexPath: IndexPath) -> Project {
+        guard let project = tableViewHandler.resultsController.object(at: indexPath) as? Project else {
+            fatalError("Expected a Project object.")
+        }
+        
+        return project
+    }
+    
     // MARK: - TableView Handler Delegate Methods
     
     override func entityName() -> String {
-        // TODO: model for Project
-        return String(describing: Post.self)
+        return String(describing: Project.self)
     }
     
     override func predicateForFetchRequest() -> NSPredicate {
@@ -161,31 +180,58 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
             predicates.append(basePredicate)
         }
         
-        // TODO:
-//        let searchText = currentSearchTerm()
-//        let filterPredicate = filterSettings.currentPostListFilter().predicateForFetchRequest
-//
-//        // If we have recently trashed posts, create an OR predicate to find posts matching the filter,
-//        // or posts that were recently deleted.
-//        if searchText?.count == 0 && recentlyTrashedPostObjectIDs.count > 0 {
-//
-//            let trashedPredicate = NSPredicate(format: "SELF IN %@", recentlyTrashedPostObjectIDs)
-//
-//            predicates.append(NSCompoundPredicate(orPredicateWithSubpredicates: [filterPredicate, trashedPredicate]))
-//        } else {
-//            predicates.append(filterPredicate)
-//        }
-//
-//        if let searchText = searchText, searchText.count > 0 {
-//            let searchPredicate = NSPredicate(format: "postTitle CONTAINS[cd] %@", searchText)
-//            predicates.append(searchPredicate)
-//        }
+        let searchText = currentSearchTerm()
+        let filterPredicate = filterSettings.currentPostListFilter().predicateForFetchRequest
+
+        // If we have recently trashed posts, create an OR predicate to find posts matching the filter,
+        // or posts that were recently deleted.
+        if searchText?.count == 0 && recentlyTrashedPostObjectIDs.count > 0 {
+
+            let trashedPredicate = NSPredicate(format: "SELF IN %@", recentlyTrashedPostObjectIDs)
+
+            predicates.append(NSCompoundPredicate(orPredicateWithSubpredicates: [filterPredicate, trashedPredicate]))
+        } else {
+            predicates.append(filterPredicate)
+        }
+
+        if let searchText = searchText, searchText.count > 0 {
+            let searchPredicate = NSPredicate(format: "postTitle CONTAINS[cd] %@", searchText)
+            predicates.append(searchPredicate)
+        }
         
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         return predicate
     }
     
     // MARK: - Table View Handling
+    
+    func sectionNameKeyPath() -> String {
+        let sortField = filterSettings.currentPostListFilter().sortField
+        return Project.sectionIdentifier(dateKeyPath: sortField.keyPath)
+    }
+    
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return type(of: self).portfolioSectionHeaderHeight
+    }
+    
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        if section == tableView.numberOfSections - 1 {
+            return WPDeviceIdentification.isRetina() ? 0.5 : 1.0
+        }
+        return 0.0
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView! {
+        let sectionInfo = tableViewHandler.resultsController.sections?[section]
+        let nibName = String(describing: PageListSectionHeaderView.self)
+        let headerView = Bundle.main.loadNibNamed(nibName, owner: nil, options: nil)![0] as! PageListSectionHeaderView
+        
+        if let sectionInfo = sectionInfo {
+            headerView.setTite(sectionInfo.name)
+        }
+        
+        return headerView
+    }
     
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView! {
         if section == tableView.numberOfSections - 1 {
@@ -194,38 +240,204 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
         return UIView(frame: CGRect.zero)
     }
     
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        let project = projectAtIndexPath(indexPath)
+        
+        if project.remoteStatus != .pushing && project.status != .trash {
+            editProject(project)
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAtIndexPath indexPath: IndexPath) -> UITableViewCell {
+        if let windowlessCell = dequeCellForWindowlessLoadingIfNeeded(tableView) {
+            return windowlessCell
+        }
+        
+        let project = projectAtIndexPath(indexPath)
+        
+        let identifier = cellIdentifierForProject(project)
+        let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)
+        
+        configureCell(cell, at: indexPath)
+        
+        return cell
+    }
+    
     override func configureCell(_ cell: UITableViewCell, at indexPath: IndexPath) {
-        // TODO:
-//        guard let cell = cell as? BasePageListCell else {
-//            preconditionFailure("The cell should be of class \(String(describing: BasePageListCell.self))")
-//        }
-//
-//        cell.accessoryType = .none
-//
-//        if cell.reuseIdentifier == type(of: self).pageCellIdentifier {
-//            cell.onAction = { [weak self] cell, button, page in
-//                self?.handleMenuAction(fromCell: cell, fromButton: button, forPage: page)
-//            }
-//        } else if cell.reuseIdentifier == type(of: self).restorePageCellIdentifier {
-//            cell.selectionStyle = .none
-//            cell.onAction = { [weak self] cell, _, page in
-//                self?.handleRestoreAction(fromCell: cell, forPage: page)
-//            }
-//        }
-//
-//        let page = pageAtIndexPath(indexPath)
-//
-//        cell.configureCell(page)
+        
+        guard let cell = cell as? BasePageListCell else {
+            preconditionFailure("The cell should be of class \(String(describing: BasePageListCell.self))")
+        }
+
+        cell.accessoryType = .none
+
+        if cell.reuseIdentifier == type(of: self).projectCellIdentifier {
+            cell.onAction = { [weak self] cell, button, project in
+                self?.handleMenuAction(fromCell: cell, fromButton: button, forProject: project)
+            }
+        } else if cell.reuseIdentifier == type(of: self).restoreProjectCellIdentifier {
+            cell.selectionStyle = .none
+            cell.onAction = { [weak self] cell, _, project in
+                self?.handleRestoreAction(fromCell: cell, forProject: project)
+            }
+        }
+
+        let project = projectAtIndexPath(indexPath)
+
+        cell.configureCell(project)
+    }
+    
+    fileprivate func cellIdentifierForProject(_ project: Project) -> String {
+        var identifier: String
+        
+        if recentlyTrashedPostObjectIDs.contains(project.objectID) == true && filterSettings.currentPostListFilter().filterType != .trashed {
+            identifier = type(of: self).restoreProjectCellIdentifier
+        } else {
+            identifier = type(of: self).projectCellIdentifier
+        }
+        
+        return identifier
     }
     
     // MARK: - Portfolio Actions
     
     override func createPost() {
-        self.createProject()
+        // TODO: implement this for edit mode
     }
     
-    func createProject() {
-        // TODO: implement this
+    fileprivate func editProject(_ apost: AbstractPost) {
+        // TODO: implement this for edit mode
+    }
+    
+    fileprivate func showEditor(post: AbstractPost) {
+        // TODO: implement this for edit mode
+    }
+    
+    fileprivate func draftProject(_ apost: AbstractPost) {
+        // TODO: implement this for edit mode
+    }
+    
+    override func promptThatPostRestoredToFilter(_ filter: PostListFilter) {
+        var message = NSLocalizedString("Project Restored to Drafts", comment: "Prompts the user that a restored project was moved to the drafts list.")
+        
+        switch filter.filterType {
+        case .published:
+            message = NSLocalizedString("Project Restored to Published", comment: "Prompts the user that a restored project was moved to the published list.")
+            break
+        case .scheduled:
+            message = NSLocalizedString("Project Restored to Scheduled", comment: "Prompts the user that a restored project was moved to the scheduled list.")
+            break
+        default:
+            break
+        }
+        
+        let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
+        
+        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(alertCancel, handler: nil)
+        alertController.presentFromRootViewController()
+    }
+    
+    // MARK: - Cell Action Handling
+    
+    fileprivate func handleMenuAction(fromCell cell: UITableViewCell, fromButton button: UIButton, forProject project: AbstractPost) {
+        let objectID = project.objectID
+        
+        let viewButtonTitle = NSLocalizedString("View", comment: "Label for a button that opens the project when tapped.")
+        let draftButtonTitle = NSLocalizedString("Move to Draft", comment: "Label for a button that moves a project to the draft folder")
+        let publishButtonTitle = NSLocalizedString("Publish Immediately", comment: "Label for a button that moves a project to the published folder, publishing with the current date/time.")
+        let trashButtonTitle = NSLocalizedString("Move to Trash", comment: "Label for a button that moves a project to the trash folder")
+        let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Label for a cancel button")
+        let deleteButtonTitle = NSLocalizedString("Delete Permanently", comment: "Label for a button that permanently deletes a project.")
+        
+        // UIAlertAction handlers
+        let publishHandler = { [weak self] (action: UIAlertAction) in
+            guard let strongSelf = self,
+                let project = strongSelf.projectForObjectID(objectID) else {
+                    return
+            }
+            
+            strongSelf.publishPost(project)
+        }
+        let draftHandler = { [weak self] (action: UIAlertAction) in
+            guard let strongSelf = self,
+                let project = strongSelf.projectForObjectID(objectID) else {
+                    return
+            }
+            
+            strongSelf.draftProject(project)
+        }
+        let deleteHandler = { [weak self] (action: UIAlertAction) in
+            guard let strongSelf = self,
+                let project = strongSelf.projectForObjectID(objectID) else {
+                    return
+            }
+            
+            strongSelf.deletePost(project)
+        }
+        let viewHandler = { [weak self] (action: UIAlertAction) in
+            guard let strongSelf = self,
+                let project = strongSelf.projectForObjectID(objectID) else {
+                    return
+            }
+            
+            strongSelf.viewPost(project)
+        }
+        
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        alertController.addCancelActionWithTitle(cancelButtonTitle, handler: nil)
+        
+        let filter = filterSettings.currentPostListFilter().filterType
+        
+        if filter == .trashed {
+            alertController.addActionWithTitle(publishButtonTitle, style: .default, handler: publishHandler)
+            alertController.addActionWithTitle(draftButtonTitle, style: .default, handler: draftHandler)
+            alertController.addActionWithTitle(deleteButtonTitle, style: .default, handler: deleteHandler)
+        } else if filter == .published {
+            alertController.addActionWithTitle(viewButtonTitle, style: .default, handler: viewHandler)
+            alertController.addActionWithTitle(draftButtonTitle, style: .default, handler: draftHandler)
+            alertController.addActionWithTitle(trashButtonTitle, style: .default, handler: deleteHandler)
+        } else {
+            alertController.addActionWithTitle(viewButtonTitle, style: .default, handler: viewHandler)
+            alertController.addActionWithTitle(publishButtonTitle, style: .default, handler: publishHandler)
+            alertController.addActionWithTitle(trashButtonTitle, style: .default, handler: deleteHandler)
+        }
+        
+        WPAnalytics.track(.postListOpenedCellMenu, withProperties: propertiesForAnalytics())
+        
+        alertController.modalPresentationStyle = .popover
+        present(alertController, animated: true, completion: nil)
+        
+        if let presentationController = alertController.popoverPresentationController {
+            presentationController.permittedArrowDirections = .any
+            presentationController.sourceView = button
+            presentationController.sourceRect = button.bounds
+        }
+    }
+    
+    fileprivate func projectForObjectID(_ objectID: NSManagedObjectID) -> Project? {
+        
+        var projectManagedObject: NSManagedObject
+        
+        do {
+            projectManagedObject = try managedObjectContext().existingObject(with: objectID)
+            
+        } catch let error as NSError {
+            DDLogError("\(NSStringFromClass(type(of: self))), \(#function), \(error)")
+            return nil
+        } catch _ {
+            DDLogError("\(NSStringFromClass(type(of: self))), \(#function), Could not find Project with ID \(objectID)")
+            return nil
+        }
+        
+        let project = projectManagedObject as? Project
+        return project
+    }
+    
+    fileprivate func handleRestoreAction(fromCell cell: UITableViewCell, forProject project: AbstractPost) {
+        restorePost(project)
     }
     
     // MARK: - Refreshing noResultsView

--- a/WordPress/Classes/ViewRelated/Portfolio/PortfolioListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/PortfolioListViewController.swift
@@ -1,10 +1,17 @@
- import Foundation
+import Foundation
 import CocoaLumberjack
 import WordPressShared
 
 class PortfolioListViewController: AbstractPostListViewController, UIViewControllerRestoration {
     
+    fileprivate static let portfolioSectionHeaderHeight = CGFloat(24.0)
+    fileprivate static let portfolioCellEstimatedRowHeight = CGFloat(47.0)
     fileprivate static let portfolioViewControllerRestorationKey = "PortfolioViewControllerRestorationKey"
+    fileprivate static let projectCellIdentifier = "ProjectCellIdentifier"
+    fileprivate static let projectCellNibName = "ProjectTableViewCell"
+    fileprivate static let restoreProjectCellIdentifier = "RestoreProjectCellIdentifier"
+    fileprivate static let restoreProjectCellNibName = "RestoreProjectTableViewCell"
+    fileprivate static let currentPortfolioListStatusFilterKey = "CurrentPortfolioListStatusFilterKey"
     
     fileprivate lazy var sectionFooterSeparatorView: UIView = {
         let footer = UIView()
@@ -61,8 +68,7 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.refreshNoResultsView = { [weak self] noResultsView in
-            // TODO:
-//            self?.handleRefreshNoResultsView(noResultsView)
+            self?.handleRefreshNoResultsView(noResultsView)
         }
         super.tableViewController = (segue.destination as! UITableViewController)
     }
@@ -78,19 +84,17 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
     override func configureTableView() {
         tableView.accessibilityIdentifier = "PortfolioTable"
         tableView.isAccessibilityElement = true
-        // TODO:
-//        tableView.estimatedRowHeight = type(of: self).pageCellEstimatedRowHeight
+        tableView.estimatedRowHeight = type(of: self).portfolioCellEstimatedRowHeight
         tableView.rowHeight = UITableViewAutomaticDimension
         
-//        let bundle = Bundle.main
+        let bundle = Bundle.main
         
         // Register the cells
-        // TODO:
-//        let pageCellNib = UINib(nibName: type(of: self).pageCellNibName, bundle: bundle)
-//        tableView.register(pageCellNib, forCellReuseIdentifier: type(of: self).pageCellIdentifier)
-//
-//        let restorePageCellNib = UINib(nibName: type(of: self).restorePageCellNibName, bundle: bundle)
-//        tableView.register(restorePageCellNib, forCellReuseIdentifier: type(of: self).restorePageCellIdentifier)
+        let projectCellNib = UINib(nibName: type(of: self).projectCellNibName, bundle: bundle)
+        tableView.register(projectCellNib, forCellReuseIdentifier: type(of: self).projectCellIdentifier)
+
+        let restoreProjectCellNib = UINib(nibName: type(of: self).restoreProjectCellNibName, bundle: bundle)
+        tableView.register(restoreProjectCellNib, forCellReuseIdentifier: type(of: self).restoreProjectCellIdentifier)
         
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
     }

--- a/WordPress/Classes/ViewRelated/Portfolio/PortfolioListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/PortfolioListViewController.swift
@@ -3,7 +3,7 @@ import CocoaLumberjack
 import WordPressShared
 
 class PortfolioListViewController: AbstractPostListViewController, UIViewControllerRestoration {
-    
+
     fileprivate static let portfolioSectionHeaderHeight = CGFloat(24.0)
     fileprivate static let portfolioCellEstimatedRowHeight = CGFloat(60.0)
     fileprivate static let portfolioViewControllerRestorationKey = "PortfolioViewControllerRestorationKey"
@@ -12,34 +12,34 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
     fileprivate static let restoreProjectCellIdentifier = "RestoreProjectCellIdentifier"
     fileprivate static let restoreProjectCellNibName = "RestoreProjectTableViewCell"
     fileprivate static let currentPortfolioListStatusFilterKey = "CurrentPortfolioListStatusFilterKey"
-    
+
     fileprivate lazy var sectionFooterSeparatorView: UIView = {
         let footer = UIView()
         footer.backgroundColor = WPStyleGuide.greyLighten20()
         return footer
     }()
-    
+
     // MARK: - GUI
-    
+
     fileprivate let animatedBox = WPAnimatedBox()
-    
+
     // MARK: - Convenience constructors
-    
+
     @objc class func controllerWithBlog(_ blog: Blog) -> PortfolioListViewController {
-        
+
         let storyBoard = UIStoryboard(name: "Portfolio", bundle: Bundle.main)
         let controller = storyBoard.instantiateViewController(withIdentifier: "PortfolioListViewController") as! PortfolioListViewController
-        
+
         controller.blog = blog
         controller.restorationClass = self
-        
+
         return controller
     }
-    
+
     // MARK: - UIViewControllerRestoration
-    
+
     class func viewController(withRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
-        
+
         let context = ContextManager.sharedInstance().mainContext
 
         guard let blogID = coder.decodeObject(forKey: portfolioViewControllerRestorationKey) as? String,
@@ -52,61 +52,61 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
 
         return self.controllerWithBlog(restoredBlog)
     }
-    
+
     // MARK: - UIStateRestoring
-    
+
     override func encodeRestorableState(with coder: NSCoder) {
-        
+
         let objectString = blog?.objectID.uriRepresentation().absoluteString
-        
+
         coder.encode(objectString, forKey: type(of: self).portfolioViewControllerRestorationKey)
-        
+
         super.encodeRestorableState(with: coder)
     }
-    
+
     // MARK: - UIViewController
-    
+
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         super.refreshNoResultsView = { [weak self] noResultsView in
             self?.handleRefreshNoResultsView(noResultsView)
         }
         super.tableViewController = (segue.destination as! UITableViewController)
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
         title = NSLocalizedString("Portfolio", comment: "Tile of the screen showing the list of projects (Portfolio) for a blog.")
     }
-    
+
     // MARK: - Configuration
-    
+
     override func configureTableView() {
         tableView.accessibilityIdentifier = "PortfolioTable"
         tableView.isAccessibilityElement = true
         tableView.estimatedRowHeight = type(of: self).portfolioCellEstimatedRowHeight
         tableView.rowHeight = UITableViewAutomaticDimension
-        
+
         let bundle = Bundle.main
-        
+
         // Register the cells
         let projectCellNib = UINib(nibName: type(of: self).projectCellNibName, bundle: bundle)
         tableView.register(projectCellNib, forCellReuseIdentifier: type(of: self).projectCellIdentifier)
 
         let restoreProjectCellNib = UINib(nibName: type(of: self).restoreProjectCellNibName, bundle: bundle)
         tableView.register(restoreProjectCellNib, forCellReuseIdentifier: type(of: self).restoreProjectCellIdentifier)
-        
+
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
     }
-    
+
     override func configureSearchController() {
         super.configureSearchController()
-        
+
         tableView.tableHeaderView = searchController.searchBar
-        
+
         tableView.scrollIndicatorInsets.top = searchController.searchBar.bounds.height
     }
-    
+
     fileprivate func noResultsTitles() -> [PostListFilter.Status: String] {
         if isSearching() {
             return noResultsTitlesWhenSearching()
@@ -114,70 +114,70 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
             return noResultsTitlesWhenFiltering()
         }
     }
-    
+
     fileprivate func noResultsTitlesWhenSearching() -> [PostListFilter.Status: String] {
         let draftMessage = String(format: NSLocalizedString("No drafts match your search for %@", comment: "The '%@' is a placeholder for the search term."), currentSearchTerm()!)
         let scheduledMessage = String(format: NSLocalizedString("No scheduled projects match your search for %@", comment: "The '%@' is a placeholder for the search term."), currentSearchTerm()!)
         let trashedMessage = String(format: NSLocalizedString("No trashed projects match your search for %@", comment: "The '%@' is a placeholder for the search term."), currentSearchTerm()!)
         let publishedMessage = String(format: NSLocalizedString("No projects match your search for %@", comment: "The '%@' is a placeholder for the search term."), currentSearchTerm()!)
-        
+
         return noResultsTitles(draftMessage, scheduled: scheduledMessage, trashed: trashedMessage, published: publishedMessage)
     }
-    
+
     fileprivate func noResultsTitlesWhenFiltering() -> [PostListFilter.Status: String] {
         let draftMessage = NSLocalizedString("You don't have any drafts.", comment: "Displayed when the user views drafts in the portfolio list and there are no projects")
         let scheduledMessage = NSLocalizedString("You don't have any scheduled projects.", comment: "Displayed when the user views scheduled projects in the portfolio list and there are no projects")
         let trashedMessage = NSLocalizedString("You don't have any projects in your trash folder.", comment: "Displayed when the user views trashed in the portfolio list and there are no projects")
         let publishedMessage = NSLocalizedString("You haven't published any projects yet.", comment: "Displayed when the user views published projects in the portfolio list and there are no projects")
-        
+
         return noResultsTitles(draftMessage, scheduled: scheduledMessage, trashed: trashedMessage, published: publishedMessage)
     }
-    
+
     fileprivate func noResultsTitles(_ draft: String, scheduled: String, trashed: String, published: String) -> [PostListFilter.Status: String] {
         return [.draft: draft,
                 .scheduled: scheduled,
                 .trashed: trashed,
                 .published: published]
     }
-    
+
     override func configureAuthorFilter() {
         // Noop
     }
-    
+
     // MARK: - Sync Methods
-    
+
     override internal func postTypeToSync() -> PostServiceType {
         return .project
     }
-    
+
     override internal func lastSyncDate() -> Date? {
         return blog?.lastProjectsSync
     }
-    
+
     // MARK: - Model Interaction
 
     fileprivate func projectAtIndexPath(_ indexPath: IndexPath) -> Project {
         guard let project = tableViewHandler.resultsController.object(at: indexPath) as? Project else {
             fatalError("Expected a Project object.")
         }
-        
+
         return project
     }
-    
+
     // MARK: - TableView Handler Delegate Methods
-    
+
     override func entityName() -> String {
         return String(describing: Project.self)
     }
-    
+
     override func predicateForFetchRequest() -> NSPredicate {
         var predicates = [NSPredicate]()
-        
+
         if let blog = blog {
             let basePredicate = NSPredicate(format: "blog = %@ && revision = nil", blog)
             predicates.append(basePredicate)
         }
-        
+
         let searchText = currentSearchTerm()
         let filterPredicate = filterSettings.currentPostListFilter().predicateForFetchRequest
 
@@ -196,75 +196,75 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
             let searchPredicate = NSPredicate(format: "postTitle CONTAINS[cd] %@", searchText)
             predicates.append(searchPredicate)
         }
-        
+
         let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         return predicate
     }
-    
+
     // MARK: - Table View Handling
-    
+
     func sectionNameKeyPath() -> String {
         let sortField = filterSettings.currentPostListFilter().sortField
         return Project.sectionIdentifier(dateKeyPath: sortField.keyPath)
     }
-    
+
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return type(of: self).portfolioSectionHeaderHeight
     }
-    
+
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         if section == tableView.numberOfSections - 1 {
             return WPDeviceIdentification.isRetina() ? 0.5 : 1.0
         }
         return 0.0
     }
-    
+
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView! {
         let sectionInfo = tableViewHandler.resultsController.sections?[section]
         let nibName = String(describing: PageListSectionHeaderView.self)
         let headerView = Bundle.main.loadNibNamed(nibName, owner: nil, options: nil)![0] as! PageListSectionHeaderView
-        
+
         if let sectionInfo = sectionInfo {
             headerView.setTite(sectionInfo.name)
         }
-        
+
         return headerView
     }
-    
+
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView! {
         if section == tableView.numberOfSections - 1 {
             return sectionFooterSeparatorView
         }
         return UIView(frame: CGRect.zero)
     }
-    
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        
+
         let project = projectAtIndexPath(indexPath)
-        
+
         if project.remoteStatus != .pushing && project.status != .trash {
             editProject(project)
         }
     }
-    
+
     @objc func tableView(_ tableView: UITableView, cellForRowAtIndexPath indexPath: IndexPath) -> UITableViewCell {
         if let windowlessCell = dequeCellForWindowlessLoadingIfNeeded(tableView) {
             return windowlessCell
         }
-        
+
         let project = projectAtIndexPath(indexPath)
-        
+
         let identifier = cellIdentifierForProject(project)
         let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)
-        
+
         configureCell(cell, at: indexPath)
-        
+
         return cell
     }
-    
+
     override func configureCell(_ cell: UITableViewCell, at indexPath: IndexPath) {
-        
+
         guard let cell = cell as? BasePageListCell else {
             preconditionFailure("The cell should be of class \(String(describing: BasePageListCell.self))")
         }
@@ -286,40 +286,40 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
 
         cell.configureCell(project)
     }
-    
+
     fileprivate func cellIdentifierForProject(_ project: Project) -> String {
         var identifier: String
-        
+
         if recentlyTrashedPostObjectIDs.contains(project.objectID) == true && filterSettings.currentPostListFilter().filterType != .trashed {
             identifier = type(of: self).restoreProjectCellIdentifier
         } else {
             identifier = type(of: self).projectCellIdentifier
         }
-        
+
         return identifier
     }
-    
+
     // MARK: - Portfolio Actions
-    
+
     override func createPost() {
         // TODO: implement this for edit mode
     }
-    
+
     fileprivate func editProject(_ apost: AbstractPost) {
         // TODO: implement this for edit mode
     }
-    
+
     fileprivate func showEditor(post: AbstractPost) {
         // TODO: implement this for edit mode
     }
-    
+
     fileprivate func draftProject(_ apost: AbstractPost) {
         // TODO: implement this for edit mode
     }
-    
+
     override func promptThatPostRestoredToFilter(_ filter: PostListFilter) {
         var message = NSLocalizedString("Project Restored to Drafts", comment: "Prompts the user that a restored project was moved to the drafts list.")
-        
+
         switch filter.filterType {
         case .published:
             message = NSLocalizedString("Project Restored to Published", comment: "Prompts the user that a restored project was moved to the published list.")
@@ -330,33 +330,33 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
         default:
             break
         }
-        
+
         let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
-        
+
         let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         alertController.addCancelActionWithTitle(alertCancel, handler: nil)
         alertController.presentFromRootViewController()
     }
-    
+
     // MARK: - Cell Action Handling
-    
+
     fileprivate func handleMenuAction(fromCell cell: UITableViewCell, fromButton button: UIButton, forProject project: AbstractPost) {
         let objectID = project.objectID
-        
+
         let viewButtonTitle = NSLocalizedString("View", comment: "Label for a button that opens the project when tapped.")
         let draftButtonTitle = NSLocalizedString("Move to Draft", comment: "Label for a button that moves a project to the draft folder")
         let publishButtonTitle = NSLocalizedString("Publish Immediately", comment: "Label for a button that moves a project to the published folder, publishing with the current date/time.")
         let trashButtonTitle = NSLocalizedString("Move to Trash", comment: "Label for a button that moves a project to the trash folder")
         let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Label for a cancel button")
         let deleteButtonTitle = NSLocalizedString("Delete Permanently", comment: "Label for a button that permanently deletes a project.")
-        
+
         // UIAlertAction handlers
         let publishHandler = { [weak self] (action: UIAlertAction) in
             guard let strongSelf = self,
                 let project = strongSelf.projectForObjectID(objectID) else {
                     return
             }
-            
+
             strongSelf.publishPost(project)
         }
         let draftHandler = { [weak self] (action: UIAlertAction) in
@@ -364,7 +364,7 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
                 let project = strongSelf.projectForObjectID(objectID) else {
                     return
             }
-            
+
             strongSelf.draftProject(project)
         }
         let deleteHandler = { [weak self] (action: UIAlertAction) in
@@ -372,7 +372,7 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
                 let project = strongSelf.projectForObjectID(objectID) else {
                     return
             }
-            
+
             strongSelf.deletePost(project)
         }
         let viewHandler = { [weak self] (action: UIAlertAction) in
@@ -380,15 +380,15 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
                 let project = strongSelf.projectForObjectID(objectID) else {
                     return
             }
-            
+
             strongSelf.viewPost(project)
         }
-        
+
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alertController.addCancelActionWithTitle(cancelButtonTitle, handler: nil)
-        
+
         let filter = filterSettings.currentPostListFilter().filterType
-        
+
         if filter == .trashed {
             alertController.addActionWithTitle(publishButtonTitle, style: .default, handler: publishHandler)
             alertController.addActionWithTitle(draftButtonTitle, style: .default, handler: draftHandler)
@@ -402,26 +402,26 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
             alertController.addActionWithTitle(publishButtonTitle, style: .default, handler: publishHandler)
             alertController.addActionWithTitle(trashButtonTitle, style: .default, handler: deleteHandler)
         }
-        
+
         WPAnalytics.track(.postListOpenedCellMenu, withProperties: propertiesForAnalytics())
-        
+
         alertController.modalPresentationStyle = .popover
         present(alertController, animated: true, completion: nil)
-        
+
         if let presentationController = alertController.popoverPresentationController {
             presentationController.permittedArrowDirections = .any
             presentationController.sourceView = button
             presentationController.sourceRect = button.bounds
         }
     }
-    
+
     fileprivate func projectForObjectID(_ objectID: NSManagedObjectID) -> Project? {
-        
+
         var projectManagedObject: NSManagedObject
-        
+
         do {
             projectManagedObject = try managedObjectContext().existingObject(with: objectID)
-            
+
         } catch let error as NSError {
             DDLogError("\(NSStringFromClass(type(of: self))), \(#function), \(error)")
             return nil
@@ -429,42 +429,42 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
             DDLogError("\(NSStringFromClass(type(of: self))), \(#function), Could not find Project with ID \(objectID)")
             return nil
         }
-        
+
         let project = projectManagedObject as? Project
         return project
     }
-    
+
     fileprivate func handleRestoreAction(fromCell cell: UITableViewCell, forProject project: AbstractPost) {
         restorePost(project)
     }
-    
+
     // MARK: - Refreshing noResultsView
-    
+
     @objc func handleRefreshNoResultsView(_ noResultsView: WPNoResultsView) {
         noResultsView.titleText = noResultsTitle()
         noResultsView.messageText = noResultsMessage()
         noResultsView.accessoryView = noResultsAccessoryView()
         noResultsView.buttonTitle = noResultsButtonTitle()
     }
-    
+
     // MARK: - NoResultsView Customizer helpers
-    
+
     fileprivate func noResultsAccessoryView() -> UIView {
         if syncHelper.isSyncing {
             animatedBox.animate(afterDelay: 0.1)
             return animatedBox
         }
-        
+
         return UIImageView(image: UIImage(named: "illustration-posts"))
     }
-    
+
     fileprivate func noResultsButtonTitle() -> String {
         if syncHelper.isSyncing == true || isSearching() {
             return ""
         }
-        
+
         let filterType = filterSettings.currentPostListFilter().filterType
-        
+
         switch filterType {
         case .trashed:
             return ""
@@ -472,25 +472,25 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
             return NSLocalizedString("Start a Project", comment: "Button title, encourages users to create their first project on their blog.")
         }
     }
-    
+
     fileprivate func noResultsTitle() -> String {
         if syncHelper.isSyncing == true {
             return NSLocalizedString("Fetching projects...", comment: "A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new projects.")
         }
-        
+
         let filter = filterSettings.currentPostListFilter()
         let titles = noResultsTitles()
         let title = titles[filter.filterType]
         return title ?? ""
     }
-    
+
     fileprivate func noResultsMessage() -> String {
         if syncHelper.isSyncing == true || isSearching() {
             return ""
         }
-        
+
         let filterType = filterSettings.currentPostListFilter().filterType
-        
+
         switch filterType {
         case .draft:
             return NSLocalizedString("Would you like to create one?", comment: "Displayed when the user views drafts in the portfolio and there are no projects")
@@ -502,9 +502,9 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
             return NSLocalizedString("Would you like to publish your first project?", comment: "Displayed when the user views published projects in the portfolio and there are no projects")
         }
     }
-    
+
     // MARK: - UISearchControllerDelegate
-    
+
     func didPresentSearchController(_ searchController: UISearchController) {
         if #available(iOS 11.0, *) {
             tableView.scrollIndicatorInsets.top = searchController.searchBar.bounds.height + searchController.searchBar.frame.origin.y - topLayoutGuide.length

--- a/WordPress/Classes/ViewRelated/Portfolio/PortfolioListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/PortfolioListViewController.swift
@@ -5,7 +5,7 @@ import WordPressShared
 class PortfolioListViewController: AbstractPostListViewController, UIViewControllerRestoration {
     
     fileprivate static let portfolioSectionHeaderHeight = CGFloat(24.0)
-    fileprivate static let portfolioCellEstimatedRowHeight = CGFloat(47.0)
+    fileprivate static let portfolioCellEstimatedRowHeight = CGFloat(60.0)
     fileprivate static let portfolioViewControllerRestorationKey = "PortfolioViewControllerRestorationKey"
     fileprivate static let projectCellIdentifier = "ProjectCellIdentifier"
     fileprivate static let projectCellNibName = "ProjectTableViewCell"

--- a/WordPress/Classes/ViewRelated/Portfolio/PortfolioListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/PortfolioListViewController.swift
@@ -25,7 +25,7 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
     
     // MARK: - Convenience constructors
     
-    class func controllerWithBlog(_ blog: Blog) -> PortfolioListViewController {
+    @objc class func controllerWithBlog(_ blog: Blog) -> PortfolioListViewController {
         
         let storyBoard = UIStoryboard(name: "Portfolio", bundle: Bundle.main)
         let controller = storyBoard.instantiateViewController(withIdentifier: "PortfolioListViewController") as! PortfolioListViewController
@@ -248,7 +248,7 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
         }
     }
     
-    func tableView(_ tableView: UITableView, cellForRowAtIndexPath indexPath: IndexPath) -> UITableViewCell {
+    @objc func tableView(_ tableView: UITableView, cellForRowAtIndexPath indexPath: IndexPath) -> UITableViewCell {
         if let windowlessCell = dequeCellForWindowlessLoadingIfNeeded(tableView) {
             return windowlessCell
         }
@@ -440,7 +440,7 @@ class PortfolioListViewController: AbstractPostListViewController, UIViewControl
     
     // MARK: - Refreshing noResultsView
     
-    func handleRefreshNoResultsView(_ noResultsView: WPNoResultsView) {
+    @objc func handleRefreshNoResultsView(_ noResultsView: WPNoResultsView) {
         noResultsView.titleText = noResultsTitle()
         noResultsView.messageText = noResultsMessage()
         noResultsView.accessoryView = noResultsAccessoryView()

--- a/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.swift
@@ -38,7 +38,7 @@ class ProjectTableViewCell: BasePageListCell {
         
         let rightPost = getRightPost(from: post)
         let str = rightPost.titleForDisplay() ?? ""
-        titleLabel.attributedText = NSAttributedString(string: str, attributes: WPStyleGuide.pageCellTitleAttributes() as? [String: Any])
+        titleLabel.attributedText = NSAttributedString(string: str, attributes: WPStyleGuide.pageCellTitleAttributes() as? [NSAttributedStringKey: Any])
     }
 
     func configureImage() {

--- a/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.swift
@@ -3,10 +3,12 @@ import UIKit
 class ProjectTableViewCell: BasePageListCell {
     @IBOutlet var titleLabel: UILabel!
     @IBOutlet var menuButton: UIButton!
+    @IBOutlet var featuredImageView: UIImageView!
     
     override var post: AbstractPost? {
         didSet {
             configureTitle()
+            configureImage()
         }
     }
     
@@ -16,6 +18,9 @@ class ProjectTableViewCell: BasePageListCell {
         super.awakeFromNib()
         
         applyStyles()
+
+        featuredImageView.clipsToBounds = true
+        featuredImageView.contentMode = .scaleAspectFill
     }
     
     // MARK: - Configuration
@@ -29,8 +34,29 @@ class ProjectTableViewCell: BasePageListCell {
             return
         }
         
-        let rightPost = post.hasRevision() ? post.revision! : post
+        let rightPost = getRightPost(from: post)
         let str = rightPost.titleForDisplay() ?? ""
         titleLabel.attributedText = NSAttributedString(string: str, attributes: WPStyleGuide.pageCellTitleAttributes() as? [String: Any])
+    }
+
+    func configureImage() {
+        guard let post = self.post else {
+            return
+        }
+        
+        let rightPost = getRightPost(from: post)
+        if let featuredImage = rightPost.featuredImage {
+            featuredImage.image(with: .zero, completionHandler: { image, error in
+                if error == nil {
+                    self.featuredImageView.image = image
+                }
+            })
+        } else {
+            self.featuredImageView.image = nil
+        }
+    }
+
+    func getRightPost(from post: AbstractPost) -> AbstractPost {
+        return post.hasRevision() ? post.revision! : post
     }
 }

--- a/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.swift
@@ -6,36 +6,36 @@ class ProjectTableViewCell: BasePageListCell {
     @IBOutlet var featuredImageView: UIImageView!
     @IBOutlet var featuredImageWidthConstraint: NSLayoutConstraint!
     @IBOutlet var featuredImageHeightConstraint: NSLayoutConstraint!
-    
+
     override var post: AbstractPost? {
         didSet {
             configureTitle()
             configureImage()
         }
     }
-    
+
     // MARK: - Life Cycle
-    
+
     override func awakeFromNib() {
         super.awakeFromNib()
-        
+
         applyStyles()
 
         featuredImageView.clipsToBounds = true
         featuredImageView.contentMode = .scaleAspectFill
     }
-    
+
     // MARK: - Configuration
-    
+
     func applyStyles() {
         WPStyleGuide.applyPageTitleStyle(titleLabel)
     }
-    
+
     func configureTitle() {
         guard let post = self.post else {
             return
         }
-        
+
         let rightPost = getRightPost(from: post)
         let str = rightPost.titleForDisplay() ?? ""
         titleLabel.attributedText = NSAttributedString(string: str, attributes: WPStyleGuide.pageCellTitleAttributes() as? [NSAttributedStringKey: Any])
@@ -45,14 +45,14 @@ class ProjectTableViewCell: BasePageListCell {
         guard let post = self.post else {
             return
         }
-        
+
         let rightPost = getRightPost(from: post)
 
         if let featuredImagePath = rightPost.pathForDisplayImage, let featuredImageURL = URL(string: featuredImagePath) {
-            if (post.blog.isHostedAtWPcom) {
+            if post.blog.isHostedAtWPcom {
                 let desiredWidth = featuredImageWidthConstraint.constant
                 let desiredHeight = featuredImageHeightConstraint.constant
-                if (post.isPrivate()) {
+                if post.isPrivate() {
                     let scale = UIScreen.main.scale
                     let scaledSize = CGSize(width: desiredWidth * scale, height: desiredHeight * scale)
                     let url = WPImageURLHelper.imageURLWithSize(scaledSize, forImageURL: featuredImageURL)

--- a/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.swift
@@ -1,0 +1,36 @@
+import UIKit
+
+class ProjectTableViewCell: BasePageListCell {
+    @IBOutlet var titleLabel: UILabel!
+    @IBOutlet var menuButton: UIButton!
+    
+    override var post: AbstractPost? {
+        didSet {
+            configureTitle()
+        }
+    }
+    
+    // MARK: - Life Cycle
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        applyStyles()
+    }
+    
+    // MARK: - Configuration
+    
+    func applyStyles() {
+        WPStyleGuide.applyPageTitleStyle(titleLabel)
+    }
+    
+    func configureTitle() {
+        guard let post = self.post else {
+            return
+        }
+        
+        let rightPost = post.hasRevision() ? post.revision! : post
+        let str = rightPost.titleForDisplay() ?? ""
+        titleLabel.attributedText = NSAttributedString(string: str, attributes: WPStyleGuide.pageCellTitleAttributes() as? [String: Any])
+    }
+}

--- a/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.xib
@@ -67,7 +67,9 @@
                 </constraints>
             </tableViewCellContentView>
             <connections>
+                <outlet property="featuredImageHeightConstraint" destination="RDO-A6-lpI" id="Y2y-5R-pXt"/>
                 <outlet property="featuredImageView" destination="fec-3M-CSo" id="940-Nz-SbN"/>
+                <outlet property="featuredImageWidthConstraint" destination="lGO-x5-vER" id="ZuO-DJ-Rfx"/>
                 <outlet property="menuButton" destination="wzV-Fy-dFb" id="BSw-4S-wh9"/>
                 <outlet property="titleLabel" destination="68g-tY-SKH" id="XGo-Y7-jOg"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.xib
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <customFonts key="customFonts">
+        <array key="NotoSerif-Regular.ttf">
+            <string>NotoSerif</string>
+        </array>
+    </customFonts>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="MZN-oM-SAV" customClass="ProjectTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="MZN-oM-SAV" id="IyV-IB-MWG">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Project Title" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="68g-tY-SKH" userLabel="Title Label">
+                        <rect key="frame" x="16" y="3" width="307" height="37.5"/>
+                        <fontDescription key="fontDescription" name="NotoSerif" family="Noto Serif" pointSize="15"/>
+                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wzV-Fy-dFb" userLabel="Menu Button">
+                        <rect key="frame" x="323" y="0.0" width="54" height="47"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="47" id="ifi-fP-qzf"/>
+                            <constraint firstAttribute="width" constant="54" id="uzb-Pc-f9y"/>
+                        </constraints>
+                        <state key="normal" image="icon-post-actionbar-more">
+                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        </state>
+                        <connections>
+                            <action selector="onAction:" destination="MZN-oM-SAV" eventType="touchUpInside" id="kGB-hi-EEu"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="wzV-Fy-dFb" firstAttribute="top" secondItem="IyV-IB-MWG" secondAttribute="top" id="AON-6B-YeV"/>
+                    <constraint firstItem="wzV-Fy-dFb" firstAttribute="leading" secondItem="68g-tY-SKH" secondAttribute="trailing" id="ffu-kQ-PG8"/>
+                    <constraint firstItem="68g-tY-SKH" firstAttribute="leading" secondItem="IyV-IB-MWG" secondAttribute="leadingMargin" id="iGe-cm-P3A"/>
+                    <constraint firstItem="68g-tY-SKH" firstAttribute="top" secondItem="IyV-IB-MWG" secondAttribute="top" constant="3" id="isC-NK-UTR"/>
+                    <constraint firstAttribute="bottom" secondItem="68g-tY-SKH" secondAttribute="bottom" constant="3" id="mcR-8b-BGx"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="wzV-Fy-dFb" secondAttribute="trailing" priority="999" constant="-18" id="wKd-9x-R7w"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="menuButton" destination="wzV-Fy-dFb" id="BSw-4S-wh9"/>
+                <outlet property="titleLabel" destination="68g-tY-SKH" id="XGo-Y7-jOg"/>
+            </connections>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="icon-post-actionbar-more" width="18" height="18"/>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.xib
@@ -17,15 +17,18 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="MZN-oM-SAV" customClass="ProjectTableViewCell">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="MZN-oM-SAV" customClass="ProjectTableViewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="47"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="MZN-oM-SAV" id="IyV-IB-MWG">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="MZN-oM-SAV" id="IyV-IB-MWG">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="46.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Project Title" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="68g-tY-SKH" userLabel="Title Label">
-                        <rect key="frame" x="16" y="3" width="307" height="37.5"/>
+                        <rect key="frame" x="16" y="3" width="307" height="40.5"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="41" id="0vt-7u-28i"/>
+                        </constraints>
                         <fontDescription key="fontDescription" name="NotoSerif" family="Noto Serif" pointSize="15"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Portfolio/ProjectTableViewCell.xib
@@ -18,25 +18,23 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="MZN-oM-SAV" customClass="ProjectTableViewCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="47"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="60"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="MZN-oM-SAV" id="IyV-IB-MWG">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="46.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="59.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Project Title" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="68g-tY-SKH" userLabel="Title Label">
-                        <rect key="frame" x="16" y="3" width="307" height="40.5"/>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fec-3M-CSo" userLabel="Featured Image">
+                        <rect key="frame" x="242" y="4" width="78" height="52"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="41" id="0vt-7u-28i"/>
+                            <constraint firstAttribute="height" constant="52" id="RDO-A6-lpI"/>
+                            <constraint firstAttribute="width" constant="78" id="lGO-x5-vER"/>
                         </constraints>
-                        <fontDescription key="fontDescription" name="NotoSerif" family="Noto Serif" pointSize="15"/>
-                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    </imageView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wzV-Fy-dFb" userLabel="Menu Button">
-                        <rect key="frame" x="323" y="0.0" width="54" height="47"/>
+                        <rect key="frame" x="323" y="0.0" width="54" height="60"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="47" id="ifi-fP-qzf"/>
+                            <constraint firstAttribute="height" constant="60" id="ifi-fP-qzf"/>
                             <constraint firstAttribute="width" constant="54" id="uzb-Pc-f9y"/>
                         </constraints>
                         <state key="normal" image="icon-post-actionbar-more">
@@ -46,20 +44,34 @@
                             <action selector="onAction:" destination="MZN-oM-SAV" eventType="touchUpInside" id="kGB-hi-EEu"/>
                         </connections>
                     </button>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Project Title" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="68g-tY-SKH" userLabel="Title Label">
+                        <rect key="frame" x="16" y="10" width="223" height="40"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="40" id="x3v-RM-w4O"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" name="NotoSerif" family="Noto Serif" pointSize="15"/>
+                        <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <nil key="highlightedColor"/>
+                    </label>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="bottom" secondItem="fec-3M-CSo" secondAttribute="bottom" constant="3.5" id="8tv-qU-l9F"/>
                     <constraint firstItem="wzV-Fy-dFb" firstAttribute="top" secondItem="IyV-IB-MWG" secondAttribute="top" id="AON-6B-YeV"/>
-                    <constraint firstItem="wzV-Fy-dFb" firstAttribute="leading" secondItem="68g-tY-SKH" secondAttribute="trailing" id="ffu-kQ-PG8"/>
-                    <constraint firstItem="68g-tY-SKH" firstAttribute="leading" secondItem="IyV-IB-MWG" secondAttribute="leadingMargin" id="iGe-cm-P3A"/>
-                    <constraint firstItem="68g-tY-SKH" firstAttribute="top" secondItem="IyV-IB-MWG" secondAttribute="top" constant="3" id="isC-NK-UTR"/>
-                    <constraint firstAttribute="bottom" secondItem="68g-tY-SKH" secondAttribute="bottom" constant="3" id="mcR-8b-BGx"/>
+                    <constraint firstItem="fec-3M-CSo" firstAttribute="leading" secondItem="68g-tY-SKH" secondAttribute="trailing" constant="3" id="ASM-Tf-4TE"/>
+                    <constraint firstItem="wzV-Fy-dFb" firstAttribute="leading" secondItem="fec-3M-CSo" secondAttribute="trailing" constant="3" id="Gze-Pp-9WL"/>
+                    <constraint firstAttribute="bottom" secondItem="68g-tY-SKH" secondAttribute="bottom" constant="9.5" id="NvE-9V-QhV"/>
+                    <constraint firstItem="68g-tY-SKH" firstAttribute="leading" secondItem="IyV-IB-MWG" secondAttribute="leadingMargin" id="Pkq-YI-IxW"/>
+                    <constraint firstItem="68g-tY-SKH" firstAttribute="top" secondItem="IyV-IB-MWG" secondAttribute="top" constant="10" id="XQ3-7y-D6P"/>
+                    <constraint firstItem="fec-3M-CSo" firstAttribute="top" secondItem="IyV-IB-MWG" secondAttribute="top" constant="4" id="iOq-mb-QIy"/>
                     <constraint firstAttribute="trailingMargin" secondItem="wzV-Fy-dFb" secondAttribute="trailing" priority="999" constant="-18" id="wKd-9x-R7w"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
+                <outlet property="featuredImageView" destination="fec-3M-CSo" id="940-Nz-SbN"/>
                 <outlet property="menuButton" destination="wzV-Fy-dFb" id="BSw-4S-wh9"/>
                 <outlet property="titleLabel" destination="68g-tY-SKH" id="XGo-Y7-jOg"/>
             </connections>
+            <point key="canvasLocation" x="32.5" y="106"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Portfolio/RestoreProjectTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/RestoreProjectTableViewCell.swift
@@ -3,26 +3,27 @@ import UIKit
 class RestoreProjectTableViewCell: BasePageListCell {
     @IBOutlet var restoreLabel: UILabel!
     @IBOutlet var restoreButton: UIButton!
-    
+
     // MARK: - Life Cycle
-    
+
     override func awakeFromNib() {
         super.awakeFromNib()
-        
+
         configureView()
         applyStyles()
     }
-    
+
     // MARK: - Configuration
-    
+
     func applyStyles() {
         WPStyleGuide.applyRestorePageLabelStyle(restoreLabel)
         WPStyleGuide.applyRestorePageButtonStyle(restoreButton)
     }
-    
+
     func configureView() {
         restoreLabel.text = NSLocalizedString("Project moved to trash.", comment: "A short message explaining that a project was moved to the trash bin.")
         let buttonTitle = NSLocalizedString("Undo", comment: "The title of an 'undo' button. Tapping the button moves a trashed project out of the trash folder.")
         restoreButton.setTitle(buttonTitle, for: .normal)
     }
+
 }

--- a/WordPress/Classes/ViewRelated/Portfolio/RestoreProjectTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Portfolio/RestoreProjectTableViewCell.swift
@@ -1,0 +1,28 @@
+import UIKit
+
+class RestoreProjectTableViewCell: BasePageListCell {
+    @IBOutlet var restoreLabel: UILabel!
+    @IBOutlet var restoreButton: UIButton!
+    
+    // MARK: - Life Cycle
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        
+        configureView()
+        applyStyles()
+    }
+    
+    // MARK: - Configuration
+    
+    func applyStyles() {
+        WPStyleGuide.applyRestorePageLabelStyle(restoreLabel)
+        WPStyleGuide.applyRestorePageButtonStyle(restoreButton)
+    }
+    
+    func configureView() {
+        restoreLabel.text = NSLocalizedString("Project moved to trash.", comment: "A short message explaining that a project was moved to the trash bin.")
+        let buttonTitle = NSLocalizedString("Undo", comment: "The title of an 'undo' button. Tapping the button moves a trashed project out of the trash folder.")
+        restoreButton.setTitle(buttonTitle, for: .normal)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Portfolio/RestoreProjectTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Portfolio/RestoreProjectTableViewCell.xib
@@ -12,15 +12,15 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="mtS-Un-VR1" customClass="RestoreProjectTableViewCell">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="mtS-Un-VR1" customClass="RestoreProjectTableViewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="47"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mtS-Un-VR1" id="uGt-2c-uiH">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="46.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Page moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9qX-7Q-3Mu" userLabel="Restore Label">
-                        <rect key="frame" x="16" y="9" width="272" height="26"/>
+                        <rect key="frame" x="16" y="10.5" width="272" height="26"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="26" id="LgM-G9-iO2"/>
                         </constraints>
@@ -29,7 +29,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QuM-Mo-Kad" userLabel="Restore Button">
-                        <rect key="frame" x="288" y="9" width="86" height="26"/>
+                        <rect key="frame" x="288" y="10.5" width="86" height="26"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="86" id="JLI-Cm-9gL"/>
                         </constraints>
@@ -46,12 +46,14 @@
                     </button>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="QuM-Mo-Kad" firstAttribute="centerY" secondItem="uGt-2c-uiH" secondAttribute="centerY" id="6Uo-X5-6fK"/>
+                    <constraint firstAttribute="bottom" secondItem="9qX-7Q-3Mu" secondAttribute="bottom" constant="10" id="374-c4-aPc"/>
+                    <constraint firstItem="QuM-Mo-Kad" firstAttribute="top" secondItem="uGt-2c-uiH" secondAttribute="top" constant="10.5" id="8Cy-H9-5Ys"/>
+                    <constraint firstItem="9qX-7Q-3Mu" firstAttribute="top" secondItem="uGt-2c-uiH" secondAttribute="top" constant="10.5" id="FCj-hB-Gw0"/>
                     <constraint firstItem="QuM-Mo-Kad" firstAttribute="height" secondItem="9qX-7Q-3Mu" secondAttribute="height" id="IxL-8c-RwO"/>
+                    <constraint firstAttribute="bottom" secondItem="QuM-Mo-Kad" secondAttribute="bottom" constant="10" id="Rqg-I9-eS4"/>
                     <constraint firstItem="9qX-7Q-3Mu" firstAttribute="leading" secondItem="uGt-2c-uiH" secondAttribute="leadingMargin" id="VP8-k2-lSz"/>
                     <constraint firstItem="QuM-Mo-Kad" firstAttribute="leading" secondItem="9qX-7Q-3Mu" secondAttribute="trailing" id="hAn-fA-TxS"/>
                     <constraint firstAttribute="trailingMargin" secondItem="QuM-Mo-Kad" secondAttribute="trailing" priority="999" constant="-15" id="nmm-ta-1HX"/>
-                    <constraint firstItem="9qX-7Q-3Mu" firstAttribute="centerY" secondItem="uGt-2c-uiH" secondAttribute="centerY" id="zRi-nK-6aw"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>

--- a/WordPress/Classes/ViewRelated/Portfolio/RestoreProjectTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Portfolio/RestoreProjectTableViewCell.xib
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="mtS-Un-VR1" customClass="RestoreProjectTableViewCell">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="mtS-Un-VR1" id="uGt-2c-uiH">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Page moved to trash." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9qX-7Q-3Mu" userLabel="Restore Label">
+                        <rect key="frame" x="16" y="9" width="272" height="26"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="26" id="LgM-G9-iO2"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <color key="textColor" red="0.33333334329999997" green="0.33333334329999997" blue="0.33333334329999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QuM-Mo-Kad" userLabel="Restore Button">
+                        <rect key="frame" x="288" y="9" width="86" height="26"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="86" id="JLI-Cm-9gL"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                        <inset key="contentEdgeInsets" minX="3" minY="0.0" maxX="0.0" maxY="0.0"/>
+                        <inset key="imageEdgeInsets" minX="-3" minY="0.0" maxX="3" maxY="0.0"/>
+                        <state key="normal" title="Undo" image="icon-post-undo">
+                            <color key="titleColor" red="0.33333334329999997" green="0.33333334329999997" blue="0.33333334329999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="titleShadowColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        </state>
+                        <connections>
+                            <action selector="onAction:" destination="mtS-Un-VR1" eventType="touchUpInside" id="Imd-dJ-l4C"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="QuM-Mo-Kad" firstAttribute="centerY" secondItem="uGt-2c-uiH" secondAttribute="centerY" id="6Uo-X5-6fK"/>
+                    <constraint firstItem="QuM-Mo-Kad" firstAttribute="height" secondItem="9qX-7Q-3Mu" secondAttribute="height" id="IxL-8c-RwO"/>
+                    <constraint firstItem="9qX-7Q-3Mu" firstAttribute="leading" secondItem="uGt-2c-uiH" secondAttribute="leadingMargin" id="VP8-k2-lSz"/>
+                    <constraint firstItem="QuM-Mo-Kad" firstAttribute="leading" secondItem="9qX-7Q-3Mu" secondAttribute="trailing" id="hAn-fA-TxS"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="QuM-Mo-Kad" secondAttribute="trailing" priority="999" constant="-15" id="nmm-ta-1HX"/>
+                    <constraint firstItem="9qX-7Q-3Mu" firstAttribute="centerY" secondItem="uGt-2c-uiH" secondAttribute="centerY" id="zRi-nK-6aw"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="restoreButton" destination="QuM-Mo-Kad" id="RlP-uH-Koc"/>
+                <outlet property="restoreLabel" destination="9qX-7Q-3Mu" id="HUJ-s5-pN3"/>
+            </connections>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <image name="icon-post-undo" width="18" height="18"/>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
@@ -83,9 +83,7 @@ class PostListFilterSettings: NSObject {
 
     @objc func keyForCurrentListStatusFilter() -> String {
         switch postType {
-        case .page:
-            return type(of: self).currentPageListStatusFilterKey
-        case .post:
+        case .page, .post, .project:
             return type(of: self).currentPageListStatusFilterKey
         default:
             return ""

--- a/WordPress/Classes/WordPress.xcdatamodeld/.xccurrentversion
+++ b/WordPress/Classes/WordPress.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>WordPress 67.xcdatamodel</string>
+	<string>WordPress 68.xcdatamodel</string>
 </dict>
 </plist>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 68.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 68.xcdatamodel/contents
@@ -197,6 +197,7 @@
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="pingbackInboundEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="pingbackOutboundEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="portfolioEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="privacy" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="relatedPostsAllowed" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="relatedPostsEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
@@ -650,7 +651,7 @@
         <element name="AccountSettings" positionX="18" positionY="153" width="128" height="225"/>
         <element name="BasePost" positionX="0" positionY="0" width="128" height="300"/>
         <element name="Blog" positionX="0" positionY="0" width="128" height="690"/>
-        <element name="BlogSettings" positionX="18" positionY="153" width="128" height="705"/>
+        <element name="BlogSettings" positionX="18" positionY="153" width="128" height="720"/>
         <element name="Category" positionX="0" positionY="0" width="128" height="120"/>
         <element name="Comment" positionX="0" positionY="0" width="128" height="343"/>
         <element name="Domain" positionX="27" positionY="153" width="128" height="105"/>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 68.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 68.xcdatamodel/contents
@@ -1,0 +1,683 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="13533" systemVersion="17B48" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="AbstractPost" representedClassName="AbstractPost" isAbstract="YES" parentEntity="BasePost">
+        <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="metaIsLocal" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="metaPublishImmediately" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="posts" inverseEntity="Blog" indexed="YES" syncable="YES"/>
+        <relationship name="media" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Media" inverseName="posts" inverseEntity="Media" indexed="YES" syncable="YES"/>
+        <relationship name="original" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="AbstractPost" inverseName="revision" inverseEntity="AbstractPost" indexed="YES" syncable="YES"/>
+        <relationship name="revision" optional="YES" minCount="1" maxCount="1" deletionRule="Cascade" destinationEntity="AbstractPost" inverseName="original" inverseEntity="AbstractPost" indexed="YES" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="Account" representedClassName="WPAccount" syncable="YES">
+        <attribute name="avatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="displayName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="email" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="emailVerified" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="userID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="username" attributeType="String" syncable="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blogs" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Blog" inverseName="account" inverseEntity="Blog" indexed="YES" syncable="YES"/>
+        <relationship name="defaultBlog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="accountForDefaultBlog" inverseEntity="Blog" syncable="YES"/>
+        <relationship name="settings" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="AccountSettings" inverseName="account" inverseEntity="AccountSettings" syncable="YES"/>
+    </entity>
+    <entity name="AccountSettings" representedClassName=".ManagedAccountSettings" syncable="YES">
+        <attribute name="aboutMe" attributeType="String" syncable="YES"/>
+        <attribute name="displayName" attributeType="String" syncable="YES"/>
+        <attribute name="email" attributeType="String" syncable="YES"/>
+        <attribute name="emailPendingAddress" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="emailPendingChange" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="firstName" attributeType="String" syncable="YES"/>
+        <attribute name="language" attributeType="String" syncable="YES"/>
+        <attribute name="lastName" attributeType="String" syncable="YES"/>
+        <attribute name="primarySiteID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="username" attributeType="String" syncable="YES"/>
+        <attribute name="webAddress" attributeType="String" syncable="YES"/>
+        <relationship name="account" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="settings" inverseEntity="Account" syncable="YES"/>
+    </entity>
+    <entity name="BasePost" representedClassName="BasePost" isAbstract="YES">
+        <attribute name="author" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="authorAvatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="content" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="date_created_gmt" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="mt_excerpt" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="password" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="pathForDisplayImage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="permaLink" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="post_thumbnail" optional="YES" attributeType="Integer 32" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="postID" optional="YES" attributeType="Integer 64" defaultValueString="-1" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="postTitle" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="remoteStatusNumber" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="status" optional="YES" attributeType="String" defaultValueString="publish">
+            <userInfo/>
+        </attribute>
+        <attribute name="suggested_slug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="wp_slug" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="comments" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Comment" inverseName="post" inverseEntity="Comment" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="Blog" representedClassName="Blog">
+        <attribute name="apiKey" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="blogID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="capabilities" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="currentThemeId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="hasOlderPages" transient="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="hasOlderPosts" transient="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="hasPaidPlan" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isActivated" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isAdmin" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isHostedAtWPcom" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isMultiAuthor" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastCommentsSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="lastPagesSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="lastPostsSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="lastStatsSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="lastUpdateWarning" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="options" optional="YES" attributeType="Transformable">
+            <userInfo/>
+        </attribute>
+        <attribute name="planID" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="planTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="postFormats" optional="YES" attributeType="Transformable">
+            <userInfo/>
+        </attribute>
+        <attribute name="url" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="userID" optional="YES" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="username" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="visible" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="xmlrpc" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="account" optional="YES" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="blogs" inverseEntity="Account" indexed="YES" syncable="YES"/>
+        <relationship name="accountForDefaultBlog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Account" inverseName="defaultBlog" inverseEntity="Account" syncable="YES"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Category" inverseName="blog" inverseEntity="Category" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="comments" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Comment" inverseName="blog" inverseEntity="Comment" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="connections" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PublicizeConnection" inverseName="blog" inverseEntity="PublicizeConnection" syncable="YES"/>
+        <relationship name="domains" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Domain" inverseName="blog" inverseEntity="Domain" syncable="YES"/>
+        <relationship name="media" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Media" inverseName="blog" inverseEntity="Media" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="menuLocations" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="MenuLocation" inverseName="blog" inverseEntity="MenuLocation" syncable="YES"/>
+        <relationship name="menus" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="Menu" inverseName="blog" inverseEntity="Menu" syncable="YES"/>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="AbstractPost" inverseName="blog" inverseEntity="AbstractPost" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="postTypes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PostType" inverseName="blog" inverseEntity="PostType" syncable="YES"/>
+        <relationship name="roles" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Role" inverseName="blog" inverseEntity="Role" syncable="YES"/>
+        <relationship name="settings" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="BlogSettings" inverseName="blog" inverseEntity="BlogSettings" syncable="YES"/>
+        <relationship name="sharingButtons" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SharingButton" inverseName="blog" inverseEntity="SharingButton" syncable="YES"/>
+        <relationship name="tags" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PostTag" inverseName="blog" inverseEntity="PostTag">
+            <userInfo/>
+        </relationship>
+        <relationship name="themes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Theme" inverseName="blog" inverseEntity="Theme" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="BlogSettings" representedClassName=".BlogSettings" syncable="YES">
+        <attribute name="commentsAllowed" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsBlacklistKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="commentsCloseAutomatically" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsCloseAutomaticallyAfterDays" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsFromKnownUsersWhitelisted" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsMaximumLinks" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsModerationKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="commentsPageSize" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsPagingEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsRequireManualModeration" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsRequireNameAndEmail" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsRequireRegistration" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsSortOrder" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsThreadingDepth" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsThreadingEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="defaultCategoryID" optional="YES" attributeType="Integer 32" defaultValueString="1" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="defaultPostFormat" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="geolocationEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="iconMediaID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="jetpackBlockMaliciousLoginAttempts" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="jetpackLoginWhiteListedIPAddresses" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="jetpackMonitorEmailNotifications" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="jetpackMonitorEnabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="jetpackMonitorPushNotifications" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="jetpackSSOEnabled" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="jetpackSSOMatchAccountsByEmail" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="jetpackSSORequireTwoStepAuthentication" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="languageID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="pingbackInboundEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="pingbackOutboundEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="privacy" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="relatedPostsAllowed" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="relatedPostsEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="relatedPostsShowHeadline" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="relatedPostsShowThumbnails" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="sharingButtonStyle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="sharingCommentLikesEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="sharingDisabledLikes" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="sharingDisabledReblogs" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="sharingLabel" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="sharingTwitterName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tagline" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="settings" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <entity name="Category" representedClassName="PostCategory">
+        <attribute name="categoryID" optional="YES" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="categoryName" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="parentID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="categories" inverseEntity="Blog" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Post" inverseName="categories" inverseEntity="Post" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
+    </entity>
+    <entity name="Comment" representedClassName="Comment">
+        <attribute name="author" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="author_email" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="author_ip" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="author_url" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="authorAvatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="commentID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="content" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="depth" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="hierarchy" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isLiked" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="likeCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="link" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="parentID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="postID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="postTitle" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="status" optional="YES" attributeType="String" indexed="YES">
+            <userInfo/>
+        </attribute>
+        <attribute name="type" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="comments" inverseEntity="Blog" syncable="YES"/>
+        <relationship name="post" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BasePost" inverseName="comments" inverseEntity="BasePost" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="Domain" representedClassName=".ManagedDomain" syncable="YES">
+        <attribute name="domainName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="domainType" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isPrimary" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="domains" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <entity name="Media" representedClassName="Media">
+        <attribute name="alt" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="caption" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="desc" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="filename" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="filesize" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="height" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="length" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="localThumbnailIdentifier" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="localThumbnailURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="localURL" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="mediaID" optional="YES" attributeType="Integer 32" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="mediaTypeString" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="postID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="remoteStatusNumber" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <attribute name="remoteThumbnailURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="remoteURL" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="shortcode" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="title" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="videopressGUID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="width" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="media" inverseEntity="Blog" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AbstractPost" inverseName="media" inverseEntity="AbstractPost" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
+    </entity>
+    <entity name="Menu" representedClassName="Menu" syncable="YES">
+        <attribute name="details" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="menuID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="menus" inverseEntity="Blog" syncable="YES"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="MenuItem" inverseName="menu" inverseEntity="MenuItem" syncable="YES"/>
+        <relationship name="locations" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MenuLocation" inverseName="menu" inverseEntity="MenuLocation" syncable="YES"/>
+    </entity>
+    <entity name="MenuItem" representedClassName="MenuItem" syncable="YES">
+        <attribute name="classes" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="contentID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="details" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="itemID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="linkTarget" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="linkTitle" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="typeFamily" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="typeLabel" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="urlStr" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="children" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MenuItem" inverseName="parent" inverseEntity="MenuItem" syncable="YES"/>
+        <relationship name="menu" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Menu" inverseName="items" inverseEntity="Menu" syncable="YES"/>
+        <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MenuItem" inverseName="children" inverseEntity="MenuItem" syncable="YES"/>
+    </entity>
+    <entity name="MenuLocation" representedClassName="MenuLocation" syncable="YES">
+        <attribute name="defaultState" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="details" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="menuLocations" inverseEntity="Blog" syncable="YES"/>
+        <relationship name="menu" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Menu" inverseName="locations" inverseEntity="Menu" syncable="YES"/>
+    </entity>
+    <entity name="Notification" representedClassName="Notification" syncable="YES">
+        <attribute name="body" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="header" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="meta" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="noticon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="notificationHash" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="notificationId" optional="YES" attributeType="String" elementID="simperiumKey" syncable="YES"/>
+        <attribute name="read" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="subject" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="timestamp" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="url" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Page" representedClassName="Page" parentEntity="AbstractPost">
+        <attribute name="parentID" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <userInfo/>
+    </entity>
+    <entity name="Person" representedClassName=".ManagedPerson" syncable="YES">
+        <attribute name="avatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="displayName" attributeType="String" syncable="YES"/>
+        <attribute name="firstName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isSuperAdmin" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="kind" optional="YES" attributeType="Integer 16" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="lastName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="linkedUserID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="role" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="userID" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="username" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Post" representedClassName="Post" parentEntity="AbstractPost">
+        <attribute name="commentCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="disabledPublicizeConnections" optional="YES" attributeType="Transformable">
+            <userInfo/>
+        </attribute>
+        <attribute name="geolocation" optional="YES" attributeType="Transformable">
+            <userInfo/>
+        </attribute>
+        <attribute name="latitudeID" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="likeCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="longitudeID" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="postFormat" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="postType" attributeType="String" defaultValueString="post" syncable="YES"/>
+        <attribute name="publicID" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="publicizeMessage" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="publicizeMessageID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tags" optional="YES" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Category" inverseName="posts" inverseEntity="Category" indexed="YES">
+            <userInfo/>
+        </relationship>
+        <userInfo/>
+    </entity>
+    <entity name="PostTag" representedClassName="PostTag">
+        <attribute name="name" attributeType="String">
+            <userInfo/>
+        </attribute>
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tagID" optional="YES" attributeType="Integer 32" defaultValueString="-1" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="tags" inverseEntity="Blog" syncable="YES"/>
+        <userInfo/>
+    </entity>
+    <entity name="PostType" representedClassName="PostType" syncable="YES">
+        <attribute name="apiQueryable" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="postTypes" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <entity name="Project" representedClassName="Project" parentEntity="AbstractPost">
+        <userInfo/>
+    </entity>
+    <entity name="PublicizeConnection" representedClassName="WordPress.PublicizeConnection" syncable="YES">
+        <attribute name="connectionID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateExpires" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateIssued" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="externalDisplay" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="externalFollowerCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="externalID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="externalName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="externalProfilePicture" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="externalProfileURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="keyringConnectionID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="keyringConnectionUserID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="refreshURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="service" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="shared" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="status" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="userID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="connections" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <entity name="PublicizeService" representedClassName="WordPress.PublicizeService" syncable="YES">
+        <attribute name="connectURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="detail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="icon" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="jetpackModuleRequired" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="jetpackSupport" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="label" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="multipleExternalUserIDSupport" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="serviceID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="ReaderAbstractTopic" representedClassName="WordPress.ReaderAbstractTopic" isAbstract="YES" syncable="YES">
+        <attribute name="algorithm" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="following" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="inUse" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="lastSynced" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="path" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="showInMenu" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="type" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ReaderPost" inverseName="topic" inverseEntity="ReaderPost" syncable="YES"/>
+    </entity>
+    <entity name="ReaderCrossPostMeta" representedClassName="WordPress.ReaderCrossPostMeta" syncable="YES">
+        <attribute name="commentURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="postID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="postURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="siteURL" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="post" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ReaderPost" inverseName="crossPostMeta" inverseEntity="ReaderPost" syncable="YES"/>
+    </entity>
+    <entity name="ReaderDefaultTopic" representedClassName="WordPress.ReaderDefaultTopic" parentEntity="ReaderAbstractTopic" syncable="YES"/>
+    <entity name="ReaderGapMarker" representedClassName="ReaderGapMarker" parentEntity="ReaderPost" syncable="YES"/>
+    <entity name="ReaderListTopic" representedClassName="WordPress.ReaderListTopic" parentEntity="ReaderAbstractTopic" syncable="YES">
+        <attribute name="isOwner" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isPublic" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="listDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="listID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="owner" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="ReaderPost" representedClassName="ReaderPost" parentEntity="BasePost" syncable="YES">
+        <attribute name="authorDisplayName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorEmail" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="commentCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="commentsOpen" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="dateSynced" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="featuredImage" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="feedID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="feedItemID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="globalID" optional="YES" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="inUse" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="isBlogPrivate" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isExternal" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isFollowing" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isJetpack" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isLiked" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isLikesEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isReblogged" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isSharingEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isSiteBlocked" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="isWPCom" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="likeCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="postAvatar" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="primaryTag" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="primaryTagSlug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="railcar" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="readingTime" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="score" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="siteIconURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="sortDate" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="sortRank" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="summary" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tags" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="wordCount" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="crossPostMeta" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ReaderCrossPostMeta" inverseName="post" inverseEntity="ReaderCrossPostMeta" syncable="YES"/>
+        <relationship name="sourceAttribution" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="SourcePostAttribution" inverseName="post" inverseEntity="SourcePostAttribution" syncable="YES"/>
+        <relationship name="topic" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ReaderAbstractTopic" inverseName="posts" inverseEntity="ReaderAbstractTopic" syncable="YES"/>
+    </entity>
+    <entity name="ReaderSearchSuggestion" representedClassName="WordPress.ReaderSearchSuggestion" syncable="YES">
+        <attribute name="date" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="searchPhrase" attributeType="String" indexed="YES" syncable="YES"/>
+    </entity>
+    <entity name="ReaderSearchTopic" representedClassName="WordPress.ReaderSearchTopic" parentEntity="ReaderAbstractTopic" syncable="YES"/>
+    <entity name="ReaderSiteTopic" representedClassName="WordPress.ReaderSiteTopic" parentEntity="ReaderAbstractTopic" syncable="YES">
+        <attribute name="feedID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="feedURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="isJetpack" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isPrivate" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="isVisible" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="postCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="siteBlavatar" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteDescription" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="siteID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="siteURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="subscriberCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+    </entity>
+    <entity name="ReaderTagTopic" representedClassName="WordPress.ReaderTagTopic" parentEntity="ReaderAbstractTopic" syncable="YES">
+        <attribute name="isRecommended" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tagID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+    </entity>
+    <entity name="ReaderTeamTopic" representedClassName="WordPress.ReaderTeamTopic" parentEntity="ReaderAbstractTopic" syncable="YES">
+        <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="Role" representedClassName=".Role" syncable="YES">
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="order" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="slug" attributeType="String" syncable="YES"/>
+        <relationship name="blog" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="roles" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <entity name="SharingButton" representedClassName="WordPress.SharingButton" syncable="YES">
+        <attribute name="buttonID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="custom" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="enabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
+        <attribute name="shortname" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="visibility" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="sharingButtons" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <entity name="SourcePostAttribution" representedClassName="SourcePostAttribution" syncable="YES">
+        <attribute name="attributionType" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="avatarURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="blogName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="blogURL" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="commentCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="likeCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="permalink" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="postID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="post" maxCount="1" deletionRule="Nullify" destinationEntity="ReaderPost" inverseName="sourceAttribution" inverseEntity="ReaderPost" syncable="YES"/>
+    </entity>
+    <entity name="Theme" representedClassName="Theme" syncable="YES">
+        <attribute name="author" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="authorUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="custom" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="demoUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="details" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="launchDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="popularityRank" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="premium" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="previewUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="price" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="purchased" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="screenshotUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="stylesheet" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="tags" optional="YES" attributeType="Transformable" syncable="YES"/>
+        <attribute name="themeId" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="themeUrl" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="trendingRank" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="version" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="themes" inverseEntity="Blog" syncable="YES"/>
+    </entity>
+    <elements>
+        <element name="AbstractPost" positionX="0" positionY="0" width="128" height="150"/>
+        <element name="Account" positionX="0" positionY="0" width="128" height="210"/>
+        <element name="AccountSettings" positionX="18" positionY="153" width="128" height="225"/>
+        <element name="BasePost" positionX="0" positionY="0" width="128" height="300"/>
+        <element name="Blog" positionX="0" positionY="0" width="128" height="675"/>
+        <element name="BlogSettings" positionX="18" positionY="153" width="128" height="705"/>
+        <element name="Category" positionX="0" positionY="0" width="128" height="120"/>
+        <element name="Comment" positionX="0" positionY="0" width="128" height="343"/>
+        <element name="Domain" positionX="27" positionY="153" width="128" height="105"/>
+        <element name="Media" positionX="0" positionY="0" width="128" height="390"/>
+        <element name="Menu" positionX="63" positionY="198" width="128" height="135"/>
+        <element name="MenuItem" positionX="45" positionY="180" width="128" height="255"/>
+        <element name="MenuLocation" positionX="54" positionY="189" width="128" height="120"/>
+        <element name="Notification" positionX="18" positionY="162" width="128" height="240"/>
+        <element name="Page" positionX="0" positionY="0" width="128" height="60"/>
+        <element name="Person" positionX="18" positionY="153" width="128" height="225"/>
+        <element name="Post" positionX="0" positionY="0" width="128" height="240"/>
+        <element name="PostTag" positionX="27" positionY="153" width="128" height="105"/>
+        <element name="PostType" positionX="27" positionY="153" width="128" height="105"/>
+        <element name="PublicizeConnection" positionX="27" positionY="162" width="128" height="330"/>
+        <element name="PublicizeService" positionX="18" positionY="153" width="128" height="195"/>
+        <element name="ReaderAbstractTopic" positionX="9" positionY="153" width="128" height="180"/>
+        <element name="ReaderCrossPostMeta" positionX="18" positionY="153" width="128" height="135"/>
+        <element name="ReaderDefaultTopic" positionX="18" positionY="162" width="128" height="45"/>
+        <element name="ReaderGapMarker" positionX="18" positionY="153" width="128" height="45"/>
+        <element name="ReaderListTopic" positionX="45" positionY="189" width="128" height="135"/>
+        <element name="ReaderPost" positionX="0" positionY="0" width="128" height="660"/>
+        <element name="ReaderSearchSuggestion" positionX="36" positionY="162" width="128" height="75"/>
+        <element name="ReaderSearchTopic" positionX="27" positionY="153" width="128" height="45"/>
+        <element name="ReaderSiteTopic" positionX="36" positionY="180" width="128" height="210"/>
+        <element name="ReaderTagTopic" positionX="27" positionY="171" width="128" height="90"/>
+        <element name="ReaderTeamTopic" positionX="27" positionY="153" width="128" height="60"/>
+        <element name="Role" positionX="36" positionY="162" width="128" height="105"/>
+        <element name="SharingButton" positionX="27" positionY="153" width="128" height="165"/>
+        <element name="SourcePostAttribution" positionX="9" positionY="153" width="128" height="225"/>
+        <element name="Theme" positionX="9" positionY="153" width="128" height="360"/>
+        <element name="Project" positionX="36" positionY="162" width="128" height="45"/>
+    </elements>
+</model>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 68.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 68.xcdatamodel/contents
@@ -109,6 +109,9 @@
         <attribute name="lastPostsSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
             <userInfo/>
         </attribute>
+        <attribute name="lastProjectsSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
+            <userInfo/>
+        </attribute>
         <attribute name="lastStatsSync" optional="YES" attributeType="Date" usesScalarValueType="NO">
             <userInfo/>
         </attribute>
@@ -646,7 +649,7 @@
         <element name="Account" positionX="0" positionY="0" width="128" height="210"/>
         <element name="AccountSettings" positionX="18" positionY="153" width="128" height="225"/>
         <element name="BasePost" positionX="0" positionY="0" width="128" height="300"/>
-        <element name="Blog" positionX="0" positionY="0" width="128" height="675"/>
+        <element name="Blog" positionX="0" positionY="0" width="128" height="690"/>
         <element name="BlogSettings" positionX="18" positionY="153" width="128" height="705"/>
         <element name="Category" positionX="0" positionY="0" width="128" height="120"/>
         <element name="Comment" positionX="0" positionY="0" width="128" height="343"/>
@@ -661,6 +664,7 @@
         <element name="Post" positionX="0" positionY="0" width="128" height="240"/>
         <element name="PostTag" positionX="27" positionY="153" width="128" height="105"/>
         <element name="PostType" positionX="27" positionY="153" width="128" height="105"/>
+        <element name="Project" positionX="36" positionY="162" width="128" height="45"/>
         <element name="PublicizeConnection" positionX="27" positionY="162" width="128" height="330"/>
         <element name="PublicizeService" positionX="18" positionY="153" width="128" height="195"/>
         <element name="ReaderAbstractTopic" positionX="9" positionY="153" width="128" height="180"/>
@@ -678,6 +682,5 @@
         <element name="SharingButton" positionX="27" positionY="153" width="128" height="165"/>
         <element name="SourcePostAttribution" positionX="9" positionY="153" width="128" height="225"/>
         <element name="Theme" positionX="9" positionY="153" width="128" height="360"/>
-        <element name="Project" positionX="36" positionY="162" width="128" height="45"/>
     </elements>
 </model>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -319,6 +319,10 @@
 		5DFA7EC81AF814E40072023B /* PageListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5DFA7EC61AF814E40072023B /* PageListTableViewCell.xib */; };
 		7059CD210F332B6500A0660B /* WPCategoryTree.m in Sources */ = {isa = PBXBuildFile; fileRef = 7059CD200F332B6500A0660B /* WPCategoryTree.m */; };
 		722F5726ACB4A276B0CF3C83 /* Pods_WordPress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */; };
+		723395DB1FC31D9B002E0215 /* ProjectTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723395DA1FC31D9B002E0215 /* ProjectTableViewCell.swift */; };
+		723395DD1FC32392002E0215 /* ProjectTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 723395DC1FC32392002E0215 /* ProjectTableViewCell.xib */; };
+		723395DF1FC326F2002E0215 /* RestoreProjectTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723395DE1FC326F2002E0215 /* RestoreProjectTableViewCell.swift */; };
+		723395E11FC3289D002E0215 /* RestoreProjectTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 723395E01FC3289D002E0215 /* RestoreProjectTableViewCell.xib */; };
 		724E30FD1FBB4F4E00F72604 /* PortfolioListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724E30FC1FBB4F4E00F72604 /* PortfolioListViewController.swift */; };
 		724E30FF1FBB546A00F72604 /* Portfolio.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724E30FE1FBB546A00F72604 /* Portfolio.storyboard */; };
 		740BD8351A0D4C3600F04D18 /* WPUploadStatusButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 740BD8341A0D4C3600F04D18 /* WPUploadStatusButton.m */; };
@@ -1522,6 +1526,10 @@
 		6EDC0E8E105881A800F68A1D /* iTunesArtwork */ = {isa = PBXFileReference; lastKnownFileType = file; path = iTunesArtwork; sourceTree = "<group>"; };
 		7059CD1F0F332B6500A0660B /* WPCategoryTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = WPCategoryTree.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		7059CD200F332B6500A0660B /* WPCategoryTree.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = WPCategoryTree.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		723395DA1FC31D9B002E0215 /* ProjectTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectTableViewCell.swift; sourceTree = "<group>"; };
+		723395DC1FC32392002E0215 /* ProjectTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProjectTableViewCell.xib; sourceTree = "<group>"; };
+		723395DE1FC326F2002E0215 /* RestoreProjectTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreProjectTableViewCell.swift; sourceTree = "<group>"; };
+		723395E01FC3289D002E0215 /* RestoreProjectTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RestoreProjectTableViewCell.xib; sourceTree = "<group>"; };
 		724E30FC1FBB4F4E00F72604 /* PortfolioListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioListViewController.swift; sourceTree = "<group>"; };
 		724E30FE1FBB546A00F72604 /* Portfolio.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Portfolio.storyboard; sourceTree = "<group>"; };
 		740BD8331A0D4C3600F04D18 /* WPUploadStatusButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPUploadStatusButton.h; sourceTree = "<group>"; };
@@ -3443,21 +3451,33 @@
 			name = Views;
 			sourceTree = "<group>";
 		};
-		724E30FA1FBB4EB900F72604 /* Portfolio */ = {
-			isa = PBXGroup;
-			children = (
-				724E30FB1FBB4EF800F72604 /* Controllers */,
-				724E30FE1FBB546A00F72604 /* Portfolio.storyboard */,
-			);
-			path = Portfolio;
-			sourceTree = "<group>";
-		};
-		724E30FB1FBB4EF800F72604 /* Controllers */ = {
+		723395D71FC31D3F002E0215 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
 				724E30FC1FBB4F4E00F72604 /* PortfolioListViewController.swift */,
 			);
-			path = Controllers;
+			name = Controllers;
+			sourceTree = "<group>";
+		};
+		723395D91FC31D56002E0215 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				723395DA1FC31D9B002E0215 /* ProjectTableViewCell.swift */,
+				723395DC1FC32392002E0215 /* ProjectTableViewCell.xib */,
+				723395DE1FC326F2002E0215 /* RestoreProjectTableViewCell.swift */,
+				723395E01FC3289D002E0215 /* RestoreProjectTableViewCell.xib */,
+			);
+			name = Views;
+			sourceTree = "<group>";
+		};
+		724E30FA1FBB4EB900F72604 /* Portfolio */ = {
+			isa = PBXGroup;
+			children = (
+				723395D71FC31D3F002E0215 /* Controllers */,
+				723395D91FC31D56002E0215 /* Views */,
+				724E30FE1FBB546A00F72604 /* Portfolio.storyboard */,
+			);
+			path = Portfolio;
 			sourceTree = "<group>";
 		};
 		7430C4471F97F0DA00E2673E /* UI */ = {
@@ -5783,7 +5803,9 @@
 				E60C2ED51DE5048200488630 /* ReaderCommentCell.xib in Resources */,
 				E6D2E1611B8AA4410000ED14 /* ReaderTagStreamHeader.xib in Resources */,
 				B5CEEB901B79244D00E7B7B0 /* CommentsTableViewCell.xib in Resources */,
+				723395E11FC3289D002E0215 /* RestoreProjectTableViewCell.xib in Resources */,
 				17D1C22F1EFBFB6C0076734A /* FancyAlerts.storyboard in Resources */,
+				723395DD1FC32392002E0215 /* ProjectTableViewCell.xib in Resources */,
 				5D69DBC4165428CA00A2D1F7 /* n.caf in Resources */,
 				E1B912811BB00EFD003C25B9 /* People.storyboard in Resources */,
 				5D2FB2831AE98C4600F1D4ED /* RestorePostTableViewCell.xib in Resources */,
@@ -6252,6 +6274,7 @@
 				B53971521D537B22006135EC /* NotificationBlock.swift in Sources */,
 				0807CB721CE670A800CDBDAC /* WPContentSearchHelper.swift in Sources */,
 				37022D931981C19000F322B7 /* VerticallyStackedButton.m in Sources */,
+				723395DF1FC326F2002E0215 /* RestoreProjectTableViewCell.swift in Sources */,
 				59DCA5211CC68AF3000F245F /* PageListViewController.swift in Sources */,
 				B5ECA6CA1DBAA0020062D7E0 /* CoreDataHelper.swift in Sources */,
 				FFC6ADDA1B56F366002F3C84 /* LocalCoreDataService.m in Sources */,
@@ -6397,6 +6420,7 @@
 				088B89891DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift in Sources */,
 				CEBD3EAB0FF1BA3B00C1396E /* Blog.m in Sources */,
 				FFDA7E501B8DF6E500B83C56 /* BlogSiteVisibilityHelper.m in Sources */,
+				723395DB1FC31D9B002E0215 /* ProjectTableViewCell.swift in Sources */,
 				438A809E1EA5DC31005D4651 /* LoginWPComViewController.swift in Sources */,
 				5DA5BF4418E32DCF005F11F9 /* Theme.m in Sources */,
 				ADF544C2195A0F620092213D /* CustomHighlightButton.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -319,6 +319,8 @@
 		5DFA7EC81AF814E40072023B /* PageListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5DFA7EC61AF814E40072023B /* PageListTableViewCell.xib */; };
 		7059CD210F332B6500A0660B /* WPCategoryTree.m in Sources */ = {isa = PBXBuildFile; fileRef = 7059CD200F332B6500A0660B /* WPCategoryTree.m */; };
 		722F5726ACB4A276B0CF3C83 /* Pods_WordPress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */; };
+		724E30FD1FBB4F4E00F72604 /* PortfolioListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724E30FC1FBB4F4E00F72604 /* PortfolioListViewController.swift */; };
+		724E30FF1FBB546A00F72604 /* Portfolio.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724E30FE1FBB546A00F72604 /* Portfolio.storyboard */; };
 		740BD8351A0D4C3600F04D18 /* WPUploadStatusButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 740BD8341A0D4C3600F04D18 /* WPUploadStatusButton.m */; };
 		742C79981E5F511C00DB1608 /* DeleteSiteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 742C79971E5F511C00DB1608 /* DeleteSiteViewController.swift */; };
 		7430C4491F97F23600E2673E /* ShareMediaFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7430C4481F97F23600E2673E /* ShareMediaFileManager.swift */; };
@@ -1520,6 +1522,8 @@
 		6EDC0E8E105881A800F68A1D /* iTunesArtwork */ = {isa = PBXFileReference; lastKnownFileType = file; path = iTunesArtwork; sourceTree = "<group>"; };
 		7059CD1F0F332B6500A0660B /* WPCategoryTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = WPCategoryTree.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		7059CD200F332B6500A0660B /* WPCategoryTree.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = WPCategoryTree.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		724E30FC1FBB4F4E00F72604 /* PortfolioListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioListViewController.swift; sourceTree = "<group>"; };
+		724E30FE1FBB546A00F72604 /* Portfolio.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Portfolio.storyboard; sourceTree = "<group>"; };
 		740BD8331A0D4C3600F04D18 /* WPUploadStatusButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPUploadStatusButton.h; sourceTree = "<group>"; };
 		740BD8341A0D4C3600F04D18 /* WPUploadStatusButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUploadStatusButton.m; sourceTree = "<group>"; };
 		742C79971E5F511C00DB1608 /* DeleteSiteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteSiteViewController.swift; sourceTree = "<group>"; };
@@ -3439,6 +3443,23 @@
 			name = Views;
 			sourceTree = "<group>";
 		};
+		724E30FA1FBB4EB900F72604 /* Portfolio */ = {
+			isa = PBXGroup;
+			children = (
+				724E30FB1FBB4EF800F72604 /* Controllers */,
+				724E30FE1FBB546A00F72604 /* Portfolio.storyboard */,
+			);
+			path = Portfolio;
+			sourceTree = "<group>";
+		};
+		724E30FB1FBB4EF800F72604 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				724E30FC1FBB4F4E00F72604 /* PortfolioListViewController.swift */,
+			);
+			path = Controllers;
+			sourceTree = "<group>";
+		};
 		7430C4471F97F0DA00E2673E /* UI */ = {
 			isa = PBXGroup;
 			children = (
@@ -3580,6 +3601,7 @@
 				E1B9127F1BB00EF1003C25B9 /* People */,
 				E1389AD91C59F78500FB2466 /* Plans */,
 				E14694041F3459A9004052C8 /* Plugins */,
+				724E30FA1FBB4EB900F72604 /* Portfolio */,
 				AC3439790E11434600E5D79B /* Post */,
 				8298F38D1EEF2B15008EB7F0 /* Ratings */,
 				CCB3A03814C8DD5100D43C3F /* Reader */,
@@ -5767,6 +5789,7 @@
 				5D2FB2831AE98C4600F1D4ED /* RestorePostTableViewCell.xib in Resources */,
 				1724DDCC1C6121D00099D273 /* Plans.storyboard in Resources */,
 				173BCE751CEB369900AE8817 /* Domains.storyboard in Resources */,
+				724E30FF1FBB546A00F72604 /* Portfolio.storyboard in Resources */,
 				5D732F991AE84E5400CD89E7 /* PostListFooterView.xib in Resources */,
 				5D6C4AFF1B603CE9005E3C43 /* EditCommentViewController.xib in Resources */,
 				B51535D41BBB16AA0029B84B /* Launch Screen.storyboard in Resources */,
@@ -6425,6 +6448,7 @@
 				B56994451B7A7EF200FF26FA /* WPStyleGuide+Comments.swift in Sources */,
 				E15644ED1CE0E4FE00D96E64 /* PlanListRow.swift in Sources */,
 				B541276B1C0F7D610015CA80 /* SettingsMultiTextViewController.m in Sources */,
+				724E30FD1FBB4F4E00F72604 /* PortfolioListViewController.swift in Sources */,
 				B5AC00681BE3C4E100F8E7C3 /* DiscussionSettingsViewController.swift in Sources */,
 				834CAE7C122D528A003DDF49 /* UIImage+Resize.m in Sources */,
 				B584758A1D51078C006734CE /* NotificationDeletion.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		723395DD1FC32392002E0215 /* ProjectTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 723395DC1FC32392002E0215 /* ProjectTableViewCell.xib */; };
 		723395DF1FC326F2002E0215 /* RestoreProjectTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723395DE1FC326F2002E0215 /* RestoreProjectTableViewCell.swift */; };
 		723395E11FC3289D002E0215 /* RestoreProjectTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 723395E01FC3289D002E0215 /* RestoreProjectTableViewCell.xib */; };
+		723395E41FC34A7E002E0215 /* Project.swift in Sources */ = {isa = PBXBuildFile; fileRef = 723395E31FC34A7E002E0215 /* Project.swift */; };
 		724E30FD1FBB4F4E00F72604 /* PortfolioListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724E30FC1FBB4F4E00F72604 /* PortfolioListViewController.swift */; };
 		724E30FF1FBB546A00F72604 /* Portfolio.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 724E30FE1FBB546A00F72604 /* Portfolio.storyboard */; };
 		740BD8351A0D4C3600F04D18 /* WPUploadStatusButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 740BD8341A0D4C3600F04D18 /* WPUploadStatusButton.m */; };
@@ -1530,6 +1531,8 @@
 		723395DC1FC32392002E0215 /* ProjectTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ProjectTableViewCell.xib; sourceTree = "<group>"; };
 		723395DE1FC326F2002E0215 /* RestoreProjectTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreProjectTableViewCell.swift; sourceTree = "<group>"; };
 		723395E01FC3289D002E0215 /* RestoreProjectTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RestoreProjectTableViewCell.xib; sourceTree = "<group>"; };
+		723395E31FC34A7E002E0215 /* Project.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Project.swift; sourceTree = "<group>"; };
+		723395E61FC47455002E0215 /* WordPress 68.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 68.xcdatamodel"; sourceTree = "<group>"; };
 		724E30FC1FBB4F4E00F72604 /* PortfolioListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortfolioListViewController.swift; sourceTree = "<group>"; };
 		724E30FE1FBB546A00F72604 /* Portfolio.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Portfolio.storyboard; sourceTree = "<group>"; };
 		740BD8331A0D4C3600F04D18 /* WPUploadStatusButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPUploadStatusButton.h; sourceTree = "<group>"; };
@@ -3039,7 +3042,6 @@
 				59E1D46D1CEF77B500126697 /* Page+CoreDataProperties.swift */,
 				591AA4FF1CEF9BF20074934F /* Post.swift */,
 				591AA5001CEF9BF20074934F /* Post+CoreDataProperties.swift */,
-				E148362E1C6DF7D8005ACF53 /* Product.swift */,
 				833AF259114575A50016DE8F /* PostAnnotation.h */,
 				833AF25A114575A50016DE8F /* PostAnnotation.m */,
 				E125445412BF5B3900D87A0A /* PostCategory.h */,
@@ -3048,6 +3050,8 @@
 				082AB9DC1C4F035E000CA523 /* PostTag.m */,
 				08B6D6F01C8F7DCE0052C52B /* PostType.h */,
 				08B6D6F11C8F7DCE0052C52B /* PostType.m */,
+				E148362E1C6DF7D8005ACF53 /* Product.swift */,
+				723395E31FC34A7E002E0215 /* Project.swift */,
 				E6374DBD1C444D8B00F24720 /* PublicizeConnection.swift */,
 				E6374DBE1C444D8B00F24720 /* PublicizeService.swift */,
 				5D42A3DC175E7452005CFF05 /* ReaderPost.h */,
@@ -6575,6 +6579,7 @@
 				FFA9148F1BA6E5170068F8BF /* RotationAwareNavigationViewController.m in Sources */,
 				5D4E30D11AA4B41A000D9904 /* WPStyleGuide+Posts.m in Sources */,
 				5D17530F1A97D2CA0031A082 /* PostCardTableViewCell.m in Sources */,
+				723395E41FC34A7E002E0215 /* Project.swift in Sources */,
 				08F8CD2F1EBD29440049D0C0 /* MediaImageExporter.swift in Sources */,
 				E13F23C314FE84600081D9CC /* NSMutableDictionary+Helpers.m in Sources */,
 				59E1D46E1CEF77B500126697 /* Page.swift in Sources */,
@@ -8892,6 +8897,7 @@
 		E125443B12BF5A7200D87A0A /* WordPress.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
+				723395E61FC47455002E0215 /* WordPress 68.xcdatamodel */,
 				F117E5841F7AA8BF003D9ACB /* WordPress 67.xcdatamodel */,
 				82FFBF4E1F45E03D00F4573F /* WordPress 66.xcdatamodel */,
 				820ADD751F3CCD70002D7F93 /* WordPress 65.xcdatamodel */,
@@ -8960,7 +8966,7 @@
 				8350E15911D28B4A00A7B073 /* WordPress.xcdatamodel */,
 				E125443D12BF5A7200D87A0A /* WordPress 2.xcdatamodel */,
 			);
-			currentVersion = F117E5841F7AA8BF003D9ACB /* WordPress 67.xcdatamodel */;
+			currentVersion = 723395E61FC47455002E0215 /* WordPress 68.xcdatamodel */;
 			name = WordPress.xcdatamodeld;
 			path = Classes/WordPress.xcdatamodeld;
 			sourceTree = "<group>";

--- a/WordPressKit/WordPressKit/BlogServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/BlogServiceRemoteREST.m
@@ -17,6 +17,9 @@ static NSString * const RemoteBlogIconKey                                   = @"
 static NSString * const RemoteBlogSettingsKey                               = @"settings";
 static NSString * const RemoteBlogDefaultCategoryKey                        = @"default_category";
 static NSString * const RemoteBlogDefaultPostFormatKey                      = @"default_post_format";
+
+static NSString * const RemoteBlogPortfolioEnabledKey                       = @"jetpack_portfolio";
+
 static NSString * const RemoteBlogCommentsAllowedKey                        = @"default_comment_status";
 static NSString * const RemoteBlogCommentsBlacklistKeys                     = @"blacklist_keys";
 static NSString * const RemoteBlogCommentsCloseAutomaticallyKey             = @"close_comments_for_old_posts";
@@ -335,6 +338,8 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     } else {
         settings.defaultPostFormat = [rawSettings stringForKey:RemoteBlogDefaultPostFormatKey];
     }
+
+    settings.portfolioEnabled = [rawSettings numberForKey:RemoteBlogPortfolioEnabledKey];
     
     // Discussion
     settings.commentsAllowed = [rawSettings numberForKey:RemoteBlogCommentsAllowedKey];
@@ -385,6 +390,8 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
 
     [parameters setValueIfNotNil:settings.defaultCategoryID forKey:RemoteBlogDefaultCategoryKey];
     [parameters setValueIfNotNil:settings.defaultPostFormat forKey:RemoteBlogDefaultPostFormatKey];
+
+    [parameters setValueIfNotNil:settings.portfolioEnabled forKey:RemoteBlogPortfolioEnabledKey];
     
     [parameters setValueIfNotNil:settings.commentsAllowed forKey:RemoteBlogCommentsAllowedKey];
     [parameters setValueIfNotNil:settings.commentsBlacklistKeys forKey:RemoteBlogCommentsBlacklistKeys];

--- a/WordPressKit/WordPressKit/RemoteBlogSettings.swift
+++ b/WordPressKit/WordPressKit/RemoteBlogSettings.swift
@@ -38,7 +38,7 @@ public class RemoteBlogSettings: NSObject {
 
     /// Represents whether the Portfolio feature is enabled or not
     ///
-    public var portfolioEnabled: NSNumber?
+    @objc public var portfolioEnabled: NSNumber?
 
     // MARK: - Discussion
 

--- a/WordPressKit/WordPressKit/RemoteBlogSettings.swift
+++ b/WordPressKit/WordPressKit/RemoteBlogSettings.swift
@@ -36,7 +36,9 @@ public class RemoteBlogSettings: NSObject {
     ///
     @objc public var defaultPostFormat: String?
 
-
+    /// Represents whether the Portfolio feature is enabled or not
+    ///
+    public var portfolioEnabled: NSNumber?
 
     // MARK: - Discussion
 


### PR DESCRIPTION
Initial PR for feature #8238.

Here's an overview of what's been implemented so far:

- Extended blog settings to read whether a Portfolio is enabled or not for a site
- Added Portfolio menu item to a site’s menu when the feature is enabled
- Created `PortfolioListViewController` (& related table view cells) to list Portfolio projects
- Created a `Project` model for Portfolio projects
- Extended CoreData model to include properties and entities required by Portfolios
- Added data fetch of posts of type `jetpack-portfolio` from REST APIs
- Added feature trigger to make sure Portfolios are only enabled when `BuildConfiguration.current == .localDeveloper`

I'm sorry about the PR size, but there's really a lot of boilerplate here, between Storyboards, XIBs, and subclassing `AbstractPostListViewController`. All feedback on how I should have made this smaller is really welcome!

Here's a preview of how this looks like in the simulator:

![portfolioreadonly](https://user-images.githubusercontent.com/5967873/33322581-16260354-d44a-11e7-85fc-ff4ee72cd501.png)
