### PR TITLE
When thumbnail is available make overlay transparent.

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -241,6 +241,11 @@ class MediaLibraryViewController: WPMediaPickerViewController {
                 } else {
                     overlayView.state = .indeterminate
                 }
+                if media.localThumbnailURL != nil {
+                    overlayView.backgroundColor = overlayView.backgroundColor?.withAlphaComponent(0.5)
+                } else {
+                    overlayView.backgroundColor = overlayView.backgroundColor?.withAlphaComponent(1)
+                }
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -241,12 +241,17 @@ class MediaLibraryViewController: WPMediaPickerViewController {
                 } else {
                     overlayView.state = .indeterminate
                 }
-                if media.localThumbnailURL != nil {
-                    overlayView.backgroundColor = overlayView.backgroundColor?.withAlphaComponent(0.5)
-                } else {
-                    overlayView.backgroundColor = overlayView.backgroundColor?.withAlphaComponent(1)
-                }
+
+                configureAppearance(for: overlayView, with: media)
             }
+        }
+    }
+
+    private func configureAppearance(for overlayView: MediaCellProgressView, with media: Media) {
+        if media.localThumbnailURL != nil {
+            overlayView.backgroundColor = overlayView.backgroundColor?.withAlphaComponent(0.5)
+        } else {
+            overlayView.backgroundColor = overlayView.backgroundColor?.withAlphaComponent(1)
         }
     }
 
@@ -659,20 +664,22 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, willShowOverlayView overlayView: UIView, forCellFor asset: WPMediaAsset) {
-        if let overlayView = overlayView as? MediaCellProgressView,
-            let media = asset as? Media {
-            switch media.remoteStatus {
-            case .processing:
-                overlayView.state = .indeterminate
-            case .pushing:
-                if let progress = MediaCoordinator.shared.progress(for: media) {
-                    overlayView.state = .progress(progress.fractionCompleted)
-                }
-            case .failed:
-                overlayView.state = .retry
-            default: break
-            }
+        guard let overlayView = overlayView as? MediaCellProgressView,
+            let media = asset as? Media else {
+            return
         }
+        switch media.remoteStatus {
+        case .processing:
+            overlayView.state = .indeterminate
+        case .pushing:
+            if let progress = MediaCoordinator.shared.progress(for: media) {
+                overlayView.state = .progress(progress.fractionCompleted)
+            }
+        case .failed:
+            overlayView.state = .retry
+        default: break
+        }
+        configureAppearance(for: overlayView, with: media)
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, shouldShowOverlayViewForCellFor asset: WPMediaAsset) -> Bool {


### PR DESCRIPTION
Fixes #8343 

To test:
 - Start the app
 - Open a media library of a blog
 - Add new media using the async option
 - Check if thumbnail of media shows when upload starts.

