### PR TITLE
Removes some old code that was causing trouble in App Settings.

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -7,7 +7,6 @@ import SVProgressHUD
 class AppSettingsViewController: UITableViewController {
     enum Sections: Int {
         case media
-        case editor
         case other
     }
 
@@ -143,35 +142,8 @@ class AppSettingsViewController: UITableViewController {
 
     // MARK: - UITableViewDelegate
 
-    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        if shouldShowEditorFooterForSection(section) {
-            let footer = UITableViewHeaderFooterView(frame: CGRect(x: 0.0,
-                                                                   y: 0.0,
-                                                                   width: tableView.frame.width,
-                                                                   height: AppSettingsViewController.aztecEditorFooterHeight))
-            footer.textLabel?.text = NSLocalizedString("Editor release notes & bug reporting",
-                                                       comment: "Label for button linking to release notes and bug reporting help for the new beta Aztec editor")
-            footer.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
-            footer.textLabel?.isUserInteractionEnabled = true
-
-            let tap = UITapGestureRecognizer(target: self, action: #selector(handleEditorFooterTap(_:)))
-            footer.addGestureRecognizer(tap)
-            return footer
-        }
-
-        return nil
-    }
-
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        if shouldShowEditorFooterForSection(section) {
-            return AppSettingsViewController.aztecEditorFooterHeight
-        }
-
         return UITableViewAutomaticDimension
-    }
-
-    private func shouldShowEditorFooterForSection(_ section: Int) -> Bool {
-        return section == Sections.editor.rawValue && EditorSettings().isEnabled(.aztec)
     }
 
     @objc fileprivate func handleEditorFooterTap(_ sender: UITapGestureRecognizer) {

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -140,17 +140,6 @@ class AppSettingsViewController: UITableViewController {
             ])
     }
 
-    // MARK: - UITableViewDelegate
-
-    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return UITableViewAutomaticDimension
-    }
-
-    @objc fileprivate func handleEditorFooterTap(_ sender: UITapGestureRecognizer) {
-        WPAppAnalytics.track(.editorAztecBetaLink)
-        FancyAlertViewController.presentWhatsNewWebView(from: self)
-    }
-
     // MARK: - Media cache methods
 
     fileprivate enum MediaCacheSettingsStatus {


### PR DESCRIPTION
### Description:

Removes some old code that was causing trouble in App Settings.

### Testing

1. Launch the app
2. Go to App Settings
3. Make sure the description label for "Usage Statistics" cannot be tapped.

<img width="374" alt="screen shot 2017-12-21 at 14 49 11" src="https://user-images.githubusercontent.com/1836005/34268082-28615aca-e65e-11e7-8083-9dd6427f350b.png">

Pinging @elibud for review since you're aware of the issue.