### PR TITLE
Site settings: Missing writing settings

### DIFF
--- a/WordPress/Classes/Models/BlogSettings+DateAndTimeFormat.swift
+++ b/WordPress/Classes/Models/BlogSettings+DateAndTimeFormat.swift
@@ -34,20 +34,8 @@ extension BlogSettings {
 
         // MARK: - Private Properties
 
-        /// Use system date formatter to get translations for free
-        ///
-        fileprivate static var longDate: String {
-            let yearMonthDateFormatter = DateFormatter()
-            yearMonthDateFormatter.dateFormat = "yyyy/MM/dd"
-            let theDate = yearMonthDateFormatter.date(from: "2017/12/17")
-
-            let longFormatter = DateFormatter()
-            longFormatter.dateStyle = .long
-            return longFormatter.string(from: theDate!)
-        }
-
         fileprivate static let descriptionMap = [
-            MonthDY.rawValue: longDate,
+            MonthDY.rawValue: NSLocalizedString("December 17, 2017", comment: "Only December needs to be translated"),
             YMD.rawValue: "2017-12-17",
             MDY.rawValue: "12/17/2017",
             DMY.rawValue: "17/12/2017"
@@ -91,8 +79,8 @@ extension BlogSettings {
         // MARK: - Private Properties
 
         fileprivate static let descriptionMap = [
-            ampmLowercase.rawValue: "5:46 " + Calendar.current.pmSymbol.lowercased(),
-            ampmUppercase.rawValue: "5:46 " + Calendar.current.pmSymbol.uppercased(),
+            ampmLowercase.rawValue: "5:46 pm",
+            ampmUppercase.rawValue: "5:46 PM",
             twentyFourHours.rawValue: "17:46",
         ]
     }

--- a/WordPress/Classes/Models/BlogSettings+DateAndTimeFormat.swift
+++ b/WordPress/Classes/Models/BlogSettings+DateAndTimeFormat.swift
@@ -91,9 +91,9 @@ extension BlogSettings {
         // MARK: - Private Properties
 
         fileprivate static let descriptionMap = [
-            ampmLowercase.rawValue: NSLocalizedString("5:46 pm", comment: "5:46 pm as in a time of day, only the 'pm' part needs translation"),
-            ampmUppercase.rawValue: NSLocalizedString("5:46 PM", comment: "5:46 PM as in a time of day, only the 'PM' part needs translation"),
-            twentyFourHours.rawValue: NSLocalizedString("17:46", comment: "No translation required"),
+            ampmLowercase.rawValue: "5:46 " + Calendar.current.pmSymbol.lowercased(),
+            ampmUppercase.rawValue: "5:46 " + Calendar.current.pmSymbol.uppercased(),
+            twentyFourHours.rawValue: "17:46",
         ]
     }
 
@@ -135,14 +135,20 @@ extension BlogSettings {
 
         // MARK: - Private Properties
 
+        fileprivate static var weekdays: [String] {
+            var calendar = Calendar.init(identifier: .gregorian)
+            calendar.locale = Locale.current
+            return calendar.weekdaySymbols
+        }
+
         fileprivate static let descriptionMap = [
-            Sunday.rawValue: NSLocalizedString("Sunday", comment: "Sunday, the day of the week."),
-            Monday.rawValue: NSLocalizedString("Monday", comment: "Monday, the day of the week."),
-            Tuesday.rawValue: NSLocalizedString("Tuesday", comment: "Tuesday, the day of the week."),
-            Wednesday.rawValue: NSLocalizedString("Wednesday", comment: "Wednesday, the day of the week."),
-            Thursday.rawValue: NSLocalizedString("Thursday", comment: "Thursday, the day of the week."),
-            Friday.rawValue: NSLocalizedString("Friday", comment: "Friday, the day of the week."),
-            Saturday.rawValue: NSLocalizedString("Saturday", comment: "Saturday, the day of the week.")
+            Sunday.rawValue: weekdays[0],
+            Monday.rawValue: weekdays[1],
+            Tuesday.rawValue: weekdays[2],
+            Wednesday.rawValue: weekdays[3],
+            Thursday.rawValue: weekdays[4],
+            Friday.rawValue: weekdays[5],
+            Saturday.rawValue: weekdays[6]
         ]
     }
 

--- a/WordPress/Classes/Models/BlogSettings+DateAndTimeFormat.swift
+++ b/WordPress/Classes/Models/BlogSettings+DateAndTimeFormat.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+/// In this extension, we implement several nested Enums (and helper setters / getters) aimed at simplifying
+/// the BlogSettings interface for handling writing date and time format properties.
+///
+extension BlogSettings {
+
+    /// Enumerates the Date format settings.
+    ///
+    enum DateFormat: String {
+        case MonthDY = "F j, Y"
+        case YMD = "Y-m-d"
+        case MDY = "m/d/Y"
+        case DMY = "d/m/Y"
+
+        /// Returns the sorted collection of all of the Localized Enum Titles.
+        ///
+        static var allTitles: [String] {
+            return allValues.flatMap { descriptionMap[$0] }
+        }
+
+        /// Returns the sorted collection of all of the possible Enum Values.
+        ///
+        static var allValues: [String] {
+            return [DateFormat.MonthDY.rawValue, DateFormat.YMD.rawValue,
+                    DateFormat.MDY.rawValue, DateFormat.DMY.rawValue]
+        }
+
+        /// Returns the localized description of the current enum value.
+        ///
+        var description: String {
+            return DateFormat.descriptionMap[rawValue]!
+        }
+
+        // MARK: - Private Properties
+
+        fileprivate static let descriptionMap = [
+            MonthDY.rawValue: NSLocalizedString("December 17, 2017", comment: "Only December needs to be translated"),
+            YMD.rawValue: NSLocalizedString("2017-12-17", comment: "No translation required"),
+            MDY.rawValue: NSLocalizedString("12/17/2017", comment: "No translation required"),
+            DMY.rawValue: NSLocalizedString("17/12/2017", comment: "No translation required")
+        ]
+    }
+
+    var dateFormatDescription: String {
+        guard let dateFormatEnum = DateFormat(rawValue: dateFormat) else {
+            return dateFormat
+        }
+        return dateFormatEnum.description
+    }
+
+    /// Enumerates the Time format settings.
+    ///
+    enum TimeFormat: String {
+        case ampmLowercase = "g:i a"
+        case ampmUppercase = "g:i A"
+        case twentyFourHours = "H:i"
+
+        /// Returns the sorted collection of all of the Localized Enum Titles.
+        /// Order is guarranteed to match exactly with *allValues*.
+        ///
+        static var allTitles: [String] {
+            return allValues.flatMap { descriptionMap[$0] }
+        }
+
+        /// Returns the sorted collection of all of the possible Enum Values.
+        ///
+        static var allValues: [String] {
+            return [TimeFormat.ampmLowercase.rawValue, TimeFormat.ampmUppercase.rawValue,
+                    TimeFormat.twentyFourHours.rawValue]
+        }
+
+        /// Returns the localized description of the current enum value.
+        ///
+        var description: String {
+            return TimeFormat.descriptionMap[rawValue]!
+        }
+
+        // MARK: - Private Properties
+
+        fileprivate static let descriptionMap = [
+            ampmLowercase.rawValue: NSLocalizedString("5:46 pm", comment: "5:46 pm as in a time of day, only the 'pm' part needs translation"),
+            ampmUppercase.rawValue: NSLocalizedString("5:46 PM", comment: "5:46 PM as in a time of day, only the 'PM' part needs translation"),
+            twentyFourHours.rawValue: NSLocalizedString("17:46", comment: "No translation required"),
+        ]
+    }
+
+    var timeFormatDescription: String {
+        guard let timeFormatEnum = TimeFormat(rawValue: timeFormat) else {
+            return timeFormat
+        }
+        return timeFormatEnum.description
+    }
+
+    /// Enumerates the days of the week.
+    ///
+    enum DaysOfTheWeek: String {
+        case Sunday = "0"
+        case Monday = "1"
+        case Tuesday = "2"
+        case Wednesday = "3"
+        case Thursday = "4"
+        case Friday = "5"
+        case Saturday = "6"
+
+        /// Returns the sorted collection of all of the Localized Enum Titles.
+        ///
+        static var allTitles: [String] {
+            return allValues.flatMap { descriptionMap[$0] }
+        }
+
+        /// Returns the sorted collection of all of the possible Enum Values.
+        ///
+        static var allValues: [String] {
+            return descriptionMap.keys.sorted()
+        }
+
+        /// Returns the localized description of the current enum value.
+        ///
+        var description: String {
+            return DaysOfTheWeek.descriptionMap[rawValue]!
+        }
+
+        // MARK: - Private Properties
+
+        fileprivate static let descriptionMap = [
+            Sunday.rawValue: NSLocalizedString("Sunday", comment: "Sunday, the day of the week."),
+            Monday.rawValue: NSLocalizedString("Monday", comment: "Monday, the day of the week."),
+            Tuesday.rawValue: NSLocalizedString("Tuesday", comment: "Tuesday, the day of the week."),
+            Wednesday.rawValue: NSLocalizedString("Wednesday", comment: "Wednesday, the day of the week."),
+            Thursday.rawValue: NSLocalizedString("Thursday", comment: "Thursday, the day of the week."),
+            Friday.rawValue: NSLocalizedString("Friday", comment: "Friday, the day of the week."),
+            Saturday.rawValue: NSLocalizedString("Saturday", comment: "Saturday, the day of the week.")
+        ]
+    }
+
+    var startOfWeekDescription: String {
+        guard let dayOfWeekEnum = DaysOfTheWeek(rawValue: startOfWeek) else {
+            return startOfWeek
+        }
+        return dayOfWeekEnum.description
+    }
+}

--- a/WordPress/Classes/Models/BlogSettings+DateAndTimeFormat.swift
+++ b/WordPress/Classes/Models/BlogSettings+DateAndTimeFormat.swift
@@ -34,11 +34,23 @@ extension BlogSettings {
 
         // MARK: - Private Properties
 
+        /// Use system date formatter to get translations for free
+        ///
+        fileprivate static var longDate: String {
+            let yearMonthDateFormatter = DateFormatter()
+            yearMonthDateFormatter.dateFormat = "yyyy/MM/dd"
+            let theDate = yearMonthDateFormatter.date(from: "2017/12/17")
+
+            let longFormatter = DateFormatter()
+            longFormatter.dateStyle = .long
+            return longFormatter.string(from: theDate!)
+        }
+
         fileprivate static let descriptionMap = [
-            MonthDY.rawValue: NSLocalizedString("December 17, 2017", comment: "Only December needs to be translated"),
-            YMD.rawValue: NSLocalizedString("2017-12-17", comment: "No translation required"),
-            MDY.rawValue: NSLocalizedString("12/17/2017", comment: "No translation required"),
-            DMY.rawValue: NSLocalizedString("17/12/2017", comment: "No translation required")
+            MonthDY.rawValue: longDate,
+            YMD.rawValue: "2017-12-17",
+            MDY.rawValue: "12/17/2017",
+            DMY.rawValue: "17/12/2017"
         ]
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/DateAndTimeFormatSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DateAndTimeFormatSettingsViewController.swift
@@ -178,8 +178,8 @@ open class DateAndTimeFormatSettingsViewController: UITableViewController {
     func pressedStartOfWeek() -> ImmuTableAction {
         return { [unowned self] row in
             let settingsViewController = SettingsSelectionViewController(style: .grouped)
-            settingsViewController.title = NSLocalizedString("Time Format",
-                                                             comment: "Writing Time Format Settings Title")
+            settingsViewController.title = NSLocalizedString("Week starts on",
+                                                             comment: "Blog Writing Settings: Weeks starts on")
             settingsViewController.currentValue = self.settings.startOfWeek as NSObject!
             settingsViewController.titles = DaysOfTheWeek.allTitles
             settingsViewController.values = DaysOfTheWeek.allValues

--- a/WordPress/Classes/ViewRelated/Blog/DateAndTimeFormatSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DateAndTimeFormatSettingsViewController.swift
@@ -1,0 +1,236 @@
+import Foundation
+import CocoaLumberjack
+import WordPressShared
+
+/// This class will display the Blog's date and time settings, and will allow the user to modify them.
+/// Upon selection, WordPress.com backend will get hit, and the new value will be persisted.
+///
+open class DateAndTimeFormatSettingsViewController: UITableViewController {
+
+    // MARK: - Private Properties
+
+    fileprivate var blog: Blog!
+    fileprivate var service: BlogService!
+    fileprivate lazy var handler: ImmuTableViewHandler = {
+        return ImmuTableViewHandler(takeOver: self)
+    }()
+
+    // MARK: - Computed Properties
+
+    fileprivate var settings: BlogSettings {
+        return blog.settings!
+    }
+
+    // MARK: - Static Properties
+
+    fileprivate static let footerHeight = CGFloat(34.0)
+    fileprivate static let learnMoreUrl = "https://codex.wordpress.org/Formatting_Date_and_Time"
+
+    // MARK: - Typealiases
+
+    fileprivate typealias DateFormat = BlogSettings.DateFormat
+    fileprivate typealias TimeFormat = BlogSettings.TimeFormat
+    fileprivate typealias DaysOfTheWeek = BlogSettings.DaysOfTheWeek
+
+    // MARK: - Initializer
+
+    @objc public convenience init(blog: Blog) {
+        self.init(style: .grouped)
+        self.blog = blog
+        self.service = BlogService(managedObjectContext: settings.managedObjectContext!)
+    }
+
+    // MARK: - View Lifecycle
+
+    open override func viewDidLoad() {
+        super.viewDidLoad()
+        title = NSLocalizedString("Date and Time Format", comment: "Title for the Date and Time Format Settings Screen")
+        ImmuTable.registerRows([NavigationItemRow.self], tableView: tableView)
+        WPStyleGuide.configureColors(for: view, andTableView: tableView)
+        reloadViewModel()
+    }
+
+    open override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        reloadViewModel()
+    }
+
+    // MARK: - Model
+
+    fileprivate func reloadViewModel() {
+        handler.viewModel = tableViewModel()
+    }
+
+    func tableViewModel() -> ImmuTable {
+
+        let dateFormatRow = NavigationItemRow(title: NSLocalizedString("Date Format",
+                                                                       comment: "Blog Writing Settings: Date Format"),
+                                              detail: settings.dateFormatDescription,
+                                              action: self.pressedDateFormat())
+
+        let timeFormatRow = NavigationItemRow(title: NSLocalizedString("Time Format",
+                                                                       comment: "Blog Writing Settings: Time Format"),
+                                              detail: settings.timeFormatDescription,
+                                              action: self.pressedTimeFormat())
+
+        let startOfWeekRow = NavigationItemRow(title: NSLocalizedString("Week starts on",
+                                                                       comment: "Blog Writing Settings: Weeks starts on"),
+                                               detail: settings.startOfWeekDescription,
+                                               action: self.pressedStartOfWeek())
+
+        return ImmuTable(sections: [
+            ImmuTableSection(
+                headerText: "",
+                rows: [dateFormatRow, timeFormatRow, startOfWeekRow],
+                footerText: nil)
+        ])
+    }
+
+    // MARK: Learn More footer
+
+    open override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return DateAndTimeFormatSettingsViewController.footerHeight
+    }
+
+    open override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        let footer = UITableViewHeaderFooterView(frame: CGRect(x: 0.0,
+                                                               y: 0.0,
+                                                               width: tableView.frame.width,
+                                                               height: DateAndTimeFormatSettingsViewController.footerHeight))
+        footer.textLabel?.text = NSLocalizedString("Learn more about date and time formatting.",
+                                                   comment: "Writing, Date and Time Settings: Learn more about date and time settings footer text")
+        footer.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
+        footer.textLabel?.isUserInteractionEnabled = true
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleLearnMoreTap(_:)))
+        footer.addGestureRecognizer(tap)
+        return footer
+    }
+
+    // MARK: - Row Handlers
+
+    func pressedDateFormat() -> ImmuTableAction {
+        return { [unowned self] row in
+            let settingsViewController = SettingsSelectionViewController(style: .grouped)
+            settingsViewController.title = NSLocalizedString("Date Format",
+                                                             comment: "Writing Date Format Settings Title")
+            settingsViewController.currentValue = self.settings.dateFormat as NSObject!
+
+            var allTitles = DateFormat.allTitles
+            var allValues = DateFormat.allValues
+
+            if let _ = DateFormat(rawValue: self.settings.dateFormat) {
+                allTitles.append(NSLocalizedString("Tap to enter a custom value",
+                                                   comment: "Message in a row indicating to tap to enter a custom value"))
+                allValues.append("")
+            } else {
+                allTitles.append(self.settings.dateFormat)
+                allValues.append(self.settings.dateFormat)
+            }
+
+            settingsViewController.titles = allTitles
+            settingsViewController.values = allValues
+            settingsViewController.editableIndex = allTitles.count - 1
+            settingsViewController.onItemSelected = { [weak self] (selected: Any?) in
+                if let newDateFormat = selected as? String {
+                    self?.settings.dateFormat = newDateFormat
+                    self?.saveSettings()
+                }
+            }
+
+            self.navigationController?.pushViewController(settingsViewController, animated: true)
+        }
+    }
+
+    func pressedTimeFormat() -> ImmuTableAction {
+        return { [unowned self] row in
+            let settingsViewController = SettingsSelectionViewController(style: .grouped)
+            settingsViewController.title = NSLocalizedString("Time Format",
+                                                             comment: "Writing Time Format Settings Title")
+            settingsViewController.currentValue = self.settings.timeFormat as NSObject!
+
+            var allTitles = TimeFormat.allTitles
+            var allValues = TimeFormat.allValues
+
+            if let _ = TimeFormat(rawValue: self.settings.timeFormat) {
+                allTitles.append(NSLocalizedString("Tap to enter a custom value",
+                                                   comment: "Message in a row indicating to tap to enter a custom value"))
+                allValues.append("")
+            } else {
+                allTitles.append(self.settings.timeFormat)
+                allValues.append(self.settings.timeFormat)
+            }
+
+            settingsViewController.titles = allTitles
+            settingsViewController.values = allValues
+            settingsViewController.editableIndex = allTitles.count - 1
+            settingsViewController.onItemSelected = { [weak self] (selected: Any?) in
+                if let newTimeFormat = selected as? String {
+                    self?.settings.timeFormat = newTimeFormat
+                    self?.saveSettings()
+                }
+            }
+
+            self.navigationController?.pushViewController(settingsViewController, animated: true)
+        }
+    }
+
+    func pressedStartOfWeek() -> ImmuTableAction {
+        return { [unowned self] row in
+            let settingsViewController = SettingsSelectionViewController(style: .grouped)
+            settingsViewController.title = NSLocalizedString("Time Format",
+                                                             comment: "Writing Time Format Settings Title")
+            settingsViewController.currentValue = self.settings.startOfWeek as NSObject!
+            settingsViewController.titles = DaysOfTheWeek.allTitles
+            settingsViewController.values = DaysOfTheWeek.allValues
+            settingsViewController.onItemSelected = { [weak self] (selected: Any?) in
+                if let newStartOfWeek = selected as? String {
+                    self?.settings.startOfWeek = newStartOfWeek
+                    self?.saveSettings()
+                }
+            }
+
+            self.navigationController?.pushViewController(settingsViewController, animated: true)
+        }
+    }
+
+    // MARK: - Footer handler
+
+    @objc fileprivate func handleLearnMoreTap(_ sender: UITapGestureRecognizer) {
+        guard let url =  URL(string: DateAndTimeFormatSettingsViewController.learnMoreUrl) else {
+            return
+        }
+        let webViewController = WebViewControllerFactory.controller(url: url)
+
+        if presentingViewController != nil {
+            navigationController?.pushViewController(webViewController, animated: true)
+        } else {
+            let navController = UINavigationController(rootViewController: webViewController)
+            present(navController, animated: true, completion: nil)
+        }
+    }
+
+    // MARK: - Persistance
+
+    fileprivate func saveSettings() {
+        service.updateSettings(for: blog,
+                               success: nil,
+                               failure: { [weak self] (error: Error) -> Void in
+                                    self?.refreshSettings()
+                                    DDLogError("Error while persisting settings: \(error)")
+                               })
+    }
+
+    fileprivate func refreshSettings() {
+        let service = BlogService(managedObjectContext: settings.managedObjectContext!)
+        service.syncSettings(for: blog,
+                             success: { [weak self] in
+                                self?.reloadViewModel()
+                                DDLogInfo("Reloaded Settings")
+                             },
+                             failure: { (error: Error) in
+                                DDLogError("Error while sync'ing blog settings: \(error)")
+                             })
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController+Swift.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+extension SiteSettingsViewController {
+
+    @objc func showDateAndTimeFormatSettings() {
+        let dateAndTimeFormatViewController = DateAndTimeFormatSettingsViewController(blog: blog)
+        navigationController?.pushViewController(dateAndTimeFormatViewController, animated: true)
+    }
+
+    @objc func showPostPerPageSetting() {
+        let pickerViewController = SettingsPickerViewController(style: .grouped)
+        pickerViewController.title = NSLocalizedString("Posts per Page", comment: "Posts per Page Title")
+        pickerViewController.switchVisible = false
+        pickerViewController.selectionText = NSLocalizedString("The number of posts to show per page.",
+                                                               comment: "Text above the selection of the number of posts to show per blog page")
+        pickerViewController.pickerFormat = NSLocalizedString("%d posts", comment: "Number of posts")
+        pickerViewController.pickerMinimumValue = self.minNumberOfPostPerPage
+        if let currentValue = blog.settings?.postsPerPage as? Int {
+            pickerViewController.pickerSelectedValue = currentValue
+            pickerViewController.pickerMaximumValue = max(currentValue, self.maxNumberOfPostPerPage)
+        } else {
+            pickerViewController.pickerMaximumValue = self.maxNumberOfPostPerPage
+        }
+        pickerViewController.onChange           = { [weak self] (enabled: Bool, newValue: Int) in
+            self?.blog.settings?.postsPerPage = newValue as NSNumber?
+            self?.saveSettings()
+        }
+
+        navigationController?.pushViewController(pickerViewController, animated: true)
+    }
+
+    // MARK: Private Properties
+
+    fileprivate var minNumberOfPostPerPage: Int { return 1 }
+    fileprivate var maxNumberOfPostPerPage: Int { return 1000 }
+
+}

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.h
@@ -8,4 +8,6 @@
 
 - (instancetype)initWithBlog:(Blog *)blog;
 
+- (void)saveSettings;
+
 @end

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -39,6 +39,8 @@ NS_ENUM(NSInteger, SiteSettingsWriting) {
     SiteSettingsWritingDefaultCategory = 0,
     SiteSettingsWritingDefaultPostFormat,
     SiteSettingsWritingRelatedPosts,
+    SiteSettingsWritingDateAndTimeFormat,
+    SiteSettingsPostPerPage,
     SiteSettingsWritingCount,
 };
 
@@ -81,6 +83,8 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
 @property (nonatomic, strong) SettingTableViewCell *defaultCategoryCell;
 @property (nonatomic, strong) SettingTableViewCell *defaultPostFormatCell;
 @property (nonatomic, strong) SettingTableViewCell *relatedPostsCell;
+@property (nonatomic, strong) SettingTableViewCell *dateAndTimeFormatCell;
+@property (nonatomic, strong) SettingTableViewCell *postsPerPageCell;
 #pragma mark - Discussion Section
 @property (nonatomic, strong) SettingTableViewCell *discussionSettingsCell;
 #pragma mark - Jetpack Settings Section
@@ -306,6 +310,28 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     return _relatedPostsCell;
 }
 
+- (SettingTableViewCell *)dateAndTimeFormatCell
+{
+    if (_dateAndTimeFormatCell) {
+        return _dateAndTimeFormatCell;
+    }
+    _dateAndTimeFormatCell = [[SettingTableViewCell alloc] initWithLabel:NSLocalizedString(@"Date and Time Format", @"Label for selecting the date and time settings section")
+                                                                editable:YES
+                                                         reuseIdentifier:nil];
+    return _dateAndTimeFormatCell;
+}
+
+- (SettingTableViewCell *)postsPerPageCell
+{
+    if (_postsPerPageCell) {
+        return _postsPerPageCell;
+    }
+    _postsPerPageCell = [[SettingTableViewCell alloc] initWithLabel:NSLocalizedString(@"Posts per page", @"Label for selecting the number of posts per page")
+                                                           editable:YES
+                                                    reuseIdentifier:nil];
+    return _postsPerPageCell;
+}
+
 - (SettingTableViewCell *)discussionSettingsCell
 {
     if (_discussionSettingsCell) {
@@ -352,6 +378,11 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     [self.defaultPostFormatCell setTextValue:self.blog.defaultPostFormatText];
 }
 
+- (void)configurePostsPerPageCell
+{
+    [self.postsPerPageCell setTextValue:self.blog.settings.postsPerPage.stringValue];
+}
+
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForWritingSettingsAtRow:(NSInteger)row
 {
     switch (row) {
@@ -365,6 +396,13 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
 
         case (SiteSettingsWritingRelatedPosts):
             return self.relatedPostsCell;
+
+        case (SiteSettingsWritingDateAndTimeFormat):
+            return self.dateAndTimeFormatCell;
+
+        case (SiteSettingsPostPerPage):
+            [self configurePostsPerPageCell];
+            return self.postsPerPageCell;
     }
     return nil;
 }
@@ -808,6 +846,14 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
 
         case SiteSettingsWritingRelatedPosts:
             [self showRelatedPostsSettings];
+            break;
+
+        case SiteSettingsWritingDateAndTimeFormat:
+            [self showDateAndTimeFormatSettings];
+            break;
+
+        case SiteSettingsPostPerPage:
+            [self showPostPerPageSetting];
             break;
     }
 }

--- a/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.h
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.h
@@ -8,7 +8,7 @@ extern NSString * const SettingsSelectionValuesKey;
 extern NSString * const SettingsSelectionHintsKey;
 extern NSString * const SettingsSelectionDefaultValueKey;
 extern NSString * const SettingsSelectionCurrentValueKey;
-
+extern NSString * const SettingsSelectionEditableIndexKey;
 
 /**
  *  @class      SettingsSelectionViewController
@@ -24,6 +24,7 @@ extern NSString * const SettingsSelectionCurrentValueKey;
 @property (nonatomic, strong) NSArray<NSString *>   *hints;
 @property (nonatomic, strong) NSObject              *defaultValue;
 @property (nonatomic, strong) NSObject              *currentValue;
+@property (nonatomic, assign) NSInteger             editableIndex;
 @property (nonatomic,   copy) void                  (^onItemSelected)(id);
 @property (nonatomic,   copy) void                  (^onRefresh)(UIRefreshControl *refreshControl);
 @property (nonatomic,   copy) void                  (^onCancel)(void);

--- a/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
@@ -1,4 +1,5 @@
 #import "SettingsSelectionViewController.h"
+#import "SettingsTextViewController.h"
 #import "NSDictionary+SafeExpectations.h"
 #import <WordPressShared/NSString+XMLExtensions.h>
 #import <WordPressShared/WPStyleGuide.h>
@@ -10,6 +11,7 @@ NSString * const SettingsSelectionValuesKey = @"Values";
 NSString * const SettingsSelectionHintsKey = @"Hints";
 NSString * const SettingsSelectionDefaultValueKey = @"DefaultValue";
 NSString * const SettingsSelectionCurrentValueKey = @"CurrentValue";
+NSString * const SettingsSelectionEditableIndexKey = @"EditableIndex";
 
 CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
 
@@ -21,10 +23,20 @@ CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
         CurrentValue    : 0,
         DefaultValue    : 0,
         Title           : "Image Resize",
-        Titles          : [ "Always Ask", "Small", "Medium", "Large", "Disabled" ],
+        Titles          : [ "Always Ask", "Small", "Medium", "Large", "Enter new value" ],
         Values          : [ 0, 1, 2, 3, 4, 5 ]
+        EditableIndex   : 5
      }
  */
+
+- (instancetype)initWithStyle:(UITableViewStyle)style {
+    self = [super initWithStyle:style];
+    if (self) {
+        // By default no item is editable
+        self.editableIndex = -1;
+    }
+    return self;
+}
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
@@ -48,6 +60,9 @@ CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
     _hints = [dictionary arrayForKey:SettingsSelectionHintsKey];
     _defaultValue = dictionary[SettingsSelectionDefaultValueKey];
     _currentValue = dictionary[SettingsSelectionCurrentValueKey] ?: _defaultValue;
+    if ([dictionary valueForKey:SettingsSelectionEditableIndexKey]) {
+        _editableIndex = [[dictionary valueForKey:SettingsSelectionEditableIndexKey] integerValue];
+    }
 }
 
 - (void)setupRefreshControl
