### PR TITLE
NotificationsViewController: self-sizing cells

### DIFF
--- a/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
+++ b/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
@@ -212,29 +212,37 @@ extension NotificationBlock {
     // MARK: - Constants
     //
     fileprivate struct Constants {
-        static let subjectRangeStylesMap: [NotificationRange.Kind: [NSAttributedStringKey: Any]] = [
-            .User: Styles.subjectBoldStyle,
-            .Post: Styles.subjectItalicsStyle,
-            .Comment: Styles.subjectItalicsStyle,
-            .Blockquote: Styles.subjectQuotedStyle,
-            .Noticon: Styles.subjectNoticonStyle
-        ]
+        static var subjectRangeStylesMap: [NotificationRange.Kind: [NSAttributedStringKey: Any]] {
+            return [
+                .User: Styles.subjectBoldStyle,
+                .Post: Styles.subjectItalicsStyle,
+                .Comment: Styles.subjectItalicsStyle,
+                .Blockquote: Styles.subjectQuotedStyle,
+                .Noticon: Styles.subjectNoticonStyle
+            ]
+        }
 
-        static let headerTitleRangeStylesMap: [NotificationRange.Kind: [NSAttributedStringKey: Any]] = [
-            .User: Styles.headerTitleBoldStyle,
-            .Post: Styles.headerTitleContextStyle,
-            .Comment: Styles.headerTitleContextStyle
-        ]
+        static var headerTitleRangeStylesMap: [NotificationRange.Kind: [NSAttributedStringKey: Any]] {
+            return [
+                .User: Styles.headerTitleBoldStyle,
+                .Post: Styles.headerTitleContextStyle,
+                .Comment: Styles.headerTitleContextStyle
+            ]
+        }
 
-        static let footerStylesMap: [NotificationRange.Kind: [NSAttributedStringKey: Any]] = [
-            .Noticon: Styles.blockNoticonStyle
-        ]
+        static var footerStylesMap: [NotificationRange.Kind: [NSAttributedStringKey: Any]] {
+            return [
+                .Noticon: Styles.blockNoticonStyle
+            ]
+        }
 
-        static let richRangeStylesMap: [NotificationRange.Kind: [NSAttributedStringKey: Any]] = [
-            .Blockquote: Styles.contentBlockQuotedStyle,
-            .Noticon: Styles.blockNoticonStyle,
-            .Match: Styles.contentBlockMatchStyle
-        ]
+        static var richRangeStylesMap: [NotificationRange.Kind: [NSAttributedStringKey: Any]] {
+            return [
+                .Blockquote: Styles.contentBlockQuotedStyle,
+                .Noticon: Styles.blockNoticonStyle,
+                .Match: Styles.contentBlockMatchStyle
+            ]
+        }
 
         static let badgeRangeStylesMap: [NotificationRange.Kind: [NSAttributedStringKey: Any]] = [
             .User: Styles.badgeBoldStyle,

--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -107,7 +107,7 @@ class Notification: NSManagedObject {
 
     /// Nukes any cached values.
     ///
-    fileprivate func resetCachedAttributes() {
+    func resetCachedAttributes() {
         cachedTimestampAsDate = nil
         cachedSubjectBlockGroup = nil
         cachedHeaderBlockGroup = nil

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -351,6 +351,7 @@ private extension NotificationsViewController {
         // UITableView
         tableView.accessibilityIdentifier  = "Notifications Table"
         tableView.cellLayoutMarginsFollowReadableWidth = false
+        tableView.estimatedSectionHeaderHeight = UITableViewAutomaticDimension
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -237,14 +237,6 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
 
     // MARK: - UITableView Methods
 
-    override func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
-        return NoteTableHeaderView.estimatedHeight
-    }
-
-    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return UITableViewAutomaticDimension
-    }
-
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard let sectionInfo = tableViewHandler.resultsController.sections?[section] else {
             return nil
@@ -359,6 +351,7 @@ private extension NotificationsViewController {
         // UITableView
         tableView.accessibilityIdentifier  = "Notifications Table"
         tableView.cellLayoutMarginsFollowReadableWidth = false
+        WPStyleGuide.configureAutomaticHeightRows(for: tableView)
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
     }
 
@@ -430,6 +423,7 @@ private extension NotificationsViewController {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(applicationDidBecomeActive), name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
         nc.addObserver(self, selector: #selector(notificationsWereUpdated), name: NSNotification.Name(rawValue: NotificationSyncMediatorDidUpdateNotifications), object: nil)
+        nc.addObserver(self, selector: #selector(dynamicTypeDidChange), name: .UIContentSizeCategoryDidChange, object: nil)
     }
 
     func startListeningToAccountNotifications() {
@@ -483,6 +477,12 @@ private extension NotificationsViewController {
             && isViewLoaded == true
             && view.window != nil {
             reloadResultsControllerIfNeeded()
+        }
+    }
+
+    @objc func dynamicTypeDidChange() {
+        tableViewHandler.resultsController.fetchedObjects?.forEach {
+            ($0 as? Notification)?.resetCachedAttributes()
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -424,7 +424,9 @@ private extension NotificationsViewController {
         let nc = NotificationCenter.default
         nc.addObserver(self, selector: #selector(applicationDidBecomeActive), name: NSNotification.Name.UIApplicationDidBecomeActive, object: nil)
         nc.addObserver(self, selector: #selector(notificationsWereUpdated), name: NSNotification.Name(rawValue: NotificationSyncMediatorDidUpdateNotifications), object: nil)
-        nc.addObserver(self, selector: #selector(dynamicTypeDidChange), name: .UIContentSizeCategoryDidChange, object: nil)
+        if #available(iOS 11.0, *) {
+            nc.addObserver(self, selector: #selector(dynamicTypeDidChange), name: .UIContentSizeCategoryDidChange, object: nil)
+        }
     }
 
     func startListeningToAccountNotifications() {

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -10,9 +10,11 @@ extension WPStyleGuide {
         // NoteTableViewHeader
         public static let sectionHeaderBackgroundColor  = UIColor(red: 0xFF/255.0, green: 0xFF/255.0, blue: 0xFF/255.0, alpha: 0xEA/255.0)
 
-        public static let sectionHeaderRegularStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: sectionHeaderParagraph,
-                                                                                     .font: sectionHeaderFont,
-                                                                                     .foregroundColor: sectionHeaderTextColor ]
+        public static var sectionHeaderRegularStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: sectionHeaderParagraph,
+                     .font: sectionHeaderFont,
+                     .foregroundColor: sectionHeaderTextColor]
+        }
 
         // NoteTableViewCell
         public static let noticonFont               = UIFont(name: "Noticons", size: 16)
@@ -32,26 +34,36 @@ extension WPStyleGuide {
         public static let noteUndoTextFont          = subjectRegularFont
 
         // Subject Text
-        public static let subjectRegularStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: subjectParagraph,
-                                                                               .font: subjectRegularFont,
-                                                                               .foregroundColor: subjectTextColor]
+        public static var subjectRegularStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: subjectParagraph,
+                     .font: subjectRegularFont,
+                     .foregroundColor: subjectTextColor ]
+        }
 
-        public static let subjectBoldStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: subjectParagraph,
-                                                                            .font: subjectBoldFont ]
+        public static var subjectBoldStyle: [NSAttributedStringKey: Any] {
+            return [.paragraphStyle: subjectParagraph,
+                    .font: subjectBoldFont ]
+        }
 
-        public static let subjectItalicsStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: subjectParagraph,
-                                                                               .font: subjectItalicsFont ]
+        public static var subjectItalicsStyle: [NSAttributedStringKey: Any] {
+            return [.paragraphStyle: subjectParagraph,
+                    .font: subjectItalicsFont ]
+        }
 
-        public static let subjectNoticonStyle: [NSAttributedStringKey: Any] = [ .paragraphStyle: subjectParagraph,
-                                                                                .font: subjectNoticonFont!,
-                                                                                .foregroundColor: subjectNoticonColor ]
+        public static var subjectNoticonStyle: [NSAttributedStringKey: Any] {
+            return [.paragraphStyle: subjectParagraph,
+                    .font: subjectNoticonFont,
+                    .foregroundColor: subjectNoticonColor ]
+        }
 
         public static let subjectQuotedStyle = blockQuotedStyle
 
         // Subject Snippet
-        public static let snippetRegularStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: snippetParagraph,
-                                                                               .font: subjectRegularFont,
-                                                                               .foregroundColor: snippetColor ]
+        public static var snippetRegularStyle: [NSAttributedStringKey: Any] {
+            return [.paragraphStyle: snippetParagraph,
+                    .font: subjectRegularFont,
+                    .foregroundColor: snippetColor ]
+        }
 
         // MARK: - Styles used by NotificationDetailsViewController
         //
@@ -63,19 +75,27 @@ extension WPStyleGuide {
         public static let headerDetailsColor        = UIColor(red: 0x00/255.0, green: 0xAA/255.0, blue: 0xDC/255.0, alpha: 0xFF/255.0)
         public static let headerDetailsRegularFont  = blockRegularFont
 
-        public static let headerTitleRegularStyle: [NSAttributedStringKey: Any] = [.font: headerTitleRegularFont,
-                                                                                   .foregroundColor: headerTitleColor]
+        public static var headerTitleRegularStyle: [NSAttributedStringKey: Any] {
+            return [.font: headerTitleRegularFont,
+                    .foregroundColor: headerTitleColor]
+        }
 
-        public static let headerTitleBoldStyle: [NSAttributedStringKey: Any] =  [.font: headerTitleBoldFont,
-                                                                                 .foregroundColor: headerTitleColor]
+        public static var headerTitleBoldStyle: [NSAttributedStringKey: Any] {
+            return  [.font: headerTitleBoldFont,
+                     .foregroundColor: headerTitleColor]
+        }
 
-        public static let headerTitleContextStyle: [NSAttributedStringKey: Any] = [.font: headerTitleItalicsFont,
-                                                                                   .foregroundColor: headerTitleContextColor]
+        public static var headerTitleContextStyle: [NSAttributedStringKey: Any] {
+            return  [.font: headerTitleItalicsFont,
+                     .foregroundColor: headerTitleContextColor]
+        }
 
         // Footer
-        public static let footerRegularStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: blockParagraph,
-                                                                              .font: blockRegularFont,
-                                                                              .foregroundColor: footerTextColor]
+        public static var footerRegularStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: blockParagraph,
+                     .font: blockRegularFont,
+                     .foregroundColor: footerTextColor]
+        }
 
         // Badges
         public static let badgeBackgroundColor      = UIColor.clear
@@ -109,49 +129,71 @@ extension WPStyleGuide {
         public static let blockUnapprovedTextColor  = WPStyleGuide.alertRedDarker()
         public static let blockUnapprovedLinkColor  = WPStyleGuide.mediumBlue()
 
-        public static let contentBlockRegularStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: contentBlockParagraph,
-                                                                                    .font: contentBlockRegularFont,
-                                                                                    .foregroundColor: blockTextColor ]
+        public static var contentBlockRegularStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: contentBlockParagraph,
+                     .font: contentBlockRegularFont,
+                     .foregroundColor: blockTextColor ]
+        }
 
-        public static let contentBlockBoldStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: contentBlockParagraph,
-                                                                                 .font: contentBlockBoldFont,
-                                                                                 .foregroundColor: blockTextColor ]
+        public static var contentBlockBoldStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: contentBlockParagraph,
+                     .font: contentBlockBoldFont,
+                     .foregroundColor: blockTextColor ]
+        }
 
-        public static let contentBlockItalicStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: contentBlockParagraph,
-                                                                                   .font: contentBlockItalicFont,
-                                                                                   .foregroundColor: blockTextColor ]
+        public static var contentBlockItalicStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: contentBlockParagraph,
+                     .font: contentBlockItalicFont,
+                     .foregroundColor: blockTextColor ]
+        }
 
