### PR TITLE
Small site icon fix for managing followed sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -293,6 +293,9 @@ extension ReaderFollowedSitesViewController: WPTableViewHandlerDelegate {
             return
         }
 
+        // Reset the site icon first to address: https://github.com/wordpress-mobile/WordPress-iOS/issues/8513
+        cell.imageView?.image = .siteIconPlaceholderImage
+
         cell.accessoryType = .disclosureIndicator
         cell.imageView?.backgroundColor = WPStyleGuide.greyLighten30()
 


### PR DESCRIPTION
Title has it. Fixes #8513 

To test:
1. Log into WPiOS with and account that follows lots of sites.
2. Open up Reader-> Followed Sites -> Manage
3. Scroll around and verify site icons are not reused on incorrect sites (a slower connection may help).
4. Profit.

@elibud Could you do a quick review for this?

