### PR TITLE
Adding is_rtl_language to Tracks

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -114,6 +114,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     userProperties[@"jetpack_user"] = @(jetpackBlogsPresent);
     userProperties[@"number_of_blogs"] = @(blogCount);
     userProperties[@"accessibility_voice_over_enabled"] = @(UIAccessibilityIsVoiceOverRunning());
+    userProperties[@"is_rtl_language"] = @(UIApplication.sharedApplication.userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft);
 
     [self.tracksService.userProperties removeAllObjects];
     [self.tracksService.userProperties addEntriesFromDictionary:userProperties];


### PR DESCRIPTION
We need a way to measure how many of the total users use the right-to-left version of the app.

This PR implement this by add a property to Tracks named `is_rtl_language` (the same name used on Android). 

**To test:**
- Open the app and check Tracks event for your user. Any event should display the `is_rtl_language`property with the corresponding value (0 if it's a ltr language).
- Change your device language to Arabic and repeat the previous test. it should show 1 for the `is_rtl_language` language.

![screen shot 2018-02-14 at 6 39 29 pm](https://user-images.githubusercontent.com/9772967/36229654-bc8eceb6-11b6-11e8-97f7-12af56426379.png)

