### PR TITLE
Share Ext: Added notification support to the share extension

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -673,6 +673,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatNotificationsUploadMediaSuccessWritePost:
             eventName = @"notifications_upload_media_success_write_post";
             break;
+        case WPAnalyticsStatNotificationsShareSuccessEditPost:
+            eventName = @"notifications_share_success_edit_post";
+            break;
         case WPAnalyticsStatOnePasswordFailed:
             eventName = @"one_password_failed";
             break;

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -118,6 +118,20 @@ final class InteractiveNotificationsManager: NSObject {
                         break
                     }
                 }
+            case .shareUploadSuccess:
+                if identifier == UNNotificationDefaultActionIdentifier {
+                    ShareNoticeNavigationCoordinator.navigateToPostList(with: userInfo)
+                    return true
+                }
+
+                if let action = NoteActionDefinition(rawValue: identifier) {
+                    switch action {
+                    case .shareEditPost:
+                        ShareNoticeNavigationCoordinator.presentEditor(with: userInfo)
+                    default:
+                        break
+                    }
+                }
             default: break
             }
         }
@@ -216,6 +230,7 @@ private extension InteractiveNotificationsManager {
         case commentReplyWithLike   = "replyto-like-comment"
         case mediaUploadSuccess     = "media-upload-success"
         case mediaUploadFailure     = "media-upload-failure"
+        case shareUploadSuccess     = "share-upload-success"
 
         var actions: [NoteActionDefinition] {
             switch self {
@@ -231,6 +246,8 @@ private extension InteractiveNotificationsManager {
                 return [.mediaWritePost]
             case .mediaUploadFailure:
                 return [.mediaRetry]
+            case .shareUploadSuccess:
+                return [.shareEditPost]
             }
         }
 
@@ -250,8 +267,8 @@ private extension InteractiveNotificationsManager {
                 options: [])
         }
 
-        static var allDefinitions = [commentApprove, commentLike, commentReply, commentReplyWithLike, mediaUploadSuccess, mediaUploadFailure]
-        static var localDefinitions = [mediaUploadSuccess, mediaUploadFailure]
+        static var allDefinitions = [commentApprove, commentLike, commentReply, commentReplyWithLike, mediaUploadSuccess, mediaUploadFailure, shareUploadSuccess]
+        static var localDefinitions = [mediaUploadSuccess, mediaUploadFailure, shareUploadSuccess]
     }
 
 
@@ -264,6 +281,7 @@ private extension InteractiveNotificationsManager {
         case commentReply     = "COMMENT_REPLY"
         case mediaWritePost   = "MEDIA_WRITE_POST"
         case mediaRetry       = "MEDIA_RETRY"
+        case shareEditPost    = "SHARE_EDIT_POST"
 
         var description: String {
             switch self {
@@ -277,6 +295,8 @@ private extension InteractiveNotificationsManager {
                 return NSLocalizedString("Write Post", comment: "Opens the editor to write a new post.")
             case .mediaRetry:
                 return NSLocalizedString("Retry", comment: "Opens the media library .")
+            case .shareEditPost:
+                return NSLocalizedString("Edit Post", comment: "Opens the editor to edit an existing post.")
             }
         }
 
@@ -294,7 +314,7 @@ private extension InteractiveNotificationsManager {
 
         var requiresForeground: Bool {
             switch self {
-            case .mediaWritePost, .mediaRetry:
+            case .mediaWritePost, .mediaRetry, .shareEditPost:
                 return true
             default: return false
             }
@@ -327,7 +347,7 @@ private extension InteractiveNotificationsManager {
             }
         }
 
-        static var allDefinitions = [commentApprove, commentLike, commentReply, mediaWritePost, mediaRetry]
+        static var allDefinitions = [commentApprove, commentLike, commentReply, mediaWritePost, mediaRetry, shareEditPost]
     }
 }
 

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -232,6 +232,7 @@ private extension InteractiveNotificationsManager {
         case mediaUploadSuccess     = "media-upload-success"
         case mediaUploadFailure     = "media-upload-failure"
         case shareUploadSuccess     = "share-upload-success"
+        case shareUploadFailure     = "share-upload-failure"
 
         var actions: [NoteActionDefinition] {
             switch self {
@@ -249,6 +250,8 @@ private extension InteractiveNotificationsManager {
                 return [.mediaRetry]
             case .shareUploadSuccess:
                 return [.shareEditPost]
+            case .shareUploadFailure:
+                return []
             }
         }
 
@@ -268,8 +271,8 @@ private extension InteractiveNotificationsManager {
                 options: [])
         }
 
-        static var allDefinitions = [commentApprove, commentLike, commentReply, commentReplyWithLike, mediaUploadSuccess, mediaUploadFailure, shareUploadSuccess]
-        static var localDefinitions = [mediaUploadSuccess, mediaUploadFailure, shareUploadSuccess]
+        static var allDefinitions = [commentApprove, commentLike, commentReply, commentReplyWithLike, mediaUploadSuccess, mediaUploadFailure, shareUploadSuccess, shareUploadFailure]
+        static var localDefinitions = [mediaUploadSuccess, mediaUploadFailure, shareUploadSuccess, shareUploadFailure]
     }
 
 
@@ -368,8 +371,9 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
                 return
         }
 
+        // If the notification orginated from the share extension, disregard this current notification and resend a new one.
         ShareExtensionSessionManager.fireUserNotificationIfNeeded(postUploadOpID)
-        completionHandler([]) // Do nothing here!
+        completionHandler([])
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter,

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -133,6 +133,11 @@ final class InteractiveNotificationsManager: NSObject {
                         break
                     }
                 }
+            case .shareUploadFailure:
+                if identifier == UNNotificationDefaultActionIdentifier {
+                    ShareNoticeNavigationCoordinator.navigateToBlogDetails(with: userInfo)
+                    return true
+                }
             default: break
             }
         }

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CocoaLumberjack
 import UserNotifications
+import WordPressFlux
 
 
 /// In this class, we'll encapsulate all of the code related to UNNotificationCategory and
@@ -355,6 +356,21 @@ private extension InteractiveNotificationsManager {
 // MARK: - UNUserNotificationCenterDelegate Conformance
 //
 extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Swift.Void) {
+        let userInfo = notification.request.content.userInfo as NSDictionary
+        let category = notification.request.content.categoryIdentifier
+
+        guard (category == ShareNoticeConstants.categorySuccessIdentifier || category == ShareNoticeConstants.categoryFailureIdentifier),
+            (userInfo.object(forKey: ShareNoticeUserInfoKey.originatedFromAppExtension) as? Bool) == true,
+            let postUploadOpID = userInfo.object(forKey: ShareNoticeUserInfoKey.postUploadOpID) as? String  else {
+                return
+        }
+
+        ShareExtensionSessionManager.fireUserNotificationIfNeeded(postUploadOpID)
+        completionHandler([]) // Do nothing here!
+    }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                        didReceive response: UNNotificationResponse,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -397,6 +397,7 @@
 		74F24F681EE8729700E8BFE8 /* xmlrpc-malformed-request-xml-error.xml in Resources */ = {isa = PBXBuildFile; fileRef = 74F24F631EE8729700E8BFE8 /* xmlrpc-malformed-request-xml-error.xml */; };
 		74F5CD381FE0646F00764E7C /* ShareExtension.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 74F5CD371FE0646F00764E7C /* ShareExtension.storyboard */; };
 		74F5CD3A1FE0653500764E7C /* ShareExtensionEditorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F5CD391FE0653500764E7C /* ShareExtensionEditorViewController.swift */; };
+		74F89407202A1965008610FA /* ExtensionNotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F89406202A1965008610FA /* ExtensionNotificationManager.swift */; };
 		74FA2EE4200E8A6C001DDC13 /* AppExtensionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FA2EE3200E8A6C001DDC13 /* AppExtensionsService.swift */; };
 		74FA4BE51FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 74FA4BE31FBFA0660031EAAD /* Extensions.xcdatamodeld */; };
 		74FA4BE61FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 74FA4BE31FBFA0660031EAAD /* Extensions.xcdatamodeld */; };
@@ -1694,6 +1695,7 @@
 		74F24F631EE8729700E8BFE8 /* xmlrpc-malformed-request-xml-error.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "xmlrpc-malformed-request-xml-error.xml"; sourceTree = "<group>"; };
 		74F5CD371FE0646F00764E7C /* ShareExtension.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ShareExtension.storyboard; sourceTree = "<group>"; };
 		74F5CD391FE0653500764E7C /* ShareExtensionEditorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionEditorViewController.swift; sourceTree = "<group>"; };
+		74F89406202A1965008610FA /* ExtensionNotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionNotificationManager.swift; sourceTree = "<group>"; };
 		74FA2EE3200E8A6C001DDC13 /* AppExtensionsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppExtensionsService.swift; sourceTree = "<group>"; };
 		74FA4BE41FBFA0660031EAAD /* Extensions.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Extensions.xcdatamodel; sourceTree = "<group>"; };
 		75305C06D345590B757E3890 /* Pods-WordPress.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.debug.xcconfig"; sourceTree = "<group>"; };
@@ -3728,6 +3730,7 @@
 		7462BFD22028CD0500B552D8 /* Notices */ = {
 			isa = PBXGroup;
 			children = (
+				74F89406202A1965008610FA /* ExtensionNotificationManager.swift */,
 				74EA3B87202A0462004F802D /* ShareNoticeConstants.swift */,
 				7462BFCF2028C49800B552D8 /* ShareNoticeViewModel.swift */,
 				7462BFD32028CD4400B552D8 /* ShareNoticeNavigationCoordinator.swift */,
@@ -7414,6 +7417,7 @@
 				74FA4BE61FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */,
 				74D06FEB1FE0788500AF1788 /* TextList+WordPress.swift in Sources */,
 				74FA2EE4200E8A6C001DDC13 /* AppExtensionsService.swift in Sources */,
+				74F89407202A1965008610FA /* ExtensionNotificationManager.swift in Sources */,
 				74D06FEC1FE0869D00AF1788 /* NSAttributedStringKey+Conversion.swift in Sources */,
 				E125F1E51E8E596200320B67 /* SharePost.swift in Sources */,
 				745EAF4A20040B220066F415 /* ShareData.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -364,6 +364,8 @@
 		745EAF452003FD050066F415 /* ShareSegueHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745EAF442003FD050066F415 /* ShareSegueHandler.swift */; };
 		745EAF472003FDAA0066F415 /* ShareExtensionAbstractViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745EAF462003FDAA0066F415 /* ShareExtensionAbstractViewController.swift */; };
 		745EAF4A20040B220066F415 /* ShareData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745EAF4920040B220066F415 /* ShareData.swift */; };
