### PR TITLE
Update Post Cell Statuses + Add Progress View

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -89,7 +89,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zle-VU-ygo">
                                 <rect key="frame" x="16" y="333" width="196" height="18"/>
                                 <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="ed0-E7-1lw">
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="ed0-E7-1lw">
                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="18" id="Ief-ts-XAf"/>
@@ -119,7 +119,7 @@
                             <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="2OR-ox-Csb">
                                 <rect key="frame" x="16" y="357" width="276" height="18"/>
                                 <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="WhA-sd-qfz">
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="WhA-sd-qfz">
                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="18" id="Jyn-II-qDA"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,7 +16,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="448"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="CUK-Fg-fJ5" id="lmn-sx-Q9M">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="447"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="447.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b5E-yQ-veP">
@@ -80,14 +80,14 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="Cbe-bm-gnv">
-                                <rect key="frame" x="16" y="307" width="276" height="17.5"/>
+                                <rect key="frame" x="16" y="307" width="276" height="17"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zle-VU-ygo">
-                                <rect key="frame" x="16" y="333.5" width="196" height="18"/>
+                                <rect key="frame" x="16" y="333" width="196" height="18"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="ed0-E7-1lw">
                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -117,7 +117,7 @@
                                 </constraints>
                             </view>
                             <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="2OR-ox-Csb">
-                                <rect key="frame" x="16" y="357.5" width="276" height="18"/>
+                                <rect key="frame" x="16" y="357" width="276" height="18"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="WhA-sd-qfz">
                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -147,7 +147,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U6E-MB-03K">
-                                <rect key="frame" x="212" y="333.5" width="80" height="18"/>
+                                <rect key="frame" x="212" y="333" width="80" height="18"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U4X-fn-9uf" customClass="PostMetaButton">
                                         <rect key="frame" x="50" y="0.0" width="30" height="18"/>
@@ -186,13 +186,25 @@
                                     </constraint>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pkq-mO-MBJ" customClass="PostCardActionBar">
-                                <rect key="frame" x="0.0" y="388.5" width="308" height="37"/>
-                                <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="37" id="WGi-rg-iHS"/>
-                                </constraints>
-                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="s3z-0r-RPP">
+                                <rect key="frame" x="0.0" y="385" width="308" height="41"/>
+                                <subviews>
+                                    <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progressViewStyle="bar" progress="0.89999997615814209" translatesAutoresizingMaskIntoConstraints="NO" id="ZTS-db-90d">
+                                        <rect key="frame" x="0.0" y="0.0" width="308" height="5"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="4" id="Y0T-gA-Cof"/>
+                                        </constraints>
+                                        <color key="trackTintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </progressView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pkq-mO-MBJ" customClass="PostCardActionBar">
+                                        <rect key="frame" x="0.0" y="4" width="308" height="37"/>
+                                        <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="37" id="WGi-rg-iHS"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
@@ -206,11 +218,11 @@
                                 <variation key="heightClass=regular-widthClass=regular" constant="9"/>
                             </constraint>
                             <constraint firstItem="9Kf-3e-Bni" firstAttribute="width" secondItem="Y9d-Yk-F4X" secondAttribute="width" id="7Pe-Cy-fJL"/>
-                            <constraint firstAttribute="trailing" secondItem="pkq-mO-MBJ" secondAttribute="trailing" id="94D-vc-Bfy"/>
                             <constraint firstItem="Cbe-bm-gnv" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="AAS-zA-QSN">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
                             <constraint firstItem="rIp-IY-Ng4" firstAttribute="top" secondItem="b5E-yQ-veP" secondAttribute="top" constant="15" id="Af8-lU-jWg"/>
