### PR TITLE
Add summary field to activities

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -22,8 +22,6 @@ open class ActivityTableViewCell: WPTableViewCell {
                                                             attributes: Style.timestampStyle())
         if activity.isFullBackup {
             gravatarImageView.isHidden = true
-            summaryLabel.attributedText = NSAttributedString(string: activity.summary,
-                                                             attributes: Style.summaryBoldStyle())
         } else {
             gravatarImageView.isHidden = false
             if let actor = activity.actor,
@@ -35,9 +33,12 @@ open class ActivityTableViewCell: WPTableViewCell {
             } else {
                 gravatarImageView.image = placeholderImage
             }
-            summaryLabel.attributedText = NSAttributedString(string: activity.summary,
-                                                             attributes: Style.summaryRegularStyle())
         }
+        let summaryAttributed = NSMutableAttributedString(string: activity.summary + ": ",
+                                                          attributes: Style.summaryBoldStyle())
+        summaryAttributed.append(NSAttributedString(string: activity.text,
+                                                    attributes: Style.summaryRegularStyle()))
+        summaryLabel.attributedText = summaryAttributed
 
         if let statusImage = Style.getIconForActivity(activity) {
             statusImageView.image = statusImage

--- a/WordPressKit/WordPressKit/Activity.swift
+++ b/WordPressKit/WordPressKit/Activity.swift
@@ -3,6 +3,7 @@ import Foundation
 public class Activity {
     public let activityID: String
     public let summary: String
+    public let text: String
     public let name: String
     public let type: String
     public let gridicon: String
@@ -20,9 +21,12 @@ public class Activity {
         guard let id = dictionary["activity_id"] as? String else {
             throw Error.missingActivityId
         }
-        guard let summaryDictionary = dictionary["content"] as? [String: AnyObject],
-              let text = summaryDictionary["text"] as? String else {
-            throw Error.missingSummaryText
+        guard let summaryText = dictionary["summary"] as? String else {
+            throw Error.missingSummary
+        }
+        guard let contentDictionary = dictionary["content"] as? [String: AnyObject],
+              let contentText = contentDictionary["text"] as? String else {
+            throw Error.missingContentText
         }
         guard let publishedString = dictionary["published"] as? String else {
             throw Error.missingPublishedDate
@@ -32,7 +36,8 @@ public class Activity {
             throw Error.incorrectPusblishedDateFormat
         }
         activityID = id
-        summary = text
+        summary = summaryText
+        text = contentText
         published = publishedDate
         name = dictionary["name"] as? String ?? ""
         type = dictionary["type"] as? String ?? ""
@@ -78,7 +83,8 @@ public class Activity {
 private extension Activity {
     enum Error: Swift.Error {
         case missingActivityId
-        case missingSummaryText
+        case missingSummary
+        case missingContentText
         case missingPublishedDate
         case incorrectPusblishedDateFormat
     }

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-bad-json-failure.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-bad-json-failure.json
@@ -16,6 +16,7 @@
         "totalItems": 20,
         "orderedItems": [
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-1.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-1.json
@@ -16,6 +16,7 @@
         "totalItems": 20,
         "orderedItems": [
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -49,6 +50,7 @@
                          }
                          },
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -83,6 +85,7 @@
                          }
                          },
                          {
+                         "summary": "Post Published",
                          "content": {"text": "activity002 published Post scheduled from wp-admin"},
                          "name": "post__published",
                          "actor": {
@@ -117,6 +120,7 @@
                          }
                          },
                          {
+                         "summary": "Post Updated",
                          "content": {"text": "activity002 updated Post scheduled from wp-admin"},
                          "name": "post__updated",
                          "actor": {
@@ -151,6 +155,7 @@
                          }
                          },
                          {
+                         "summary": "Post Published",
                          "content": {"text": "activity002 published Post scheduled post"},
                          "name": "post__published",
                          "actor": {
@@ -185,6 +190,7 @@
                          }
                          },
                          {
+                         "summary": "Post Updated",
                          "content": {"text": "activity002 updated Post scheduled post"},
                          "name": "post__updated",
                          "actor": {
@@ -219,6 +225,7 @@
                          }
                          },
                          {
+                         "summary": "Post Updated",
                          "content": {"text": "activity002 updated Post scheduled post"},
                          "name": "post__updated",
                          "actor": {
@@ -253,6 +260,7 @@
                          }
                          },
                          {
+                         "summary": "User Added",
                          "content": {"text": "activity002 added user elibud to site."},
                          "name": "user__registered",
                          "actor": {

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-2.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-2.json
@@ -16,6 +16,7 @@
         "totalItems": 20,
         "orderedItems": [
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -49,6 +50,7 @@
                          }
                          },
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -82,6 +84,7 @@
                          }
                          },
                          {
+                         "summary": "Post Published",
                          "content": {"text": "activity002 published Post scheduled from wp-admin"},
                          "name": "post__published",
                          "actor": {
@@ -116,6 +119,7 @@
                          }
                          },
                          {
+                         "summary": "Post Updated",
                          "content": {"text": "activity002 updated Post scheduled from wp-admin"},
                          "name": "post__updated",
                          "actor": {
@@ -150,6 +154,7 @@
                          }
                          },
                          {
+                         "summary": "Post Published",
                          "content": {"text": "activity002 published Post scheduled post"},
                          "name": "post__published",
                          "actor": {
@@ -184,6 +189,7 @@
                          }
                          },
                          {
+                         "summary": "Post Updated",
                          "content": {"text": "activity002 updated Post scheduled post"},
                          "name": "post__updated",
                          "actor": {
@@ -218,6 +224,7 @@
                          }
                          },
                          {
+                         "summary": "Post Updated",
                          "content": {"text": "activity002 updated Post scheduled post"},
                          "name": "post__updated",
                          "actor": {
@@ -252,6 +259,7 @@
                          }
                          },
                          {
+                         "summary": "User Added",
                          "content": {"text": "activity002 added user elibud to site."},
                          "name": "user__registered",
                          "actor": {
@@ -285,6 +293,7 @@
                          }
                          },
                          {
+                         "summary": "User Removed",
                          "content": {"text": "activity002 removed Elisa from site and reassigned their content to ."},
                          "name": "user__deleted",
                          "actor": {
@@ -325,6 +334,7 @@
                          }
                          },
                          {
+                         "summary": "User Modified",
                          "content": {"text": "activity002 modified user Elisa"},
                          "name": "user__updated",
                          "actor": {
@@ -358,6 +368,7 @@
                          }
                          },
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -391,6 +402,7 @@
                          }
                          },
                          {
+                         "summary": "User Logged Out",
                          "content": {"text": "activity002 logged out"},
                          "name": "user__logout",
                          "actor": {
@@ -424,6 +436,7 @@
                          }
                          },
                          {
+                         "summary": "User Added",
                          "content": {"text": "activity002 added user  to site."},
                          "name": "user__registered",
                          "actor": {
@@ -457,6 +470,7 @@
                          }
                          },
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -490,6 +504,7 @@
                          }
                          },
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -523,6 +538,7 @@
                          }
                          },
                          {
+                         "summary": "Post Published",
                          "content": {"text": " published post What would you do with\\u2026"},
                          "name": "post__published",
                          "actor": {
@@ -557,6 +573,7 @@
                          }
                          },
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "Jurewicz72 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -590,6 +607,7 @@
                          }
                          },
                          {
+                         "summary": "Post Published",
                          "content": {"text":" published post RT @photomatt: Upload Once, Blog\\u2026"},
                          "name": "post__published",
                          "actor": {
@@ -624,6 +642,7 @@
                          }
                          },
                          {
+                         "summary": "Post Updated",
                          "content": {"text": " updated post RT @Lunarbaboon: New comic about\\u2026"},
                          "name": "post__updated",
                          "actor": {
@@ -658,6 +677,7 @@
                          }
                          },
                          {
+                         "summary": "Post Published",
                          "content": {"text": " published post RT @Lunarbaboon: New comic about\\u2026"},
                          "name": "post__published",
                          "actor": {

--- a/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-3.json
+++ b/WordPressKit/WordPressKitTests/Mock Data/activity-log-success-3.json
@@ -16,6 +16,7 @@
         "totalItems": 19,
         "orderedItems": [
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -49,6 +50,7 @@
                          }
                          },
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -82,6 +84,7 @@
                          }
                          },
                          {
+                         "summary": "Post Published",
                          "content": {"text": "activity002 published Post scheduled from wp-admin"},
                          "name": "post__published",
                          "actor": {
@@ -116,6 +119,7 @@
                          }
                          },
                          {
+                         "summary": "Post Updated",
                          "content": {"text": "activity002 updated Post scheduled from wp-admin"},
                          "name": "post__updated",
                          "actor": {
@@ -150,6 +154,7 @@
                          }
                          },
                          {
+                         "summary": "Post Published",
                          "content": {"text": "activity002 published Post scheduled post"},
                          "name": "post__published",
                          "actor": {
@@ -184,6 +189,7 @@
                          }
                          },
                          {
+                         "summary": "Post Updated",
                          "content": {"text": "activity002 updated Post scheduled post"},
                          "name": "post__updated",
                          "actor": {
@@ -218,6 +224,7 @@
                          }
                          },
                          {
+                         "summary": "Post Updated",
                          "content": {"text": "activity002 updated Post scheduled post"},
                          "name": "post__updated",
                          "actor": {
@@ -252,6 +259,7 @@
                          }
                          },
                          {
+                         "summary": "User Added",
                          "content": {"text": "activity002 added user elibud to site."},
                          "name": "user__registered",
                          "actor": {
@@ -285,6 +293,7 @@
                          }
                          },
                          {
+                         "summary": "User Removed",
                          "content": {"text": "activity002 removed Elisa from site and reassigned their content to ."},
                          "name": "user__deleted",
                          "actor": {
@@ -325,6 +334,7 @@
                          }
                          },
                          {
+                         "summary": "User Modified",
                          "content": {"text": "activity002 modified user Elisa"},
                          "name": "user__updated",
                          "actor": {
@@ -358,6 +368,7 @@
                          }
                          },
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -391,6 +402,7 @@
                          }
                          },
                          {
+                         "summary": "User Logged Out",
                          "content": {"text": "activity002 logged out"},
                          "name": "user__logout",
                          "actor": {
@@ -424,6 +436,7 @@
                          }
                          },
                          {
+                         "summary": "User Added",
                          "content": {"text": "activity002 added user  to site."},
                          "name": "user__registered",
                          "actor": {
@@ -457,6 +470,7 @@
                          }
                          },
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -490,6 +504,7 @@
                          }
                          },
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "activity002 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -523,6 +538,7 @@
                          }
                          },
                          {
+                         "summary": "Post Published",
                          "content": {"text": " published post What would you do with\\u2026"},
                          "name": "post__published",
                          "actor": {
@@ -557,6 +573,7 @@
                          }
                          },
                          {
+                         "summary": "Login Succeeded",
                          "content": {"text": "Jurewicz72 logged in successfully"},
                          "name": "user__login",
                          "actor": {
@@ -590,6 +607,7 @@
                          }
                          },
                          {
+                         "summary": "Post Published",
                          "content": {"text": " published post RT @photomatt: Upload Once, Blog\\u2026"},
                          "name": "post__published",
                          "actor": {
@@ -624,6 +642,7 @@
                          }
                          },
                          {
+                         "summary": "Post Updated",
                          "content": {"text": " updated post RT @Lunarbaboon: New comic about\\u2026"},
                          "name": "post__updated",
                          "actor": {


### PR DESCRIPTION
**Another update for** #7832 

Recently the activity format changed to have two fields, a summary and a text. In this PR we a re updating the mobile version of the Activity Log to display the summary bolded and the activity text next to it.

**To test:**

On a site with the Activity Log enabled check that the feed looks good.

![simulator screen shot - iphone 8 - 2017-12-26 at 13 57 56](https://user-images.githubusercontent.com/5558824/34360979-d1957df8-ea44-11e7-9dc3-120d651727d4.png)

cc: @mattmiklic 
