### PR TITLE
Remove file import / iCloud Files feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -3,7 +3,6 @@
 @objc
 enum FeatureFlag: Int {
     case exampleFeature
-    case iCloudFilesSupport
     case socialSignup
     case jetpackDisconnect
     case activity
@@ -14,8 +13,6 @@ enum FeatureFlag: Int {
         switch self {
         case .exampleFeature:
             return true
-        case .iCloudFilesSupport:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .socialSignup:
             return BuildConfiguration.current == .localDeveloper
         case .jetpackDisconnect:

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2316,7 +2316,7 @@ extension AztecPostViewController {
 
         toolbarButtons.append(makeToolbarButton(identifier: .mediaLibrary))
 
-        if #available(iOS 11, *), FeatureFlag.iCloudFilesSupport.enabled {
+        if #available(iOS 11, *) {
             toolbarButtons.append(makeToolbarButton(identifier: .otherApplications))
         }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -236,24 +236,14 @@ class MediaLibraryViewController: WPMediaPickerViewController {
     // MARK: - Actions
 
     @objc fileprivate func addTapped() {
-        if #available(iOS 11, *), FeatureFlag.iCloudFilesSupport.enabled {
-            showOptionsMenu()
-        }
-        else {
-            showMediaPicker()
-        }
+        showOptionsMenu()
     }
 
     private func showMediaPicker() {
         let options = WPMediaPickerOptions()
         options.showMostRecentFirst = true
         options.filter = [.all]
-
-        // If iOS11, media capture is available via showOptionsMenu()
-        if #available(iOS 11, *) {
-            // NOTE: once iCloudFilesSupport is permanently enabled, this needs to be false.
-            options.allowCaptureOfMedia = !(FeatureFlag.iCloudFilesSupport.enabled)
-        }
+        options.allowCaptureOfMedia = false
 
         let picker = WPNavigationMediaPickerViewController(options: options)
         picker.dataSource = WPPHAssetDataSource()
@@ -275,8 +265,10 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             self.showMediaPicker()
         }
 
-        menuAlert.addDefaultActionWithTitle(NSLocalizedString("Other Apps", comment: "Menu option used for adding media from other applications.")) { _ in
-            self.showDocumentPicker()
+        if #available(iOS 11.0, *) {
+            menuAlert.addDefaultActionWithTitle(NSLocalizedString("Other Apps", comment: "Menu option used for adding media from other applications.")) { _ in
+                self.showDocumentPicker()
+            }
         }
 
         menuAlert.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Cancel button"))


### PR DESCRIPTION
This PR removes the feature flag for iCloud Files / other apps import in the media library and Aztec. Note that this feature is only available in iOS 11.

**To test:**

* Go to a site's Media Library, tap the + button and check that:
  * On iOS 11 there is an 'Other Apps' option, and you can use it to import a file to the app.
  * On iOS 10, there's just a Photo Library and (if you're testing on a device) a "Take Photo or Video" option.
* Open the editor, tap the + button on the left of the formatting toolbar and check that:
  * On iOS 11 there is a '...' option, and you can use it to import a file to the app.
  * On iOS 10, there's just a Photo Library, Media Library, and (if you're testing on a device) a Camera option.