### PR TITLE
Notifications: Fixing Event Handling

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -753,7 +753,11 @@ private extension NotificationDetailsViewController {
 
         // Setup: Callbacks
         cell.onUrlClick = { [weak self] url in
-            self?.displayURL(url as URL)
+            guard let `self` = self, self.isViewOnScreen() else {
+                return
+            }
+
+            self.displayURL(url)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
@@ -98,8 +98,4 @@ class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource
         onAttachmentClick?(textAttachment)
         return false
     }
-
-
-    // MARK: - Constants
-    private static let defaultLabelPadding = UIEdgeInsets(top: 0.0, left: 12.0, bottom: 0.0, right: 12.0)
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
@@ -65,9 +65,9 @@ class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource
         selectionStyle = .none
 
         assert(textView != nil)
-        textView.contentInset = UIEdgeInsets.zero
-        textView.textContainerInset = UIEdgeInsets.zero
-        textView.backgroundColor = UIColor.clear
+        textView.contentInset = .zero
+        textView.textContainerInset = .zero
+        textView.backgroundColor = .clear
         textView.editable = false
         textView.selectable = true
         textView.dataDetectorTypes = UIDataDetectorTypes()

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
@@ -2,7 +2,13 @@ import Foundation
 import WordPressShared
 
 
+// MARK: - NoteBlockTextTableViewCell
+//
 class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource, RichTextViewDelegate {
+
+    // MARK: - IBOutlets
+    @IBOutlet private weak var textView: RichTextView!
+
     // MARK: - Public Properties
     @objc var onUrlClick: ((URL) -> Void)?
     @objc var onAttachmentClick: ((NSTextAttachment) -> Void)?
@@ -95,8 +101,5 @@ class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource
 
 
     // MARK: - Constants
-    @objc static let defaultLabelPadding = UIEdgeInsets(top: 0.0, left: 12.0, bottom: 0.0, right: 12.0)
-
-    // MARK: - IBOutlets
-    @IBOutlet fileprivate weak var textView: RichTextView!
+    private static let defaultLabelPadding = UIEdgeInsets(top: 0.0, left: 12.0, bottom: 0.0, right: 12.0)
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
@@ -79,7 +79,7 @@ class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource
 
 
     // MARK: - RichTextView Data Source
-    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange) -> Bool {
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         onUrlClick?(URL)
         return false
     }


### PR DESCRIPTION
### Details:
In this PR we're fixing a bug that caused `Stats are Booming` notification link, to redirect to a Website, instead of opening the native Stats.

Needs Review: @frosty 
Sir, may i bug you with a review?. Thanks in advance!!

Fixes #7070

### To test:
1. Receive a Stats are Booming notification (DM me! i've got a testing account ready!)
2. Open it's details
3. Perform a long press / regular press over any of the links

Verify that the native Stats UI shows up.

