### PR TITLE
Set Hound to fail PRs due to violations

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,6 @@
 swift:
     config_file: .swiftlint.yml
-    fail_on_violations: true
 ruby:
   enabled: false
+
+fail_on_violations: true

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,5 @@
 swift:
     config_file: .swiftlint.yml
+    fail_on_violations: true
 ruby:
   enabled: false


### PR DESCRIPTION
As described in the title – PRs currently have Hound as a required step, but it never fails them even if there are violations. This PR enables a setting so that violations will fail the PR check.

