### PR TITLE
ReaderPostCell: fix crash with disabled comments.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -439,7 +439,8 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         // But only if it is from wpcom or jetpack (external is not yet supported).
         // Nesting this conditional cos it seems clearer that way
         if contentProvider!.isWPCom() || contentProvider!.isJetpack() {
-            if (enableLoggedInFeatures && contentProvider!.commentsOpen()) || contentProvider!.commentCount().intValue > 0 {
+            let commentCount = contentProvider!.commentCount()?.intValue ?? 0
+            if (enableLoggedInFeatures && contentProvider!.commentsOpen()) || commentCount > 0 {
 
                 commentActionButton.tag = CardAction.comment.rawValue
                 commentActionButton.isHidden = false


### PR DESCRIPTION
Fixes #8669.

I didn't manage to get it to reproduce "naturally", but I have a hunch what has to happen.

1) A post you're viewing must have comments disabled.
2) For some reason, the `ReaderPost.commentCount` property must be `nil`.

First one is easy enough to force to happen, I couldn't think of a way to make 2) happen naturally, so I just put 

```
- (NSNumber *)commentCount {
    return nil;
}
``` 
in `ReaderPost.m`.

To test: 

Reproduce the steps above, see that it crashed before and doesn't crash after applying this patch.