### PR TITLE
BlogListViewController: Crash Failsafe

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -718,6 +718,13 @@ static NSInteger HideSearchMinSites = 3;
         }
     }
 
+    /// Issue #7284:
+    /// Prevents pushing BlogDetailsViewController, if it was already in the hierarchy.
+    ///
+    if ([self.navigationController.viewControllers containsObject:self.blogDetailsViewController]) {
+        return;
+    }
+
     [self.navigationController pushViewController:self.blogDetailsViewController animated:animated];
 }
 


### PR DESCRIPTION
### Details:
Although i couldn't directly reproduce this issue, in this PR we're adding a failsafe that should prevent any `BlogDetailsViewController` instance from being pushed, twice, in the blogList's navigation controller.

Needs Review: @nheagy 
Nate, maaaay i bug you with a hopefully simple PR?. I'm aware it's a band aid fix, but should be better than the actual crash. I could not find any flow to trigger the actual crash.

Thanks in advance!!

Closes #7284

### To test:
1. Verify that pushing any blog's details works correctly (from the blog list)
2. Trigger the 3d Touch menu from the springboard. Verify that `Stats` works a expected.

