### PR TITLE
Tweak line breaks on Jetpack login prompt

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
@@ -140,7 +140,7 @@ class JetpackLoginViewController: UIViewController {
 
         if jetPack.isConnected {
             if jetPack.isUpdatedToRequiredVersion {
-                message = NSLocalizedString("Looks like you have Jetpack set up on your site. Congrats! \n" +
+                message = NSLocalizedString("Looks like you have Jetpack set up on your site. Congrats! " +
                                             "Log in with your WordPress.com credentials to enable " +
                                             "Stats and Notifications.",
                                             comment: "Message asking the user to sign into Jetpack with WordPress.com credentials")


### PR DESCRIPTION
There was indeed a line break after the "Congrats!". This PR removes it.

![login-prompt](https://user-images.githubusercontent.com/8739/35723949-5ec359fa-07fc-11e8-908c-400bea83afde.png)
