### PR TITLE
Fix: NUX Buttons that are always white

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginPrologueSignupMethodViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginPrologueSignupMethodViewController.swift
@@ -51,6 +51,7 @@ class LoginPrologueSignupMethodViewController: UIViewController {
             self?.present(navController, animated: true, completion: nil)
         }
         buttonViewController.stackView?.insertArrangedSubview(termsButton, at: 0)
+        buttonViewController.backgroundColor = WPStyleGuide.lightGrey()
     }
 
     @IBAction func dismissTapped() {

--- a/WordPress/Classes/ViewRelated/NUX/LoginPrologueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginPrologueViewController.swift
@@ -74,6 +74,7 @@ class LoginPrologueViewController: UIViewController, UIViewControllerTransitioni
         buttonViewController.setupButtomButton(title: createTitle, isPrimary: false) { [weak self] in
             self?.signupTapped()
         }
+        buttonViewController.backgroundColor = WPStyleGuide.lightGrey()
     }
 
     // MARK: - Setup and Config

--- a/WordPress/Classes/ViewRelated/NUX/NUXButtonView.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/NUXButtonView.storyboard
@@ -28,7 +28,7 @@
                                 <rect key="frame" x="20" y="20" width="335" height="103"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="knN-O6-M86" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="335" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="335" height="33"/>
                                         <accessibility key="accessibilityConfiguration" identifier="connectSite"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="YB6-LI-NGI"/>
@@ -42,7 +42,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M7J-a3-klP" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="70" width="335" height="33"/>
+                                        <rect key="frame" x="0.0" y="53" width="335" height="50"/>
                                         <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="SiB-Xy-stR"/>
@@ -77,6 +77,7 @@
                     <size key="freeformSize" width="375" height="148"/>
                     <connections>
                         <outlet property="bottomButton" destination="M7J-a3-klP" id="cpl-TM-lX1"/>
+                        <outlet property="buttonHolder" destination="d2l-kB-WtE" id="LGA-3V-qgh"/>
                         <outlet property="shadowView" destination="RrB-Aa-ADd" id="LZa-Jn-ghb"/>
                         <outlet property="stackView" destination="xzf-f5-7zQ" id="frG-Oo-nB4"/>
                         <outlet property="topButton" destination="knN-O6-M86" id="3fN-Bh-Z8O"/>

--- a/WordPress/Classes/ViewRelated/NUX/NUXButtonViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXButtonViewController.swift
@@ -22,8 +22,10 @@ class NUXButtonViewController: UIViewController {
     @IBOutlet var stackView: UIStackView?
     @IBOutlet var bottomButton: NUXButton?
     @IBOutlet var topButton: NUXButton?
+    @IBOutlet var buttonHolder: UIView?
 
     open var delegate: NUXButtonViewControllerDelegate?
+    open var backgroundColor: UIColor?
 
     private var topButtonConfig: NUXButtonConfig?
     private var bottomButtonConfig: NUXButtonConfig?
@@ -40,6 +42,9 @@ class NUXButtonViewController: UIViewController {
 
         configure(button: bottomButton, withConfig: bottomButtonConfig)
         configure(button: topButton, withConfig: topButtonConfig)
+        if let bgColor = backgroundColor, let holder = buttonHolder {
+            holder.backgroundColor = bgColor
+        }
     }
 
     private func configure(button: NUXButton?, withConfig buttonConfig: NUXButtonConfig?) {

--- a/WordPress/Classes/ViewRelated/NUX/NUXButtonViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXButtonViewController.swift
@@ -38,22 +38,18 @@ class NUXButtonViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        if let buttonConfig = bottomButtonConfig, let bottomButton = bottomButton {
-            bottomButton.setTitle(buttonConfig.title, for: UIControlState())
-            bottomButton.accessibilityIdentifier = accessibilityIdentifier(for: buttonConfig.title)
-            bottomButton.isPrimary = buttonConfig.isPrimary
-            bottomButton.isHidden = false
-        } else {
-            bottomButton?.isHidden = true
-        }
+        configure(button: bottomButton, withConfig: bottomButtonConfig)
+        configure(button: topButton, withConfig: topButtonConfig)
+    }
 
-        if let buttonConfig = topButtonConfig, let topButton = topButton {
-            topButton.setTitle(buttonConfig.title, for: UIControlState())
-            topButton.accessibilityIdentifier = accessibilityIdentifier(for: buttonConfig.title)
-            topButton.isPrimary = buttonConfig.isPrimary
-            topButton.isHidden = false
+    private func configure(button: NUXButton?, withConfig buttonConfig: NUXButtonConfig?) {
+        if let buttonConfig = buttonConfig, let button = button {
+            button.setTitle(buttonConfig.title, for: UIControlState())
+            button.accessibilityIdentifier = accessibilityIdentifier(for: buttonConfig.title)
+            button.isPrimary = buttonConfig.isPrimary
+            button.isHidden = false
         } else {
-            topButton?.isHidden = true
+            button?.isHidden = true
         }
     }
 


### PR DESCRIPTION
In some cases the NUXButtons at the bottom of the screen were white when they should be blue. This fixes that.

![simulator screen shot - iphone x - 2018-02-20 at 14 08 20](https://user-images.githubusercontent.com/517257/36446739-e4f6f208-1647-11e8-9662-3b403ef95998.png)
![simulator screen shot - iphone x - 2018-02-20 at 14 08 36](https://user-images.githubusercontent.com/517257/36446747-e8520b0e-1647-11e8-963b-fae1c8308e81.png)


To test:
- Check out the site creation flow for blue buttons

