### PR TITLE
Media Library Async: Local notifications when app in background

### DIFF
--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -12,6 +12,10 @@ struct Notice {
     /// An optional subtitle for the notice
     let message: String?
 
+    /// If provided, the notice will be presented as a system notification when
+    /// the app isn't in the foreground.
+    let notificationInfo: NoticeNotificationInfo?
+
     /// A title for an optional action button that can be displayed as part of
     /// a notice
     let actionTitle: String?
@@ -20,19 +24,34 @@ struct Notice {
     /// is tapped, if you've provided an action title
     let actionHandler: (() -> Void)?
 
-    init(title: String, message: String? = nil) {
+    init(title: String, message: String? = nil, notificationInfo: NoticeNotificationInfo? = nil) {
         self.title = title
         self.message = message
+        self.notificationInfo = notificationInfo
         self.actionTitle = nil
         self.actionHandler = nil
     }
 
-    init(title: String, message: String? = nil, actionTitle: String, actionHandler: @escaping (() -> Void)) {
+    init(title: String, message: String? = nil, notificationInfo: NoticeNotificationInfo? = nil, actionTitle: String, actionHandler: @escaping (() -> Void)) {
         self.title = title
         self.message = message
+        self.notificationInfo = notificationInfo
         self.actionTitle = actionTitle
         self.actionHandler = actionHandler
     }
+}
+
+struct NoticeNotificationInfo {
+    /// Unique identifier for this notice. When displayed as a system notification,
+    /// this value will be used as the `UNNotificationRequest`'s identifier.
+    let identifier: String
+
+    /// Optional category identifier for this notice. If provided, this value
+    /// will be used as the `UNNotificationContent`'s category identifier.
+    let categoryIdentifier: String?
+
+    /// If provided, this will be added to the `UNNotificationRequest` for this notice.
+    let userInfo: [String: Any]?
 }
 
 /// NoticeActions can be posted to control or report the display of notices.

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -100,14 +100,20 @@ final class InteractiveNotificationsManager: NSObject {
     }
 
     func handleLocalNotificationAction(with identifier: String, category: String, userInfo: NSDictionary, responseText: String?) -> Bool {
-        if let action = NoteActionDefinition(rawValue: identifier) {
-            switch action {
-            case .mediaWritePost:
-                MediaNoticeNavigationCoordinator.presentEditor(with: userInfo)
-            default:
-                break
+        if let noteCategory = NoteCategoryDefinition(rawValue: category),
+            noteCategory == .mediaUploadSuccess {
+            if let action = NoteActionDefinition(rawValue: identifier) {
+                switch action {
+                case .mediaWritePost:
+                    MediaNoticeNavigationCoordinator.presentEditor(with: userInfo)
+                default:
+                    break
+                }
+            } else if identifier == UNNotificationDefaultActionIdentifier {
+                MediaNoticeNavigationCoordinator.navigateToMediaLibrary(with: userInfo)
             }
         }
+
         return true
     }
 }

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -93,12 +93,21 @@ final class InteractiveNotificationsManager: NSObject {
             } else {
                 DDLogError("Tried to reply to a comment notification with no text")
             }
+        default: break
         }
 
         return true
     }
 
     func handleLocalNotificationAction(with identifier: String, category: String, userInfo: NSDictionary, responseText: String?) -> Bool {
+        if let action = NoteActionDefinition(rawValue: identifier) {
+            switch action {
+            case .mediaWritePost:
+                MediaNoticeNavigationCoordinator.presentEditor(with: userInfo)
+            default:
+                break
+            }
+        }
         return true
     }
 }
@@ -204,7 +213,7 @@ private extension InteractiveNotificationsManager {
             case .commentReplyWithLike:
                 return [.commentReply, .commentLike]
             case .mediaUploadSuccess:
-                return []
+                return [.mediaWritePost]
             }
         }
 
