### PR TITLE
Post status action bar: Use UIIamge functions to flip the button icon

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
@@ -315,9 +315,8 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
                                    highlightedImage:nil];
     } else {
         item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"More", @"")
-                                              image:[UIImage imageNamed:@"icon-post-actionbar-more"]
+                                              image:[[UIImage imageNamed:@"icon-post-actionbar-more"] imageFlippedForRightToLeftLayoutDirection]
                                    highlightedImage:nil];
-        item.imageInsets = [InsetsHelper flipForRightToLeftLayoutDirection:MoreButtonImageInsets];
     }
     return item;
 }


### PR DESCRIPTION
InsetsHelper doesn't have the context to determine when to flip the image, and using the UIImage function is used in the other action bar functions.

Fixes #8211

To test: Load up the posts list and make sure the image is positioned correctly.  Switch to a RTL language and make sure its also correct there.

LTR:
![simulator screen shot - iphone 6 - 2017-12-03 at 13 51 45](https://user-images.githubusercontent.com/363753/33529112-8a52ce66-d831-11e7-9683-d7e080a0ca15.png)

RTL:
![simulator screen shot - iphone 6 - 2017-12-03 at 13 54 10](https://user-images.githubusercontent.com/363753/33529113-914b4cac-d831-11e7-894b-e14fb78a7e60.png)



