### PR TITLE
Make html visual distinction clearer

### DIFF
--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -48,7 +48,7 @@ final class InteractiveNotificationsManager: NSObject {
     ///
     @objc func requestAuthorization() {
         let notificationCenter = UNUserNotificationCenter.current()
-        notificationCenter.requestAuthorization(options: [.badge, .sound, .alert], completionHandler: { (_,_)  in })
+        notificationCenter.requestAuthorization(options: [.badge, .sound, .alert], completionHandler: { (_, _)  in })
     }
 
     /// Handle an action taken from a remote notification

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -52,6 +52,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
         let accessibilityLabel = NSLocalizedString("Rich Content", comment: "Post Rich content")
         self.configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
+        textView.font = Fonts.regular
 
         let linkAttributes: [NSAttributedStringKey: Any] = [.underlineStyle: NSUnderlineStyle.styleSingle.rawValue,
                                                             .foregroundColor: Colors.aztecLinkColor]
@@ -101,6 +102,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
         let accessibilityLabel = NSLocalizedString("HTML Content", comment: "Post HTML content")
         self.configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
+        textView.font = Fonts.monospace
 
         textView.isHidden = true
         textView.delegate = self
@@ -694,7 +696,6 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     private func configureDefaultProperties(for textView: UITextView, accessibilityLabel: String) {
         textView.accessibilityLabel = accessibilityLabel
-        textView.font = Fonts.regular
         textView.keyboardDismissMode = .interactive
         textView.textColor = UIColor.darkText
         textView.translatesAutoresizingMaskIntoConstraints = false
@@ -3491,6 +3492,7 @@ extension AztecPostViewController {
         static let blogPicker               = Fonts.semiBold
         static let mediaPickerInsert        = WPFontManager.systemMediumFont(ofSize: 15.0)
         static let mediaOverlay             = WPFontManager.systemSemiBoldFont(ofSize: 15.0)
+        static let monospace                = UIFont(name: "Menlo-Regular", size: 16.0)!
     }
 
     struct Restoration {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -334,7 +334,7 @@ class AztecPostViewController: UIViewController, PostEditor {
             case .richText:
                 richTextView.becomeFirstResponder()
             }
-            
+
             updateFormatBar()
 
             refreshEditorVisibility()
@@ -940,7 +940,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 // MARK: - Format Bar Updating
 
 extension AztecPostViewController {
-    
+
     func updateFormatBar() {
         switch mode {
         case .html:
@@ -949,36 +949,36 @@ extension AztecPostViewController {
             updateFormatBarForVisualMode()
         }
     }
-    
+
     /// Updates the format bar for HTML mode.
     ///
     private func updateFormatBarForHTMLMode() {
         assert(mode == .html)
-        
+
         guard let toolbar = richTextView.inputAccessoryView as? Aztec.FormatBar else {
             return
         }
-        
+
         toolbar.selectItemsMatchingIdentifiers([FormattingIdentifier.sourcecode.rawValue])
     }
-    
+
     /// Updates the format bar for visual mode.
     ///
     private func updateFormatBarForVisualMode() {
         assert(mode == .richText)
-        
+
         guard let toolbar = richTextView.inputAccessoryView as? Aztec.FormatBar else {
             return
         }
-        
+
         var identifiers = [FormattingIdentifier]()
-        
+
         if richTextView.selectedRange.length > 0 {
             identifiers = richTextView.formatIdentifiersSpanningRange(richTextView.selectedRange)
         } else {
             identifiers = richTextView.formatIdentifiersForTypingAttributes()
         }
-        
+
         toolbar.selectItemsMatchingIdentifiers(identifiers.map({ $0.rawValue }))
     }
 }
@@ -1412,9 +1412,9 @@ extension AztecPostViewController: UITextViewDelegate {
 
     func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
         textView.textAlignment = .natural
-        
+
         let htmlButton = formatBar.items.first(where: { $0.identifier == FormattingIdentifier.sourcecode.rawValue })!
-        
+
         switch textView {
         case titleTextField:
             formatBar.enabled = false
@@ -1425,9 +1425,9 @@ extension AztecPostViewController: UITextViewDelegate {
         default:
             break
         }
-        
+
         htmlButton.isEnabled = true
-        
+
         if mediaPickerInputViewController == nil {
             textView.inputAccessoryView = formatBar
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -52,7 +52,6 @@ class AztecPostViewController: UIViewController, PostEditor {
 
         let accessibilityLabel = NSLocalizedString("Rich Content", comment: "Post Rich content")
         self.configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
-        textView.font = Fonts.regular
 
         let linkAttributes: [NSAttributedStringKey: Any] = [.underlineStyle: NSUnderlineStyle.styleSingle.rawValue,
                                                             .foregroundColor: Colors.aztecLinkColor]
@@ -91,7 +90,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     /// Raw HTML Editor
     ///
     fileprivate(set) lazy var htmlTextView: UITextView = {
-        let storage = HTMLStorage(defaultFont: Fonts.regular)
+        let storage = HTMLStorage(defaultFont: Fonts.monospace)
         let layoutManager = NSLayoutManager()
         let container = NSTextContainer()
 
@@ -102,7 +101,6 @@ class AztecPostViewController: UIViewController, PostEditor {
 
         let accessibilityLabel = NSLocalizedString("HTML Content", comment: "Post HTML content")
         self.configureDefaultProperties(for: textView, accessibilityLabel: accessibilityLabel)
-        textView.font = Fonts.monospace
 
         textView.isHidden = true
         textView.delegate = self


### PR DESCRIPTION
## Description

Fixes #7341 

Makes the distinction between HTML and Visual Mode clearer by:

- Changing the HTML editing mode font to Menlo.
- Highlighting the HTML button in the toolbar while in HTML mode.

fyi @jeremeylduvall, @iamthomasbishop 

## Testing

Just launch the editor, and switch back and forth between visual and HTML mode.
Check that the above description matches what you see.