### PR TITLE
Update version of endpoint being used on me/sites

### DIFF
--- a/WordPressKit/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/AccountServiceRemoteREST.m
@@ -246,7 +246,7 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
                        failure:(void (^)(NSError *))failure
 {
     NSString *requestUrl = [self pathForEndpoint:@"me/sites"
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
     [self.wordPressComRestApi GET:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {


### PR DESCRIPTION
Fixes #8515

This PR updates the version of the endpoint that is being used for `me/sites` to version 1.2.

The only difference I detected using a diff tools is that the new endpoint is not offering the following entry `site.plans.free_trial`

To test:
 - Start the app from scratch
 - Check that the sites are sync correct
 - Go around inside some sites and check if any information is missing
 - Site plan and Site Settings are good places to check.

