### PR TITLE
Activity Log: feed data update

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -75,12 +75,7 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
         super.viewDidAppear(animated)
 
         service.getActivityForSite(siteID, count: 1000, success: { (activities, _) in
-            do {
-                self.viewModel = try .ready(ActivityUtils.rewriteStream(activities: activities))
-            } catch {
-                DDLogError("Error rewriting activities stream \(error)")
-                self.viewModel = .ready(activities)
-            }
+            self.viewModel = .ready(activities)
         }, failure: { error in
             DDLogError("Error loading activities: \(error)")
             self.viewModel = .error(String(describing: error))

--- a/WordPressKit/WordPressKit/Activity.swift
+++ b/WordPressKit/WordPressKit/Activity.swift
@@ -10,7 +10,7 @@ public class Activity {
     public let rewindable: Bool
     public let rewindID: String?
     public let published: Date
-    public var isDiscarded: Bool = false
+    public var isDiscarded: Bool
     public let actor: ActivityActor?
     public let object: ActivityObject?
     public let target: ActivityObject?
@@ -39,6 +39,7 @@ public class Activity {
         gridicon = dictionary["gridicon"] as? String ?? ""
         status = dictionary["status"] as? String ?? ""
         rewindable = dictionary["is_rewindable"] as? Bool ?? false
+        isDiscarded = dictionary["is_discarded"] as? Bool ?? false
         rewindID = dictionary["rewind_id"] as? String
         if let actorData = dictionary["actor"] as? [String: AnyObject] {
             actor = ActivityActor(dictionary: actorData)

--- a/WordPressKit/WordPressKit/Activity.swift
+++ b/WordPressKit/WordPressKit/Activity.swift
@@ -20,7 +20,7 @@ public class Activity {
         guard let id = dictionary["activity_id"] as? String else {
             throw Error.missingActivityId
         }
-        guard let summaryDictionary = dictionary["summary"] as? [String: AnyObject],
+        guard let summaryDictionary = dictionary["content"] as? [String: AnyObject],
               let text = summaryDictionary["text"] as? String else {
             throw Error.missingSummaryText
         }

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-bad-json-failure.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-bad-json-failure.json
@@ -16,7 +16,7 @@
         "totalItems": 20,
         "orderedItems": [
                          {
-                         "summary": "activity002 logged in successfully",
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-1.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-1.json
@@ -16,7 +16,7 @@
         "totalItems": 20,
         "orderedItems": [
                          {
-                         "summary": {"text": "activity002 logged in successfully"},
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -49,7 +49,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 logged in successfully"},
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -83,7 +83,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 published Post scheduled from wp-admin"},
+                         "content": {"text": "activity002 published Post scheduled from wp-admin"},
                          "name": "post__published",
                          "actor": {
                          "type": "Person",
@@ -117,7 +117,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 updated Post scheduled from wp-admin"},
+                         "content": {"text": "activity002 updated Post scheduled from wp-admin"},
                          "name": "post__updated",
                          "actor": {
                          "type": "Person",
@@ -151,7 +151,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 published Post scheduled post"},
+                         "content": {"text": "activity002 published Post scheduled post"},
                          "name": "post__published",
                          "actor": {
                          "type": "Person",
@@ -185,7 +185,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 updated Post scheduled post"},
+                         "content": {"text": "activity002 updated Post scheduled post"},
                          "name": "post__updated",
                          "actor": {
                          "type": "Person",
@@ -219,7 +219,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 updated Post scheduled post"},
+                         "content": {"text": "activity002 updated Post scheduled post"},
                          "name": "post__updated",
                          "actor": {
                          "type": "Person",
@@ -253,7 +253,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 added user elibud to site."},
+                         "content": {"text": "activity002 added user elibud to site."},
                          "name": "user__registered",
                          "actor": {
                          "type": "Person",

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-2.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-2.json
@@ -16,7 +16,7 @@
         "totalItems": 20,
         "orderedItems": [
                          {
-                         "summary": {"text": "activity002 logged in successfully"},
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -49,7 +49,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 logged in successfully"},
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -82,7 +82,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 published Post scheduled from wp-admin"},
+                         "content": {"text": "activity002 published Post scheduled from wp-admin"},
                          "name": "post__published",
                          "actor": {
                          "type": "Person",
@@ -116,7 +116,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 updated Post scheduled from wp-admin"},
+                         "content": {"text": "activity002 updated Post scheduled from wp-admin"},
                          "name": "post__updated",
                          "actor": {
                          "type": "Person",
@@ -150,7 +150,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 published Post scheduled post"},
+                         "content": {"text": "activity002 published Post scheduled post"},
                          "name": "post__published",
                          "actor": {
                          "type": "Person",
@@ -184,7 +184,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 updated Post scheduled post"},
+                         "content": {"text": "activity002 updated Post scheduled post"},
                          "name": "post__updated",
                          "actor": {
                          "type": "Person",
@@ -218,7 +218,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 updated Post scheduled post"},
+                         "content": {"text": "activity002 updated Post scheduled post"},
                          "name": "post__updated",
                          "actor": {
                          "type": "Person",
@@ -252,7 +252,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 added user elibud to site."},
+                         "content": {"text": "activity002 added user elibud to site."},
                          "name": "user__registered",
                          "actor": {
                          "type": "Person",
@@ -285,7 +285,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 removed Elisa from site and reassigned their content to ."},
+                         "content": {"text": "activity002 removed Elisa from site and reassigned their content to ."},
                          "name": "user__deleted",
                          "actor": {
                          "type": "Person",
@@ -325,7 +325,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 modified user Elisa"},
+                         "content": {"text": "activity002 modified user Elisa"},
                          "name": "user__updated",
                          "actor": {
                          "type": "Person",
@@ -358,7 +358,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 logged in successfully"},
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -391,7 +391,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 logged out"},
+                         "content": {"text": "activity002 logged out"},
                          "name": "user__logout",
                          "actor": {
                          "type": "Person",
@@ -424,7 +424,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 added user  to site."},
+                         "content": {"text": "activity002 added user  to site."},
                          "name": "user__registered",
                          "actor": {
                          "type": "Person",
@@ -457,7 +457,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 logged in successfully"},
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -490,7 +490,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 logged in successfully"},
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -523,7 +523,7 @@
                          }
                          },
                          {
-                         "summary": {"text": " published post What would you do with\\u2026"},
+                         "content": {"text": " published post What would you do with\\u2026"},
                          "name": "post__published",
                          "actor": {
                          "type": "Person",
@@ -557,7 +557,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "Jurewicz72 logged in successfully"},
+                         "content": {"text": "Jurewicz72 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -590,7 +590,7 @@
                          }
                          },
                          {
-                         "summary": {"text":" published post RT @photomatt: Upload Once, Blog\\u2026"},
+                         "content": {"text":" published post RT @photomatt: Upload Once, Blog\\u2026"},
                          "name": "post__published",
                          "actor": {
                          "type": "Person",
@@ -624,7 +624,7 @@
                          }
                          },
                          {
-                         "summary": {"text": " updated post RT @Lunarbaboon: New comic about\\u2026"},
+                         "content": {"text": " updated post RT @Lunarbaboon: New comic about\\u2026"},
                          "name": "post__updated",
                          "actor": {
                          "type": "Person",
@@ -658,7 +658,7 @@
                          }
                          },
                          {
-                         "summary": {"text": " published post RT @Lunarbaboon: New comic about\\u2026"},
+                         "content": {"text": " published post RT @Lunarbaboon: New comic about\\u2026"},
                          "name": "post__published",
                          "actor": {
                          "type": "Person",

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-3.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-3.json
@@ -16,7 +16,7 @@
         "totalItems": 19,
         "orderedItems": [
                          {
-                         "summary": {"text": "activity002 logged in successfully"},
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -49,7 +49,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 logged in successfully"},
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -82,7 +82,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 published Post scheduled from wp-admin"},
+                         "content": {"text": "activity002 published Post scheduled from wp-admin"},
                          "name": "post__published",
                          "actor": {
                          "type": "Person",
@@ -116,7 +116,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 updated Post scheduled from wp-admin"},
+                         "content": {"text": "activity002 updated Post scheduled from wp-admin"},
                          "name": "post__updated",
                          "actor": {
                          "type": "Person",
@@ -150,7 +150,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 published Post scheduled post"},
+                         "content": {"text": "activity002 published Post scheduled post"},
                          "name": "post__published",
                          "actor": {
                          "type": "Person",
@@ -184,7 +184,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 updated Post scheduled post"},
+                         "content": {"text": "activity002 updated Post scheduled post"},
                          "name": "post__updated",
                          "actor": {
                          "type": "Person",
@@ -218,7 +218,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 updated Post scheduled post"},
+                         "content": {"text": "activity002 updated Post scheduled post"},
                          "name": "post__updated",
                          "actor": {
                          "type": "Person",
@@ -252,7 +252,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 added user elibud to site."},
+                         "content": {"text": "activity002 added user elibud to site."},
                          "name": "user__registered",
                          "actor": {
                          "type": "Person",
@@ -285,7 +285,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 removed Elisa from site and reassigned their content to ."},
+                         "content": {"text": "activity002 removed Elisa from site and reassigned their content to ."},
                          "name": "user__deleted",
                          "actor": {
                          "type": "Person",
@@ -325,7 +325,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 modified user Elisa"},
+                         "content": {"text": "activity002 modified user Elisa"},
                          "name": "user__updated",
                          "actor": {
                          "type": "Person",
@@ -358,7 +358,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 logged in successfully"},
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -391,7 +391,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 logged out"},
+                         "content": {"text": "activity002 logged out"},
                          "name": "user__logout",
                          "actor": {
                          "type": "Person",
@@ -424,7 +424,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 added user  to site."},
+                         "content": {"text": "activity002 added user  to site."},
                          "name": "user__registered",
                          "actor": {
                          "type": "Person",
@@ -457,7 +457,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 logged in successfully"},
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -490,7 +490,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "activity002 logged in successfully"},
+                         "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -523,7 +523,7 @@
                          }
                          },
                          {
-                         "summary": {"text": " published post What would you do with\\u2026"},
+                         "content": {"text": " published post What would you do with\\u2026"},
                          "name": "post__published",
                          "actor": {
                          "type": "Person",
@@ -557,7 +557,7 @@
                          }
                          },
                          {
-                         "summary": {"text": "Jurewicz72 logged in successfully"},
+                         "content": {"text": "Jurewicz72 logged in successfully"},
                          "name": "user__login",
                          "actor": {
                          "type": "Person",
@@ -590,7 +590,7 @@
                          }
                          },
                          {
-                         "summary": {"text": " published post RT @photomatt: Upload Once, Blog\\u2026"},
+                         "content": {"text": " published post RT @photomatt: Upload Once, Blog\\u2026"},
                          "name": "post__published",
                          "actor": {
                          "type": "Person",
@@ -624,7 +624,7 @@
                          }
                          },
                          {
-                         "summary": {"text": " updated post RT @Lunarbaboon: New comic about\\u2026"},
+                         "content": {"text": " updated post RT @Lunarbaboon: New comic about\\u2026"},
                          "name": "post__updated",
                          "actor": {
                          "type": "Person",


### PR DESCRIPTION
**Another step for** #7832 

Two changes go into this PR:
1. The field `summary` was moved to `content`.
2. We are removing our client side calculations for `isDiscarded` since they are now happening server side. We are keeping the code though since it might be useful when we (if we) implement review previews.

**To test:**

Fetch the Activity Log in a site with discarded events, check that they are displaying appropriately.

Note: This one is waiting on a server side change to be merged, I'll ping you @koke when it's ready.
