### PR TITLE
Fix incorrectly formatted string

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -136,8 +136,9 @@ extension ActivityListViewController: ActivityRewindPresenter {
         let title = NSLocalizedString("Rewind Site",
                                       comment: "Title displayed in the Rewind Site alert, should match Calypso")
         let rewindDate = activity.published.mediumStringWithUTCTime()
-        let message = NSLocalizedString("Are you sure you want to rewind your site back to \(rewindDate)\nThis will remove all content and options created or changed since then.",
-                                        comment: "Mesage displayed in the Rewind Site alert, the palceholder holds a date, should match Calypso.")
+        let messageFormat = NSLocalizedString("Are you sure you want to rewind your site back to %@\nThis will remove all content and options created or changed since then.",
+                                              comment: "Message displayed in the Rewind Site alert, the placeholder holds a date, should match Calypso.")
+        let message = String(format: messageFormat, rewindDate)
 
         let alertController = UIAlertController(title: title,
                                                 message: message,

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -136,7 +136,7 @@ extension ActivityListViewController: ActivityRewindPresenter {
         let title = NSLocalizedString("Rewind Site",
                                       comment: "Title displayed in the Rewind Site alert, should match Calypso")
         let rewindDate = activity.published.mediumStringWithUTCTime()
-        let messageFormat = NSLocalizedString("Are you sure you want to rewind your site back to %@\nThis will remove all content and options created or changed since then.",
+        let messageFormat = NSLocalizedString("Are you sure you want to rewind your site back to %@?\nThis will remove all content and options created or changed since then.",
                                               comment: "Message displayed in the Rewind Site alert, the placeholder holds a date, should match Calypso.")
         let message = String(format: messageFormat, rewindDate)
 


### PR DESCRIPTION
This PR fixes a string that was being formatted in a way that was problematic for translators.

**To test:**

On a Jetpack site:
1. Go to Site Settings -> Activity
2. Tap on an activity that has a blue ribbon on the left
3. Check that the string looks good

cc: @akirk 

