### PR TITLE
Tags: Increase number of items fetched

### DIFF
--- a/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -148,7 +148,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
                    failure:(nullable void (^)(NSError *error))failure
 {
     [self getTaxonomyWithType:TaxonomyRESTTagIdentifier
-                   parameters:nil
+                   parameters:@{TaxonomyRESTNumberParameter: @(TaxonomyRESTNumberMaxValue)}
                       success:^(NSDictionary *responseObject) {
                           success([self remoteTagsWithJSONArray:[responseObject arrayForKey:TaxonomyRESTTagIdentifier]]);
                       } failure:failure];

--- a/WordPressKit/WordPressKitTests/TaxonomyServiceRemoteRESTTests.m
+++ b/WordPressKit/WordPressKitTests/TaxonomyServiceRemoteRESTTests.m
@@ -185,10 +185,14 @@
 - (void)testThatGetTagsWorks
 {
     NSString *url = [self GETtaxonomyURLWithType:@"tags"];
-    
+
+    BOOL (^parametersCheckBlock)(id obj) = ^BOOL(NSDictionary *parameters) {
+        return ([parameters isKindOfClass:[NSDictionary class]] && [[parameters objectForKey:@"number"] integerValue] == 1000);
+    };
+
     WordPressComRestApi *api = self.service.wordPressComRestApi;
     OCMStub([api GET:[OCMArg isEqual:url]
-          parameters:[OCMArg isNil]
+          parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
     


### PR DESCRIPTION
**Fixes** #8477 

Bug fix: fetch 1000 tags per site, the API default value was 100.

**To test:**

In a site with more than one hundred tags, go to Settings->Tags and check that they are all present.
Targeting `9.2` as this is a bug on a non-release feature.

cc:  @diegoreymendez