+                            <constraint firstAttribute="bottom" secondItem="s3z-0r-RPP" secondAttribute="bottom" id="Gdq-0f-ujY"/>
                             <constraint firstItem="9Kf-3e-Bni" firstAttribute="height" secondItem="Y9d-Yk-F4X" secondAttribute="height" id="Ik5-0h-Hzq"/>
                             <constraint firstItem="Y9d-Yk-F4X" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" id="JnV-Io-ZDa"/>
                             <constraint firstAttribute="trailing" secondItem="E9Y-IT-TUt" secondAttribute="trailing" constant="16" id="Ll1-Y8-bQN">
@@ -234,9 +246,13 @@
                             <constraint firstAttribute="trailing" secondItem="rIp-IY-Ng4" secondAttribute="trailing" constant="16" id="U9A-yx-smS">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
+                            <constraint firstItem="s3z-0r-RPP" firstAttribute="top" secondItem="2OR-ox-Csb" secondAttribute="bottom" priority="900" constant="13" id="VIq-Lu-L4K">
+                                <variation key="heightClass=regular-widthClass=regular" constant="16"/>
+                            </constraint>
                             <constraint firstItem="2OR-ox-Csb" firstAttribute="top" secondItem="zle-VU-ygo" secondAttribute="bottom" constant="6" id="cCR-ch-CxK">
                                 <variation key="heightClass=regular-widthClass=regular" constant="8"/>
                             </constraint>
+                            <constraint firstItem="s3z-0r-RPP" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" id="gOy-hI-5zc"/>
                             <constraint firstItem="9Kf-3e-Bni" firstAttribute="centerY" secondItem="Y9d-Yk-F4X" secondAttribute="centerY" id="gtR-TW-HUc"/>
                             <constraint firstItem="Cbe-bm-gnv" firstAttribute="top" secondItem="E9Y-IT-TUt" secondAttribute="bottom" constant="9" id="hdt-ZQ-dHo">
                                 <variation key="heightClass=regular-widthClass=regular" constant="7"/>
@@ -244,13 +260,9 @@
                             <constraint firstAttribute="trailing" secondItem="2OR-ox-Csb" secondAttribute="trailing" constant="16" id="iO3-Io-6Bk">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
-                            <constraint firstItem="pkq-mO-MBJ" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" id="pl8-s7-Mjm"/>
                             <constraint firstAttribute="trailing" secondItem="Y9d-Yk-F4X" secondAttribute="trailing" id="rWg-Oz-OEh"/>
-                            <constraint firstAttribute="bottom" secondItem="pkq-mO-MBJ" secondAttribute="bottom" id="tgK-m9-bll"/>
+                            <constraint firstAttribute="trailing" secondItem="s3z-0r-RPP" secondAttribute="trailing" id="sqT-If-FB1"/>
                             <constraint firstItem="U6E-MB-03K" firstAttribute="leading" secondItem="zle-VU-ygo" secondAttribute="trailing" id="wYq-9R-DJF"/>
-                            <constraint firstItem="pkq-mO-MBJ" firstAttribute="top" secondItem="2OR-ox-Csb" secondAttribute="bottom" priority="900" constant="13" id="waW-2I-Gom">
-                                <variation key="heightClass=regular-widthClass=regular" constant="16"/>
-                            </constraint>
                             <constraint firstItem="9Kf-3e-Bni" firstAttribute="centerX" secondItem="Y9d-Yk-F4X" secondAttribute="centerX" id="wiK-lq-Dtf"/>
                         </constraints>
                     </view>
@@ -294,13 +306,14 @@
                 <outlet property="postCardImageViewBottomConstraint" destination="N8M-5Y-cWJ" id="lhh-cM-CR0"/>
                 <outlet property="postCardImageViewHeightConstraint" destination="0wl-TX-0Ed" id="lHP-O3-pox"/>
                 <outlet property="postContentView" destination="b5E-yQ-veP" id="m4f-f7-d0h"/>
