### PR TITLE
Tag creation and edition improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SettingsTitleSubtitleController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SettingsTitleSubtitleController.swift
@@ -324,6 +324,7 @@ extension SettingsTitleSubtitleController: UITextViewDelegate {
         if textView == descriptionTextField &&
            text == "\n" {
             descriptionTextField.resignFirstResponder()
+            navigationController?.popViewController(animated: true)
         }
         return true
     }

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SettingsTitleSubtitleController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SettingsTitleSubtitleController.swift
@@ -118,6 +118,7 @@ final class SettingsTitleSubtitleController: UITableViewController {
         setupNavigationBar()
         setupTitle()
         setupTable()
+        nameTextField.becomeFirstResponder()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -175,8 +176,8 @@ final class SettingsTitleSubtitleController: UITableViewController {
         returnValue.clearButtonMode = .whileEditing
         returnValue.font = WPStyleGuide.tableviewTextFont()
         returnValue.textColor = WPStyleGuide.darkGrey()
+        returnValue.delegate = self
         returnValue.returnKeyType = .done
-        returnValue.keyboardType = .default
 
         returnValue.addTarget(self, action: #selector(textChanged), for: .editingChanged)
 
@@ -189,6 +190,7 @@ final class SettingsTitleSubtitleController: UITableViewController {
         returnValue.font = WPStyleGuide.tableviewTextFont()
         returnValue.textColor = WPStyleGuide.darkGrey()
         returnValue.delegate = self
+        returnValue.returnKeyType = .done
 
         return returnValue
     }
@@ -312,9 +314,29 @@ extension SettingsTitleSubtitleController {
     }
 }
 
-// MARK: - Tag subtitle updates
+// MARK: - UITextViewDelegate
 extension SettingsTitleSubtitleController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         content.subtitle = textView.text
+    }
+
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if textView == descriptionTextField &&
+           text == "\n" {
+            descriptionTextField.resignFirstResponder()
+        }
+        return true
+    }
+}
+
+// MARK: - UITextFieldDelegate
+extension SettingsTitleSubtitleController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if textField == nameTextField {
+            nameTextField.resignFirstResponder()
+            descriptionTextField.becomeFirstResponder()
+            return false
+        }
+        return true
     }
 }


### PR DESCRIPTION
**Fixes** #8471 

Automatically make the Name TextField the first responder, and move on to the Description TextView when Done is tapped. When Done is tapped on the Description field the VC should be dismissed and the changes saved.

**To test:**

Go to Settings -> Tags, select an existing tag and create a new one, for both cases check that:

1. The Name field should be the first responder.
2. Tapping done should move you to the Description field.
3. Tapping done again should dismiss the VC and take you to the tag list.
4. Changes should be saved.

