### PR TITLE
Makes the soft keyboard active when launching share extension

### DIFF
--- a/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
@@ -62,6 +62,7 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
         textView.formattingDelegate = self
         textView.textAttachmentDelegate = self
         textView.backgroundColor = ShareColors.aztecBackground
+        textView.tintColor = ShareColors.aztecCursorColor
         textView.linkTextAttributes = NSAttributedStringKey.convertToRaw(attributes: linkAttributes)
         textView.textAlignment = .natural
 
@@ -108,7 +109,8 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.textAlignment = .natural
         textView.isScrollEnabled = false
-        textView.backgroundColor = .clear
+        textView.tintColor = ShareColors.aztecCursorColor
+        textView.backgroundColor = ShareColors.aztecBackground
         textView.spellCheckingType = .default
 
         return textView
@@ -1293,6 +1295,7 @@ fileprivate extension ShareExtensionEditorViewController {
         static let aztecLinkColor                       = WPStyleGuide.mediumBlue()
         static let aztecFormatBarDisabledColor          = WPStyleGuide.greyLighten20()
         static let aztecFormatBarDividerColor           = WPStyleGuide.greyLighten30()
+        static let aztecCursorColor                     = WPStyleGuide.wordPressBlue()
         static let aztecFormatBarBackgroundColor        = UIColor.white
         static let aztecFormatBarInactiveColor: UIColor = UIColor(hexString: "7B9AB1")
         static let aztecFormatBarActiveColor: UIColor   = UIColor(hexString: "11181D")


### PR DESCRIPTION
Title has it.

![share_keyboard](https://user-images.githubusercontent.com/154014/35589906-e0d8f0be-05ca-11e8-8a13-63ac735b4009.gif)

Fixes #8540 

**To test:**
1. Launch the share extension (with text/photos/web)
2. Verify the soft keyboard appears and the cursor is positioned at the end of the post.
3. Press the next button, verify the keyboard is dismissed.
4. Press the back button, verify the keyboard appears again.

Also, try the same thing on an iPad with the hardware keyboard attached/not attached.

@SergioEstevao would you mind taking a peek at this?

/cc @folletto 