### PR TITLE
Fixes for RTL layout in the Login section.

### DIFF
--- a/WordPress/Classes/Extensions/UIControl+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIControl+Helpers.swift
@@ -99,3 +99,40 @@ extension ControlEventBindable where Self: UIBarButtonItem {
         self.controlEventHandlers.append(handler)
     }
 }
+
+
+// MARK: - Internationalization helper
+
+extension UIControl {
+    public enum NaturalContentHorizontalAlignment {
+        case leading
+        case trailing
+    }
+
+    /// iOS 10 compatible leading/trailing contentHorizontalAlignment. Prefer this to set content alignment to respect Right-to-Left language layouts.
+    ///
+    public var naturalContentHorizontalAlignment: NaturalContentHorizontalAlignment? {
+        get {
+            switch contentHorizontalAlignment {
+            case .left, .leading:
+                return .leading
+            case .right, .trailing:
+                return .trailing
+            default:
+                return nil
+            }
+        }
+
+        set(alignment) {
+            if #available(iOS 11.0, *) {
+                contentHorizontalAlignment = (alignment == .leading) ? .leading : .trailing
+            } else {
+                if userInterfaceLayoutDirection() == .leftToRight {
+                    contentHorizontalAlignment = (alignment == .leading) ? .left : .right
+                } else {
+                    contentHorizontalAlignment = (alignment == .leading) ? .right : .left
+                }
+            }
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -145,22 +145,22 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ozJ-hT-OEw">
-                                <rect key="frame" x="-4" y="64" width="391" height="612"/>
+                                <rect key="frame" x="0.0" y="64" width="383" height="612"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KAn-ug-oE6">
-                                        <rect key="frame" x="0.0" y="0.0" width="391" height="548"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="383" height="548"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="JdU-yW-tzf">
-                                                <rect key="frame" x="0.0" y="194" width="391" height="102"/>
+                                                <rect key="frame" x="0.0" y="194" width="383" height="102"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DKR-9c-zZQ">
-                                                        <rect key="frame" x="20" y="0.0" width="351" height="38"/>
+                                                        <rect key="frame" x="20" y="0.0" width="343" height="38"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XXO-aV-keK" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="58" width="391" height="44"/>
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XXO-aV-keK" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="58" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
                                                         <constraints>
@@ -180,7 +180,7 @@
                                                         </connections>
                                                     </textField>
                                                     <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qqt-eq-gac">
-                                                        <rect key="frame" x="20" y="102" width="351" height="40"/>
+                                                        <rect key="frame" x="20" y="102" width="343" height="40"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="40" placeholder="YES" id="0GR-cF-ntU"/>
                                                         </constraints>
@@ -209,10 +209,10 @@
                                         </constraints>
                                     </view>
                                     <stackView contentMode="scaleToFill" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" distribution="equalSpacing" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6i6-CG-3Tg">
-                                        <rect key="frame" x="20" y="548" width="351" height="44"/>
+                                        <rect key="frame" x="20" y="548" width="343" height="44"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5Hn-ZK-h9k">
-                                                <rect key="frame" x="0.0" y="7" width="307" height="30"/>
+                                                <rect key="frame" x="0.0" y="7" width="299" height="30"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="addSelfHostedButton"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <state key="normal" title="Log into your site by entering your site address instead.">
@@ -223,7 +223,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OZC-xf-OAn" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="315" y="0.0" width="36" height="44"/>
+                                                <rect key="frame" x="307" y="0.0" width="36" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="PgU-lW-anB"/>
@@ -268,10 +268,10 @@
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="ozJ-hT-OEw" firstAttribute="top" secondItem="bn3-aC-RIM" secondAttribute="bottom" id="S6n-FZ-9Yc"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="ozJ-hT-OEw" secondAttribute="trailing" constant="-20" id="Uuo-bm-Be2"/>
+                            <constraint firstAttribute="trailing" secondItem="ozJ-hT-OEw" secondAttribute="trailing" id="Uuo-bm-Be2"/>
                             <constraint firstItem="ozJ-hT-OEw" firstAttribute="centerX" secondItem="e5n-Bf-JaL" secondAttribute="centerX" id="ZpP-No-8Mw"/>
                             <constraint firstItem="tip-gy-Hwr" firstAttribute="top" secondItem="ozJ-hT-OEw" secondAttribute="bottom" id="h6K-00-qtf"/>
-                            <constraint firstItem="ozJ-hT-OEw" firstAttribute="leading" secondItem="e5n-Bf-JaL" secondAttribute="leadingMargin" constant="-20" id="lqe-jU-dLs"/>
+                            <constraint firstItem="ozJ-hT-OEw" firstAttribute="leading" secondItem="e5n-Bf-JaL" secondAttribute="leading" id="lqe-jU-dLs"/>
                         </constraints>
                         <variation key="heightClass=regular-widthClass=regular">
                             <mask key="constraints">
@@ -369,7 +369,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="yx4-Vw-DFk">
                                                 <rect key="frame" x="0.0" y="95" width="375" height="176"/>
                                                 <subviews>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email Address" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="It3-g0-cxp" customClass="WPWalkthroughTextField">
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email Address" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="It3-g0-cxp" customClass="WPWalkthroughTextField">
                                                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="nuxEmailField"/>
@@ -384,7 +384,7 @@
                                                             <outlet property="delegate" destination="QDy-AC-sAr" id="XW1-iz-4zI"/>
                                                         </connections>
                                                     </textField>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MMG-3p-JWU" customClass="WPWalkthroughTextField">
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MMG-3p-JWU" customClass="WPWalkthroughTextField">
                                                         <rect key="frame" x="0.0" y="44" width="375" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="nuxUsernameField"/>
@@ -400,7 +400,7 @@
                                                             <outlet property="delegate" destination="QDy-AC-sAr" id="CdW-xP-Q0C"/>
                                                         </connections>
                                                     </textField>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uNv-KX-D1D" customClass="WPWalkthroughTextField">
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uNv-KX-D1D" customClass="WPWalkthroughTextField">
                                                         <rect key="frame" x="0.0" y="88" width="375" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="nuxPasswordField"/>
@@ -416,7 +416,7 @@
                                                             <outlet property="delegate" destination="QDy-AC-sAr" id="xqe-J2-thL"/>
                                                         </connections>
                                                     </textField>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Site Address (URL)" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HNy-PM-AgS" customClass="WPWalkthroughTextField">
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Site Address (URL)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HNy-PM-AgS" customClass="WPWalkthroughTextField">
                                                         <rect key="frame" x="0.0" y="132" width="375" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="nuxUrlField"/>
@@ -555,6 +555,8 @@
                         <outlet property="topLayoutGuideAdjustmentConstraint" destination="g5e-48-rwT" id="wK6-By-loG"/>
                         <outlet property="usernameField" destination="MMG-3p-JWU" id="nMk-0h-ogG"/>
                         <outlet property="verticalCenterConstraint" destination="XFf-th-GSA" id="ybo-1G-a14"/>
+                        <outlet property="wpcomLabel" destination="BHQ-iH-Ffv" id="5TJ-A2-3Im"/>
+                        <outlet property="wpcomLabelTrailingConstraint" destination="IPK-cg-i4q" id="Ss5-ld-6mE"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lhb-00-kKg" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -607,7 +609,7 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="tW0-In-DwC">
                                                 <rect key="frame" x="0.0" y="247.5" width="383" height="88"/>
                                                 <subviews>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ESh-DI-dtB" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Username / Email" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ESh-DI-dtB" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
@@ -623,7 +625,7 @@
                                                             <outlet property="delegate" destination="SZS-o3-1P7" id="NfG-gH-Yct"/>
                                                         </connections>
                                                     </textField>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oi5-Kd-TEW" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="oi5-Kd-TEW" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="44" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
@@ -793,7 +795,7 @@
                                                             </label>
                                                         </subviews>
                                                     </stackView>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BtS-3D-CIU" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="28.5" width="383" height="44"/>
                                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="passwordField"/>
@@ -817,7 +819,7 @@
                                                     <constraint firstItem="BtS-3D-CIU" firstAttribute="width" secondItem="3be-99-g62" secondAttribute="width" id="uoX-on-LUd"/>
                                                 </constraints>
                                             </stackView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZqY-I8-yWG">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZqY-I8-yWG">
                                                 <rect key="frame" x="20" y="340" width="343" height="18"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="pswdErrorLabel"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
@@ -952,7 +954,7 @@
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Verification Code" clearsOnBeginEditing="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="A2K-lq-6XM" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Verification Code" textAlignment="natural" clearsOnBeginEditing="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="A2K-lq-6XM" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="247.5" width="383" height="44"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="Verification Code"/>
@@ -1470,7 +1472,7 @@
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="example.wordpress.com" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZrT-CY-qD7" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="example.wordpress.com" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZrT-CY-qD7" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="252" width="391" height="44"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="usernameField"/>

--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -87,7 +87,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
     /// configures the text fields
     ///
     @objc func configureTextFields() {
-        verificationCodeField.textInsets = WPStyleGuide.edgeInsetForLoginTextFields()
+        verificationCodeField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
     }
 
     /// Configures the appearance and state of the submit button.

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -115,6 +115,7 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         selfHostedSigninButton.setTitle(selfHostedTitle, for: UIControlState())
         selfHostedSigninButton.setTitle(selfHostedTitle, for: .highlighted)
         selfHostedSigninButton.titleLabel?.numberOfLines = 0
+        selfHostedSigninButton.naturalContentHorizontalAlignment = .leading
     }
 
 
@@ -179,7 +180,7 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     /// in `loginFields`.
     ///
     @objc func configureEmailField() {
-        emailTextField.textInsets = WPStyleGuide.edgeInsetForLoginTextFields()
+        emailTextField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
         emailTextField.text = loginFields.username
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
@@ -121,7 +121,7 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
         usernameField.text = loginFields.username
         passwordField.text = loginFields.password
         passwordField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
-        usernameField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields() 
+        usernameField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSelfHostedViewController.swift
@@ -118,10 +118,10 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
     /// Configures the content of the text fields based on what is saved in `loginFields`.
     ///
     @objc func configureTextFields() {
-        usernameField.textInsets = WPStyleGuide.edgeInsetForLoginTextFields()
-        passwordField.textInsets = WPStyleGuide.edgeInsetForLoginTextFields()
         usernameField.text = loginFields.username
         passwordField.text = loginFields.password
+        passwordField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
+        usernameField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields() 
     }
 
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
@@ -83,7 +83,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
     /// Configures the content of the text fields based on what is saved in `loginFields`.
     ///
     @objc func configureTextFields() {
-        siteURLField.textInsets = WPStyleGuide.edgeInsetForLoginTextFields()
+        siteURLField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
         siteURLField.text = loginFields.siteAddress
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginWPComViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginWPComViewController.swift
@@ -113,7 +113,7 @@ class LoginWPComViewController: LoginViewController, NUXKeyboardResponder {
 
     @objc func configureTextFields() {
         passwordField?.text = loginFields.password
-        passwordField?.textInsets = WPStyleGuide.edgeInsetForLoginTextFields()
+        passwordField?.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
         emailLabel?.text = loginFields.username
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/Signup.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Signup.storyboard
@@ -46,7 +46,7 @@
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HTy-KJ-his" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
+                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HTy-KJ-his" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="58" width="375" height="44"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="usernameField"/>

--- a/WordPress/Classes/ViewRelated/NUX/SignupEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEmailViewController.swift
@@ -68,7 +68,7 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         emailField.placeholder = NSLocalizedString("Email address", comment: "Placeholder for a textfield. The user may enter their email address.")
         emailField.accessibilityIdentifier = "Email address"
-        emailField.textInsets = WPStyleGuide.edgeInsetForLoginTextFields()
+        emailField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
 
         let submitButtonTitle = NSLocalizedString("Next", comment: "Title of a button. The text should be capitalized.").localizedCapitalized
         submitButton?.setTitle(submitButtonTitle, for: UIControlState())

--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -15,10 +15,13 @@ import WordPressShared
     @IBOutlet weak var submitButton: NUXSubmitButton!
     @IBOutlet weak var statusLabel: UILabel!
     @IBOutlet weak var termsButton: UIButton!
+    @IBOutlet weak var wpcomLabel: UILabel!
     @IBOutlet var bottomContentConstraint: NSLayoutConstraint?
     @IBOutlet var verticalCenterConstraint: NSLayoutConstraint?
     @IBOutlet var topLayoutGuideAdjustmentConstraint: NSLayoutConstraint!
     @IBOutlet var formTopMarginConstraint: NSLayoutConstraint!
+    @IBOutlet weak var wpcomLabelTrailingConstraint: NSLayoutConstraint!
+
     @objc var onePasswordButton: UIButton!
     @objc var didCorrectEmailOnce: Bool = false
     @objc var userDefinedSiteAddress: Bool = false
@@ -128,6 +131,17 @@ import WordPressShared
         let submitButtonTitle = NSLocalizedString("Create Account", comment: "Title of a button. The text should be uppercase.").localizedUppercase
         submitButton.setTitle(submitButtonTitle, for: UIControlState())
         submitButton.setTitle(submitButtonTitle, for: .highlighted)
+
+        //The wpcom label is always at the left of the screen, independently of the user layout direction.
+        if view.userInterfaceLayoutDirection() == .rightToLeft {
+            let siteFieldLeftViewWidth = siteURLField.leftView?.frame.width ?? 0
+            let wpcomRightInset = -(siteFieldLeftViewWidth + siteURLField.contentInsets.left + siteURLField.textInsets.left)
+            let textfieldLeftEdgeInset = wpcomLabel.bounds.width + WPStyleGuide.textInsetsForLoginTextFieldWithLeftView().left
+            wpcomLabelTrailingConstraint.constant = wpcomRightInset
+            siteURLField.textInsets = UIEdgeInsets(top: 0, left: textfieldLeftEdgeInset, bottom: 0, right: 0)
+        } else {
+            siteURLField.textInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: wpcomLabel.bounds.width)
+        }
     }
 
 
@@ -220,6 +234,11 @@ import WordPressShared
     /// Sets up the view's colors and style
     @objc open func setupStyles() {
         WPStyleGuide.configureColorsForSigninView(view)
+
+        emailField.contentInsets    = WPStyleGuide.edgeInsetForLoginTextFields()
+        usernameField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
+        passwordField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
+        siteURLField.contentInsets  = WPStyleGuide.edgeInsetForLoginTextFields()
     }
 
     /// Whether the view layout should be adjusted for smaller screens

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationDomainSearchTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationDomainSearchTableViewCell.swift
@@ -28,7 +28,7 @@ class SiteCreationDomainSearchTableViewCell: UITableViewCell {
         super.awakeFromNib()
         textField?.text = placeholder
         textField?.delegate = self
-        textField?.textInsets = Constants.textInsetsWithIcon
+        textField?.contentInsets = Constants.textInsetsWithIcon
         textField?.placeholder = NSLocalizedString("Type to get more suggestions", comment: "Placeholder text for domain search during site creation.")
         textField?.accessibilityIdentifier = "Domain search field"
 

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationSiteDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationSiteDetailsViewController.swift
@@ -80,8 +80,8 @@ class SiteCreationSiteDetailsViewController: NUXViewController, NUXKeyboardRespo
         navigationItem.title = NSLocalizedString("Create New Site", comment: "Create New Site title.")
         WPStyleGuide.configureColors(for: view, andTableView: nil)
         nextButton.isEnabled = false
-        siteTitleField.textInsets = WPStyleGuide.edgeInsetForLoginTextFields()
-        taglineField.textInsets = WPStyleGuide.edgeInsetForLoginTextFields()
+        siteTitleField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
+        taglineField.contentInsets = WPStyleGuide.edgeInsetForLoginTextFields()
     }
 
     private func setLabelText() {

--- a/WordPress/Classes/ViewRelated/NUX/WPStyleGuide+Login.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WPStyleGuide+Login.swift
@@ -29,7 +29,6 @@ extension WPStyleGuide {
         onePasswordButton.sizeToFit()
 
         textField.rightView = onePasswordButton
-        textField.rightViewPadding = UIOffset(horizontal: 20.0, vertical: 0.0)
         textField.rightViewMode = .always
 
         onePasswordButton.addTarget(target, action: selector, for: .touchUpInside)
@@ -63,7 +62,11 @@ extension WPStyleGuide {
     ///
     ///
     @objc class func edgeInsetForLoginTextFields() -> UIEdgeInsets {
-        return UIEdgeInsetsMake(7, 20, 7, 20)
+        return UIEdgeInsets(top: 7, left: 20, bottom: 7, right: 20)
+    }
+
+    @objc class func textInsetsForLoginTextFieldWithLeftView() -> UIEdgeInsets {
+        return UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
     }
 
     /// Return the system font in medium weight for the given style
@@ -89,7 +92,7 @@ extension WPStyleGuide {
         let button = UIButton()
         button.clipsToBounds = true
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.contentHorizontalAlignment = .left
+        button.naturalContentHorizontalAlignment = .leading
         button.titleLabel?.font = font
         button.titleLabel?.numberOfLines = 0
         button.titleLabel?.lineBreakMode = .byWordWrapping

--- a/WordPress/Classes/ViewRelated/NUX/WPWalkthroughTextField.h
+++ b/WordPress/Classes/ViewRelated/NUX/WPWalkthroughTextField.h
@@ -6,9 +6,36 @@ IB_DESIGNABLE
 @property (nonatomic) IBInspectable BOOL showTopLineSeparator;
 @property (nonatomic) IBInspectable BOOL showSecureTextEntryToggle;
 @property (nonatomic) IBInspectable UIImage *leftViewImage;
-@property (nonatomic) UIEdgeInsets textInsets;
-@property (nonatomic) UIOffset rightViewPadding;
 
+/// Width for the left view. Set to 0 to use the given frame in the view.
+/// Default is: 30
+///
+@property (nonatomic) CGFloat leadingViewWidth;
+
+/// Width for the right view. Set to 0 to use the given frame in the view.
+/// Default is: 40
+///
+@property (nonatomic) CGFloat trailingViewWidth;
+
+/// Insets around the text area.
+/// This value is mirrored in Right-to-Left layout
+///
+@property (nonatomic) UIEdgeInsets textInsets;
+
+/// Insets around the leading (left) view.
+/// This value is mirrored in Right-to-Left layout
+///
+@property (nonatomic) UIEdgeInsets leadingViewInsets;
+
+/// Insets around the trailing (right) view.
+/// This value is mirrored in Right-to-Left layout
+///
+@property (nonatomic) UIEdgeInsets trailingViewInsets;
+
+/// Insets around the whole content of the textfield.
+/// This value is mirrored in Right-to-Left layout
+///
+@property (nonatomic) UIEdgeInsets contentInsets;
 
 - (instancetype)initWithLeftViewImage:(UIImage *)image;
 

--- a/WordPress/Classes/ViewRelated/NUX/WPWalkthroughTextField.m
+++ b/WordPress/Classes/ViewRelated/NUX/WPWalkthroughTextField.m
@@ -46,33 +46,45 @@ NSInteger const LeftImageSpacing = 8;
 {
     if (leftViewImage) {
         _leftViewImage = leftViewImage;
-
-        self.leftView = [[UIImageView alloc] initWithImage:leftViewImage];
+        UIImageView *imageView = [[UIImageView alloc] initWithImage:leftViewImage];
+        if (self.leadingViewWidth > 0) {
+            imageView.frame = [self frameForLeadingView];
+            imageView.contentMode = [self isLayoutLeftToRight] ? UIViewContentModeLeft : UIViewContentModeRight;
+        } else {
+            [imageView sizeToFit];
+        }
+        self.leftView = imageView;
         self.leftViewMode = UITextFieldViewModeAlways;
     } else {
         self.leftView = nil;
     }
 }
 
+-(void)setRightView:(UIView *)rightView {
+    if (self.trailingViewWidth > 0) {
+        rightView.frame = [self frameForTrailingView];
+        rightView.contentMode = [self isLayoutLeftToRight] ? UIViewContentModeRight : UIViewContentModeLeft;
+        if ([rightView isKindOfClass:[UIButton class]]) {
+            UIButton *button = (UIButton *)rightView;
+            if ([self isLayoutLeftToRight]) {
+                [button setContentHorizontalAlignment:UIControlContentHorizontalAlignmentRight];
+            } else {
+                [button setContentHorizontalAlignment:UIControlContentHorizontalAlignmentLeft];
+            }
+        }
+    }
+    [super setRightView:rightView];
+}
+
 - (void)commonInit
 {
-    self.textInsets = UIEdgeInsetsMake(7, 10, 7, 10);
+    self.leadingViewWidth = 30.f;
+    self.trailingViewWidth = 40.f;
+
     self.layer.cornerRadius = 0.0;
     self.clipsToBounds = YES;
     self.showTopLineSeparator = NO;
     self.showSecureTextEntryToggle = NO;
-
-    self.secureTextEntryImageVisible = [Gridicon iconOfType:GridiconTypeVisible];
-    self.secureTextEntryImageHidden = [Gridicon iconOfType:GridiconTypeNotVisible];
-
-    self.secureTextEntryToggle = [UIButton buttonWithType:UIButtonTypeCustom];
-    self.secureTextEntryToggle.clipsToBounds = true;
-    self.secureTextEntryToggle.tintColor = [WPStyleGuide greyLighten10];
-    self.secureTextEntryToggle.frame = CGRectMake(0, 0, 40, 30);
-    [self.secureTextEntryToggle addTarget:self action:@selector(secureTextEntryToggleAction:) forControlEvents:UIControlEventTouchUpInside];
-
-    [self addSubview:self.secureTextEntryToggle];
-    [self updateSecureTextEntryToggleImage];
 
     // Apply styles to the placeholder if one was set in IB.
     if (self.placeholder) {
@@ -84,6 +96,28 @@ NSInteger const LeftImageSpacing = 8;
     }
 }
 
+- (void)awakeFromNib {
+    [super awakeFromNib];
+    [self configureSecureTextEntryToggle];
+}
+
+- (void)configureSecureTextEntryToggle {
+    if (self.showSecureTextEntryToggle == NO) {
+        return;
+    }
+    self.secureTextEntryImageVisible = [Gridicon iconOfType:GridiconTypeVisible];
+    self.secureTextEntryImageHidden = [Gridicon iconOfType:GridiconTypeNotVisible];
+
+    self.secureTextEntryToggle = [UIButton buttonWithType:UIButtonTypeCustom];
+    self.secureTextEntryToggle.clipsToBounds = true;
+    self.secureTextEntryToggle.tintColor = [WPStyleGuide greyLighten10];
+    [self.secureTextEntryToggle addTarget:self action:@selector(secureTextEntryToggleAction:) forControlEvents:UIControlEventTouchUpInside];
+
+    [self updateSecureTextEntryToggleImage];
+    self.rightView = self.secureTextEntryToggle;
+    self.rightViewMode = UITextFieldViewModeAlways;
+}
+
 - (CGSize)intrinsicContentSize
 {
     return CGSizeMake(0.0, 44.0);
@@ -92,107 +126,116 @@ NSInteger const LeftImageSpacing = 8;
 - (void)drawRect:(CGRect)rect
 {
     // Draw top border
-    if (_showTopLineSeparator) {
+    if (!self.showTopLineSeparator) {
+        return;
+    }
 
-        CGContextRef context = UIGraphicsGetCurrentContext();
+    CGContextRef context = UIGraphicsGetCurrentContext();
 
-        UIBezierPath *path = [UIBezierPath bezierPath];
-        [path moveToPoint:CGPointMake(CGRectGetMinX(rect) + _textInsets.left, CGRectGetMinY(rect))];
+    UIBezierPath *path = [UIBezierPath bezierPath];
+    CGFloat emptySpace = self.contentInsets.left;
+    if ([self isLayoutLeftToRight]) {
+        [path moveToPoint:CGPointMake(CGRectGetMinX(rect) + emptySpace, CGRectGetMinY(rect))];
         [path addLineToPoint:CGPointMake(CGRectGetMaxX(rect), CGRectGetMinY(rect))];
-        [path setLineWidth:[[UIScreen mainScreen] scale] / 2.0];
-        CGContextAddPath(context, path.CGPath);
-        CGContextSetStrokeColorWithColor(context, [UIColor colorWithWhite:0.87 alpha:1.0].CGColor);
-        CGContextStrokePath(context);
-    }
-}
-
-- (void)layoutSubviews
-{
-    [super layoutSubviews];
-
-    self.secureTextEntryToggle.hidden = !self.showSecureTextEntryToggle;
-    if (self.showSecureTextEntryToggle) {
-        CGFloat secureImagePadding = [self calculateSecureImagePadding];
-        CGRect frame = self.secureTextEntryToggle.frame;
-        if ([self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight) {
-            frame = CGRectIntegral(CGRectMake(CGRectGetWidth(self.bounds) - CGRectGetWidth(self.secureTextEntryToggle.frame) - secureImagePadding,
-                                              (CGRectGetHeight(self.bounds) - CGRectGetHeight(self.secureTextEntryToggle.frame)) / 2.0,
-                                              CGRectGetWidth(self.secureTextEntryToggle.frame),
-                                              CGRectGetHeight(self.secureTextEntryToggle.frame)));
-        } else {
-            frame = CGRectIntegral(CGRectMake(CGRectGetMinX(self.bounds) + secureImagePadding,
-                                              (CGRectGetHeight(self.bounds) - CGRectGetHeight(self.secureTextEntryToggle.frame)) / 2.0,
-                                              CGRectGetWidth(self.secureTextEntryToggle.frame),
-                                              CGRectGetHeight(self.secureTextEntryToggle.frame)));
-        }
-        self.secureTextEntryToggle.frame = frame;
-        [self bringSubviewToFront:self.secureTextEntryToggle];
-    }
-}
-
-- (CGFloat)calculateSecureImagePadding {
-    CGFloat desiredPadding = 20.0;
-    CGSize imageSize = self.secureTextEntryToggle.imageView.image.size;
-    CGSize buttonSize = self.secureTextEntryToggle.frame.size;
-    CGFloat buttonPadding = (buttonSize.width - imageSize.width) / 2.0;
-    return desiredPadding - buttonPadding;
-}
-
-- (CGRect)calculateTextRectForBounds:(CGRect)bounds
-{
-    CGRect returnRect;
-    
-    if (_leftViewImage) {
-        CGFloat leftViewWidth = _leftViewImage.size.width;
-        returnRect = CGRectMake(leftViewWidth + LeftImageSpacing + _textInsets.left, _textInsets.top, bounds.size.width - leftViewWidth - LeftImageSpacing - _textInsets.left - _textInsets.right, bounds.size.height - _textInsets.top - _textInsets.bottom);
     } else {
-        returnRect = CGRectMake(_textInsets.left, _textInsets.top, bounds.size.width - _textInsets.left - _textInsets.right, bounds.size.height - _textInsets.top - _textInsets.bottom);
+        [path moveToPoint:CGPointMake(CGRectGetMinX(rect), CGRectGetMinY(rect))];
+        [path addLineToPoint:CGPointMake(CGRectGetMaxX(rect) - emptySpace, CGRectGetMinY(rect))];
     }
 
-    if (self.showSecureTextEntryToggle) {
-        returnRect.size.width -= CGRectGetWidth(self.secureTextEntryToggle.frame);
-    }
-    
-    if (self.rightView && self.rightViewMode != UITextFieldViewModeNever) {
-        returnRect.size.width -= CGRectGetWidth(self.rightView.frame);
-    }
+    [path setLineWidth:[[UIScreen mainScreen] scale] / 2.0];
+    CGContextAddPath(context, path.CGPath);
+    CGContextSetStrokeColorWithColor(context, [UIColor colorWithWhite:0.87 alpha:1.0].CGColor);
+    CGContextStrokePath(context);
 
-    return CGRectIntegral(returnRect);
 }
 
-// placeholder position
+
+/// Returns the drawing rectangle for the text field’s text.
+///
 - (CGRect)textRectForBounds:(CGRect)bounds
 {
-    return [self calculateTextRectForBounds:bounds];
+    CGRect rect = [super textRectForBounds:bounds];
+    return [self textAreaRectForProposedRect:rect];
 }
 
-// text position
+/// Returns the rectangle in which editable text can be displayed.
+///
 - (CGRect)editingRectForBounds:(CGRect)bounds
 {
-    return [self calculateTextRectForBounds:bounds];
+    CGRect rect = [super editingRectForBounds:bounds];
+    return [self textAreaRectForProposedRect:rect];
 }
 
-// left view position
+/// Returns the drawing rectangle of the receiver’s left overlay view.
+/// This value is always the view seen at the left side, independently of the layout direction.
+///
 - (CGRect)leftViewRectForBounds:(CGRect)bounds
 {
-
-    if (_leftViewImage) {
-        return CGRectIntegral(CGRectMake(_textInsets.left, (CGRectGetHeight(bounds) - _leftViewImage.size.height) / 2.0, _leftViewImage.size.width, _leftViewImage.size.height));
+    CGRect rect = [super leftViewRectForBounds:bounds];
+    if ([self isLayoutLeftToRight]) {
+        rect.origin.x += self.leadingViewInsets.left + self.contentInsets.left;
+    } else {
+        rect.origin.x += self.trailingViewInsets.right + self.contentInsets.right;
     }
-
-    return [super leftViewRectForBounds:bounds];
+    return rect;
 }
 
-// Right view position
+/// Returns the drawing location of the receiver’s right overlay view.
+/// This value is always the view seen at the right side, independently of the layout direction.
+///
 - (CGRect)rightViewRectForBounds:(CGRect)bounds
 {
-    CGRect textRect = [super rightViewRectForBounds:bounds];
-    textRect.origin.x -= _rightViewPadding.horizontal;
-    textRect.origin.y -= _rightViewPadding.vertical;
-    
-    return textRect;
+    CGRect rect = [super rightViewRectForBounds:bounds];
+    if ([self isLayoutLeftToRight]) {
+        rect.origin.x -= self.trailingViewInsets.right + self.contentInsets.right;
+    } else {
+        rect.origin.x -= self.leadingViewInsets.left + self.contentInsets.left;
+    }
+    return rect;
 }
 
+#pragma mark - Helpers
+
+- (BOOL)isLayoutLeftToRight
+{
+    return [self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight;
+}
+
+/// Returns the rectangle in which both editable text and the placeholder can be displayed.
+///
+- (CGRect)textAreaRectForProposedRect:(CGRect)rect
+{
+    rect.size.width -= self.textInsets.left + self.textInsets.right;
+    if ([self isLayoutLeftToRight]) {
+        rect.origin.x   += self.textInsets.left + self.leadingViewInsets.right;
+        rect.size.width -= self.leadingViewInsets.right + self.contentInsets.right;
+        if (self.leftView == nil) {
+            rect.origin.x   += self.contentInsets.left;
+            rect.size.width -= self.contentInsets.right;
+        }
+    } else {
+        rect.origin.x   += self.textInsets.right + self.trailingViewInsets.left;
+        rect.size.width -= self.leadingViewInsets.right + self.trailingViewInsets.left;
+        if (self.rightView == nil) {
+            rect.origin.x   += self.contentInsets.right;
+            rect.size.width -= self.contentInsets.left;
+        }
+        if (self.leftView == nil) {
+            rect.size.width -= self.contentInsets.left;
+        }
+    }
+    return rect;
+}
+
+- (CGRect)frameForTrailingView
+{
+    return CGRectMake(0, 0, self.trailingViewWidth, CGRectGetHeight(self.bounds));
+}
+
+- (CGRect)frameForLeadingView
+{
+    return CGRectMake(0, 0, self.leadingViewWidth, CGRectGetHeight(self.bounds));
+}
 
 #pragma mark - Secure Text Entry
 
@@ -210,7 +253,7 @@ NSInteger const LeftImageSpacing = 8;
 - (void)secureTextEntryToggleAction:(id)sender
 {
     self.secureTextEntry = !self.secureTextEntry;
-    
+
     // Save and re-apply the current selection range to save the cursor position
     UITextRange *currentTextRange = self.selectedTextRange;
     [self becomeFirstResponder];
@@ -221,6 +264,7 @@ NSInteger const LeftImageSpacing = 8;
 {
     UIImage *image = self.isSecureTextEntry ? self.secureTextEntryImageHidden : self.secureTextEntryImageVisible;
     [self.secureTextEntryToggle setImage:image forState:UIControlStateNormal];
+    [self.secureTextEntryToggle sizeToFit];
 }
 
 @end


### PR DESCRIPTION
- Fixes for RTL layout in the Login section.
- Refactor of the `WPWalkthroughTextField` class to work well with RTL layout.

![1](https://user-images.githubusercontent.com/9772967/36057598-c4647cf6-0dee-11e8-8b19-6aea35ea0406.png)

**NOTE:**
- There is a breaking change for the `WPWalkthroughTextField` class: The new `contentInsets` take the place of the old `textInsets` property.
- The `textInsets` property is now the inset around just the text area. In most cases, should be fine to leave the default value ( `.zero` )
- The new `leadingViewWidth` helps to give extra space between the left image and the text. The default value should work fine unless we start using bigger (or longer) images. This also helps to perfectly align the left images and text of many textfields when they are stacked vertically.
- The rest should continue working like it did before.
- There are new extra options for specific customizations if necessary.

Fixes #8575 (Login area)

### To test:
Building with Xcode:

Edit Scheme
Options
Application Language
Arabic (or Right-to-Left Pseudolanguage)
Run the app
Navigate the login area

### On device:

Set the system language to Arabic
Run the app
Navigate the login area