### PR TITLE
Require Jetpack 5.6 for plugin management

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -456,7 +456,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
         case BlogFeaturePlans:
             return [self isHostedAtWPcom] && [self isAdmin];
         case BlogFeaturePluginManagement:
-            return [self supportsRestApi] && ![self isHostedAtWPcom];
+            return [self supportsPluginManagement];
         case BlogFeatureJetpackSettings:
             return [self supportsRestApi] && ![self isHostedAtWPcom] && [self isAdmin];
         case BlogFeaturePushNotifications:
@@ -535,6 +535,14 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
 - (BOOL)supportsPushNotifications
 {
     return [self accountIsDefaultAccount];
+}
+
+- (BOOL)supportsPluginManagement
+{
+    NSString *requiredJetpackVersion = @"5.6";
+    return [self supportsRestApi]
+        && ![self isHostedAtWPcom]
+        && [self.jetpack.version compare:requiredJetpackVersion options:NSNumericSearch] != NSOrderedAscending;
 }
 
 - (BOOL)accountIsDefaultAccount

--- a/WordPressKit/WordPressKit/RemoteBlogOptionsHelper.m
+++ b/WordPressKit/WordPressKit/RemoteBlogOptionsHelper.m
@@ -27,6 +27,7 @@
                                           @"gmt_offset",
                                           @"allowed_file_types",
                                           @"frame_nonce",
+                                          @"jetpack_version",
                                           @"blog_public"
                                           ];
 


### PR DESCRIPTION
Show plugins section only for sites  with Jetpack 5.6 or newer

See #8318 

To test:

- [x] Plugin section should not be visible in WordPress.com sites
- [x] Plugin section should not be visible in Jetpack sites with Jetpack < 5.6
- [x] Plugin section should be visible in Jetpack sites with Jetpack >= 5.6
- [x] Plugin section should not be visible in self-hosted sites without Jetpack
