### PR TITLE
Async Media: Add Write Post action to success notice

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -275,6 +275,8 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
         if let notice = model?.notice {
             ActionDispatcher.dispatch(NoticeAction.post(notice))
         }
+
+        mediaProgressCoordinator.stopTrackingOfAllMedia()
     }
 }
 

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -271,30 +271,10 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
     }
 
     func mediaProgressCoordinatorDidFinishUpload(_ mediaProgressCoordinator: MediaProgressCoordinator) {
-        if let notice = self.notice(for: mediaProgressCoordinator) {
+        let model = MediaProgressCoordinatorNoticeViewModel(mediaProgressCoordinator: mediaProgressCoordinator)
+        if let notice = model?.notice {
             ActionDispatcher.dispatch(NoticeAction.post(notice))
         }
-    }
-
-    private func notice(for mediaProgressCoordinator: MediaProgressCoordinator) -> Notice? {
-        guard !mediaProgressCoordinator.isRunning,
-            let progress = mediaProgressCoordinator.mediaGlobalProgress else {
-            return nil
-        }
-
-        guard !mediaProgressCoordinator.hasFailedMedia else {
-            return nil
-        }
-
-        let title: String
-        let completedUnits = progress.completedUnitCount
-        if completedUnits == 1 {
-            title = NSLocalizedString("Media uploaded (%ld file)", comment: "Alert displayed to the user when a single media item has uploaded successfully.")
-        } else {
-            title = NSLocalizedString("Media uploaded (%ld files)", comment: "Alert displayed to the user when multiple media items have uploaded successfully.")
-        }
-
-        return Notice(title: String.localizedStringWithFormat(title, completedUnits))
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -1,3 +1,4 @@
+
 struct MediaProgressCoordinatorNoticeViewModel {
     private let mediaProgressCoordinator: MediaProgressCoordinator
     private let progress: Progress

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -1,0 +1,62 @@
+struct MediaProgressCoordinatorNoticeViewModel {
+    private let mediaProgressCoordinator: MediaProgressCoordinator
+    private let progress: Progress
+
+    init?(mediaProgressCoordinator: MediaProgressCoordinator) {
+        guard !mediaProgressCoordinator.isRunning,
+            let progress = mediaProgressCoordinator.mediaGlobalProgress else {
+                return nil
+        }
+
+        guard !mediaProgressCoordinator.hasFailedMedia else {
+            return nil
+        }
+
+        self.mediaProgressCoordinator = mediaProgressCoordinator
+        self.progress = progress
+    }
+
+    var notice: Notice? {
+        if let blog = blogInContext {
+            return Notice(title: title,
+                          actionTitle: actionTitle,
+                          actionHandler: {
+                            let editor = EditPostViewController(blog: blog)
+                            editor.modalPresentationStyle = .fullScreen
+                            WPTabBarController.sharedInstance().present(editor, animated: false, completion: nil)
+                            WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "media_upload_notice"], with: blog)
+            })
+        } else {
+            return Notice(title: title)
+        }
+    }
+
+    var title: String {
+        let completedUnits = progress.completedUnitCount
+        if completedUnits == 1 {
+            return NSLocalizedString("Media uploaded (1 file)", comment: "Alert displayed to the user when a single media item has uploaded successfully.")
+        } else {
+            return String(format: NSLocalizedString("Media uploaded (%ld files)", comment: "Alert displayed to the user when multiple media items have uploaded successfully."), completedUnits)
+        }
+    }
+
+    let actionTitle: String = NSLocalizedString("Write Post", comment: "Button title. Opens the editor to write a new post.")
+
+    private var blogInContext: Blog? {
+        guard let mediaID = mediaProgressCoordinator.inProgressMediaIDs.first,
+            let media = mediaProgressCoordinator.media(withIdentifier: mediaID) else {
+                return nil
+        }
+
+        let context = ContextManager.sharedInstance().mainContext
+
+        var blog = media.blog
+        if blog.managedObjectContext != context,
+            let objectInContext = try? context.existingObject(with: blog.objectID),
+            let blogInContext = objectInContext as? Blog {
+            blog = blogInContext
+        }
+
+        return blog
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		17D1C22F1EFBFB6C0076734A /* FancyAlerts.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 17D1C22E1EFBFB6C0076734A /* FancyAlerts.storyboard */; };
 		17D2FDC21C6A468A00944265 /* PlanComparisonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */; };
 		17D4335A1EFD2F2900CAB602 /* FancyAlertViewController+AztecWhatsNew.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D433591EFD2F2900CAB602 /* FancyAlertViewController+AztecWhatsNew.swift */; };
+		17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */; };
 		17D975AF1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */; };
 		17EC9FC61DDC761D00D5BE8E /* UIWindow+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17EC9FC51DDC761D00D5BE8E /* UIWindow+Helpers.swift */; };
 		17F0AE301F091563007D5A6B /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F0AE2F1F091563007D5A6B /* ConfettiView.swift */; };
@@ -1307,6 +1308,7 @@
 		17D1C22E1EFBFB6C0076734A /* FancyAlerts.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = FancyAlerts.storyboard; sourceTree = "<group>"; };
 		17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanComparisonViewController.swift; sourceTree = "<group>"; };
 		17D433591EFD2F2900CAB602 /* FancyAlertViewController+AztecWhatsNew.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "FancyAlertViewController+AztecWhatsNew.swift"; sourceTree = "<group>"; };
+		17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProgressCoordinatorNoticeViewModel.swift; sourceTree = "<group>"; };
 		17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Aztec.swift"; sourceTree = "<group>"; };
 		17EC9FC51DDC761D00D5BE8E /* UIWindow+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIWindow+Helpers.swift"; sourceTree = "<group>"; };
 		17F0AE2F1F091563007D5A6B /* ConfettiView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfettiView.swift; sourceTree = "<group>"; };
@@ -3445,6 +3447,7 @@
 				1782BE831E70063100A91E7D /* MediaItemViewController.swift */,
 				177074841FB209F100951A4A /* MediaCellProgressView.swift */,
 				7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */,
+				17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -6674,6 +6677,7 @@
 				B50C0C661EF42B6400372C65 /* FormatBarItemProviders.swift in Sources */,
 				E137B1661F8B77D4006AC7FC /* WebNavigationDelegate.swift in Sources */,
 				937D9A0F19F83812007B9D5F /* WordPress-22-23.xcmappingmodel in Sources */,
+				17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */,
 				5D1D04761B7A50B100CDE646 /* ReaderStreamViewController.swift in Sources */,
 				B57B92BD1B73B08100DFF00B /* SeparatorsView.swift in Sources */,
 				E69BA1981BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m in Sources */,


### PR DESCRIPTION
Implements #8397.

This PR adds a "Write Post" action to the notice that is displayed when media finishes uploading asynchronously to the media library.

![simulator screen shot - iphone x - 2018-01-03 at 14 03 01](https://user-images.githubusercontent.com/4780/34523345-f247f9e0-f08e-11e7-8603-aa6516838407.png)

Tapping the Write Post button will display the editor for the blog you just uploaded media to.

**To test:**

* Select a blog and upload some media items using the async upload option in the media library
* Tap the Write Post button on the notice that's displayed, and ensure the editor is presented for the correct blog.
* Close the editor and upload media to a different blog. Ensure the notice shows the correct count for the media items you just uploaded, and that the Write Post button shows the editor for the new blog.
