### PR TITLE
Signup: social login fail ‘Sign up’ option now goes to new flow

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -519,10 +519,18 @@ extension LoginEmailViewController: LoginSocialErrorViewControllerDelegate {
     }
     func retryAsSignup() {
         cleanupAfterSocialErrors()
-        let storyboard = UIStoryboard(name: "Login", bundle: nil)
-        if let controller = storyboard.instantiateViewController(withIdentifier: "SignupViewController") as? NUXAbstractViewController {
-            controller.loginFields = loginFields
-            navigationController?.pushViewController(controller, animated: true)
+
+        if FeatureFlag.socialSignup.enabled {
+            let storyboard = UIStoryboard(name: "Signup", bundle: nil)
+            if let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? SignupEmailViewController {
+                navigationController?.pushViewController(controller, animated: true)
+            }
+        } else {
+            let storyboard = UIStoryboard(name: "Login", bundle: nil)
+            if let controller = storyboard.instantiateViewController(withIdentifier: "SignupViewController") as? NUXAbstractViewController {
+                controller.loginFields = loginFields
+                navigationController?.pushViewController(controller, animated: true)
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -523,6 +523,7 @@ extension LoginEmailViewController: LoginSocialErrorViewControllerDelegate {
         if FeatureFlag.socialSignup.enabled {
             let storyboard = UIStoryboard(name: "Signup", bundle: nil)
             if let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? SignupEmailViewController {
+                controller.loginFields = loginFields
                 navigationController?.pushViewController(controller, animated: true)
             }
         } else {

--- a/WordPress/Classes/ViewRelated/NUX/SignupEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEmailViewController.swift
@@ -48,6 +48,10 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         configureViewForEditingIfNeeded()
+
+        // If email address already exists, pre-populate it.
+        emailField.text = loginFields.emailAddress
+
         configureSubmitButton(animating: false)
     }
 


### PR DESCRIPTION
**Ref:** #8109 

**To test:**
- Logout of app if necessary.
- Select 'Log In'.
- Select 'Log in with Google'.
- Select an email account that is _not_ associated with a WordPress.com account.
- On the 'Connected but...' screen, select 'Sign up'.
<img width="250" alt="error_page" src="https://user-images.githubusercontent.com/1816888/36570803-05495686-17f1-11e8-8d25-67cb3872436c.png">

- Verify it goes to the new signup with email flow, with the email address populated.
<img width="250" alt="redirect" src="https://user-images.githubusercontent.com/1816888/36570814-19a04928-17f1-11e8-98e7-f72298dcf981.png">

cc: @nheagy