@@ -171,14 +186,37 @@ CGFloat const SettingsSelectionDefaultTableViewCellHeight = 44.0f;
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
     [tableView deselectRowAtIndexPath:indexPath animated:YES];
-
     NSObject *val = self.values[indexPath.row];
-    self.currentValue = val;
-    
+
+    if (indexPath.row == self.editableIndex) {
+        SettingsTextViewController *siteTitleViewController = [[SettingsTextViewController alloc] initWithText:self.values[indexPath.row]
+                                                                                                   placeholder:NSLocalizedString(@"Enter a custom value", @"Enter a custom value")
+                                                                                                          hint:@""];
+        siteTitleViewController.onValueChanged = ^(id value) {
+            if (![value isEqualToString:self.values[indexPath.row]]) {
+                NSMutableArray *updatedValues = [NSMutableArray arrayWithArray:self.values];
+                updatedValues[indexPath.row] = value;
+                self.values = updatedValues;
+                NSMutableArray *updatedTitles = [NSMutableArray arrayWithArray:self.titles];
+                updatedTitles[indexPath.row] = value;
+                self.titles = updatedTitles;
+                [self updateSelectedValue:value];
+            }
+        };
+        [self.navigationController pushViewController:siteTitleViewController animated:YES];
+
+    } else {
+        [self updateSelectedValue:val];
+    }
+}
+
+- (void)updateSelectedValue:(NSObject *)newValue
+{
+    self.currentValue = newValue;
     [self.tableView reloadData];
 
     if (self.onItemSelected != nil) {
-        self.onItemSelected(val);
+        self.onItemSelected(newValue);
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -347,6 +347,8 @@
 		7E52B7181FC89F2400B55EB8 /* MediaNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */; };
 		820ADD701F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */; };
 		820ADD721F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */; };
