### PR TITLE
Fix redirect extraction in connection flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackConnectionWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackConnectionWebViewController.swift
@@ -209,8 +209,7 @@ private extension JetpackConnectionWebViewController {
         return URLComponents(url: url, resolvingAgainstBaseURL: false)?
             .queryItems?
             .first(where: { $0.name == "redirect_to" })?
-            .value?
-            .removingPercentEncoding
+            .value
             .flatMap(URL.init(string:))
     }
 


### PR DESCRIPTION
The previous code was unnecessarily decoding the parameter, which meant
it would break when the blog title had some escaped characters.

To test:

- Make sure your site title has some punctuation in it (e.g. `Koke's .org Sandbox`)
- Go through the connection flow
- You should not see any error pages