+                <outlet property="progressView" destination="ZTS-db-90d" id="2pV-jz-L4i"/>
                 <outlet property="snippetLabel" destination="Cbe-bm-gnv" id="ccW-VN-byK"/>
                 <outlet property="snippetLowerConstraint" destination="54w-4V-wCw" id="g8b-qX-e62"/>
                 <outlet property="statusHeightConstraint" destination="IM4-IL-uMR" id="rF3-yu-usm"/>
                 <outlet property="statusImageView" destination="WhA-sd-qfz" id="ReK-dr-pWS"/>
                 <outlet property="statusLabel" destination="mYl-tz-yRu" id="1gE-I5-KP6"/>
                 <outlet property="statusView" destination="2OR-ox-Csb" id="5Gf-8n-sCx"/>
-                <outlet property="statusViewLowerConstraint" destination="waW-2I-Gom" id="7fg-Vt-ZRR"/>
+                <outlet property="statusViewLowerConstraint" destination="VIq-Lu-L4K" id="OzP-HQ-r7v"/>
                 <outlet property="titleLabel" destination="E9Y-IT-TUt" id="OkD-t8-pdp"/>
                 <outlet property="titleLowerConstraint" destination="hdt-ZQ-dHo" id="S9M-Vr-tjG"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Gridicons
 
 /// Encapsulates status display logic for PostCardTableViewCells.
 ///
@@ -16,6 +17,10 @@ class PostCardStatusViewModel: NSObject {
         return post.statusForDisplay()
     }
 
