### PR TITLE
Feature: Toggle AMP in Site Settings

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -6,8 +6,6 @@ data model as well as any custom migrations.
 ## WordPress 68
 - @elibud 2017-12-12
 - `BlogSettings` added the following string properties: `dateFormat`, `timeFormat`, `startOfWeek`, the following non optional boolean properties `ampSupported`, `ampEnabled` with default value `NO` and an int_32 `postsPerPage` property.
-- @asifmohd 2017-11-20
-- `BlogSettings` added `gmtOffset` Float property, and `timeZoneString` String property. Stores the timezone setting of a blog.
 
 ## WordPress 67
 - @3vangelos 2017-09-26

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,7 +5,9 @@ data model as well as any custom migrations.
 
 ## WordPress 68
 - @elibud 2017-12-12
-- `BlogSettings` added the following string properties: `dateFormat`, `timeFormat`, `startOfWeek`, the following boolean properties `ampSupported`, `ampEnabled` and an int_32 `postsPerPage` property.
+- `BlogSettings` added the following string properties: `dateFormat`, `timeFormat`, `startOfWeek`, the following non optional boolean properties `ampSupported`, `ampEnabled` with default value `NO` and an int_32 `postsPerPage` property.
+- @asifmohd 2017-11-20
+- `BlogSettings` added `gmtOffset` Float property, and `timeZoneString` String property. Stores the timezone setting of a blog.
 
 ## WordPress 67
 - @3vangelos 2017-09-26

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -60,6 +60,7 @@ NS_ENUM(NSInteger, SiteSettingsSection) {
     SiteSettingsSectionAccount,
     SiteSettingsSectionWriting,
     SiteSettingsSectionDiscussion,
+    SiteSettingsSectionTraffic,
     SiteSettingsSectionJetpackSettings,
     SiteSettingsSectionAdvanced,
 };
@@ -83,6 +84,8 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
 @property (nonatomic, strong) SettingTableViewCell *relatedPostsCell;
 #pragma mark - Discussion Section
 @property (nonatomic, strong) SettingTableViewCell *discussionSettingsCell;
+#pragma mark - Traffic Section
+@property (nonatomic, strong) SettingTableViewCell *trafficSettingsCell;
 #pragma mark - Jetpack Settings Section
 @property (nonatomic, strong) SettingTableViewCell *jetpackSecurityCell;
 @property (nonatomic, strong) SettingTableViewCell *jetpackConnectionCell;
@@ -165,6 +168,10 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
         }
     }
 
+    if (self.blog.settings.ampSupported) {
+        [sections addObject:@(SiteSettingsSectionTraffic)];
+    }
+
     if ([self.blog supports:BlogFeatureSiteManagement]) {
         [sections addObject:@(SiteSettingsSectionAdvanced)];
     }
@@ -209,6 +216,10 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
             return SiteSettingsWritingCount;
         }
         case SiteSettingsSectionDiscussion:
+        {
+            return 1;
+        }
+        case SiteSettingsSectionTraffic:
         {
             return 1;
         }
@@ -316,6 +327,17 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
                                                                  editable:YES
                                                           reuseIdentifier:nil];
     return _discussionSettingsCell;
+}
+
+- (SettingTableViewCell *)trafficSettingsCell
+{
+    if (_trafficSettingsCell) {
+        return _trafficSettingsCell;
+    }
+    _trafficSettingsCell = [[SettingTableViewCell alloc] initWithLabel:NSLocalizedString(@"Traffic", @"Label for selecting the Blog Traffic Settings section")
+                                                              editable:YES
+                                                       reuseIdentifier:nil];
+    return _trafficSettingsCell;
 }
 
 - (SettingTableViewCell *)jetpackSecurityCell
@@ -549,6 +571,9 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
         case SiteSettingsSectionDiscussion:
             return self.discussionSettingsCell;
 
+        case SiteSettingsSectionTraffic:
+            return self.trafficSettingsCell;
+
         case SiteSettingsSectionJetpackSettings:
             return [self tableView:tableView cellForJetpackSettingsAtRow:indexPath.row];
 
@@ -649,6 +674,19 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     };
     
     [self.navigationController pushViewController:languageViewController animated:YES];
