### PR TITLE
Aztec: Data Loss

### DIFF
--- a/WordPress/Classes/Extensions/String+RegEx.swift
+++ b/WordPress/Classes/Extensions/String+RegEx.swift
@@ -57,13 +57,13 @@ extension String {
         var newString = self
 
         for match in matches.reversed() {
-            let matchRange = range(from: match.range)
+            let matchRange = range(fromUTF16NSRange: match.range)
             let matchString = String(self[matchRange])
 
             var submatchStrings = [String]()
 
             for submatchIndex in 0 ..< match.numberOfRanges {
-                let submatchRange = self.range(from: match.range(at: submatchIndex))
+                let submatchRange = self.range(fromUTF16NSRange: match.range(at: submatchIndex))
                 let submatchString = String(self[submatchRange])
 
                 submatchStrings.append(submatchString)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 		B538F3891EF46EC8001003D5 /* UnknownEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B538F3881EF46EC8001003D5 /* UnknownEditorViewController.swift */; };
 		B53971501D537763006135EC /* NotificationBlockGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = B539714F1D537763006135EC /* NotificationBlockGroup.swift */; };
 		B53971521D537B22006135EC /* NotificationBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53971511D537B22006135EC /* NotificationBlock.swift */; };
+		B539C2B01FFD52DC00CBC177 /* CalypsoProcessorOutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B539C2AF1FFD52DB00CBC177 /* CalypsoProcessorOutTests.swift */; };
 		B53AD9BC1BE95687009AB87E /* SettingsTextViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B53AD9B91BE95687009AB87E /* SettingsTextViewController.m */; };
 		B53AD9BF1BE9584B009AB87E /* SettingsSelectionViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = B53AD9BE1BE9584A009AB87E /* SettingsSelectionViewController.m */; };
 		B53B02B31CAC3AAC003190A0 /* GravatarPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53B02B21CAC3AAC003190A0 /* GravatarPickerViewController.swift */; };
@@ -1914,6 +1915,7 @@
 		B538F3881EF46EC8001003D5 /* UnknownEditorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UnknownEditorViewController.swift; sourceTree = "<group>"; };
 		B539714F1D537763006135EC /* NotificationBlockGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationBlockGroup.swift; sourceTree = "<group>"; };
 		B53971511D537B22006135EC /* NotificationBlock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationBlock.swift; sourceTree = "<group>"; };
+		B539C2AF1FFD52DB00CBC177 /* CalypsoProcessorOutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = CalypsoProcessorOutTests.swift; path = Aztec/CalypsoProcessorOutTests.swift; sourceTree = "<group>"; };
 		B53AD9B81BE95687009AB87E /* SettingsTextViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SettingsTextViewController.h; sourceTree = "<group>"; };
 		B53AD9B91BE95687009AB87E /* SettingsTextViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SettingsTextViewController.m; sourceTree = "<group>"; };
 		B53AD9BD1BE9584A009AB87E /* SettingsSelectionViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SettingsSelectionViewController.h; sourceTree = "<group>"; };
@@ -5556,6 +5558,7 @@
 				FF7691671EE06D1C00713F4B /* VideoProcessorTests.swift */,
 				FF8032651EE9E22200861F28 /* MediaProgressCoordinatorTests.swift */,
 				B55FFCFB1F0350700070812C /* CalypsoProcessorInTests.swift */,
+				B539C2AF1FFD52DB00CBC177 /* CalypsoProcessorOutTests.swift */,
 			);
 			name = Aztec;
 			sourceTree = "<group>";
@@ -7135,6 +7138,7 @@
 				E1AB5A091E0BF31E00574B4E /* ArrayTests.swift in Sources */,
 				93B853231B4416A30064FE72 /* WPAnalyticsTrackerAutomatticTracksTests.m in Sources */,
 				82301B8F1E787420009C9C4E /* AppRatingUtilityTests.swift in Sources */,
+				B539C2B01FFD52DC00CBC177 /* CalypsoProcessorOutTests.swift in Sources */,
 				74B335EC1F06F9520053A184 /* MockWordPressComRestApi.swift in Sources */,
 				E1926C091C779868009F3C2C /* PlanListViewControllerTest.swift in Sources */,
 				E135965D1E7152D1006C6606 /* RecentSitesServiceTests.swift in Sources */,

--- a/WordPress/WordPressTest/Aztec/CalypsoProcessorOutTests.swift
+++ b/WordPress/WordPressTest/Aztec/CalypsoProcessorOutTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import WordPress
+
+
+// MARK: - CalypsoProcessorOutTests
+//
+class CalypsoProcessorOutTests: XCTestCase {
+
+    let processor = CalypsoProcessorOut()
+
+    /// Verifies that strings containing emoji characters do not result in data loss.
+    ///
+    /// Reference: https://github.com/wordpress-mobile/AztecEditor-iOS/issues/885
+    ///
+    /// Input:
+    ///     - "Test &amp; Test 😊<br> lalalalala"
+    ///
+    /// Expected Output:
+    ///     - "Test &amp; Test 😊\nlalalalala"
+    ///
+    func testStringsWithEmojiDoNotResultInDataLoss() {
+        let input = "Test &amp; Test 😊<br> lalalalala"
+        let expected = "Test &amp; Test 😊\nlalalalala"
+        let output = processor.process(input)
+
+        XCTAssertEqual(output, expected)
+    }
+}


### PR DESCRIPTION
### Details:
In this PR we're fixing a NSRange conversion, source of a data loss bug.

Fixes #8399

### Details:
1. Launch WPiOS
2. Open Aztec and paste the sample HTML snippet attached below
3. Publish the post
4. Verify that the post shows up correctly
5. Edit the post in Aztec: Perform no changes, but hit the **update** button
6. Refresh the post in your browser

Verify that the post is in pristine condition, and no single character has been lost.

Needs Review: @diegoreymendez 
cc @bummytime 


--

```
Test &amp; Test 😊<strong>Test &amp; Test</strong>&lt;


1 tablespoon olive oil&lt;	 	 
 lb. sweet Italian sausage, removed from casings&lt;	 	 
 medium carrots, peeled, sliced into thin half-moons&lt;	 	 
 stalks celery, trimmed, thinly sliced&lt;	 	 
 medium yellow onion, diced small&lt;	 	 
 cloves garlic, minced&lt;	 	 
/4 cup tomato paste&lt;	 	 
 bay leaves&lt;	 	 
 tablespoon fresh thyme leaves (or 1/2 teaspoon dried)&lt;	 	 
/4 teaspoon red pepper flakes, optional&lt;	 	 
 cups chicken stock&lt;	 	 
-4 cups water (as needed)&lt;	 	 
 15-ounce cans cannellini beans, drained and rinsed (about 3 cups)&lt;	 	 
 bunch lacinato kale, cleaned, stems removed and torn into pieces&lt;	 	 
/4 cup chopped fresh parsley&lt;	 	 
osher or sea salt to taste, if needed
```

  