### PR TITLE
Remove log statement from handleEventsForBackgroundURLSession

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -363,7 +363,6 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     // 21-Oct-2017: We are only handling background URLSessions initiated by the share extension so there
     // is no need to inspect the identifier beyond the simple check here.
     if ([identifier containsString:WPAppGroupName]) {
-        DDLogInfo(@"Rejoining session with identifier: %@ with application in state: %@", identifier, application.applicationState);
         ShareExtensionSessionManager *sessionManager = [[ShareExtensionSessionManager alloc] initWithAppGroup:WPAppGroupName backgroundSessionIdentifier:identifier];
         sessionManager.backgroundSessionCompletionBlock = ^{
             dispatch_async(dispatch_get_main_queue(), completionHandler);


### PR DESCRIPTION
Fixes #8283 

Removes a log statement that is causing a crash when background NSURLSession resumes WPiOS when initiated from the share extension. See the issue for more details ☝️ 

This PR is for 9.0, `develop` already has this change.