+    private var postStatus: BasePost.Status? {
+        return post.status
+    }
+
     @objc
     var shouldHideStatusView: Bool {
         guard let status = status else {
@@ -27,37 +32,42 @@ class PostCardStatusViewModel: NSObject {
 
     @objc
     var statusImage: UIImage? {
-        guard let status = post.status else {
+        guard let status = postStatus else {
             return nil
         }
 
         switch status {
         case .pending:
-            return UIImage(named: "icon-post-status-pending")
+            return Gridicon.iconOfType(.chat)
         case .scheduled:
-            return UIImage(named: "icon-post-status-scheduled")
+            return Gridicon.iconOfType(.scheduled)
         case .trash:
-            return UIImage(named: "icon-post-status-trashed")
+            return Gridicon.iconOfType(.trash)
         default:
-            return UIImage(named: "icon-post-status-pending")
+            return UIDevice.isPad() ? Gridicon.iconOfType(.tablet) : Gridicon.iconOfType(.phone)
         }
     }
 
     @objc
     var statusColor: UIColor {
-        guard let status = post.status else {
-            return WPStyleGuide.grey()
+        guard let status = postStatus else {
+            return WPStyleGuide.darkGrey()
         }
 
         switch status {
         case .pending:
-            return WPStyleGuide.jazzyOrange()
+            return WPStyleGuide.validGreen()
         case .scheduled:
-            return WPStyleGuide.wordPressBlue()
+            return WPStyleGuide.mediumBlue()
         case .trash:
             return WPStyleGuide.errorRed()
         default:
-            return WPStyleGuide.jazzyOrange()
+            return WPStyleGuide.darkGrey()
         }
+    }
+
+    @objc
+    var shouldHideProgressView: Bool {
+        return true
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -1,0 +1,63 @@
+import UIKit
+
+/// Encapsulates status display logic for PostCardTableViewCells.
+///
+class PostCardStatusViewModel: NSObject {
+    private let post: Post
+
+    @objc
+    init(post: Post) {
+        self.post = post
+        super.init()
+    }
+
+    @objc
+    var status: String? {
+        return post.statusForDisplay()
+    }
+
+    @objc
+    var shouldHideStatusView: Bool {
+        guard let status = status else {
+            return true
+        }
+
+        return status.count == 0
+    }
+
+    @objc
+    var statusImage: UIImage? {
+        guard let status = post.status else {
+            return nil
+        }
+
+        switch status {
+        case .pending:
+            return UIImage(named: "icon-post-status-pending")
+        case .scheduled:
+            return UIImage(named: "icon-post-status-scheduled")
+        case .trash:
+            return UIImage(named: "icon-post-status-trashed")
+        default:
+            return UIImage(named: "icon-post-status-pending")
+        }
+    }
+
+    @objc
+    var statusColor: UIColor {
+        guard let status = post.status else {
+            return WPStyleGuide.grey()
+        }
+
+        switch status {
+        case .pending:
+            return WPStyleGuide.jazzyOrange()
+        case .scheduled:
+            return WPStyleGuide.wordPressBlue()
+        case .trash:
+            return WPStyleGuide.errorRed()
+        default:
+            return WPStyleGuide.jazzyOrange()
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -188,6 +188,8 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     [WPStyleGuide applyPostStatusStyle:self.statusLabel];
     [WPStyleGuide applyPostMetaButtonStyle:self.metaButtonRight];
     [WPStyleGuide applyPostMetaButtonStyle:self.metaButtonLeft];
+    [WPStyleGuide applyPostProgressViewStyle:self.progressView];
+
     self.dateImageView.tintColor = self.dateLabel.textColor;
     self.actionBar.backgroundColor = [WPStyleGuide lightGrey];
     self.postContentView.layer.borderColor = [[WPStyleGuide postCardBorderColor] CGColor];

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -41,6 +41,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 @property (nonatomic, strong) IBOutlet UIView *metaView;
 @property (nonatomic, strong) IBOutlet UIButton *metaButtonRight;
 @property (nonatomic, strong) IBOutlet UIButton *metaButtonLeft;
+@property (nonatomic, strong) IBOutlet UIProgressView *progressView;
 @property (nonatomic, strong) IBOutlet PostCardActionBar *actionBar;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *headerViewLeftConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *headerViewHeightConstraint;
@@ -50,7 +51,6 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *dateViewLowerConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *statusHeightConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *statusViewLowerConstraint;
-@property (nonatomic, strong) IBOutlet NSLayoutConstraint *postContentBottomConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *postCardImageViewBottomConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *postCardImageViewHeightConstraint;
 
@@ -209,6 +209,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     [self configureDate];
     [self configureStatusView];
     [self configureMetaButtons];
+    [self configureProgressView];
     [self configureActionBar];
 
     [self setNeedsUpdateConstraints];
@@ -394,6 +395,14 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     metaButton.hidden = NO;
 }
 
+#pragma mark - Configure Progress View
+
+- (void)configureProgressView
+{
+    if (!self.progressView.isHidden) {
+        self.progressView.hidden = NO;
+    }
+}
 
 #pragma mark - Configure Actionbar
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -320,8 +320,9 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 - (void)configureStatusView
 {
-    NSString *str = [self.post statusForDisplay];
-    self.statusView.hidden = ([str length] == 0);
+    PostCardStatusViewModel *model = [[PostCardStatusViewModel alloc] initWithPost:self.post];
+
+    self.statusView.hidden = model.shouldHideStatusView;
     if (self.statusView.hidden) {
         self.dateViewLowerConstraint.constant = 0.0;
         self.statusHeightConstraint.constant = 0.0;
@@ -330,25 +331,9 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
         self.statusHeightConstraint.constant = self.statusViewHeight;
     }
 
-    self.statusLabel.text = str;
-    // Set the correct icon and text color
-    if ([[self.post status] isEqualToString:PostStatusPending]) {
-        self.statusImageView.image = [UIImage imageNamed:@"icon-post-status-pending"];
-        self.statusLabel.textColor = [WPStyleGuide jazzyOrange];
-    } else if ([[self.post status] isEqualToString:PostStatusScheduled]) {
-        self.statusImageView.image = [UIImage imageNamed:@"icon-post-status-scheduled"];
-        self.statusLabel.textColor = [WPStyleGuide wordPressBlue];
-    } else if ([[self.post status] isEqualToString:PostStatusTrash]) {
-        self.statusImageView.image = [UIImage imageNamed:@"icon-post-status-trashed"];
-        self.statusLabel.textColor = [WPStyleGuide errorRed];
-    } else if (!self.statusView.hidden) {
-        self.statusImageView.image = [UIImage imageNamed:@"icon-post-status-pending"];
-        self.statusLabel.textColor = [WPStyleGuide jazzyOrange];
-    } else {
-        self.statusLabel.text = nil;
-        self.statusImageView.image = nil;
-        self.statusLabel.textColor = [WPStyleGuide grey];
-    }
+    self.statusLabel.text = model.status;
+    self.statusImageView.image = model.statusImage;
+    self.statusLabel.textColor = model.statusColor;
 
     [self.statusView setNeedsUpdateConstraints];
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -8,6 +8,7 @@
 #import "WordPress-Swift.h"
 #import "FLAnimatedImage.h"
 
+@import Gridicons;
 
 
 static const UIEdgeInsets ActionbarButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
@@ -187,6 +188,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     [WPStyleGuide applyPostStatusStyle:self.statusLabel];
     [WPStyleGuide applyPostMetaButtonStyle:self.metaButtonRight];
     [WPStyleGuide applyPostMetaButtonStyle:self.metaButtonLeft];
+    self.dateImageView.tintColor = self.dateLabel.textColor;
     self.actionBar.backgroundColor = [WPStyleGuide lightGrey];
     self.postContentView.layer.borderColor = [[WPStyleGuide postCardBorderColor] CGColor];
     self.postContentView.layer.borderWidth = 1.0;
@@ -316,6 +318,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 {
     AbstractPost *post = [self.post latest];
     self.dateLabel.text = [post dateStringForDisplay];
+    self.dateImageView.image = [Gridicon iconOfType:GridiconTypeTime];
 }
 
 - (void)configureStatusView
@@ -333,6 +336,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
     self.statusLabel.text = model.status;
     self.statusImageView.image = model.statusImage;
+    self.statusImageView.tintColor = model.statusColor;
     self.statusLabel.textColor = model.statusColor;
 
     [self.statusView setNeedsUpdateConstraints];
@@ -384,8 +388,11 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 - (void)configureProgressView
 {
-    if (!self.progressView.isHidden) {
-        self.progressView.hidden = NO;
+    PostCardStatusViewModel *model = [[PostCardStatusViewModel alloc] initWithPost:self.post];
+    BOOL shouldHide = model.shouldHideProgressView;
+
+    if (self.progressView.isHidden != shouldHide) {
+        self.progressView.hidden = shouldHide;
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -77,7 +77,7 @@
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z3W-ou-g2J">
                                 <rect key="frame" x="16" y="119" width="196" height="18"/>
                                 <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="38V-Vw-GfJ">
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="38V-Vw-GfJ">
                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="18" id="5A1-u0-oUB"/>
@@ -107,7 +107,7 @@
                             <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="O28-fP-tpX">
                                 <rect key="frame" x="16" y="143" width="276" height="18"/>
                                 <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="8Cs-fq-wSe">
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="8Cs-fq-wSe">
                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="18" id="hdA-We-Wej"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12118" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,7 +16,7 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="238"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="sqZ-hd-ibO" id="MWK-lj-FaS">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="237"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="237.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lk7-nZ-b0t">
@@ -40,7 +40,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l4E-Qn-Vgl">
-                                        <rect key="frame" x="42" y="18" width="234" height="15"/>
+                                        <rect key="frame" x="42" y="18" width="234" height="14.5"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -68,14 +68,14 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="POV-pe-wu8">
-                                <rect key="frame" x="16" y="90" width="276" height="24"/>
+                                <rect key="frame" x="16" y="90" width="276" height="20"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z3W-ou-g2J">
-                                <rect key="frame" x="16" y="123" width="196" height="18"/>
+                                <rect key="frame" x="16" y="119" width="196" height="18"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="38V-Vw-GfJ">
                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -85,7 +85,7 @@
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q5D-nc-yvr">
-                                        <rect key="frame" x="21" y="2" width="175" height="15"/>
+                                        <rect key="frame" x="21" y="2.5" width="175" height="14.5"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -105,7 +105,7 @@
                                 </constraints>
                             </view>
                             <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="O28-fP-tpX">
-                                <rect key="frame" x="16" y="147" width="276" height="18"/>
+                                <rect key="frame" x="16" y="143" width="276" height="18"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="8Cs-fq-wSe">
                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -115,7 +115,7 @@
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbu-l3-L8G">
-                                        <rect key="frame" x="21" y="2" width="255" height="15"/>
+                                        <rect key="frame" x="21" y="2.5" width="255" height="14.5"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -135,7 +135,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YwV-AJ-Nvl">
-                                <rect key="frame" x="212" y="123" width="80" height="18"/>
+                                <rect key="frame" x="212" y="119" width="80" height="18"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ovg-ci-Pfb" customClass="PostMetaButton">
                                         <rect key="frame" x="50" y="0.0" width="30" height="18"/>
@@ -174,40 +174,50 @@
                                     <constraint firstAttribute="centerY" secondItem="Ovg-ci-Pfb" secondAttribute="centerY" id="jAb-xl-YQh"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BlB-Gp-P6A" customClass="PostCardActionBar">
-                                <rect key="frame" x="0.0" y="178" width="308" height="37"/>
-                                <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="37" id="tqV-2T-l9Q"/>
-                                </constraints>
-                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="j4z-aU-Xng">
+                                <rect key="frame" x="0.0" y="174" width="308" height="41"/>
+                                <subviews>
+                                    <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progressViewStyle="bar" progress="0.90000000000000002" translatesAutoresizingMaskIntoConstraints="NO" id="33v-Uz-9S6">
+                                        <rect key="frame" x="0.0" y="0.0" width="308" height="5"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="4" id="gFE-it-kOj"/>
+                                        </constraints>
+                                        <color key="trackTintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </progressView>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BlB-Gp-P6A" customClass="PostCardActionBar">
+                                        <rect key="frame" x="0.0" y="4" width="308" height="37"/>
+                                        <color key="backgroundColor" red="0.90196079019999997" green="0.90196079019999997" blue="0.90196079019999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="37" id="tqV-2T-l9Q"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="BlB-Gp-P6A" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="0LN-fC-xEM"/>
                             <constraint firstItem="OuO-i7-2Ds" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="2pB-iJ-nFa">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
                             <constraint firstItem="Z3W-ou-g2J" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="3cg-8s-lSo">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
+                            <constraint firstItem="j4z-aU-Xng" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="3s3-ga-Srq"/>
                             <constraint firstItem="POV-pe-wu8" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="7ce-1f-hAw">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
                             <constraint firstAttribute="trailing" secondItem="OuO-i7-2Ds" secondAttribute="trailing" constant="16" id="9p6-eN-M0a">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
-                            <constraint firstAttribute="trailing" secondItem="BlB-Gp-P6A" secondAttribute="trailing" id="EAF-04-Ort"/>
                             <constraint firstItem="O28-fP-tpX" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="EvA-em-Rnw">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
-                            <constraint firstItem="BlB-Gp-P6A" firstAttribute="top" secondItem="O28-fP-tpX" secondAttribute="bottom" priority="900" constant="13" id="KPL-Ie-Sml">
-                                <variation key="heightClass=regular-widthClass=regular" constant="16"/>
-                            </constraint>
-                            <constraint firstAttribute="bottom" secondItem="BlB-Gp-P6A" secondAttribute="bottom" id="SVN-uV-BWH"/>
                             <constraint firstItem="OuO-i7-2Ds" firstAttribute="top" secondItem="Lk7-nZ-b0t" secondAttribute="top" constant="15" id="Seu-o3-dkG"/>
                             <constraint firstAttribute="trailing" secondItem="POV-pe-wu8" secondAttribute="trailing" constant="16" id="SjY-e4-XWL">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
+                            </constraint>
+                            <constraint firstItem="j4z-aU-Xng" firstAttribute="top" secondItem="O28-fP-tpX" secondAttribute="bottom" priority="900" constant="13" id="UOb-p1-7gL">
+                                <variation key="heightClass=regular-widthClass=regular" constant="16"/>
                             </constraint>
                             <constraint firstItem="Z3W-ou-g2J" firstAttribute="top" secondItem="POV-pe-wu8" secondAttribute="bottom" constant="9" id="cgz-3E-MrQ">
                                 <variation key="heightClass=regular-widthClass=regular" constant="9"/>
@@ -220,6 +230,7 @@
                             <constraint firstAttribute="trailing" secondItem="xIT-FJ-g43" secondAttribute="trailing" constant="16" id="la2-OA-0qr">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
+                            <constraint firstAttribute="trailing" secondItem="j4z-aU-Xng" secondAttribute="trailing" id="nGX-5S-icg"/>
                             <constraint firstAttribute="trailing" secondItem="YwV-AJ-Nvl" secondAttribute="trailing" constant="16" id="pcg-aA-VMp">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
@@ -227,6 +238,7 @@
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
                             <constraint firstItem="YwV-AJ-Nvl" firstAttribute="centerY" secondItem="Z3W-ou-g2J" secondAttribute="centerY" id="uVU-DQ-Fre"/>
+                            <constraint firstAttribute="bottom" secondItem="j4z-aU-Xng" secondAttribute="bottom" id="vjY-yY-LTP"/>
                             <constraint firstItem="POV-pe-wu8" firstAttribute="top" secondItem="xIT-FJ-g43" secondAttribute="bottom" constant="5" id="wZc-29-y5d">
                                 <variation key="heightClass=regular-widthClass=regular" constant="7"/>
                             </constraint>
@@ -271,13 +283,14 @@
                 <outlet property="metaButtonRight" destination="Ovg-ci-Pfb" id="dCB-Tf-ED7"/>
                 <outlet property="metaView" destination="YwV-AJ-Nvl" id="KYr-Rj-rfE"/>
                 <outlet property="postContentView" destination="Lk7-nZ-b0t" id="Neo-yT-N8p"/>
+                <outlet property="progressView" destination="33v-Uz-9S6" id="6hg-3o-AaE"/>
                 <outlet property="snippetLabel" destination="POV-pe-wu8" id="fTi-7j-wzx"/>
                 <outlet property="snippetLowerConstraint" destination="cgz-3E-MrQ" id="eKC-rg-HSr"/>
                 <outlet property="statusHeightConstraint" destination="c7m-Gx-kDz" id="njw-Hw-OiF"/>
                 <outlet property="statusImageView" destination="8Cs-fq-wSe" id="8o2-uv-ADi"/>
                 <outlet property="statusLabel" destination="Dbu-l3-L8G" id="lyN-NY-bWT"/>
                 <outlet property="statusView" destination="O28-fP-tpX" id="KK2-3b-YCm"/>
-                <outlet property="statusViewLowerConstraint" destination="KPL-Ie-Sml" id="7rN-LS-zG6"/>
+                <outlet property="statusViewLowerConstraint" destination="UOb-p1-7gL" id="4fz-Tl-27S"/>
                 <outlet property="titleLabel" destination="xIT-FJ-g43" id="2X9-c5-Gja"/>
                 <outlet property="titleLowerConstraint" destination="wZc-29-y5d" id="3Ng-mr-ILH"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.h
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.h
@@ -29,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)applyPostMetaButtonStyle:(UIButton *)button;
 
++ (void)applyPostProgressViewStyle:(UIProgressView *)progressView;
+
 + (void)applyRestorePostLabelStyle:(UILabel *)label;
 
 + (void)applyRestorePostButtonStyle:(UIButton *)button;

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -79,6 +79,13 @@
     [button setTitleColor:[self grey] forState:UIControlStateNormal];
 }
 
++ (void)applyPostProgressViewStyle:(UIProgressView *)progressView
+{
+    progressView.trackTintColor = [WPStyleGuide greyLighten20];
+    progressView.progressTintColor = [WPStyleGuide mediumBlue];
+    progressView.tintColor = [WPStyleGuide mediumBlue];
+}
+
 + (void)applyRestorePostLabelStyle:(UILabel *)label
 {
     [self configureLabelForDeviceDependantStyle:label];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */; };
 		17D975AF1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */; };
 		17F0AE301F091563007D5A6B /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F0AE2F1F091563007D5A6B /* ConfettiView.swift */; };
+		17F67C56203D81430072001E /* PostCardStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F67C55203D81430072001E /* PostCardStatusViewModel.swift */; };
 		17FCA6811FD84B4600DBA9C8 /* NoticeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */; };
 		1D3623260D0F684500981E51 /* WordPressAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* WordPressAppDelegate.m */; };
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
@@ -1445,6 +1446,7 @@
 		17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProgressCoordinatorNoticeViewModel.swift; sourceTree = "<group>"; };
 		17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Aztec.swift"; sourceTree = "<group>"; };
 		17F0AE2F1F091563007D5A6B /* ConfettiView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfettiView.swift; sourceTree = "<group>"; };
+		17F67C55203D81430072001E /* PostCardStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardStatusViewModel.swift; sourceTree = "<group>"; };
 		17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStore.swift; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D3623240D0F684500981E51 /* WordPressAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressAppDelegate.h; sourceTree = "<group>"; };
@@ -3775,6 +3777,7 @@
 				5D732F981AE84E5400CD89E7 /* PostListFooterView.xib */,
 				5DAFEAB61AF2CA6E00B3E1D7 /* PostMetaButton.h */,
 				5DAFEAB71AF2CA6E00B3E1D7 /* PostMetaButton.m */,
+				17F67C55203D81430072001E /* PostCardStatusViewModel.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -7023,6 +7026,7 @@
 				1702BBDC1CEDEA6B00766A33 /* BadgeLabel.swift in Sources */,
 				93C1148518EDF6E100DAC95C /* BlogService.m in Sources */,
 				E69EF9D51BFA539F00ED0554 /* ReaderDetailViewController.swift in Sources */,
+				17F67C56203D81430072001E /* PostCardStatusViewModel.swift in Sources */,
 				E63BBC961C5168BE00598BE8 /* SharingAuthorizationHelper.m in Sources */,
 				B55853F719630D5400FAF6C3 /* NSAttributedString+Util.m in Sources */,
 				ACBAB5FE0E121C7300F38795 /* PostSettingsViewController.m in Sources */,


### PR DESCRIPTION
This PR extracts the logic for the status label in post list cells into a view model, which will make it easier to add uploading statuses for async. I've also updated the icons and colours for the statuses, to match our latest designs:

![4b15f725-7bb1-4452-bd2b-483814d295d7](https://user-images.githubusercontent.com/4780/36504255-ce791d02-1747-11e8-874e-c2addd0bb3f6.png)

Here are how these look in the cells:

![statuses](https://user-images.githubusercontent.com/4780/36504467-82527de6-1748-11e8-83be-91073a336e26.png)

Some of the states aren't in there yet as they're currently not supported. They'll be added as we add async support later.

I've also taken this opportunity to add a progress view to the bottom of the cell, which will be used when uploading posts / media, but it's currently hidden by default. 

**To test:**

* Check I've converted the logic correctly!
* If you want, you can either create posts of these different types (create a local post with no internet connection, schedule a post, mark a post as pending, trash a post), or edit the `postStatus` var in `PostCardStatusViewModel` to return different statuses.
* You can show the progress view by modifying `shouldHideProgressView` to return `false`