### PR TITLE
Issue/8349 WebKitViewController iPad Sharing Crash

### DIFF
--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -194,6 +194,9 @@ class WebKitViewController: UIViewController {
         }
 
         let activityViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        activityViewController.modalPresentationStyle = .popover
+        activityViewController.popoverPresentationController?.barButtonItem = shareButton
+
         activityViewController.completionWithItemsHandler = { (type, completed, _, _) in
             if completed, let type = type?.rawValue {
                 WPActivityDefaults.trackActivityType(type)


### PR DESCRIPTION
Fixes #8349 

This PR fixes a crash when attempting to share from the new WebKitViewController on iPad.

**To test:**

* Run the app on iPad / iPad Simulator
* In the blog details view controller, tap View Site at the bottom
* In the web view, tap the share icon, and check the activity view controller appears
* Prior to this PR, the app would crash when clicking the icon
