### PR TITLE
Integrates the latest from Aztec into WPiOS.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -55,7 +55,7 @@ target 'WordPress' do
   pod 'Gridicons', '0.14'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.26'
-  pod 'WordPress-Aztec-iOS', '1.0.0-beta.16'
+  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '9291295aa7b97313e271b97e3e84238d1d379cea'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile
+++ b/Podfile
@@ -55,7 +55,7 @@ target 'WordPress' do
   pod 'Gridicons', '0.14'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.26'
-  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '9291295aa7b97313e271b97e3e84238d1d379cea'
+  pod 'WordPress-Aztec-iOS', '=1.0.0-beta.17'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -113,7 +113,7 @@ PODS:
   - Starscream (3.0.3)
   - SVProgressHUD (2.2.2)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0-beta.16)
+  - WordPress-Aztec-iOS (1.0.0-beta.15)
   - WPMediaPicker (0.26)
   - wpxmlrpc (0.8.3)
 
@@ -145,7 +145,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.3)
   - SVProgressHUD (= 2.2.2)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (= 1.0.0-beta.16)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `9291295aa7b97313e271b97e3e84238d1d379cea`)
   - WPMediaPicker (= 0.26)
   - wpxmlrpc (= 0.8.3)
 
@@ -153,11 +153,17 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
+  WordPress-Aztec-iOS:
+    :commit: 9291295aa7b97313e271b97e3e84238d1d379cea
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
+  WordPress-Aztec-iOS:
+    :commit: 9291295aa7b97313e271b97e3e84238d1d379cea
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -190,10 +196,10 @@ SPEC CHECKSUMS:
   Starscream: dfb1b3f39506717ee52b67fb48de0c8269504cbc
   SVProgressHUD: 59b2d3dabacbd051576d21d32293ca7228dc18b0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 2cfc5bb64f44b79af11659f7dd7a256a1033092e
+  WordPress-Aztec-iOS: aec0aef6608a79d8120b40717d6f14ec7ec5ae59
   WPMediaPicker: 847c1f84f93fda7dda8cc9a8cbc1ffb6e47dea63
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 5417dd6c474ecda1054de781eec8e7327f809158
+PODFILE CHECKSUM: b12310056368b48e44c19f58c59110e7019c76d1
 
 COCOAPODS: 1.3.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -113,7 +113,7 @@ PODS:
   - Starscream (3.0.3)
   - SVProgressHUD (2.2.2)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0-beta.15)
+  - WordPress-Aztec-iOS (1.0.0-beta.17)
   - WPMediaPicker (0.26)
   - wpxmlrpc (0.8.3)
 
@@ -145,7 +145,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.3)
   - SVProgressHUD (= 2.2.2)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `9291295aa7b97313e271b97e3e84238d1d379cea`)
+  - WordPress-Aztec-iOS (= 1.0.0-beta.17)
   - WPMediaPicker (= 0.26)
   - wpxmlrpc (= 0.8.3)
 
@@ -153,17 +153,11 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
-  WordPress-Aztec-iOS:
-    :commit: 9291295aa7b97313e271b97e3e84238d1d379cea
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
-  WordPress-Aztec-iOS:
-    :commit: 9291295aa7b97313e271b97e3e84238d1d379cea
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -196,10 +190,10 @@ SPEC CHECKSUMS:
   Starscream: dfb1b3f39506717ee52b67fb48de0c8269504cbc
   SVProgressHUD: 59b2d3dabacbd051576d21d32293ca7228dc18b0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: aec0aef6608a79d8120b40717d6f14ec7ec5ae59
+  WordPress-Aztec-iOS: 0f8ffe01c51d0df7a3a73d91cb52331e63f80d49
   WPMediaPicker: 847c1f84f93fda7dda8cc9a8cbc1ffb6e47dea63
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: b12310056368b48e44c19f58c59110e7019c76d1
+PODFILE CHECKSUM: 93a4349f448c176c393a7473fc8168d9b716902d
 
 COCOAPODS: 1.3.1

--- a/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
+++ b/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
@@ -34,7 +34,7 @@ class PostAttachmentTests: XCTestCase {
         let imageName = "someExampleImage.jpg"
         let altValue = "additional alt"
 
-        let richTextView = TextView(defaultFont: UIFont(), defaultMissingImage: UIImage())
+        let richTextView = TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: UIImage())
         let delegate = MockAttachmentDelegate()
         richTextView.textAttachmentDelegate = delegate
         richTextView.attributedText = NSAttributedString(string: prefixString)
@@ -68,7 +68,7 @@ class PostAttachmentTests: XCTestCase {
         let imageName = "someExampleImage.jpg"
         let altValue = ""
 
-        let richTextView = TextView(defaultFont: UIFont(), defaultMissingImage: UIImage())
+        let richTextView = TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: UIImage())
         let delegate = MockAttachmentDelegate()
         richTextView.textAttachmentDelegate = delegate
         richTextView.attributedText = NSAttributedString(string: prefixString)
@@ -102,7 +102,7 @@ class PostAttachmentTests: XCTestCase {
         let imageName = "someExampleImage.jpg"
         let linkURLValue = URL(string: "https://wordpress.com/")!
 
-        let richTextView = TextView(defaultFont: UIFont(), defaultMissingImage: UIImage())
+        let richTextView = TextView(defaultFont: UIFont.systemFont(ofSize: 14), defaultMissingImage: UIImage())
         let delegate = MockAttachmentDelegate()
         richTextView.textAttachmentDelegate = delegate
         richTextView.attributedText = NSAttributedString(string: prefixString)


### PR DESCRIPTION
## Description

Integrates Aztec 1.0.0-beta.17 into WPiOS.

Also fixes some unit tests which were broken with the update.

## Priority

This is high priority since we need it to release WPiOS 9.2 as soon as possible.

## Testing

General testing.  Make sure nothing important is broken.