### PR TITLE
Update Media Picker to 0.27

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.1'
   pod 'Gridicons', '0.14'
   pod 'NSURL+IDN', '0.3'
-  pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'a57ed6de4d5f8cec7c20712c5dae879e273ceed5'
+  pod 'WPMediaPicker', '0.27'
   pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'1b9e6398f054f8726cf40de9e9a2ace753804502'
 
   target 'WordPressTest' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -114,7 +114,7 @@ PODS:
   - SVProgressHUD (2.2.2)
   - UIDeviceIdentifier (0.5.0)
   - WordPress-Aztec-iOS (1.0.0-beta.18.1)
-  - WPMediaPicker (0.26)
+  - WPMediaPicker (0.27)
   - wpxmlrpc (0.8.3)
 
 DEPENDENCIES:
@@ -146,7 +146,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.2)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `1b9e6398f054f8726cf40de9e9a2ace753804502`)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `a57ed6de4d5f8cec7c20712c5dae879e273ceed5`)
+  - WPMediaPicker (= 0.27)
   - wpxmlrpc (= 0.8.3)
 
 EXTERNAL SOURCES:
@@ -156,9 +156,6 @@ EXTERNAL SOURCES:
   WordPress-Aztec-iOS:
     :commit: 1b9e6398f054f8726cf40de9e9a2ace753804502
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WPMediaPicker:
-    :commit: a57ed6de4d5f8cec7c20712c5dae879e273ceed5
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -167,9 +164,6 @@ CHECKOUT OPTIONS:
   WordPress-Aztec-iOS:
     :commit: 1b9e6398f054f8726cf40de9e9a2ace753804502
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WPMediaPicker:
-    :commit: a57ed6de4d5f8cec7c20712c5dae879e273ceed5
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -203,9 +197,9 @@ SPEC CHECKSUMS:
   SVProgressHUD: 59b2d3dabacbd051576d21d32293ca7228dc18b0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-Aztec-iOS: 2e99ee80c61ba9d5f5a38560043b273830f2c9d6
-  WPMediaPicker: 847c1f84f93fda7dda8cc9a8cbc1ffb6e47dea63
+  WPMediaPicker: 1fe532b4ff215a9dd259f08439376fc0dbab1039
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: cc9b815b05c4ecfa4f898cb2e437229c00375e05
+PODFILE CHECKSUM: e332228a2ce171e91ef3322c378b68d83239df4d
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
This PR updates the MediaPicker to 0.27. We were already pointing to the latest commit, but I've now pushed it as a formal release.
