### PR TITLE
Draft ext: Verify the user is logged in when launched

### DIFF
--- a/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
@@ -109,6 +109,26 @@ class ShareExtensionAbstractViewController: UIViewController, ShareSegueHandler 
 // MARK: - Misc Helpers
 
 extension ShareExtensionAbstractViewController {
+    func verifyAuthCredentials(onSuccess: (() -> Void)?) {
+        guard oauth2Token == nil else {
+            onSuccess?()
+            return
+        }
+
+        let title = NSLocalizedString("Sharing error", comment: "Share extension dialog title - displayed when user is missing a login token.")
+        let message = NSLocalizedString("Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again.", comment: "Share extension dialog text  - displayed when user is missing a login token.")
+        let accept = NSLocalizedString("Cancel sharing", comment: "Share extension dialog dismiss button label - displayed when user is missing a login token.")
+
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let alertAction = UIAlertAction(title: accept, style: .default) { (action) in
+            self.cleanUpSharedContainer()
+            self.dismiss(animated: true, completion: self.dismissalCompletionBlock)
+        }
+
+        alertController.addAction(alertAction)
+        present(alertController, animated: true, completion: nil)
+    }
+
     func saveImageToSharedContainer(_ image: UIImage) -> URL? {
         guard let encodedMedia = image.resizeWithMaximumSize(maximumImageSize).JPEGEncoded(),
             let mediaDirectory = ShareMediaFileManager.shared.mediaUploadDirectoryURL else {

--- a/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
@@ -204,8 +204,8 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
         super.viewDidAppear(animated)
 
         verifyAuthCredentials {
-            startListeningToNotifications()
-            makeRichTextViewFirstResponderAndPlaceCursorAtEnd()
+            self.startListeningToNotifications()
+            self.makeRichTextViewFirstResponderAndPlaceCursorAtEnd()
         }
     }
 
@@ -1241,26 +1241,6 @@ private extension ShareExtensionEditorViewController {
                 // Clear out the extension context after loading it once. We don't need it anymore.
                 self?.context = nil
         }
-    }
-
-    func verifyAuthCredentials(onSuccess: (() -> Void)) {
-        guard oauth2Token == nil else {
-            onSuccess()
-            return
-        }
-
-        let title = NSLocalizedString("Sharing error", comment: "Share extension dialog title - displayed when user is missing a login token.")
-        let message = NSLocalizedString("Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again.", comment: "Share extension dialog text  - displayed when user is missing a login token.")
-        let accept = NSLocalizedString("Cancel sharing", comment: "Share extension dialog dismiss button label - displayed when user is missing a login token.")
-
-        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let alertAction = UIAlertAction(title: accept, style: .default) { (action) in
-            self.cleanUpSharedContainer()
-            self.dismiss(animated: true, completion: self.dismissalCompletionBlock)
-        }
-
-        alertController.addAction(alertAction)
-        present(alertController, animated: true, completion: nil)
     }
 }
 

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -128,6 +128,12 @@ class ShareModularViewController: ShareExtensionAbstractViewController {
         reloadSitesIfNeeded()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        verifyAuthCredentials(onSuccess: nil)
+    }
+
     // MARK: - Setup Helpers
 
     fileprivate func loadContentIfNeeded() {


### PR DESCRIPTION
Fixes #8648 

This PR moves the `verifyAuthCredentials()` function from `ShareExtensionEditorViewController` to `ShareExtensionAbstractViewController` so both the editor _and_ modules VC call it after being launched. The net effect here is that when a logged out user attempts to save a draft, she will see this error and be prompted to log into WPiOS.

**To test:**
With a user logged into WPiOS:
* [x] Share extension --> Open a web page in Safari and verify the user can share that page successfully.
* [x] Draft extension --> Open a web page in Safari and verify the user can "Save as Draft" successfully.

Now log out of WPiOS completely:
* [x] Share extension --> Open a web page in Safari and verify the user will see [this error](https://user-images.githubusercontent.com/154014/36384169-fd1adde4-1553-11e8-8c9b-187741c6c048.png) when launching the share extension.
* [x] Draft extension --> Open a web page in Safari and verify the user will see [this error](https://user-images.githubusercontent.com/154014/36384169-fd1adde4-1553-11e8-8c9b-187741c6c048.png) when launching the "Save as Draft" action extension.

@elibud This should be a quick PR...would you mind taking a peek? 😸 
