### PR TITLE
Show a notice if a plugin update fails

### DIFF
--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -59,10 +59,6 @@ class NoticeStore: StatefulStore<NoticeStoreState> {
     }
 
     override func onDispatch(_ action: Action) {
-        guard FeatureFlag.notices.enabled else {
-            return
-        }
-
         guard let action = action as? NoticeAction else {
             return
         }

--- a/WordPress/Classes/Stores/PluginStore.swift
+++ b/WordPress/Classes/Stores/PluginStore.swift
@@ -262,6 +262,8 @@ private extension PluginStore {
                         updatedPlugin.updateState = .available(version)
                     })
                     state.updatesInProgress[site]?.remove(pluginID)
+                    let message = String(format: NSLocalizedString("Error updating %@.", comment: "There was an error updating a plugin, placeholder is the plugin name"), plugin.name)
+                    ActionDispatcher.dispatch(NoticeAction.post(Notice(title: message)))
                 })
                 print("Error updating plugin: \(error)")
         })

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -10,7 +10,6 @@ enum FeatureFlag: Int {
     case asyncUploadsInMediaLibrary
     case activity
     case siteCreation
-    case notices
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -30,8 +29,6 @@ enum FeatureFlag: Int {
         case .activity:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .siteCreation:
-            return BuildConfiguration.current == .localDeveloper
-        case .notices:
             return BuildConfiguration.current == .localDeveloper
         }
     }


### PR DESCRIPTION
As discussed, I removing the feature flag on notices since this is shipping in 9.1

See #8318 

To test:

- Go to plugins on a Jetpack site that has an update available
- Make sure the update will fail, changed permissions on the plugins folder so it wasn't writable, you can also take down the server, or add a mu-plugin that just calls `die()` 😬 
- The app should show a notice (alert) when the update fails.


