### PR TITLE
Fix the missing links opening in preview

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -164,7 +164,14 @@
         return YES;
     }
 
-    if (navigationType == UIWebViewNavigationTypeLinkClicked || navigationType == UIWebViewNavigationTypeFormSubmitted) {
+    if (navigationType == UIWebViewNavigationTypeLinkClicked) {
+        // Open the link
+        UIApplication *application = [UIApplication sharedApplication];
+        [application openURL:[request URL] options:@{} completionHandler:nil];
+        return NO;
+    }
+    
+    if (navigationType == UIWebViewNavigationTypeFormSubmitted) {
         return NO;
     }
     return YES;


### PR DESCRIPTION
Fixes #8304 

To test:
Go to Blog Posts in the app and select a post with links, tap "View", long-press a link, tap "Open"

Behavior:
External links should open in the external browser. Internal links (to the same blog) should open in the app.

Note: 
The previous behavior on "UIWebViewNavigationTypeLinkClicked" was to simply return "NO" without taking any action. Clearly someone put it the code for a reason, but I can't figure it out. I didn't find any way to make a call to the class where the new behavior is inappropriate, but I'm new to this codebase. So, if you are aware of cases where the old path has to be followed, please let me know so that I can add the proper checks.

