### PR TITLE
Refactor video thumbnail generation

### DIFF
--- a/WordPress/Classes/Utility/Media/MediaVideoExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaVideoExporter.swift
@@ -169,6 +169,7 @@ class MediaVideoExporter: MediaExporter {
     ///
     /// - imageOptions: ImageExporter options for the generated thumbnail image.
     ///
+    @discardableResult
     func exportPreviewImageForVideo(atURL url: URL, imageOptions: MediaImageExporter.Options?, onCompletion: @escaping OnMediaExport, onError: @escaping OnExportError) -> Progress {
         let asset = AVURLAsset(url: url)
         guard asset.isExportable else {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3130,9 +3130,7 @@ extension AztecPostViewController {
     }
 
     fileprivate func resetMediaAttachmentOverlay(_ mediaAttachment: MediaAttachment) {
-        if mediaAttachment is ImageAttachment {
-            mediaAttachment.overlayImage = nil
-        }
+        mediaAttachment.overlayImage = nil
         mediaAttachment.message = nil
         mediaAttachment.shouldHideBorder = false
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2961,13 +2961,6 @@ extension AztecPostViewController {
         }
     }
 
-    private func URLForTemporaryFileWithFileExtension(_ fileExtension: String) -> URL {
-        assert(!fileExtension.isEmpty, "file Extension cannot be empty")
-        let fileName = "\(ProcessInfo.processInfo.globallyUniqueString)_file.\(fileExtension)"
-        let fileURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
-        return fileURL
-    }
-
     fileprivate func displayActions(forAttachment attachment: MediaAttachment, position: CGPoint) {
         let attachmentID = attachment.identifier
         let title: String = MediaAttachmentActionSheet.title

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2948,28 +2948,15 @@ extension AztecPostViewController {
                     DDLogError("Unable to find information for VideoPress video with ID = \(videoPressID). Details: \(error.localizedDescription)")
                 })
             } else if let videoSrcURL = videoAttachment.srcURL, videoAttachment.posterURL == nil {
-                let asset = AVURLAsset(url: videoSrcURL as URL, options: nil)
-                let imgGenerator = AVAssetImageGenerator(asset: asset)
-                imgGenerator.maximumSize = .zero
-                imgGenerator.appliesPreferredTrackTransform = true
-                let timeToCapture = NSValue(time: CMTimeMake(0, 1))
-                imgGenerator.generateCGImagesAsynchronously(forTimes: [timeToCapture],
-                                                            completionHandler: { (time, cgImage, actualTime, result, error) in
-                    guard let cgImage = cgImage else {
-                        return
+                let thumbnailGenerator = MediaVideoExporter(url: videoSrcURL)
+                thumbnailGenerator.exportPreviewImageForVideo(atURL: videoSrcURL, imageOptions: nil, onCompletion: { (exportResult) in
+                    DispatchQueue.main.async {
+                        videoAttachment.posterURL = exportResult.url
+                        self.richTextView.refresh(videoAttachment)
                     }
-                    let uiImage = UIImage(cgImage: cgImage)
-                    let url = self.URLForTemporaryFileWithFileExtension(".jpg")
-                    do {
-                        try uiImage.writeJPEGToURL(url)
-                        DispatchQueue.main.async {
-                            videoAttachment.posterURL = url
-                            self.richTextView.refresh(videoAttachment)
-                        }
-                    } catch {
-                        DDLogError("Unable to grab frame from video = \(videoSrcURL). Details: \(error.localizedDescription)")
-                    }
-                })
+                }, onError: { (error) in
+                    DDLogError("Unable to grab frame from video = \(videoSrcURL). Details: \(error.localizedDescription)")
+                })                
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2956,7 +2956,7 @@ extension AztecPostViewController {
                     }
                 }, onError: { (error) in
                     DDLogError("Unable to grab frame from video = \(videoSrcURL). Details: \(error.localizedDescription)")
-                })                
+                })
             }
         }
     }


### PR DESCRIPTION
This PR refactor a bit of code that was being used in Aztec to generate thumbnails.
Because the same code already exists on an MediaVideoExporter I refactored it to use that exporter.

To test:
 - Add a self-hosted site that doesn't use Jetpack
 - Create a post
 - Insert a video to it
 - Switch to HTML and back to visual
 - See that thumbnail is generated correctly.


