### PR TITLE
Update Aztec to beta 18.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -56,7 +56,7 @@ target 'WordPress' do
   pod 'Gridicons', '0.14'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.26'
-  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git', :commit => '018f9dc45d806c9317bd927a4890e9a19467accd'
+  pod 'WordPress-Aztec-iOS', '1.0.0-beta.18'
 
   target 'WordPressTest' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -114,7 +114,7 @@ PODS:
   - SVProgressHUD (2.2.2)
   - TTTAttributedLabel (2.0.0)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0-beta.16)
+  - WordPress-Aztec-iOS (1.0.0-beta.18)
   - WPMediaPicker (0.26)
   - wpxmlrpc (0.8.3)
 
@@ -147,7 +147,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.2)
   - TTTAttributedLabel (= 2.0)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git`, commit `018f9dc45d806c9317bd927a4890e9a19467accd`)
+  - WordPress-Aztec-iOS (= 1.0.0-beta.18)
   - WPMediaPicker (= 0.26)
   - wpxmlrpc (= 0.8.3)
 
@@ -155,17 +155,11 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
-  WordPress-Aztec-iOS:
-    :commit: 018f9dc45d806c9317bd927a4890e9a19467accd
-    :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.1
-  WordPress-Aztec-iOS:
-    :commit: 018f9dc45d806c9317bd927a4890e9a19467accd
-    :git: https://github.com/wordpress-mobile/WordPress-Aztec-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -199,10 +193,10 @@ SPEC CHECKSUMS:
   SVProgressHUD: 59b2d3dabacbd051576d21d32293ca7228dc18b0
   TTTAttributedLabel: 8cffe8e127e4e82ff3af1e5386d4cd0ad000b656
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 4713c6e5d3ccd4ce7457a16e6b43b58d1c0cc6a8
+  WordPress-Aztec-iOS: 8929857a18735f01cf2ea6e7de96ec79ed2958ec
   WPMediaPicker: 847c1f84f93fda7dda8cc9a8cbc1ffb6e47dea63
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: f9cea8b1257db29abe2eba356b64a96452d5ad38
+PODFILE CHECKSUM: 4b6ef78ca7ea772d396703d05331ede9c280252c
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
This PR updates Aztec to beta 18.

The main change in beta 18 is a change on the TextViewAttachmentDelegate for the deleteAttachment callback.
This was already integrated on the main app but referring to a version of the pod using a commit SHA reference. This update the reference to use an official Aztec reference.

To test:
 - Make sure the project compiles and passes unit tests correctly.