+}
+
+- (void)showTrafficSettingsForBlog:(Blog *)blog
+{
+    NSParameterAssert(blog);
+
+    __weak __typeof__(self) weakSelf = self;
+
+    TrafficSettingsViewController *trafficViewController = [[TrafficSettingsViewController alloc] initWithBlog:blog onChange:^(BOOL isAMPEnabled) {
+        weakSelf.blog.settings.ampEnabled = isAMPEnabled;
+        [weakSelf saveSettings];
+    }];
+    [self.navigationController pushViewController:trafficViewController animated:YES];
 }
 
 - (void)tableView:(UITableView *)tableView didSelectInGeneralSectionRow:(NSInteger)row
@@ -876,6 +914,10 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
 
         case SiteSettingsSectionDiscussion:
             [self showDiscussionSettingsForBlog:self.blog];
+            break;
+
+        case SiteSettingsSectionTraffic:
+            [self showTrafficSettingsForBlog:self.blog];
             break;
 
         case SiteSettingsSectionJetpackSettings:

--- a/WordPress/Classes/ViewRelated/Blog/TrafficSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/TrafficSettingsViewController.swift
@@ -32,28 +32,14 @@ class TrafficSettingsViewController: UITableViewController, ImmuTablePresenter {
     override func viewDidLoad() {
         title = NSLocalizedString("Traffic", comment: "Title for Traffic settings")
         ImmuTable.registerRows([SwitchRow.self], tableView: tableView)
-
-        // setup the viewModel
-        let isAMPEnabled = self.blog.settings?.ampEnabled ?? false
-        handler.viewModel = TrafficSettingsViewModel.ready(isAMPEnabled, self.onChange).tableViewModel()
+        handler.viewModel = self.tableViewModel()
     }
-}
 
-enum TrafficSettingsViewModel {
-    /**
-     - Parameters
-     - First param: - Indicates if AMP is enabled for the site
-     - Second param: - Action block to be executed when user toggles the Switch.
-     */
-    case ready(Bool, ((Bool) -> Void))
-
-    func tableViewModel() -> ImmuTable {
-        switch self {
-        case .ready(let isAMPEnabled, let action):
-            let switchTitle: String = NSLocalizedString("Accelerated Mobile Pages (AMP)", comment: "Label for AMP toggle")
-            let row = SwitchRow(title: switchTitle, value: isAMPEnabled, onChange: action)
-            let section = ImmuTableSection(rows: [row])
-            return ImmuTable(sections: [section])
-        }
+    private func tableViewModel() -> ImmuTable {
+        let isAMPEnabled = self.blog.settings?.ampEnabled ?? false
+        let switchTitle: String = NSLocalizedString("Accelerated Mobile Pages (AMP)", comment: "Label for AMP toggle")
+        let row = SwitchRow(title: switchTitle, value: isAMPEnabled, onChange: self.onChange)
+        let section = ImmuTableSection(rows: [row])
+        return ImmuTable(sections: [section])
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/TrafficSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/TrafficSettingsViewController.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+class TrafficSettingsViewController: UITableViewController, ImmuTablePresenter {
+
+    /// Designated Initializer
+    ///
+    /// - Parameter
+    /// - Blog: The blog for which we want to display the traffic settings
+    /// - OnChange: The closure to be executed when the switch is toggled
+    ///
+    @objc public convenience init(blog: Blog, onChange: @escaping ((Bool) -> Void)) {
+        self.init(style: .grouped)
+        self.blog = blog
+        self.onChange = onChange
+    }
+
+    // MARK: - Private Properties
+
+    /// Blog for which to show the Traffic settings
+    ///
+    private var blog: Blog!
+
+    /// Callback to be executed whenever the Blog's amp enabled setting changes.
+    ///
+    private var onChange: ((Bool) -> Void)!
+
+    /// ImmuTableViewHandler, takes over the datasource, delegate from this VC
+    private lazy var handler: ImmuTableViewHandler = {
+        return ImmuTableViewHandler(takeOver: self)
+    }()
+
+    override func viewDidLoad() {
+        title = NSLocalizedString("Traffic", comment: "Title for Traffic settings")
+        ImmuTable.registerRows([SwitchRow.self], tableView: tableView)
+
+        // setup the viewModel
+        let isAMPEnabled = self.blog.settings?.ampEnabled ?? false
+        handler.viewModel = TrafficSettingsViewModel.ready(isAMPEnabled, self.onChange).tableViewModel()
+    }
+}
+
+enum TrafficSettingsViewModel {
+    /**
+     - Parameters
+     - First param: - Indicates if AMP is enabled for the site
+     - Second param: - Action block to be executed when user toggles the Switch.
+     */
+    case ready(Bool, ((Bool) -> Void))
+
+    func tableViewModel() -> ImmuTable {
+        switch self {
+        case .ready(let isAMPEnabled, let action):
+            let switchTitle: String = NSLocalizedString("Accelerated Mobile Pages (AMP)", comment: "Label for AMP toggle")
+            let row = SwitchRow(title: switchTitle, value: isAMPEnabled, onChange: action)
+            let section = ImmuTableSection(rows: [row])
+            return ImmuTable(sections: [section])
+        }
+    }
+}

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 68.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 68.xcdatamodel/contents
@@ -161,8 +161,8 @@
         <userInfo/>
     </entity>
     <entity name="BlogSettings" representedClassName=".BlogSettings" syncable="YES">
-        <attribute name="ampEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="ampSupported" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="ampEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="ampSupported" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="commentsAllowed" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="commentsBlacklistKeys" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="commentsCloseAutomatically" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -978,6 +978,7 @@
 		E6F66D421E00966000F875A5 /* UIImage+Rotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F66D411E00966000F875A5 /* UIImage+Rotation.swift */; };
 		E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */; };
 		E8DEE110E4BC3FA1974AB1BB /* Pods_WordPressTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B921F5DD9A1F257C792EC225 /* Pods_WordPressTest.framework */; };
