### PR TITLE
PluginViewModel: use a string format that friendlier to translations.

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -36,7 +36,7 @@ class PluginViewModel: Observable {
         switch plugin.state.updateState {
         case .updated:
             versionRow = TextRow(
-                title: NSLocalizedString("Version \(version)", comment: "Version of an installed plugin"),
+                title: String(format: NSLocalizedString("Version %@", comment: "Version of an installed plugin"), version),
                 value: NSLocalizedString("Installed", comment: "Indicates the state of the plugin")
             )
         case .available(let newVersion):


### PR DESCRIPTION
To test:
Go to plugin details and make sure version number still displays correctly. 