### PR TITLE
Improve alert when removing a plugin.

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -135,7 +135,7 @@ class PluginViewModel: Observable {
         } else {
             disclaimer = NSLocalizedString("This will delete all associated files and data.", comment: "Warning when confirming to remove a plugin that's inactive")
         }
-        let message = "\(question) \(disclaimer)"
+        let message = "\(question)\n\(disclaimer)"
         let alert = UIAlertController(
             title: NSLocalizedString("Remove Plugin?", comment: "Title for the alert to confirm a plugin removal"),
             message: message, preferredStyle: .alert)

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -118,14 +118,24 @@ class PluginViewModel: Observable {
     }
 
     private func confirmRemovalAlert(plugin: Plugin) -> UIAlertController {
-        let message: String
+        let question: String
         if let siteTitle = getSiteTitle() {
-            let messageTemplate = NSLocalizedString("Are you sure you want to remove %1$@ from %2$@? This will deactivate the plugin and delete all associated files and data.", comment: "Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title.")
-            message = String(format: messageTemplate, plugin.name, siteTitle)
+            question = String(
+                format: NSLocalizedString("Are you sure you want to remove %1$@ from %2$@?", comment: "Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title."),
+                plugin.name,
+                siteTitle)
         } else {
-            let messageTemplate = NSLocalizedString("Are you sure you want to remove %1$@? This will deactivate the plugin and delete all associated files and data.", comment: "Text for the alert to confirm a plugin removal. %1$@ is the plugin name.")
-            message = String(format: messageTemplate, plugin.name)
+            question = String(
+                format: NSLocalizedString("Are you sure you want to remove %1$@?", comment: "Text for the alert to confirm a plugin removal. %1$@ is the plugin name."),
+                plugin.name)
         }
+        let disclaimer: String
+        if plugin.state.active {
+            disclaimer = NSLocalizedString("This will deactivate the plugin and delete all associated files and data.", comment: "Warning when confirming to remove a plugin that's active")
+        } else {
+            disclaimer = NSLocalizedString("This will delete all associated files and data.", comment: "Warning when confirming to remove a plugin that's inactive")
+        }
+        let message = "\(question) \(disclaimer)"
         let alert = UIAlertController(
             title: NSLocalizedString("Remove Plugin?", comment: "Title for the alert to confirm a plugin removal"),
             message: message, preferredStyle: .alert)


### PR DESCRIPTION
If the plugin is not active, don't say it will deactivate on removal

Fixes #8424 

To test:

- Try to remove a plugin
- If it's active, the alert should say it will deactivate
- If it's inactive, the alert should not say it will deactivate
