### PR TITLE
NotificationsViewController: Prevents pushing multiple DetailsView

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -505,6 +505,7 @@ extension NotificationsViewController {
         markAsRead(note: note)
 
         // Display Details
+        //
         if let postID = note.metaPostID, let siteID = note.metaSiteID, note.kind == .Matcher {
             let readerViewController = ReaderDetailViewController.controllerWithPostID(postID, siteID: siteID)
             showDetailViewController(readerViewController, sender: nil)
@@ -515,8 +516,14 @@ extension NotificationsViewController {
         // would be missing entirely when launching the app from the background and presenting a notification.
         // The issue seems tied to performing a `pop` in `prepareToShowDetailsForNotification` and presenting
         // the new detail view controller at the same time. More info: https://github.com/wordpress-mobile/WordPress-iOS/issues/6976
+        //
+        // Plus: Avoid pushing multiple DetailsViewController's, upon quick & repeated touch events.
+        //
+        view.isUserInteractionEnabled = false
+
         DispatchQueue.main.async {
             self.performSegue(withIdentifier: NotificationDetailsViewController.classNameWithoutNamespaces(), sender: note)
+            self.view.isUserInteractionEnabled = true
         }
     }
 


### PR DESCRIPTION
### Details:
Although i've been unable to directly reproduce this crash, i've noted the following snippet in the crashlog:

```
6  WordPress                      0x1003f10c0 @objc NoteBlockActionsTableViewCell.replyWasPressed(AnyObject) -> () + 4299002048
```

**replyWasPressed** is expected to **only** be used in iPad Devices. On iPhone devices, the method should never run. Yet, we've got 86% of crashlogs on iPhone devices.

While testing this one, i've manated to trigger a scenario in which multiple DetailsViewController's get pushed ([sample video here](https://cloudup.com/cXaSLF9mqka)).

I'm suspecting the crashlogs are (somehow) picking invalid symbols // corrupt. In this PR we're preventing the "multiple details push", which may trigger a wide variety of issues.

We'll revisit if the crash shows up again in WPiOS 9.2.

Needs Review: @frosty 
Closes #7287

Last PR of the week, promise!! thanks in advance!!

--

### To test:
1. Launch WPiOS
2. Open the Notifications Tab

Verify that pressing any row multiple times (as quickly as possible) pushes the details view just once.




  