### PR TITLE
Add option to Retry All failed uploads.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2924,6 +2924,7 @@ extension AztecPostViewController {
     }
 
     fileprivate func retryFailedMediaUpload(media: Media, attachment: MediaAttachment) {
+        errorsForAttachmentUploads.removeValue(forKey: media.uploadID)
         resetMediaAttachmentOverlay(attachment)
         attachment.progress = 0
         richTextView.refresh(attachment)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3013,12 +3013,27 @@ extension AztecPostViewController {
                                                     self.mediaCoordinator.cancelUploadAndDeleteMedia(media)
                 })
             }
+        } else {
+            alertController.addActionWithTitle(attachment is ImageAttachment ? MediaAttachmentActionSheet.removeImageActionTitle : MediaAttachmentActionSheet.removeVideoActionTitle,
+                style: .destructive,
+                handler: { (action) in
+                    self.richTextView.remove(attachmentID: attachmentID)
+            })
         }
         if let mediaUploadID = attachment.uploadID,
            let media = mediaCoordinator.media(withObjectID: mediaUploadID),
            let error = errorsForAttachmentUploads[media.uploadID] {
             showDefaultActions = false
             message = error.localizedDescription
+
+            if errorsForAttachmentUploads.count > 1 {
+                alertController.addActionWithTitle(MediaAttachmentActionSheet.retryAllFailedUploadsActionTitle,
+                                                   style: .default,
+                                                   handler: { [weak self] (action) in
+                                                    self?.retryAllFailedMediaUploads()
+                })
+            }
+
             alertController.addActionWithTitle(MediaAttachmentActionSheet.retryUploadActionTitle,
                                                style: .default,
                                                handler: { [weak self] (action) in
@@ -3028,13 +3043,6 @@ extension AztecPostViewController {
                                                 }
                                                 strongSelf.retryFailedMediaUpload(media: media, attachment: attachment)
             })
-            if errorsForAttachmentUploads.count > 1 {
-                alertController.addActionWithTitle(MediaAttachmentActionSheet.retryAllFailedUploadsActionTitle,
-                                                   style: .default,
-                                                   handler: { [weak self] (action) in
-                                                    self?.retryAllFailedMediaUploads()
-                })
-            }
         }
 
         if showDefaultActions {
@@ -3052,11 +3060,7 @@ extension AztecPostViewController {
                 })
             }
         }
-        alertController.addActionWithTitle(MediaAttachmentActionSheet.removeActionTitle,
-                                           style: .destructive,
-                                           handler: { (action) in
-                                            self.richTextView.remove(attachmentID: attachmentID)
-        })
+
         alertController.title = title
         alertController.message = message
         alertController.popoverPresentationController?.sourceView = richTextView
