### PR TITLE
Implemented self-sizing cells in some 'Me' sub-sections

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/ActivityLogViewController.m
@@ -41,9 +41,8 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
-    [self.tableView setRowHeight:WPTableViewDefaultRowHeight];
 
+    [WPStyleGuide configureAutomaticHeightRowsFor:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self loadLogFiles];
 

--- a/WordPress/Classes/ViewRelated/Me/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/SupportViewController.m
@@ -109,8 +109,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
 {
     [super viewDidLoad];
     
-    [self.tableView setRowHeight:WPTableViewDefaultRowHeight];
-
+    [WPStyleGuide configureAutomaticHeightRowsFor:self.tableView];
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
 
     [self.navigationController setNavigationBarHidden:NO animated:YES];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -151,13 +151,6 @@ open class NotificationSettingsViewController: UIViewController {
         return cell
     }
 
-    @objc open func tableView(_ tableView: UITableView, heightForRowAtIndexPath indexPath: IndexPath) -> CGFloat {
-        let isBlogSection   = indexPath.section == Section.blog.rawValue
-        let isNotPagination = !isPaginationRow(indexPath)
-
-        return isBlogSection && isNotPagination ? blogRowHeight : WPTableViewDefaultRowHeight
-    }
-
     @objc open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         // Hide when the section is empty!
         if isSectionEmpty(section) {


### PR DESCRIPTION
This PR implement self-sizing cells in the following controllers:

- ActivityLogViewController
- SupportViewController
- NotificationSettingsViewController

Fixes #8673 

![me](https://user-images.githubusercontent.com/9772967/36513812-3db25c30-1750-11e8-9f62-94fc43547207.png)

To test:

- Run the app in the Simulator
- Open the 'Accessibility Inspector'
- Choose 'Simulator' as the inspector target.
- Visit the mentioned sections in the app.
- Change font size in the Accessibility Inspector
