### PR TITLE
Activity Log: enable on internal builds

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -31,7 +31,7 @@ enum FeatureFlag: Int {
         case .asyncUploadsInMediaLibrary:
             return BuildConfiguration.current == .localDeveloper
         case .activity:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .siteCreation:
             return BuildConfiguration.current == .localDeveloper
         case .notices:

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -74,7 +74,7 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        service.getActivityForSite(siteID, count: 100, success: { (activities, _) in
+        service.getActivityForSite(siteID, count: 1000, success: { (activities, _) in
             do {
                 self.viewModel = try .ready(ActivityUtils.rewriteStream(activities: activities))
             } catch {


### PR DESCRIPTION
In this PR I'm increasing the number of fetched activities to 1000 and enabling the activity log on internal builds.

**To test:**
Go to a site with activity log and check that the feed is long ;)

