### PR TITLE
Tag fixes

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SettingsTitleSubtitleController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SettingsTitleSubtitleController.swift
@@ -15,12 +15,14 @@ final class SettingsTitleSubtitleController: UITableViewController {
         var subtitle: String?
         var titleHeader: String?
         var subtitleHeader: String?
+        var titleErrorFooter: String?
 
-        init(title: String?, subtitle: String?, titleHeader: String? = nil, subtitleHeader: String? = nil) {
+        init(title: String?, subtitle: String?, titleHeader: String? = nil, subtitleHeader: String? = nil, titleErrorFooter: String? = nil) {
             self.title = title
             self.subtitle = subtitle
             self.titleHeader = titleHeader
             self.subtitleHeader = subtitleHeader
+            self.titleErrorFooter = titleErrorFooter
         }
     }
 
@@ -62,6 +64,8 @@ final class SettingsTitleSubtitleController: UITableViewController {
                 return WPTableViewDefaultRowHeight * 3
             }
         }
+
+        static let footerHeight = CGFloat(34.0)
     }
 
     private lazy var nameCell: WPTableViewCell = {
@@ -258,6 +262,37 @@ extension SettingsTitleSubtitleController {
         }
     }
 
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        let contentSection = Sections.section(for: section)
+        switch contentSection {
+        case .name:
+            return content.titleErrorFooter
+        case .description:
+            return nil
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        let contentSection = Sections.section(for: section)
+        switch contentSection {
+        case .name:
+            return Sections.footerHeight
+        case .description:
+            return 0.0
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
+        let contentSection = Sections.section(for: section)
+        if contentSection == .name {
+            if let footer = view as? UITableViewHeaderFooterView {
+                footer.textLabel?.textColor = WPStyleGuide.errorRed()
+            }
+            // By default the footer is hidden, it will be shown if the user leaves the title empty
+            view.isHidden = true
+        }
+    }
+
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let sectionForIndexPath = Sections.section(for: indexPath.section)
         switch sectionForIndexPath {
@@ -280,8 +315,11 @@ extension SettingsTitleSubtitleController {
 extension SettingsTitleSubtitleController {
     @objc
     fileprivate func textChanged(_ textField: UITextField) {
-        content.title = textField.text
+        content.title = textField.text?.trim()
         setupTitle()
+        if let title = content.title {
+            tableView.footerView(forSection: Sections.name.rawValue)?.isHidden = title.count > 0
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SettingsTitleSubtitleController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SettingsTitleSubtitleController.swift
@@ -65,7 +65,6 @@ final class SettingsTitleSubtitleController: UITableViewController {
             }
         }
 
-        static let footerHeight = CGFloat(34.0)
     }
 
     private lazy var nameCell: WPTableViewCell = {
@@ -269,16 +268,6 @@ extension SettingsTitleSubtitleController {
             return content.titleErrorFooter
         case .description:
             return nil
-        }
-    }
-
-    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        let contentSection = Sections.section(for: section)
-        switch contentSection {
-        case .name:
-            return Sections.footerHeight
-        case .description:
-            return 0.0
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -286,10 +286,12 @@ extension SiteTagsViewController {
     fileprivate func navigate(to tag: PostTag?) {
         let titleSectionHeader = NSLocalizedString("Tag", comment: "Section header for tag name in Tag Details View.")
         let subtitleSectionHeader = NSLocalizedString("Description", comment: "Section header for tag name in Tag Details View.")
+        let titleErrorFooter = NSLocalizedString("Name Required", comment: "Error to be displayed when a tag is empty")
         let content = SettingsTitleSubtitleController.Content(title: tag?.name,
                                                               subtitle: tag?.tagDescription,
                                                               titleHeader: titleSectionHeader,
-                                                              subtitleHeader: subtitleSectionHeader)
+                                                              subtitleHeader: subtitleSectionHeader,
+                                                              titleErrorFooter: titleErrorFooter)
         let confirmationContent = confirmation()
         let tagDetailsView = SettingsTitleSubtitleController(content: content, confirmation: confirmationContent)
 

--- a/WordPress/Classes/ViewRelated/Cells/TitleBadgeDisclosureCell.xib
+++ b/WordPress/Classes/ViewRelated/Cells/TitleBadgeDisclosureCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,10 +20,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ML5-iW-nUY">
-                        <rect key="frame" x="16" y="12" width="188" height="21"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="188" id="Kz7-QF-nuN"/>
-                        </constraints>
+                        <rect key="frame" x="16" y="12" width="240" height="21"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -44,6 +41,7 @@
                     <constraint firstAttribute="trailing" secondItem="w1Y-xN-3cQ" secondAttribute="trailing" id="A7b-B8-e3f"/>
                     <constraint firstItem="w1Y-xN-3cQ" firstAttribute="centerY" secondItem="ML5-iW-nUY" secondAttribute="centerY" id="Hhb-4h-77B"/>
                     <constraint firstItem="ML5-iW-nUY" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="U5T-DO-cef"/>
+                    <constraint firstAttribute="trailing" secondItem="ML5-iW-nUY" secondAttribute="trailing" constant="64" id="xnd-ed-4h1"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>


### PR DESCRIPTION
**Fixes** #8473 #8475 

**To test:**
1. Check that you can't enter a tag that has only spaces.
2. Check that editing a tag to be empty displays an error.
3. Check that the tag text is wider and adjusts accordingly when rotating the device.

cc: @diegoreymendez another one that will be merged on `9.2`