### PR TITLE
LoginFacade: Nuking dead login method

### DIFF
--- a/WordPress/Classes/Services/LoginFacade.h
+++ b/WordPress/Classes/Services/LoginFacade.h
@@ -20,15 +20,6 @@
  */
 - (void)signInWithLoginFields:(LoginFields *)loginFields;
 
-
-/**
- *  This method will attempt to sign in to a self hosted/.com site.
- *  XMLRPC endpoint discover is NOT performed.
- *
- *  @param loginFields the fields representing the site we are attempting to login to.
- */
-- (void)loginWithLoginFields:(LoginFields *)loginFields;
-
 /**
  *  This method will attempt to sign in to a self hosted/.com site.
  *  The XML-RPC endpoint should be present in the loginFields.siteUrl field.

--- a/WordPress/Classes/Services/LoginFacade.m
+++ b/WordPress/Classes/Services/LoginFacade.m
@@ -41,17 +41,6 @@
     }
 }
 
-- (void)loginWithLoginFields:(LoginFields *)loginFields
-{
-    NSAssert(self.delegate != nil, @"Must set delegate to use service");
-
-    if (loginFields.meta.userIsDotCom || loginFields.siteAddress.isWordPressComPath) {
-        [self signInToWordpressDotCom:loginFields];
-    } else {
-        [self loginToSelfHosted:loginFields];
-    }
-}
-
 - (void)requestOneTimeCodeWithLoginFields:(LoginFields *)loginFields
 {
     [self.wordpressComOAuthClientFacade requestOneTimeCodeWithUsername:loginFields.username password:loginFields.password success:^{
@@ -158,15 +147,15 @@
         loginFields.meta.xmlrpcURL = xmlRPCURL;
         [self loginToSelfHosted:loginFields];
     };
-    
-    void (^guessXMLRPCURLFailure)(NSError *) = ^(NSError *error){        
+
+    void (^guessXMLRPCURLFailure)(NSError *) = ^(NSError *error){
         [WPAppAnalytics track:WPAnalyticsStatLoginFailedToGuessXMLRPC error:error];
         [WPAppAnalytics track:WPAnalyticsStatLoginFailed error:error];
         [self.delegate displayRemoteError:error];
     };
-    
+
     [self.delegate displayLoginMessage:NSLocalizedString(@"Authenticating", nil)];
-    
+
     NSString *siteUrl = [NSURL IDNEncodedURL:loginFields.siteAddress];
     [self.wordpressXMLRPCAPIFacade guessXMLRPCURLForSite:siteUrl success:guessXMLRPCURLSuccess failure:guessXMLRPCURLFailure];
 }


### PR DESCRIPTION
### Details:
Accidentally stumbled upon a dead method, not being used _anywhere_. Please:

1. Verify WPiOS builds
2. Verify the unit tests stay green

Needs Review: @bummytime 
Sir, may i bug you with a superquick PR?

Thanks in advance!!


