### PR TITLE
Media Library: Add async support for capture and document picker

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -32,10 +32,6 @@ class MediaCoordinator: NSObject {
     /// - parameter blog: The blog that the asset should be added to.
     ///
     func addMedia(from asset: ExportableAsset, to blog: Blog) {
-        guard let asset = asset as? PHAsset else {
-            return
-        }
-
         let service = MediaService(managedObjectContext: backgroundContext)
         service.createMedia(with: asset,
                             objectID: blog.objectID,

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -537,7 +537,6 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             if let mediaInfo = mediaInfo as NSDictionary? {
                 self?.processMediaCaptured(mediaInfo)
             }
-            self?.useUploadCoordinator = false
             self?.capturePresenter = nil
         }
 
@@ -558,6 +557,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
 
             if FeatureFlag.asyncUploadsInMediaLibrary.enabled && strongSelf.useUploadCoordinator {
                 MediaCoordinator.shared.addMedia(from: media, to: strongSelf.blog)
+                strongSelf.useUploadCoordinator = false
             } else {
                 strongSelf.addMediaAssets([media])
             }


### PR DESCRIPTION
This PR updates image capture and "Other Apps" document selection to use the new async upload methods.

Note that the code will get a bit neater once we remove the feature flag.

**To test:**

* On a device, try the "Take Photo or Video" and "Other Apps" upload options.
* Check that they upload in an async manner, with no HUD
