### PR TITLE
Issue/8642 NUX Fancy Alert Dimming

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/NUXViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXViewController.swift
@@ -61,3 +61,15 @@ class NUXViewController: UIViewController, NUXViewControllerBase, UIViewControll
         return shouldShowCancelButtonBase()
     }
 }
+
+extension NUXViewController {
+    // Required so that any FancyAlertViewControllers presented within the NUX
+    // use the correct dimmed backing view.
+    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        if presented is FancyAlertViewController {
+            return FancyAlertPresentationController(presentedViewController: presented, presenting: presenting)
+        }
+
+        return nil
+    }
+}


### PR DESCRIPTION
Fixes #8642 

This PR adds back the implementation of `presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController?` which allows `FancyAlertViewController`s in the NUX to have a dimmed background view.

**To test:**

* Start a fresh install of the app, or log out.
* Tap Log In
* Tap "Log in to your site by entering your site address instead"
* Tap "Need help finding your site address?"
* Ensure that the background behind the alert is dimmed, providing contrast against the alert.