### PR TITLE
Fix connection flow redirect handling.

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackConnectionWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackConnectionWebViewController.swift
@@ -82,20 +82,20 @@ extension JetpackConnectionWebViewController: WKNavigationDelegate {
         }
 
         Debug.log("🚀🔌 Step: \(step)")
+        if step.isAdminPage,
+            let redirect = pendingSiteRedirect {
+            pendingSiteRedirect = nil
+            decisionHandler(.cancel)
+            webView.load(URLRequest(url: redirect))
+            return
+        }
+
         switch step {
         case .siteLoginForm(let redirect):
             performSiteLogin(redirect: redirect, decisionHandler: decisionHandler)
         case .dotComLoginForm(let redirect):
             decisionHandler(.cancel)
             performDotComLogin(redirect: redirect)
-        case .siteAdmin:
-            if let redirect = pendingSiteRedirect {
-                pendingSiteRedirect = nil
-                decisionHandler(.cancel)
-                webView.load(URLRequest(url: redirect))
-            } else {
-                decisionHandler(.allow)
-            }
         case .mobileRedirect:
             decisionHandler(.cancel)
             handleMobileRedirect()
@@ -140,6 +140,15 @@ private extension JetpackConnectionWebViewController {
                 return "WordPress.com login, redirecting to \(redirect)"
             case .mobileRedirect:
                 return "Mobile Redirect, end of the connection flow"
+            }
+        }
+
+        var isAdminPage: Bool {
+            switch self {
+            case .sitePluginDetail, .sitePluginInstallation, .sitePlugins, .siteAdmin:
+                return true
+            case .siteLoginForm, .dotComLoginForm, .mobileRedirect:
+                return false
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackConnectionWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackConnectionWebViewController.swift
@@ -225,8 +225,8 @@ private extension JetpackConnectionWebViewController {
         }
         service.syncBlog(
             blog,
-            success: { [account] in
-                guard let account = account else {
+            success: { [weak self] in
+                guard let account = self?.account ?? self?.defaultAccount() else {
                     // If there's no account let's pretend this worked
                     // We don't know what to do, but at least it will dismiss
                     // the connection flow and refresh the site state
@@ -256,9 +256,7 @@ private extension JetpackConnectionWebViewController {
     }
 
     func performDotComLogin(redirect: URL) {
-        let context = ContextManager.sharedInstance().mainContext
-        let service = AccountService(managedObjectContext: context)
-        if let account = service.defaultWordPressComAccount(),
+        if let account = defaultAccount(),
             let token = account.authToken,
             let username = account.username {
             authenticateWithDotCom(username: username, token: token, redirect: redirect)
@@ -304,6 +302,12 @@ private extension JetpackConnectionWebViewController {
         if let redirect = pendingDotComRedirect {
             performDotComLogin(redirect: redirect)
         }
+    }
+
+    func defaultAccount() -> WPAccount? {
+        let context = ContextManager.sharedInstance().mainContext
+        let service = AccountService(managedObjectContext: context)
+        return service.defaultWordPressComAccount()
     }
 
     enum Debug {


### PR DESCRIPTION
After a round of testing, it was reported that the flow was redirecting
to the plugin installation page right after selecting "Connect to
WordPress.com".

The problem was the current step switch was too specific, and it was
only clearing the site redirect if visiting an admin page other than
the expected ones (this was a workaround because poopy.life takes you
to wp-admin instead of the passed redirect_to URL).

This change will check if the detected step is any admin page and
prioritize using the redirect if there is a pending one.

To test:

1. Create a jurassic.ninja test site without Jetpack: https://jurassic.ninja/create?nojetpack
2. Add a new user to the site with my own email address
3. Log in to the test site in the app with that new user account
4. Try to set up Jetpack in the app
