### PR TITLE
ReaderFollowedSitesViewController:  Implemented self-sizing cells

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -328,6 +328,10 @@ extension ReaderFollowedSitesViewController: WPTableViewHandlerDelegate {
 
 
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableViewAutomaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
         return 54.0
     }
 


### PR DESCRIPTION
Fixes #8666 

This PR implements self-sizing cells in `ReaderFollowedSitesViewController`

![followed](https://user-images.githubusercontent.com/9772967/36513594-2fcdb728-174f-11e8-83ee-e9cd3338bfc4.png)


To test:

- Run the app in the Simulator
- Open the 'Accessibility Inspector'
- Choose 'Simulator' as the inspector target.
- Visit `ReaderFollowedSitesViewController ` in the app.
- Change font size in the Accessibility Inspector