### PR TITLE
Fix WPBlogSelectorButton image position

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
@@ -15,14 +15,7 @@
     [button setImage:[UIImage imageNamed:@"icon-nav-chevron"] forState:UIControlStateNormal];
     [button setAccessibilityHint:NSLocalizedString(@"Tap to select which blog to post to", @"This is the blog picker in the editor")];
 
-    // Show image always in the opposite direction than a normal UIButton
     BOOL isLayoutLeftToRight = [button userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight;
-    if (isLayoutLeftToRight) {
-        button.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    } else {
-        button.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
-    }
-
     switch (button.buttonStyle) {
         case WPBlogSelectorButtonTypeSingleLine:
             button.titleLabel.numberOfLines = 1;
@@ -50,6 +43,25 @@
     }
     
     return button;
+}
+
+- (void)didMoveToSuperview
+{
+    [super didMoveToSuperview];
+    [self invertLayout];
+}
+
+/// Inverts the layout to show the image at the right side
+///
+- (void)invertLayout
+{
+    BOOL isLayoutLeftToRight = [self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight;
+
+    if (isLayoutLeftToRight) {
+        self.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
+    } else {
+        self.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
+    }
 }
 
 - (void)setButtonMode:(WPBlogSelectorButtonMode)value

--- a/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
@@ -51,7 +51,7 @@
     [self invertLayout];
 }
 
-/// Inverts the layout to show the image at the right side
+/// Inverts the layout to show the image on the trailing side
 ///
 - (void)invertLayout
 {


### PR DESCRIPTION
This PR fixes the position of the blog selector button image when restoring the app state from the editor

Fixes #8707 

This could be a UIKit bug (not sure). 
Fixed by changing when the `semanticContentAttribute` is set to flip the layout (and move the button image to the right)

To test:

- Build and run the app in Xcode
- Open the editor
- Exit to the home screen
- Stop the app in Xcode
- Re-run the app
- Blog picker button arrow should be at the right side of the button.