### PR TITLE
Fix issue with crashes on startup on iPhone X.

### DIFF
--- a/WordPress/Vendor/ALIterativeMigrator.m
+++ b/WordPress/Vendor/ALIterativeMigrator.m
@@ -366,6 +366,7 @@
                                                               inDirectory:directory];
       for (NSString* momdPath in momdPaths)
       {
+         if (url) { continue; }
          url = [bundle URLForResource:modelName
                         withExtension:@"mom"
                          subdirectory:[momdPath lastPathComponent]];


### PR DESCRIPTION
So, no idea why this is apparently _only_ happening on the X.

The bug is pretty obvious in retrospective — the code was iterating over a list of potential places where the `.momd` file might be, but _it never checked if it already found one_. 

This in turn meant, that the order of items in the array returned from `pathsForResourcesOfType:_inDirectory` mattered. For some reason, on iPhone X the `Extensions.momd` was after `WordPress.momd`, so the actual, correct result got overriden with `nil`, which lead to 💥.

Why the order was apparently different on the X then any other device still remains a mystery.

