### PR TITLE
Draft extension: Improve show / hide transitions on iPad

### DIFF
--- a/WordPress/WordPressDraftActionExtension/MainDraftActionViewController.swift
+++ b/WordPress/WordPressDraftActionExtension/MainDraftActionViewController.swift
@@ -35,7 +35,7 @@ class MainDraftActionViewController: UIViewController {
 
 private extension MainDraftActionViewController {
     func setupAppearance() {
-        self.view.backgroundColor = UIColor.white
+        self.view.backgroundColor = .white
         let navigationBarAppearace = UINavigationBar.appearance()
         navigationBarAppearace.barTintColor = WPStyleGuide.lightGrey()
         navigationBarAppearace.barStyle = .default
@@ -50,15 +50,24 @@ private extension MainDraftActionViewController {
             self.extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
         }
 
-        let shareNavController = UINavigationController(rootViewController: modularController)
+        let shareNavController = MainDraftNavigationController(rootViewController: modularController)
         shareNavController.transitioningDelegate = extensionTransitioningManager
         shareNavController.modalPresentationStyle = .custom
-        present(shareNavController, animated: true, completion: nil)
+        present(shareNavController, animated: !shareNavController.shouldFillContentContainer, completion: nil)
     }
 
     func trackExtensionLaunch() {
         let tracks = Tracks(appGroupName: WPAppGroupName)
         let oauth2Token = ShareExtensionService.retrieveShareExtensionToken()
         tracks.trackExtensionLaunched(oauth2Token != nil)
+    }
+}
+
+private class MainDraftNavigationController: UINavigationController, ExtensionPresentationTarget {
+    var shouldFillContentContainer: Bool {
+        // On iPad, we want the draft action extension to be displayed full size within the
+        // presenting view controller, to avoid graphical issues.
+        // See https://github.com/wordpress-mobile/WordPress-iOS/issues/8646 for more info.
+        return UIDevice.isPad()
     }
 }

--- a/WordPress/WordPressShareExtension/ExtensionPresentationController.swift
+++ b/WordPress/WordPressShareExtension/ExtensionPresentationController.swift
@@ -1,5 +1,11 @@
 import UIKit
 
+/// Allows certain presented view controllers to request themselves to be
+/// presented at full size instead of inset within the container.
+protocol ExtensionPresentationTarget {
+    var shouldFillContentContainer: Bool { get }
+}
+
 class ExtensionPresentationController: UIPresentationController {
 
     // MARK: - Private Properties
@@ -40,6 +46,11 @@ class ExtensionPresentationController: UIPresentationController {
     }
 
     override func size(forChildContentContainer container: UIContentContainer, withParentContainerSize parentSize: CGSize) -> CGSize {
+        if let target = container as? ExtensionPresentationTarget,
+            target.shouldFillContentContainer == true {
+            return parentSize
+        }
+
         let widthRatio = traitCollection.verticalSizeClass != .compact ? Appearance.widthRatio : Appearance.widthRatioCompactVertical
         let heightRatio = traitCollection.verticalSizeClass != .compact ? Appearance.heightRatio : Appearance.heightRatioCompactVertical
         return CGSize(width: (parentSize.width * widthRatio), height: (parentSize.height * heightRatio))

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -217,10 +217,24 @@ class ShareModularViewController: ShareExtensionAbstractViewController {
 // MARK: - Actions
 
 extension ShareModularViewController {
+    fileprivate func dismiss() {
+        // In regular width size classes (iPad), action extensions are displayed
+        // in a small modal, which looks strange when this VC is dismissed
+        // before the main / presenting controller with its white background.
+        // This workaround simply dismisses the modular VC along with the main extension VC.
+        // See https://github.com/wordpress-mobile/WordPress-iOS/issues/8646 for more info.
+        guard UIDevice.isPad() == false && originatingExtension != .saveToDraft else {
+            dismissalCompletionBlock?()
+            return
+        }
+
+        dismiss(animated: true, completion: dismissalCompletionBlock)
+    }
+
     @objc func cancelWasPressed() {
         tracks.trackExtensionCancelled()
         cleanUpSharedContainer()
-        dismiss(animated: true, completion: self.dismissalCompletionBlock)
+        dismiss()
     }
 
     @objc func backWasPressed() {
@@ -628,7 +642,7 @@ fileprivate extension ShareModularViewController {
                                                localMediaFileURLs: localImageURLs,
                                                requestEnqueued: {
                                                 self.tracks.trackExtensionPosted(self.shareData.postStatus.rawValue)
-                                                self.dismiss(animated: true, completion: self.dismissalCompletionBlock)
+                                                self.dismiss()
             }, onFailure: {
                 let error = self.createErrorWithDescription("Failed to save and upload post with media.")
                 self.tracks.trackExtensionError(error)
@@ -643,7 +657,7 @@ fileprivate extension ShareModularViewController {
                                              siteID: siteID,
                                              onComplete: {
                                                 self.tracks.trackExtensionPosted(self.shareData.postStatus.rawValue)
-                                                self.dismiss(animated: true, completion: self.dismissalCompletionBlock)
+                                                self.dismiss()
             }, onFailure: {
                 let error = self.createErrorWithDescription("Failed to save and upload post with no media.")
                 self.tracks.trackExtensionError(error)
@@ -667,7 +681,7 @@ fileprivate extension ShareModularViewController {
         let dismissAction = UIAlertAction(title: dismissButtonText, style: .cancel) { (action) in
             self.showCancellingView()
             self.cleanUpSharedContainer()
-            self.dismiss(animated: true, completion: self.dismissalCompletionBlock)
+            self.dismiss()
         }
         alertController.addAction(dismissAction)
 


### PR DESCRIPTION
Fixes #8646

This PR improves the transitions of the draft extension on iPad. I've made two main changes:

* On iPad, the action extension modular view controller isn't inset within the presenting view controller, so you never see the white background. This particularly fixes the issue in regular size classes, where you could see the white border around the share extension, and gives it a little more space.
* On iPad, I've disabled the transitions when presenting / dismissing the modular VC within the presenting container, so that it just gets shown / dismissed with it, like a regular modal.

**Before:**

![ipad-preso-2](https://user-images.githubusercontent.com/4780/36508559-f22df2f6-1754-11e8-84c9-2455500ac2af.gif)

**After:**

![ipad-preso-1](https://user-images.githubusercontent.com/4780/36508565-f76a88e2-1754-11e8-9db9-9c20b36eac01.gif)

**To test:**

* Try presenting and dismissing the draft extension in a variety of split sizes on iPad and see if the transition / presentation looks better than before
* Check that the main share extension still looks okay
* Check that everything still works as it did before on iPhone

cc @folletto 