@@ -233,9 +242,10 @@ private extension InteractiveNotificationsManager {
     /// Describes the custom actions that WPiOS can perform in response to a Push notification.
     ///
     enum NoteActionDefinition: String {
-        case commentApprove = "COMMENT_MODERATE_APPROVE"
-        case commentLike    = "COMMENT_LIKE"
-        case commentReply   = "COMMENT_REPLY"
+        case commentApprove   = "COMMENT_MODERATE_APPROVE"
+        case commentLike      = "COMMENT_LIKE"
+        case commentReply     = "COMMENT_REPLY"
+        case mediaWritePost   = "MEDIA_WRITE_POST"
 
         var description: String {
             switch self {
@@ -245,6 +255,8 @@ private extension InteractiveNotificationsManager {
                 return NSLocalizedString("Like", comment: "Like (verb)")
             case .commentReply:
                 return NSLocalizedString("Reply", comment: "Reply to a comment (verb)")
+            case .mediaWritePost:
+                return NSLocalizedString("Write Post", comment: "Opens the editor to write a new post.")
             }
         }
 
@@ -261,7 +273,11 @@ private extension InteractiveNotificationsManager {
         }
 
         var requiresForeground: Bool {
-            return false
+            switch self {
+            case .mediaWritePost:
+                return true
+            default: return false
+            }
         }
 
         var notificationActionOptions: UNNotificationActionOptions {
@@ -291,7 +307,7 @@ private extension InteractiveNotificationsManager {
             }
         }
 
-        static var allDefinitions = [commentApprove, commentLike, commentReply]
+        static var allDefinitions = [commentApprove, commentLike, commentReply, mediaWritePost]
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
@@ -6,7 +6,8 @@ typedef NS_ENUM(NSUInteger, BlogDetailsSubsection) {
     BlogDetailsSubsectionStats,
     BlogDetailsSubsectionPosts,
     BlogDetailsSubsectionCustomize,
-    BlogDetailsSubsectionThemes
+    BlogDetailsSubsectionThemes,
+    BlogDetailsSubsectionMedia
 };
 
 @interface BlogDetailsViewController : UITableViewController <UIViewControllerRestoration> {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -301,6 +301,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                 [self showThemes];
             }
             break;
+        case BlogDetailsSubsectionMedia:
+            self.restorableSelectedIndexPath = indexPath;
+            [self.tableView selectRowAtIndexPath:indexPath
+                                        animated:NO
+                                  scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
+            [self showMediaLibrary];
+            break;
     }
 }
 
@@ -314,6 +321,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         case BlogDetailsSubsectionThemes:
         case BlogDetailsSubsectionCustomize:
             return [NSIndexPath indexPathForRow:0 inSection:2];
+        case BlogDetailsSubsectionMedia:
+            return [NSIndexPath indexPathForRow:2 inSection:1];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+class MediaNoticeNavigationCoordinator {
+    private static let blogIDKey = "blog_id"
+
+    static func presentEditor(with userInfo: NSDictionary) {
+        let context = ContextManager.sharedInstance().mainContext
+
+        if let blogID = userInfo[MediaNoticeNavigationCoordinator.blogIDKey] as? String,
+            let URIRepresentation = URL(string: blogID),
+            let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: URIRepresentation),
+            let managedObject = try? context.existingObject(with: objectID),
+            let blog = managedObject as? Blog {
+            presentEditor(for: blog, source: "media_upload_notification")
+        }
+    }
+
+    static func presentEditor(for blog: Blog, source: String) {
+        let editor = EditPostViewController(blog: blog)
+        editor.modalPresentationStyle = .fullScreen
+        WPTabBarController.sharedInstance().present(editor, animated: false, completion: nil)
+        WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": source], with: blog)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
@@ -4,13 +4,7 @@ class MediaNoticeNavigationCoordinator {
     private static let blogIDKey = "blog_id"
 
     static func presentEditor(with userInfo: NSDictionary) {
-        let context = ContextManager.sharedInstance().mainContext
-
-        if let blogID = userInfo[MediaNoticeNavigationCoordinator.blogIDKey] as? String,
-            let URIRepresentation = URL(string: blogID),
-            let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: URIRepresentation),
-            let managedObject = try? context.existingObject(with: objectID),
-            let blog = managedObject as? Blog {
+        if let blog = blog(from: userInfo) {
             presentEditor(for: blog, source: "media_upload_notification")
         }
     }
@@ -20,5 +14,25 @@ class MediaNoticeNavigationCoordinator {
         editor.modalPresentationStyle = .fullScreen
         WPTabBarController.sharedInstance().present(editor, animated: false, completion: nil)
         WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": source], with: blog)
+    }
+
+    static func navigateToMediaLibrary(with userInfo: NSDictionary) {
+        if let blog = blog(from: userInfo) {
+            WPTabBarController.sharedInstance().switchMySitesTabToMedia(for: blog)
+        }
+    }
+
+    private static func blog(from userInfo: NSDictionary) -> Blog? {
+        let context = ContextManager.sharedInstance().mainContext
+
+        guard let blogID = userInfo[MediaNoticeNavigationCoordinator.blogIDKey] as? String,
+            let URIRepresentation = URL(string: blogID),
+            let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: URIRepresentation),
+            let managedObject = try? context.existingObject(with: objectID),
+            let blog = managedObject as? Blog else {
+                return nil
+        }
+
+        return blog
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -37,10 +37,7 @@ struct MediaProgressCoordinatorNoticeViewModel {
                       notificationInfo: notificationInfo,
                       actionTitle: actionTitle,
                       actionHandler: {
-                        let editor = EditPostViewController(blog: blog)
-                        editor.modalPresentationStyle = .fullScreen
-                        WPTabBarController.sharedInstance().present(editor, animated: false, completion: nil)
-                        WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "media_upload_notice"], with: blog)
+                        MediaNoticeNavigationCoordinator.presentEditor(for: blog, source: "media_upload_notice")
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -30,10 +30,11 @@ struct MediaProgressCoordinatorNoticeViewModel {
 
     private var successNotice: Notice {
         guard let blog = blogInContext else {
-            return Notice(title: title)
+            return Notice(title: title, notificationInfo: notificationInfo)
         }
 
         return Notice(title: title,
+                      notificationInfo: notificationInfo,
                       actionTitle: actionTitle,
                       actionHandler: {
                         let editor = EditPostViewController(blog: blog)
@@ -52,6 +53,18 @@ struct MediaProgressCoordinatorNoticeViewModel {
                             MediaCoordinator.shared.retryMedia(media)
                         }
         })
+    }
+
+    private var notificationInfo: NoticeNotificationInfo {
+        var userInfo = [String : Any]()
+
+        if let blog = blogInContext {
+            userInfo["blog_id"] = blog.objectID.uriRepresentation().absoluteString
+        }
+
+        return NoticeNotificationInfo(identifier: UUID().uuidString,
+                                      categoryIdentifier: "media-upload-success",
+                                      userInfo: userInfo)
     }
 
     var title: String {

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -264,6 +264,12 @@ class WPSplitViewController: UISplitViewController {
 
         detailNavigationStackHasBeenModified = true
 
+        if let navigationController = viewControllers.first as? UINavigationController,
+            traitCollection.containsTraits(in: UITraitCollection(horizontalSizeClass: .compact)) {
+            navigationController.show(vc, sender: sender)
+            return
+        }
+
         super.showDetailViewController(detailVC, sender: sender)
     }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -41,6 +41,7 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 
 - (void)switchMySitesTabToAddNewSite;
 - (void)switchMySitesTabToStatsViewForBlog:(Blog *)blog;
+- (void)switchMySitesTabToMediaForBlog:(Blog *)blog;
 - (void)switchMySitesTabToCustomizeViewForBlog:(Blog *)blog;
 - (void)switchMySitesTabToThemesViewForBlog:(Blog *)blog;
 - (void)switchTabToPostsListForPost:(AbstractPost *)post;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -542,6 +542,27 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     }
 }
 
+- (void)switchMySitesTabToMediaForBlog:(Blog *)blog
+{
+    if (self.selectedIndex == WPTabMySites) {
+        UIViewController *topViewController = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
+        if ([topViewController isKindOfClass:[MediaLibraryViewController class]]) {
+            MediaLibraryViewController *mediaVC = (MediaLibraryViewController *)topViewController;
+            if (mediaVC.blog == blog) {
+                // If media is already selected for the specified blog, do nothing.
+                return;
+            }
+        }
+    }
+    
+    [self switchMySitesTabToBlogDetailsForBlog:blog];
+
+    BlogDetailsViewController *blogDetailVC = (BlogDetailsViewController *)self.blogListNavigationController.topViewController;
+    if ([blogDetailVC isKindOfClass:[BlogDetailsViewController class]]) {
+        [blogDetailVC showDetailViewForSubsection:BlogDetailsSubsectionMedia];
+    }
+}
+
 - (void)switchMySitesTabToCustomizeViewForBlog:(Blog *)blog
 {
     [self switchMySitesTabToThemesViewForBlog:blog];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		173BCE791CEB780800AE8817 /* Domain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173BCE781CEB780800AE8817 /* Domain.swift */; };
 		174122051EFDCBBF00AFA901 /* FancyAlertPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174122041EFDCBBF00AFA901 /* FancyAlertPresentationController.swift */; };
 		1746D7771D2165AE00B11D77 /* ForcePopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */; };
+		1750BD6D201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1750BD6C201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift */; };
 		1751E5911CE0E552000CA08D /* KeyValueDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */; };
 		1751E5931CE23801000CA08D /* NSAttributedString+StyledHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */; };
 		1759F1701FE017BF0003EC81 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1759F16F1FE017BF0003EC81 /* Queue.swift */; };
