### PR TITLE
Login: Adopts ImmuTable. Hides option when wpcom only.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -348,7 +348,7 @@ class LoginEmailViewController: LoginViewController, SigninKeyboardResponder {
                 errorDescription = error.localizedDescription
             }
 
-            let socialErrorVC = LoginSocialErrorViewController(title: errorTitle, description: errorDescription)
+            let socialErrorVC = LoginSocialErrorViewController(title: errorTitle, description: errorDescription, restrictToWPCom: restrictToWPCom)
             let socialErrorNav = LoginNavigationController(rootViewController: socialErrorVC)
             socialErrorVC.delegate = self
             present(socialErrorNav, animated: true) {}

--- a/WordPress/Classes/ViewRelated/NUX/LoginSocialErrorCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSocialErrorCell.swift
@@ -1,9 +1,7 @@
 class LoginSocialErrorCell: UITableViewCell {
-    private let errorTitle: String
-    private let errorDescription: String
-    private let titleLabel: UILabel
-    private let descriptionLabel: UILabel
-    private let labelStack: UIStackView
+    private let titleLabel = UILabel()
+    private let descriptionLabel = UILabel()
+    private let labelStack = UIStackView()
 
     private struct Constants {
         static let labelSpacing: CGFloat = 15.0
@@ -12,24 +10,18 @@ class LoginSocialErrorCell: UITableViewCell {
     }
 
     @objc init(title: String, description: String) {
-        errorTitle = title
-        errorDescription = description
-        titleLabel = UILabel()
-        descriptionLabel = UILabel()
-        labelStack = UIStackView()
-
         super.init(style: .default, reuseIdentifier: "LoginSocialErrorCell")
+        titleLabel.text = title
+        descriptionLabel.text = description
+        layoutLabels()
+    }
 
+    override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
         layoutLabels()
     }
 
     required init?(coder aDecoder: NSCoder) {
-        errorTitle = aDecoder.value(forKey: "errorTitle") as? String ?? ""
-        errorDescription = aDecoder.value(forKey: "errorDescription") as? String ?? ""
-        titleLabel = UILabel()
-        descriptionLabel = UILabel()
-        labelStack = UIStackView()
-
         super.init(coder: aDecoder)
 
         layoutLabels()
@@ -57,9 +49,11 @@ class LoginSocialErrorCell: UITableViewCell {
             contentView.layoutMarginsGuide.trailingAnchor.constraint(equalTo: labelStack.trailingAnchor)
             ])
 
+        backgroundColor = WPStyleGuide.greyLighten30()
+    }
+
+    func configureCell(_ errorTitle: String, errorDescription: String) {
         titleLabel.text = errorTitle.localizedUppercase
         descriptionLabel.text = errorDescription
-
-        backgroundColor = WPStyleGuide.greyLighten30()
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginSocialErrorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSocialErrorViewController.swift
@@ -12,33 +12,22 @@ protocol LoginSocialErrorViewControllerDelegate {
 class LoginSocialErrorViewController: UITableViewController, LoginWithLogoAndHelpViewController {
     fileprivate var errorTitle: String
     fileprivate var errorDescription: String
+    fileprivate var restrictToWPCom = false
     var helpBadge: WPNUXHelpBadgeLabel!
     var helpButton: UIButton!
     @objc var delegate: LoginSocialErrorViewControllerDelegate?
+    @objc var handler: ImmuTableViewHandler!
 
-    fileprivate enum Sections: Int {
-        case titleAndDescription = 0
-        case buttons = 1
-
-        static var count: Int {
-            return buttons.rawValue + 1
-        }
-    }
-
-    fileprivate enum Buttons: Int {
-        case tryEmail = 0
-        case tryAddress = 1
-        case signup = 2
-    }
 
     /// Create and instance of LoginSocialErrorViewController
     ///
     /// - Parameters:
     ///   - title: The title that will be shown on the error VC
     ///   - description: A brief explination of what failed during social login
-    @objc init(title: String, description: String) {
+    @objc init(title: String, description: String, restrictToWPCom: Bool) {
         errorTitle = title
         errorDescription = description
+        self.restrictToWPCom = restrictToWPCom
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -58,25 +47,59 @@ class LoginSocialErrorViewController: UITableViewController, LoginWithLogoAndHel
         helpButton = helpButtonResult
         helpBadge = helpBadgeResult
         addWordPressLogoToNavController()
+
+        ImmuTable.registerRows([
+            LoginSocialErrorDescriptionRow.self,
+            LoginSocialErrorButtonRow.self,
+            ], tableView: self.tableView)
+
+        handler = ImmuTableViewHandler(takeOver: self)
+        handler.viewModel = tableViewModel()
     }
 
-    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard indexPath.section == Sections.buttons.rawValue,
-            let delegate = delegate else {
-            return
-        }
+    fileprivate func tableViewModel() -> ImmuTable {
+        let descriptionRow = LoginSocialErrorDescriptionRow(title: errorTitle, detail: errorDescription)
 
-        switch indexPath.row {
-        case Buttons.tryEmail.rawValue:
-            delegate.retryWithEmail()
-        case Buttons.tryAddress.rawValue:
-            delegate.retryWithAddress()
-        case Buttons.signup.rawValue:
-            fallthrough
-        default:
-            delegate.retryAsSignup()
+        var buttonRows = [ImmuTableRow]()
+        buttonRows.append(LoginSocialErrorButtonRow(buttonText: NSLocalizedString("Try with another email", comment: "When social login fails, this button offers to let the user try again with a differen email address"),
+                                                    buttonIcon: Gridicon.iconOfType(.undo),
+                                                    action: retryWithEmailAction()))
+
+        if !restrictToWPCom {
+            buttonRows.append(LoginSocialErrorButtonRow(buttonText: NSLocalizedString("Try with the site address", comment: "When social login fails, this button offers to let them try tp login using a URL"),
+                                                        buttonIcon: Gridicon.iconOfType(.domains),
+                                                        action: retryWithAddressAction()))
+        }
+        buttonRows.append(LoginSocialErrorButtonRow(buttonText: NSLocalizedString("Sign up", comment: "When social login fails, this button offers to let them signup for a new WordPress.com account"),
+                                                    buttonIcon: Gridicon.iconOfType(.mySites),
+                                                    action: retryAsSignUpAction()))
+
+        return ImmuTable(sections: [
+            ImmuTableSection(rows: [descriptionRow]),
+            ImmuTableSection(rows: buttonRows)
+            ])
+
+    }
+
+    /// MARK: - ImmuTable Actions
+    func retryWithEmailAction() -> ImmuTableAction {
+        return { [weak self] _ in
+            self?.delegate?.retryWithEmail()
         }
     }
+
+    func retryWithAddressAction() -> ImmuTableAction {
+        return { [weak self] _ in
+            self?.delegate?.retryWithAddress()
+        }
+    }
+
+    func retryAsSignUpAction() -> ImmuTableAction {
+        return { [weak self] _ in
+            self?.delegate?.retryAsSignup()
+        }
+    }
+
 
     // MARK: - LoginWithLogoAndHelpViewController methods
 
@@ -92,93 +115,42 @@ class LoginSocialErrorViewController: UITableViewController, LoginWithLogoAndHel
 }
 
 
-// MARK: UITableViewDelegate methods
+// MARK: ImmuTableRows
 
-extension LoginSocialErrorViewController {
-    private struct RowHeightConstants {
-        static let estimate: CGFloat = 45.0
-        static let automatic: CGFloat = UITableViewAutomaticDimension
+struct LoginSocialErrorDescriptionRow: ImmuTableRow {
+    static let cell = ImmuTableCell.class(LoginSocialErrorCell.self)
+    var title: String = ""
+    var detail: String = ""
+    var action: ImmuTableAction?
+
+    init(title: String, detail: String) {
+        self.title = title
+        self.detail = detail
     }
 
-    override func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return RowHeightConstants.estimate
-    }
-
-    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return RowHeightConstants.automatic
+    func configureCell(_ cell: UITableViewCell) {
+        guard let cell = cell as? LoginSocialErrorCell else {
+            return
+        }
+        cell.configureCell(title, errorDescription: detail)
     }
 }
 
+struct LoginSocialErrorButtonRow: ImmuTableRow {
+    static let cell = ImmuTableCell.class(UITableViewCell.self)
+    var buttonText: String
+    var buttonIcon: UIImage
+    var action: ImmuTableAction?
 
-// MARK: UITableViewDataSource methods
-
-extension LoginSocialErrorViewController {
-    private struct Constants {
-        static let buttonCount = 3
+    init(buttonText: String, buttonIcon: UIImage, action: @escaping ImmuTableAction) {
+        self.buttonText = buttonText
+        self.buttonIcon = buttonIcon
+        self.action = action
     }
 
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        return Sections.count
-    }
-
-    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        switch section {
-        case Sections.titleAndDescription.rawValue:
-            return 1
-        case Sections.buttons.rawValue:
-            return Constants.buttonCount
-        default:
-            return 0
-        }
-    }
-
-    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell: UITableViewCell
-        switch indexPath.section {
-        case Sections.titleAndDescription.rawValue:
-            cell = titleAndDescriptionCell()
-        case Sections.buttons.rawValue:
-            fallthrough
-        default:
-            cell = buttonCell(index: indexPath.row)
-        }
-        return cell
-    }
-
-    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        let footer = UIView()
-        footer.backgroundColor = WPStyleGuide.greyLighten20()
-        return footer
-    }
-
-    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return 0.5
-    }
-
-    private func titleAndDescriptionCell() -> UITableViewCell {
-        return LoginSocialErrorCell(title: errorTitle, description: errorDescription)
-    }
-
-    private func buttonCell(index: Int) -> UITableViewCell {
-        let cell = UITableViewCell()
-        let buttonText: String
-        let buttonIcon: UIImage
-        switch index {
-        case Buttons.tryEmail.rawValue:
-            buttonText = NSLocalizedString("Try with another email", comment: "When social login fails, this button offers to let the user try again with a differen email address")
-            buttonIcon = Gridicon.iconOfType(.undo)
-        case Buttons.tryAddress.rawValue:
-            buttonText = NSLocalizedString("Try with the site address", comment: "When social login fails, this button offers to let them try tp login using a URL")
-            buttonIcon = Gridicon.iconOfType(.domains)
-        case Buttons.signup.rawValue:
-            fallthrough
-        default:
-            buttonText = NSLocalizedString("Sign up", comment: "When social login fails, this button offers to let them signup for a new WordPress.com account")
-            buttonIcon = Gridicon.iconOfType(.mySites)
-        }
+    func configureCell(_ cell: UITableViewCell) {
         cell.textLabel?.text = buttonText
         cell.textLabel?.textColor = WPStyleGuide.darkGrey()
         cell.imageView?.image = buttonIcon.imageWithTintColor(WPStyleGuide.grey())
-        return cell
     }
 }


### PR DESCRIPTION
Refs #8388 

For grins I thought I'd make a quick pass at a patch for #8388 before going afk. Since the current implementation relied on enums for sections, rows, and counts, and we'd need something a bit more flexible for conditionally showing content, I thought it might be interesting to see what an implementation based on ImmuTable would look like.

This seems to work okay for the error screen but I noticed `LoginSocialErrorCell` is also used in `SiteCreationDomainsViewController` and I haven't investigated how the changes here might impact how its used there. (I'm not too sure how best to view that screen just now.)

Feel free to use, modify, or reject this one as you see fit. :)

cc @nheagy and @ScoutHarris 

