### PR TITLE
Allow insert media from iCloud and add failsafes when import fails.

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -150,7 +150,14 @@
     Blog *blog = media.blog;
     id<MediaServiceRemote> remote = [self remoteForBlog:blog];
     RemoteMedia *remoteMedia = [self remoteMediaFromMedia:media];
-
+    if (media.absoluteLocalURL == nil) {
+        if (failure) {
+            failure([NSError errorWithDomain:NSURLErrorDomain
+                                        code:NSURLErrorFileDoesNotExist
+                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Media doesn't have an associated file to upload.", @"Error message to show to users when trying to upload a media object with no local file associated")}]);
+        }
+        return;
+    }
     // Even though jpeg is a valid extension, use jpg instead for the widest possible
     // support.  Some third-party image related plugins prefer the .jpg extension.
     // See https://github.com/wordpress-mobile/WordPress-iOS/issues/4663

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3043,24 +3043,26 @@ extension AztecPostViewController {
            let error = media.error {
             showDefaultActions = false
             message = error.localizedDescription
+            // only show retry options if we at least have a local file to try to upload again.
+            if media.absoluteLocalURL != nil {
+                if failedMediaIDs.count > 1 {
+                    alertController.addActionWithTitle(MediaAttachmentActionSheet.retryAllFailedUploadsActionTitle,
+                                                       style: .default,
+                                                       handler: { [weak self] (action) in
+                                                        self?.retryAllFailedMediaUploads()
+                    })
+                }
 
-            if failedMediaIDs.count > 1 {
-                alertController.addActionWithTitle(MediaAttachmentActionSheet.retryAllFailedUploadsActionTitle,
+                alertController.addActionWithTitle(MediaAttachmentActionSheet.retryUploadActionTitle,
                                                    style: .default,
                                                    handler: { [weak self] (action) in
-                                                    self?.retryAllFailedMediaUploads()
+                                                    guard let strongSelf = self,
+                                                        let attachment = strongSelf.richTextView.attachment(withId: attachmentID) else {
+                                                            return
+                                                    }
+                                                    strongSelf.retryFailedMediaUpload(media: media, attachment: attachment)
                 })
             }
-
-            alertController.addActionWithTitle(MediaAttachmentActionSheet.retryUploadActionTitle,
-                                               style: .default,
-                                               handler: { [weak self] (action) in
-                                                guard let strongSelf = self,
-                                                    let attachment = strongSelf.richTextView.attachment(withId: attachmentID) else {
-                                                        return
-                                                }
-                                                strongSelf.retryFailedMediaUpload(media: media, attachment: attachment)
-            })
         }
 
         if showDefaultActions {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -339,8 +339,14 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             if let error = media.error {
                 alertController.message = error.localizedDescription
             }
-            alertController.addDefaultActionWithTitle(NSLocalizedString("Retry Upload", comment: "User action to retry media upload.")) { _ in
-                MediaCoordinator.shared.retryMedia(media)
+            if media.absoluteLocalURL != nil {
+                alertController.addDefaultActionWithTitle(NSLocalizedString("Retry Upload", comment: "User action to retry media upload.")) { _ in
+                    MediaCoordinator.shared.retryMedia(media)
+                }
+            } else {
+                alertController.addDefaultActionWithTitle(NSLocalizedString("Delete", comment: "User action to delete media.")) { _ in
+                    MediaCoordinator.shared.delete(media: media)
+                }
             }
         }
 

--- a/WordPressKit/WordPressKit/MediaServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/MediaServiceRemoteREST.m
@@ -194,6 +194,15 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
     if (media.postID != nil && [media.postID compare:@(0)] == NSOrderedDescending) {
         parameters[@"attrs[0][parent_id]"] = media.postID;
     }
+    if (media.localURL == nil || filename == nil || type == nil) {
+        if (failure) {
+            NSError *error = [NSError errorWithDomain:NSURLErrorDomain
+                                                 code:NSURLErrorFileDoesNotExist
+                                             userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Media doesn't have an associated file to upload.", @"Error message to show to users when trying to upload a media object with no local file associated")}];
+            failure(error);
+        }
+        return;
+    }
     FilePart *filePart = [[FilePart alloc] initWithParameterName:@"media[]" url:media.localURL filename:filename mimeType:type];
     __block NSProgress *localProgress = [self.wordPressComRestApi multipartPOST:requestUrl
                                                                      parameters:parameters

--- a/WordPressKit/WordPressKit/MediaServiceRemoteXMLRPC.m
+++ b/WordPressKit/WordPressKit/MediaServiceRemoteXMLRPC.m
@@ -119,7 +119,15 @@
 {
     NSString *type = media.mimeType;
     NSString *filename = media.file;
-    
+    if (media.localURL == nil || filename == nil || type == nil) {
+        if (failure) {
+            NSError *error = [NSError errorWithDomain:NSURLErrorDomain
+                                                 code:NSURLErrorFileDoesNotExist
+                                             userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Media doesn't have an associated file to upload.", @"Error message to show to users when trying to upload a media object with no local file associated")}];
+            failure(error);
+        }
+        return;
+    }
     NSMutableDictionary *data = [NSMutableDictionary dictionaryWithDictionary:@{
                            @"name": filename,
                            @"type": type,


### PR DESCRIPTION
Fixes #8592 

This PR adds a fix to the `MediaAssetExporter` class to allow export of assets stored in the iCloud. The fix consists in allowing the PHImageManager to do an asynchronous request when media is not stored locally, otherwise the request for image fails. 

It also adds failsafe code to the MediaService and remote objects to prevent crashes when trying to upload Media that doesn't have a local file assigned. To finish it of it also adds options on the UI to remove/delete Media when that scenario is detected.

To test:
 - Create a new post
 - Insert a media object that is on iCloud or in a shared stream and is not cached on the device (media that is not open or never opened full screen on that device)
 - Check that insert works
 - Try the same on the media library.

