### PR TITLE
Add support for https://wordpress.com/log-in/jetpack URL

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackConnectionWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackConnectionWebViewController.swift
@@ -201,7 +201,8 @@ private extension JetpackConnectionWebViewController {
 
     func isDotComLogin(url: URL) -> Bool {
         let dotComLoginURL = URL(string: "https://wordpress.com/log-in")!
-        return url.matchesPath(in: dotComLoginURL)
+        let dotComJetpackLoginURL = URL(string: "https://wordpress.com/log-in/jetpack")!
+        return url.matchesPath(in: dotComLoginURL) || url.matchesPath(in: dotComJetpackLoginURL)
     }
 
     func extractRedirect(url: URL) -> URL? {


### PR DESCRIPTION
**Fixes** #8657 

**To test:**
~If the backend has not been updated yet test that connecting a Jetpack site works properly, if the backend has been updated fake the URL by replacing `https://wordpress.com/log-in` with `https://wordpress.com/log-in/jetpack` ;)~

The backend has been updated to go back to `https://wordpress.com/log-in` so in order to test this you will have to replace `https://wordpress.com/log-in` by `https://wordpress.com/log-in/jetpack` in `func isDotComLogin(url: URL) -> Bool`
