### PR TITLE
Media Library / Coordinator: Track photo + video uploads w/ origin

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -27,10 +27,11 @@ class MediaCoordinator: NSObject {
     ///
     /// - parameter asset: The asset to add.
     /// - parameter blog: The blog that the asset should be added to.
+    /// - parameter origin: The location in the app where the upload was initiated (optional).
     ///
     @discardableResult
-    func addMedia(from asset: ExportableAsset, to blog: Blog) -> Media {
-        return self.addMedia(from: asset, to: blog.objectID)
+    func addMedia(from asset: ExportableAsset, to blog: Blog, origin: MediaUploadOrigin? = nil) -> Media {
+        return self.addMedia(from: asset, to: blog.objectID, origin: origin)
     }
 
     /// Adds the specified media asset to the specified post. The upload process
@@ -38,14 +39,15 @@ class MediaCoordinator: NSObject {
     ///
     /// - parameter asset: The asset to add.
     /// - parameter post: The post that the asset should be added to.
+    /// - parameter origin: The location in the app where the upload was initiated (optional).
     ///
     @discardableResult
-    func addMedia(from asset: ExportableAsset, to post: AbstractPost) -> Media {
-        return self.addMedia(from: asset, to: post.objectID)
+    func addMedia(from asset: ExportableAsset, to post: AbstractPost, origin: MediaUploadOrigin? = nil) -> Media {
+        return self.addMedia(from: asset, to: post.objectID, origin: origin)
     }
 
     @discardableResult
-    private func addMedia(from asset: ExportableAsset, to objectID: NSManagedObjectID) -> Media {
+    private func addMedia(from asset: ExportableAsset, to objectID: NSManagedObjectID, origin: MediaUploadOrigin? = nil) -> Media {
         mediaProgressCoordinator.track(numberOfItems: 1)
         let service = MediaService(managedObjectContext: mainContext)
         let totalProgress = Progress.discreteProgress(totalUnitCount: MediaExportProgressUnits.done)
@@ -74,7 +76,7 @@ class MediaCoordinator: NSObject {
                                     return
                                 }
 
-                                let uploadProgress = strongSelf.uploadMedia(media)
+                                let uploadProgress = strongSelf.uploadMedia(media, origin: origin)
                                 totalProgress.addChild(uploadProgress, withPendingUnitCount: MediaExportProgressUnits.threeQuartersDone)
         })
         processing(media)
@@ -145,7 +147,7 @@ class MediaCoordinator: NSObject {
         service.delete(media, success: nil, failure: nil)
     }
 
-    @discardableResult private func uploadMedia(_ media: Media) -> Progress {
+    @discardableResult private func uploadMedia(_ media: Media, origin: MediaUploadOrigin? = nil) -> Progress {
         let service = MediaService(managedObjectContext: backgroundContext)
 
         var progress: Progress? = nil
@@ -153,6 +155,7 @@ class MediaCoordinator: NSObject {
         service.uploadMedia(media,
                             progress: &progress,
                             success: {
+                                self.trackUploadOf(media, origin: origin)
                                 self.end(media)
         }, failure: { error in
             guard let nserror = error as NSError? else {
@@ -166,6 +169,18 @@ class MediaCoordinator: NSObject {
         } else {
             return Progress.discreteCompletedProgress()
         }
+    }
+
+    private func trackUploadOf(_ media: Media, origin: MediaUploadOrigin?) {
+        guard let origin = origin,
+            let event = origin.eventForMediaType(media.mediaType) else {
+            return
+        }
+
+        let properties = WPAppAnalytics.properties(for: media)
+        WPAppAnalytics.track(event,
+                             withProperties: properties,
+                             with: media.blog)
     }
 
     // MARK: - Progress
@@ -419,5 +434,23 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
 extension Media {
     var uploadID: String {
         return objectID.uriRepresentation().absoluteString
+    }
+}
+
+/// Used for analytics to track where an upload was started within the app.
+/// Currently only supports media library, but we'll add editor support
+/// when we bring async there.
+///
+enum MediaUploadOrigin {
+    case mediaLibrary
+
+    func eventForMediaType(_ mediaType: MediaType) -> WPAnalyticsStat? {
+        switch (self, mediaType) {
+        case (.mediaLibrary, .image):
+            return .mediaLibraryAddedPhoto
+        case (.mediaLibrary, .video):
+            return .mediaLibraryAddedVideo
+        default: return nil
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -460,7 +460,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
                 return
             }
 
-            MediaCoordinator.shared.addMedia(from: media, to: blog)
+            MediaCoordinator.shared.addMedia(from: media, to: blog, origin: .mediaLibrary)
         }
 
         guard let mediaType = mediaInfo[UIImagePickerControllerMediaType] as? String else { return }
@@ -486,7 +486,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
 extension MediaLibraryViewController: UIDocumentPickerDelegate {
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
         for documentURL in urls as [NSURL] {
-            MediaCoordinator.shared.addMedia(from: documentURL, to: blog)
+            MediaCoordinator.shared.addMedia(from: documentURL, to: blog, origin: .mediaLibrary)
         }
     }
 
@@ -531,7 +531,7 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
             assets.count > 0 else { return }
 
         for asset in assets {
-            MediaCoordinator.shared.addMedia(from: asset, to: blog)
+            MediaCoordinator.shared.addMedia(from: asset, to: blog, origin: .mediaLibrary)
         }
     }
 
@@ -645,22 +645,6 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
         selectedAsset = asset
 
         return MediaItemViewController(media: asset)
-    }
-
-    fileprivate func trackUploadFor(_ media: Media) {
-        let properties = WPAppAnalytics.properties(for: media)
-
-        switch media.mediaType {
-        case .image:
-            WPAppAnalytics.track(.mediaLibraryAddedPhoto,
-                                 withProperties: properties,
-                                 with: blog)
-        case .video:
-            WPAppAnalytics.track(.mediaLibraryAddedVideo,
-                                 withProperties: properties,
-                                 with: blog)
-        default: break
-        }
     }
 
     func mediaPickerControllerWillBeginLoadingData(_ picker: WPMediaPickerViewController) {


### PR DESCRIPTION
This PR re-introduces tracking of uploads in the media library. We inadvertently removed it when switching over to async uploads. 

Now that the user can leave the media library during uploads, the `MediaCoordinator` seems to be the best place to track successful uploads, instead of the media library VC itself (which may not be around when the uploads complete). I've updated the coordinator to allow us to pass in the origin of the uploads (i.e. where the user was when uploading – media library or editor), so that we can report the correct event later.

**To test:**

* Stick a breakpoint in `TracksService.m`, around line 156 (`[self.remote sendBatchOfEvents:jsonEvents`). 
* Perform some uploads in the media library, and log out the `jsonEvents` when the breakpoint is hit – you should see `wpios_media_library_photo_added` and `wpios_media_library_video_added` events as appropriate.