+		F042A3AA1FE4E17600C6884B /* TrafficSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F042A3A91FE4E17500C6884B /* TrafficSettingsViewController.swift */; };
 		F1049F331F39FCF9004DF0BB /* CalypsoProcessorOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */; };
 		F128C31C1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */; };
 		F1564E5B18946087009F8F97 /* NSStringHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F1564E5A18946087009F8F97 /* NSStringHelpersTests.m */; };
@@ -2459,6 +2460,7 @@
 		E6F66D411E00966000F875A5 /* UIImage+Rotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Rotation.swift"; sourceTree = "<group>"; };
 		E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarProfile.swift; sourceTree = "<group>"; };
 		EF379F0A70B6AC45330EE287 /* Pods-WordPressTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release.xcconfig"; sourceTree = "<group>"; };
+		F042A3A91FE4E17500C6884B /* TrafficSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrafficSettingsViewController.swift; sourceTree = "<group>"; };
 		F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CalypsoProcessorOut.swift; sourceTree = "<group>"; };
 		F117E5841F7AA8BF003D9ACB /* WordPress 67.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 67.xcdatamodel"; sourceTree = "<group>"; };
 		F128C31A1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPNavigationMediaPickerViewController+StatusBarStyle.h"; sourceTree = "<group>"; };
@@ -4038,6 +4040,7 @@
 				FF1933FD1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.h */,
 				FF1933FE1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m */,
 				82B85DF81EDDB807004FD510 /* SiteIconPickerPresenter.swift */,
+				F042A3A91FE4E17500C6884B /* TrafficSettingsViewController.swift */,
 			);
 			path = Blog;
 			sourceTree = "<group>";
@@ -6340,6 +6343,7 @@
 				5DB3BA0818D11D8D00F3F3E9 /* PublishDatePickerView.m in Sources */,
 				5D2B30B91B7411C700DA15F3 /* ReaderCardDiscoverAttributionView.swift in Sources */,
 				E1E89C6C1FD80E74006E7A33 /* Plugin.swift in Sources */,
+				F042A3AA1FE4E17600C6884B /* TrafficSettingsViewController.swift in Sources */,
 				E1C265C91BECFCDD00DC4C6B /* WPCrashlyticsLogger.m in Sources */,
 				319D6E7B19E447500013871C /* Suggestion.m in Sources */,
 				594399931B45091000539E21 /* WPAuthTokenIssueSolver.m in Sources */,


### PR DESCRIPTION
Fixes #7831 

- Adds a Traffic section to Site Settings
- Traffic section has the AMP setting toggle inside
- Traffic section and the AMP setting toggle is only shown to users if their blog has `amp_is_supported` set to true.

To test:
- Go to site settings for a Jetpack enabled WordPress site on mobile as well as web.
- Check if the AMP setting displayed on mobile is the same as displayed on web.
- Try toggling the AMP setting
- Observe the same is reflected on web as well.
- For a website where the AMP plugin is not installed, the Traffic section should not show up


Preview:
![amp_settings](https://user-images.githubusercontent.com/4892875/34067676-812f4244-e252-11e7-9828-0c1103cd6c79.gif)
