### PR TITLE
Save, delete and update tags locally and remotely

### DIFF
--- a/WordPress/Classes/Services/PostTagService.h
+++ b/WordPress/Classes/Services/PostTagService.h
@@ -44,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)deleteTag:(PostTag*)tag
           forBlog:(Blog *)blog
-          success:(nullable void (^)(NSArray <PostTag *> *tags))success
+          success:(nullable void (^)(void))success
           failure:(nullable void (^)(NSError *error))failure;
 
 /**

--- a/WordPress/Classes/Services/PostTagService.h
+++ b/WordPress/Classes/Services/PostTagService.h
@@ -48,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
           failure:(nullable void (^)(NSError *error))failure;
 
 /**
- Commits a tag assigned to a blog
+ Saves a tag assigned to a blog
  */
 - (void)saveTag:(PostTag*)tag
           forBlog:(Blog *)blog

--- a/WordPress/Classes/Services/PostTagService.h
+++ b/WordPress/Classes/Services/PostTagService.h
@@ -51,9 +51,9 @@ NS_ASSUME_NONNULL_BEGIN
  Saves a tag assigned to a blog
  */
 - (void)saveTag:(PostTag*)tag
-          forBlog:(Blog *)blog
-          success:(nullable void (^)(PostTag *tag))success
-          failure:(nullable void (^)(NSError *error))failure;
+        forBlog:(Blog *)blog
+        success:(nullable void (^)(PostTag *tag))success
+        failure:(nullable void (^)(NSError *error))failure;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Services/PostTagService.h
+++ b/WordPress/Classes/Services/PostTagService.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)saveTag:(PostTag*)tag
           forBlog:(Blog *)blog
-          success:(nullable void (^)(NSArray <PostTag *> *tags))success
+          success:(nullable void (^)(PostTag *tag))success
           failure:(nullable void (^)(NSError *error))failure;
 @end
 

--- a/WordPress/Classes/Services/PostTagService.h
+++ b/WordPress/Classes/Services/PostTagService.h
@@ -43,13 +43,17 @@ NS_ASSUME_NONNULL_BEGIN
  Deletes a tag assigned to a blog
  */
 - (void)deleteTag:(PostTag*)tag
-          forBlog:(Blog *)blog;
+          forBlog:(Blog *)blog
+          success:(nullable void (^)(NSArray <PostTag *> *tags))success
+          failure:(nullable void (^)(NSError *error))failure;
 
 /**
  Commits a tag assigned to a blog
  */
 - (void)commitTag:(PostTag*)tag
-          forBlog:(Blog *)blog;
+          forBlog:(Blog *)blog
+          success:(nullable void (^)(NSArray <PostTag *> *tags))success
+          failure:(nullable void (^)(NSError *error))failure;
 
 @end
 

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -128,9 +128,9 @@ static const NSInteger PostTagIdDefaultValue = -1;
 }
 
 - (void)saveTag:(PostTag*)tag
