### PR TITLE
Refactor UIEdgeInsets image flip logic

### DIFF
--- a/WordPress/Classes/Extensions/UIEdgeInsets.swift
+++ b/WordPress/Classes/Extensions/UIEdgeInsets.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 extension UIEdgeInsets {
-    func flippedForRightToLeftLayoutDirection() -> UIEdgeInsets {
+    fileprivate func flippedForRightToLeftLayoutDirection() -> UIEdgeInsets {
         return UIEdgeInsets(top: top, left: right, bottom: bottom, right: left)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
@@ -315,9 +315,8 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
                                    highlightedImage:nil];
     } else {
         item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"More", @"")
-                                              image:[UIImage imageNamed:@"icon-post-actionbar-more"]
+                                              image:[[UIImage imageNamed:@"icon-post-actionbar-more"] imageFlippedForRightToLeftLayoutDirection]
                                    highlightedImage:nil];
-        item.imageInsets = [InsetsHelper flipForRightToLeftLayoutDirection:MoreButtonImageInsets];
     }
     return item;
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -15,7 +15,7 @@ import WordPressShared
         super.awakeFromNib()
 
         applyStyles()
-        adjustInsetsForTextDirection()
+        followButton.flipInsetsForRightToLeftLayoutDirection()
     }
 
     @objc func applyStyles() {
@@ -36,16 +36,6 @@ import WordPressShared
 
     @objc open func enableLoggedInFeatures(_ enable: Bool) {
         followButton.isHidden = !enable
-    }
-
-    fileprivate func adjustInsetsForTextDirection() {
-        guard userInterfaceLayoutDirection() == .rightToLeft else {
-            return
-        }
-
-        followButton.contentEdgeInsets = followButton.contentEdgeInsets.flippedForRightToLeftLayoutDirection()
-        followButton.imageEdgeInsets = followButton.imageEdgeInsets.flippedForRightToLeftLayoutDirection()
-        followButton.titleEdgeInsets = followButton.titleEdgeInsets.flippedForRightToLeftLayoutDirection()
     }
 
     // MARK: - Actions


### PR DESCRIPTION
Make the function on UIEdgeInset private so all calls go through UIButton that is aware of the language direction.

https://github.com/wordpress-mobile/WordPress-iOS/pull/8253 is required for this as it removed one call to the function that is now private.


