### PR TITLE
Keep track of automanaged plugins.

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -662,6 +662,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
         _jetpack.connectedUsername = [self getOptionValue:@"jetpack_user_login"];
     }
     _jetpack.connectedEmail = [self getOptionValue:@"jetpack_user_email"];
+    _jetpack.automatedTransfer = [[[self getOptionValue:@"is_automated_transfer"] numericValue] boolValue];
     return _jetpack;
 }
 

--- a/WordPress/Classes/Models/JetpackState.h
+++ b/WordPress/Classes/Models/JetpackState.h
@@ -16,6 +16,7 @@ extern NSString * const JetpackVersionMinimumRequired;
 @property (nonatomic, strong) NSString *version;
 @property (nonatomic, strong) NSString *connectedUsername;
 @property (nonatomic, strong) NSString *connectedEmail;
+@property (nonatomic, assign) BOOL automatedTransfer;
 
 #pragma mark Helpers
 

--- a/WordPress/Classes/Stores/PluginStore.swift
+++ b/WordPress/Classes/Stores/PluginStore.swift
@@ -309,6 +309,15 @@ private extension PluginStore {
                 return plugin
             })
         }
+        if isAutomatedTransfer(site: site) {
+            plugins.plugins = plugins.plugins.map({ (plugin) in
+                var plugin = plugin
+                if ["akismet", "jetpack", "vaultpress"].contains(plugin.slug) {
+                    plugin.automanaged = true
+                }
+                return plugin
+            })
+        }
         transaction { (state) in
             state.plugins[site] = plugins
             state.fetching[site] = false
@@ -360,6 +369,13 @@ private extension PluginStore {
             }
             state.fetchingDirectoryEntry[slug] = false
         }
+    }
+
+    func isAutomatedTransfer(site: JetpackSiteRef) -> Bool {
+        let context = ContextManager.sharedInstance().mainContext
+        let predicate = NSPredicate(format: "blogID = %i AND account.username = %@", site.siteID, site.username)
+        let blog = context.firstObject(ofType: Blog.self, matching: predicate)
+        return blog?.jetpack?.automatedTransfer ?? false
     }
 
     func remote(site: JetpackSiteRef) -> PluginServiceRemote? {

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -67,7 +67,7 @@ class PluginViewModel: Observable {
         }
 
         var autoupdatesRow: ImmuTableRow?
-        if capabilities.autoupdate {
+        if capabilities.autoupdate && !plugin.state.automanaged {
             autoupdatesRow = SwitchRow(
                 title: NSLocalizedString("Autoupdates", comment: "Whether a plugin has enabled automatic updates"),
                 value: plugin.state.autoupdate,

--- a/WordPressKit/WordPressKit/PluginServiceRemote.swift
+++ b/WordPressKit/WordPressKit/PluginServiceRemote.swift
@@ -162,6 +162,7 @@ fileprivate extension PluginServiceRemote {
                            version: version,
                            updateState: updateState,
                            autoupdate: autoupdate,
+                           automanaged: false,
                            url: url)
 
     }

--- a/WordPressKit/WordPressKit/PluginState.swift
+++ b/WordPressKit/WordPressKit/PluginState.swift
@@ -69,7 +69,7 @@ public extension PluginState {
     }
 
     var deactivateAllowed: Bool {
-        return !isJetpack
+        return !isJetpack && !automanaged
     }
 
     var isJetpack: Bool {

--- a/WordPressKit/WordPressKit/PluginState.swift
+++ b/WordPressKit/WordPressKit/PluginState.swift
@@ -26,6 +26,7 @@ public struct PluginState: Equatable {
     public let version: String?
     public var updateState: UpdateState
     public var autoupdate: Bool
+    public var automanaged: Bool
     public let url: URL?
 
     public static func ==(lhs: PluginState, rhs: PluginState) -> Bool {
@@ -36,12 +37,16 @@ public struct PluginState: Equatable {
             && lhs.version == rhs.version
             && lhs.updateState == rhs.updateState
             && lhs.autoupdate == rhs.autoupdate
+            && lhs.automanaged == rhs.automanaged
             && lhs.url == rhs.url
     }
 }
 
 public extension PluginState {
     var stateDescription: String {
+        if automanaged {
+            return NSLocalizedString("Auto-managed on this site", comment: "The plugin can not be manually updated or deactivated")
+        }
         switch (active, autoupdate) {
         case (false, false):
             return NSLocalizedString("Inactive, Autoupdates off", comment: "The plugin is not active on the site and has not enabled automatic updates")

--- a/WordPressKit/WordPressKit/RemoteBlogOptionsHelper.m
+++ b/WordPressKit/WordPressKit/RemoteBlogOptionsHelper.m
@@ -28,6 +28,7 @@
                                           @"allowed_file_types",
                                           @"frame_nonce",
                                           @"jetpack_version",
+                                          @"is_automated_transfer",
                                           @"blog_public"
                                           ];
 


### PR DESCRIPTION
We don't allow some plugins to be removed or managed for automated transfer sites

See #8318 

To test:

- [x] Go to plugins on an AT site, make sure you can't deactivate, remove, set to autoupdate any of the auto-managed plugins (Jetpack, Vaultpress, Akismet)
- [x] Go to plugins on a regular Jetpack site, make sure you can't  deactivate or remove Jetpack, setting autoupdate should be available. You should be able to manage Vaultpress and Akismet