-        public static let contentBlockQuotedStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: contentBlockParagraph,
-                                                                                   .font: contentBlockItalicFont,
-                                                                                   .foregroundColor: blockQuotedColor ]
+        public static var contentBlockQuotedStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: contentBlockParagraph,
+                     .font: contentBlockItalicFont,
+                     .foregroundColor: blockQuotedColor ]
+        }
 
-        public static let contentBlockMatchStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: contentBlockParagraph,
-                                                                                  .font: contentBlockRegularFont,
-                                                                                  .foregroundColor: blockLinkColor ]
+        public static var contentBlockMatchStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: contentBlockParagraph,
+                     .font: contentBlockRegularFont,
+                     .foregroundColor: blockLinkColor ]
+        }
 
-        public static let blockRegularStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: blockParagraph,
-                                                                             .font: blockRegularFont,
-                                                                             .foregroundColor: blockTextColor ]
+        public static var blockRegularStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: blockParagraph,
+                     .font: blockRegularFont,
+                     .foregroundColor: blockTextColor ]
+        }
 
-        public static let blockBoldStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: blockParagraph,
-                                                                          .font: blockBoldFont,
-                                                                          .foregroundColor: blockTextColor ]
+        public static var blockBoldStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: blockParagraph,
+                     .font: blockBoldFont,
+                     .foregroundColor: blockTextColor ]
+        }
 
