### PR TITLE
BlogListViewController: Implemented self-sizing cells

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -806,7 +806,7 @@ static NSInteger HideSearchMinSites = 3;
     [self.navigationController pushViewController:self.blogDetailsViewController animated:animated];
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
+- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     return [WPBlogTableViewCell cellHeight];
 }


### PR DESCRIPTION
Fixes #8662 

This PR implements self-sizing cells in the Blogs list section

![sites](https://user-images.githubusercontent.com/9772967/36513068-7af0ce46-174c-11e8-95cc-51c88037d92e.png)

### Steps to reproduce the behavior

- Run the app in the Simulator
- Open the 'Accessibility Inspector'
- Choose 'Simulator' as the inspector target.
- Go to WPiOS and visit `My Sites` section
- Change font size in the Accessibility Inspector