### PR TITLE
Remove social login feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -4,7 +4,6 @@
 enum FeatureFlag: Int {
     case exampleFeature
     case iCloudFilesSupport
-    case googleLogin
     case socialSignup
     case jetpackDisconnect
     case asyncUploadsInMediaLibrary
@@ -19,8 +18,6 @@ enum FeatureFlag: Int {
             return true
         case .iCloudFilesSupport:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
-        case .googleLogin:
-            return true
         case .socialSignup:
             return false // placeholder until the first social signup screen is added
         case .jetpackDisconnect:

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -129,8 +129,7 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
 
     /// Add the log in with Google button to the view
     @objc func addGoogleButton() {
-        guard Feature.enabled(.googleLogin),
-            let instructionLabel = instructionLabel,
+        guard let instructionLabel = instructionLabel,
             let stackView = inputStack else {
             return
         }


### PR DESCRIPTION
Fixes #8036 

Removes the social login feature flag.

To test:
 - Make sure Google login still works
- And everything still builds.

Needs Review: @ScoutHarris 
Stephenie, got time to peak at this?

