### PR TITLE
Pop title and subtitle controller after users tap Done in the extende…

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SettingsTitleSubtitleController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SettingsTitleSubtitleController.swift
@@ -324,6 +324,7 @@ extension SettingsTitleSubtitleController: UITextViewDelegate {
         if textView == descriptionTextField &&
            text == "\n" {
             descriptionTextField.resignFirstResponder()
+            navigationController?.popViewController(animated: true)
         }
         return true
     }


### PR DESCRIPTION
Fixes part of #8471 

To test:

Tapping done when the focus is on the description field should dismiss the VC and take you to the tag list.
