### PR TITLE
Show new flow from Me tab with ability to cancel it

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -441,20 +441,27 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
     ///
     fileprivate func promptForLoginOrSignup() {
         let controller = UIAlertController.init(title: nil, message: nil, preferredStyle: .actionSheet)
-        controller.addActionWithTitle(NSLocalizedString("Log In", comment: "Button title.  Tapping takes the user to the login form."),
-            style: .default,
-            handler: { (_) in
-                WordPressAuthenticator.showLoginForJustWPComFromPresenter(self)
-        })
-        controller.addActionWithTitle(NSLocalizedString("Create a WordPress site", comment: "Button title. Tapping takes the user to a form where they can create a new WordPress site."),
-                                      style: .default,
-                                      handler: { (_) in
-                                        let controller = SignupViewController.controller()
-                                        let navController = NUXNavigationController(rootViewController: controller)
-                                        self.present(navController, animated: true, completion: nil)
 
+        if FeatureFlag.socialSignup.enabled {
+            WordPressAuthenticator.showLoginFromPresenter(self, animated: true, thenEditor: false, showCancel: true)
+        } else {
+            controller.addActionWithTitle(NSLocalizedString("Log In",
+                                                            comment: "Button title.  Tapping takes the user to the login form."),
+                                          style: .default,
+                                          handler: { (_) in
+                                            WordPressAuthenticator.showLoginForJustWPComFromPresenter(self)
+                                          })
 
-        })
+            controller.addActionWithTitle(NSLocalizedString("Create a WordPress site",
+                                                            comment: "Button title. Tapping takes the user to a form where they can create a new WordPress site."),
+                                          style: .default,
+                                          handler: { (_) in
+                                            let controller = SignupViewController.controller()
+                                            let navController = NUXNavigationController(rootViewController: controller)
+                                            self.present(navController, animated: true, completion: nil)
+                                          })
+        }
+
         controller.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Cancel"))
         controller.modalPresentationStyle = .popover
         present(controller, animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/NUX/LoginPrologueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginPrologueViewController.swift
@@ -7,6 +7,7 @@ class LoginPrologueViewController: UIViewController, UIViewControllerTransitioni
 
     @IBOutlet var loginButton: UIButton!
     @IBOutlet var signupButton: UIButton!
+    var showCancel = false
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent
@@ -73,6 +74,12 @@ class LoginPrologueViewController: UIViewController, UIViewControllerTransitioni
         }
         buttonViewController.setupButtomButton(title: createTitle, isPrimary: false) { [weak self] in
             self?.signupTapped()
+        }
+        if showCancel {
+            let cancelTitle = NSLocalizedString("Cancel", comment: "Button title. Tapping it cancels the login flow.")
+            buttonViewController.setupTertiaryButton(title: cancelTitle, isPrimary: false) { [weak self] in
+                self?.dismiss(animated: true, completion: nil)
+            }
         }
         buttonViewController.backgroundColor = WPStyleGuide.lightGrey()
     }

--- a/WordPress/Classes/ViewRelated/NUX/NUXButtonView.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/NUXButtonView.storyboard
@@ -28,7 +28,7 @@
                                 <rect key="frame" x="20" y="20" width="335" height="103"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="knN-O6-M86" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="335" height="33"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="335" height="50"/>
                                         <accessibility key="accessibilityConfiguration" identifier="connectSite"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="YB6-LI-NGI"/>
@@ -42,7 +42,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M7J-a3-klP" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="53" width="335" height="50"/>
+                                        <rect key="frame" x="0.0" y="70" width="335" height="33"/>
                                         <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="SiB-Xy-stR"/>
@@ -57,6 +57,24 @@
                                         </state>
                                         <connections>
                                             <action selector="primaryButtonPressed:" destination="aOG-7h-6d9" eventType="touchUpInside" id="W8M-wW-PhN"/>
+                                        </connections>
+                                    </button>
+                                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uAF-kU-f7P" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="103" width="335" height="50"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="wCg-rE-NtX"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                        <state key="normal" title="Cancel Button">
+                                            <color key="titleColor" cocoaTouchSystemColor="darkTextColor"/>
+                                        </state>
+                                        <state key="selected" backgroundImage="beveled-blue-button-down"/>
+                                        <state key="highlighted" backgroundImage="beveled-blue-button-down">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="tertiaryButtonPressed:" destination="aOG-7h-6d9" eventType="touchUpInside" id="RwH-F2-dDX"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -80,6 +98,7 @@
                         <outlet property="buttonHolder" destination="d2l-kB-WtE" id="LGA-3V-qgh"/>
                         <outlet property="shadowView" destination="RrB-Aa-ADd" id="LZa-Jn-ghb"/>
                         <outlet property="stackView" destination="xzf-f5-7zQ" id="frG-Oo-nB4"/>
+                        <outlet property="tertiaryButton" destination="uAF-kU-f7P" id="B6D-lx-GhC"/>
                         <outlet property="topButton" destination="knN-O6-M86" id="3fN-Bh-Z8O"/>
                     </connections>
                 </viewController>