+		7462BFD02028C49800B552D8 /* ShareNoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7462BFCF2028C49800B552D8 /* ShareNoticeViewModel.swift */; };
+		7462BFD42028CD4400B552D8 /* ShareNoticeNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7462BFD32028CD4400B552D8 /* ShareNoticeNavigationCoordinator.swift */; };
 		746A6F571E71C691003B67E3 /* DeleteSite.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 746A6F561E71C691003B67E3 /* DeleteSite.storyboard */; };
 		746D6B251FBF701F003C45BE /* SharedCoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 746D6B241FBF701F003C45BE /* SharedCoreDataStack.swift */; };
 		7470840F1E269669002CA726 /* JetpackLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7470840D1E269669002CA726 /* JetpackLoginViewController.swift */; };
@@ -544,12 +546,12 @@
 		9859DF86202107C600FB848E /* SiteCreationCategoryTableViewCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9859DF85202107C600FB848E /* SiteCreationCategoryTableViewCells.swift */; };
 		9859DF882021099800FB848E /* SiteCreationCategoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9859DF872021099800FB848E /* SiteCreationCategoryTableViewCell.xib */; };
 		9859DF8A20210B2100FB848E /* SiteCreationInstructionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9859DF8920210B2100FB848E /* SiteCreationInstructionTableViewCell.xib */; };
-		98B24D5A2017E2520082BA78 /* NUXButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B24D592017E2510082BA78 /* NUXButtonViewController.swift */; };
-		98B24D5D2017E39A0082BA78 /* NUXButtonView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 98B24D5C2017E39A0082BA78 /* NUXButtonView.storyboard */; };
-		98B24D5F2017E5490082BA78 /* SiteCreationEpilogueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B24D5E2017E5490082BA78 /* SiteCreationEpilogueViewController.swift */; };
 		98A437AE20069098004A8A57 /* SiteCreationDomainsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A437AD20069097004A8A57 /* SiteCreationDomainsTableViewController.swift */; };
 		98A437B0200693C0004A8A57 /* SiteCreationDomainsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A437AF200693C0004A8A57 /* SiteCreationDomainsViewController.swift */; };
 		98AD07651FFFF96B00485ACA /* SiteCreationSiteDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AD07641FFFF96A00485ACA /* SiteCreationSiteDetailsViewController.swift */; };
+		98B24D5A2017E2520082BA78 /* NUXButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B24D592017E2510082BA78 /* NUXButtonViewController.swift */; };
+		98B24D5D2017E39A0082BA78 /* NUXButtonView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 98B24D5C2017E39A0082BA78 /* NUXButtonView.storyboard */; };
+		98B24D5F2017E5490082BA78 /* SiteCreationEpilogueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B24D5E2017E5490082BA78 /* SiteCreationEpilogueViewController.swift */; };
 		98BFAAFF201F9D0200FDBE56 /* BlogListNoResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BFAAFE201F9D0100FDBE56 /* BlogListNoResultsViewController.swift */; };
 		98BFAB01201FA04700FDBE56 /* BlogListNoResults.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 98BFAB00201FA04700FDBE56 /* BlogListNoResults.storyboard */; };
 		98C43E861FE98092006FEF54 /* SignupNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C43E851FE98092006FEF54 /* SignupNavigationController.swift */; };
@@ -1668,6 +1670,8 @@
 		745EAF442003FD050066F415 /* ShareSegueHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSegueHandler.swift; sourceTree = "<group>"; };
 		745EAF462003FDAA0066F415 /* ShareExtensionAbstractViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionAbstractViewController.swift; sourceTree = "<group>"; };
 		745EAF4920040B220066F415 /* ShareData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareData.swift; sourceTree = "<group>"; };
+		7462BFCF2028C49800B552D8 /* ShareNoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareNoticeViewModel.swift; sourceTree = "<group>"; };
+		7462BFD32028CD4400B552D8 /* ShareNoticeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareNoticeNavigationCoordinator.swift; sourceTree = "<group>"; };
 		746A6F561E71C691003B67E3 /* DeleteSite.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = DeleteSite.storyboard; sourceTree = "<group>"; };
 		746D6B241FBF701F003C45BE /* SharedCoreDataStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedCoreDataStack.swift; sourceTree = "<group>"; };
 		7470840D1E269669002CA726 /* JetpackLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackLoginViewController.swift; sourceTree = "<group>"; };
@@ -1929,12 +1933,12 @@
 		9859DF85202107C600FB848E /* SiteCreationCategoryTableViewCells.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteCreationCategoryTableViewCells.swift; sourceTree = "<group>"; };
 		9859DF872021099800FB848E /* SiteCreationCategoryTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SiteCreationCategoryTableViewCell.xib; sourceTree = "<group>"; };
 		9859DF8920210B2100FB848E /* SiteCreationInstructionTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SiteCreationInstructionTableViewCell.xib; sourceTree = "<group>"; };
-		98B24D592017E2510082BA78 /* NUXButtonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NUXButtonViewController.swift; sourceTree = "<group>"; };
-		98B24D5C2017E39A0082BA78 /* NUXButtonView.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = NUXButtonView.storyboard; sourceTree = "<group>"; };
-		98B24D5E2017E5490082BA78 /* SiteCreationEpilogueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationEpilogueViewController.swift; sourceTree = "<group>"; };
 		98A437AD20069097004A8A57 /* SiteCreationDomainsTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteCreationDomainsTableViewController.swift; sourceTree = "<group>"; };
 		98A437AF200693C0004A8A57 /* SiteCreationDomainsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationDomainsViewController.swift; sourceTree = "<group>"; };
 		98AD07641FFFF96A00485ACA /* SiteCreationSiteDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteCreationSiteDetailsViewController.swift; sourceTree = "<group>"; };
+		98B24D592017E2510082BA78 /* NUXButtonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NUXButtonViewController.swift; sourceTree = "<group>"; };
+		98B24D5C2017E39A0082BA78 /* NUXButtonView.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = NUXButtonView.storyboard; sourceTree = "<group>"; };
+		98B24D5E2017E5490082BA78 /* SiteCreationEpilogueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationEpilogueViewController.swift; sourceTree = "<group>"; };
 		98BFAAFE201F9D0100FDBE56 /* BlogListNoResultsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlogListNoResultsViewController.swift; sourceTree = "<group>"; };
 		98BFAB00201FA04700FDBE56 /* BlogListNoResults.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = BlogListNoResults.storyboard; sourceTree = "<group>"; };
 		98C43E851FE98092006FEF54 /* SignupNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupNavigationController.swift; sourceTree = "<group>"; };
@@ -3718,6 +3722,15 @@
 			name = Protocols;
 			sourceTree = "<group>";
 		};
+		7462BFD22028CD0500B552D8 /* Notices */ = {
+			isa = PBXGroup;
+			children = (
+				7462BFCF2028C49800B552D8 /* ShareNoticeViewModel.swift */,
+				7462BFD32028CD4400B552D8 /* ShareNoticeNavigationCoordinator.swift */,
+			);
+			name = Notices;
+			sourceTree = "<group>";
+		};
 		74FA2EE2200E8A1D001DDC13 /* Services */ = {
 			isa = PBXGroup;
 			children = (
@@ -4039,6 +4052,7 @@
 			children = (
 				74FA4BDB1FBF994F0031EAAD /* Data */,
 				B5FA22851C99F63B0016CA7C /* Extensions */,
+				7462BFD22028CD0500B552D8 /* Notices */,
 				745EAF432003FC930066F415 /* Protocols */,
 				74FA2EE2200E8A1D001DDC13 /* Services */,
 				741D1478200D5533003DFD30 /* Style */,
@@ -6678,6 +6692,7 @@
 				B53971501D537763006135EC /* NotificationBlockGroup.swift in Sources */,
 				1759F1801FE1460C0003EC81 /* NoticeView.swift in Sources */,
 				B53971521D537B22006135EC /* NotificationBlock.swift in Sources */,
+				7462BFD02028C49800B552D8 /* ShareNoticeViewModel.swift in Sources */,
 				0807CB721CE670A800CDBDAC /* WPContentSearchHelper.swift in Sources */,
 				74AF4D7C1FE417D200E3EBFE /* PostUploadOperation.swift in Sources */,
 				37022D931981C19000F322B7 /* VerticallyStackedButton.m in Sources */,
@@ -6852,6 +6867,7 @@
 				B52C4C7D199D4CD3009FD823 /* NoteBlockUserTableViewCell.swift in Sources */,
 				E64384831C628FCC0052ADB5 /* WPStyleGuide+Sharing.swift in Sources */,
 				177074851FB209F100951A4A /* MediaCellProgressView.swift in Sources */,
+				7462BFD42028CD4400B552D8 /* ShareNoticeNavigationCoordinator.swift in Sources */,
 				43B3823C20090AE8008434F4 /* NUXViewControllerBase.swift in Sources */,
 				2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */,
 				F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -391,6 +391,8 @@
 		74D06FEA1FE0787400AF1788 /* Header+WordPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C631EF42B3A00372C65 /* Header+WordPress.swift */; };
 		74D06FEB1FE0788500AF1788 /* TextList+WordPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50C0C611EF42AF200372C65 /* TextList+WordPress.swift */; };
 		74D06FEC1FE0869D00AF1788 /* NSAttributedStringKey+Conversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = B56F25871FBDE502005C33E4 /* NSAttributedStringKey+Conversion.swift */; };
