### PR TITLE
Aztec: Fixes a crash when navigating back from the media library

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1455,7 +1455,7 @@ extension AztecPostViewController: UITextViewDelegate {
     func textViewShouldBeginEditing(_ textView: UITextView) -> Bool {
         textView.textAlignment = .natural
 
-        let htmlButton = formatBar.items.first(where: { $0.identifier == FormattingIdentifier.sourcecode.rawValue })!
+        let htmlButton = formatBar.items.first(where: { $0.identifier == FormattingIdentifier.sourcecode.rawValue })
 
         switch textView {
         case titleTextField:
@@ -1468,7 +1468,7 @@ extension AztecPostViewController: UITextViewDelegate {
             break
         }
 
-        htmlButton.isEnabled = true
+        htmlButton?.isEnabled = true
 
         if mediaPickerInputViewController == nil {
             textView.inputAccessoryView = formatBar


### PR DESCRIPTION
Fixes #8271 

Aztec was crashing when navigating back from the media library. In addition to the steps outlined in the original issue, it's also possible to trigger this by showing the fullscreen picker and then tapping Cancel. The crash arises from Aztec attempting to enable the HTML button in the toolbar, which doesn't exist while inserting media.

To test:

* See the original issue for replication steps.
* Also show the WordPress Media Library, then cancel it.
