### PR TITLE
Fix typo in not a WordPress site message

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
@@ -167,7 +167,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
                 strongSelf.displayError(message: msg)
 
             } else if err.domain == "WordPressKit.WordPressOrgXMLRPCValidatorError" && err.code == WordPressOrgXMLRPCValidatorError.invalid.rawValue {
-                let msg = NSLocalizedString("We're sure this is a great site -- but it's not a WordPress site, so you can't connect it to with this app.",
+                let msg = NSLocalizedString("We're sure this is a great site - but it's not a WordPress site, so you can't connect to it with this app.",
                                             comment: "Error message shown a URL points to a valid site but not a WordPress site.")
                 strongSelf.displayError(message: msg)
 


### PR DESCRIPTION
**Fixes** #8597 

**To test:**
Follow the steps on the issue and check that the displayed message is correct.

@jklausa another small one for you that has to be merged on Monday, thank you :)