### PR TITLE
Fix date parsing for plugin directory entries

### DIFF
--- a/WordPressKit/WordPressKit/PluginDirectoryServiceRemote.swift
+++ b/WordPressKit/WordPressKit/PluginDirectoryServiceRemote.swift
@@ -4,6 +4,7 @@ import Alamofire
 public struct PluginDirectoryGetInformationEndpoint: Endpoint {
     static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
         formatter.dateFormat = "YYYY-MM-dd h:mma z"
         return formatter
     }()

--- a/WordPressKit/WordPressKit/PluginDirectoryServiceRemote.swift
+++ b/WordPressKit/WordPressKit/PluginDirectoryServiceRemote.swift
@@ -4,7 +4,7 @@ import Alamofire
 public struct PluginDirectoryGetInformationEndpoint: Endpoint {
     static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US")
+        formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.dateFormat = "YYYY-MM-dd h:mma z"
         return formatter
     }()


### PR DESCRIPTION
Fixes #8421 

To test:

- Make sure your phone/simulator is in Spanish
- Go to a site's plugins
- Make sure the icons are loading
