### PR TITLE
Display comments on Reader Detail for Jetpack sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -655,7 +655,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         // Show comments if logged in and comments are enabled, or if comments exist.
         // But only if it is from wpcom (jetpack and external is not yet supported).
         // Nesting this conditional cos it seems clearer that way
-        if post.isWPCom && !shouldHideComments {
+        if (post.isWPCom || post.isJetpack) && !shouldHideComments {
             let commentCount = post.commentCount?.intValue ?? 0
             if (ReaderHelpers.isLoggedIn() && post.commentsOpen) || commentCount > 0 {
                 configureCommentActionButton()


### PR DESCRIPTION
**Fixes** #8297 

**To test:**

On Reader:

1. Find a post for a Jetpack site on reader (an example on the original issue).
2. Navigate to the post detail.
3. Check that the comment icon is present at the footer.

CC: @diegoreymendez targeting 9.0 on this one since it's a new Jetpack feature that should work on all fronts. 