+		821738091FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821738081FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift */; };
+		8217380B1FE05EE600BEC94C /* BlogSettings+DateAndTimeFormat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8217380A1FE05EE600BEC94C /* BlogSettings+DateAndTimeFormat.swift */; };
 		822876F11E929CFD00696BF7 /* ReachabilityUtils+OnlineActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822876F01E929CFD00696BF7 /* ReachabilityUtils+OnlineActions.swift */; };
 		822D60B11F4C747E0016C46D /* JetpackSecuritySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822D60B01F4C747E0016C46D /* JetpackSecuritySettingsViewController.swift */; };
 		822D60B91F4CCC7A0016C46D /* BlogJetpackSettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822D60B81F4CCC7A0016C46D /* BlogJetpackSettingsService.swift */; };
@@ -358,6 +360,7 @@
 		8298F3921EEF3BA7008EB7F0 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8298F3911EEF3BA7008EB7F0 /* StoreKit.framework */; };
 		82B67B361FC726CD006FB593 /* Memoize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B67B351FC726CD006FB593 /* Memoize.swift */; };
 		82B85DF91EDDB807004FD510 /* SiteIconPickerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82B85DF81EDDB807004FD510 /* SiteIconPickerPresenter.swift */; };
+		82C420761FE44BD900CFB15B /* SiteSettingsViewController+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82C420751FE44BD900CFB15B /* SiteSettingsViewController+Swift.swift */; };
 		82FC61241FA8ADAD00A1757E /* ActivityTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FC611C1FA8ADAC00A1757E /* ActivityTableViewCell.swift */; };
 		82FC61251FA8ADAD00A1757E /* ActivityListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FC611D1FA8ADAC00A1757E /* ActivityListViewController.swift */; };
 		82FC61261FA8ADAD00A1757E /* ActivityTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 82FC611E1FA8ADAC00A1757E /* ActivityTableViewCell.xib */; };
