### PR TITLE
Media Library Async: Show notice for failed uploads

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
@@ -98,6 +98,10 @@ public class MediaProgressCoordinator: NSObject {
             return
         }
         progress.setUserInfoObject(error, forKey: .mediaError)
+
+        DispatchQueue.main.async {
+            self.refreshMediaProgress()
+        }
     }
 
     // MARK: - Methods to check state of a mediaID process
@@ -186,10 +190,13 @@ public class MediaProgressCoordinator: NSObject {
         }
 
         for progress in mediaInProgress.values {
-            if !progress.isCancelled && (progress.totalUnitCount != progress.completedUnitCount) {
+            if !progress.isCancelled &&
+                !progress.isFailed &&
+                progress.totalUnitCount != progress.completedUnitCount {
                 return true
             }
         }
+
         return false
     }
 
@@ -197,12 +204,7 @@ public class MediaProgressCoordinator: NSObject {
     ///
     @objc
     var hasFailedMedia: Bool {
-        for progress in mediaInProgress.values {
-            if !progress.isCancelled && progress.userInfo[.mediaError] != nil {
-                return true
-            }
-        }
-        return false
+        return !failedMediaIDs.isEmpty
     }
 
     /// Returns a list of media IDs that were cancelled.
@@ -235,13 +237,7 @@ public class MediaProgressCoordinator: NSObject {
     ///
     @objc
     var failedMediaIDs: [String] {
-        var failedMediaIDs = [String]()
-        for (key, progress) in mediaInProgress {
-            if !progress.isCancelled && progress.userInfo[.mediaError] != nil {
-                failedMediaIDs.append(key)
-            }
-        }
-        return failedMediaIDs
+        return mediaInProgress.filter({ $0.value.isFailed }).map({ $0.key })
     }
 
     // MARK: - KeyPath observer method for the global progress property
@@ -321,5 +317,10 @@ public class MediaProgressCoordinator: NSObject {
             mediaInProgress.removeValue(forKey: key)
         }
     }
+}
 