+		74EA3B88202A0462004F802D /* ShareNoticeConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74EA3B87202A0462004F802D /* ShareNoticeConstants.swift */; };
+		74EA3B89202A0462004F802D /* ShareNoticeConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74EA3B87202A0462004F802D /* ShareNoticeConstants.swift */; };
 		74F24F671EE8729700E8BFE8 /* xmlrpc-bad-username-password-error.xml in Resources */ = {isa = PBXBuildFile; fileRef = 74F24F621EE8729700E8BFE8 /* xmlrpc-bad-username-password-error.xml */; };
 		74F24F681EE8729700E8BFE8 /* xmlrpc-malformed-request-xml-error.xml in Resources */ = {isa = PBXBuildFile; fileRef = 74F24F631EE8729700E8BFE8 /* xmlrpc-malformed-request-xml-error.xml */; };
 		74F5CD381FE0646F00764E7C /* ShareExtension.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 74F5CD371FE0646F00764E7C /* ShareExtension.storyboard */; };
@@ -1687,6 +1689,7 @@
 		74AF4D711FE417D200E3EBFE /* PostUploadOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostUploadOperation.swift; sourceTree = "<group>"; };
 		74B335EB1F06F9520053A184 /* MockWordPressComRestApi.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockWordPressComRestApi.swift; sourceTree = "<group>"; };
 		74CEF0761F9AA0F700B729CA /* ShareExtensionSessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionSessionManager.swift; sourceTree = "<group>"; };
+		74EA3B87202A0462004F802D /* ShareNoticeConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareNoticeConstants.swift; sourceTree = "<group>"; };
 		74F24F621EE8729700E8BFE8 /* xmlrpc-bad-username-password-error.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "xmlrpc-bad-username-password-error.xml"; sourceTree = "<group>"; };
 		74F24F631EE8729700E8BFE8 /* xmlrpc-malformed-request-xml-error.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "xmlrpc-malformed-request-xml-error.xml"; sourceTree = "<group>"; };
 		74F5CD371FE0646F00764E7C /* ShareExtension.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ShareExtension.storyboard; sourceTree = "<group>"; };
@@ -3725,6 +3728,7 @@
 		7462BFD22028CD0500B552D8 /* Notices */ = {
 			isa = PBXGroup;
 			children = (
+				74EA3B87202A0462004F802D /* ShareNoticeConstants.swift */,
 				7462BFCF2028C49800B552D8 /* ShareNoticeViewModel.swift */,
 				7462BFD32028CD4400B552D8 /* ShareNoticeNavigationCoordinator.swift */,
 			);
@@ -7232,6 +7236,7 @@
 				98D60B9E1FFEE3D800145190 /* SiteCreationThemeSelectionCell.swift in Sources */,
 				5D42A3E2175E7452005CFF05 /* ReaderPost.m in Sources */,
 				B50C0C561EF42A0000372C65 /* ShortcodeProcessor.swift in Sources */,
+				74EA3B88202A0462004F802D /* ShareNoticeConstants.swift in Sources */,
 				B587797F19B799D800E57C5A /* UIImageView+Networking.swift in Sources */,
 				FF1933FF1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m in Sources */,
 				B54075D41D3D7D5B0095C318 /* IntrinsicTableView.swift in Sources */,
@@ -7398,6 +7403,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				741E224B1FC0E5C0007967AB /* UploadOperation.swift in Sources */,
+				74EA3B89202A0462004F802D /* ShareNoticeConstants.swift in Sources */,
 				B50248AF1C96FF6200AFBDED /* WPStyleGuide+Share.swift in Sources */,
 				E1CE41661E8D1026000CF5A4 /* ShareExtractor.swift in Sources */,
 				930F09191C7E1C1E00995926 /* ShareExtensionService.swift in Sources */,

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -285,12 +285,12 @@ fileprivate extension AppExtensionsService {
         uploadPost(forUploadOpWithObjectID: uploadPostOpID, onComplete: {
             // Schedule a local success notification
             if let uploadPostOp = self.coreDataStack.fetchPostUploadOp(withObjectID: uploadPostOpID) {
-                ExtensionNotificationManager.scheduleSuccessNotification(postID: String(uploadPostOp.remotePostID), blogID: String(uploadPostOp.siteID))
+                ExtensionNotificationManager.scheduleSuccessNotification(postID: String(uploadPostOp.remotePostID), blogID: String(uploadPostOp.siteID), mediaItemCount: mediaUploadOps.count)
             }
         }, onFailure: {
             // Schedule a local failure notification
             if let uploadPostOp = self.coreDataStack.fetchPostUploadOp(withObjectID: uploadPostOpID) {
-                ExtensionNotificationManager.scheduleFailureNotification(postID: String(uploadPostOp.remotePostID), blogID: String(uploadPostOp.siteID))
+                ExtensionNotificationManager.scheduleFailureNotification(postID: String(uploadPostOp.remotePostID), blogID: String(uploadPostOp.siteID), mediaItemCount: mediaUploadOps.count)
             }
         })
     }

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -117,13 +117,17 @@ extension AppExtensionsService {
         uploadPost(forUploadOpWithObjectID: uploadPostOpID, onComplete: {
             // Schedule a local success notification
             if let uploadPostOp = self.coreDataStack.fetchPostUploadOp(withObjectID: uploadPostOpID) {
-                ExtensionNotificationManager.scheduleSuccessNotification(postID: String(uploadPostOp.remotePostID), blogID: String(uploadPostOp.siteID))
+                ExtensionNotificationManager.scheduleSuccessNotification(postUploadOpID: uploadPostOp.objectID.uriRepresentation().absoluteString,
+                                                                         postID: String(uploadPostOp.remotePostID),
+                                                                         blogID: String(uploadPostOp.siteID))
             }
             onComplete?()
         }, onFailure: {
             // Schedule a local failure notification
             if let uploadPostOp = self.coreDataStack.fetchPostUploadOp(withObjectID: uploadPostOpID) {
-                ExtensionNotificationManager.scheduleFailureNotification(postID: String(uploadPostOp.remotePostID), blogID: String(uploadPostOp.siteID))
+                ExtensionNotificationManager.scheduleFailureNotification(postUploadOpID: uploadPostOp.objectID.uriRepresentation().absoluteString,
+                                                                         postID: String(uploadPostOp.remotePostID),
+                                                                         blogID: String(uploadPostOp.siteID))
             }
 
             // Error is already logged in coredata so no need to do it here.
@@ -285,12 +289,18 @@ fileprivate extension AppExtensionsService {
         uploadPost(forUploadOpWithObjectID: uploadPostOpID, onComplete: {
             // Schedule a local success notification
             if let uploadPostOp = self.coreDataStack.fetchPostUploadOp(withObjectID: uploadPostOpID) {
-                ExtensionNotificationManager.scheduleSuccessNotification(postID: String(uploadPostOp.remotePostID), blogID: String(uploadPostOp.siteID), mediaItemCount: mediaUploadOps.count)
+                ExtensionNotificationManager.scheduleSuccessNotification(postUploadOpID: uploadPostOp.objectID.uriRepresentation().absoluteString,
+                                                                         postID: String(uploadPostOp.remotePostID),
+                                                                         blogID: String(uploadPostOp.siteID),
+                                                                         mediaItemCount: mediaUploadOps.count)
             }
         }, onFailure: {
             // Schedule a local failure notification
             if let uploadPostOp = self.coreDataStack.fetchPostUploadOp(withObjectID: uploadPostOpID) {
-                ExtensionNotificationManager.scheduleFailureNotification(postID: String(uploadPostOp.remotePostID), blogID: String(uploadPostOp.siteID), mediaItemCount: mediaUploadOps.count)
+                ExtensionNotificationManager.scheduleFailureNotification(postUploadOpID: uploadPostOp.objectID.uriRepresentation().absoluteString,
+                                                                         postID: String(uploadPostOp.remotePostID),
+                                                                         blogID: String(uploadPostOp.siteID),
+                                                                         mediaItemCount: mediaUploadOps.count)
             }
         })
     }

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -95,7 +95,8 @@ extension AppExtensionsService {
 // MARK: - Uploading Posts
 
 extension AppExtensionsService {
-    /// Saves a new post to the share container db and then uploads it synchronously.
+    /// Saves a new post to the share container db and then uploads it synchronously. This function
+    /// WILL schedule a local notification to fire upon success or failure.
     ///
     /// - Parameters:
     ///   - title: Post title
@@ -114,49 +115,18 @@ extension AppExtensionsService {
 
         let uploadPostOpID = coreDataStack.savePostOperation(remotePost, groupIdentifier: groupIdentifier, with: .pending)
         uploadPost(forUploadOpWithObjectID: uploadPostOpID, onComplete: {
+            // Schedule a local success notification
+            if let uploadPostOp = self.coreDataStack.fetchPostUploadOp(withObjectID: uploadPostOpID) {
+                ExtensionNotificationManager.scheduleSuccessNotification(postID: String(uploadPostOp.remotePostID), blogID: String(uploadPostOp.siteID))
+            }
             onComplete?()
         }, onFailure: {
+            // Schedule a local failure notification
+            if let uploadPostOp = self.coreDataStack.fetchPostUploadOp(withObjectID: uploadPostOpID) {
+                ExtensionNotificationManager.scheduleFailureNotification(postID: String(uploadPostOp.remotePostID), blogID: String(uploadPostOp.siteID))
+            }
+
             // Error is already logged in coredata so no need to do it here.
-            onFailure?()
-        })
-    }
-
-    /// Uploads an already-saved post synchronously.
-    ///
-    /// - Parameters:
-    ///   - uploadOpObjectID: Managed object ID for the post
-    ///   - onComplete: Completion handler executed after a post is uploaded to the server.
-    ///   - onFailure: The (optional) failure handler.
-    ///
-    func uploadPost(forUploadOpWithObjectID uploadOpObjectID: NSManagedObjectID, onComplete: CompletionBlock?, onFailure: FailureBlock?) {
-        guard let postUploadOp = coreDataStack.fetchPostUploadOp(withObjectID: uploadOpObjectID) else {
-            DDLogError("Error uploading post in share extension — could not fetch saved post.")
-            onFailure?()
-            return
-        }
-
-        let remotePost = postUploadOp.remotePost
-        coreDataStack.updateStatus(.inProgress, forUploadOpWithObjectID: uploadOpObjectID)
-
-        // 15-Nov-2017: Creating a post without media on the PostServiceRemoteREST does not use background uploads
-        let remote = PostServiceRemoteREST(wordPressComRestApi: simpleRestAPI, siteID: remotePost.siteID)
-        remote.createPost(remotePost, success: { post in
-            if let post = post {
-                DDLogInfo("Post \(post.postID.stringValue) sucessfully uploaded to site \(post.siteID.stringValue)")
-                if let postID = post.postID {
-                    self.coreDataStack.updatePostOperation(with: .complete, remotePostID: postID.int64Value, forPostUploadOpWithObjectID: uploadOpObjectID)
-                } else {
-                    self.coreDataStack.updateStatus(.complete, forUploadOpWithObjectID: uploadOpObjectID)
-                }
-                onComplete?()
-            }
-        }, failure: { error in
-            var errorString = "Error creating post in share extension"
-            if let error = error as NSError? {
-                errorString += ": \(error.localizedDescription)"
-            }
-            DDLogError(errorString)
-            self.coreDataStack.updateStatus(.error, forUploadOpWithObjectID: uploadOpObjectID)
             onFailure?()
         })
     }
@@ -286,6 +256,11 @@ fileprivate extension AppExtensionsService {
         return (uploadMediaOpIDs, allRemoteMedia)
     }
 
+    /// This function takes the already-uploaded media, inserts it into the provided post, and then
+    /// uploads the post. This function WILL schedule a local notification to fire upon success or failure.
+    ///
+    /// - Parameter uploadPostOpID: Managed object ID for the post
+    ///
     func combinePostWithMediaAndUpload(forPostUploadOpWithObjectID uploadPostOpID: NSManagedObjectID) {
         guard let postUploadOp = coreDataStack.fetchPostUploadOp(withObjectID: uploadPostOpID),
             let groupID = postUploadOp.groupID,
@@ -307,7 +282,57 @@ fileprivate extension AppExtensionsService {
             postUploadOp.postContent = imgPostUploadProcessor.process(content)
         }
         coreDataStack.saveContext()
-        uploadPost(forUploadOpWithObjectID: uploadPostOpID, onComplete: nil, onFailure: nil)
+        uploadPost(forUploadOpWithObjectID: uploadPostOpID, onComplete: {
+            // Schedule a local success notification
+            if let uploadPostOp = self.coreDataStack.fetchPostUploadOp(withObjectID: uploadPostOpID) {
+                ExtensionNotificationManager.scheduleSuccessNotification(postID: String(uploadPostOp.remotePostID), blogID: String(uploadPostOp.siteID))
+            }
+        }, onFailure: {
+            // Schedule a local failure notification
+            if let uploadPostOp = self.coreDataStack.fetchPostUploadOp(withObjectID: uploadPostOpID) {
+                ExtensionNotificationManager.scheduleFailureNotification(postID: String(uploadPostOp.remotePostID), blogID: String(uploadPostOp.siteID))
+            }
+        })
+    }
+
+    /// Uploads an already-saved post synchronously.
+    ///
+    /// - Parameters:
+    ///   - uploadOpObjectID: Managed object ID for the post
+    ///   - onComplete: Completion handler executed after a post is uploaded to the server.
+    ///   - onFailure: The (optional) failure handler.
+    ///
+    func uploadPost(forUploadOpWithObjectID uploadOpObjectID: NSManagedObjectID, onComplete: CompletionBlock?, onFailure: FailureBlock?) {
+        guard let postUploadOp = coreDataStack.fetchPostUploadOp(withObjectID: uploadOpObjectID) else {
+            DDLogError("Error uploading post in share extension — could not fetch saved post.")
+            onFailure?()
+            return
+        }
+
+        let remotePost = postUploadOp.remotePost
+        coreDataStack.updateStatus(.inProgress, forUploadOpWithObjectID: uploadOpObjectID)
+
+        // 15-Nov-2017: Creating a post without media on the PostServiceRemoteREST does not use background uploads
+        let remote = PostServiceRemoteREST(wordPressComRestApi: simpleRestAPI, siteID: remotePost.siteID)
+        remote.createPost(remotePost, success: { post in
+            if let post = post {
+                DDLogInfo("Post \(post.postID.stringValue) sucessfully uploaded to site \(post.siteID.stringValue)")
+                if let postID = post.postID {
+                    self.coreDataStack.updatePostOperation(with: .complete, remotePostID: postID.int64Value, forPostUploadOpWithObjectID: uploadOpObjectID)
+                } else {
+                    self.coreDataStack.updateStatus(.complete, forUploadOpWithObjectID: uploadOpObjectID)
+                }
+                onComplete?()
+            }
+        }, failure: { error in
+            var errorString = "Error creating post in share extension"
+            if let error = error as NSError? {
+                errorString += ": \(error.localizedDescription)"
+            }
+            DDLogError(errorString)
+            self.coreDataStack.updateStatus(.error, forUploadOpWithObjectID: uploadOpObjectID)
+            onFailure?()
+        })
     }
 }
 

--- a/WordPress/WordPressShareExtension/ExtensionNotificationManager.swift
+++ b/WordPress/WordPressShareExtension/ExtensionNotificationManager.swift
@@ -12,7 +12,7 @@ class ExtensionNotificationManager {
     ///   - mediaItemCount: Number of media items included with the post. Default is 0.
     ///
     static func scheduleSuccessNotification(postID: String, blogID: String, mediaItemCount: Int = 0, notificationDate: Date = Date()) {
-        let userInfo = createUserInfoDict(postID: postID, blogID: blogID)
+        let userInfo = makeUserInfoDict(postID: postID, blogID: blogID)
         let title = ShareNoticeText.successTitle(mediaItemCount: mediaItemCount)
         let body = notificationDate.mediumString()
         scheduleLocalNotification(title: title, body: body, category: ShareNoticeConstants.categorySuccessIdentifier, userInfo: userInfo)
@@ -26,7 +26,7 @@ class ExtensionNotificationManager {
     ///   - mediaItemCount: Number of media items included with the post. Default is 0.
     ///
     static func scheduleFailureNotification(postID: String, blogID: String, mediaItemCount: Int = 0, notificationDate: Date = Date()) {
-        let userInfo = createUserInfoDict(postID: postID, blogID: blogID)
+        let userInfo = makeUserInfoDict(postID: postID, blogID: blogID)
         let title = ShareNoticeText.successTitle(mediaItemCount: mediaItemCount)
         let body = notificationDate.mediumString()
         scheduleLocalNotification(title: title, body: body, category: ShareNoticeConstants.categoryFailureIdentifier, userInfo: userInfo)
@@ -59,7 +59,7 @@ class ExtensionNotificationManager {
         })
     }
 
-    private static func createUserInfoDict(postID: String, blogID: String) -> [String: Any] {
+    private static func makeUserInfoDict(postID: String, blogID: String) -> [String: Any] {
         var userInfo = [String: Any]()
         userInfo[ShareNoticeUserInfoKey.postID] = postID
         userInfo[ShareNoticeUserInfoKey.blogID] = blogID

--- a/WordPress/WordPressShareExtension/ExtensionNotificationManager.swift
+++ b/WordPress/WordPressShareExtension/ExtensionNotificationManager.swift
@@ -1,0 +1,68 @@
+import Foundation
+import UserNotifications
+
+/// This handles the scheduling of user notifications in app extensions only.
+///
+class ExtensionNotificationManager {
+    /// Convenience function to schedule a local success notification.
+    ///
+    /// - Parameters:
+    ///   - postID: ID string representing a post
+    ///   - blogID: ID string representing a blog/site
+    ///   - mediaItemCount: Number of media items included with the post. Default is 0.
+    ///
+    static func scheduleSuccessNotification(postID: String, blogID: String, mediaItemCount: Int = 0, notificationDate: Date = Date()) {
+        let userInfo = createUserInfoDict(postID: postID, blogID: blogID)
+        let title = ShareNoticeText.successTitle(mediaItemCount: mediaItemCount)
+        let body = notificationDate.mediumString()
+        scheduleLocalNotification(title: title, body: body, category: ShareNoticeConstants.categorySuccessIdentifier, userInfo: userInfo)
+    }
+
+    /// Convenience function to schedule a local failure notification.
+    ///
+    /// - Parameters:
+    ///   - postID: ID string representing a post
+    ///   - blogID: ID string representing a blog/site
+    ///   - mediaItemCount: Number of media items included with the post. Default is 0.
+    ///
+    static func scheduleFailureNotification(postID: String, blogID: String, mediaItemCount: Int = 0, notificationDate: Date = Date()) {
+        let userInfo = createUserInfoDict(postID: postID, blogID: blogID)
+        let title = ShareNoticeText.successTitle(mediaItemCount: mediaItemCount)
+        let body = notificationDate.mediumString()
+        scheduleLocalNotification(title: title, body: body, category: ShareNoticeConstants.categoryFailureIdentifier, userInfo: userInfo)
+    }
+
+    /// Schedules a local notification with the provided content, category identifier, and time delay.
+    ///
+    /// - Parameters:
+    ///   - title: Title of notification alert
+    ///   - body: Body of notification alert
+    ///   - category: The identifier of the app-defined category object.
+    ///   - userInfo: Dictionary that represents the user info payload for the notification.
+    ///   - interval: The time (in seconds) that must elapse before the trigger fires. This value must be greater than zero (default is 3 seconds).
+    ///
+    static func scheduleLocalNotification(title: String, body: String, category: String, userInfo: [String: Any]?, delay: TimeInterval = 3.0) {
+        let notificationContent = UNMutableNotificationContent()
+        notificationContent.title = title
+        notificationContent.body = body
+        notificationContent.categoryIdentifier = category
+        if let userInfo = userInfo {
+            notificationContent.userInfo = userInfo
+        }
+
+        let notificationTrigger = UNTimeIntervalNotificationTrigger(timeInterval: delay, repeats: false)
+        let notificationRequest = UNNotificationRequest(identifier: UUID().uuidString, content: notificationContent, trigger: notificationTrigger)
+        UNUserNotificationCenter.current().add(notificationRequest, withCompletionHandler: { error in
+            if let error = error {
+                DDLogError("Unable to add notification request (\(error), \(error.localizedDescription))")
+            }
+        })
+    }
+
+    private static func createUserInfoDict(postID: String, blogID: String) -> [String: Any] {
+        var userInfo = [String: Any]()
+        userInfo[ShareNoticeUserInfoKey.postID] = postID
+        userInfo[ShareNoticeUserInfoKey.blogID] = blogID
+        return userInfo
+    }
+}

--- a/WordPress/WordPressShareExtension/ExtensionNotificationManager.swift
+++ b/WordPress/WordPressShareExtension/ExtensionNotificationManager.swift
@@ -7,12 +7,13 @@ class ExtensionNotificationManager {
     /// Convenience function to schedule a local success notification.
     ///
     /// - Parameters:
+    ///   - postUploadOpID: ID string representing a post upload object
     ///   - postID: ID string representing a post
     ///   - blogID: ID string representing a blog/site
     ///   - mediaItemCount: Number of media items included with the post. Default is 0.
     ///
-    static func scheduleSuccessNotification(postID: String, blogID: String, mediaItemCount: Int = 0, notificationDate: Date = Date()) {
-        let userInfo = makeUserInfoDict(postID: postID, blogID: blogID)
+    static func scheduleSuccessNotification(postUploadOpID: String, postID: String, blogID: String, mediaItemCount: Int = 0, notificationDate: Date = Date()) {
+        let userInfo = makeUserInfoDict(postUploadOpID: postUploadOpID, postID: postID, blogID: blogID)
         let title = ShareNoticeText.successTitle(mediaItemCount: mediaItemCount)
         let body = notificationDate.mediumString()
         scheduleLocalNotification(title: title, body: body, category: ShareNoticeConstants.categorySuccessIdentifier, userInfo: userInfo)
@@ -21,12 +22,13 @@ class ExtensionNotificationManager {
     /// Convenience function to schedule a local failure notification.
     ///
     /// - Parameters:
+    ///   - postUploadOpID: ID string representing a post upload object
     ///   - postID: ID string representing a post
     ///   - blogID: ID string representing a blog/site
     ///   - mediaItemCount: Number of media items included with the post. Default is 0.
     ///
-    static func scheduleFailureNotification(postID: String, blogID: String, mediaItemCount: Int = 0, notificationDate: Date = Date()) {
-        let userInfo = makeUserInfoDict(postID: postID, blogID: blogID)
+    static func scheduleFailureNotification(postUploadOpID: String, postID: String, blogID: String, mediaItemCount: Int = 0, notificationDate: Date = Date()) {
+        let userInfo = makeUserInfoDict(postUploadOpID: postUploadOpID, postID: postID, blogID: blogID)
         let title = ShareNoticeText.successTitle(mediaItemCount: mediaItemCount)
         let body = notificationDate.mediumString()
         scheduleLocalNotification(title: title, body: body, category: ShareNoticeConstants.categoryFailureIdentifier, userInfo: userInfo)
@@ -59,10 +61,12 @@ class ExtensionNotificationManager {
         })
     }
 
-    private static func makeUserInfoDict(postID: String, blogID: String) -> [String: Any] {
+    private static func makeUserInfoDict(postUploadOpID: String, postID: String, blogID: String) -> [String: Any] {
         var userInfo = [String: Any]()
+        userInfo[ShareNoticeUserInfoKey.postUploadOpID] = postUploadOpID
         userInfo[ShareNoticeUserInfoKey.postID] = postID
         userInfo[ShareNoticeUserInfoKey.blogID] = blogID
+        userInfo[ShareNoticeUserInfoKey.originatedFromAppExtension] = true
         return userInfo
     }
 }

--- a/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
@@ -1,6 +1,5 @@
 import CoreData
 import UIKit
-import UserNotifications
 import WordPressKit
 
 /// A base class for the various Share Extension view controllers.
@@ -117,30 +116,6 @@ extension ShareExtensionAbstractViewController {
     func createErrorWithDescription(_ description: String) -> NSError {
         let userInfo = [NSLocalizedDescriptionKey: description]
         return NSError(domain: "ShareExtensionAbstractViewController", code: 0, userInfo: userInfo)
-    }
-
-    // FIXME: This is NOT final!
-    func scheduleLocalNotification() {
-        // Create Notification Content
-        let notificationContent = UNMutableNotificationContent()
-
-        // Configure Notification Content
-        notificationContent.title = "WordPress!"
-        notificationContent.body = "A local Notification from the Share eXtension!"
-        notificationContent.categoryIdentifier = "share-upload-success"
-
-        // Add Trigger
-        let notificationTrigger = UNTimeIntervalNotificationTrigger(timeInterval: 3.0, repeats: false)
-
-        // Create Notification Request
-        let notificationRequest = UNNotificationRequest(identifier: UUID().uuidString, content: notificationContent, trigger: notificationTrigger)
-
-        // Add Request to User Notification Center
-        UNUserNotificationCenter.current().add(notificationRequest, withCompletionHandler: { error in
-            if let error = error {
-                DDLogError("Unable to Add Notification Request (\(error), \(error.localizedDescription))")
-            }
-        })
     }
 }
 

--- a/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
@@ -1,5 +1,6 @@
 import CoreData
 import UIKit
+import UserNotifications
 import WordPressKit
 
 /// A base class for the various Share Extension view controllers.
@@ -116,6 +117,30 @@ extension ShareExtensionAbstractViewController {
     func createErrorWithDescription(_ description: String) -> NSError {
         let userInfo = [NSLocalizedDescriptionKey: description]
         return NSError(domain: "ShareExtensionAbstractViewController", code: 0, userInfo: userInfo)
+    }
+
+    // FIXME: This is NOT final!
+    func scheduleLocalNotification() {
+        // Create Notification Content
+        let notificationContent = UNMutableNotificationContent()
+
+        // Configure Notification Content
+        notificationContent.title = "WordPress!"
+        notificationContent.body = "A local Notification from the Share eXtension!"
+        notificationContent.categoryIdentifier = "share-upload-success"
+
+        // Add Trigger
+        let notificationTrigger = UNTimeIntervalNotificationTrigger(timeInterval: 3.0, repeats: false)
+
+        // Create Notification Request
+        let notificationRequest = UNNotificationRequest(identifier: UUID().uuidString, content: notificationContent, trigger: notificationTrigger)
+
+        // Add Request to User Notification Center
+        UNUserNotificationCenter.current().add(notificationRequest, withCompletionHandler: { error in
+            if let error = error {
+                DDLogError("Unable to Add Notification Request (\(error), \(error.localizedDescription))")
+            }
+        })
     }
 }
 

--- a/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
@@ -199,8 +199,12 @@ import WordPressFlux
 
         // We need to first sync the specific post to WPiOS so that we can open it for editing if needed.
         let postService = PostService(managedObjectContext: context)
-        postService.getPostWithID(NSNumber(value: postUploadOp.remotePostID), for: blog, success: { _ in
-            let model = ShareNoticeViewModel(postOperation: postUploadOp, mediaOperations: mediaUploadOps)
+        postService.getPostWithID(NSNumber(value: postUploadOp.remotePostID), for: blog, success: { post in
+            guard let post = post as? Post else {
+                return
+            }
+
+            let model = ShareNoticeViewModel(postOperation: postUploadOp, post: post, mediaOperations: mediaUploadOps)
             if let notice = model?.notice {
                 ActionDispatcher.dispatch(NoticeAction.post(notice))
             }

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -494,8 +494,8 @@ fileprivate extension ShareModularViewController {
                                                siteID: siteID,
                                                localMediaFileURLs: localImageURLs,
                                                requestEnqueued: {
-                                                 self.tracks.trackExtensionPosted(self.shareData.postStatus.rawValue)
-                                                 self.dismiss(animated: true, completion: self.dismissalCompletionBlock)
+                                                self.tracks.trackExtensionPosted(self.shareData.postStatus.rawValue)
+                                                self.dismiss(animated: true, completion: self.dismissalCompletionBlock)
             }, onFailure: {
                 let error = self.createErrorWithDescription("Failed to save and upload post with media.")
                 self.tracks.trackExtensionError(error)
@@ -508,6 +508,7 @@ fileprivate extension ShareModularViewController {
                                              status: shareData.postStatus.rawValue,
                                              siteID: siteID,
                                              onComplete: {
+                                                self.scheduleLocalNotification()
                                                 self.tracks.trackExtensionPosted(self.shareData.postStatus.rawValue)
                                                 self.dismiss(animated: true, completion: self.dismissalCompletionBlock)
             }, onFailure: {

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -508,7 +508,6 @@ fileprivate extension ShareModularViewController {
                                              status: shareData.postStatus.rawValue,
                                              siteID: siteID,
                                              onComplete: {
-                                                self.scheduleLocalNotification()
                                                 self.tracks.trackExtensionPosted(self.shareData.postStatus.rawValue)
                                                 self.dismiss(animated: true, completion: self.dismissalCompletionBlock)
             }, onFailure: {

--- a/WordPress/WordPressShareExtension/ShareNoticeConstants.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeConstants.swift
@@ -17,13 +17,13 @@ enum ShareNoticeUserInfoKey {
 struct ShareNoticeText {
     static let actionEditPost       = NSLocalizedString("Edit Post", comment: "Button title. Opens the editor to edit an existing post.")
 
-    static let successTitleDefault  = NSLocalizedString("1 post uploaded.", comment: "Alert displayed to the user when a single post has been successfully uploaded.")
-    static let successTitleSingular = NSLocalizedString("Uploaded 1 post, 1 file.", comment: "System notification displayed to the user when a single post and 1 file has uploaded successfully.")
-    static let successTitlePlural   = NSLocalizedString("Uploaded 1 post, %ld files.", comment: "System notification displayed to the user when a single post and multiple files have uploaded successfully.")
+    static let successTitleDefault  = NSLocalizedString("1 post uploaded", comment: "Alert displayed to the user when a single post has been successfully uploaded.")
+    static let successTitleSingular = NSLocalizedString("Uploaded 1 post, 1 file", comment: "System notification displayed to the user when a single post and 1 file has uploaded successfully.")
+    static let successTitlePlural   = NSLocalizedString("Uploaded 1 post, %ld files", comment: "System notification displayed to the user when a single post and multiple files have uploaded successfully.")
 
-    static let failureTitleDefault  = NSLocalizedString("Unable to upload 1 post.", comment: "Alert displayed to the user when a single post has failed to upload.")
-    static let failureTitleSingular = NSLocalizedString("Unable to upload 1 post, 1 file.", comment: "Alert displayed to the user when a single post and 1 file has failed to upload.")
-    static let failureTitlePlural   = NSLocalizedString("Unable to upload 1 post, %ld files.", comment: "Alert displayed to the user when a single post and multiple files have failed to upload.")
+    static let failureTitleDefault  = NSLocalizedString("Unable to upload 1 post", comment: "Alert displayed to the user when a single post has failed to upload.")
+    static let failureTitleSingular = NSLocalizedString("Unable to upload 1 post, 1 file", comment: "Alert displayed to the user when a single post and 1 file has failed to upload.")
+    static let failureTitlePlural   = NSLocalizedString("Unable to upload 1 post, %ld files", comment: "Alert displayed to the user when a single post and multiple files have failed to upload.")
 
     /// Helper method to provide the formatted version of a success title based on the media item count.
     ///

--- a/WordPress/WordPressShareExtension/ShareNoticeConstants.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeConstants.swift
@@ -7,7 +7,12 @@ enum ShareNoticeConstants {
     static let categoryFailureIdentifier = "share-upload-failure"
 }
 
-enum ShareNoticeText {
+enum ShareNoticeUserInfoKey {
+    static let blogID = "blog_id"
+    static let postID = "post_id"
+}
+
+struct ShareNoticeText {
     static let actionEditPost       = NSLocalizedString("Edit Post", comment: "Button title. Opens the editor to edit an existing post.")
 
     static let successTitleDefault  = NSLocalizedString("1 post uploaded.", comment: "Alert displayed to the user when a single post has been successfully uploaded.")
@@ -17,9 +22,35 @@ enum ShareNoticeText {
     static let failureTitleDefault  = NSLocalizedString("Unable to upload 1 post.", comment: "Alert displayed to the user when a single post has failed to upload.")
     static let failureTitleSingular = NSLocalizedString("Unable to upload 1 post, 1 file.", comment: "Alert displayed to the user when a single post and 1 file has failed to upload.")
     static let failureTitlePlural   = NSLocalizedString("Unable to upload 1 post, %ld files.", comment: "Alert displayed to the user when a single post and multiple files have failed to upload.")
-}
 
-enum ShareNoticeUserInfoKey {
-    static let blogID = "blog_id"
-    static let postID = "post_id"
+    /// Helper method to provide the formatted version of a success title based on the media item count.
+    ///
+    static func successTitle(mediaItemCount: Int = 0) -> String {
+        if mediaItemCount == 0 {
+            return successTitleDefault
+        } else {
+            return pluralize(mediaItemCount, singular: successTitleSingular, plural: successTitlePlural)
+        }
+    }
+
+    /// Helper method to provide the formatted version of a failure title based on the media item count.
+    ///
+    static func failureTitle(mediaItemCount: Int = 0) -> String {
+        if mediaItemCount == 0 {
+            return failureTitlePlural
+        } else {
+            return pluralize(mediaItemCount, singular: failureTitleSingular, plural: failureTitlePlural)
+        }
+    }
+
+    /// Helper method to provide the singular or plural (formatted) version of a
+    /// string based on a count.
+    ///
+    private static func pluralize(_ count: Int, singular: String, plural: String) -> String {
+        if count == 1 {
+            return singular
+        } else {
+            return String(format: plural, count)
+        }
+    }
 }

--- a/WordPress/WordPressShareExtension/ShareNoticeConstants.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeConstants.swift
@@ -1,0 +1,25 @@
+/// A collection of notification constants shared between the app extensions
+/// and WPiOS.
+///
+enum ShareNoticeConstants {
+    static let notificationSourceSuccess = "share_success_notification"
+    static let categorySuccessIdentifier = "share-upload-success"
+    static let categoryFailureIdentifier = "share-upload-failure"
+}
+
+enum ShareNoticeText {
+    static let actionEditPost       = NSLocalizedString("Edit Post", comment: "Button title. Opens the editor to edit an existing post.")
+
+    static let successTitleDefault  = NSLocalizedString("1 post uploaded.", comment: "Alert displayed to the user when a single post has been successfully uploaded.")
+    static let successTitleSingular = NSLocalizedString("Uploaded 1 post, 1 file.", comment: "System notification displayed to the user when a single post and 1 file has uploaded successfully.")
+    static let successTitlePlural   = NSLocalizedString("Uploaded 1 post, %ld files.", comment: "System notification displayed to the user when a single post and multiple files have uploaded successfully.")
+
+    static let failureTitleDefault  = NSLocalizedString("Unable to upload 1 post.", comment: "Alert displayed to the user when a single post has failed to upload.")
+    static let failureTitleSingular = NSLocalizedString("Unable to upload 1 post, 1 file.", comment: "Alert displayed to the user when a single post and 1 file has failed to upload.")
+    static let failureTitlePlural   = NSLocalizedString("Unable to upload 1 post, %ld files.", comment: "Alert displayed to the user when a single post and multiple files have failed to upload.")
+}
+
+enum ShareNoticeUserInfoKey {
+    static let blogID = "blog_id"
+    static let postID = "post_id"
+}

--- a/WordPress/WordPressShareExtension/ShareNoticeConstants.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeConstants.swift
@@ -10,6 +10,8 @@ enum ShareNoticeConstants {
 enum ShareNoticeUserInfoKey {
     static let blogID = "blog_id"
     static let postID = "post_id"
+    static let postUploadOpID = "post_upload_op_id"
+    static let originatedFromAppExtension = "originated_from_app_extension"
 }
 
 struct ShareNoticeText {

--- a/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
@@ -1,0 +1,36 @@
+import UIKit
+
+/// This class simply exists to coordinate the display of various sections of
+/// the app in response to actions taken by the user from app extension notifications.
+///
+class ShareNoticeNavigationCoordinator {
+    static func presentEditor(with userInfo: NSDictionary) {
+        guard let post = post(from: userInfo) else {
+            return
+        }
+
+        presentEditor(for: post, source: "share_upload_notification")
+    }
+
+    static func presentEditor(for post: Post, source: String) {
+        //FIXME: Add analytics
+
+        let editor = EditPostViewController.init(post: post)
+        editor.modalPresentationStyle = .fullScreen
+        WPTabBarController.sharedInstance().present(editor, animated: false, completion: nil)
+    }
+
+    private static func post(from userInfo: NSDictionary) -> Post? {
+        let context = ContextManager.sharedInstance().mainContext
+
+        guard let postID = userInfo[ShareNoticeUserInfoKey.postID] as? String,
+            let URIRepresentation = URL(string: postID),
+            let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: URIRepresentation),
+            let managedObject = try? context.existingObject(with: objectID),
+            let post = managedObject as? Post else {
+                return nil
+        }
+
+        return post
+    }
+}

--- a/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
@@ -32,6 +32,16 @@ class ShareNoticeNavigationCoordinator {
         })
     }
 
+    static func navigateToBlogDetails(with userInfo: NSDictionary) {
+        fetchBlog(from: userInfo, onSuccess: { blog in
+            if let blog = blog {
+                WPTabBarController.sharedInstance().switchMySitesTabToBlogDetails(for: blog)
+            }
+        }, onFailure: {
+            DDLogError("Could not fetch blog from share notification.")
+        })
+    }
+
     private static func fetchPost(from userInfo: NSDictionary,
                                   onSuccess: @escaping (_ post: Post?) -> Void,
                                   onFailure: @escaping () -> Void) {
@@ -57,5 +67,20 @@ class ShareNoticeNavigationCoordinator {
         }, failure: { error in
             onFailure()
         })
+    }
+
+    private static func fetchBlog(from userInfo: NSDictionary,
+                                  onSuccess: @escaping (_ blog: Blog?) -> Void,
+                                  onFailure: @escaping () -> Void) {
+        guard let siteIDString = userInfo[ShareNoticeUserInfoKey.blogID] as? String,
+            let siteID = NumberFormatter().number(from: siteIDString) else {
+                onFailure()
+                return
+        }
+
+        let context = ContextManager.sharedInstance().mainContext
+        let blogService = BlogService(managedObjectContext: context)
+        let blog = blogService.blog(byBlogId: siteID)
+        onSuccess(blog)
     }
 }

--- a/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 /// This class simply exists to coordinate the display of various sections of
-/// the app in response to actions taken by the user from app extension notifications.
+/// the app in response to actions taken by the user from share/app extension notifications.
 ///
 class ShareNoticeNavigationCoordinator {
     static func presentEditor(with userInfo: NSDictionary) {
@@ -13,7 +13,7 @@ class ShareNoticeNavigationCoordinator {
     }
 
     static func presentEditor(for post: Post, source: String) {
-        //FIXME: Add analytics
+        WPAppAnalytics.track(.notificationsShareSuccessEditPost, with: post)
 
         let editor = EditPostViewController.init(post: post)
         editor.modalPresentationStyle = .fullScreen

--- a/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
@@ -20,6 +20,12 @@ class ShareNoticeNavigationCoordinator {
         WPTabBarController.sharedInstance().present(editor, animated: false, completion: nil)
     }
 
+    static func navigateToPostList(with userInfo: NSDictionary) {
+        if let post = post(from: userInfo) {
+            WPTabBarController.sharedInstance().switchTabToPostsList(for: post)
+        }
+    }
+
     private static func post(from userInfo: NSDictionary) -> Post? {
         let context = ContextManager.sharedInstance().mainContext
 

--- a/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
@@ -1,15 +1,16 @@
 struct ShareNoticeViewModel {
-    private let uploadedPost: PostUploadOperation
     private let postInContext: Post?
-    private let uploadedMedia: [MediaUploadOperation]?
+    private let uploadStatus: UploadOperation.UploadStatus
+    private let uploadedMediaCount: Int
 
-    init?(postOperation: PostUploadOperation, post: Post?, mediaOperations: [MediaUploadOperation]? = nil) {
-        guard postOperation.currentStatus != .pending, postOperation.currentStatus != .inProgress else {
+    init?(post: Post?, uploadStatus: UploadOperation.UploadStatus, uploadedMediaCount: Int = 0) {
+        guard uploadStatus != .pending, uploadStatus != .inProgress else {
             return nil
         }
-        self.uploadedPost = postOperation
-        self.uploadedMedia = mediaOperations
+
         self.postInContext = post
+        self.uploadStatus = uploadStatus
+        self.uploadedMediaCount = uploadedMediaCount
     }
 
     var notice: Notice? {
@@ -23,7 +24,7 @@ struct ShareNoticeViewModel {
     // MARK: - Private Vars
 
     private var uploadSuccessful: Bool {
-        return uploadedPost.currentStatus == .complete
+        return uploadStatus == .complete
     }
 
     private var successNotice: Notice {
@@ -55,6 +56,7 @@ struct ShareNoticeViewModel {
             userInfo[ShareNoticeUserInfoKey.postID] = post.postID
             userInfo[ShareNoticeUserInfoKey.blogID] = post.blog.dotComID?.stringValue
         }
+        userInfo[ShareNoticeUserInfoKey.originatedFromAppExtension] = false
 
         return NoticeNotificationInfo(identifier: UUID().uuidString,
                                       categoryIdentifier: notificationCategoryIdentifier,
@@ -76,19 +78,19 @@ struct ShareNoticeViewModel {
     }
 
     private var successfulTitle: String {
-        guard let uploadedMedia = uploadedMedia else {
+        if uploadedMediaCount == 0 {
             return ShareNoticeText.successTitleDefault
         }
 
-        return ShareNoticeText.successTitle(mediaItemCount: uploadedMedia.count)
+        return ShareNoticeText.successTitle(mediaItemCount: uploadedMediaCount)
     }
 
     private var failedTitle: String {
-        guard let uploadedMedia = uploadedMedia else {
+        if uploadedMediaCount == 0 {
             return ShareNoticeText.failureTitleDefault
         }
 
-        return ShareNoticeText.failureTitle(mediaItemCount: uploadedMedia.count)
+        return ShareNoticeText.failureTitle(mediaItemCount: uploadedMediaCount)
     }
 
     private var notificationBody: String {

--- a/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
@@ -1,0 +1,103 @@
+enum ShareNoticeUserInfoKey {
+    static let blogID = "blog_id"
+    static let postID = "post_id"
+}
+
+struct ShareNoticeViewModel {
+    private let uploadedPost: PostUploadOperation
+
+    init?(postOperation: PostUploadOperation) {
+        guard postOperation.currentStatus != .pending, postOperation.currentStatus != .inProgress else {
+            return nil
+        }
+        self.uploadedPost = postOperation
+    }
+
+    private var uploadSuccessful: Bool {
+        return uploadedPost.currentStatus == .complete
+    }
+
+    var notice: Notice? {
+        if uploadSuccessful {
+            return successNotice
+        } else {
+            return failureNotice
+        }
+    }
+
+    private var successNotice: Notice {
+        guard let post = postInContext else {
+            return Notice(title: notificationTitle, message: notificationBody, notificationInfo: notificationInfo)
+        }
+
+        return Notice(title: notificationTitle,
+                      message: notificationBody,
+                      feedbackType: .success,
+                      notificationInfo: notificationInfo,
+                      actionTitle: NSLocalizedString("Edit Post", comment: "Button title. Opens the editor to edit an existing post."),
+                      actionHandler: {
+                        ShareNoticeNavigationCoordinator.presentEditor(for: post, source: "share_upload_notification")
+        })
+    }
+
+    private var failureNotice: Notice {
+        return Notice(title: notificationTitle,
+                      message: notificationBody,
+                      feedbackType: .error,
+                      notificationInfo: notificationInfo)
+    }
+
+    private var notificationInfo: NoticeNotificationInfo {
+        var userInfo = [String: Any]()
+
+        if let post = postInContext {
+            userInfo[ShareNoticeUserInfoKey.postID] = post.objectID.uriRepresentation().absoluteString
+            userInfo[ShareNoticeUserInfoKey.blogID] = post.blog.objectID.uriRepresentation().absoluteString
+        }
+
+        return NoticeNotificationInfo(identifier: UUID().uuidString,
+                                      categoryIdentifier: notificationCategoryIdentifier,
+                                      title: notificationTitle,
+                                      body: notificationBody,
+                                      userInfo: userInfo)
+    }
+
+    private var notificationCategoryIdentifier: String {
+        return uploadSuccessful ? "share-upload-success" : "share-upload-failure"
+    }
+
+    var notificationTitle: String {
+        if uploadSuccessful {
+            return NSLocalizedString("Post uploaded", comment: "Title on alert displayed to the user when a single post has been uploaded.")
+        } else {
+            return NSLocalizedString("Post upload failed", comment: "Title on alert displayed to the user when a single post has failed to upload.")
+        }
+    }
+
+    var notificationBody: String? {
+        if uploadSuccessful {
+            return postInContext?.titleForDisplay() ?? NSLocalizedString("1 post successfully shared", comment: "Alert displayed to the user when a single post has been successfully shared.")
+        } else {
+            return NSLocalizedString("1 post not uploaded", comment: "Alert displayed to the user when a single post item has failed to upload.")
+        }
+    }
+
+    private var postInContext: Post? {
+        let context = ContextManager.sharedInstance().mainContext
+        let blogService = BlogService(managedObjectContext: context)
+
+        guard uploadedPost.remotePostID > 0,
+            uploadedPost.siteID > 0,
+            let blog = blogService.blog(byBlogId: NSNumber(value: uploadedPost.siteID)) else {
+            return nil
+        }
+
+        let postID = NSNumber(value: uploadedPost.remotePostID)
+        let postService = PostService(managedObjectContext: context)
+        guard let post = postService.findPost(withID: postID, in: blog) as? Post else {
+            return nil
+        }
+
+        return post
+    }
+}

--- a/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
@@ -50,8 +50,8 @@ struct ShareNoticeViewModel {
         var userInfo = [String: Any]()
 
         if let post = postInContext {
-            userInfo[ShareNoticeUserInfoKey.postID] = post.objectID.uriRepresentation().absoluteString
-            userInfo[ShareNoticeUserInfoKey.blogID] = post.blog.objectID.uriRepresentation().absoluteString
+            userInfo[ShareNoticeUserInfoKey.postID] = post.postID
+            userInfo[ShareNoticeUserInfoKey.blogID] = post.blog.dotComID?.stringValue
         }
 
         return NoticeNotificationInfo(identifier: UUID().uuidString,
@@ -78,9 +78,7 @@ struct ShareNoticeViewModel {
             return ShareNoticeText.successTitleDefault
         }
 
-        return pluralize(uploadedMedia.count,
-                         singular: ShareNoticeText.successTitleSingular,
-                         plural: ShareNoticeText.successTitlePlural)
+        return ShareNoticeText.successTitle(mediaItemCount: uploadedMedia.count)
     }
 
     private var failedTitle: String {
@@ -88,9 +86,7 @@ struct ShareNoticeViewModel {
             return ShareNoticeText.failureTitleDefault
         }
 
-        return pluralize(uploadedMedia.count,
-                         singular: ShareNoticeText.failureTitleSingular,
-                         plural: ShareNoticeText.failureTitlePlural)
+        return ShareNoticeText.failureTitle(mediaItemCount: uploadedMedia.count)
     }
 
     private var notificationBody: String {
@@ -105,7 +101,7 @@ struct ShareNoticeViewModel {
         guard uploadedPost.remotePostID > 0,
             uploadedPost.siteID > 0,
             let blog = blogService.blog(byBlogId: NSNumber(value: uploadedPost.siteID)) else {
-            return nil
+                return nil
         }
 
         let postID = NSNumber(value: uploadedPost.remotePostID)
@@ -115,16 +111,5 @@ struct ShareNoticeViewModel {
         }
 
         return post
-    }
-}
-
-/// Helper method to provide the singular or plural (formatted) version of a
-/// string based on a count.
-///
-private func pluralize(_ count: Int, singular: String, plural: String) -> String {
-    if count == 1 {
-        return singular
-    } else {
-        return String(format: plural, count)
     }
 }

--- a/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
@@ -94,7 +94,6 @@ struct ShareNoticeViewModel {
     }
 
     private var notificationBody: String {
-        let dateString = postInContext?.dateForDisplay()?.mediumString() ?? Date().mediumString()
-        return "\(dateString)."
+        return postInContext?.dateForDisplay()?.mediumString() ?? Date().mediumString()
     }
 }

--- a/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
@@ -1,8 +1,3 @@
-enum ShareNoticeUserInfoKey {
-    static let blogID = "blog_id"
-    static let postID = "post_id"
-}
-
 struct ShareNoticeViewModel {
     private let uploadedPost: PostUploadOperation
     private let uploadedMedia: [MediaUploadOperation]?
@@ -15,16 +10,18 @@ struct ShareNoticeViewModel {
         self.uploadedMedia = mediaOperations
     }
 
-    private var uploadSuccessful: Bool {
-        return uploadedPost.currentStatus == .complete
-    }
-
     var notice: Notice? {
         if uploadSuccessful {
             return successNotice
         } else {
             return failureNotice
         }
+    }
+
+    // MARK: - Private Vars
+
+    private var uploadSuccessful: Bool {
+        return uploadedPost.currentStatus == .complete
     }
 
     private var successNotice: Notice {
@@ -36,9 +33,9 @@ struct ShareNoticeViewModel {
                       message: notificationBody,
                       feedbackType: .success,
                       notificationInfo: notificationInfo,
-                      actionTitle: NSLocalizedString("Edit Post", comment: "Button title. Opens the editor to edit an existing post."),
+                      actionTitle: ShareNoticeText.actionEditPost,
                       actionHandler: {
-                        ShareNoticeNavigationCoordinator.presentEditor(for: post, source: "share_success_notification")
+                        ShareNoticeNavigationCoordinator.presentEditor(for: post, source: ShareNoticeConstants.notificationSourceSuccess)
         })
     }
 
@@ -65,40 +62,40 @@ struct ShareNoticeViewModel {
     }
 
     private var notificationCategoryIdentifier: String {
-        return uploadSuccessful ? "share-upload-success" : "share-upload-failure"
+        return uploadSuccessful ? ShareNoticeConstants.categorySuccessIdentifier : ShareNoticeConstants.categoryFailureIdentifier
     }
 
-    var notificationTitle: String {
+    private var notificationTitle: String {
         if uploadSuccessful {
-            return successfulDescription
+            return successfulTitle
         } else {
-            return failedDescription
+            return failedTitle
         }
     }
 
-    var notificationBody: String {
+    private var successfulTitle: String {
+        guard let uploadedMedia = uploadedMedia else {
+            return ShareNoticeText.successTitleDefault
+        }
+
+        return pluralize(uploadedMedia.count,
+                         singular: ShareNoticeText.successTitleSingular,
+                         plural: ShareNoticeText.successTitlePlural)
+    }
+
+    private var failedTitle: String {
+        guard let uploadedMedia = uploadedMedia else {
+            return ShareNoticeText.failureTitleDefault
+        }
+
+        return pluralize(uploadedMedia.count,
+                         singular: ShareNoticeText.failureTitleSingular,
+                         plural: ShareNoticeText.failureTitlePlural)
+    }
+
+    private var notificationBody: String {
         let dateString = postInContext?.dateForDisplay()?.mediumString() ?? Date().mediumString()
         return "\(dateString)."
-    }
-
-    private var successfulDescription: String {
-        guard let uploadedMedia = uploadedMedia else {
-            return NSLocalizedString("1 post uploaded.", comment: "Alert displayed to the user when a single post has been successfully uploaded.")
-        }
-
-        return pluralize(uploadedMedia.count,
-                         singular: NSLocalizedString("Successfully uploaded 1 post, 1 file.", comment: "System notification displayed to the user when a single post and 1 file has uploaded successfully."),
-                         plural: NSLocalizedString("Successfully uploaded 1 post, %ld files.", comment: "System notification displayed to the user when a single post and multiple files have uploaded successfully."))
-    }
-
-    private var failedDescription: String {
-        guard let uploadedMedia = uploadedMedia else {
-            return NSLocalizedString("Unable to upload 1 post.", comment: "Alert displayed to the user when a single post has failed to upload.")
-        }
-
-        return pluralize(uploadedMedia.count,
-                         singular: NSLocalizedString("Unable to upload 1 post, 1 file.", comment: "Alert displayed to the user when a single post and 1 file has failed to upload."),
-                         plural: NSLocalizedString("Unable to upload 1 post, %ld files.", comment: "Alert displayed to the user when a single post and multiple files have failed to upload."))
     }
 
     private var postInContext: Post? {

--- a/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
@@ -1,13 +1,15 @@
 struct ShareNoticeViewModel {
     private let uploadedPost: PostUploadOperation
+    private let postInContext: Post?
     private let uploadedMedia: [MediaUploadOperation]?
 
-    init?(postOperation: PostUploadOperation, mediaOperations: [MediaUploadOperation]? = nil) {
+    init?(postOperation: PostUploadOperation, post: Post?, mediaOperations: [MediaUploadOperation]? = nil) {
         guard postOperation.currentStatus != .pending, postOperation.currentStatus != .inProgress else {
             return nil
         }
         self.uploadedPost = postOperation
         self.uploadedMedia = mediaOperations
+        self.postInContext = post
     }
 
     var notice: Notice? {
@@ -92,24 +94,5 @@ struct ShareNoticeViewModel {
     private var notificationBody: String {
         let dateString = postInContext?.dateForDisplay()?.mediumString() ?? Date().mediumString()
         return "\(dateString)."
-    }
-
-    private var postInContext: Post? {
-        let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-
-        guard uploadedPost.remotePostID > 0,
-            uploadedPost.siteID > 0,
-            let blog = blogService.blog(byBlogId: NSNumber(value: uploadedPost.siteID)) else {
-                return nil
-        }
-
-        let postID = NSNumber(value: uploadedPost.remotePostID)
-        let postService = PostService(managedObjectContext: context)
-        guard let post = postService.findPost(withID: postID, in: blog) as? Post else {
-            return nil
-        }
-
-        return post
     }
 }

--- a/WordPress/WordPressShareExtension/SharedCoreDataStack.swift
+++ b/WordPress/WordPressShareExtension/SharedCoreDataStack.swift
@@ -93,6 +93,21 @@ extension SharedCoreDataStack {
         return groupID
     }
 
+    /// Fetch the post upload op for the provided managed object ID string
+    ///
+    /// - Parameter objectID: Managed object ID string for a given post upload op
+    /// - Returns: PostUploadOperation or nil
+    ///
+    func fetchPostUploadOp(withObjectID objectID: String) -> PostUploadOperation? {
+        guard let storeCoordinator = managedContext.persistentStoreCoordinator,
+            let url = URL(string: objectID),
+            let managedObjectID = storeCoordinator.managedObjectID(forURIRepresentation: url) else {
+                return nil
+        }
+
+        return fetchPostUploadOp(withObjectID: managedObjectID)
+    }
+
     /// Fetch the post upload op for the provided managed object ID
     ///
     /// - Parameter postUploadOpObjectID: Managed object ID for a given post upload op

--- a/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -154,6 +154,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatNotificationsSiteFollowAction,
     WPAnalyticsStatNotificationsSiteUnfollowAction,
     WPAnalyticsStatNotificationsUploadMediaSuccessWritePost,
+    WPAnalyticsStatNotificationsShareSuccessWritePost,
     WPAnalyticsStatOnePasswordFailed,
     WPAnalyticsStatOnePasswordLogin,
     WPAnalyticsStatOnePasswordSignup,

--- a/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -154,7 +154,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatNotificationsSiteFollowAction,
     WPAnalyticsStatNotificationsSiteUnfollowAction,
     WPAnalyticsStatNotificationsUploadMediaSuccessWritePost,
-    WPAnalyticsStatNotificationsShareSuccessWritePost,
+    WPAnalyticsStatNotificationsShareSuccessEditPost,
     WPAnalyticsStatOnePasswordFailed,
     WPAnalyticsStatOnePasswordLogin,
     WPAnalyticsStatOnePasswordSignup,


### PR DESCRIPTION
This PR adds notification support to the share extension. Because of the non-deterministic nature of _either_ WPiOS _or_ the extension getting the "did complete" callback, I needed to fire off notifs from 2 different places:
* `ExtensionNotificationManager.swift` (via share extension)
* `ShareExtensionSessionManager.swift` (via WPiOS)

![test2](https://user-images.githubusercontent.com/154014/35894652-7092b36c-0b79-11e8-83f6-67055ce5f665.gif)
![test3](https://user-images.githubusercontent.com/154014/35894656-75faf5a8-0b79-11e8-8f7e-9286fa859250.gif)

Two things to note here: 
1. The retry action is not implemented in this PR and will be part of the retry work itself.
2. IF the share extension's callback handles the post response...in-app notifs will not work. Perhaps @frosty could offer up some guidance here with his recent work on all this. :-)

Fixes #8146 

**Test 1:**
1. Open the Photos app and share 1 or 2 images.
2. Don't launch WPiOS.
3. You should see a iOS notification after a few seconds.
4. Tap the notification and it should launch WPiOS

**Test 2:**
1. Open the Photos app and share 1 or 2 images.
2. Quickly launch WPiOS after tapping "Publish" on the share extension.
3. You should see an in-app notification after a few seconds.
4. Tap the "Edit Post" action and verify it opens the post in question.

**Test 3:**
1. Open Safari and share a web page.
2. Don't launch WPiOS.
3. You should see a iOS notification after a few seconds.
4. Tap the notification and it should launch WPiOS.

@frosty Would you mind taking a peek at this? Thank you!!!!