@@ -1573,6 +1576,8 @@
 		820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSectionHeaderView.swift; sourceTree = "<group>"; };
 		820ADD751F3CCD70002D7F93 /* WordPress 65.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 65.xcdatamodel"; sourceTree = "<group>"; };
 		821738071FE03F7A00BEC94C /* WordPress 68.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 68.xcdatamodel"; sourceTree = "<group>"; };
+		821738081FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateAndTimeFormatSettingsViewController.swift; sourceTree = "<group>"; };
+		8217380A1FE05EE600BEC94C /* BlogSettings+DateAndTimeFormat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogSettings+DateAndTimeFormat.swift"; sourceTree = "<group>"; };
 		821EB18D1EDF391800E4CD8C /* WordPress 60.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 60.xcdatamodel"; sourceTree = "<group>"; };
 		82270C8E1E3FBF72005F697D /* WordPress 56.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 56.xcdatamodel"; sourceTree = "<group>"; };
 		822876F01E929CFD00696BF7 /* ReachabilityUtils+OnlineActions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ReachabilityUtils+OnlineActions.swift"; sourceTree = "<group>"; };
@@ -1588,6 +1593,7 @@
 		8298F3911EEF3BA7008EB7F0 /* StoreKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = StoreKit.framework; path = System/Library/Frameworks/StoreKit.framework; sourceTree = SDKROOT; };
 		82B67B351FC726CD006FB593 /* Memoize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Memoize.swift; sourceTree = "<group>"; };
 		82B85DF81EDDB807004FD510 /* SiteIconPickerPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteIconPickerPresenter.swift; sourceTree = "<group>"; };
+		82C420751FE44BD900CFB15B /* SiteSettingsViewController+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SiteSettingsViewController+Swift.swift"; sourceTree = "<group>"; };
 		82FA39771EB132090058A2D0 /* WordPress 59.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 59.xcdatamodel"; sourceTree = "<group>"; };
 		82FC611C1FA8ADAC00A1757E /* ActivityTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityTableViewCell.swift; sourceTree = "<group>"; };
 		82FC611D1FA8ADAC00A1757E /* ActivityListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityListViewController.swift; sourceTree = "<group>"; };
@@ -4026,10 +4032,12 @@
 				FF8DDCDE1B5DB1C10098826F /* SettingTableViewCell.m */,
 				83FEFC7311FF6C5A0078B462 /* SiteSettingsViewController.h */,
 				83FEFC7411FF6C5A0078B462 /* SiteSettingsViewController.m */,
