### PR TITLE
Allow wpcom accounts to be reauthenticated when restored from backup

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -62,6 +62,7 @@ import WordPressShared
         let context = ContextManager.sharedInstance().mainContext
         let loginFields = LoginFields()
         if let account = AccountService(managedObjectContext: context).defaultWordPressComAccount() {
+            loginFields.emailAddress = account.email
             loginFields.username = account.username
         }
 
@@ -70,6 +71,7 @@ import WordPressShared
             fatalError("unable to create wpcom password screen")
         }
 
+        controller.loginFields = loginFields
         controller.dismissBlock = onDismissed
         return NUXNavigationController(rootViewController: controller)
     }


### PR DESCRIPTION
Fixes #8098

Current builds will enter an unescapable login flow when restored from backup, which clears out the auth token from the keychain. This will allow those accounts to be reauthenticated.

### To test:

To recreate the conditions of the bug, the wpcom auth token has to be deleted without deleting the whole app. I suggest putting this snippet in `application:willFinishLaunchingWithOptions:`. It has to go before `[WordPressAppDelegate fixKeychainAccess]`.

```swift
AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
    NSError *error = nil;
    [SFHFKeychainUtils deleteItemForUsername:defaultAccount.username andServiceName:@"public-api.wordpress.com" error:nil];
```

When launched with that the auth token will be destroyed and the reauthentication UI will appear. Without this patch, the app should be unusable. With this change entering the correct password should enable the app to resume working.

Needs review: @aerych 
