### PR TITLE
Add methods for cancel uploads.

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -43,8 +43,9 @@ class MediaCoordinator: NSObject {
                                 guard let media = media else {
                                     return
                                 }
-
-                                self?.uploadMedia(media)
+                                if !media.isDeleted {
+                                    self?.uploadMedia(media)
+                                }
         })
     }
 
@@ -55,6 +56,32 @@ class MediaCoordinator: NSObject {
         }
 
         uploadMedia(media)
+    }
+
+    /// Cancels any ongoing upload of the Media and deletes it.
+    ///
+    /// - Parameter media: the object to cancel and delete
+    ///
+    func cancelUploadAndDeleteMedia(_ media: Media) {
+        cancelUpload(of: media)
+        delete(media: media)
+    }
+
+    /// Cancels any ongoing upload for the media object
+    ///
+    /// - Parameter media: the media object to cancel the upload
+    ///
+    func cancelUpload(of media: Media) {
+        mediaProgressCoordinator.cancelAndStopTrack(of: media.uploadID)
+    }
+
+    /// Deletes a media object from the storage
+    ///
+    /// - Parameter media: the media object to delete
+    ///
+    func delete(media: Media){
+        let service = MediaService(managedObjectContext: backgroundContext)
+        service.delete(media, success: nil, failure: nil)
     }
 
     private func uploadMedia(_ media: Media) {

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -79,7 +79,7 @@ class MediaCoordinator: NSObject {
     ///
     /// - Parameter media: the media object to delete
     ///
-    func delete(media: Media){
+    func delete(media: Media) {
         let service = MediaService(managedObjectContext: backgroundContext)
         service.delete(media, success: nil, failure: nil)
     }

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -40,12 +40,10 @@ class MediaCoordinator: NSObject {
                             objectID: blog.objectID,
                             thumbnailCallback: nil,
                             completion: { [weak self] media, error in
-                                guard let media = media else {
+                                guard let media = media, !media.isDeleted else {
                                     return
                                 }
-                                if !media.isDeleted {
-                                    self?.uploadMedia(media)
-                                }
+                                self?.uploadMedia(media)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -394,7 +394,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
     fileprivate func presentRetryOptions(for media: Media) {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alertController.addDestructiveActionWithTitle(NSLocalizedString("Cancel Upload", comment: "Media Library option to cancel an in-progress or failed upload.")) { _ in
-            MediaCoordinator.shared.cancelUploadAndDeleteMedia(media)            
+            MediaCoordinator.shared.cancelUploadAndDeleteMedia(media)
         }
 
         if media.remoteStatus == .failed {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -394,12 +394,13 @@ class MediaLibraryViewController: WPMediaPickerViewController {
     fileprivate func presentRetryOptions(for media: Media) {
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alertController.addDestructiveActionWithTitle(NSLocalizedString("Cancel Upload", comment: "Media Library option to cancel an in-progress or failed upload.")) { _ in
-            let service = MediaService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-            service.deleteMedia([media], progress: nil, success: nil, failure: nil)
+            MediaCoordinator.shared.cancelUploadAndDeleteMedia(media)            
         }
 
-        alertController.addDefaultActionWithTitle(NSLocalizedString("Retry Upload", comment: "User action to retry media upload.")) { _ in
-            MediaCoordinator.shared.retryMedia(media)
+        if media.remoteStatus == .failed {
+            alertController.addDefaultActionWithTitle(NSLocalizedString("Retry Upload", comment: "User action to retry media upload.")) { _ in
+                MediaCoordinator.shared.retryMedia(media)
+            }
         }
 
         alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: ""))
@@ -704,7 +705,7 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
         }
 
         switch media.remoteStatus {
-        case .failed:
+        case .failed, .pushing:
             presentRetryOptions(for: media)
         case .sync:
             if let viewController = mediaItemViewController(for: asset) {


### PR DESCRIPTION
Fixes #8307 

To test:
 - Start the app
 - Open a blog media library
 - Tap on + to add an object
 - While the upload is ongoing tap on the media
 - Select the option Cancel Upload


