### PR TITLE
Issue/8242 size full

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -19,7 +19,7 @@ class AztecAttachmentViewController: UITableViewController {
 
     var alignment = ImageAttachment.Alignment.none
     var linkURL: URL?
-    var size = ImageAttachment.Size.full
+    var size = ImageAttachment.Size.none
     var alt: String?
 
     var onUpdate: ((_ alignment: ImageAttachment.Alignment, _ size: ImageAttachment.Size, _ linkURL: URL?, _ altText: String?) -> Void)?
@@ -160,7 +160,7 @@ class AztecAttachmentViewController: UITableViewController {
     }
 
     func displaySizeSelector(row: ImmuTableRow) {
-        let values: [ImageAttachment.Size] = [.thumbnail, .medium, .large, .full]
+        let values: [ImageAttachment.Size] = [.thumbnail, .medium, .large, .full, .none]
 
         let titles = values.map { (value) in
             return value.localizedString
@@ -239,7 +239,8 @@ extension ImageAttachment.Size {
         case .thumbnail: return NSLocalizedString("Thumbnail", comment: "Thumbnail image size. Should be the same as in core WP.")
         case .medium: return NSLocalizedString("Medium", comment: "Medium image size. Should be the same as in core WP.")
         case .large: return NSLocalizedString("Large", comment: "Large image size. Should be the same as in core WP.")
-        case .none, .full: return NSLocalizedString("Full Size", comment: "Full size image. (default). Should be the same as in core WP.")
+        case .full: return NSLocalizedString("Full Size", comment: "Full size image. (default). Should be the same as in core WP.")
+        case .none: return NSLocalizedString("None", comment: "No size class defined for the image. Should be the same as in core WP.")
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2582,7 +2582,7 @@ extension AztecPostViewController {
 
             switch expected {
             case .image:
-                newAttachment = imageAttachmentWithPlaceholder()
+                newAttachment = insertImageAttachment()
                 newStatType = .editorAddedPhotoViaOtherApps
             case .video:
                 newAttachment = videoAttachmentWithPlaceholder()
@@ -2618,7 +2618,7 @@ extension AztecPostViewController {
     }
 
     fileprivate func insertDeviceImage(phAsset: PHAsset) {
-        let attachment = imageAttachmentWithPlaceholder()
+        let attachment = insertImageAttachment()
         let mediaService = MediaService(managedObjectContext: ContextManager.sharedInstance().mainContext)
         mediaService.createMedia(with: phAsset,
                                  forPost: post.objectID,
@@ -2651,14 +2651,14 @@ extension AztecPostViewController {
         }
     }
 
-    private func imageAttachmentWithPlaceholder() -> ImageAttachment {
-        let attachment = richTextView.replaceWithImage(at: self.richTextView.selectedRange, sourceURL: URL(string: "placeholder://")!, placeHolderImage: Assets.defaultMissingImage)
+    private func insertImageAttachment(with url: URL = Constants.placeholderMediaLink) -> ImageAttachment {
+        let attachment = richTextView.replaceWithImage(at: self.richTextView.selectedRange, sourceURL: url, placeHolderImage: Assets.defaultMissingImage)
         attachment.size = .full
         return attachment
     }
 
     private func videoAttachmentWithPlaceholder() -> VideoAttachment {
-        return richTextView.replaceWithVideo(at: richTextView.selectedRange, sourceURL: URL(string: "placeholder://")!, posterURL: URL(string: "placeholder://")!, placeHolderImage: Assets.defaultMissingImage)
+        return richTextView.replaceWithVideo(at: richTextView.selectedRange, sourceURL: Constants.placeholderMediaLink, posterURL: Constants.placeholderMediaLink, placeHolderImage: Assets.defaultMissingImage)
     }
 
     private func handleThumbnailURL(_ thumbnailURL: URL, attachment: Any) {
@@ -2695,7 +2695,7 @@ extension AztecPostViewController {
         }
         switch media.mediaType {
         case .image:
-            let attachment = richTextView.replaceWithImage(at: richTextView.selectedRange, sourceURL: remoteURL, placeHolderImage: Assets.defaultMissingImage)
+            let attachment = insertImageAttachment(with: remoteURL)
             attachment.alt = media.alt
             WPAppAnalytics.track(.editorAddedPhotoViaWPMediaLibrary, withProperties: WPAppAnalytics.properties(for: media, mediaOrigin: selectedMediaOrigin), with: post)
         case .video:
@@ -2720,13 +2720,13 @@ extension AztecPostViewController {
 
     fileprivate func insertLocalSiteMediaLibrary(media: Media) {
 
-        var tempMediaURL = URL(string: "placeholder://")!
+        var tempMediaURL = Constants.placeholderMediaLink
         if let absoluteURL = media.absoluteLocalURL {
             tempMediaURL = absoluteURL
         }
         var attachment: MediaAttachment?
         if media.mediaType == .image {
-            attachment = self.richTextView.replaceWithImage(at: richTextView.selectedRange, sourceURL: tempMediaURL, placeHolderImage: Assets.defaultMissingImage)
+            attachment = insertImageAttachment(with: tempMediaURL)
             WPAppAnalytics.track(.editorAddedPhotoViaWPMediaLibrary, withProperties: WPAppAnalytics.properties(for: media, mediaOrigin: selectedMediaOrigin), with: post)
         } else if media.mediaType == .video,
             let remoteURLStr = media.remoteURL,
@@ -3375,6 +3375,7 @@ extension AztecPostViewController {
         static let mediaPickerKeyboardHeightRatioLandscape  = CGFloat(0.30)
         static let mediaOverlayBorderWidth  = CGFloat(3.0)
         static let mediaOverlayIconSize     = CGSize(width: 32, height: 32)
+        static let placeholderMediaLink = URL(string: "placeholder://")!
 
         struct Animations {
             static let formatBarMediaButtonRotationDuration: TimeInterval = 0.3

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2652,7 +2652,9 @@ extension AztecPostViewController {
     }
 
     private func imageAttachmentWithPlaceholder() -> ImageAttachment {
-        return richTextView.replaceWithImage(at: self.richTextView.selectedRange, sourceURL: URL(string: "placeholder://")!, placeHolderImage: Assets.defaultMissingImage)
+        let attachment = richTextView.replaceWithImage(at: self.richTextView.selectedRange, sourceURL: URL(string: "placeholder://")!, placeHolderImage: Assets.defaultMissingImage)
+        attachment.size = .full
+        return attachment
     }
 
     private func videoAttachmentWithPlaceholder() -> VideoAttachment {


### PR DESCRIPTION
Fixes #8242 

This PR make sure that images inserted using Aztec have `size-full` class set by default, the same as Calypso.

To test:
  - Start a new post using Aztec
  - Insert an image
 - Switch to HTML and check if `size-full` is set


