### PR TITLE
Media notices: Pre-insert uploaded media into new editor post

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -652,6 +652,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatNotificationsTappedViewReader:
             eventName = @"notification_tapped_view_reader";
             break;
+        case WPAnalyticsStatNotificationsUploadMediaSuccessWritePost:
+            eventName = @"notifications_upload_media_success_write_post";
+            break;
         case WPAnalyticsStatOnePasswordFailed:
             eventName = @"one_password_failed";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
@@ -7,6 +7,7 @@ public extension WPAppAnalytics {
         case inlinePicker
         case fullScreenPicker
         case documentPicker
+        case mediaUploadWritePost
         case none
 
         public var description: String {
@@ -14,6 +15,7 @@ public extension WPAppAnalytics {
             case .inlinePicker: return "inline_picker"
             case .fullScreenPicker: return "full_screen_picker"
             case .documentPicker: return "document_picker"
+            case .mediaUploadWritePost: return "media_write_post"
             case .none: return "not_identified"
             }
         }

--- a/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
@@ -246,6 +246,17 @@ public class MediaProgressCoordinator: NSObject {
         return failedMediaIDs.flatMap({ media(withIdentifier: $0) })
     }
 
+    /// Returns a list of all media objects that have completed successfully
+    ///
+    var successfulMedia: [Media] {
+        guard !isRunning else {
+            return []
+        }
+
+        let mediaIDs = mediaInProgress.filter({ !$0.value.isFailed && !$0.value.isCancelled })
+        return mediaIDs.flatMap({ media(withIdentifier: $0.key) })
+    }
+
     // MARK: - KeyPath observer method for the global progress property
 
     public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2732,7 +2732,13 @@ extension AztecPostViewController {
 
     /// Insert media to the post from the site's media library.
     ///
-    func insertSiteMediaLibrary(media: Media) {
+    func prepopulateMediaItems(_ media: [Media]) {
+        selectedMediaOrigin = .mediaUploadWritePost
+
+        media.forEach({ insertSiteMediaLibrary(media: $0) })
+    }
+
+    private func insertSiteMediaLibrary(media: Media) {
         if media.hasRemote {
             insertRemoteSiteMediaLibrary(media: media)
         } else {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2730,7 +2730,9 @@ extension AztecPostViewController {
         insert(exportableAsset: phAsset, source: .localLibrary)
     }
 
-    fileprivate func insertSiteMediaLibrary(media: Media) {
+    /// Insert media to the post from the site's media library.
+    ///
+    func insertSiteMediaLibrary(media: Media) {
         if media.hasRemote {
             insertRemoteSiteMediaLibrary(media: media)
         } else {

--- a/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
@@ -6,13 +6,14 @@ import UIKit
 class MediaNoticeNavigationCoordinator {
     static func presentEditor(with userInfo: NSDictionary) {
         if let blog = blog(from: userInfo) {
-            presentEditor(for: blog, source: "media_upload_notification")
+            presentEditor(for: blog, source: "media_upload_notification", media: successfulMedia(from: userInfo))
         }
     }
 
-    static func presentEditor(for blog: Blog, source: String) {
+    static func presentEditor(for blog: Blog, source: String, media: [Media]) {
         let editor = EditPostViewController(blog: blog)
         editor.modalPresentationStyle = .fullScreen
+        editor.insertedMedia = media
         WPTabBarController.sharedInstance().present(editor, animated: false, completion: nil)
         WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": source], with: blog)
     }
@@ -24,7 +25,7 @@ class MediaNoticeNavigationCoordinator {
     }
 
     static func retryMediaUploads(with userInfo: NSDictionary) {
-        let media = self.media(from: userInfo)
+        let media = failedMedia(from: userInfo)
         media.forEach({ MediaCoordinator.shared.retryMedia($0) })
     }
 
@@ -42,10 +43,18 @@ class MediaNoticeNavigationCoordinator {
         return blog
     }
 
-    private static func media(from userInfo: NSDictionary) -> [Media] {
+    private static func successfulMedia(from userInfo: NSDictionary) -> [Media] {
+        return media(from: userInfo, withKey: MediaNoticeUserInfoKey.mediaIDs)
+    }
+
+    private static func failedMedia(from userInfo: NSDictionary) -> [Media] {
+        return media(from: userInfo, withKey: MediaNoticeUserInfoKey.failedMediaIDs)
+    }
+
+    private static func media(from userInfo: NSDictionary, withKey key: String) -> [Media] {
         let context = ContextManager.sharedInstance().mainContext
 
-        if let mediaIDs = userInfo[MediaNoticeUserInfoKey.failedMediaIDs] as? [String] {
+        if let mediaIDs = userInfo[key] as? [String] {
             let media = mediaIDs.flatMap({ mediaID -> Media? in
                 if let URIRepresentation = URL(string: mediaID),
                     let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: URIRepresentation),

--- a/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
@@ -11,6 +11,8 @@ class MediaNoticeNavigationCoordinator {
     }
 
     static func presentEditor(for blog: Blog, source: String, media: [Media]) {
+        WPAppAnalytics.track(.notificationsUploadMediaSuccessWritePost, with: blog)
+
         let editor = EditPostViewController(blog: blog)
         editor.modalPresentationStyle = .fullScreen
         editor.insertedMedia = media

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -1,11 +1,13 @@
 enum MediaNoticeUserInfoKey {
     static let blogID = "blog_id"
     static let failedMediaIDs = "failed_media_ids"
+    static let mediaIDs = "media_ids"
 }
 
 struct MediaProgressCoordinatorNoticeViewModel {
     private let mediaProgressCoordinator: MediaProgressCoordinator
     private let progress: Progress
+    private let successfulMedia: [Media]
     private let failedMedia: [Media]
 
     init?(mediaProgressCoordinator: MediaProgressCoordinator) {
@@ -17,6 +19,7 @@ struct MediaProgressCoordinatorNoticeViewModel {
         self.mediaProgressCoordinator = mediaProgressCoordinator
         self.progress = progress
 
+        successfulMedia = mediaProgressCoordinator.successfulMedia
         failedMedia = mediaProgressCoordinator.failedMedia
     }
 
@@ -41,7 +44,7 @@ struct MediaProgressCoordinatorNoticeViewModel {
                       notificationInfo: notificationInfo,
                       actionTitle: actionTitle,
                       actionHandler: {
-                        MediaNoticeNavigationCoordinator.presentEditor(for: blog, source: "media_upload_notice")
+                        MediaNoticeNavigationCoordinator.presentEditor(for: blog, source: "media_upload_notice", media: self.successfulMedia)
         })
     }
 
@@ -64,7 +67,9 @@ struct MediaProgressCoordinatorNoticeViewModel {
             userInfo[MediaNoticeUserInfoKey.blogID] = blog.objectID.uriRepresentation().absoluteString
         }
 
-        if !uploadSuccessful {
+        if uploadSuccessful {
+            userInfo[MediaNoticeUserInfoKey.mediaIDs] = successfulMedia.map({ $0.objectID.uriRepresentation().absoluteString })
+        } else {
             userInfo[MediaNoticeUserInfoKey.failedMediaIDs] = failedMedia.map({ $0.objectID.uriRepresentation().absoluteString })
         }
 

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -143,9 +143,10 @@ class EditPostViewController: UIViewController {
         postPost.present(navController, animated: !showImmediately) {
             generator.impactOccurred()
 
-            self.insertedMedia?.forEach({
-                (editor as! AztecPostViewController).insertSiteMediaLibrary(media: $0)
-            })
+            if let insertedMedia = self.insertedMedia,
+                let aztec = editor as? AztecPostViewController {
+                aztec.prepopulateMediaItems(insertedMedia)
+            }
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -6,6 +6,8 @@ class EditPostViewController: UIViewController {
     @objc var showImmediately: Bool = false
     /// appear with the media picker open
     @objc var openWithMediaPicker: Bool = false
+    /// appear with media pre-inserted into the post
+    var insertedMedia: [Media]? = nil
 
     @objc fileprivate(set) var post: Post?
     fileprivate var hasShownEditor = false
@@ -140,6 +142,10 @@ class EditPostViewController: UIViewController {
 
         postPost.present(navController, animated: !showImmediately) {
             generator.impactOccurred()
+
+            self.insertedMedia?.forEach({
+                (editor as! AztecPostViewController).insertSiteMediaLibrary(media: $0)
+            })
         }
     }
 

--- a/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -147,6 +147,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatNotificationsSettingsUpdated,
     WPAnalyticsStatNotificationsSiteFollowAction,
     WPAnalyticsStatNotificationsSiteUnfollowAction,
+    WPAnalyticsStatNotificationsUploadMediaSuccessWritePost,
     WPAnalyticsStatOnePasswordFailed,
     WPAnalyticsStatOnePasswordLogin,
     WPAnalyticsStatOnePasswordSignup,


### PR DESCRIPTION
Fixes #8520. This PR updates the behaviour to show the editor when the user taps the Write Post button in successful media upload notices. Now, when the editor is presented, the post will be pre-populated with the uploaded media items.

**To test:**

* In the media library, start some media items uploading
* When the upload completes, tap the **Write Post** button on the Notice
* Check that the editor is displayed with the new media items ready populated
* Also test the same but exit to the home screen once we've started items uploading, and using the Write Post action from the system notification that's displayed.