### PR TITLE
Update pod file to use MediaPicker 0.26

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.1'
   pod 'Gridicons', '0.14'
   pod 'NSURL+IDN', '0.3'
-  pod 'WPMediaPicker', '0.25'
+  pod 'WPMediaPicker', '0.26'
   pod 'WordPress-Aztec-iOS', '1.0.0-beta.16'
 
   target 'WordPressTest' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -114,7 +114,7 @@ PODS:
   - SVProgressHUD (2.2.2)
   - UIDeviceIdentifier (0.5.0)
   - WordPress-Aztec-iOS (1.0.0-beta.16)
-  - WPMediaPicker (0.25)
+  - WPMediaPicker (0.26)
   - wpxmlrpc (0.8.3)
 
 DEPENDENCIES:
@@ -146,7 +146,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.2)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (= 1.0.0-beta.16)
-  - WPMediaPicker (= 0.25)
+  - WPMediaPicker (= 0.26)
   - wpxmlrpc (= 0.8.3)
 
 EXTERNAL SOURCES:
@@ -191,9 +191,9 @@ SPEC CHECKSUMS:
   SVProgressHUD: 59b2d3dabacbd051576d21d32293ca7228dc18b0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-Aztec-iOS: 2cfc5bb64f44b79af11659f7dd7a256a1033092e
-  WPMediaPicker: 80c7401edd8ca05d4277f43afc691662f3a26614
+  WPMediaPicker: 847c1f84f93fda7dda8cc9a8cbc1ffb6e47dea63
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 3562d507bced2844bb4fee5a3348d5a37505fd86
+PODFILE CHECKSUM: 5417dd6c474ecda1054de781eec8e7327f809158
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
Updates the media picker to version 0.26

There wasn't any API changes on this version it's mainly bug fixes inside the pod, so the changes are very small, check [here](https://github.com/wordpress-mobile/MediaPicker-iOS/milestone/51?closed=1) to see what they were.

To test:
 - Run the app and just see if the main uses of the picker are correct: Media Library, Post Editor, Site Icon Picker, Gravatar Picker.