--- a/WordPress/Classes/ViewRelated/NUX/NUXButtonViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXButtonViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 @objc protocol NUXButtonViewControllerDelegate {
     func primaryButtonPressed()
     @objc optional func secondaryButtonPressed()
+    @objc optional func tertiaryButtonPressed()
 }
 
 private struct NUXButtonConfig {
@@ -22,6 +23,7 @@ class NUXButtonViewController: UIViewController {
     @IBOutlet var stackView: UIStackView?
     @IBOutlet var bottomButton: NUXButton?
     @IBOutlet var topButton: NUXButton?
+    @IBOutlet var tertiaryButton: NUXButton?
     @IBOutlet var buttonHolder: UIView?
 
     open var delegate: NUXButtonViewControllerDelegate?
@@ -29,6 +31,7 @@ class NUXButtonViewController: UIViewController {
 
     private var topButtonConfig: NUXButtonConfig?
     private var bottomButtonConfig: NUXButtonConfig?
+    private var tertiaryButtonConfig: NUXButtonConfig?
 
     // MARK: - View
 
@@ -42,6 +45,7 @@ class NUXButtonViewController: UIViewController {
 
         configure(button: bottomButton, withConfig: bottomButtonConfig)
         configure(button: topButton, withConfig: topButtonConfig)
+        configure(button: tertiaryButton, withConfig: tertiaryButtonConfig)
         if let bgColor = backgroundColor, let holder = buttonHolder {
             holder.backgroundColor = bgColor
         }
@@ -65,10 +69,15 @@ class NUXButtonViewController: UIViewController {
     /// - Parameters:
     ///   - primary: Title string for primary button. Required.
     ///   - secondary: Title string for secondary button. Optional.
-    func setButtonTitles(primary: String, secondary: String? = nil) {
+    ///   - tertiary: Title string for the tertiary button. Optional.
+    ///
+    func setButtonTitles(primary: String, secondary: String? = nil, tertiary: String? = nil) {
         bottomButtonConfig = NUXButtonConfig(title: primary, isPrimary: true, callback: nil)
         if let secondaryTitle = secondary {
             topButtonConfig = NUXButtonConfig(title: secondaryTitle, isPrimary: false, callback: nil)
+        }
+        if let tertiaryTitle = tertiary {
+            tertiaryButtonConfig = NUXButtonConfig(title: tertiaryTitle, isPrimary: false, callback: nil)
         }
     }
 
@@ -78,6 +87,11 @@ class NUXButtonViewController: UIViewController {
 
     func setupButtomButton(title: String, isPrimary: Bool = false, onTap callback: @escaping CallBackType) {
         bottomButtonConfig = NUXButtonConfig(title: title, isPrimary: isPrimary, callback: callback)
+    }
+
+    func setupTertiaryButton(title: String, isPrimary: Bool = false, onTap callback: @escaping CallBackType) {
+        tertiaryButton?.isHidden = false
+        tertiaryButtonConfig = NUXButtonConfig(title: title, isPrimary: isPrimary, callback: callback)
     }
 
     // MARK: - Helpers
@@ -100,6 +114,14 @@ class NUXButtonViewController: UIViewController {
     @IBAction func secondaryButtonPressed(_ sender: Any) {
         guard let callback = topButtonConfig?.callback else {
             delegate?.secondaryButtonPressed?()
+            return
+        }
+        callback()
+    }
+
+    @IBAction func tertiaryButtonPressed(_ sender: Any) {
+        guard let callback = tertiaryButtonConfig?.callback else {
+            delegate?.tertiaryButtonPressed?()
             return
         }
         callback()

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
@@ -20,12 +20,19 @@ import WordPressShared
 
     /// Used to present the new login flow from the app delegate
     @objc class func showLoginFromPresenter(_ presenter: UIViewController, animated: Bool, thenEditor: Bool) {
+        showLoginFromPresenter(presenter, animated: animated, thenEditor: thenEditor, showCancel: false)
+    }
+
+    class func showLoginFromPresenter(_ presenter: UIViewController, animated: Bool, thenEditor: Bool, showCancel: Bool) {
         defer {
             trackOpenedLogin()
         }
 
         let storyboard = UIStoryboard(name: "Login", bundle: nil)
         if let controller = storyboard.instantiateInitialViewController() {
+            if let childController = controller.childViewControllers.first as? LoginPrologueViewController {
+                childController.showCancel = showCancel
+            }
             presenter.present(controller, animated: animated, completion: nil)
         }
     }


### PR DESCRIPTION
**Fixes** #8694 

![simulator screen shot - iphone 8 - 2018-02-22 at 19 08 11](https://user-images.githubusercontent.com/5558824/36568121-95bb5ab4-1807-11e8-9dbe-d0b22bf18fc2.png)

**To test:**

Do a clean stall of the app and test that:
1. The login/signup initial screen doesn't show the cancel button.
2. After adding a self-hosted site to the app, go to the Me tab and tap on LogIn, there should be a Cancel button available and it should dismiss the flow.
3. That I didn't break anything else.