@@ -3532,12 +3536,13 @@ extension AztecPostViewController {
     struct MediaAttachmentActionSheet {
         static let title = NSLocalizedString("Media Options", comment: "Title for action sheet with media options.")
         static let dismissActionTitle = NSLocalizedString("Dismiss", comment: "User action to dismiss media options.")
-        static let stopUploadActionTitle = NSLocalizedString("Stop Upload", comment: "User action to stop upload.")
-        static let retryUploadActionTitle = NSLocalizedString("Retry Upload", comment: "User action to retry media upload.")
-        static let retryAllFailedUploadsActionTitle = NSLocalizedString("Retry All Failed Uploads", comment: "User action to retry all failed media uploads.")
+        static let stopUploadActionTitle = NSLocalizedString("Stop upload", comment: "User action to stop upload.")
+        static let retryUploadActionTitle = NSLocalizedString("Retry", comment: "User action to retry media upload.")
+        static let retryAllFailedUploadsActionTitle = NSLocalizedString("Retry all", comment: "User action to retry all failed media uploads.")
         static let editActionTitle = NSLocalizedString("Edit", comment: "User action to edit media details.")
-        static let playVideoActionTitle = NSLocalizedString("Play Video", comment: "User action to play a video on the editor.")
-        static let removeActionTitle = NSLocalizedString("Remove", comment: "User action to remove media.")
+        static let playVideoActionTitle = NSLocalizedString("Play video", comment: "User action to play a video on the editor.")
+        static let removeImageActionTitle = NSLocalizedString("Remove image", comment: "User action to remove image.")
+        static let removeVideoActionTitle = NSLocalizedString("Remove video", comment: "User action to remove video.")
         static let failedMediaActionTitle = NSLocalizedString("Failed to insert media.\n Please tap for options.", comment: "Error message to show to use when media insertion on a post fails")
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2912,6 +2912,25 @@ extension AztecPostViewController {
         errorsForAttachmentUploads.removeAll()
     }
 
+    fileprivate func retryAllFailedMediaUploads() {
+        let failedMediaIDs = errorsForAttachmentUploads.keys
+        for mediaID in failedMediaIDs {
+            guard let attachment = self.findAttachment(withUploadID: mediaID),
+                let media = mediaCoordinator.media(withObjectID: mediaID) else {
+                continue
+            }
+            retryFailedMediaUpload(media: media, attachment: attachment)
+        }
+    }
+
+    fileprivate func retryFailedMediaUpload(media: Media, attachment: MediaAttachment) {
+        resetMediaAttachmentOverlay(attachment)
+        attachment.progress = 0
+        richTextView.refresh(attachment)
+        mediaCoordinator.retryMedia(media)
+        observe(media: media, statType: .editorUploadMediaRetried)
+    }
+
     fileprivate func processMediaAttachments() {
         processMediaWithErrorAttachments()
         processVideoPressAttachments()
@@ -3002,17 +3021,19 @@ extension AztecPostViewController {
             alertController.addActionWithTitle(MediaAttachmentActionSheet.retryUploadActionTitle,
                                                style: .default,
                                                handler: { [weak self] (action) in
-                                                //retry upload
                                                 guard let strongSelf = self,
                                                     let attachment = strongSelf.richTextView.attachment(withId: attachmentID) else {
                                                         return
                                                 }
-                                                strongSelf.resetMediaAttachmentOverlay(attachment)
-                                                attachment.progress = 0
-                                                strongSelf.richTextView.refresh(attachment)
-                                                strongSelf.mediaCoordinator.retryMedia(media)
-                                                strongSelf.observe(media: media, statType: .editorUploadMediaRetried)
+                                                strongSelf.retryFailedMediaUpload(media: media, attachment: attachment)
             })
+            if errorsForAttachmentUploads.count > 1 {
+                alertController.addActionWithTitle(MediaAttachmentActionSheet.retryAllFailedUploadsActionTitle,
+                                                   style: .default,
+                                                   handler: { [weak self] (action) in
+                                                    self?.retryAllFailedMediaUploads()
+                })
+            }
         }
 
         if showDefaultActions {
@@ -3512,6 +3533,7 @@ extension AztecPostViewController {
         static let dismissActionTitle = NSLocalizedString("Dismiss", comment: "User action to dismiss media options.")
         static let stopUploadActionTitle = NSLocalizedString("Stop Upload", comment: "User action to stop upload.")
         static let retryUploadActionTitle = NSLocalizedString("Retry Upload", comment: "User action to retry media upload.")
+        static let retryAllFailedUploadsActionTitle = NSLocalizedString("Retry All Failed Uploads", comment: "User action to retry all failed media uploads.")
         static let editActionTitle = NSLocalizedString("Edit", comment: "User action to edit media details.")
         static let playVideoActionTitle = NSLocalizedString("Play Video", comment: "User action to play a video on the editor.")
         static let removeActionTitle = NSLocalizedString("Remove", comment: "User action to remove media.")


### PR DESCRIPTION
Fixes #8507

This PR adds an option to do retry all of failed media uploads on Aztec.

To test:
 - Start a new post
 - Turn On airplane mode
 - Add multiple media objects to the post
 - See them all fail
 - Turn Off Airplane mode
 - Tap on one media
 - Check that Retry All Failed Media option shows off
 - Tap on it
 - Check if media is uploaded correctly.


