### PR TITLE
App Extensions: Update ShareExtractor to handle multiple images and plain text

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -364,7 +364,6 @@ int ddLogLevel = DDLogLevelInfo;
     // 21-Oct-2017: We are only handling background URLSessions initiated by the share extension so there
     // is no need to inspect the identifier beyond the simple check here.
     if ([identifier containsString:WPAppGroupName]) {
-        DDLogInfo(@"Rejoining session with identifier: %@ with application in state: %@", identifier, application.applicationState);
         ShareExtensionSessionManager *sessionManager = [[ShareExtensionSessionManager alloc] initWithAppGroup:WPAppGroupName backgroundSessionIdentifier:identifier];
         sessionManager.backgroundSessionCompletionBlock = ^{
             dispatch_async(dispatch_get_main_queue(), completionHandler);

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -5,8 +5,8 @@ import UIKit
 /// A type that represents the information we can extract from an extension context
 ///
 struct ExtractedShare {
-    let text: String
-    let image: UIImage?
+    var text: String
+    var images: [UIImage]
 }
 
 /// A type that represents the information we can extract from an extension context
@@ -50,9 +50,10 @@ struct ShareExtractor {
     ///
     func loadShare(completion: @escaping (ExtractedShare) -> Void) {
         extractText { text in
-            self.extractImage { image in
-                let text = text ?? ""
-                completion(ExtractedShare(text: text, image: image))
+            self.extractImages { images in
+                let returnedText = text ?? ""
+                let returnedImages = images ?? [UIImage]()
+                completion(ExtractedShare(text: returnedText, images: returnedImages))
             }
         }
     }
@@ -66,7 +67,6 @@ struct ShareExtractor {
     var validContent: Bool {
         return textExtractor != nil || imageExtractor != nil
     }
-
 }
 
 
@@ -77,7 +77,8 @@ private extension ShareExtractor {
         return [
             SharePostExtractor(),
             PropertyListExtractor(),
-            URLExtractor()
+            URLExtractor(),
+            PlainTextExtractor()
         ]
     }
 
@@ -96,25 +97,35 @@ private extension ShareExtractor {
             completion(nil)
             return
         }
-        textExtractor.extract(context: extensionContext) { share in
-            completion(share?.text)
+        textExtractor.extract(context: extensionContext) { extractedItems in
+            guard extractedItems.count > 0 else {
+                completion(nil)
+                return
+            }
+            let combinedText = extractedItems.flatMap({ $0.text }).map({ $0 + " " }).joined()
+            completion(combinedText)
         }
     }
 
-    func extractImage(completion: @escaping (UIImage?) -> Void) {
+    func extractImages(completion: @escaping ([UIImage]?) -> Void) {
         guard let imageExtractor = imageExtractor else {
             completion(nil)
             return
         }
-        imageExtractor.extract(context: extensionContext) { share in
-            completion(share?.image)
+        imageExtractor.extract(context: extensionContext) { extractedItems in
+            guard extractedItems.count > 0 else {
+                completion(nil)
+                return
+            }
+            let images = extractedItems.flatMap({ $0.image })
+            completion(images)
         }
     }
 }
 
 private protocol ExtensionContentExtractor {
     func canHandle(context: NSExtensionContext) -> Bool
-    func extract(context: NSExtensionContext, completion: @escaping (ExtractedItem?) -> Void)
+    func extract(context: NSExtensionContext, completion: @escaping ([ExtractedItem]) -> Void)
 }
 
 private protocol TypeBasedExtensionContentExtractor: ExtensionContentExtractor {
@@ -128,19 +139,35 @@ private extension TypeBasedExtensionContentExtractor {
         return !context.itemProviders(ofType: acceptedType).isEmpty
     }
 
-    func extract(context: NSExtensionContext, completion: @escaping (ExtractedItem?) -> Void) {
-        guard let provider = context.itemProviders(ofType: acceptedType).first else {
+    func extract(context: NSExtensionContext, completion: @escaping ([ExtractedItem]) -> Void) {
+        let itemProviders = context.itemProviders(ofType: acceptedType)
+        guard itemProviders.count > 0 else {
             DispatchQueue.main.async {
-                completion(nil)
+                completion([ExtractedItem]())
             }
             return
         }
-        provider.loadItem(forTypeIdentifier: acceptedType, options: nil) { (payload, error) in
-            let payload = payload as? Payload
-            let result = payload.flatMap(self.convert(payload:))
 
-            DispatchQueue.main.async {
-                completion(result)
+        // There 1 or more valid item providers here, lets work through them
+        var results = [ExtractedItem]()
+        var itemsToLoad = 0
+        for provider in itemProviders {
+            itemsToLoad += 1
+            // Remember, this is an async call....
+            provider.loadItem(forTypeIdentifier: acceptedType, options: nil) { (payload, error) in
+                let payload = payload as? Payload
+                let result = payload.flatMap(self.convert(payload:))
+                if let result = result {
+                    results.append(result)
+                }
+                itemsToLoad -= 1
+
+                // This only gets called when _all_ of the items are loaded
+                if itemsToLoad == 0 {
+                    DispatchQueue.main.async {
+                        completion(results)
+                    }
+                }
             }
         }
     }
@@ -203,9 +230,21 @@ private struct PropertyListExtractor: TypeBasedExtensionContentExtractor {
     func string(in dictionary: [String: Any], forKey key: String) -> String? {
         guard let value = dictionary[key] as? String,
             !value.isEmpty else {
-            return nil
+                return nil
         }
         return value
+    }
+}
+
+private struct PlainTextExtractor: TypeBasedExtensionContentExtractor {
+    typealias Payload = String
+    let acceptedType = kUTTypePlainText as String
+
+    func convert(payload: String) -> ExtractedItem? {
+        guard !payload.isEmpty else {
+            return nil
+        }
+        return .text(payload)
     }
 }
 

--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -226,7 +226,9 @@ private extension ShareViewController {
         ShareExtractor(extensionContext: extensionContext)
             .loadShare { [weak self] share in
                 self?.textView.text = share.text
-                if let image = share.image {
+
+                // Just using the first image for now.
+                if let image = share.images.first {
                     self?.imageLoaded(image: image)
                 }
         }


### PR DESCRIPTION
## Discussion

This PR is the first of a series that will eventually address uploading multiple media files (#8179) via the app extensions. `ShareExtractor.swift` is updated to handle extracting plain text shares: 

![sharing_plain_text](https://user-images.githubusercontent.com/154014/33572009-4f7a5ec8-d8f7-11e7-912a-543bc522e562.gif)

`ShareExtractor.swift` also now has the ability to extract of multiple images (this is not used right now). For now, we are using the first shared image in `ExtractedShare`'s `images` array. It should be noted the share extension is still not activated if the user selected more than 1 media item in the host app so this shouldn't be an issue.

Fixes #8261 and partially addresses #5200

## To Test

There are a couple of sharing scenarios to test here:

1. **Plain Text Sharing:** Open Safari (or another app) and attempt to share using the context menu (as in the GIF above ☝️). Verify the selected text is displayed in the share UI.

2. **Property List Sharing:** Open Safari and attempt to share using the share menu in the toolbar at the bottom of the screen. Verify the the Web Page Title and URL is displayed in the share UI.

3. **Property List Sharing:** Open Safari and _select some text on a web page_. Attempt to share using the share menu in the toolbar at the bottom of the screen. Verify the selected text and URL is displayed in the share UI.

4. **Photo List Sharing:** Open Photos and attempt to share an image. Verify the Photo is displayed in the share UI. Now post the image to a site. Verify the image and any updated text is saved on the web side.

5. **URL Sharing:** Open Safari and long press on a URL link on a web page. Verify the URL is displayed in the share UI.

@frosty would you mind taking a peek at this one?

