### PR TITLE
Uses specific XCTest matchers over XCTAssertEqual

### DIFF
--- a/WordPress/WordPressTest/PostListFilterTests.swift
+++ b/WordPress/WordPressTest/PostListFilterTests.swift
@@ -8,7 +8,7 @@ class PostListFilterTests: XCTestCase {
         let descriptors = filter.sortDescriptors
         XCTAssertEqual(descriptors.count, 1)
         XCTAssertEqual(descriptors[0].key, "date_created_gmt")
-        XCTAssertEqual(descriptors[0].ascending, false)
+        XCTAssertFalse(descriptors[0].ascending)
     }
 
 
@@ -17,7 +17,7 @@ class PostListFilterTests: XCTestCase {
         let descriptors = filter.sortDescriptors
         XCTAssertEqual(descriptors.count, 1)
         XCTAssertEqual(descriptors[0].key, "dateModified")
-        XCTAssertEqual(descriptors[0].ascending, false)
+        XCTAssertFalse(descriptors[0].ascending)
     }
 
     func testSortDescriptorForScheduled() {
@@ -25,7 +25,7 @@ class PostListFilterTests: XCTestCase {
         let descriptors = filter.sortDescriptors
         XCTAssertEqual(descriptors.count, 1)
         XCTAssertEqual(descriptors[0].key, "date_created_gmt")
-        XCTAssertEqual(descriptors[0].ascending, true)
+        XCTAssertTrue(descriptors[0].ascending)
     }
 
     func testSortDescriptorForTrashed() {
@@ -33,7 +33,7 @@ class PostListFilterTests: XCTestCase {
         let descriptors = filter.sortDescriptors
         XCTAssertEqual(descriptors.count, 1)
         XCTAssertEqual(descriptors[0].key, "date_created_gmt")
-        XCTAssertEqual(descriptors[0].ascending, false)
+        XCTAssertFalse(descriptors[0].ascending)
     }
 
     func testSectionIdentifiersMatchSortDescriptors() {


### PR DESCRIPTION
Hi there! I'm working on a [SwiftLint](https://github.com/realm/SwiftLint) rule which enforces specific matchers over `XCTAssertEqual` and `XCTAssertNotEqual`. For instance,  `XCTAssertEqual(true, foo)` throws a violations and suggests `XCTAssertTrue` instead.

SwiftLint's build system runs against popular open source software - which includes this one - and some violations were detected.

This pull request is just a suggestion. Feel free to reject it if it's relevant for the project.