### PR TITLE
JetpackLoginViewController: LoginButton > NUXButton

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.xib
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.xib
@@ -50,7 +50,7 @@
                                         <action selector="didTouchSignInButton:" destination="-1" eventType="touchUpInside" id="4XZ-kZ-sw4"/>
                                     </connections>
                                 </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qm1-Pi-98R" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qm1-Pi-98R" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="335" width="300" height="30"/>
                                     <state key="normal" title="Set up Jetpack"/>
                                     <userDefinedRuntimeAttributes>

--- a/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.xib
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.xib
@@ -40,7 +40,7 @@
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lMy-o2-gd3" customClass="LoginButton" customModule="WordPress" customModuleProvider="target">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lMy-o2-gd3" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="275" width="300" height="30"/>
                                     <state key="normal" title="Log in"/>
                                     <userDefinedRuntimeAttributes>


### PR DESCRIPTION
### Details:
[LoginButton was renamed over to NUXButton](https://github.com/wordpress-mobile/WordPress-iOS/commit/bb7cd2284567ee6753f76b46aca7d681d788e865) ~18 days ago, but we've missed two NIB references to `LoginButton`.

Needs Review: @elibud 
Fixes #8652

Thanks in advance Eli!!

### Scenario: Self Hosted Connected to Jetpack
1. Fresh Install
2. Log into a self hosted site, that's connected to wpcom via Jetpack. **Do NOT log into dotcom, go via the self hosted sequence!**
3. Open the Notifications Tab

Verify that the `Log In` button looks as expected.

### Scenario: Self Hosted Disconnected from Jetpack
Repeat the same steps as above, but with a self hosted that's **not** connected to Jetpack.

