### PR TITLE
Media Async: Display failure notices as notifications when the app is in the background

### DIFF
--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -207,6 +207,7 @@ private extension InteractiveNotificationsManager {
         case commentReply           = "replyto-comment"
         case commentReplyWithLike   = "replyto-like-comment"
         case mediaUploadSuccess     = "media-upload-success"
+        case mediaUploadFailure     = "media-upload-failure"
 
         var actions: [NoteActionDefinition] {
             switch self {
@@ -220,6 +221,8 @@ private extension InteractiveNotificationsManager {
                 return [.commentReply, .commentLike]
             case .mediaUploadSuccess:
                 return [.mediaWritePost]
+            case .mediaUploadFailure:
+                return []
             }
         }
 
@@ -239,8 +242,8 @@ private extension InteractiveNotificationsManager {
                 options: [])
         }
 
-        static var allDefinitions = [commentApprove, commentLike, commentReply, commentReplyWithLike, mediaUploadSuccess]
-        static var localDefinitions = [mediaUploadSuccess]
+        static var allDefinitions = [commentApprove, commentLike, commentReply, commentReplyWithLike, mediaUploadSuccess, mediaUploadFailure]
+        static var localDefinitions = [mediaUploadSuccess, mediaUploadFailure]
     }
 
 

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -100,17 +100,25 @@ final class InteractiveNotificationsManager: NSObject {
     }
 
     func handleLocalNotificationAction(with identifier: String, category: String, userInfo: NSDictionary, responseText: String?) -> Bool {
-        if let noteCategory = NoteCategoryDefinition(rawValue: category),
-            noteCategory == .mediaUploadSuccess {
-            if let action = NoteActionDefinition(rawValue: identifier) {
-                switch action {
-                case .mediaWritePost:
-                    MediaNoticeNavigationCoordinator.presentEditor(with: userInfo)
-                default:
-                    break
+        if let noteCategory = NoteCategoryDefinition(rawValue: category) {
+            switch noteCategory {
+            case .mediaUploadSuccess, .mediaUploadFailure:
+                if identifier == UNNotificationDefaultActionIdentifier {
+                    MediaNoticeNavigationCoordinator.navigateToMediaLibrary(with: userInfo)
+                    return true
                 }
-            } else if identifier == UNNotificationDefaultActionIdentifier {
-                MediaNoticeNavigationCoordinator.navigateToMediaLibrary(with: userInfo)
+
+                if let action = NoteActionDefinition(rawValue: identifier) {
+                    switch action {
+                    case .mediaWritePost:
+                        MediaNoticeNavigationCoordinator.presentEditor(with: userInfo)
+                    case .mediaRetry:
+                        MediaNoticeNavigationCoordinator.retryMediaUploads(with: userInfo)
+                    default:
+                        break
+                    }
+                }
+            default: break
             }
         }
 
@@ -222,7 +230,7 @@ private extension InteractiveNotificationsManager {
             case .mediaUploadSuccess:
                 return [.mediaWritePost]
             case .mediaUploadFailure:
-                return []
+                return [.mediaRetry]
             }
         }
 
@@ -255,6 +263,7 @@ private extension InteractiveNotificationsManager {
         case commentLike      = "COMMENT_LIKE"
         case commentReply     = "COMMENT_REPLY"
         case mediaWritePost   = "MEDIA_WRITE_POST"
+        case mediaRetry       = "MEDIA_RETRY"
 
         var description: String {
             switch self {
@@ -266,6 +275,8 @@ private extension InteractiveNotificationsManager {
                 return NSLocalizedString("Reply", comment: "Reply to a comment (verb)")
             case .mediaWritePost:
                 return NSLocalizedString("Write Post", comment: "Opens the editor to write a new post.")
+            case .mediaRetry:
+                return NSLocalizedString("Retry", comment: "Opens the media library .")
             }
         }
 
@@ -283,7 +294,7 @@ private extension InteractiveNotificationsManager {
 
         var requiresForeground: Bool {
             switch self {
-            case .mediaWritePost:
+            case .mediaWritePost, .mediaRetry:
                 return true
             default: return false
             }
@@ -316,7 +327,7 @@ private extension InteractiveNotificationsManager {
             }
         }
 
-        static var allDefinitions = [commentApprove, commentLike, commentReply, mediaWritePost]
+        static var allDefinitions = [commentApprove, commentLike, commentReply, mediaWritePost, mediaRetry]
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -1,3 +1,7 @@
+enum MediaNoticeUserInfoKey {
+    static let blogID = "blog_id"
+    static let failedMediaIDs = "failed_media_ids"
+}
 
 struct MediaProgressCoordinatorNoticeViewModel {
     private let mediaProgressCoordinator: MediaProgressCoordinator
@@ -57,7 +61,11 @@ struct MediaProgressCoordinatorNoticeViewModel {
         var userInfo = [String: Any]()
 
         if let blog = blogInContext {
-            userInfo["blog_id"] = blog.objectID.uriRepresentation().absoluteString
+            userInfo[MediaNoticeUserInfoKey.blogID] = blog.objectID.uriRepresentation().absoluteString
+        }
+
+        if !uploadSuccessful {
+            userInfo[MediaNoticeUserInfoKey.failedMediaIDs] = failedMedia.map({ $0.objectID.uriRepresentation().absoluteString })
         }
 
         return NoticeNotificationInfo(identifier: UUID().uuidString,

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -44,6 +44,7 @@ struct MediaProgressCoordinatorNoticeViewModel {
     private var failureNotice: Notice {
         return Notice(title: title,
                       message: message,
+                      notificationInfo: notificationInfo,
                       actionTitle: NSLocalizedString("Retry", comment: "User action to retry media upload."),
                       actionHandler: {
                         for media in self.failedMedia {
@@ -60,8 +61,12 @@ struct MediaProgressCoordinatorNoticeViewModel {
         }
 
         return NoticeNotificationInfo(identifier: UUID().uuidString,
-                                      categoryIdentifier: "media-upload-success",
+                                      categoryIdentifier: notificationCategoryIdentifier,
                                       userInfo: userInfo)
+    }
+
+    private var notificationCategoryIdentifier: String {
+        return uploadSuccessful ? "media-upload-success" : "media-upload-failure"
     }
 
     var title: String {


### PR DESCRIPTION
In #8469, we displayed media async successful upload notices as local system notifications if they occur when the app is in the background. In this PR we do the same for failure notices.

**To test:**

* In the Media Library, start some media uploading
* Before the media completes, exit to the home screen and cause the uploads to fail (I used Airplane Mode)
* You should see a system notification confirming that the uploads failed.
  * If you tap the notification, you'll be taken back to the media library in the app (you could also test this by navigating away from the media library in the app before leaving to the home screen)
  * If you pull down on the notification, you should reveal a Retry action. Tapping this should take you back to the media library and attempt to retry the uploads. The best way to test this is to turn airplane mode off when you see the notification appear, and then interact with the notification so that the Retry will be successful.