### PR TITLE
MediaService: mark errors in callbacks to methods dealing with uploading media as nullable

### DIFF
--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -53,7 +53,7 @@
 - (void)uploadMedia:(nonnull Media *)media
            progress:(NSProgress * __nullable __autoreleasing * __nullable) progress
             success:(nullable void (^)(void))success
-            failure:(nullable void (^)(NSError * _Nonnull error))failure;
+            failure:(nullable void (^)(NSError * _Nullable error))failure;
 
 
 /**
@@ -67,7 +67,7 @@
  */
 - (void)updateMedia:(nonnull Media *)media
             success:(nullable void (^)(void))success
-            failure:(nullable void (^)(NSError * _Nonnull error))failure;
+            failure:(nullable void (^)(NSError * _Nullable error))failure;
 
 /**
  Updates multiple media objects similar to -updateMedia:success:failure: but batches them
@@ -79,7 +79,7 @@
  */
 - (void)updateMedia:(nonnull NSArray<Media *> *)mediaObjects
      overallSuccess:(nullable void (^)(void))overallSuccess
-            failure:(nullable void (^)(NSError * _Nonnull error))failure;
+            failure:(nullable void (^)(NSError * _Nullable error))failure;
 
 /**
  Deletes the Media object from the server. Note the Media is deleted, not trashed.

--- a/WordPress/Classes/Services/MediaUploadCoordinator.swift
+++ b/WordPress/Classes/Services/MediaUploadCoordinator.swift
@@ -50,7 +50,9 @@ class MediaUploadCoordinator: MediaProgressCoordinatorDelegate {
                                                     success: {
                                                         self.end(media)
                                 }, failure: { error in
-                                    self.mediaProgressCoordinator.attach(error: error as NSError, toMediaID: mediaID)
+                                    if let error = error {
+                                        self.mediaProgressCoordinator.attach(error: error as NSError, toMediaID: mediaID)
+                                    }
                                     self.end(media)
                                 })
                                 if let taskProgress = progress {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -473,7 +473,9 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             self?.unpauseDataSource()
             self?.trackUploadFor(media)
             }, failure: { error in
-                self.mediaProgressCoordinator.attach(error: error as NSError, toMediaID: mediaID)
+                if let error = error {
+                    self.mediaProgressCoordinator.attach(error: error as NSError, toMediaID: mediaID)
+                }
                 self.unpauseDataSource()
         })
 


### PR DESCRIPTION
Fixes issue where the app would sometimes crash when the error passed to the `failure` block would be `nil`, despite being marked as `_Nonnull` in the header.