### PR TITLE
Activity Log: Step 1 for design v1

### DIFF
--- a/WordPress/Classes/Extensions/Array.swift
+++ b/WordPress/Classes/Extensions/Array.swift
@@ -37,3 +37,29 @@ extension Array where Element: Equatable {
         })
     }
 }
+
+extension Array {
+    /// Returns an array of [(Value, [Element])] resulting of grouping the sorted elements
+    /// of the original array by Value.
+    ///
+    public func sortedGroup<Value: Equatable>(keyPath: KeyPath<Element, Value>) -> [(Value, [Element])] {
+        var currentValue: Value?
+        var currentGroup = [Element]()
+        var result = [(Value, [Element])]()
+        forEach { (element) in
+            let value = element[keyPath: keyPath]
+            if currentValue != value {
+                if let currentValue = currentValue {
+                    result.append((currentValue, currentGroup))
+                }
+                currentValue = value
+                currentGroup = []
+            }
+            currentGroup.append(element)
+        }
+        if let currentValue = currentValue {
+            result.append((currentValue, currentGroup))
+        }
+        return result
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -114,6 +114,14 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
 
 }
 
+// MARK: - UITableViewDelegate
+
+extension ActivityListViewController {
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 0.0
+    }
+}
+
 // MARK: - WPNoResultsViewDelegate
 
 extension ActivityListViewController: WPNoResultsViewDelegate {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -394,7 +394,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     if ([Feature enabled:FeatureFlagActivity] && [self.blog supports:BlogFeatureActivity]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Activity", @"Noun. Links to a blog's Activity screen.")
-                                                        image:[Gridicon iconOfType:GridiconTypeStatsAlt]
+                                                        image:[Gridicon iconOfType:GridiconTypeHistory]
                                                      callback:^{
                                                          [weakSelf showActivity];
                                                      }]];

--- a/WordPress/WordPressTest/Extensions/ArrayTests.swift
+++ b/WordPress/WordPressTest/Extensions/ArrayTests.swift
@@ -35,4 +35,55 @@ class ArrayTests: XCTestCase {
         let result = test.differentIndices(other)
         XCTAssertEqual(result, [1])
     }
+
+    func testSortedGroupEmptyArray() {
+        let test = [TestElement]()
+        let result = test.sortedGroup(keyPath: \TestElement.key)
+        XCTAssertEqual(result.count, 0)
+    }
+
+    func testSortedGroupCase1() {
+        let test: [TestElement] = [TestElement(key: "a", value: 1), TestElement(key: "a", value: 2)]
+        let result = test.sortedGroup(keyPath: \TestElement.key)
+        XCTAssertEqual(result[0].0, test[0].key)
+        XCTAssertEqual(result[0].1[0], test[0])
+        XCTAssertEqual(result[0].1[1], test[1])
+    }
+
+    func testSortedGroupCase2() {
+        let test: [TestElement] = [TestElement(key: "a", value: 1), TestElement(key: "b", value: 1)]
+        let result = test.sortedGroup(keyPath: \TestElement.key)
+        XCTAssertEqual(result[0].0, test[0].key)
+        XCTAssertEqual(result[1].0, test[1].key)
+        XCTAssertEqual(result[0].1[0], test[0])
+        XCTAssertEqual(result[1].1[0], test[1])
+    }
+
+    func testSortedGroupCase3() {
+        let test: [TestElement] = [TestElement(key: "a", value: 1), TestElement(key: "b", value: 1),
+                                   TestElement(key: "b", value: 2), TestElement(key: "c", value: 1)]
+        let result = test.sortedGroup(keyPath: \TestElement.key)
+        XCTAssertEqual(result[0].0, test[0].key)
+        XCTAssertEqual(result[1].0, test[1].key)
+        XCTAssertEqual(result[2].0, test[3].key)
+        XCTAssertEqual(result[0].1[0], test[0])
+        XCTAssertEqual(result[1].1[0], test[1])
+        XCTAssertEqual(result[1].1[1], test[2])
+        XCTAssertEqual(result[2].1[0], test[3])
+    }
+
+}
+
+class TestElement: Equatable {
+    var key: String
+    var value: Int
+
+    init(key: String, value: Int) {
+        self.key = key
+        self.value = value
+    }
+}
+
+func ==(lhs: TestElement, rhs: TestElement) -> Bool {
+    return lhs.key == rhs.key && lhs.value == rhs.value
 }

--- a/WordPressKit/WordPressKit/Activity.swift
+++ b/WordPressKit/WordPressKit/Activity.swift
@@ -78,6 +78,10 @@ public class Activity {
         return self.name == ActivityName.fullBackup
     }()
 
+    public lazy var publishedDateUTCWithoutTime: String = {
+        return self.published.longUTCStringWithoutTime()
+    }()
+
 }
 
 private extension Activity {

--- a/WordPressShared/WordPressShared/NSDate+Helpers.swift
+++ b/WordPressShared/WordPressShared/NSDate+Helpers.swift
@@ -44,6 +44,14 @@ extension Date {
             return formatter
         }()
 
+        static let longUTCDate: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.dateStyle = .long
+            formatter.timeStyle = .none
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            return formatter
+        }()
+
         static let shortDateTime: DateFormatter = {
             let formatter = DateFormatter()
             formatter.doesRelativeDateFormatting = true
@@ -126,6 +134,14 @@ extension Date {
     ///
     public func mediumStringWithTime() -> String {
         return DateFormatters.mediumDateTime.string(from: self)
+    }
+
+    /// Formats the current date as (non relative) long date (no time) in UTC.
+    ///
+    /// - Example: January 6th, 2018
+    ///
+    public func longUTCStringWithoutTime() -> String {
+        return DateFormatters.longUTCDate.string(from: self)
     }
 
     /// Formats the current date as (non relattive) medium date/time in UTC.


### PR DESCRIPTION
Another step on https://github.com/wordpress-mobile/WordPress-iOS/issues/7832

- Updated Activity icon on the blog settings screen.
- Grouped activities by date on the feed.
- Filtered out discarded activities.

**To test:**

On a site with AL enabled check that what  you see on mobile matches the web minus the discarded activities, which will not be displayed on mobile for now as per the last designs from @mattmiklic.

The grouping code on `ActivityListViewModel` is not meant to be permanent since we will have to face the paging + persistence issue eventually.

