### PR TITLE
Add Gmail detection to OpenMail

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/NUXLinkMailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXLinkMailViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import MessageUI
 
 /// Step two in the auth link flow. This VC prompts the user to open their email
 /// app to look for the emailed authentication link.
@@ -87,9 +88,29 @@ class NUXLinkMailViewController: LoginViewController {
     // MARK: - Actions
 
     @IBAction func handleOpenMailTapped(_ sender: UIButton) {
-        let url = URL(string: "message://")!
-        UIApplication.shared.open(url)
+        if MFMailComposeViewController.canSendMail() {
+            let url = URL(string: "message://")!
+            UIApplication.shared.open(url)
+        } else if let googleMailURL = URL(string: "googlegmail://"),
+            UIApplication.shared.canOpenURL(googleMailURL) {
+            UIApplication.shared.open(googleMailURL)
+        } else {
+            showAlertToCheckEmail()
+        }
     }
+
+    func showAlertToCheckEmail() {
+        let title = NSLocalizedString("Please check your email", comment: "Alert title for check your email during logIn/signUp.")
+        let message = NSLocalizedString("Please open your email app and look for an email from WordPress.com.", comment: "Message to ask the user to check their email and look for a WordPress.com email.")
+
+        let alertController =  UIAlertController(title: title,
+                                                 message: message,
+                                                 preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(NSLocalizedString("OK",
+                                                                   comment: "Button title. An acknowledgement of the message displayed in a prompt."))
+        alertController.presentFromRootViewController()
+    }
+
 
     @IBAction func handleUsePasswordTapped(_ sender: UIButton) {
         WordPressAuthenticator.post(event: .loginMagicLinkExited)


### PR DESCRIPTION
**Fixes** #8681 

This PR adds detection for AppleMail and Gmail, so when the `Open Mail` button is tapped it will only attempt to open either of those apps if it is configured on the device.

**To test:**

There's three different scenarios to test:
1. Apple Mail configured -> Apple Mail should be opened
2. Gmail configured (Apple mail not on the device) -> Gmail should be opened
3. None installed -> An alert should be display requesting the user to check their email

cc: @nheagy 