### PR TITLE
Permanently enabling new Site Creation flow.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -20,7 +20,7 @@ enum FeatureFlag: Int {
         case .activity:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .siteCreation:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         }
     }
 }


### PR DESCRIPTION
Ref #8110 

To test:
- Go to create a site. 
- Verify it shows the new site creation flow.


