### PR TITLE
Media async notices: Use successful upload count to account for cancelled items

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -6,21 +6,22 @@ enum MediaNoticeUserInfoKey {
 
 struct MediaProgressCoordinatorNoticeViewModel {
     private let mediaProgressCoordinator: MediaProgressCoordinator
-    private let progress: Progress
     private let successfulMedia: [Media]
     private let failedMedia: [Media]
 
     init?(mediaProgressCoordinator: MediaProgressCoordinator) {
-        guard !mediaProgressCoordinator.isRunning,
-            let progress = mediaProgressCoordinator.mediaGlobalProgress else {
+        guard !mediaProgressCoordinator.isRunning else {
                 return nil
         }
 
         self.mediaProgressCoordinator = mediaProgressCoordinator
-        self.progress = progress
 
         successfulMedia = mediaProgressCoordinator.successfulMedia
         failedMedia = mediaProgressCoordinator.failedMedia
+
+        guard successfulMedia.count + failedMedia.count > 0 else {
+            return nil
+        }
     }
 
     private var uploadSuccessful: Bool {
@@ -88,7 +89,7 @@ struct MediaProgressCoordinatorNoticeViewModel {
 
     var title: String {
         if uploadSuccessful {
-            return pluralize(Int(progress.completedUnitCount),
+            return pluralize(successfulMedia.count,
                              singular: NSLocalizedString("Media uploaded (1 file)", comment: "Alert displayed to the user when a single media item has uploaded successfully."),
                              plural: NSLocalizedString("Media uploaded (%ld files)", comment: "Alert displayed to the user when multiple media items have uploaded successfully."))
         } else {
@@ -97,7 +98,7 @@ struct MediaProgressCoordinatorNoticeViewModel {
     }
 
     var message: String? {
-        guard !uploadSuccessful && progress.completedUnitCount >= 1 else {
+        guard !uploadSuccessful && successfulMedia.count >= 1 else {
             return nil
         }
 
@@ -121,7 +122,7 @@ struct MediaProgressCoordinatorNoticeViewModel {
     }
 
     private var successfulUploadsDescription: String {
-        return pluralize(Int(progress.completedUnitCount),
+        return pluralize(successfulMedia.count,
                          singular: NSLocalizedString("1 file successfully uploaded", comment: "System notification displayed to the user when a single media item has uploaded successfully."),
                          plural: NSLocalizedString("%ld files successfully uploaded", comment: "System notification displayed to the user when multiple media items have uploaded successfully."))
     }


### PR DESCRIPTION
Fixes #8590. This PR switches the notice view model for async uploads to use the successful item count instead of the progress completed unit count. The successful items array provided by the progress coordinator has any cancelled items removed from it, which means we don't incorrectly show cancelled items as part of the successful item count.

**To test:**

* In the media library, begin one item uploading and then cancel it. No notice should be displayed.
* In the media library, begin multiple items uploading and cancel one of them. After the others have successfully uploaded, the notice displayed should show the count of successful uploads, not counting the one you cancelled.
* In the media library, begin multiple items uploading and cancel one of them. Switch on airplane mode so that all the others fail. The notice displayed should just show the correct count of failed uploads (previously it would've said the cancelled item was successfully uploaded).