### PR TITLE
Fix/7236 invite people self sizing cells

### DIFF
--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -115,6 +115,7 @@ class InvitePersonViewController: UITableViewController {
         setupNavigationBar()
         setupDefaultRole()
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
+        WPStyleGuide.configureAutomaticHeightRows(for: tableView)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -134,6 +135,16 @@ class InvitePersonViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
         WPStyleGuide.configureTableViewSectionFooter(view)
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        // Workaround for UIKit issue where labels text are set to nil
+        // when user changes system font size in static tables (dynamic type)
+        setupRoleCell()
+        refreshRoleCell()
+        refreshUsernameCell()
+        refreshMessageTextView()
+        return super.tableView(tableView, cellForRowAt: indexPath)
     }
 
 

--- a/WordPress/Classes/ViewRelated/People/RoleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/RoleViewController.swift
@@ -29,6 +29,7 @@ class RoleViewController: UITableViewController {
         title = NSLocalizedString("Role", comment: "User Roles Title")
         setupActivityIndicator()
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
+        WPStyleGuide.configureAutomaticHeightRows(for: tableView)
     }
 
     // MARK: - Private Helpers


### PR DESCRIPTION
Fixes partially #7236 

In `InvitePersonViewController`:
This PR implements a simple workaround to allow self-sizing cells respond correctly to user changes of font size (dynamic type) in a static table.

Since UIKit set the text to nil when the font size changes, we set them back when the cells reload. It's not too efficient but it's a small table.

I also added support for self-sizing cells in the `RoleViewController`. It was simple enough to add it together (+1 line).

**To test:**

Sections:
- Blog -> People -> Add (`InvitePersonViewController`)
- Blog -> People -> Add -> Role (`RoleViewController`)

Run the app in the Simulator

- Open the 'Accessibility Inspector' (Xcode dev tools)
- Choose 'Simulator' as the inspector target.
- Visit the mentioned sections in the app.
- Change font size in the Accessibility Inspector