### PR TITLE
Decoupling Authentication Flow: Mark III

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/FancyAlertViewController+LoginError.swift
+++ b/WordPress/Classes/ViewRelated/NUX/FancyAlertViewController+LoginError.swift
@@ -1,5 +1,7 @@
 import UIKit
 import wpxmlrpc
+import SafariServices
+
 
 extension FancyAlertViewController {
     private struct Strings {
@@ -96,7 +98,7 @@ extension FancyAlertViewController {
         }
 
         if error.code == NSURLErrorBadURL {
-            return alertForBadURLMessage(message)
+            return alertForBadURL(with: message)
         }
 
         return alertForGenericErrorMessage(message, loginFields: loginFields, sourceTag: sourceTag)
@@ -182,19 +184,19 @@ extension FancyAlertViewController {
     ///
     /// - Parameter message: The error message to show.
     ///
-    private static func alertForBadURLMessage(_ message: String) -> FancyAlertViewController {
+    private static func alertForBadURL(with message: String) -> FancyAlertViewController {
         let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
             controller.dismiss(animated: true) {
                 // Find the topmost view controller that we can present from
-                guard let appDelegate = UIApplication.shared.delegate,
-                    let window = appDelegate.window,
-                    let viewController = window?.topmostPresentedViewController,
+                guard let viewController = UIApplication.shared.delegate?.window??.topmostPresentedViewController,
                     let url = URL(string: "https://apps.wordpress.org/support/#faq-ios-3")
-                    else { return }
+                    else {
+                        return
+                }
 
-                let webController = WebViewControllerFactory.controller(url: url)
-                let navController = UINavigationController(rootViewController: webController)
-                viewController.present(navController, animated: true, completion: nil)
+                let safariViewController = SFSafariViewController(url: url)
+                safariViewController.modalPresentationStyle = .pageSheet
+                viewController.present(safariViewController, animated: true, completion: nil)
             }
         }
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import CocoaLumberjack
 import WordPressShared
+import SafariServices
 
 
 /// Create a new WordPress.com account and blog.
@@ -469,10 +470,13 @@ import WordPressShared
 
 
     @IBAction func handleTermsOfServiceButtonTapped(_ sender: UIButton) {
-        let url = URL(string: WPAutomatticTermsOfServiceURL)!
-        let controller = WebViewControllerFactory.controller(url: url)
-        let navController = RotationAwareNavigationViewController(rootViewController: controller)
-        present(navController, animated: true, completion: nil)
+        guard let url = URL(string: WPAutomatticTermsOfServiceURL) else {
+            return
+        }
+
+        let safariViewController = SFSafariViewController(url: url)
+        safariViewController.modalPresentationStyle = .pageSheet
+        present(safariViewController, animated: true, completion: nil)
     }
 
 


### PR DESCRIPTION
### Notes:
- This PR was already submitted, reviewed + approved via #8608.
- Reverted via #8643: Wasn't supposed to be merged for the next two weeks

Resubmitting this one. @frosty mind taking a sweep peek? (exact same code as before, but this one will be merged in two weeks from now).

Thanks!!

### Details:
In this small PR we're replacing all of the **WPWebViewController** usage with **SFSafariViewController**. We're doing so because:

- In these points, there is no need for wpcom authentication
- This will definitely help us split the Login Flow into it's own framework

Needs Review: @frosty  
Thanks in advance!

 
### Scenario: Signup
1. Disable the [socialSignup feature here](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift#L17)
2. Fresh install > **Create a WordPress Site**
3. Tap over the **Terms of Service** label at the bottom.

Verify that SFSafariViewController shows up onscreen!

### Scenario: Login
1. Make [this method public](https://github.com/wordpress-mobile/WordPress-iOS/compare/issue/decoupling-auth-flow-from-wpios-mark-3?expand=1#diff-3db241debe865356e11e94ea8b8e2110R187)
2. Edit **LoginViewController** and paste this snippet in the viewDidLoad method:

```
        let controller = FancyAlertViewController.alertForBadURL(with: "Some message")
        controller.modalPresentationStyle = .custom
        controller.transitioningDelegate = self
        present(controller, animated: true, completion: nil)
```
3. Fresh Install
4. Press over the **Login** button
5. Verify that the **FancyAlert** shows up immediately. 
6. Press over the `Need more help?` link

Verify that SFSafariViewController shows up onscreen!
