### PR TITLE
Cleaned up login alert for share extension

### DIFF
--- a/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
@@ -1253,9 +1253,9 @@ private extension ShareExtensionEditorViewController {
             return
         }
 
-        let title = NSLocalizedString("Login to WordPress to Share", comment: "Share extension dialog title - displayed when user is missing a login token.")
-        let message = NSLocalizedString("Please launch the WordPress app and log in, then try again.", comment: "Share extension dialog text  - displayed when user is missing a login token.")
-        let accept = NSLocalizedString("Cancel Sharing", comment: "Share extension dialog dismiss button label - displayed when user is missing a login token.")
+        let title = NSLocalizedString("Sharing error", comment: "Share extension dialog title - displayed when user is missing a login token.")
+        let message = NSLocalizedString("Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again.", comment: "Share extension dialog text  - displayed when user is missing a login token.")
+        let accept = NSLocalizedString("Cancel sharing", comment: "Share extension dialog dismiss button label - displayed when user is missing a login token.")
 
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let alertAction = UIAlertAction(title: accept, style: .default) { (action) in


### PR DESCRIPTION
This PR changes the alert text displayed to a user when they don't have an oauth token set when the share extension launches:

<img width="537" alt="screen shot 2018-01-31 at 3 11 30 pm" src="https://user-images.githubusercontent.com/154014/35647959-d6ba5f94-0699-11e8-9dbe-4cae1e7749a5.png">

Note that this PR is merely a stopgap. In a subsequent PR, we need to get smarter about what the user needs to do in order to share something to WordPress. e.g:

>    I'm not logged in at all.
>    I'm logged in to a WordPress.com account with no sites.
>    I'm logged in to a self-hosted site that doesn't use Jetpack.

Addresses part of #8552 for WPiOS 9.3

To test:
1. Launch WPiOS and log out.
2. Open Safari and attempt to share a webpage. 
3. Verify the alert text matches the image above ☝️ 

@elibud Could you give this a quick 👀 ?


