### PR TITLE
Add missing icon mapping

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/WPStyleGuide+Activity.swift
+++ b/WordPress/Classes/ViewRelated/Activity/WPStyleGuide+Activity.swift
@@ -96,6 +96,7 @@ extension WPStyleGuide {
         // fix to have all the names correctly mapping.
         private static let stringToGridiconTypeMapping: [String: GridiconType] = [
             "checkmark": GridiconType.checkmark,
+            "cloud": GridiconType.cloud,
             "cog": GridiconType.cog,
             "comment": GridiconType.comment,
             "cross": GridiconType.cross,


### PR DESCRIPTION
**Fixes:** 
A new icon is being used for the backup activity and we were missing a mapping for it. 

**To test:**
Run the app, go to the Activity Log and check that backups have an icon.