+				82C420751FE44BD900CFB15B /* SiteSettingsViewController+Swift.swift */,
 				FFDA7E4E1B8DF6E500B83C56 /* BlogSiteVisibilityHelper.h */,
 				FFDA7E4F1B8DF6E500B83C56 /* BlogSiteVisibilityHelper.m */,
 				B54346951C6A707D0010B3AD /* LanguageViewController.swift */,
 				E1468DE61E794A4D0044D80F /* LanguageSelectorViewController.swift */,
+				821738081FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift */,
 				B5AC00671BE3C4E100F8E7C3 /* DiscussionSettingsViewController.swift */,
 				827704F01F607C0E002E8A03 /* JetpackConnectionViewController.swift */,
 				822D60B01F4C747E0016C46D /* JetpackSecuritySettingsViewController.swift */,
@@ -4137,6 +4145,7 @@
 				B5EEDB961C91F10400676B2B /* Blog+Interface.swift */,
 				B5D889401BEBE30A007C4684 /* BlogSettings.swift */,
 				B55F1AA71C10936600FD04D4 /* BlogSettings+Discussion.swift */,
+				8217380A1FE05EE600BEC94C /* BlogSettings+DateAndTimeFormat.swift */,
 			);
 			name = Blog;
 			sourceTree = "<group>";
