### PR TITLE
Update plans icon to Jetpack logo

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -52,7 +52,7 @@ target 'WordPress' do
   # WordPress components
   # --------------------
   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.1'
-  pod 'Gridicons', '0.13'
+  pod 'Gridicons', '0.14'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.25'
   pod 'WordPress-Aztec-iOS', '1.0.0-beta.16'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -48,7 +48,7 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.1.3)
     - GoogleToolboxForMac/NSString+URLArguments (= 2.1.3)
   - GoogleToolboxForMac/NSString+URLArguments (2.1.3)
-  - Gridicons (0.13)
+  - Gridicons (0.14)
   - GTMOAuth2 (1.1.6):
     - GTMSessionFetcher (~> 1.1)
   - GTMSessionFetcher (1.1.12):
@@ -129,7 +129,7 @@ DEPENDENCIES:
   - FLAnimatedImage (= 1.0.12)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - GoogleSignIn (= 4.1.1)
-  - Gridicons (= 0.13)
+  - Gridicons (= 0.14)
   - HockeySDK (= 5.1.1)
   - lottie-ios (= 1.5.1)
   - MGSwipeTableCell (= 1.6.6)
@@ -173,7 +173,7 @@ SPEC CHECKSUMS:
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   GoogleSignIn: 3fdaa34a2ba04dbd7a25d7db39aecb0da98d5bdc
   GoogleToolboxForMac: 2501e2ad72a52eb3dfe7bd9aee7dad11b858bd20
-  Gridicons: f4125fa1e07b26e140f791d36f339973a8575261
+  Gridicons: 558073b1ff34092a49336ee0955ad97d2ef799f0
   GTMOAuth2: c77fe325e4acd453837e72d91e3b5f13116857b2
   GTMSessionFetcher: ebaa1f79a5366922c1735f1566901f50beba23b7
   HockeySDK: a240b3c62ac6b8ccd4301ee65cf25a8e5c9c0556
@@ -194,6 +194,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 80c7401edd8ca05d4277f43afc691662f3a26614
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 10e57c72f0861493d862a2899e5bd18f5ba530a3
+PODFILE CHECKSUM: 3562d507bced2844bb4fee5a3348d5a37505fd86
 
 COCOAPODS: 1.3.1

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -403,7 +403,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if ([self.blog supports:BlogFeaturePlans]) {
         BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Plans", @"Action title. Noun. Links to a blog's Plans screen.")
                                                          identifier:BlogDetailsPlanCellIdentifier
-                                                              image:[Gridicon iconOfType:GridiconTypeClipboard]
+                                                              image:[Gridicon iconOfType:GridiconTypePlans]
                                                            callback:^{
                                                                [weakSelf showPlans];
                                                            }];


### PR DESCRIPTION
**Fixes** #8418 

**To test:**
For a .com site go to Site Settings and check that the plan icons is now the Jetpack logo.