@@ -1302,6 +1303,7 @@
 		173BCE781CEB780800AE8817 /* Domain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Domain.swift; sourceTree = "<group>"; };
 		174122041EFDCBBF00AFA901 /* FancyAlertPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FancyAlertPresentationController.swift; sourceTree = "<group>"; };
 		1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForcePopoverPresenter.swift; sourceTree = "<group>"; };
+		1750BD6C201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaNoticeNavigationCoordinator.swift; sourceTree = "<group>"; };
 		1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValueDatabase.swift; sourceTree = "<group>"; };
 		1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+StyledHTML.swift"; sourceTree = "<group>"; };
 		1759F16F1FE017BF0003EC81 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
@@ -3482,6 +3484,7 @@
 				177074841FB209F100951A4A /* MediaCellProgressView.swift */,
 				7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */,
 				17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */,
+				1750BD6C201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -6610,6 +6613,7 @@
 				B500A4841D5B8D5E00FC8A96 /* NotificationMedia.swift in Sources */,
 				E11E775A1E72932F0072AD40 /* BlogListDataSource.swift in Sources */,
 				1730D4A31E97E3E400326B7C /* MediaItemTableViewCells.swift in Sources */,
+				1750BD6D201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift in Sources */,
 				E6ED09091D46AD29003283C4 /* ReaderFollowedSitesStreamHeader.swift in Sources */,
 				E66969E41B9E68B200EC9C00 /* ReaderPostToReaderPost37to38.swift in Sources */,
 				08216FD01CDBF96000304BA7 /* MenuItemSourceFooterView.m in Sources */,


### PR DESCRIPTION
This PR displays media library async 'success' notices as local notifications if the app is in the background when the notice is posted.

![notifications-1](https://user-images.githubusercontent.com/4780/35156904-31ac37b6-fd2a-11e7-9943-722b6ffb97be.gif)

I had to make a change to how we show detail view controllers in the split view controller, so please also check this on iPad.

**To test:**

* On a device where you've agreed to notifications for WPiOS:
* Go to the Media Library for a site, and start some media uploading
* Exit to the Home screen of your device before the uploads complete
* Wait for a notification to appear (it should state that the uploads completed successfully)
* There are two actions to test for the notification:
  * Tap the notification itself, and you should be taken to the media library for the site you were uploading media to. Also try navigating away from the media library before you leave the app, and check the notification takes you back to the right place.
  * When the notification comes in at the top of the screen, pull it down and tap the "Write Post" button. This should open the post editor for the blog you were uploading media to.