@@ -6459,6 +6468,7 @@
 				E60646801CB3133000A3073F /* SigninEditingState.swift in Sources */,
 				59DD94341AC479ED0032DD6B /* WPLogger.m in Sources */,
 				E151C0C61F3889DF00710A83 /* PluginListRow.swift in Sources */,
+				8217380B1FE05EE600BEC94C /* BlogSettings+DateAndTimeFormat.swift in Sources */,
 				313692791A5D6F7900EBE645 /* HelpshiftUtils.m in Sources */,
 				088B89891DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift in Sources */,
 				CEBD3EAB0FF1BA3B00C1396E /* Blog.m in Sources */,
@@ -6705,11 +6715,13 @@
 				7E52B7181FC89F2400B55EB8 /* MediaNoResultsView.swift in Sources */,
 				B5A9B7C31BFA6F3100FC30A5 /* NSString+Helpers.swift in Sources */,
 				1746D7771D2165AE00B11D77 /* ForcePopoverPresenter.swift in Sources */,
+				821738091FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift in Sources */,
 				5D6C4B081B603E03005E3C43 /* WPContentSyncHelper.swift in Sources */,
 				85D239AF1AE5A5FC0074768D /* HelpshiftEnabledFacade.m in Sources */,
 				E6A2158E1D10627500DE5270 /* ReaderMenuViewModel.swift in Sources */,
 				176579F71C63A40F0000978E /* PurchaseButton.swift in Sources */,
 				B587798719B799EB00E57C5A /* NotificationBlock+Interface.swift in Sources */,
+				82C420761FE44BD900CFB15B /* SiteSettingsViewController+Swift.swift in Sources */,
 				E6A3384C1BB08E3F00371587 /* ReaderGapMarker.m in Sources */,
 				E1CFC1571E0AC8FF001DF9E9 /* Pattern.swift in Sources */,
 				4346FD9B1EBA4FF40031452F /* LoginEpilogueUserInfoCell.swift in Sources */,


### PR DESCRIPTION
**Another part of** #7831 

**To test:**

On a .com and Jetpack site try editing the following settings:

- Date Format
- Time Format
- Start of the Week
- Posts per page

To verify that everything is OK you will have to use the API or wp-admin because Calypso is too aggressive about caching and doesn't consider other apps modifying the site settings.