-          forBlog:(Blog *)blog
-          success:(nullable void (^)(NSArray <PostTag *> *tags))success
-          failure:(nullable void (^)(NSError *error))failure
+        forBlog:(Blog *)blog
+        success:(nullable void (^)(PostTag *tag))success
+        failure:(nullable void (^)(NSError *error))failure
 {
     if (tag.tagID.integerValue == PostTagIdDefaultValue) {
         [self saveNewTag:tag
@@ -210,7 +210,7 @@ static const NSInteger PostTagIdDefaultValue = -1;
 
 - (void)saveNewTag:(PostTag *)tag
               blog:(Blog *)blog
-           success:(nullable void (^)(NSArray <PostTag *> *tags))success
+           success:(nullable void (^)(PostTag *tag))success
            failure:(nullable void (^)(NSError *error))failure
 {
     NSLog(@"this is a new tag");
@@ -218,7 +218,7 @@ static const NSInteger PostTagIdDefaultValue = -1;
 
 - (void)updateExistingTag:(PostTag *)tag
                      blog:(Blog *)blog
-                  success:(nullable void (^)(NSArray <PostTag *> *tags))success
+                  success:(nullable void (^)(PostTag *tag))success
                   failure:(nullable void (^)(NSError *error))failure
 {
     NSLog(@"this is a tag to be updated");
@@ -230,7 +230,8 @@ static const NSInteger PostTagIdDefaultValue = -1;
 
     [remote createTag:remoteTag success:^(RemotePostTag * _Nonnull tag) {
         if (success) {
-            success(tag);
+            PostTag *localTag = [self tagFromRemoteTag:tag blog:blog];
+            success(localTag);
         }
     } failure:^(NSError * _Nonnull error) {
         [self handleError:error forBlog:blog withFailure:failure];

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -222,7 +222,6 @@ static const NSInteger PostTagIdDefaultValue = -1;
            success:(nullable void (^)(PostTag *tag))success
            failure:(nullable void (^)(NSError *error))failure
 {
-    [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
     RemotePostTag *remoteTag = [self remoteTagWith:tag];
     NSObject<TaxonomyServiceRemote> *remote = [self remoteForBlog:blog];
     [remote createTag:remoteTag success:^(RemotePostTag * _Nonnull tag) {

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -229,7 +229,9 @@ static const NSInteger PostTagIdDefaultValue = -1;
     RemotePostTag *remoteTag = [self remoteTagWith:tag];
 
     [remote createTag:remoteTag success:^(RemotePostTag * _Nonnull tag) {
-        // Do something?
+        if (success) {
+            success(tag);
+        }
     } failure:^(NSError * _Nonnull error) {
         [self handleError:error forBlog:blog withFailure:failure];
     }];

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -223,15 +223,13 @@ static const NSInteger PostTagIdDefaultValue = -1;
            success:(nullable void (^)(PostTag *tag))success
            failure:(nullable void (^)(NSError *error))failure
 {
-    NSLog(@"this is a new tag");
-
-    NSObject<TaxonomyServiceRemote> *remote = [self remoteForBlog:blog];
-
     RemotePostTag *remoteTag = [self remoteTagWith:tag];
+    NSObject<TaxonomyServiceRemote> *remote = [self remoteForBlog:blog];
 
     [remote createTag:remoteTag success:^(RemotePostTag * _Nonnull tag) {
         if (success) {
             PostTag *localTag = [self tagFromRemoteTag:tag blog:blog];
+            [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
             success(localTag);
         }
     } failure:^(NSError * _Nonnull error) {
@@ -244,23 +242,16 @@ static const NSInteger PostTagIdDefaultValue = -1;
                   success:(nullable void (^)(PostTag *tag))success
                   failure:(nullable void (^)(NSError *error))failure
 {
-    NSLog(@"this is a tag to be updated");
-
-    /*
-    NSObject<TaxonomyServiceRemote> *remote = [self remoteForBlog:blog];
-
-    //TODO. Commit the tag locally first
     RemotePostTag *remoteTag = [self remoteTagWith:tag];
-
-    [remote createTag:remoteTag success:^(RemotePostTag * _Nonnull tag) {
+    NSObject<TaxonomyServiceRemote> *remote = [self remoteForBlog:blog];
+    [remote updateTag:remoteTag success:^(RemotePostTag * _Nonnull remoteTag) {
+        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
         if (success) {
-            PostTag *localTag = [self tagFromRemoteTag:tag blog:blog];
-            success(localTag);
+            success(tag);
         }
     } failure:^(NSError * _Nonnull error) {
         [self handleError:error forBlog:blog withFailure:failure];
     }];
-    */
 }
 
 - (RemotePostTag*)remoteTagWith:(PostTag *)tag

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -133,7 +133,9 @@ static const NSInteger PostTagIdDefaultValue = -1;
         if (success) {
             success();
         }
-    } failure:failure];
+    } failure:^(NSError * _Nonnull error) {
+        [self handleError:error forBlog:blog withFailure:failure];
+    }];
 }
 
 - (void)saveTag:(PostTag*)tag

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -245,9 +245,10 @@ static const NSInteger PostTagIdDefaultValue = -1;
     RemotePostTag *remoteTag = [self remoteTagWith:tag];
     NSObject<TaxonomyServiceRemote> *remote = [self remoteForBlog:blog];
     [remote updateTag:remoteTag success:^(RemotePostTag * _Nonnull remoteTag) {
+        PostTag *localTag = [self tagFromRemoteTag:remoteTag blog:blog];
         [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
         if (success) {
-            success(tag);
+            success(localTag);
         }
     } failure:^(NSError * _Nonnull error) {
         [self handleError:error forBlog:blog withFailure:failure];

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -128,7 +128,6 @@ static const NSInteger PostTagIdDefaultValue = -1;
     RemotePostTag *remoteTag = [self remoteTagWith:tag];
 
     [remote deleteTag:remoteTag success:^(RemotePostTag * _Nonnull remoteTag) {
-        NSLog(@"The tag was actually deleted");
         [self.managedObjectContext deleteObject:tag];
         [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
         if (success) {

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -127,9 +127,10 @@ static const NSInteger PostTagIdDefaultValue = -1;
 
     RemotePostTag *remoteTag = [self remoteTagWith:tag];
 
+    [self.managedObjectContext deleteObject:tag];
+    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+
     [remote deleteTag:remoteTag success:^(void) {
-        [self.managedObjectContext deleteObject:tag];
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
         if (success) {
             success();
         }

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -244,10 +244,9 @@ static const NSInteger PostTagIdDefaultValue = -1;
     RemotePostTag *remoteTag = [self remoteTagWith:tag];
     NSObject<TaxonomyServiceRemote> *remote = [self remoteForBlog:blog];
     [remote updateTag:remoteTag success:^(RemotePostTag * _Nonnull remoteTag) {
-        PostTag *localTag = [self tagFromRemoteTag:remoteTag blog:blog];
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+        [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
         if (success) {
-            success(localTag);
+            success(tag);
         }
     } failure:^(NSError * _Nonnull error) {
         [self handleError:error forBlog:blog withFailure:failure];

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -243,7 +243,11 @@ static const NSInteger PostTagIdDefaultValue = -1;
 {
     RemotePostTag *remoteTag = [self remoteTagWith:tag];
     NSObject<TaxonomyServiceRemote> *remote = [self remoteForBlog:blog];
-    [remote updateTag:remoteTag success:^(RemotePostTag * _Nonnull remoteTag) {
+    [remote updateTag:remoteTag success:^(RemotePostTag * _Nonnull updatedTag) {
+        tag.tagID = updatedTag.tagID;
+        tag.tagDescription = updatedTag.tagDescription;
+        tag.slug= updatedTag.slug;
+        tag.name = updatedTag.name;
         [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
         if (success) {
             success(tag);

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -6,6 +6,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+static const NSInteger PostTagIdDefaultValue = -1;
+
 @interface PostTagService ()
 
 @end
@@ -126,8 +128,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)commitTag:(PostTag*)tag
           forBlog:(Blog *)blog
 {
-    //Not implemented yet
-    NSLog(@"Commit tag %@ for blog %@", tag, blog);
+    if (tag.tagID.integerValue == PostTagIdDefaultValue) {
+        [self saveNewTag:tag blog:blog];
+    } else {
+        [self updateExistingTag:tag blog:blog];
+    }
 }
 
 #pragma mark - helpers
@@ -191,6 +196,18 @@ NS_ASSUME_NONNULL_BEGIN
     }
     
     return [tags firstObject];
+}
+
+- (void)saveNewTag:(PostTag *)tag
+              blog:(Blog *)blog
+{
+    NSLog(@"this is a new tag");
+}
+
+- (void)updateExistingTag:(PostTag *)tag
+                     blog:(Blog *)blog
+{
+    NSLog(@"this is a tag to be updated");
 }
 
 - (void)handleError:(nullable NSError *)error forBlog:(nullable Blog *)blog withFailure:(nullable void(^)(NSError *error))failure

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -214,6 +214,19 @@ static const NSInteger PostTagIdDefaultValue = -1;
            failure:(nullable void (^)(NSError *error))failure
 {
     NSLog(@"this is a new tag");
+
+    NSObject<TaxonomyServiceRemote> *remote = [self remoteForBlog:blog];
+
+    RemotePostTag *remoteTag = [self remoteTagWith:tag];
+
+    [remote createTag:remoteTag success:^(RemotePostTag * _Nonnull tag) {
+        if (success) {
+            PostTag *localTag = [self tagFromRemoteTag:tag blog:blog];
+            success(localTag);
+        }
+    } failure:^(NSError * _Nonnull error) {
+        [self handleError:error forBlog:blog withFailure:failure];
+    }];
 }
 
 - (void)updateExistingTag:(PostTag *)tag
@@ -223,6 +236,7 @@ static const NSInteger PostTagIdDefaultValue = -1;
 {
     NSLog(@"this is a tag to be updated");
 
+    /*
     NSObject<TaxonomyServiceRemote> *remote = [self remoteForBlog:blog];
 
     //TODO. Commit the tag locally first
@@ -236,6 +250,7 @@ static const NSInteger PostTagIdDefaultValue = -1;
     } failure:^(NSError * _Nonnull error) {
         [self handleError:error forBlog:blog withFailure:failure];
     }];
+    */
 }
 
 - (RemotePostTag*)remoteTagWith:(PostTag *)tag

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -222,13 +222,13 @@ static const NSInteger PostTagIdDefaultValue = -1;
            success:(nullable void (^)(PostTag *tag))success
            failure:(nullable void (^)(NSError *error))failure
 {
+    [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
     RemotePostTag *remoteTag = [self remoteTagWith:tag];
     NSObject<TaxonomyServiceRemote> *remote = [self remoteForBlog:blog];
-
     [remote createTag:remoteTag success:^(RemotePostTag * _Nonnull tag) {
         if (success) {
             PostTag *localTag = [self tagFromRemoteTag:tag blog:blog];
-            [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+            [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
             success(localTag);
         }
     } failure:^(NSError * _Nonnull error) {

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -194,6 +194,7 @@ static const NSInteger PostTagIdDefaultValue = -1;
                                                              inManagedObjectContext:self.managedObjectContext];
         tag = [[PostTag alloc] initWithEntity:entityDescription insertIntoManagedObjectContext:self.managedObjectContext];
         tag.tagID = remoteTag.tagID;
+        tag.tagDescription = remoteTag.tagDescription;
         tag.blog = blog;
     }
     

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -120,11 +120,21 @@ static const NSInteger PostTagIdDefaultValue = -1;
 
 - (void)deleteTag:(PostTag*)tag
           forBlog:(Blog *)blog
-          success:(nullable void (^)(NSArray <PostTag *> *tags))success
+          success:(nullable void (^)(void))success
           failure:(nullable void (^)(NSError *error))failure
 {
-    //Not implemented yet
-    NSLog(@"Delete tag %@ for blog %@", tag, blog);
+    NSObject<TaxonomyServiceRemote> *remote = [self remoteForBlog:blog];
+
+    RemotePostTag *remoteTag = [self remoteTagWith:tag];
+
+    [remote deleteTag:remoteTag success:^(RemotePostTag * _Nonnull remoteTag) {
+        NSLog(@"The tag was actually deleted");
+        [self.managedObjectContext deleteObject:tag];
+        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+        if (success) {
+            success();
+        }
+    } failure:failure];
 }
 
 - (void)saveTag:(PostTag*)tag

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -127,7 +127,7 @@ static const NSInteger PostTagIdDefaultValue = -1;
 
     RemotePostTag *remoteTag = [self remoteTagWith:tag];
 
-    [remote deleteTag:remoteTag success:^(RemotePostTag * _Nonnull remoteTag) {
+    [remote deleteTag:remoteTag success:^(void) {
         [self.managedObjectContext deleteObject:tag];
         [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
         if (success) {

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -231,8 +231,11 @@ extension SiteTagsViewController {
 
     private func delete(_ tag: PostTag) {
         let tagsService = PostTagService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        tagsService.delete(tag, for: blog, success: nil, failure: nil)
-        
+        refreshControl?.beginRefreshing()
+        tagsService.delete(tag, for: blog, success: {
+            self.refreshControl?.endRefreshing()
+            self.tableView.reloadData()
+        }, failure: nil)
     }
 
     private func save(_ tag: PostTag) {

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -44,7 +44,6 @@ final class SiteTagsViewController: UITableViewController, NSFetchedResultsContr
     }()
 
     private var isPerformingInitialSync = false
-    //private var isSyncing = false
 
     @objc
     public init(blog: Blog) {
@@ -64,13 +63,13 @@ final class SiteTagsViewController: UITableViewController, NSFetchedResultsContr
         applyTitle()
         setupTable()
         setupNavigationBar()
+
+        refreshTags()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        print("===== refresh results view controller =====")
         refreshResultsController(predicate: defaultPredicate)
-        refreshTags()
         refreshNoResultsView()
     }
 
@@ -105,7 +104,6 @@ final class SiteTagsViewController: UITableViewController, NSFetchedResultsContr
         resultsController.fetchRequest.sortDescriptors = sortDescriptors
         do {
             try resultsController.performFetch()
-            print("==== reloading data 1")
             tableView.reloadData()
         } catch {
             tagsFailedLoading(error: error)
@@ -114,7 +112,6 @@ final class SiteTagsViewController: UITableViewController, NSFetchedResultsContr
 
     @objc private func refreshTags() {
         isPerformingInitialSync = true
-        print("===== refresh tags =====")
         let tagsService = PostTagService(managedObjectContext: ContextManager.sharedInstance().mainContext)
         tagsService.syncTags(for: blog, success: { [weak self] tags in
             self?.isPerformingInitialSync = false

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -235,7 +235,9 @@ extension SiteTagsViewController {
         tagsService.delete(tag, for: blog, success: {
             self.refreshControl?.endRefreshing()
             self.tableView.reloadData()
-        }, failure: nil)
+        }, failure: { error in
+            self.refreshControl?.endRefreshing()
+        })
     }
 
     private func save(_ tag: PostTag) {
@@ -244,7 +246,9 @@ extension SiteTagsViewController {
         tagsService.save(tag, for: blog, success: { [weak self] tag in
             self?.refreshControl?.endRefreshing()
             self?.tableView.reloadData()
-        }, failure: nil)
+        }, failure: { error in
+                self.refreshControl?.endRefreshing()
+        })
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -237,7 +237,11 @@ extension SiteTagsViewController {
 
     private func save(_ tag: PostTag) {
         let tagsService = PostTagService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        tagsService.save(tag, for: blog, success: nil, failure: nil)
+        refreshControl?.beginRefreshing()
+        tagsService.save(tag, for: blog, success: { [weak self] tag in
+            self?.refreshControl?.endRefreshing()
+            self?.tableView.reloadData()
+        }, failure: nil)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -43,7 +43,8 @@ final class SiteTagsViewController: UITableViewController, NSFetchedResultsContr
         return returnValue
     }()
 
-    private var isSyncing = false
+    private var isPerformingInitialSync = false
+    //private var isSyncing = false
 
     @objc
     public init(blog: Blog) {
@@ -67,6 +68,7 @@ final class SiteTagsViewController: UITableViewController, NSFetchedResultsContr
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        print("===== refresh results view controller =====")
         refreshResultsController(predicate: defaultPredicate)
         refreshTags()
         refreshNoResultsView()
@@ -103,7 +105,7 @@ final class SiteTagsViewController: UITableViewController, NSFetchedResultsContr
         resultsController.fetchRequest.sortDescriptors = sortDescriptors
         do {
             try resultsController.performFetch()
-
+            print("==== reloading data 1")
             tableView.reloadData()
         } catch {
             tagsFailedLoading(error: error)
@@ -111,10 +113,11 @@ final class SiteTagsViewController: UITableViewController, NSFetchedResultsContr
     }
 
     @objc private func refreshTags() {
-        isSyncing = true
+        isPerformingInitialSync = true
+        print("===== refresh tags =====")
         let tagsService = PostTagService(managedObjectContext: ContextManager.sharedInstance().mainContext)
         tagsService.syncTags(for: blog, success: { [weak self] tags in
-            self?.isSyncing = false
+            self?.isPerformingInitialSync = false
             self?.refreshControl?.endRefreshing()
             self?.refreshNoResultsView()
         }) { [weak self] error in
@@ -152,7 +155,7 @@ final class SiteTagsViewController: UITableViewController, NSFetchedResultsContr
             return
         }
 
-        if isSyncing {
+        if isPerformingInitialSync {
             setupLoadingView()
         } else {
             setupEmptyResultsView()

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -230,12 +230,13 @@ extension SiteTagsViewController {
 
     private func delete(_ tag: PostTag) {
         let tagsService = PostTagService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        tagsService.delete(tag, for: blog)
+        tagsService.delete(tag, for: blog, success: nil, failure: nil)
+        
     }
 
     private func save(_ tag: PostTag) {
         let tagsService = PostTagService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        tagsService.commit(tag, for: blog)
+        tagsService.commit(tag, for: blog, success: nil, failure: nil)
     }
 }
 

--- a/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.h
+++ b/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSArray *)defaultXMLRPCArguments;
 - (NSArray *)XMLRPCArgumentsWithExtra:(_Nullable id)extra;
-- (NSArray *)XMLRPCArgumentsWithExtraDefaults:(id)extraDefaults andExtra:(_Nullable id)extra;
+- (NSArray *)XMLRPCArgumentsWithExtraDefaults:(NSArray *)extraDefaults andExtra:(_Nullable id)extra;
 
 @end
 

--- a/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.h
+++ b/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.h
@@ -12,6 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSArray *)defaultXMLRPCArguments;
 - (NSArray *)XMLRPCArgumentsWithExtra:(_Nullable id)extra;
+- (NSArray *)XMLRPCArgumentsWithExtraDefault:(id)extraDefault andExtra:(id)extra;
 
 @end
 

--- a/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.h
+++ b/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.h
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSArray *)defaultXMLRPCArguments;
 - (NSArray *)XMLRPCArgumentsWithExtra:(_Nullable id)extra;
-- (NSArray *)XMLRPCArgumentsWithExtraDefault:(id)extraDefault andExtra:(id)extra;
+- (NSArray *)XMLRPCArgumentsWithExtraDefaults:(id)extraDefaults andExtra:(_Nullable id)extra;
 
 @end
 

--- a/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.m
+++ b/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.m
@@ -53,14 +53,10 @@
     return [NSArray arrayWithArray:result];
 }
 
-- (NSArray *)XMLRPCArgumentsWithExtraDefaults:(id)extraDefaults andExtra:(_Nullable id)extra {
+- (NSArray *)XMLRPCArgumentsWithExtraDefaults:(NSArray *)extraDefaults andExtra:(_Nullable id)extra {
     NSMutableArray *result = [[self defaultXMLRPCArguments] mutableCopy];
-    if ([extraDefaults isKindOfClass:[NSArray class]]) {
-        [result addObjectsFromArray:extraDefaults];
-    } else if (extra != nil) {
-        [result addObject:extraDefaults];
-    }
-    
+    [result addObjectsFromArray:extraDefaults];
+
     if ([extra isKindOfClass:[NSArray class]]) {
         [result addObjectsFromArray:extra];
     } else if (extra != nil) {

--- a/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.m
+++ b/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.m
@@ -53,7 +53,7 @@
     return [NSArray arrayWithArray:result];
 }
 
-- (NSArray *)XMLRPCArgumentsWithExtraDefaults:(id)extraDefaults andExtra:(_Nullable id)extra; {
+- (NSArray *)XMLRPCArgumentsWithExtraDefaults:(id)extraDefaults andExtra:(_Nullable id)extra {
     NSMutableArray *result = [[self defaultXMLRPCArguments] mutableCopy];
     if ([extraDefaults isKindOfClass:[NSArray class]]) {
         [result addObjectsFromArray:extraDefaults];

--- a/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.m
+++ b/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.m
@@ -53,4 +53,16 @@
     return [NSArray arrayWithArray:result];
 }
 
+- (NSArray *)XMLRPCArgumentsWithExtraDefault:(id)extraDefault andExtra:(id)extra {
+    NSMutableArray *result = [[self defaultXMLRPCArguments] mutableCopy];
+    [result addObject:extraDefault];
+    if ([extra isKindOfClass:[NSArray class]]) {
+        [result addObjectsFromArray:extra];
+    } else if (extra != nil) {
+        [result addObject:extra];
+    }
+
+    return [NSArray arrayWithArray:result];
+}
+
 @end

--- a/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.m
+++ b/WordPressKit/WordPressKit/ServiceRemoteWordPressXMLRPC.m
@@ -53,9 +53,14 @@
     return [NSArray arrayWithArray:result];
 }
 
-- (NSArray *)XMLRPCArgumentsWithExtraDefault:(id)extraDefault andExtra:(id)extra {
+- (NSArray *)XMLRPCArgumentsWithExtraDefaults:(id)extraDefaults andExtra:(_Nullable id)extra; {
     NSMutableArray *result = [[self defaultXMLRPCArguments] mutableCopy];
-    [result addObject:extraDefault];
+    if ([extraDefaults isKindOfClass:[NSArray class]]) {
+        [result addObjectsFromArray:extraDefaults];
+    } else if (extra != nil) {
+        [result addObject:extraDefaults];
+    }
+    
     if ([extra isKindOfClass:[NSArray class]]) {
         [result addObjectsFromArray:extra];
     } else if (extra != nil) {

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemote.h
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemote.h
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
  Delete a tag with the site.
  */
 - (void)deleteTag:(RemotePostTag *)tag
-		  success:(nullable void (^)(RemotePostTag *tag))success
+		  success:(nullable void (^)(void))success
 		  failure:(nullable void (^)(NSError *error))failure;
 
 /**

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemote.h
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemote.h
@@ -47,6 +47,13 @@ NS_ASSUME_NONNULL_BEGIN
           failure:(nullable void (^)(NSError *error))failure;
 
 /**
+ Delete a tag with the site.
+ */
+- (void)deleteTag:(RemotePostTag *)tag
+		  success:(nullable void (^)(RemotePostTag *tag))success
+		  failure:(nullable void (^)(NSError *error))failure;
+
+/**
  Fetch a list of tags associated with the site.
  Note: Requests no paging parameters via the API defaulting the response.
  */

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemote.h
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemote.h
@@ -47,6 +47,13 @@ NS_ASSUME_NONNULL_BEGIN
           failure:(nullable void (^)(NSError *error))failure;
 
 /**
+ Update a tag with the site.
+ */
+- (void)updateTag:(RemotePostTag *)tag
+		  success:(nullable void (^)(RemotePostTag *tag))success
+		  failure:(nullable void (^)(NSError *error))failure;
+
+/**
  Delete a tag with the site.
  */
 - (void)deleteTag:(RemotePostTag *)tag

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -113,8 +113,6 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 {
 	NSParameterAssert(tag.name.length > 0);
 
-	NSLog(@"=== will update tag with id %@", tag.tagID);
-
 	NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
 	parameters[TaxonomyRESTSlugParameter] = tag.slug;
 	parameters[TaxonomyRESTNameParameter] = tag.name;

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -96,6 +96,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
     parameters[TaxonomyRESTNameParameter] = tag.name;
+	parameters[TaxonomyRESTDescriptionParameter] = tag.tagDescription;
     
     [self createTaxonomyWithType:TaxonomyRESTTagIdentifier
                       parameters:parameters

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -113,9 +113,12 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 {
 	NSParameterAssert(tag.name.length > 0);
 
+	NSLog(@"=== will update tag with id %@", tag.tagID);
+
 	NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
 	parameters[TaxonomyRESTSlugParameter] = tag.slug;
 	parameters[TaxonomyRESTNameParameter] = tag.name;
+	parameters[TaxonomyRESTIDParameter] = tag.tagID;
 	parameters[TaxonomyRESTDescriptionParameter] = tag.tagDescription;
 
 	[self updateTaxonomyWithType:TaxonomyRESTTagIdentifier

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -96,7 +96,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
     parameters[TaxonomyRESTNameParameter] = tag.name;
-	parameters[TaxonomyRESTDescriptionParameter] = tag.tagDescription;
+    parameters[TaxonomyRESTDescriptionParameter] = tag.tagDescription;
     
     [self createTaxonomyWithType:TaxonomyRESTTagIdentifier
                       parameters:parameters
@@ -109,39 +109,39 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 }
 
 - (void)updateTag:(RemotePostTag *)tag
-		  success:(nullable void (^)(RemotePostTag *tag))success
-		  failure:(nullable void (^)(NSError *error))failure
+          success:(nullable void (^)(RemotePostTag *tag))success
+          failure:(nullable void (^)(NSError *error))failure
 {
-	NSParameterAssert(tag.name.length > 0);
-
-	NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
-	parameters[TaxonomyRESTSlugParameter] = tag.slug;
-	parameters[TaxonomyRESTNameParameter] = tag.name;
-	parameters[TaxonomyRESTDescriptionParameter] = tag.tagDescription;
-
-	[self updateTaxonomyWithType:TaxonomyRESTTagIdentifier
-					  parameters:parameters success:^(NSDictionary * _Nonnull responseObject) {
-						  if (success) {
-							  RemotePostTag *receivedTag = [self remoteTagWithJSONDictionary:responseObject];
-							  success(receivedTag);
-						  }
-					  } failure:failure];
+    NSParameterAssert(tag.name.length > 0);
+    
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+    parameters[TaxonomyRESTSlugParameter] = tag.slug;
+    parameters[TaxonomyRESTNameParameter] = tag.name;
+    parameters[TaxonomyRESTDescriptionParameter] = tag.tagDescription;
+    
+    [self updateTaxonomyWithType:TaxonomyRESTTagIdentifier
+                      parameters:parameters success:^(NSDictionary * _Nonnull responseObject) {
+                          if (success) {
+                              RemotePostTag *receivedTag = [self remoteTagWithJSONDictionary:responseObject];
+                              success(receivedTag);
+                          }
+                      } failure:failure];
 }
 
 - (void)deleteTag:(RemotePostTag *)tag
-		  success:(nullable void (^)(void))success
-		  failure:(nullable void (^)(NSError *error))failure
+          success:(nullable void (^)(void))success
+          failure:(nullable void (^)(NSError *error))failure
 {
-	NSParameterAssert(tag.name.length > 0);
-
-	NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
-	parameters[TaxonomyRESTSlugParameter] = tag.slug;
-
-	[self deleteTaxonomyWithType:TaxonomyRESTTagIdentifier parameters:parameters success:^(NSDictionary * _Nonnull responseObject) {
-		if (success) {
-			success();
-		}
-	} failure:failure];
+    NSParameterAssert(tag.name.length > 0);
+    
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
+    parameters[TaxonomyRESTSlugParameter] = tag.slug;
+    
+    [self deleteTaxonomyWithType:TaxonomyRESTTagIdentifier parameters:parameters success:^(NSDictionary * _Nonnull responseObject) {
+        if (success) {
+            success();
+        }
+    } failure:failure];
 }
 
 - (void)getTagsWithSuccess:(void (^)(NSArray <RemotePostTag *> *tags))success
@@ -188,19 +188,19 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
     NSString *requestUrl = [self pathForEndpoint:path withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
     [self.wordPressComRestApi POST:requestUrl
-        parameters:parameters
-           success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
-               if (![responseObject isKindOfClass:[NSDictionary class]]) {
-                   NSString *message = [NSString stringWithFormat:@"Invalid response creating taxonomy of type: %@", typeIdentifier];
-                   [self handleResponseErrorWithMessage:message url:requestUrl failure:failure];
-                   return;
-               }
-               success(responseObject);
-           } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
-               if (failure) {
-                   failure(error);
-               }
-           }];
+                        parameters:parameters
+                           success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
+                               if (![responseObject isKindOfClass:[NSDictionary class]]) {
+                                   NSString *message = [NSString stringWithFormat:@"Invalid response creating taxonomy of type: %@", typeIdentifier];
+                                   [self handleResponseErrorWithMessage:message url:requestUrl failure:failure];
+                                   return;
+                               }
+                               success(responseObject);
+                           } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
+                               if (failure) {
+                                   failure(error);
+                               }
+                           }];
 }
 
 - (void)getTaxonomyWithType:(NSString *)typeIdentifier
@@ -213,69 +213,69 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
     [self.wordPressComRestApi GET:requestUrl
-       parameters:parameters
-          success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
-              if (![responseObject isKindOfClass:[NSDictionary class]]) {
-                  NSString *message = [NSString stringWithFormat:@"Invalid response requesting taxonomy of type: %@", typeIdentifier];
-                  [self handleResponseErrorWithMessage:message url:requestUrl failure:failure];
-                  return;
-              }
-              success(responseObject);
-          } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
-              if (failure) {
-                  failure(error);
-              }
-          }];
+                       parameters:parameters
+                          success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
+                              if (![responseObject isKindOfClass:[NSDictionary class]]) {
+                                  NSString *message = [NSString stringWithFormat:@"Invalid response requesting taxonomy of type: %@", typeIdentifier];
+                                  [self handleResponseErrorWithMessage:message url:requestUrl failure:failure];
+                                  return;
+                              }
+                              success(responseObject);
+                          } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
+                              if (failure) {
+                                  failure(error);
+                              }
+                          }];
 }
 
 - (void)deleteTaxonomyWithType:(NSString *)typeIdentifier
-					parameters:(nullable NSDictionary *)parameters
-					   success:(void (^)(NSDictionary *responseObject))success
-					   failure:(nullable void (^)(NSError *error))failure
+                    parameters:(nullable NSDictionary *)parameters
+                       success:(void (^)(NSDictionary *responseObject))success
+                       failure:(nullable void (^)(NSError *error))failure
 {
-	NSString *path = [NSString stringWithFormat:@"sites/%@/%@/slug:%@/delete?context=edit", self.siteID, typeIdentifier, parameters[TaxonomyRESTSlugParameter]];
-	NSString *requestUrl = [self pathForEndpoint:path
-									 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
-
-	[self.wordPressComRestApi POST:requestUrl
-						parameters:nil
-						   success:^(id _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
-							   if (![responseObject isKindOfClass:[NSDictionary class]]) {
-								   NSString *message = [NSString stringWithFormat:@"Invalid response deleting taxonomy of type: %@", typeIdentifier];
-								   [self handleResponseErrorWithMessage:message url:requestUrl failure:failure];
-								   return;
-							   }
-							   success(responseObject);
-						   } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
-							   if (failure) {
-								   failure(error);
-							   }
-						   }];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/%@/slug:%@/delete?context=edit", self.siteID, typeIdentifier, parameters[TaxonomyRESTSlugParameter]];
+    NSString *requestUrl = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    
+    [self.wordPressComRestApi POST:requestUrl
+                        parameters:nil
+                           success:^(id _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
+                               if (![responseObject isKindOfClass:[NSDictionary class]]) {
+                                   NSString *message = [NSString stringWithFormat:@"Invalid response deleting taxonomy of type: %@", typeIdentifier];
+                                   [self handleResponseErrorWithMessage:message url:requestUrl failure:failure];
+                                   return;
+                               }
+                               success(responseObject);
+                           } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
+                               if (failure) {
+                                   failure(error);
+                               }
+                           }];
 }
 
 - (void)updateTaxonomyWithType:(NSString *)typeIdentifier
-					parameters:(nullable NSDictionary *)parameters
-					   success:(void (^)(NSDictionary *responseObject))success
-					   failure:(nullable void (^)(NSError *error))failure
+                    parameters:(nullable NSDictionary *)parameters
+                       success:(void (^)(NSDictionary *responseObject))success
+                       failure:(nullable void (^)(NSError *error))failure
 {
-	NSString *path = [NSString stringWithFormat:@"sites/%@/%@/slug:%@?context=edit", self.siteID, typeIdentifier, parameters[TaxonomyRESTSlugParameter]];
-	NSString *requestUrl = [self pathForEndpoint:path
-									 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
-
-	[self.wordPressComRestApi POST:requestUrl
-						parameters:parameters
-						   success:^(id _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
-							   if (![responseObject isKindOfClass:[NSDictionary class]]) {
-								   NSString *message = [NSString stringWithFormat:@"Invalid response updating taxonomy of type: %@", typeIdentifier];
-								   [self handleResponseErrorWithMessage:message url:requestUrl failure:failure];
-								   return;
-							   }
-							   success(responseObject);
-						   } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
-							   if (failure) {
-								   failure(error);
-							   }
-						   }];
+    NSString *path = [NSString stringWithFormat:@"sites/%@/%@/slug:%@?context=edit", self.siteID, typeIdentifier, parameters[TaxonomyRESTSlugParameter]];
+    NSString *requestUrl = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    
+    [self.wordPressComRestApi POST:requestUrl
+                        parameters:parameters
+                           success:^(id _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
+                               if (![responseObject isKindOfClass:[NSDictionary class]]) {
+                                   NSString *message = [NSString stringWithFormat:@"Invalid response updating taxonomy of type: %@", typeIdentifier];
+                                   [self handleResponseErrorWithMessage:message url:requestUrl failure:failure];
+                                   return;
+                               }
+                               success(responseObject);
+                           } failure:^(NSError * _Nonnull error, NSHTTPURLResponse *httpResponse) {
+                               if (failure) {
+                                   failure(error);
+                               }
+                           }];
 }
 
 

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -242,7 +242,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 						parameters:nil
 						   success:^(id _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
 							   if (![responseObject isKindOfClass:[NSDictionary class]]) {
-								   NSString *message = [NSString stringWithFormat:@"Invalid response creating taxonomy of type: %@", typeIdentifier];
+								   NSString *message = [NSString stringWithFormat:@"Invalid response deleting taxonomy of type: %@", typeIdentifier];
 								   [self handleResponseErrorWithMessage:message url:requestUrl failure:failure];
 								   return;
 							   }
@@ -267,7 +267,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 						parameters:parameters
 						   success:^(id _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
 							   if (![responseObject isKindOfClass:[NSDictionary class]]) {
-								   NSString *message = [NSString stringWithFormat:@"Invalid response creating taxonomy of type: %@", typeIdentifier];
+								   NSString *message = [NSString stringWithFormat:@"Invalid response updating taxonomy of type: %@", typeIdentifier];
 								   [self handleResponseErrorWithMessage:message url:requestUrl failure:failure];
 								   return;
 							   }

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -120,8 +120,8 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 
 	[self updateTaxonomyWithType:TaxonomyRESTTagIdentifier
 					  parameters:parameters success:^(NSDictionary * _Nonnull responseObject) {
-						  RemotePostTag *receivedTag = [self remoteTagWithJSONDictionary:responseObject];
 						  if (success) {
+							  RemotePostTag *receivedTag = [self remoteTagWithJSONDictionary:responseObject];
 							  success(receivedTag);
 						  }
 					  } failure:failure];

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -115,6 +115,8 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 
 	NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
 	parameters[TaxonomyRESTSlugParameter] = tag.slug;
+	parameters[TaxonomyRESTNameParameter] = tag.name;
+	parameters[TaxonomyRESTDescriptionParameter] = tag.tagDescription;
 
 	[self updateTaxonomyWithType:TaxonomyRESTTagIdentifier
 					  parameters:parameters success:^(NSDictionary * _Nonnull responseObject) {
@@ -260,7 +262,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 									 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
 	[self.wordPressComRestApi POST:requestUrl
-						parameters:nil
+						parameters:parameters
 						   success:^(id _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
 							   if (![responseObject isKindOfClass:[NSDictionary class]]) {
 								   NSString *message = [NSString stringWithFormat:@"Invalid response creating taxonomy of type: %@", typeIdentifier];

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -118,7 +118,6 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 	NSMutableDictionary *parameters = [NSMutableDictionary dictionary];
 	parameters[TaxonomyRESTSlugParameter] = tag.slug;
 	parameters[TaxonomyRESTNameParameter] = tag.name;
-	parameters[TaxonomyRESTIDParameter] = tag.tagID;
 	parameters[TaxonomyRESTDescriptionParameter] = tag.tagDescription;
 
 	[self updateTaxonomyWithType:TaxonomyRESTTagIdentifier

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -128,7 +128,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 }
 
 - (void)deleteTag:(RemotePostTag *)tag
-		  success:(nullable void (^)(RemotePostTag *tag))success
+		  success:(nullable void (^)(void))success
 		  failure:(nullable void (^)(NSError *error))failure
 {
 	NSParameterAssert(tag.name.length > 0);
@@ -138,7 +138,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 
 	[self deleteTaxonomyWithType:TaxonomyRESTTagIdentifier parameters:parameters success:^(NSDictionary * _Nonnull responseObject) {
 		if (success) {
-			success(tag);
+			success();
 		}
 	} failure:failure];
 }

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -230,7 +230,6 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 								   failure(error);
 							   }
 						   }];
-
 }
 
 #pragma mark - helpers

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -102,9 +102,13 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
                          } failure:failure];
 }
 
-/**
- Delete a tag with the site.
- */
+- (void)updateTag:(RemotePostTag *)tag
+		  success:(nullable void (^)(RemotePostTag *tag))success
+		  failure:(nullable void (^)(NSError *error))failure
+{
+	
+}
+
 - (void)deleteTag:(RemotePostTag *)tag
 		  success:(nullable void (^)(RemotePostTag *tag))success
 		  failure:(nullable void (^)(NSError *error))failure

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -90,7 +90,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 {
     NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
     [extraParameters setObject:tag.name ?: [NSNull null] forKey:TaxonomyXMLRPCNameParameter];
-	[extraParameters setObject:tag.description ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
+    [extraParameters setObject:tag.description ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
     
     [self createTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
                       parameters:extraParameters
@@ -105,36 +105,36 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 }
 
 - (void)updateTag:(RemotePostTag *)tag
-		  success:(nullable void (^)(RemotePostTag *tag))success
-		  failure:(nullable void (^)(NSError *error))failure
+          success:(nullable void (^)(RemotePostTag *tag))success
+          failure:(nullable void (^)(NSError *error))failure
 {
-	NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
-	[extraParameters setObject:tag.tagID ?: [NSNull null] forKey:TaxonomyXMLRPCIDParameter];
-	[extraParameters setObject:tag.name ?: [NSNull null] forKey:TaxonomyXMLRPCNameParameter];
-	[extraParameters setObject:tag.description ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
-
-	[self editTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
-					parameters:extraParameters success:^(BOOL response) {
-						if (success) {
-							success(tag);
-						}
-					} failure:failure];
+    NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
+    [extraParameters setObject:tag.tagID ?: [NSNull null] forKey:TaxonomyXMLRPCIDParameter];
+    [extraParameters setObject:tag.name ?: [NSNull null] forKey:TaxonomyXMLRPCNameParameter];
+    [extraParameters setObject:tag.description ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
+    
+    [self editTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
+                    parameters:extraParameters success:^(BOOL response) {
+                        if (success) {
+                            success(tag);
+                        }
+                    } failure:failure];
 }
 
 - (void)deleteTag:(RemotePostTag *)tag
-		  success:(nullable void (^)(void))success
-		  failure:(nullable void (^)(NSError *error))failure
+          success:(nullable void (^)(void))success
+          failure:(nullable void (^)(NSError *error))failure
 {
-	NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
-	[extraParameters setObject:tag.tagID ?: [NSNull null] forKey:TaxonomyXMLRPCIDParameter];
-
-	[self deleteTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
-					  parameters:extraParameters success:^(BOOL response) {
-						  if (success) {
-							  success();
-						  }
-					  } failure:failure];
-	
+    NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
+    [extraParameters setObject:tag.tagID ?: [NSNull null] forKey:TaxonomyXMLRPCIDParameter];
+    
+    [self deleteTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
+                      parameters:extraParameters success:^(BOOL response) {
+                          if (success) {
+                              success();
+                          }
+                      } failure:failure];
+    
 }
 
 - (void)getTagsWithSuccess:(void (^)(NSArray<RemotePostTag *> *))success
@@ -229,61 +229,61 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 }
 
 - (void)deleteTaxonomyWithType:(NSString *)typeIdentifier
-					parameters:(nullable NSDictionary *)parameters
-					   success:(void (^)(BOOL response))success
-					   failure:(nullable void (^)(NSError *error))failure
+                    parameters:(nullable NSDictionary *)parameters
+                       success:(void (^)(BOOL response))success
+                       failure:(nullable void (^)(NSError *error))failure
 {
-	NSMutableDictionary *mutableParametersDict = [NSMutableDictionary dictionaryWithDictionary:@{@"taxonomy": typeIdentifier}];
-	NSArray *xmlrpcParameters = nil;
-	if (parameters.count) {
-		[mutableParametersDict addEntriesFromDictionary:parameters];
-	}
-
-	xmlrpcParameters = [self XMLRPCArgumentsWithExtra:mutableParametersDict];
-
-	[self.api callMethod:@"wp.deleteTerm"
-			  parameters:xmlrpcParameters
-				 success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-					 if (![responseObject respondsToSelector:@selector(boolValue)]) {
-						 NSString *message = [NSString stringWithFormat:@"Invalid response deleting taxonomy of type: %@", typeIdentifier];
-						 [self handleResponseErrorWithMessage:message method:@"wp.deleteTerm" failure:failure];
-						 return;
-					 }
-					 success([responseObject boolValue]);
-				 } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
-					 if (failure) {
-						 failure(error);
-					 }
-				 }];
+    NSMutableDictionary *mutableParametersDict = [NSMutableDictionary dictionaryWithDictionary:@{@"taxonomy": typeIdentifier}];
+    NSArray *xmlrpcParameters = nil;
+    if (parameters.count) {
+        [mutableParametersDict addEntriesFromDictionary:parameters];
+    }
+    
+    xmlrpcParameters = [self XMLRPCArgumentsWithExtra:mutableParametersDict];
+    
+    [self.api callMethod:@"wp.deleteTerm"
+              parameters:xmlrpcParameters
+                 success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+                     if (![responseObject respondsToSelector:@selector(boolValue)]) {
+                         NSString *message = [NSString stringWithFormat:@"Invalid response deleting taxonomy of type: %@", typeIdentifier];
+                         [self handleResponseErrorWithMessage:message method:@"wp.deleteTerm" failure:failure];
+                         return;
+                     }
+                     success([responseObject boolValue]);
+                 } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+                     if (failure) {
+                         failure(error);
+                     }
+                 }];
 }
 
 - (void)editTaxonomyWithType:(NSString *)typeIdentifier
-				  parameters:(nullable NSDictionary *)parameters
-					 success:(void (^)(BOOL response))success
-					 failure:(nullable void (^)(NSError *error))failure
+                  parameters:(nullable NSDictionary *)parameters
+                     success:(void (^)(BOOL response))success
+                     failure:(nullable void (^)(NSError *error))failure
 {
-	NSMutableDictionary *mutableParametersDict = [NSMutableDictionary dictionaryWithDictionary:@{@"taxonomy": typeIdentifier}];
-	NSArray *xmlrpcParameters = nil;
-	if (parameters.count) {
-		[mutableParametersDict addEntriesFromDictionary:parameters];
-	}
-
-	xmlrpcParameters = [self XMLRPCArgumentsWithExtra:mutableParametersDict];
-
-	[self.api callMethod:@"wp.editTerm"
-			  parameters:xmlrpcParameters
-				 success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-					 if (![responseObject respondsToSelector:@selector(boolValue)]) {
-						 NSString *message = [NSString stringWithFormat:@"Invalid response editing taxonomy of type: %@", typeIdentifier];
-						 [self handleResponseErrorWithMessage:message method:@"wp.editTerm" failure:failure];
-						 return;
-					 }
-					 success([responseObject boolValue]);
-				 } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
-					 if (failure) {
-						 failure(error);
-					 }
-				 }];
+    NSMutableDictionary *mutableParametersDict = [NSMutableDictionary dictionaryWithDictionary:@{@"taxonomy": typeIdentifier}];
+    NSArray *xmlrpcParameters = nil;
+    if (parameters.count) {
+        [mutableParametersDict addEntriesFromDictionary:parameters];
+    }
+    
+    xmlrpcParameters = [self XMLRPCArgumentsWithExtra:mutableParametersDict];
+    
+    [self.api callMethod:@"wp.editTerm"
+              parameters:xmlrpcParameters
+                 success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+                     if (![responseObject respondsToSelector:@selector(boolValue)]) {
+                         NSString *message = [NSString stringWithFormat:@"Invalid response editing taxonomy of type: %@", typeIdentifier];
+                         [self handleResponseErrorWithMessage:message method:@"wp.editTerm" failure:failure];
+                         return;
+                     }
+                     success([responseObject boolValue]);
+                 } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+                     if (failure) {
+                         failure(error);
+                     }
+                 }];
 }
 
 #pragma mark - helpers

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -109,6 +109,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 		  failure:(nullable void (^)(NSError *error))failure
 {
 	NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
+	[extraParameters setObject:tag.tagID ?: [NSNull null] forKey:TaxonomyXMLRPCIDParameter];
 	[extraParameters setObject:tag.name ?: [NSNull null] forKey:TaxonomyXMLRPCNameParameter];
 	[extraParameters setObject:tag.description ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
 

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -234,13 +234,8 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
                        success:(void (^)(BOOL response))success
                        failure:(nullable void (^)(NSError *error))failure
 {
-    NSMutableDictionary *mutableParametersDict = [NSMutableDictionary dictionaryWithDictionary:@{@"taxonomy": typeIdentifier}];
-    NSArray *xmlrpcParameters = nil;
-    if (parameters.count) {
-        [mutableParametersDict addEntriesFromDictionary:parameters];
-    }
-    
-    xmlrpcParameters = [self XMLRPCArgumentsWithExtraDefault:termId andExtra:mutableParametersDict];
+    NSArray *xmlrpcParameters = [self XMLRPCArgumentsWithExtraDefaults:@[typeIdentifier, termId]
+                                                              andExtra:nil];
     
     [self.api callMethod:@"wp.deleteTerm"
               parameters:xmlrpcParameters
@@ -270,7 +265,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
         [mutableParametersDict addEntriesFromDictionary:parameters];
     }
 
-    xmlrpcParameters = [self XMLRPCArgumentsWithExtraDefault:termId andExtra:mutableParametersDict];
+    xmlrpcParameters = [self XMLRPCArgumentsWithExtraDefaults:termId andExtra:mutableParametersDict];
     
     [self.api callMethod:@"wp.editTerm"
               parameters:xmlrpcParameters

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -357,19 +357,6 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
     }
 }
 
-#pragma mark - XML-RPC parameters
-- (NSArray *)XMLRPCArgumentsWithExtraDefault:(id)extraDefault andExtra:(id)extra {
-    NSMutableArray *result = [[self defaultXMLRPCArguments] mutableCopy];
-    [result addObject:extraDefault];
-    if ([extra isKindOfClass:[NSArray class]]) {
-        [result addObjectsFromArray:extra];
-    } else if (extra != nil) {
-        [result addObject:extra];
-    }
-
-    return [NSArray arrayWithArray:result];
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -239,7 +239,36 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 				 success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
 					 if (![responseObject respondsToSelector:@selector(numericValue)]) {
 						 NSString *message = [NSString stringWithFormat:@"Invalid response deleting taxonomy of type: %@", typeIdentifier];
-						 [self handleResponseErrorWithMessage:message method:@"wp.newTerm" failure:failure];
+						 [self handleResponseErrorWithMessage:message method:@"wp.deleteTerm" failure:failure];
+						 return;
+					 }
+					 success(responseObject);
+				 } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+					 if (failure) {
+						 failure(error);
+					 }
+				 }];
+}
+
+- (void)editTaxonomyWithType:(NSString *)typeIdentifier
+				  parameters:(nullable NSDictionary *)parameters
+					 success:(void (^)(NSString *responseString))success
+					 failure:(nullable void (^)(NSError *error))failure
+{
+	NSMutableDictionary *mutableParametersDict = [NSMutableDictionary dictionaryWithDictionary:@{@"taxonomy": typeIdentifier}];
+	NSArray *xmlrpcParameters = nil;
+	if (parameters.count) {
+		[mutableParametersDict addEntriesFromDictionary:parameters];
+	}
+
+	xmlrpcParameters = [self XMLRPCArgumentsWithExtra:mutableParametersDict];
+
+	[self.api callMethod:@"wp.editTerm"
+			  parameters:xmlrpcParameters
+				 success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+					 if (![responseObject respondsToSelector:@selector(numericValue)]) {
+						 NSString *message = [NSString stringWithFormat:@"Invalid response editing taxonomy of type: %@", typeIdentifier];
+						 [self handleResponseErrorWithMessage:message method:@"wp.editTerm" failure:failure];
 						 return;
 					 }
 					 success(responseObject);

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -238,7 +238,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 			  parameters:xmlrpcParameters
 				 success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
 					 if (![responseObject respondsToSelector:@selector(numericValue)]) {
-						 NSString *message = [NSString stringWithFormat:@"Invalid response creating taxonomy of type: %@", typeIdentifier];
+						 NSString *message = [NSString stringWithFormat:@"Invalid response deleting taxonomy of type: %@", typeIdentifier];
 						 [self handleResponseErrorWithMessage:message method:@"wp.newTerm" failure:failure];
 						 return;
 					 }

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -98,6 +98,9 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
                              RemotePostTag *newTag = [RemotePostTag new];
                              NSString *tagID = responseString;
                              newTag.tagID = [tagID numericValue];
+                             newTag.name = tag.name;
+                             newTag.tagDescription = tag.tagDescription;
+                             newTag.slug = tag.slug;
                              if (success) {
                                  success(newTag);
                              }

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -249,7 +249,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 
 - (void)editTaxonomyWithType:(NSString *)typeIdentifier
 				  parameters:(nullable NSDictionary *)parameters
-					 success:(void (^)(NSString *responseString))success
+					 success:(void (^)(BOOL response))success
 					 failure:(nullable void (^)(NSError *error))failure
 {
 	NSMutableDictionary *mutableParametersDict = [NSMutableDictionary dictionaryWithDictionary:@{@"taxonomy": typeIdentifier}];
@@ -263,12 +263,12 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 	[self.api callMethod:@"wp.editTerm"
 			  parameters:xmlrpcParameters
 				 success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-					 if (![responseObject respondsToSelector:@selector(numericValue)]) {
+					 if (![responseObject respondsToSelector:@selector(boolValue)]) {
 						 NSString *message = [NSString stringWithFormat:@"Invalid response editing taxonomy of type: %@", typeIdentifier];
 						 [self handleResponseErrorWithMessage:message method:@"wp.editTerm" failure:failure];
 						 return;
 					 }
-					 success(responseObject);
+					 success([responseObject boolValue]);
 				 } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
 					 if (failure) {
 						 failure(error);

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -108,7 +108,16 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 		  success:(nullable void (^)(RemotePostTag *tag))success
 		  failure:(nullable void (^)(NSError *error))failure
 {
-	
+	NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
+	[extraParameters setObject:tag.name ?: [NSNull null] forKey:TaxonomyXMLRPCNameParameter];
+	[extraParameters setObject:tag.description ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
+
+	[self editTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
+					parameters:extraParameters success:^(BOOL response) {
+						if (success) {
+							success(tag);
+						}
+					} failure:failure];
 }
 
 - (void)deleteTag:(RemotePostTag *)tag

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -98,9 +98,6 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
                              RemotePostTag *newTag = [RemotePostTag new];
                              NSString *tagID = responseString;
                              newTag.tagID = [tagID numericValue];
-							 newTag.name = tag.name;
-							 newTag.tagDescription = tag.tagDescription;
-							 newTag.slug = tag.slug;
                              if (success) {
                                  success(newTag);
                              }
@@ -122,7 +119,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 	[extraParameters setObject:tag.tagID ?: [NSNull null] forKey:TaxonomyXMLRPCIDParameter];
 
 	[self deleteTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
-					  parameters:extraParameters success:^(NSString * _Nonnull responseString) {
+					  parameters:extraParameters success:^(BOOL response) {
 						  if (success) {
 							  success(tag);
 						  }
@@ -223,7 +220,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 
 - (void)deleteTaxonomyWithType:(NSString *)typeIdentifier
 					parameters:(nullable NSDictionary *)parameters
-					   success:(void (^)(NSString *responseString))success
+					   success:(void (^)(BOOL response))success
 					   failure:(nullable void (^)(NSError *error))failure
 {
 	NSMutableDictionary *mutableParametersDict = [NSMutableDictionary dictionaryWithDictionary:@{@"taxonomy": typeIdentifier}];
@@ -237,12 +234,12 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 	[self.api callMethod:@"wp.deleteTerm"
 			  parameters:xmlrpcParameters
 				 success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-					 if (![responseObject respondsToSelector:@selector(numericValue)]) {
+					 if (![responseObject respondsToSelector:@selector(boolValue)]) {
 						 NSString *message = [NSString stringWithFormat:@"Invalid response deleting taxonomy of type: %@", typeIdentifier];
 						 [self handleResponseErrorWithMessage:message method:@"wp.deleteTerm" failure:failure];
 						 return;
 					 }
-					 success(responseObject);
+					 success([responseObject boolValue]);
 				 } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
 					 if (failure) {
 						 failure(error);

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -14,6 +14,7 @@ static NSString * const TaxonomyXMLRPCTagIdentifier = @"post_tag";
 static NSString * const TaxonomyXMLRPCIDParameter = @"term_id";
 static NSString * const TaxonomyXMLRPCSlugParameter = @"slug";
 static NSString * const TaxonomyXMLRPCNameParameter = @"name";
+static NSString * const TaxonomyXMLRPCDescriptionParameter = @"description";
 static NSString * const TaxonomyXMLRPCParentParameter = @"parent";
 static NSString * const TaxonomyXMLRPCSearchParameter = @"search";
 static NSString * const TaxonomyXMLRPCOrderParameter = @"order";
@@ -89,6 +90,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 {
     NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
     [extraParameters setObject:tag.name ?: [NSNull null] forKey:TaxonomyXMLRPCNameParameter];
+	[extraParameters setObject:tag.description ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
     
     [self createTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
                       parameters:extraParameters
@@ -96,6 +98,9 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
                              RemotePostTag *newTag = [RemotePostTag new];
                              NSString *tagID = responseString;
                              newTag.tagID = [tagID numericValue];
+							 newTag.name = tag.name;
+							 newTag.tagDescription = tag.tagDescription;
+							 newTag.slug = tag.slug;
                              if (success) {
                                  success(newTag);
                              }

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -128,16 +128,13 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
           success:(nullable void (^)(void))success
           failure:(nullable void (^)(NSError *error))failure
 {
-    NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
-    [extraParameters setObject:tag.tagID ?: [NSNull null] forKey:TaxonomyXMLRPCIDParameter];
-    
     [self deleteTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
-                      parameters:extraParameters success:^(BOOL response) {
+                          termId:tag.tagID
+                      parameters:nil success:^(BOOL response) {
                           if (success) {
                               success();
                           }
                       } failure:failure];
-    
 }
 
 - (void)getTagsWithSuccess:(void (^)(NSArray<RemotePostTag *> *))success
@@ -232,6 +229,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 }
 
 - (void)deleteTaxonomyWithType:(NSString *)typeIdentifier
+                        termId:(NSNumber *)termId
                     parameters:(nullable NSDictionary *)parameters
                        success:(void (^)(BOOL response))success
                        failure:(nullable void (^)(NSError *error))failure
@@ -242,7 +240,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
         [mutableParametersDict addEntriesFromDictionary:parameters];
     }
     
-    xmlrpcParameters = [self XMLRPCArgumentsWithExtra:mutableParametersDict];
+    xmlrpcParameters = [self XMLRPCArgumentsWithExtraDefault:termId andExtra:mutableParametersDict];
     
     [self.api callMethod:@"wp.deleteTerm"
               parameters:xmlrpcParameters

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -121,7 +121,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 }
 
 - (void)deleteTag:(RemotePostTag *)tag
-		  success:(nullable void (^)(RemotePostTag *tag))success
+		  success:(nullable void (^)(void))success
 		  failure:(nullable void (^)(NSError *error))failure
 {
 	NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
@@ -130,7 +130,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 	[self deleteTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
 					  parameters:extraParameters success:^(BOOL response) {
 						  if (success) {
-							  success(tag);
+							  success();
 						  }
 					  } failure:failure];
 	

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -112,11 +112,11 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
           failure:(nullable void (^)(NSError *error))failure
 {
     NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
-    [extraParameters setObject:tag.tagID ?: [NSNull null] forKey:TaxonomyXMLRPCIDParameter];
     [extraParameters setObject:tag.name ?: [NSNull null] forKey:TaxonomyXMLRPCNameParameter];
     [extraParameters setObject:tag.tagDescription ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
     
     [self editTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
+                        termId:tag.tagID
                     parameters:extraParameters success:^(BOOL response) {
                         if (success) {
                             success(tag);
@@ -261,6 +261,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 }
 
 - (void)editTaxonomyWithType:(NSString *)typeIdentifier
+                      termId:(NSNumber *)termId
                   parameters:(nullable NSDictionary *)parameters
                      success:(void (^)(BOOL response))success
                      failure:(nullable void (^)(NSError *error))failure
@@ -270,8 +271,8 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
     if (parameters.count) {
         [mutableParametersDict addEntriesFromDictionary:parameters];
     }
-    
-    xmlrpcParameters = [self XMLRPCArgumentsWithExtra:mutableParametersDict];
+
+    xmlrpcParameters = [self XMLRPCArgumentsWithExtraDefault:termId andExtra:mutableParametersDict];
     
     [self.api callMethod:@"wp.editTerm"
               parameters:xmlrpcParameters
@@ -356,6 +357,19 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
     if (failure) {
         failure(error);
     }
+}
+
+#pragma mark - XML-RPC parameters
+- (NSArray *)XMLRPCArgumentsWithExtraDefault:(id)extraDefault andExtra:(id)extra {
+    NSMutableArray *result = [[self defaultXMLRPCArguments] mutableCopy];
+    [result addObject:extraDefault];
+    if ([extra isKindOfClass:[NSArray class]]) {
+        [result addObjectsFromArray:extra];
+    } else if (extra != nil) {
+        [result addObject:extra];
+    }
+
+    return [NSArray arrayWithArray:result];
 }
 
 @end

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -111,7 +111,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
     NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
     [extraParameters setObject:tag.tagID ?: [NSNull null] forKey:TaxonomyXMLRPCIDParameter];
     [extraParameters setObject:tag.name ?: [NSNull null] forKey:TaxonomyXMLRPCNameParameter];
-    [extraParameters setObject:tag.description ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
+    [extraParameters setObject:tag.tagDescription ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
     
     [self editTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
                     parameters:extraParameters success:^(BOOL response) {

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -90,7 +90,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
 {
     NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
     [extraParameters setObject:tag.name ?: [NSNull null] forKey:TaxonomyXMLRPCNameParameter];
-    [extraParameters setObject:tag.description ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
+    [extraParameters setObject:tag.tagDescription ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
     
     [self createTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
                       parameters:extraParameters

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -265,7 +265,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
         [mutableParametersDict addEntriesFromDictionary:parameters];
     }
 
-    xmlrpcParameters = [self XMLRPCArgumentsWithExtraDefaults:termId andExtra:mutableParametersDict];
+    xmlrpcParameters = [self XMLRPCArgumentsWithExtraDefaults:@[termId] andExtra:mutableParametersDict];
     
     [self.api callMethod:@"wp.editTerm"
               parameters:xmlrpcParameters

--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -114,7 +114,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
     NSMutableDictionary *extraParameters = [NSMutableDictionary dictionary];
     [extraParameters setObject:tag.name ?: [NSNull null] forKey:TaxonomyXMLRPCNameParameter];
     [extraParameters setObject:tag.tagDescription ?: [NSNull null] forKey:TaxonomyXMLRPCDescriptionParameter];
-    
+
     [self editTaxonomyWithType:TaxonomyXMLRPCTagIdentifier
                         termId:tag.tagID
                     parameters:extraParameters success:^(BOOL response) {
@@ -319,6 +319,7 @@ static NSString * const TaxonomyXMLRPCOffsetParameter = @"offset";
     tag.tagID = [xmlrpcDictionary numberForKey:TaxonomyXMLRPCIDParameter];
     tag.name = [xmlrpcDictionary stringForKey:TaxonomyXMLRPCNameParameter];
     tag.slug = [xmlrpcDictionary stringForKey:TaxonomyXMLRPCSlugParameter];
+    tag.tagDescription = [xmlrpcDictionary stringForKey:TaxonomyXMLRPCDescriptionParameter];
     return tag;
 }
 


### PR DESCRIPTION
Implements part of #8232 

Another early PR to check the general direction I've taken. 😊 

This one contains updates to the `PostTagService` and the Rest and XMLRPC taxonomies.

Saving and deleting seem to work fine, updating tags is a bit broken though. I am still looking into it, but in the meantime, more work for you, @aerych ! 😛 