### PR TITLE
PluginStore: try to enable auto-update and the plugin itself after installation

### DIFF
--- a/WordPress/Classes/Stores/PluginStore.swift
+++ b/WordPress/Classes/Stores/PluginStore.swift
@@ -456,6 +456,8 @@ private extension PluginStore {
 
                 let message = String(format: NSLocalizedString("Succesfully installed %@.", comment: "Notice displayed after installing a plug-in."), installedPlugin.name)
                 ActionDispatcher.dispatch(NoticeAction.post(Notice(title: message)))
+                ActionDispatcher.dispatch(PluginAction.activate(id: installedPlugin.id, site: site))
+                ActionDispatcher.dispatch(PluginAction.enableAutoupdates(id: installedPlugin.id, site: site))
             },
             failure: { [weak self] error in
                 self?.state.updatesInProgress[site]?.remove(plugin.slug)

--- a/WordPress/Classes/Stores/PluginStore.swift
+++ b/WordPress/Classes/Stores/PluginStore.swift
@@ -6,6 +6,7 @@ enum PluginAction: Action {
     case deactivate(id: String, site: JetpackSiteRef)
     case enableAutoupdates(id: String, site: JetpackSiteRef)
     case disableAutoupdates(id: String, site: JetpackSiteRef)
+    case activateAndEnableAutoupdates(id: String, site: JetpackSiteRef)
     case install(plugin: PluginDirectoryEntry, site: JetpackSiteRef)
     case update(id: String, site: JetpackSiteRef)
     case remove(id: String, site: JetpackSiteRef)
@@ -246,6 +247,8 @@ class PluginStore: QueryStore<PluginStoreState, PluginQuery> {
             enableAutoupdatesPlugin(pluginID: pluginID, site: site)
         case .disableAutoupdates(let pluginID, let site):
             disableAutoupdatesPlugin(pluginID: pluginID, site: site)
+        case .activateAndEnableAutoupdates(let pluginID, let site):
+            activateAndEnableAutoupdatesPlugin(pluginID: pluginID, site: site)
         case .install(let plugin, let site):
             installPlugin(plugin: plugin, site: site)
         case .update(let pluginID, let site):
@@ -437,6 +440,25 @@ private extension PluginStore {
         })
     }
 
+    func activateAndEnableAutoupdatesPlugin(pluginID: String, site: JetpackSiteRef) {
+        guard getPlugin(id: pluginID, site: site) != nil else {
+            return
+        }
+        state.modifyPlugin(id: pluginID, site: site) { plugin in
+            plugin.autoupdate = true
+            plugin.active = true
+        }
+        remote(site: site)?.activateAndEnableAutoupdated(pluginID: pluginID,
+                                                         siteID: site.siteID,
+                                                         success: {},
+                                                         failure: { [weak self] error in
+                                                            self?.state.modifyPlugin(id: pluginID, site: site) { plugin in
+                                                                plugin.autoupdate = false
+                                                                plugin.active = false
+                                                            }
+        })
+    }
+
     func installPlugin(plugin: PluginDirectoryEntry, site: JetpackSiteRef) {
         guard let remote = remote(site: site), !isInstallingPlugin(site: site, slug: plugin.slug),
             getPlugin(slug: plugin.slug, site: site) == nil else {
@@ -456,8 +478,7 @@ private extension PluginStore {
 
                 let message = String(format: NSLocalizedString("Succesfully installed %@.", comment: "Notice displayed after installing a plug-in."), installedPlugin.name)
                 ActionDispatcher.dispatch(NoticeAction.post(Notice(title: message)))
-                ActionDispatcher.dispatch(PluginAction.activate(id: installedPlugin.id, site: site))
-                ActionDispatcher.dispatch(PluginAction.enableAutoupdates(id: installedPlugin.id, site: site))
+                ActionDispatcher.dispatch(PluginAction.activateAndEnableAutoupdates(id: installedPlugin.id, site: site))
             },
             failure: { [weak self] error in
                 self?.state.updatesInProgress[site]?.remove(plugin.slug)

--- a/WordPressKit/WordPressKit/PluginServiceRemote.swift
+++ b/WordPressKit/WordPressKit/PluginServiceRemote.swift
@@ -107,6 +107,14 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         modifyPlugin(parameters: parameters, pluginID: pluginID, siteID: siteID, success: success, failure: failure)
     }
 
+    public func activateAndEnableAutoupdated(pluginID: String, siteID: Int, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+        let parameters = [
+            "active": "true",
+            "autoupdate": "true"
+            ] as [String: AnyObject]
+        modifyPlugin(parameters: parameters, pluginID: pluginID, siteID: siteID, success: success, failure: failure)
+    }
+
     public func install(pluginSlug: String, siteID: Int, success: @escaping (PluginState) -> Void, failure: @escaping (Error) -> Void) {
         let endpoint = "sites/\(siteID)/plugins/\(pluginSlug)/install"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_2)!


### PR DESCRIPTION
This was delightfully simple to implement, thanks to the Store architecture.

To test:
1. Pick any plugin that's not installed yet 
2. Try to install it
3. Verify that that it'll get automatically enabled and the auto-updates will be enabled too.


