### PR TITLE
Site settings: AMP

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController+Swift.swift
@@ -29,9 +29,47 @@ extension SiteSettingsViewController {
         navigationController?.pushViewController(pickerViewController, animated: true)
     }
 
+    // MARK: AMP footer
+
+    open override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        guard isTrafficSettingsSection(section) else {
+            return nil
+        }
+
+        let footer = UITableViewHeaderFooterView()
+        footer.textLabel?.text = NSLocalizedString("Your WordPress.com site supports the use of Accelerated Mobile Pages, a Google-led initiative that dramatically speeds up loading times on mobile devices.",
+                                                   comment: "Footer for AMP Traffic Site Setting, should match Calypso.")
+        footer.textLabel?.numberOfLines = 0
+        footer.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
+        footer.textLabel?.isUserInteractionEnabled = true
+
+        let tap = UITapGestureRecognizer(target: self, action: #selector(handleAMPFooterTap(_:)))
+        footer.addGestureRecognizer(tap)
+        return footer
+    }
+
+    @objc fileprivate func handleAMPFooterTap(_ sender: UITapGestureRecognizer) {
+        guard let url =  URL(string: self.ampSupportURL) else {
+            return
+        }
+        let webViewController = WebViewControllerFactory.controller(url: url)
+
+        if presentingViewController != nil {
+            navigationController?.pushViewController(webViewController, animated: true)
+        } else {
+            let navController = UINavigationController(rootViewController: webViewController)
+            present(navController, animated: true, completion: nil)
+        }
+    }
+
+    override open func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        WPStyleGuide.configureTableViewSectionFooter(view)
+    }
+
     // MARK: Private Properties
 
     fileprivate var minNumberOfPostPerPage: Int { return 1 }
     fileprivate var maxNumberOfPostPerPage: Int { return 1000 }
+    fileprivate var ampSupportURL: String { return "https://support.wordpress.com/amp-accelerated-mobile-pages/" }
 
 }

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController+Swift.swift
@@ -14,12 +14,12 @@ extension SiteSettingsViewController {
         pickerViewController.selectionText = NSLocalizedString("The number of posts to show per page.",
                                                                comment: "Text above the selection of the number of posts to show per blog page")
         pickerViewController.pickerFormat = NSLocalizedString("%d posts", comment: "Number of posts")
-        pickerViewController.pickerMinimumValue = self.minNumberOfPostPerPage
+        pickerViewController.pickerMinimumValue = minNumberOfPostPerPage
         if let currentValue = blog.settings?.postsPerPage as? Int {
             pickerViewController.pickerSelectedValue = currentValue
-            pickerViewController.pickerMaximumValue = max(currentValue, self.maxNumberOfPostPerPage)
+            pickerViewController.pickerMaximumValue = max(currentValue, maxNumberOfPostPerPage)
         } else {
-            pickerViewController.pickerMaximumValue = self.maxNumberOfPostPerPage
+            pickerViewController.pickerMaximumValue = maxNumberOfPostPerPage
         }
         pickerViewController.onChange           = { [weak self] (enabled: Bool, newValue: Int) in
             self?.blog.settings?.postsPerPage = newValue as NSNumber?

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.h
@@ -9,5 +9,6 @@
 - (instancetype)initWithBlog:(Blog *)blog;
 
 - (void)saveSettings;
+- (BOOL)isTrafficSettingsSection:(NSInteger)section;
 
 @end


### PR DESCRIPTION
**Fixes** #7831 

This setting is available only for public WordPress.com sites. The irony that we are doing it in the Jetpack project does not escape me.

**To test:**

Site Settings -> Traffic, turn on and off, check that is saved. 
Tap on the footer, check that it takes you to the support page for AMP.

cc: @nbradbury in case it helps on Android

Thanks in advance
