### PR TITLE
Fix bottom padding in login on iPhone X

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SigninKeyboardResponder.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninKeyboardResponder.swift
@@ -148,7 +148,17 @@ extension SigninKeyboardResponder where Self: NUXAbstractViewController {
         if keyboardFrame.maxY > UIScreen.main.bounds.size.height {
             return view.frame.height - keyboardFrame.minY
         }
-        return keyboardFrame.height
+        var bottomAdjust: CGFloat = 0
+        var heightDelta = keyboardFrame.height
+        if #available(iOS 11, *) {
+            bottomAdjust = view.safeAreaInsets.bottom
+        }
+
+        if keyboardFrame.height > bottomAdjust {
+            heightDelta -= bottomAdjust
+        }
+
+        return heightDelta
     }
 
 }

--- a/WordPress/Classes/ViewRelated/NUX/SigninKeyboardResponder.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SigninKeyboardResponder.swift
@@ -148,17 +148,13 @@ extension SigninKeyboardResponder where Self: NUXAbstractViewController {
         if keyboardFrame.maxY > UIScreen.main.bounds.size.height {
             return view.frame.height - keyboardFrame.minY
         }
+
+        // If the safe area has a bottom height, subtract that.
         var bottomAdjust: CGFloat = 0
-        var heightDelta = keyboardFrame.height
         if #available(iOS 11, *) {
             bottomAdjust = view.safeAreaInsets.bottom
         }
-
-        if keyboardFrame.height > bottomAdjust {
-            heightDelta -= bottomAdjust
-        }
-
-        return heightDelta
+        return keyboardFrame.height - bottomAdjust
     }
 
 }


### PR DESCRIPTION
Fixes #8335

Login buttons now have appropriate padding on iPhone X:

![8335 iphone x padding fix](https://user-images.githubusercontent.com/517257/34421430-d086ddbc-ebd4-11e7-85a7-186a8623afdb.png)


To test:
- Ensure that the login button is in the right place on iOS 11 and 10 devices, on iPhone X, regular iPhone, and iPad

Needs review: @aerych 
Got time for one more before you go?