-        public static let blockItalicsStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: blockParagraph,
-                                                                             .font: blockItalicsFont,
-                                                                             .foregroundColor: blockTextColor ]
+        public static var blockItalicsStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: blockParagraph,
+                     .font: blockItalicsFont,
+                     .foregroundColor: blockTextColor ]
+        }
 
-        public static let blockQuotedStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: blockParagraph,
-                                                                            .font: blockItalicsFont,
-                                                                            .foregroundColor: blockQuotedColor ]
+        public static var blockQuotedStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: blockParagraph,
+                     .font: blockItalicsFont,
+                     .foregroundColor: blockQuotedColor ]
+        }
 
-        public static let blockMatchStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: blockParagraph,
-                                                                           .font: blockRegularFont,
-                                                                           .foregroundColor: blockLinkColor ]
+        public static var blockMatchStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: blockParagraph,
+                     .font: blockRegularFont,
+                     .foregroundColor: blockLinkColor ]
+        }
 
-        public static let blockNoticonStyle: [NSAttributedStringKey: Any] = [.paragraphStyle: blockParagraph,
-                                                                             .font: blockNoticonFont!,
-                                                                             .foregroundColor: blockNoticonColor ]
+        public static var blockNoticonStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: blockParagraph,
+                     .font: blockNoticonFont,
+                     .foregroundColor: blockNoticonColor ]
+        }
 
         // Action Buttons
         public static let blockActionDisabledColor  = UIColor(red: 0x7F/255.0, green: 0x9E/255.0, blue: 0xB4/255.0, alpha: 0xFF/255.0)
