### PR TITLE
Media async: Add retry action to failure notice

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
@@ -240,6 +240,12 @@ public class MediaProgressCoordinator: NSObject {
         return mediaInProgress.filter({ $0.value.isFailed }).map({ $0.key })
     }
 
+    /// Returns a list of all media objects that have an error attached
+    ///
+    var failedMedia: [Media] {
+        return failedMediaIDs.flatMap({ media(withIdentifier: $0) })
+    }
+
     // MARK: - KeyPath observer method for the global progress property
 
     public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -13,8 +13,7 @@ struct MediaProgressCoordinatorNoticeViewModel {
         self.mediaProgressCoordinator = mediaProgressCoordinator
         self.progress = progress
 
-        let failedMediaIDs = mediaProgressCoordinator.failedMediaIDs
-        failedMedia = failedMediaIDs.flatMap({ mediaProgressCoordinator.media(withIdentifier: $0) })
+        failedMedia = mediaProgressCoordinator.failedMedia
     }
 
     private var uploadSuccessful: Bool {

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -2,6 +2,7 @@
 struct MediaProgressCoordinatorNoticeViewModel {
     private let mediaProgressCoordinator: MediaProgressCoordinator
     private let progress: Progress
+    private let failedMedia: [Media]
 
     init?(mediaProgressCoordinator: MediaProgressCoordinator) {
         guard !mediaProgressCoordinator.isRunning,
@@ -11,6 +12,9 @@ struct MediaProgressCoordinatorNoticeViewModel {
 
         self.mediaProgressCoordinator = mediaProgressCoordinator
         self.progress = progress
+
+        let failedMediaIDs = mediaProgressCoordinator.failedMediaIDs
+        failedMedia = failedMediaIDs.flatMap({ mediaProgressCoordinator.media(withIdentifier: $0) })
     }
 
     private var uploadSuccessful: Bool {
@@ -41,7 +45,14 @@ struct MediaProgressCoordinatorNoticeViewModel {
     }
 
     private var failureNotice: Notice {
-        return Notice(title: title, message: message)
+        return Notice(title: title,
+                      message: message,
+                      actionTitle: NSLocalizedString("Retry", comment: "User action to retry media upload."),
+                      actionHandler: {
+                        for media in self.failedMedia {
+                            MediaCoordinator.shared.retryMedia(media)
+                        }
+        })
     }
 
     var title: String {


### PR DESCRIPTION
Refs #8409 

This PR adds the Retry action to failed media uploads.

**To test:**

* You have to be quite quick to test this! If you struggle, you can increase the `dismissDelay` in `NoticePresenter.Animations`.
* Start some media uploading in the media library and cause it to fail – for example, switch to airplane mode.
* As soon as the media's failed, turn off airplane mode and dismiss control center
* You should still see the 'failed to upload' notice at the bottom of the WP app – it should have a Retry button
* Tap Retry, and you should see the media attempt to upload again
