### PR TITLE
Don't pre-auth Jetpack FAQ link

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
@@ -201,7 +201,7 @@ class JetpackLoginViewController: UIViewController {
         guard let url =  URL(string: url) else {
             return
         }
-        let webViewController = WebViewControllerFactory.controller(url: url, blog: blog)
+        let webViewController = WebViewControllerFactory.controller(url: url)
 
         if presentingViewController != nil {
             navigationController?.pushViewController(webViewController, animated: true)


### PR DESCRIPTION
This was authenticating with the blog prior to loading a link on
apps.wordpress.com, and it wasn't redirecting properly, showing the
blog's wp-admin instead.

To test:

- Go to Stats on a self hosted site without Jetpack
- Ensure the more information link loads the FAQ