### PR TITLE
Fix mergeBlogs to match deleted blogs

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -633,7 +633,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
 
     if ([toDelete count] > 0) {
         for (Blog *blog in account.blogs) {
-            if ([toDelete containsObject:blog.xmlrpc]) {
+            if ([toDelete containsObject:blog.dotComID]) {
                 [self.managedObjectContext deleteObject:blog];
             }
         }


### PR DESCRIPTION
The algorithm was calculating a list of blog IDs to be removed, but then it was trying to match those with the xmlrpc URL 🤦

Fixes #8605 

To test:

1. Connect any Jetpack site (e.g. created with jurassic.ninja)
2. Disconnect that site
3. Check your sites list, make sure the site is gone