### PR TITLE
Issue/8448 Fix Notice display issues

### DIFF
--- a/WordPress/Classes/Extensions/UIView+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIView+Helpers.swift
@@ -15,21 +15,21 @@ extension UIView {
     }
 
     @objc func pinSubviewToAllEdges(_ subview: UIView) {
-        let newConstraints = [
-            NSLayoutConstraint(item: self, attribute: .leading, relatedBy: .equal, toItem: subview, attribute: .leading, multiplier: 1, constant: 0),
-            NSLayoutConstraint(item: self, attribute: .trailing, relatedBy: .equal, toItem: subview, attribute: .trailing, multiplier: 1, constant: 0),
-            NSLayoutConstraint(item: self, attribute: .bottom, relatedBy: .equal, toItem: subview, attribute: .bottom, multiplier: 1, constant: 0),
-            NSLayoutConstraint(item: self, attribute: .top, relatedBy: .equal, toItem: subview, attribute: .top, multiplier: 1, constant: 0)
-        ]
-
-        addConstraints(newConstraints)
+        NSLayoutConstraint.activate([
+            leadingAnchor.constraint(equalTo: subview.leadingAnchor),
+            trailingAnchor.constraint(equalTo: subview.trailingAnchor),
+            topAnchor.constraint(equalTo: subview.topAnchor),
+            bottomAnchor.constraint(equalTo: subview.bottomAnchor),
+            ])
     }
 
     @objc func pinSubviewToAllEdgeMargins(_ subview: UIView) {
-        subview.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor).isActive = true
-        subview.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor).isActive = true
-        subview.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor).isActive = true
-        subview.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor).isActive = true
+        NSLayoutConstraint.activate([
+            layoutMarginsGuide.leadingAnchor.constraint(equalTo: subview.leadingAnchor),
+            layoutMarginsGuide.trailingAnchor.constraint(equalTo: subview.trailingAnchor),
+            layoutMarginsGuide.topAnchor.constraint(equalTo: subview.topAnchor),
+            layoutMarginsGuide.bottomAnchor.constraint(equalTo: subview.bottomAnchor),
+            ])
     }
 
     @objc func findFirstResponder() -> UIView? {

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -68,6 +68,7 @@ class NoticePresenter: NSObject {
             }
 
             self.animatePresentation(fromState: {}, toState: fromState, completion: {
+                noticeContainerView.removeFromSuperview()
                 self.dismiss()
             })
         }

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -89,7 +89,7 @@ class NoticeView: UIView {
 
         NSLayoutConstraint.activate([
             labelStackView.leadingAnchor.constraint(equalTo: backgroundView.layoutMarginsGuide.leadingAnchor),
-            labelStackView.layoutMarginsGuide.trailingAnchor.constraint(equalTo: actionBackgroundView.leadingAnchor),
+            labelStackView.layoutMarginsGuide.trailingAnchor.constraint(equalTo: actionBackgroundView.leadingAnchor, constant: -Appearance.layoutMargins.right),
             labelStackView.topAnchor.constraint(equalTo: backgroundView.layoutMarginsGuide.topAnchor),
             labelStackView.bottomAnchor.constraint(equalTo: backgroundView.layoutMarginsGuide.bottomAnchor)
             ])

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -108,7 +108,12 @@ class NoticeView: UIView {
 
     private func configureForNotice() {
         titleLabel.text = notice.title
-        messageLabel.text = notice.message
+
+        if let message = notice.message {
+            messageLabel.text = message
+        } else {
+            titleLabel.numberOfLines = 2
+        }
 
         if let actionTitle = notice.actionTitle {
             actionButton.setTitle(actionTitle, for: .normal)

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -1,6 +1,8 @@
 import UIKit
 
 class NoticeView: UIView {
+    private let contentStackView = UIStackView()
+
     private let backgroundView =  UIVisualEffectView(effect: UIBlurEffect(style: .extraLight))
     private let actionBackgroundView = UIView()
 
@@ -21,8 +23,9 @@ class NoticeView: UIView {
         layer.masksToBounds = true
 
         configureBackgroundViews()
-        configureActionButton()
+        configureContentStackView()
         configureLabels()
+        configureActionButton()
         configureDismissRecognizer()
 
         configureForNotice()
@@ -34,64 +37,35 @@ class NoticeView: UIView {
 
     private func configureBackgroundViews() {
         addSubview(backgroundView)
-        addSubview(actionBackgroundView)
-
         backgroundView.translatesAutoresizingMaskIntoConstraints = false
-        actionBackgroundView.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            backgroundView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            backgroundView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            backgroundView.topAnchor.constraint(equalTo: topAnchor),
-            backgroundView.bottomAnchor.constraint(equalTo: bottomAnchor)
-            ])
-
-        NSLayoutConstraint.activate([
-            actionBackgroundView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            actionBackgroundView.topAnchor.constraint(equalTo: topAnchor),
-            actionBackgroundView.bottomAnchor.constraint(equalTo: bottomAnchor)
-            ])
-
-        backgroundView.layoutMargins = Appearance.layoutMargins
-        actionBackgroundView.layoutMargins = Appearance.layoutMargins
-
-        actionBackgroundView.backgroundColor = Appearance.actionBackgroundColor
+        pinSubviewToAllEdges(backgroundView)
     }
 
-    private func configureActionButton() {
-        actionBackgroundView.addSubview(actionButton)
-        actionButton.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            actionButton.leadingAnchor.constraint(equalTo: actionBackgroundView.layoutMarginsGuide.leadingAnchor),
-            actionButton.trailingAnchor.constraint(equalTo: actionBackgroundView.layoutMarginsGuide.trailingAnchor),
-            actionButton.topAnchor.constraint(equalTo: actionBackgroundView.layoutMarginsGuide.topAnchor),
-            actionButton.bottomAnchor.constraint(equalTo: actionBackgroundView.layoutMarginsGuide.bottomAnchor)
-            ])
-
-        actionButton.titleLabel?.font = Appearance.actionButtonFont
-        actionButton.setTitleColor(WPStyleGuide.mediumBlue(), for: .normal)
-        actionButton.addTarget(self, action: #selector(actionButtonTapped), for: .touchUpInside)
+    private func configureContentStackView() {
+        contentStackView.axis = .horizontal
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        backgroundView.contentView.addSubview(contentStackView)
+        backgroundView.contentView.pinSubviewToAllEdges(contentStackView)
     }
 
     private func configureLabels() {
         let labelStackView = UIStackView()
+        labelStackView.translatesAutoresizingMaskIntoConstraints = false
         labelStackView.alignment = .leading
         labelStackView.axis = .vertical
         labelStackView.spacing = Appearance.labelLineSpacing
         labelStackView.isBaselineRelativeArrangement = true
+        labelStackView.isLayoutMarginsRelativeArrangement = true
+        labelStackView.layoutMargins = Appearance.layoutMargins
+
         labelStackView.addArrangedSubview(titleLabel)
         labelStackView.addArrangedSubview(messageLabel)
 
-        backgroundView.contentView.addSubview(labelStackView)
-
-        labelStackView.translatesAutoresizingMaskIntoConstraints = false
+        contentStackView.addArrangedSubview(labelStackView)
 
         NSLayoutConstraint.activate([
-            labelStackView.leadingAnchor.constraint(equalTo: backgroundView.layoutMarginsGuide.leadingAnchor),
-            labelStackView.layoutMarginsGuide.trailingAnchor.constraint(equalTo: actionBackgroundView.leadingAnchor, constant: -Appearance.layoutMargins.right),
-            labelStackView.topAnchor.constraint(equalTo: backgroundView.layoutMarginsGuide.topAnchor),
-            labelStackView.bottomAnchor.constraint(equalTo: backgroundView.layoutMarginsGuide.bottomAnchor)
+            labelStackView.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor),
+            labelStackView.bottomAnchor.constraint(equalTo: backgroundView.contentView.bottomAnchor)
             ])
 
         titleLabel.font = Appearance.titleLabelFont
@@ -99,6 +73,29 @@ class NoticeView: UIView {
 
         titleLabel.textColor = WPStyleGuide.darkGrey()
         messageLabel.textColor = WPStyleGuide.darkGrey()
+    }
+
+    private func configureActionButton() {
+        contentStackView.addArrangedSubview(actionBackgroundView)
+        actionBackgroundView.translatesAutoresizingMaskIntoConstraints = false
+
+        actionBackgroundView.layoutMargins = Appearance.layoutMargins
+        actionBackgroundView.backgroundColor = Appearance.actionBackgroundColor
+
+        actionBackgroundView.addSubview(actionButton)
+        actionButton.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            actionBackgroundView.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor),
+            actionBackgroundView.bottomAnchor.constraint(equalTo: backgroundView.contentView.bottomAnchor),
+            ])
+
+        actionBackgroundView.pinSubviewToAllEdgeMargins(actionButton)
+
+        actionButton.titleLabel?.font = Appearance.actionButtonFont
+        actionButton.setTitleColor(WPStyleGuide.mediumBlue(), for: .normal)
+        actionButton.addTarget(self, action: #selector(actionButtonTapped), for: .touchUpInside)
+        actionButton.setContentCompressionResistancePriority(.required, for: .horizontal)
     }
 
     private func configureDismissRecognizer() {


### PR DESCRIPTION
Fixes #8448.

This PR fixes a number of issues with Notices:

* Old notices were not being removed from their superview, so we were leaving a stack of them in the view hierarchy:

<img width="873" alt="screen shot 2018-01-17 at 09 54 19" src="https://user-images.githubusercontent.com/4780/35089441-dd73febe-fc2e-11e7-9641-130c3897a941.png">

* This caused a bug where notices could stack up on top of one another.
* With a long title and message, the action button could become truncated.
* When the action button was removed, padding on the trailing end of the labels was too large.
* When the action button was visible, padding on the trailing end of the labels was too small.
* If no message is present, the title label will now wrap to two lines.

![notices-before-after](https://user-images.githubusercontent.com/4780/35090189-cc43e2ba-fc30-11e7-8ff5-8b8e6942948a.png)

There were actually some quite big issues here, so I think perhaps we should pull this into release once it's approved / merged.

I also updated the `UIView+Helper` auto layout helpers to modernise them a bit – it might be worth double checking that the pieces of the app that use those still look okay. I did run through them and I think it's fine.

**To test:**

* Run through each of the examples in the screenshot below. I simply imported `WordPressFlux` into `MeViewController` and dispatched a notice action on `viewWillAppear`.
