### PR TITLE
Fix/8575 rtl layout details

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -121,7 +121,7 @@ open class DeleteSiteViewController: UITableViewController {
                                            comment: "Paragraph 2 of 2 of main text body for the delete screen.")
 
         let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.alignment = .left
+        paragraphStyle.alignment = .natural
 
         let attributes: [NSAttributedStringKey: Any] = [.font: WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular),
                                                         .foregroundColor: WPStyleGuide.darkGrey(),
@@ -144,6 +144,8 @@ open class DeleteSiteViewController: UITableViewController {
                                                             comment: "Button label for contacting support"),
                                                             attributes: contactButtonAttributes),
                                                             for: .normal)
+
+        supportButton.naturalContentHorizontalAlignment = .leading
     }
 
     /// One time setup of fourth section (delete button)

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -196,7 +196,7 @@ extension WPStyleGuide {
         // User Cell Helpers
         public static func configureFollowButton(_ button: UIButton) {
             // General
-            button.contentHorizontalAlignment = .left
+            button.naturalContentHorizontalAlignment = .leading
             button.backgroundColor = .clear
             button.titleLabel?.font = WPStyleGuide.subtitleFont()
 

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -218,7 +218,7 @@ extension WPStyleGuide {
             button.setImage(followIcon.imageWithTintColor(normalColor), for: .normal)
             button.setImage(followingIcon.imageWithTintColor(selectedColor), for: .selected)
             button.setImage(followingIcon.imageWithTintColor(highlightedColor), for: .highlighted)
-            button.imageEdgeInsets = UIEdgeInsets(top: 1, left: -4, bottom: 0, right: 0)
+            button.imageEdgeInsets = UIEdgeInsets(top: 1, left: -4, bottom: 0, right: -4)
             button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 4, bottom: 0, right: 0)
 
             // Strings

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.xib
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11201" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,23 +16,28 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xw2-zx-vFl">
+                    <rect key="frame" x="-1" y="-1" width="322" height="66"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="66b-Vx-jim">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
                     <subviews>
                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-reader-header-tag" translatesAutoresizingMaskIntoConstraints="NO" id="3tN-sa-FJf">
+                            <rect key="frame" x="16" y="16" width="32" height="32"/>
                             <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294119999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="width" priority="999" constant="32" id="LWg-u3-u8R"/>
                                 <constraint firstAttribute="height" constant="32" id="oBW-R7-lJg"/>
                             </constraints>
                         </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" horizontalCompressionResistancePriority="740" text="Manage Site" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rlf-7m-KPD">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" horizontalCompressionResistancePriority="740" text="Manage Site" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rlf-7m-KPD">
+                            <rect key="frame" x="58" y="23.5" width="216" height="17"/>
                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="2R7-Bw-ts8">
+                            <rect key="frame" x="284" y="22" width="20" height="20"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="20" id="4tQ-LN-5aj"/>
                                 <constraint firstAttribute="width" constant="20" id="sFR-fr-BWy"/>
@@ -38,6 +47,7 @@
                     <edgeInsets key="layoutMargins" top="16" left="16" bottom="16" right="16"/>
                 </stackView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EFi-ME-clV" customClass="PostMetaButton">
+                    <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                     <inset key="titleEdgeInsets" minX="4" minY="0.0" maxX="0.0" maxY="0.0"/>
                     <state key="normal">

--- a/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
@@ -1,4 +1,5 @@
 #import "WPBlogSelectorButton.h"
+#import "WordPress-Swift.h"
 
 @implementation WPBlogSelectorButton
 
@@ -11,57 +12,42 @@
     button.titleLabel.adjustsFontSizeToFitWidth = NO;
     [button setImage:[UIImage imageNamed:@"icon-nav-chevron"] forState:UIControlStateNormal];
     [button setAccessibilityHint:NSLocalizedString(@"Tap to select which blog to post to", @"This is the blog picker in the editor")];
-    
+
+    // Show image always in the opposite direction than a normal UIButton
+    BOOL isLayoutLeftToRight = [button userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight;
+    if (isLayoutLeftToRight) {
+        button.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+    } else {
+        button.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
+
     switch (button.buttonStyle) {
         case WPBlogSelectorButtonTypeSingleLine:
             button.titleLabel.numberOfLines = 1;
-            button.titleLabel.textAlignment = NSTextAlignmentLeft;
+            button.titleLabel.textAlignment = NSTextAlignmentNatural;
             button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
             button.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
-            [button setImageEdgeInsets:UIEdgeInsetsMake(0, 4, 0, 0)];
+            if (isLayoutLeftToRight) {
+                [button setTitleEdgeInsets:UIEdgeInsetsMake(0, -4, 0, 0)];
+            } else {
+                [button setImageEdgeInsets:UIEdgeInsetsMake(0, -4, 0, 0)];
+            }
             break;
         case WPBlogSelectorButtonTypeStacked:
-        default:
             button.titleLabel.numberOfLines = 2;
-            button.titleLabel.textAlignment = NSTextAlignmentCenter;
+            button.titleLabel.textAlignment = NSTextAlignmentNatural;
             button.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
-            [button setImageEdgeInsets:UIEdgeInsetsMake(0, 4, 0, 10)];
-            [button setTitleEdgeInsets:UIEdgeInsetsMake(0, 10, 0, 0)];
+            if (isLayoutLeftToRight) {
+                [button setImageEdgeInsets:UIEdgeInsetsMake(0, -4, 0, -10)];
+                [button setTitleEdgeInsets:UIEdgeInsetsMake(0, -10, 0, 0)];
+            } else {
+                [button setImageEdgeInsets:UIEdgeInsetsMake(0, -10, 0, 0)];
+                [button setTitleEdgeInsets:UIEdgeInsetsMake(0, -4, 0, -10)];
+            }
             break;
     }
     
     return button;
-}
-
-- (void)layoutSubviews
-{
-    [super layoutSubviews];
-    self.titleLabel.frame = [self titleRectForContentRect:self.bounds];
-    self.imageView.frame = [self imageRectForContentRect:self.bounds];
-}
-
-- (CGRect)imageRectForContentRect:(CGRect)contentRect
-{
-    CGRect frame = [super imageRectForContentRect:contentRect];
-    frame.origin.x = CGRectGetMaxX([self titleRectForContentRect:contentRect]) + self.imageEdgeInsets.left;
-    return frame;
-}
-
-- (CGRect)titleRectForContentRect:(CGRect)contentRect
-{
-    CGRect frame = [super titleRectForContentRect:contentRect];
-    frame.size.width = MIN(frame.size.width, CGRectGetWidth(contentRect) - CGRectGetWidth([super imageRectForContentRect:contentRect]) - self.imageEdgeInsets.right);
-    switch (self.buttonStyle) {
-        case WPBlogSelectorButtonTypeSingleLine:
-            frame.origin.x = 0.0;
-            break;
-        case WPBlogSelectorButtonTypeStacked:
-        default:
-            frame.origin.x = CGRectGetMidX(contentRect) - CGRectGetWidth(frame) / 2.0;
-            break;
-    }
-    
-    return frame;
 }
 
 - (void)setButtonMode:(WPBlogSelectorButtonMode)value

--- a/WordPress/Classes/ViewRelated/Views/WPUploadStatusButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPUploadStatusButton.m
@@ -1,5 +1,6 @@
 #import "WPUploadStatusButton.h"
 #import <WordPressShared/WPFontManager.h>
+#import "WordPress-Swift.h"
 
 @implementation WPUploadStatusButton
 
@@ -26,7 +27,11 @@
     indicator.autoresizingMask = UIViewAutoresizingNone;
     CGFloat halfButtonHeight = self.bounds.size.height / 2;
     CGFloat buttonWidth = self.bounds.size.width;
-    indicator.center = CGPointMake(buttonWidth - halfButtonHeight , halfButtonHeight);
+    if ([self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight) {
+        indicator.center = CGPointMake(buttonWidth - halfButtonHeight , halfButtonHeight);
+    } else { // Position the loading indicator to the left of the button
+        indicator.center = CGPointMake(-halfButtonHeight , halfButtonHeight);
+    }
     [self addSubview:indicator];
     [indicator startAnimating];
     return self;


### PR DESCRIPTION
Fixes #8575 

This PR fixes some RTL layout problems. Specifically:

- Follow button in notifications area

![2](https://user-images.githubusercontent.com/9772967/36108816-79095f0a-0ffc-11e8-8127-f7f048e35883.png)

- Delete site warning

![3](https://user-images.githubusercontent.com/9772967/36108987-dbc2e260-0ffc-11e8-940f-841866bd75cd.png)

- Reader header

![4](https://user-images.githubusercontent.com/9772967/36109066-12b5fa82-0ffd-11e8-80b1-59205918c854.png)

- Aztec editor navigation buttons

![5](https://user-images.githubusercontent.com/9772967/36109252-9ccdc15a-0ffd-11e8-8920-9c20cdd5accd.png)

![6](https://user-images.githubusercontent.com/9772967/36109541-7b068b46-0ffe-11e8-849e-923da2259973.png)


###To test:

**Building with Xcode:**

Edit Scheme
Options
Application Language
Arabic (or Right-to-Left Pseudolanguage)
Run the app
Navigate the corresponding areas

**On device:**

Set the system language to Arabic
Run the app
Navigate the corresponding areas
