### PR TITLE
Update WordPressKit to handle background uploads of multiple media items

### DIFF
--- a/WordPress/WordPressShareExtension/ShareViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareViewController.swift
@@ -327,9 +327,10 @@ private extension ShareViewController {
             return
         }
 
-        // The success and error blocks will probably never get called here, but let's add them just in case. Shared
-        // container cleanup will most likely occur in the container (WPiOS) app after the background session completes.
-        remote.createPost(remotePost, with: remoteMedia, requestEnqueued: {
+        // NOTE: The success and error closures **may** get called here - it’s non-deterministic as to whether WPiOS
+        // or the extension gets the "did complete" callback. So unfortunatly, we need to have the logic to complete
+        // post share here as well as WPiOS.
+        remote.createPost(remotePost, with: remoteMedia, requestEnqueued: { task in
             requestEnqueued()
         }, success: {_ in
             ShareMediaFileManager.shared.purgeUploadDirectory()

--- a/WordPressKit/WordPressKit/MediaServiceRemoteREST.h
+++ b/WordPressKit/WordPressKit/MediaServiceRemoteREST.h
@@ -6,7 +6,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MediaServiceRemoteREST : SiteServiceRemoteWordPressComREST <MediaServiceRemote>
 
-- (RemoteMedia *)remoteMediaFromJSONDictionary:(NSDictionary *)jsonMedia;
++ (RemoteMedia *)remoteMediaFromJSONDictionary:(NSDictionary *)jsonMedia;
++ (NSArray *)remoteMediaFromJSONArray:(NSArray *)jsonMedia;
+
+/**
+ *  @brief      Upload multiple media items to the remote site.
+ *
+ *  @discussion This purpose of this method is to give app extensions the ability to upload media via background sessions.
+ *
+ *  @param  mediaItems      The media items to create remotely.
+ *  @param  requestEnqueued The block that will be executed when the network request is queued.  Can be nil.
+ *  @param  success         The block that will be executed on success.  Can be nil.
+ *  @param  failure         The block that will be executed on failure.  Can be nil.
+ */
+- (void)uploadMedia:(NSArray *)mediaItems
+    requestEnqueued:(void (^)(NSNumber *taskID))requestEnqueued
+            success:(void (^)(NSArray *remoteMedia))success
+            failure:(void (^)(NSError *error))failure;
 
 @end
 

--- a/WordPressKit/WordPressKit/MediaServiceRemoteREST.h
+++ b/WordPressKit/WordPressKit/MediaServiceRemoteREST.h
@@ -6,7 +6,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MediaServiceRemoteREST : SiteServiceRemoteWordPressComREST <MediaServiceRemote>
 
+/**
+ Populates a RemoteMedia instance using values from a json dict returned
+ from the endpoint.
+
+ @param jsonMedia Media dictionary returned from the remote endpoint
+ @return A RemoteMedia instance
+ */
 + (RemoteMedia *)remoteMediaFromJSONDictionary:(NSDictionary *)jsonMedia;
+
+
+/**
+ Populates a array of RemoteMedia instances using an array of json dicts returned
+ from the endpoint.
+
+ @param jsonMedia An array of media dicts returned from the remote endpoint
+ @return A array of RemoteMedia instances
+ */
 + (NSArray *)remoteMediaFromJSONArray:(NSArray *)jsonMedia;
 
 /**

--- a/WordPressKit/WordPressKit/PostServiceRemoteREST.h
+++ b/WordPressKit/WordPressKit/PostServiceRemoteREST.h
@@ -20,7 +20,7 @@
  */
 - (void)createPost:(RemotePost *)post
          withMedia:(RemoteMedia *)media
-   requestEnqueued:(void (^)(void))requestEnqueued
+   requestEnqueued:(void (^)(NSNumber *taskID))requestEnqueued
            success:(void (^)(RemotePost *))success
            failure:(void (^)(NSError *))failure;
 

--- a/WordPressKit/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/PostServiceRemoteREST.m
@@ -121,7 +121,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 
 - (void)createPost:(RemotePost *)post
          withMedia:(RemoteMedia *)media
-   requestEnqueued:(void (^)(void))requestEnqueued
+   requestEnqueued:(void (^)(NSNumber *taskID))requestEnqueued
            success:(void (^)(RemotePost *))success
            failure:(void (^)(NSError *))failure
 {
@@ -141,9 +141,9 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     [self.wordPressComRestApi multipartPOST:requestUrl
                                  parameters:parameters
                                   fileParts:@[filePart]
-                            requestEnqueued:^{
+                            requestEnqueued:^(NSNumber *taskID) {
                                 if (requestEnqueued) {
-                                    requestEnqueued();
+                                    requestEnqueued(taskID);
                                 }
     } success:^(id  _Nonnull responseObject, NSHTTPURLResponse * _Nullable httpResponse) {
         RemotePost *post = [self remotePostFromJSONDictionary:responseObject];

--- a/WordPressKit/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressKit/WordPressComRestApi.swift
@@ -28,7 +28,7 @@ open class WordPressComRestApi: NSObject {
     @objc open static let ErrorKeyErrorCode: String = "WordPressComRestApiErrorCodeKey"
     @objc open static let ErrorKeyErrorMessage: String = "WordPressComRestApiErrorMessageKey"
 
-    public typealias RequestEnqueuedBlock = () -> Void
+    public typealias RequestEnqueuedBlock = (_ taskID : NSNumber) -> Void
     public typealias SuccessResponseBlock = (_ responseObject: AnyObject, _ httpResponse: HTTPURLResponse?) -> ()
     public typealias FailureReponseBlock = (_ error: NSError, _ httpResponse: HTTPURLResponse?) -> ()
 
@@ -224,7 +224,7 @@ open class WordPressComRestApi: NSObject {
      - parameter URLString:  the endpoint to connect
      - parameter parameters: the parameters to use on the request
      - parameter fileParts:  the file parameters that are added to the multipart request
-     - parameter requestEnqueued: callback to be called on when the fileparts are serialized and request is added to the background session. Defaults to nil
+     - parameter requestEnqueued: callback to be called when the fileparts are serialized and request is added to the background session. Defaults to nil
      - parameter success:    callback to be called on successful request
      - parameter failure:    callback to be called on failed request
 
@@ -259,7 +259,7 @@ open class WordPressComRestApi: NSObject {
                     success(responseObject as AnyObject, response as? HTTPURLResponse)
                 }
             }
-            requestEnqueued?()
+            requestEnqueued?(NSNumber(value: task.taskIdentifier))
             task.resume()
             progress.cancellationHandler = {
                 task.cancel()

--- a/WordPressKit/WordPressKitTests/MediaServiceRemoteRESTTests.swift
+++ b/WordPressKit/WordPressKitTests/MediaServiceRemoteRESTTests.swift
@@ -81,6 +81,31 @@ class MediaServiceRemoteRESTTests: XCTestCase {
         XCTAssertEqual(errorDescription, response["errors"]![0])
     }
 
+    func testCreateMultipleMedia() {
+
+        let response = ["media": [["ID": 1],["ID": 1]]]
+        let media = [mockRemoteMedia(), mockRemoteMedia()]
+        var remoteMedia: [RemoteMedia]?
+        mediaServiceRemote.uploadMedia(media, requestEnqueued: { _ in }, success: {
+            remoteMedia = $0 as? [RemoteMedia]
+        }, failure: { _ in })
+        mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
+        XCTAssertEqual(media[0].mediaID, remoteMedia?[0].mediaID)
+        XCTAssertEqual(media[1].mediaID, remoteMedia?[1].mediaID)
+    }
+
+    func testCreateMultipleMediaError() {
+
+        let response = ["errors": ["some error"]]
+        let media = [mockRemoteMedia(), mockRemoteMedia()]
+        var errorDescription = ""
+        mediaServiceRemote.uploadMedia(media, requestEnqueued: { _ in }, success: { _ in }, failure: {
+            errorDescription = $0.localizedDescription
+        })
+        mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
+        XCTAssertEqual(errorDescription, response["errors"]![0])
+    }
+
     func testUpdateMediaPath() {
 
         let media = mockRemoteMedia()

--- a/WordPressKit/WordPressKitTests/MediaServiceRemoteRESTTests.swift
+++ b/WordPressKit/WordPressKitTests/MediaServiceRemoteRESTTests.swift
@@ -219,7 +219,7 @@ class MediaServiceRemoteRESTTests: XCTestCase {
                                                       "height": height,
                                                       "width": width]
 
-        let remoteMedia = mediaServiceRemote.remoteMedia(fromJSONDictionary: jsonDictionary)
+        let remoteMedia = MediaServiceRemoteREST.remoteMedia(fromJSONDictionary: jsonDictionary)
         XCTAssertEqual(remoteMedia.mediaID?.intValue, id)
         XCTAssertEqual(remoteMedia.url?.absoluteString, url)
         XCTAssertEqual(remoteMedia.guid?.absoluteString, guid)
@@ -233,5 +233,82 @@ class MediaServiceRemoteRESTTests: XCTestCase {
         XCTAssertEqual(remoteMedia.alt, alt)
         XCTAssertEqual(remoteMedia.height?.intValue, height)
         XCTAssertEqual(remoteMedia.width?.intValue, width)
+    }
+
+    func testRemoteMediaJSONArrayParsing() {
+        let id = 1
+        let id2 = 2
+        let url = "http://www.wordpress.com"
+        let guid = "http://www.gravatar.com"
+        let date = "2016-12-14T22:00:00Z"
+        let postID = 2
+        let file = "file"
+        let mimeType = "img/jpeg"
+        let title = "title"
+        let caption = "caption"
+        let description = "description"
+        let alt = "alt"
+        let height = 321
+        let width = 432
+
+        let jsonDictionary1: [String : Any] = ["ID": id,
+                                              "URL": url,
+                                              "guid": guid,
+                                              "date": date,
+                                              "post_ID": postID,
+                                              "mime_type": mimeType,
+                                              "file": file,
+                                              "title": title,
+                                              "caption": caption,
+                                              "description": description,
+                                              "alt": alt,
+                                              "height": height,
+                                              "width": width]
+
+        let jsonDictionary2: [String : Any] = ["ID": id2,
+                                               "URL": url,
+                                               "guid": guid,
+                                               "date": date,
+                                               "post_ID": postID,
+                                               "mime_type": mimeType,
+                                               "file": file,
+                                               "title": title,
+                                               "caption": caption,
+                                               "description": description,
+                                               "alt": alt,
+                                               "height": height,
+                                               "width": width]
+        let jsonArray = [jsonDictionary1, jsonDictionary2]
+
+
+        let remoteMediaArray: [RemoteMedia] = MediaServiceRemoteREST.remoteMedia(fromJSONArray: jsonArray) as! [RemoteMedia]
+
+        XCTAssertEqual(remoteMediaArray[0].mediaID?.intValue, id)
+        XCTAssertEqual(remoteMediaArray[0].url?.absoluteString, url)
+        XCTAssertEqual(remoteMediaArray[0].guid?.absoluteString, guid)
+        XCTAssertEqual(remoteMediaArray[0].date, Date.dateWithISO8601String(date)!)
+        XCTAssertEqual(remoteMediaArray[0].postID?.intValue, postID)
+        XCTAssertEqual(remoteMediaArray[0].file, file)
+        XCTAssertEqual(remoteMediaArray[0].mimeType, mimeType)
+        XCTAssertEqual(remoteMediaArray[0].title, title)
+        XCTAssertEqual(remoteMediaArray[0].caption, caption)
+        XCTAssertEqual(remoteMediaArray[0].descriptionText, description)
+        XCTAssertEqual(remoteMediaArray[0].alt, alt)
+        XCTAssertEqual(remoteMediaArray[0].height?.intValue, height)
+        XCTAssertEqual(remoteMediaArray[0].width?.intValue, width)
+
+        XCTAssertEqual(remoteMediaArray[1].mediaID?.intValue, id2)
+        XCTAssertEqual(remoteMediaArray[1].url?.absoluteString, url)
+        XCTAssertEqual(remoteMediaArray[1].guid?.absoluteString, guid)
+        XCTAssertEqual(remoteMediaArray[1].date, Date.dateWithISO8601String(date)!)
+        XCTAssertEqual(remoteMediaArray[1].postID?.intValue, postID)
+        XCTAssertEqual(remoteMediaArray[1].file, file)
+        XCTAssertEqual(remoteMediaArray[1].mimeType, mimeType)
+        XCTAssertEqual(remoteMediaArray[1].title, title)
+        XCTAssertEqual(remoteMediaArray[1].caption, caption)
+        XCTAssertEqual(remoteMediaArray[1].descriptionText, description)
+        XCTAssertEqual(remoteMediaArray[1].alt, alt)
+        XCTAssertEqual(remoteMediaArray[1].height?.intValue, height)
+        XCTAssertEqual(remoteMediaArray[1].width?.intValue, width)
     }
 }


### PR DESCRIPTION
## Discussion

This PR is the 2nd of a series that addresses uploading multiple media files (#8179) via the app extensions.  This PR:
* Adds 2 new methods to `MediaServiceRemoteREST` that will eventually be leveraged in #8179. For now, a few unit tests were added.
* Updates the returned `RequestEnqueuedBlock` from `WordPressComRestApi.swift` to include the background session's task ID. This task ID is _required_ in future PRs (used in working with NSURLSession + app extensions when crossing process boundaries)
* Contains a minor function call update in `ShareViewController.swift`
* Made `remoteMediaFromJSONDictionary` and `remoteMediaFromJSONArray` class methods.
* Includes some new/updated unit tests

Fixes #8264
Ref: #8263

## To Test

* Verify that sharing media still works as expected (still only a max of 1 pic and still creates a gallery).
* Verify uploading of media in Aztec still works as expected.
* Verify all of the unit tests are green ✅ 
* If you want to see the new "upload multiple media" logic from `MediaServiceRemoteREST` in action, [check out this feature branch](https://github.com/wordpress-mobile/WordPress-iOS/tree/issue/8179-share-multiple-media-items).

@SergioEstevao would you mind taking a look? Thanks!