+extension Progress {
+    var isFailed: Bool {
+        return !isCancelled && userInfo[.mediaError] != nil
+    }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3092,7 +3092,7 @@ extension AztecPostViewController {
 
         // Is upload still going?
         if let mediaProgress = mediaProgressCoordinator.progress(forMediaID: mediaID),
-            mediaProgress.completedUnitCount < mediaProgress.totalUnitCount {
+            mediaProgress.completedUnitCount < mediaProgress.totalUnitCount && !mediaProgress.isFailed {
             alertController.addActionWithTitle(NSLocalizedString("Stop Upload", comment: "User action to stop upload."),
                                                style: .destructive,
                                                handler: { (action) in

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -9,39 +9,80 @@ struct MediaProgressCoordinatorNoticeViewModel {
                 return nil
         }
 
-        guard !mediaProgressCoordinator.hasFailedMedia else {
-            return nil
-        }
-
         self.mediaProgressCoordinator = mediaProgressCoordinator
         self.progress = progress
     }
 
+    private var uploadSuccessful: Bool {
+        return !mediaProgressCoordinator.hasFailedMedia
+    }
+
     var notice: Notice? {
-        if let blog = blogInContext {
-            return Notice(title: title,
-                          actionTitle: actionTitle,
-                          actionHandler: {
-                            let editor = EditPostViewController(blog: blog)
-                            editor.modalPresentationStyle = .fullScreen
-                            WPTabBarController.sharedInstance().present(editor, animated: false, completion: nil)
-                            WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "media_upload_notice"], with: blog)
-            })
+        if uploadSuccessful {
+            return successNotice
         } else {
+            return failureNotice
+        }
+    }
+
+    private var successNotice: Notice {
+        guard let blog = blogInContext else {
             return Notice(title: title)
         }
+
+        return Notice(title: title,
+                      actionTitle: actionTitle,
+                      actionHandler: {
+                        let editor = EditPostViewController(blog: blog)
+                        editor.modalPresentationStyle = .fullScreen
+                        WPTabBarController.sharedInstance().present(editor, animated: false, completion: nil)
+                        WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "media_upload_notice"], with: blog)
+        })
+    }
+
+    private var failureNotice: Notice {
+        return Notice(title: title, message: message)
     }
 
     var title: String {
-        let completedUnits = progress.completedUnitCount
-        if completedUnits == 1 {
-            return NSLocalizedString("Media uploaded (1 file)", comment: "Alert displayed to the user when a single media item has uploaded successfully.")
+        if uploadSuccessful {
+            let completedUnits = progress.completedUnitCount
+            if completedUnits == 1 {
+                return NSLocalizedString("Media uploaded (1 file)", comment: "Alert displayed to the user when a single media item has uploaded successfully.")
+            } else {
+                return String(format: NSLocalizedString("Media uploaded (%ld files)", comment: "Alert displayed to the user when multiple media items have uploaded successfully."), completedUnits)
+            }
         } else {
-            return String(format: NSLocalizedString("Media uploaded (%ld files)", comment: "Alert displayed to the user when multiple media items have uploaded successfully."), completedUnits)
+            let failedUnits = mediaProgressCoordinator.failedMediaIDs.count
+            if failedUnits == 1 {
+                return NSLocalizedString("1 file not uploaded", comment: "Alert displayed to the user when a single media item has failed to upload.")
+            } else {
+                return String(format: NSLocalizedString("%ld files not uploaded", comment: "Alert displayed to the user when multiple media items have failed to upload."), failedUnits)
+            }
         }
     }
 
-    let actionTitle: String = NSLocalizedString("Write Post", comment: "Button title. Opens the editor to write a new post.")
+    var message: String? {
+        guard !uploadSuccessful else {
+            return nil
+        }
+
+        switch progress.completedUnitCount {
+        case 1:
+            return NSLocalizedString("1 file successfully uploaded", comment: "Alert displayed to the user when a single media item has failed to upload.")
+        case 1...:
+            return String(format: NSLocalizedString("%ld files successfully uploaded", comment: "Alert displayed to the user when multiple media items have failed to upload."), progress.completedUnitCount)
+        default: return nil
+        }
+    }
+
+    var actionTitle: String {
+        if uploadSuccessful {
+            return NSLocalizedString("Write Post", comment: "Button title. Opens the editor to write a new post.")
+        } else {
+            return NSLocalizedString("Retry", comment: "Button title, displayed when media has failed to upload. Allows the user to try the upload again.")
+        }
+    }
 
     private var blogInContext: Blog? {
         guard let mediaID = mediaProgressCoordinator.inProgressMediaIDs.first,

--- a/WordPressKit/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressKit/WordPressComRestApi.swift
@@ -247,10 +247,11 @@ open class WordPressComRestApi: NSObject {
         }
         serializeRequest(URLString, parameters: parameters, fileParts: fileParts, success:{ (request, temporaryURL) in
             let task = self.uploadSessionManager.uploadTask(with: request as URLRequest, fromFile: temporaryURL, progress: progressUpdater) { (response, result, error) in
-                progress.completedUnitCount = progress.totalUnitCount
                 if let error = error {
+                    progress.completedUnitCount = 0
                     failure(error as NSError, response as? HTTPURLResponse)
                 } else {
+                    progress.completedUnitCount = progress.totalUnitCount
                     guard let responseObject = result else {
                         failure(WordPressComRestApiError.unknown as NSError , response as? HTTPURLResponse)
                         return

--- a/WordPressKit/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -183,13 +183,14 @@ open class WordPressOrgXMLRPCApi: NSObject {
                     progress.totalUnitCount = requestProgress.totalUnitCount + 1
                     progress.completedUnitCount = requestProgress.completedUnitCount
                 }.response(queue: DispatchQueue.global()) { (response) in
-                    progress.completedUnitCount = progress.totalUnitCount
                     do {
                         let responseObject = try self.handleResponseWithData(response.data, urlResponse: response.response, error: response.error as NSError?)
+                        progress.completedUnitCount = progress.totalUnitCount
                         DispatchQueue.main.async {
                             success(responseObject, response.response)
                         }
                     } catch let error as NSError {
+                        progress.completedUnitCount = 0
                         DispatchQueue.main.async {
                             failure(error, response.response)
                         }


### PR DESCRIPTION
Implements #8402.

This PR adds a notice which will be displayed when async uploads fail in the media library.

If all current uploads fail to complete, a notice like this will be displayed:

![img_1124](https://user-images.githubusercontent.com/4780/34614562-cbd81564-f229-11e7-8ab4-f4d0deb1af07.PNG)

If any of the uploads are successful, that number will also be included:

![img_1125](https://user-images.githubusercontent.com/4780/34614565-ceb71f1e-f229-11e7-9bee-dcc79b922658.PNG)

I had to make some changes to the way failures are handled within `MediaProgressCoordinator` and `WordPressComRestApi` / XMLRPC to get this working, so it's important we test that this hasn't broken anything else. I added / changed some unit tests to verify this behaviour too.

I had to make these changes because I was seeing a problem where sometimes when uploads failed  a success message would be shown, or if only some uploads failed the wrong failure count would be shown. The issue seems to be with the previous behaviour:

* First, within the Rest API we were updating the upload's progress, then calling the failure or completion blocks.
* When the upload had either completed or failed, the progress would be set to 100%.
* This would trigger the progress observer in `MediaProgressCoordinator`. Because the failure block hadn't yet been called, we wouldn't have attached an error to the failed uploads, but the progress coordinator would detect the upload as complete / successful because the progress was 100%.

I changed this behaviour so that in the case of a failure we set the progress to 0%. Then, when the failure block is called, we'll attach the error and check if all of the uploads have completed or failed. If so, the `progress coordinator` is not `running` any more.

Hopefully this makes sense, but let me know if you have any questions! @SergioEstevao I'm tagging you for review, but I'm not expecting you to look at this until you're back from AFK!

**To test:**

In the media library, using the async upload function:

* Upload a few files and check they upload successfully and the success notice is shown
* Upload a few files and make them all fail (airplane mode or similar). Ensure the notice is shown with the correct count.
* Upload a few files and let some succeed and some fail. Again, check the correct counts are shown.
* Run unit tests.
* Check with both self hosted and wpcom
* Check that uploads in Aztec still work as expected.