@@ -251,13 +293,13 @@ extension WPStyleGuide {
 
         // ParagraphStyle's
         fileprivate static let sectionHeaderParagraph   = NSMutableParagraphStyle(
-            minLineHeight: headerLineSize, maxLineHeight: headerLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
+            minLineHeight: headerLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
         )
         fileprivate static let subjectParagraph         = NSMutableParagraphStyle(
-            minLineHeight: subjectLineSize, maxLineHeight: subjectLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
+            minLineHeight: subjectLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
         )
         fileprivate static let snippetParagraph         = NSMutableParagraphStyle(
-            minLineHeight: snippetLineSize, maxLineHeight: snippetLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
+            minLineHeight: snippetLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
         )
         fileprivate static let blockParagraph           = NSMutableParagraphStyle(
             minLineHeight: blockLineSize, lineBreakMode: .byWordWrapping, alignment: .natural
@@ -279,11 +321,20 @@ extension WPStyleGuide {
         fileprivate static let headerTitleContextColor  = WPStyleGuide.allTAllShadeGrey()
 
         // Fonts
-        fileprivate static let sectionHeaderFont        = WPFontManager.systemSemiBoldFont(ofSize: headerFontSize)
-        fileprivate static let subjectRegularFont       = WPFontManager.systemRegularFont(ofSize: subjectFontSize)
-        fileprivate static let subjectBoldFont          = WPFontManager.systemSemiBoldFont(ofSize: subjectFontSize)
-        fileprivate static let subjectItalicsFont       = WPFontManager.systemItalicFont(ofSize: subjectFontSize)
-        fileprivate static let subjectNoticonFont       = UIFont(name: "Noticons", size: subjectNoticonSize)
+        fileprivate static var sectionHeaderFont: UIFont {
+            return WPStyleGuide.fontForTextStyle(.caption1, fontWeight: .semibold)
+        }
+        fileprivate static var subjectRegularFont: UIFont {
+            return WPStyleGuide.fontForTextStyle(.subheadline)
+        }
+        fileprivate static var subjectBoldFont: UIFont {
+            return WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .bold)
+        }
+        fileprivate static var subjectItalicsFont: UIFont {
+            return  WPStyleGuide.fontForTextStyle(.subheadline, symbolicTraits: .traitItalic)
+        }
+
+        fileprivate static let subjectNoticonFont       = UIFont(name: "Noticons", size: subjectNoticonSize)!
         fileprivate static let headerTitleRegularFont   = blockRegularFont
         fileprivate static let headerTitleItalicsFont   = blockItalicsFont
         fileprivate static let blockItalicsFont         = WPFontManager.systemItalicFont(ofSize: blockFontSize)

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -322,16 +322,32 @@ extension WPStyleGuide {
 
         // Fonts
         fileprivate static var sectionHeaderFont: UIFont {
-            return WPStyleGuide.fontForTextStyle(.caption1, fontWeight: .semibold)
+            if #available(iOS 11.0, *) {
+                return WPStyleGuide.fontForTextStyle(.caption1, fontWeight: .semibold)
+            } else {
+                return WPFontManager.systemSemiBoldFont(ofSize: headerFontSize)
+            }
         }
         fileprivate static var subjectRegularFont: UIFont {
-            return WPStyleGuide.fontForTextStyle(.subheadline)
+            if #available(iOS 11.0, *) {
+                return WPStyleGuide.fontForTextStyle(.subheadline)
+            } else {
+                return WPFontManager.systemRegularFont(ofSize: subjectFontSize)
+            }
         }
         fileprivate static var subjectBoldFont: UIFont {
-            return WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .bold)
+            if #available(iOS 11.0, *) {
+                return WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .bold)
+            } else {
+                return WPFontManager.systemSemiBoldFont(ofSize: subjectFontSize)
+            }
         }
         fileprivate static var subjectItalicsFont: UIFont {
-            return  WPStyleGuide.fontForTextStyle(.subheadline, symbolicTraits: .traitItalic)
+            if #available(iOS 11.0, *) {
+                return  WPStyleGuide.fontForTextStyle(.subheadline, symbolicTraits: .traitItalic)
+            } else {
+                return WPFontManager.systemItalicFont(ofSize: subjectFontSize)
+            }
         }
 
         fileprivate static let subjectNoticonFont       = UIFont(name: "Noticons", size: subjectNoticonSize)!

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.swift
@@ -12,7 +12,6 @@ class NoteTableHeaderView: UIView {
             let unwrappedTitle = newValue?.localizedUppercase ?? String()
             let attributes = Style.sectionHeaderRegularStyle
             titleLabel.attributedText = NSAttributedString(string: unwrappedTitle, attributes: attributes)
-            setNeedsLayout()
         }
         get {
             return titleLabel.text

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableHeaderView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,14 +20,14 @@
                     <rect key="frame" x="0.0" y="0.0" width="700" height="66"/>
                     <subviews>
                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" image="reader-postaction-time" translatesAutoresizingMaskIntoConstraints="NO" id="imt-VI-wdh" userLabel="Icon">
-                            <rect key="frame" x="14" y="25" width="16" height="16"/>
+                            <rect key="frame" x="20" y="25" width="16" height="16"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="16" id="4kI-NL-bJP"/>
                                 <constraint firstAttribute="height" constant="16" id="G7c-hu-Hc6"/>
                             </constraints>
                         </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="240" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zK2-Ta-Z1W" userLabel="Title">
-                            <rect key="frame" x="34" y="0.0" width="652" height="66"/>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="240" verticalHuggingPriority="240" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zK2-Ta-Z1W" userLabel="Title">
+                            <rect key="frame" x="40" y="4" width="640" height="58"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -39,10 +39,10 @@
                     <constraints>
                         <constraint firstItem="zK2-Ta-Z1W" firstAttribute="leading" secondItem="imt-VI-wdh" secondAttribute="trailing" constant="4" id="5gJ-xQ-IIv"/>
                         <constraint firstItem="imt-VI-wdh" firstAttribute="centerY" secondItem="AjL-Ni-9e0" secondAttribute="centerY" id="7ht-6A-0hZ"/>
-                        <constraint firstItem="zK2-Ta-Z1W" firstAttribute="top" secondItem="AjL-Ni-9e0" secondAttribute="top" id="84n-R2-3hp"/>
+                        <constraint firstItem="zK2-Ta-Z1W" firstAttribute="top" secondItem="AjL-Ni-9e0" secondAttribute="top" constant="4" id="84n-R2-3hp"/>
+                        <constraint firstAttribute="bottom" secondItem="zK2-Ta-Z1W" secondAttribute="bottom" constant="4" id="H5r-aJ-Jgz"/>
                         <constraint firstItem="imt-VI-wdh" firstAttribute="leading" secondItem="AjL-Ni-9e0" secondAttribute="leadingMargin" id="X3z-pE-0Uc"/>
                         <constraint firstItem="zK2-Ta-Z1W" firstAttribute="trailing" secondItem="AjL-Ni-9e0" secondAttribute="trailingMargin" id="seF-xR-8yi"/>
-                        <constraint firstItem="zK2-Ta-Z1W" firstAttribute="centerY" secondItem="imt-VI-wdh" secondAttribute="centerY" id="ttr-ae-OMz"/>
                     </constraints>
                 </view>
             </subviews>


### PR DESCRIPTION
Adopted dynamic types and self-sizing cells in the notifications table.

Fixes #8700 

This fixes just the tableView cells and section header.
The table header view ("what do you think about WordPress?") is not addressed. It's a beast of its own.

The changes necessary where mostly to clear the style cache when the user changes the system font size and change the font/attributes constants to computed properties, so they get new values after the font change.

**Design:**
I chose to use `.subheadline` font for the cells text since it was the most similar to the used before. It's still 1 point bigger for iPhone and 1 point smaller for iPad.

For the same reason I chose `.caption1` for the section header.

![1](https://user-images.githubusercontent.com/9772967/36593032-e78dda82-1876-11e8-9989-4daf19c478db.png)

**Review**
@iamthomasbishop Would you mind to take a look at the final result?
@jleandroperez This might be interesting for you too. I destroyed some of your art work in `WPStyleGuide+Notifications.swift` 😱

**Testing**
I recommend using the `Accessibility Inspector` with the Simulator to change font sizes easier:

- Run the app in the Simulator
- Open the 'Accessibility Inspector'
- Choose 'Simulator' as the inspector target.
- Visit the mentioned sections in the app.
- Change font size in the Accessibility Inspector