### PR TITLE
Issue/8627: Fix trash icon flicker in media library

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -371,8 +371,9 @@ class MediaLibraryViewController: WPMediaPickerViewController {
 
     private func registerChangeObserver() {
         assert(mediaLibraryChangeObserverKey == nil)
-        mediaLibraryChangeObserverKey = pickerDataSource.registerChangeObserverBlock({ [weak self] _, _, _, _, _ in
+        mediaLibraryChangeObserverKey = pickerDataSource.registerChangeObserverBlock({ [weak self] _, removed, inserted, _, _ in
             guard let strongSelf = self else { return }
+            guard removed.count > 0 || inserted.count > 0 else { return }
 
             strongSelf.updateViewState(for: strongSelf.pickerDataSource.numberOfAssets())
 


### PR DESCRIPTION
Fixes #8627 

This PR updates the logic in the media library to only update the view state (no results view, search bar, navigation items) if the asset count changes (by adding or removing items).

**To test:**

* View the media library for a site that has lots of media.
* Enter Edit mode, and scroll down.
* Ensure that the trash icon doesn't flicker (see original issue) as thumbnails load in.
* Also try adding media to an empty library and check that the no results view is removed, the search bar is added, and the Edit button appears.
* Try removing all media from a library and check that the no results view is added, the search bar is removed, and the Edit button is removed.