### PR TITLE
Use main context for insertion.

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -47,7 +47,7 @@ class MediaCoordinator: NSObject {
     @discardableResult
     private func addMedia(from asset: ExportableAsset, to objectID: NSManagedObjectID) -> Media {
         mediaProgressCoordinator.track(numberOfItems: 1)
-        let service = MediaService(managedObjectContext: backgroundContext)
+        let service = MediaService(managedObjectContext: mainContext)
         let totalProgress = Progress.discreteProgress(totalUnitCount: MediaExportProgressUnits.done)
         var creationProgress: Progress? = nil
         let media = service.createMedia(with: asset,


### PR DESCRIPTION
Fixes #8549 

This PR changes the context where insertions are done to avoid scenarios where the app get's deadlocked waiting for a secondary thread to get active to execute the work.

To test:
 - Check ticket for steps on how to reproduce.

