### PR TITLE
Rename pages section to site pages and move it up

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -420,17 +420,18 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Site Pages", @"Noun. Title. Links to the blog's Pages screen.")
+                                                    image:[Gridicon iconOfType:GridiconTypePages]
+                                                 callback:^{
+                                                     [weakSelf showPageList];
+                                                 }]];
+
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Blog Posts", @"Noun. Title. Links to the blog's Posts screen.")
                                                     image:[Gridicon iconOfType:GridiconTypePosts]
                                                  callback:^{
                                                      [weakSelf showPostList];
                                                  }]];
 
-    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Pages", @"Noun. Title. Links to the blog's Pages screen.")
-                                                    image:[Gridicon iconOfType:GridiconTypePages]
-                                                 callback:^{
-                                                     [weakSelf showPageList];
-                                                 }]];
 
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Media", @"Noun. Title. Links to the blog's Media library.")
                                                     image:[Gridicon iconOfType:GridiconTypeImage]

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -77,7 +77,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = NSLocalizedString("Pages", comment: "Tile of the screen showing the list of pages for a blog.")
+        title = NSLocalizedString("Site Pages", comment: "Tile of the screen showing the list of pages for a blog.")
     }
 
     // MARK: - Configuration

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -77,7 +77,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = NSLocalizedString("Site Pages", comment: "Tile of the screen showing the list of pages for a blog.")
+        title = NSLocalizedString("Site Pages", comment: "Title of the screen showing the list of pages for a blog.")
     }
 
     // MARK: - Configuration

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -110,7 +110,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = NSLocalizedString("Posts", comment: "Tile of the screen showing the list of posts for a blog.")
+        title = NSLocalizedString("Blog Posts", comment: "Title of the screen showing the list of posts for a blog.")
     }
 
     // MARK: - Configuration


### PR DESCRIPTION
**Fixes** #8419 

**To test:**
Check that the 'Pages' section title is updated to 'Site Pages' and that that section and the 'Blog Posts' section works correctly.
Also, 'Site Pages' should be the first item under 'Publish'

