### PR TITLE
Login: Tweaks magic link handling for jetpack logins.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginLinkRequestViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginLinkRequestViewController.swift
@@ -116,7 +116,7 @@ class LoginLinkRequestViewController: LoginViewController {
 
     @objc func didRequestAuthenticationLink() {
         WPAppAnalytics.track(.loginMagicLinkRequested)
-        SigninHelpers.saveEmailAddressForTokenAuth(loginFields.username)
+        SigninHelpers.storeLoginInfoForTokenAuth(loginFields)
         performSegue(withIdentifier: .showLinkMailView, sender: self)
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -10,7 +10,7 @@ import WordPressShared
     @objc static let WPSigninDidFinishNotification = "WPSigninDidFinishNotification"
 
     fileprivate enum Constants {
-        static let AuthenticationInfoKey = "AuthenticationInfoKey"
+        static let authenticationInfoKey = "authenticationInfoKey"
         static let jetpackBlogIDURL = "jetpackBlogIDURL"
         static let username = "username"
     }
@@ -358,13 +358,13 @@ import WordPressShared
     /// - Parameter loginFields: The loginFields instance from which to save.
     ///
     class func storeLoginInfoForTokenAuth(_ loginFields: LoginFields) {
-        let dict: NSMutableDictionary = [
+        var dict: [String: String] = [
             Constants.username: loginFields.username
         ]
         if let url = loginFields.meta.jetpackBlogID?.uriRepresentation().absoluteString {
-            dict.setValue(url, forKey: Constants.jetpackBlogIDURL)
+            dict[Constants.jetpackBlogIDURL] = url
         }
-        UserDefaults.standard.set(dict, forKey: Constants.AuthenticationInfoKey)
+        UserDefaults.standard.set(dict, forKey: Constants.authenticationInfoKey)
     }
 
 
@@ -373,7 +373,7 @@ import WordPressShared
     /// - Returns: A loginFields instance or nil.
     ///
     class func retrieveLoginInfoForTokenAuth() -> LoginFields? {
-        guard let dict = UserDefaults.standard.dictionary(forKey: Constants.AuthenticationInfoKey) else {
+        guard let dict = UserDefaults.standard.dictionary(forKey: Constants.authenticationInfoKey) else {
             return nil
         }
 
@@ -396,7 +396,7 @@ import WordPressShared
     /// Removes stored login information from NSUserDefaults
     ///
     class func deleteLoginInfoForTokenAuth() {
-        UserDefaults.standard.removeObject(forKey: Constants.AuthenticationInfoKey)
+        UserDefaults.standard.removeObject(forKey: Constants.authenticationInfoKey)
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninHelpers.swift
@@ -6,10 +6,14 @@ import WordPressShared
 /// A collection of helper methods for NUX.
 ///
 @objc class SigninHelpers: NSObject {
-    fileprivate static let AuthenticationEmailKey = "AuthenticationEmailKey"
     fileprivate static let WPComSuffix = ".wordpress.com"
     @objc static let WPSigninDidFinishNotification = "WPSigninDidFinishNotification"
 
+    fileprivate enum Constants {
+        static let AuthenticationInfoKey = "AuthenticationInfoKey"
+        static let jetpackBlogIDURL = "jetpackBlogIDURL"
+        static let username = "username"
+    }
 
     // MARK: - Helpers for presenting the login flow
 
@@ -113,15 +117,19 @@ import WordPressShared
             return false
         }
 
-        let accountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        if let account = accountService.defaultWordPressComAccount() {
-            DDLogInfo("App opened with authentication link but there is already an existing wpcom account. \(account)")
+        guard let loginFields = retrieveLoginInfoForTokenAuth() else {
+            DDLogInfo("App opened with authentication link but info wasn't found for token.")
             return false
         }
 
-        guard let email = getEmailAddressForTokenAuth() else {
-            DDLogInfo("App opened with authentication link but email wasn't found for token.")
-            return false
+        let accountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        if let account = accountService.defaultWordPressComAccount() {
+            // The only time we should expect a magic link login when there is already a default wpcom account
+            // is when a user is logging into Jetpack.
+            if !loginFields.meta.jetpackLogin {
+                DDLogInfo("App opened with authentication link but there is already an existing wpcom account. \(account)")
+                return false
+            }
         }
 
         let storyboard = UIStoryboard(name: "Login", bundle: nil)
@@ -129,7 +137,8 @@ import WordPressShared
             DDLogInfo("App opened with authentication link but couldn't create login screen.")
             return false
         }
-        loginController.email = email
+        loginController.loginFields = loginFields
+        loginController.email = loginFields.username
         loginController.token = token
         let controller = loginController
         WPAppAnalytics.track(.loginMagicLinkOpened)
@@ -156,7 +165,7 @@ import WordPressShared
             presenter.present(navController, animated: false, completion: nil)
         }
 
-        deleteEmailAddressForTokenAuth()
+        deleteLoginInfoForTokenAuth()
         return true
     }
 
@@ -342,31 +351,52 @@ import WordPressShared
     }
 
 
-    // MARK: - Helpers for Saved Magic Link Email
+    // MARK: - Helpers for Saved Magic Link Info
 
-
-    /// Saves the specified email address in NSUserDefaults
+    /// Saves certain login information in NSUserDefaults
     ///
-    /// - Parameter email: The email address to save.
+    /// - Parameter loginFields: The loginFields instance from which to save.
     ///
-    @objc class func saveEmailAddressForTokenAuth(_ email: String) {
-        UserDefaults.standard.set(email, forKey: AuthenticationEmailKey)
+    class func storeLoginInfoForTokenAuth(_ loginFields: LoginFields) {
+        let dict: NSMutableDictionary = [
+            Constants.username: loginFields.username
+        ]
+        if let url = loginFields.meta.jetpackBlogID?.uriRepresentation().absoluteString {
+            dict.setValue(url, forKey: Constants.jetpackBlogIDURL)
+        }
+        UserDefaults.standard.set(dict, forKey: Constants.AuthenticationInfoKey)
     }
 
 
-    /// Removes the saved email address from NSUserDefaults
+    /// Retrieves stored login information if any.
     ///
-    @objc class func deleteEmailAddressForTokenAuth() {
-        UserDefaults.standard.removeObject(forKey: AuthenticationEmailKey)
+    /// - Returns: A loginFields instance or nil.
+    ///
+    class func retrieveLoginInfoForTokenAuth() -> LoginFields? {
+        guard let dict = UserDefaults.standard.dictionary(forKey: Constants.AuthenticationInfoKey) else {
+            return nil
+        }
+
+        let loginFields = LoginFields()
+        if let username = dict[Constants.username] as? String {
+            loginFields.username = username
+        }
+
+        let store = ContextManager.sharedInstance().persistentStoreCoordinator
+        if  let path = dict[Constants.jetpackBlogIDURL] as? String,
+            let url = URL(string: path),
+            let objectID = store.managedObjectID(forURIRepresentation: url) {
+            loginFields.meta.jetpackBlogID = objectID
+        }
+
+        return loginFields
     }
 
 
-    /// Fetches a saved email address if one exists.
+    /// Removes stored login information from NSUserDefaults
     ///
-    /// - Returns: The email address as a string or nil.
-    ///
-    @objc class func getEmailAddressForTokenAuth() -> String? {
-        return UserDefaults.standard.string(forKey: AuthenticationEmailKey)
+    class func deleteLoginInfoForTokenAuth() {
+        UserDefaults.standard.removeObject(forKey: Constants.AuthenticationInfoKey)
     }
 
 

--- a/WordPress/WordPressTest/SigninHelperTests.swift
+++ b/WordPress/WordPressTest/SigninHelperTests.swift
@@ -115,14 +115,18 @@ class SigninHelperTests: XCTestCase {
 
     func testEmailAddressTokenHandling() {
         let email = "example@email.com"
+        let loginFields = LoginFields()
+        loginFields.username = email
+        SigninHelpers.storeLoginInfoForTokenAuth(loginFields)
 
-        SigninHelpers.saveEmailAddressForTokenAuth(email)
-        var retrievedEmail = SigninHelpers.getEmailAddressForTokenAuth()
+        var retrievedLoginFields = SigninHelpers.retrieveLoginInfoForTokenAuth()
+        let retrievedEmail = loginFields.username
         XCTAssert(email == retrievedEmail, "The email retrived should match the email that was saved.")
 
-        SigninHelpers.deleteEmailAddressForTokenAuth()
-        retrievedEmail = SigninHelpers.getEmailAddressForTokenAuth()
-        XCTAssert(retrievedEmail == nil, "Saved email should be deleted after calling deleteEmailAddressForTokenAuth.")
+        SigninHelpers.deleteLoginInfoForTokenAuth()
+        retrievedLoginFields = SigninHelpers.retrieveLoginInfoForTokenAuth()
+
+        XCTAssert(retrievedLoginFields == nil, "Saved loginFields should be deleted after calling deleteLoginInfoForTokenAuth.")
     }
 
 }


### PR DESCRIPTION
Fixes #8389 
This PR tweaks the way magic link logins are handled when the user is trying to log in to Jetpack.

Changes made include:
- Updates the information saved to UserDefaults so a Jetpack login is properly identified when launching the app via a magic link.
- Updates the default WordPress account check to allow a Jetpack connection.

This should resolve the issue where a user can be left on the "open email" screen after using a magic link.

**Note**: You can test magic links in the simulator by opening the magic link email in your desktop browser, copying the link (don't click on it) and then pasting the link in Safari in the simulator. 

To test:
**Scenario 1**:
Confirm magic links still function as expected. 

**Scenario 2**:
Be signed into a wpcom account. 
Add a self-hosted blog that is connected to Jetpack via a different wpcom account. 
Log into Jetpack via the stats screen and choose the magic link option. 
Confirm the link works and you end up viewing the stats screen for that blog.

@jleandroperez would you be game for a review? 

cc @nheagy @ScoutHarris @koke @elibud 
