### PR TITLE
Refactor display video methods

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3104,6 +3104,7 @@ extension AztecPostViewController {
                 return
             }
             guard let videoURL = URL(string: videoURLString) else {
+                self.displayUnableToPlayVideoAlert()
                 return
             }
             videoAttachment.srcURL = videoURL
@@ -3112,7 +3113,8 @@ extension AztecPostViewController {
             }
             self.richTextView.refresh(videoAttachment)
             self.displayVideoPlayer(for: videoURL)
-        }, failure: { (error) in
+        }, failure: { [weak self] (error) in
+            self?.displayUnableToPlayVideoAlert()
             DDLogError("Unable to find information for VideoPress video with ID = \(videoPressID). Details: \(error.localizedDescription)")
         })
     }
@@ -3126,6 +3128,13 @@ extension AztecPostViewController {
         controller.player = player
         player.play()
         present(controller, animated: true, completion: nil)
+    }
+
+    func displayUnableToPlayVideoAlert() {
+        let alertController = UIAlertController(title: MediaUnableToPlayVideoAlert.title, message: MediaUnableToPlayVideoAlert.message, preferredStyle: .alert)
+        alertController.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .`default`, handler: nil))
+        present(alertController, animated: true, completion: nil)
+        return
     }
 
     func placeholderImage(for attachment: NSTextAttachment) -> UIImage {
@@ -3577,5 +3586,10 @@ extension AztecPostViewController {
         static let message = NSLocalizedString("You are currently uploading media. This action will cancel uploads in progress.\n\nAre you sure?", comment: "This prompt is displayed when the user attempts to stop media uploads in the post editor.")
         static let acceptTitle  = NSLocalizedString("Yes", comment: "Yes")
         static let cancelTitle  = NSLocalizedString("Not Now", comment: "Nicer dialog answer for \"No\".")
+    }
+
+    struct MediaUnableToPlayVideoAlert {
+        static let title = NSLocalizedString("Unable to play video", comment: "Dialog box title for when the user is cancelling an upload.")
+        static let message = NSLocalizedString("We are unable to get information from this video at the moment. Please try later.", comment: "This prompt is displayed when the user attempts to play a video in the editor but for some reason we are unable to retrieve from the server.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3590,6 +3590,6 @@ extension AztecPostViewController {
 
     struct MediaUnableToPlayVideoAlert {
         static let title = NSLocalizedString("Unable to play video", comment: "Dialog box title for when the user is cancelling an upload.")
-        static let message = NSLocalizedString("We are unable to get information from this video at the moment. Please try later.", comment: "This prompt is displayed when the user attempts to play a video in the editor but for some reason we are unable to retrieve from the server.")
+        static let message = NSLocalizedString("Something went wrong. Please check your connectivity and try again.", comment: "This prompt is displayed when the user attempts to play a video in the editor but for some reason we are unable to retrieve from the server.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2887,7 +2887,7 @@ extension AztecPostViewController {
 
         let message = MediaAttachmentActionSheet.failedMediaActionTitle
 
-        let attributeMessage = NSAttributedString(string: message, attributes: mediaMessageAttributes)
+        let attributeMessage = NSAttributedString(string: message, attributes: Constants.mediaMessageAttributes)
         attachment.message = attributeMessage
         attachment.overlayImage = Gridicon.iconOfType(.refresh, withSize: Constants.mediaOverlayIconSize)
         attachment.shouldHideBorder = true
@@ -3128,15 +3128,6 @@ extension AztecPostViewController {
         present(controller, animated: true, completion: nil)
     }
 
-    var mediaMessageAttributes: [NSAttributedStringKey: Any] {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.alignment = .center
-
-        return [.font: Fonts.mediaOverlay,
-                .paragraphStyle: paragraphStyle,
-                .foregroundColor: UIColor.white]
-    }
-
     func placeholderImage(for attachment: NSTextAttachment) -> UIImage {
         let icon: UIImage
         switch attachment {
@@ -3217,7 +3208,7 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
 
             // ...and mark the newly tapped attachment
             let message = ""
-            attachment.message = NSAttributedString(string: message, attributes: mediaMessageAttributes)
+            attachment.message = NSAttributedString(string: message, attributes: Constants.mediaMessageAttributes)
             richTextView.refresh(attachment)
             currentSelectedAttachment = attachment
         }
@@ -3494,6 +3485,14 @@ extension AztecPostViewController {
         static let mediaOverlayBorderWidth  = CGFloat(3.0)
         static let mediaOverlayIconSize     = CGSize(width: 32, height: 32)
         static let mediaPlaceholderImageSize = CGSize(width: 128, height: 128)
+        static let mediaMessageAttributes: [NSAttributedStringKey: Any] = {
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.alignment = .center
+
+            return [.font: Fonts.mediaOverlay,
+                    .paragraphStyle: paragraphStyle,
+                    .foregroundColor: UIColor.white]
+        }()
         static let placeholderMediaLink = URL(string: "placeholder://")!
 
         struct Animations {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3093,27 +3093,27 @@ extension AztecPostViewController {
         guard let videoURL = videoAttachment.srcURL else {
             return
         }
-        if let videoPressID = videoAttachment.videoPressID {
-            // It's videoPress video so let's fetch the information for the video
-            let mediaService = MediaService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-            mediaService.getMediaURL(fromVideoPressID: videoPressID, in: self.post.blog, success: { (videoURLString, posterURLString) in
-                guard let videoURL = URL(string: videoURLString) else {
-                    return
-                }
-                videoAttachment.srcURL = videoURL
-                if let validPosterURLString = posterURLString, let posterURL = URL(string: validPosterURLString) {
-                    videoAttachment.posterURL = posterURL
-                }
-                self.richTextView.refresh(videoAttachment)
-                self.displayVideoPlayer(for: videoURL)
-            }, failure: { (error) in
-                DDLogError("Unable to find information for VideoPress video with ID = \(videoPressID). Details: \(error.localizedDescription)")
-            })
-        } else {
+        guard let videoPressID = videoAttachment.videoPressID else {
             displayVideoPlayer(for: videoURL)
+            return
         }
+        // It's videoPress video so let's fetch the information for the video
+        let mediaService = MediaService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        mediaService.getMediaURL(fromVideoPressID: videoPressID, in: self.post.blog, success: { (videoURLString, posterURLString) in
+            guard let videoURL = URL(string: videoURLString) else {
+                return
+            }
+            videoAttachment.srcURL = videoURL
+            if let validPosterURLString = posterURLString, let posterURL = URL(string: validPosterURLString) {
+                videoAttachment.posterURL = posterURL
+            }
+            self.richTextView.refresh(videoAttachment)
+            self.displayVideoPlayer(for: videoURL)
+        }, failure: { (error) in
+            DDLogError("Unable to find information for VideoPress video with ID = \(videoPressID). Details: \(error.localizedDescription)")
+        })
     }
-    
+
     func displayVideoPlayer(for videoURL: URL) {
         let asset = AVURLAsset(url: videoURL)
         let controller = AVPlayerViewController()

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3099,7 +3099,10 @@ extension AztecPostViewController {
         }
         // It's videoPress video so let's fetch the information for the video
         let mediaService = MediaService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        mediaService.getMediaURL(fromVideoPressID: videoPressID, in: self.post.blog, success: { (videoURLString, posterURLString) in
+        mediaService.getMediaURL(fromVideoPressID: videoPressID, in: self.post.blog, success: { [weak self] (videoURLString, posterURLString) in
+            guard let `self` = self else {
+                return
+            }
             guard let videoURL = URL(string: videoURLString) else {
                 return
             }


### PR DESCRIPTION
This PR refactors the location and code layout of the display video methods and improves the error handling when videos are not retrievable.

To test:
 - Create a new post.
 - Add a new video to it.
 - Wait for upload to finish
 - Now turn off the internet (airplane mode)
 - Tap on the video and select the option Play
 - See if an alert shows up
 - Turn Internet on again
 - Tap again to play video
 - see if video plays correctly.

