### PR TITLE
Issue/8682 Separate post vs media library progress in MediaCoordinator

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -35,24 +35,24 @@ class MediaCoordinator: NSObject {
     /// - returns: The progress coordinator for the specified post. If a coordinator
     ///            does not exist, one will be created.
     private func coordinator(for post: AbstractPost) -> MediaProgressCoordinator {
-        var coordinator: MediaProgressCoordinator?
+        var cachedCoordinator: MediaProgressCoordinator?
 
         progressCoordinatorQueue.sync {
-            coordinator = postMediaProgressCoordinators[post]
+            cachedCoordinator = postMediaProgressCoordinators[post]
         }
 
-        if let coordinator = coordinator {
-            return coordinator
+        if let cachedCoordinator = cachedCoordinator {
+            return cachedCoordinator
         }
 
-        coordinator = MediaProgressCoordinator()
-        coordinator!.delegate = self
+        let coordinator = MediaProgressCoordinator()
+        coordinator.delegate = self
 
         progressCoordinatorQueue.async(flags: .barrier) {
             self.postMediaProgressCoordinators[post] = coordinator
         }
 
-        return coordinator!
+        return coordinator
     }
 
     /// - returns: The progress coordinator for the specified media item. Either

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -506,9 +506,13 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
     }
 
     func mediaProgressCoordinatorDidFinishUpload(_ mediaProgressCoordinator: MediaProgressCoordinator) {
-        let model = MediaProgressCoordinatorNoticeViewModel(mediaProgressCoordinator: mediaProgressCoordinator)
-        if let notice = model?.notice {
-            ActionDispatcher.dispatch(NoticeAction.post(notice))
+        // Currently, we only want to show a successful upload notice for uploads
+        // initiated within the media library.
+        if mediaProgressCoordinator == mediaLibraryProgressCoordinator {
+            let model = MediaProgressCoordinatorNoticeViewModel(mediaProgressCoordinator: mediaProgressCoordinator)
+            if let notice = model?.notice {
+                ActionDispatcher.dispatch(NoticeAction.post(notice))
+            }
         }
 
         mediaProgressCoordinator.stopTrackingOfAllMedia()

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -377,10 +377,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     ///
     fileprivate lazy var devicePhotoLibraryDataSource = WPPHAssetDataSource()
 
-    fileprivate lazy var mediaCoordinator: MediaCoordinator = {
-        let coordinator = MediaCoordinator()
-        return coordinator
-    }()
+    fileprivate let mediaCoordinator = MediaCoordinator.shared
 
     /// Media Progress View
     ///


### PR DESCRIPTION
Implements #8682.

This PR adds multiple progress coordinators to the MediaCoordinator, to separately track uploads for posts vs items uploaded through the media library. This will allow us to handle their completion separately in the future.

**To test:**

* First, ensure that uploads through both the media library and Aztec function as you'd expect, and progress is reported correctly.
* On `develop`, upload some media items in the editor on an iPhone device. When the uploads complete, you'll feel Taptic feedback as a notice is posted to report success. If you exit the editor quickly, you'll see the 'media uploaded' notice still at the bottom of the screen.
* Re-test that same scenario on this branch, and you'll get no feedback and see that no notice is posted in this situation any more as we can now differentiate between media library and post uploads.
* Ensure that notices are displayed for media library uploads.

