### PR TITLE
Fix media thumbnail generation

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -66,7 +66,9 @@
         media.mediaType = exportable.assetMediaType;
         media.remoteStatus = MediaRemoteStatusProcessing;
         [self.managedObjectContext save: nil];
+    }];
 
+    [self.managedObjectContext performBlock:^{
         // Setup completion handlers
         void(^completionWithMedia)(Media *) = ^(Media *media) {
             // Pre-generate a thumbnail image, see the method notes.

--- a/WordPress/Classes/Services/MediaThumbnailService.swift
+++ b/WordPress/Classes/Services/MediaThumbnailService.swift
@@ -75,7 +75,7 @@ class MediaThumbnailService: LocalCoreDataService {
             let attemptDownloadingThumbnail: () -> Void = {
                 self.downloadThumbnail(forMedia: media, preferredSize: preferredSize, onCompletion: { (image) in
                     guard let image = image else {
-                        onCompletion(nil)
+                        onError?(MediaThumbnailExporter.ThumbnailExportError.failedToGenerateThumbnailFileURL)
                         return
                     }
                     self.exportQueue.async {

--- a/WordPress/Classes/Utility/Media/MediaImageExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaImageExporter.swift
@@ -181,7 +181,7 @@ class MediaImageExporter: MediaExporter {
                 throw ImageExportError.imageSourceIsAnUnknownType
             }
             return exportImageSource(source,
-                              filename: url.deletingPathExtension().lastPathComponent,
+                              filename: UUID().uuidString,
                               type: options.exportImageType ?? utType as String,
                               onCompletion: onCompletion,
                               onError: onError)

--- a/WordPress/Classes/Utility/Media/MediaThumbnailExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaThumbnailExporter.swift
@@ -165,7 +165,7 @@ class MediaThumbnailExporter: MediaExporter {
     ///
     @discardableResult func exportThumbnail(forImage image: UIImage, onCompletion: @escaping OnThumbnailExport, onError: @escaping OnExportError) -> Progress {
         let exporter = MediaImageExporter(image: image, filename: UUID().uuidString)
-        exporter.mediaDirectoryType = .cache
+        exporter.mediaDirectoryType = .temporary
         exporter.options = imageExporterOptions
         return exporter.export(onCompletion: { (export) in
                                 self.exportImageToThumbnailCache(export, onCompletion: onCompletion, onError: onError)


### PR DESCRIPTION
Fixes 

This PR tries to address issues with thumbnail generation where sometimes thumbnails are not being create at all.

To test:
 - Open the app
 - Open the media library of a site ( preferably one that wasn't sync before)
 - Check if thumbnail are generated correctly
 - Try the same by adding new media to the media library.


