### PR TITLE
Fix orientation of images when copy pasted to a post

### DIFF
--- a/WordPress/Classes/Utility/Media/MediaImageExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaImageExporter.swift
@@ -275,24 +275,25 @@ class MediaImageExporter: MediaExporter {
             var imageProperties: [NSString: Any] = (CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? Dictionary) ?? [:]
             // Configure destination properties
             imageProperties[kCGImageDestinationLossyCompressionQuality] = lossyCompressionQuality
-            // Configure orientation properties to default .up or 1
-            imageProperties[kCGImagePropertyOrientation] = Int(CGImagePropertyOrientation.up.rawValue) as CFNumber
-            if var tiffProperties = imageProperties[kCGImagePropertyTIFFDictionary] as? [NSString: Any] {
-                // Remove TIFF orientation value
-                tiffProperties.removeValue(forKey: kCGImagePropertyTIFFOrientation)
-                imageProperties[kCGImagePropertyTIFFDictionary] = tiffProperties
-            }
-            if var iptcProperties = imageProperties[kCGImagePropertyIPTCImageOrientation] as? [NSString: Any] {
-                // Remove IPTC orientation value
-                iptcProperties.removeValue(forKey: kCGImagePropertyIPTCImageOrientation)
-                imageProperties[kCGImagePropertyIPTCImageOrientation] = iptcProperties
-            }
 
             // Keep track of the image's width and height
             var width: CGFloat?
             var height: CGFloat?
 
             if let maximumSize = maximumSize {
+                // Configure orientation properties to default .up or 1
+                imageProperties[kCGImagePropertyOrientation] = Int(CGImagePropertyOrientation.up.rawValue) as CFNumber
+                if var tiffProperties = imageProperties[kCGImagePropertyTIFFDictionary] as? [NSString: Any] {
+                    // Remove TIFF orientation value
+                    tiffProperties.removeValue(forKey: kCGImagePropertyTIFFOrientation)
+                    imageProperties[kCGImagePropertyTIFFDictionary] = tiffProperties
+                }
+                if var iptcProperties = imageProperties[kCGImagePropertyIPTCImageOrientation] as? [NSString: Any] {
+                    // Remove IPTC orientation value
+                    iptcProperties.removeValue(forKey: kCGImagePropertyIPTCImageOrientation)
+                    imageProperties[kCGImagePropertyIPTCImageOrientation] = iptcProperties
+                }
+
                 // Configure options for generating the thumbnail, such as the maximum size.
                 let thumbnailOptions: [NSString: Any] = [kCGImageSourceThumbnailMaxPixelSize: maximumSize,
                                                        kCGImageSourceCreateThumbnailFromImageAlways: true,

--- a/WordPress/WordPressTest/MediaImageExporterTests.swift
+++ b/WordPress/WordPressTest/MediaImageExporterTests.swift
@@ -174,7 +174,8 @@ class MediaImageExporterTests: XCTestCase {
         let exporter = MediaImageExporter(image: image, filename: nil)
         exporter.mediaDirectoryType = .temporary
         exporter.export(onCompletion: { (imageExport) in
-            MediaImageExporterTests.validateImageExportedWithExpectedOrientation(export: imageExport, expected: .up)
+            // If not resising the image the orientation stays the same has the original
+            MediaImageExporterTests.validateImageExportedWithExpectedOrientation(export: imageExport, expected: .leftMirrored)
             MediaExporterTests.cleanUpExportedMedia(atURL: imageExport.url)
             expect.fulfill()
         }) { (error) in

--- a/WordPress/WordPressTest/MediaImageExporterTests.swift
+++ b/WordPress/WordPressTest/MediaImageExporterTests.swift
@@ -170,7 +170,7 @@ class MediaImageExporterTests: XCTestCase {
             XCTFail("Error: the test portrait image was not in the expected orientation, expected: \(UIImageOrientation.leftMirrored.rawValue) but read: \(image.imageOrientation.rawValue)")
             return
         }
-        let expect = self.expectation(description: "image export by UIImage and correcting the orientation")
+        let expect = self.expectation(description: "image export by UIImage and keeping the orientation")
         let exporter = MediaImageExporter(image: image, filename: nil)
         exporter.mediaDirectoryType = .temporary
         exporter.export(onCompletion: { (imageExport) in

--- a/WordPress/WordPressTest/MediaImageExporterTests.swift
+++ b/WordPress/WordPressTest/MediaImageExporterTests.swift
@@ -164,7 +164,7 @@ class MediaImageExporterTests: XCTestCase {
 
     // MARK: - Image export orientation testing
 
-    func testExportingAPortraitImageAndCorrectingTheOrientationWorks() {
+    func testExportingAPortraitImageWithoutResizeKeepsTheOrientationWorks() {
         let image = MediaImageExporterTests.imageForFileNamed(testImageNameInPortrait)
         if image.imageOrientation != .leftMirrored {
             XCTFail("Error: the test portrait image was not in the expected orientation, expected: \(UIImageOrientation.leftMirrored.rawValue) but read: \(image.imageOrientation.rawValue)")


### PR DESCRIPTION
Fixes #8613 

This PR, changes the place were we remove the orientation info to only be done when we are resizing the images and use the `kCGImageSourceCreateThumbnailWithTransform` option. ]
When we just copying the full size image we should keep the original orientation info.

To test:
 - Check the ticket above for step on how to reproduce

