### PR TITLE
Widened MediaProperties.bytes to Int64 in WPAppAnalytics+Media.swift

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
@@ -52,7 +52,7 @@ public extension WPAppAnalytics {
             properties[MediaProperties.durationSeconds] = media.length
         }
         if let filesize = media.filesize {
-            properties[MediaProperties.bytes] = filesize.intValue * 1024
+            properties[MediaProperties.bytes] = filesize.int64Value * 1024
         }
         return properties
     }


### PR DESCRIPTION
Fixes #8280 which affects older, 32bit devices.

This PR widens the `MediaProperties.bytes` value in `WPAppAnalytics+Media.swift` to an int64 which should (hopefully) prevent the overflow problem we are seeing in the issue ☝️. 

**To test:**
Open Aztec and upload some media so the media analytics fires. Make sure everything works as expected. If possible, test on an older device too.

@SergioEstevao would you mind taking a peek?

/cc @diegoreymendez @elibud 

