### PR TITLE
Issue/8714 Consolidate Media tracking

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -133,7 +133,9 @@ class MediaCoordinator: NSObject {
                                     return
                                 }
 
-                                let uploadProgress = strongSelf.uploadMedia(media, origin: origin)
+                                strongSelf.trackUploadOf(media, origin: origin)
+
+                                let uploadProgress = strongSelf.uploadMedia(media)
                                 totalProgress.addChild(uploadProgress, withPendingUnitCount: MediaExportProgressUnits.threeQuartersDone)
         })
         processing(media)
@@ -231,7 +233,7 @@ class MediaCoordinator: NSObject {
                             failure: failure)
     }
 
-    @discardableResult private func uploadMedia(_ media: Media, origin: MediaUploadOrigin? = nil) -> Progress {
+    @discardableResult private func uploadMedia(_ media: Media) -> Progress {
         let service = MediaService(managedObjectContext: backgroundContext)
 
         var progress: Progress? = nil
@@ -239,7 +241,6 @@ class MediaCoordinator: NSObject {
         service.uploadMedia(media,
                             progress: &progress,
                             success: {
-                                self.trackUploadOf(media, origin: origin)
                                 self.end(media)
         }, failure: { error in
             guard let nserror = error as NSError? else {

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -85,9 +85,9 @@ class MediaCoordinator: NSObject {
     /// - parameter origin: The location in the app where the upload was initiated (optional).
     ///
     @discardableResult
-    func addMedia(from asset: ExportableAsset, to blog: Blog, origin: MediaUploadOrigin? = nil) -> Media {
+    func addMedia(from asset: ExportableAsset, to blog: Blog, analyticsInfo: MediaAnalyticsInfo? = nil) -> Media {
         let coordinator = mediaLibraryProgressCoordinator
-        return self.addMedia(from: asset, to: blog.objectID, coordinator: coordinator, origin: origin)
+        return self.addMedia(from: asset, to: blog.objectID, coordinator: coordinator, analyticsInfo: analyticsInfo)
     }
 
     /// Adds the specified media asset to the specified post. The upload process
@@ -98,13 +98,13 @@ class MediaCoordinator: NSObject {
     /// - parameter origin: The location in the app where the upload was initiated (optional).
     ///
     @discardableResult
-    func addMedia(from asset: ExportableAsset, to post: AbstractPost, origin: MediaUploadOrigin? = nil) -> Media {
+    func addMedia(from asset: ExportableAsset, to post: AbstractPost, analyticsInfo: MediaAnalyticsInfo? = nil) -> Media {
         let coordinator = self.coordinator(for: post)
-        return self.addMedia(from: asset, to: post.objectID, coordinator: coordinator, origin: origin)
+        return self.addMedia(from: asset, to: post.objectID, coordinator: coordinator, analyticsInfo: analyticsInfo)
     }
 
     @discardableResult
-    private func addMedia(from asset: ExportableAsset, to objectID: NSManagedObjectID, coordinator: MediaProgressCoordinator, origin: MediaUploadOrigin? = nil) -> Media {
+    private func addMedia(from asset: ExportableAsset, to objectID: NSManagedObjectID, coordinator: MediaProgressCoordinator, analyticsInfo: MediaAnalyticsInfo? = nil) -> Media {
         coordinator.track(numberOfItems: 1)
         let service = MediaService(managedObjectContext: mainContext)
         let totalProgress = Progress.discreteProgress(totalUnitCount: MediaExportProgressUnits.done)
@@ -133,7 +133,7 @@ class MediaCoordinator: NSObject {
                                     return
                                 }
 
-                                strongSelf.trackUploadOf(media, origin: origin)
+                                strongSelf.trackUploadOf(media, analyticsInfo: analyticsInfo)
 
                                 let uploadProgress = strongSelf.uploadMedia(media)
                                 totalProgress.addChild(uploadProgress, withPendingUnitCount: MediaExportProgressUnits.threeQuartersDone)
@@ -165,8 +165,9 @@ class MediaCoordinator: NSObject {
     /// Starts the upload of an already existing local media object
     ///
     /// - Parameter media: the media to upload
+    /// - parameter origin: The location in the app where the upload was initiated (optional).
     ///
-    func addMedia(_ media: Media) {
+    func addMedia(_ media: Media, analyticsInfo: MediaAnalyticsInfo? = nil) {
         guard media.remoteStatus == .local else {
             DDLogError("Can't try to upload Media that isn't local only. \(String(describing: media))")
             return
@@ -256,13 +257,13 @@ class MediaCoordinator: NSObject {
         }
     }
 
-    private func trackUploadOf(_ media: Media, origin: MediaUploadOrigin?) {
-        guard let origin = origin,
-            let event = origin.eventForMediaType(media.mediaType) else {
+    private func trackUploadOf(_ media: Media, analyticsInfo: MediaAnalyticsInfo?) {
+        guard let info = analyticsInfo,
+            let event = info.eventForMediaType(media.mediaType) else {
             return
         }
 
-        let properties = WPAppAnalytics.properties(for: media)
+        let properties = info.properties(for: media)
         WPAppAnalytics.track(event,
                              withProperties: properties,
                              with: media.blog)
@@ -576,23 +577,5 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
 extension Media {
     var uploadID: String {
         return objectID.uriRepresentation().absoluteString
-    }
-}
-
-/// Used for analytics to track where an upload was started within the app.
-/// Currently only supports media library, but we'll add editor support
-/// when we bring async there.
-///
-enum MediaUploadOrigin {
-    case mediaLibrary
-
-    func eventForMediaType(_ mediaType: MediaType) -> WPAnalyticsStat? {
-        switch (self, mediaType) {
-        case (.mediaLibrary, .image):
-            return .mediaLibraryAddedPhoto
-        case (.mediaLibrary, .video):
-            return .mediaLibraryAddedVideo
-        default: return nil
-        }
     }
 }

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -150,11 +150,13 @@ class MediaCoordinator: NSObject {
     ///
     /// - Parameter media: the media object to retry the upload
     ///
-    func retryMedia(_ media: Media) {
+    func retryMedia(_ media: Media, analyticsInfo: MediaAnalyticsInfo? = nil) {
         guard media.remoteStatus == .failed else {
             DDLogError("Can't retry Media upload that hasn't failed. \(String(describing: media))")
             return
         }
+
+        trackRetryUploadOf(media, analyticsInfo: analyticsInfo)
 
         let coordinator = self.coordinator(for: media)
         coordinator.track(numberOfItems: 1)
@@ -261,6 +263,18 @@ class MediaCoordinator: NSObject {
         guard let info = analyticsInfo,
             let event = info.eventForMediaType(media.mediaType) else {
             return
+        }
+
+        let properties = info.properties(for: media)
+        WPAppAnalytics.track(event,
+                             withProperties: properties,
+                             with: media.blog)
+    }
+
+    private func trackRetryUploadOf(_ media: Media, analyticsInfo: MediaAnalyticsInfo?) {
+        guard let info = analyticsInfo,
+            let event = info.retryEvent else {
+                return
         }
 
         let properties = info.properties(for: media)

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -584,6 +584,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatMediaLibraryAddedVideo:
             eventName = @"media_library_video_added";
             break;
+        case WPAnalyticsStatMediaLibraryUploadMediaRetried:
+            eventName = @"media_library_upload_media_retried";
+            break;
         case WPAnalyticsStatMediaServiceUploadStarted:
             eventName = @"media_service_upload_started";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
@@ -62,7 +62,7 @@ public struct MediaAnalyticsInfo {
         switch origin {
         case .mediaLibrary:
             return nil
-        case .editor(_):
+        case .editor:
             return .editorUploadMediaRetried
         }
     }

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
@@ -54,6 +54,11 @@ public struct MediaAnalyticsInfo {
     let origin: MediaUploadOrigin
     let selectionMethod: MediaSelectionMethod?
 
+    init(origin: MediaUploadOrigin, selectionMethod: MediaSelectionMethod? = nil) {
+        self.origin = origin
+        self.selectionMethod = selectionMethod
+    }
+
     func eventForMediaType(_ mediaType: MediaType) -> WPAnalyticsStat? {
         return origin.eventForMediaType(mediaType)
     }
@@ -61,7 +66,7 @@ public struct MediaAnalyticsInfo {
     var retryEvent: WPAnalyticsStat? {
         switch origin {
         case .mediaLibrary:
-            return nil
+            return .mediaLibraryUploadMediaRetried
         case .editor:
             return .editorUploadMediaRetried
         }

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
@@ -58,6 +58,15 @@ public struct MediaAnalyticsInfo {
         return origin.eventForMediaType(mediaType)
     }
 
+    var retryEvent: WPAnalyticsStat? {
+        switch origin {
+        case .mediaLibrary:
+            return nil
+        case .editor(_):
+            return .editorUploadMediaRetried
+        }
+    }
+
     func properties(for media: Media) -> [String: Any] {
         guard let selectionMethod = selectionMethod else {
             return WPAppAnalytics.properties(for: media)
@@ -119,6 +128,7 @@ enum MediaUploadOrigin {
 /// Used for analytics to track the source of a media item
 ///
 enum MediaSource {
+    case none
     case deviceLibrary
     case otherApps
     case wpMediaLibrary

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2904,8 +2904,9 @@ extension AztecPostViewController {
         resetMediaAttachmentOverlay(attachment)
         attachment.progress = 0
         richTextView.refresh(attachment)
-        mediaCoordinator.retryMedia(media)
-        WPAppAnalytics.track(.editorUploadMediaRetried, withProperties: WPAppAnalytics.properties(for: media, selectionMethod: mediaSelectionMethod), with: self.post.blog)
+
+        let info = MediaAnalyticsInfo(origin: .editor(.none), selectionMethod: mediaSelectionMethod)
+        mediaCoordinator.retryMedia(media, analyticsInfo: info)
     }
 
     fileprivate func processMediaAttachments() {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -344,7 +344,8 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             }
             if media.absoluteLocalURL != nil {
                 alertController.addDefaultActionWithTitle(NSLocalizedString("Retry Upload", comment: "User action to retry media upload.")) { _ in
-                    MediaCoordinator.shared.retryMedia(media)
+                    let info = MediaAnalyticsInfo(origin: .mediaLibrary)
+                    MediaCoordinator.shared.retryMedia(media, analyticsInfo: info)
                 }
             } else {
                 alertController.addDefaultActionWithTitle(NSLocalizedString("Delete", comment: "User action to delete media.")) { _ in

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -464,7 +464,8 @@ class MediaLibraryViewController: WPMediaPickerViewController {
                 return
             }
 
-            MediaCoordinator.shared.addMedia(from: media, to: blog, origin: .mediaLibrary)
+            let info = MediaAnalyticsInfo(origin: .mediaLibrary, selectionMethod: .fullScreenPicker)
+            MediaCoordinator.shared.addMedia(from: media, to: blog, analyticsInfo: info)
         }
 
         guard let mediaType = mediaInfo[UIImagePickerControllerMediaType] as? String else { return }
@@ -490,7 +491,8 @@ class MediaLibraryViewController: WPMediaPickerViewController {
 extension MediaLibraryViewController: UIDocumentPickerDelegate {
     func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
         for documentURL in urls as [NSURL] {
-            MediaCoordinator.shared.addMedia(from: documentURL, to: blog, origin: .mediaLibrary)
+            let info = MediaAnalyticsInfo(origin: .mediaLibrary, selectionMethod: .documentPicker)
+            MediaCoordinator.shared.addMedia(from: documentURL, to: blog, analyticsInfo: info)
         }
     }
 
@@ -535,7 +537,8 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
             assets.count > 0 else { return }
 
         for asset in assets {
-            MediaCoordinator.shared.addMedia(from: asset, to: blog, origin: .mediaLibrary)
+            let info = MediaAnalyticsInfo(origin: .mediaLibrary, selectionMethod: .fullScreenPicker)
+            MediaCoordinator.shared.addMedia(from: asset, to: blog, analyticsInfo: info)
         }
     }
 

--- a/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -124,6 +124,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatMediaLibrarySharedItemLink,
     WPAnalyticsStatMediaLibraryAddedPhoto,
     WPAnalyticsStatMediaLibraryAddedVideo,
+    WPAnalyticsStatMediaLibraryUploadMediaRetried,
     WPAnalyticsStatMediaServiceUploadStarted,
     WPAnalyticsStatMediaServiceUploadFailed,
     WPAnalyticsStatMediaServiceUploadSuccessful,


### PR DESCRIPTION
Fixes #8714.

This PR moves tracking events for adding photos and videos into `MediaCoordinator`. Previously, Aztec did its own tracking of these events. It also moves the "editorAddedPhoto" / "mediaLibraryAddedPhoto" etc events to be posted just before the upload takes place – previously, we were waiting for a successful result. This is in line with Android, and I think makes sense as we still post a MediaService success / failure event depending on the result.

We needed to pass some extra information forward to the coordinator to track editor events properly (previously we were just passing the 'origin' – media library or editor). I've added a smaller wrapper to handle this, called `MediaAnalyticsInfo`.

**To test:**

* Open up the Tracks live view for your test user, run through each of the following scenarios, and check the correct data is tracked. Note that events may take a while (10, 20 minutes) to show up in the live view.
* Media library: Add a photo from the device
* Media library: Add a video from the device
* Media library: Add media from another app
* Aztec: Add a photo from the inline picker
* Aztec: Add a video from the inline picker
* Aztec: Add a photo from the full screen picker
* Aztec: Add a video from the full screen picker
* Aztec: Add a photo from the WP media library
* Aztec: Add a video from the WP media library
* Aztec: Add a photo from another app
* Aztec: Add a video from another app

Ensure the correct event is posted – either `editor_photo_added`, `editor_video_added`, `media_library_photo_added`, or `media_library_video_added`. For the editor events, there should be a `via` property which contains where the media came from - local library, remote library, other apps. For all events, there should also be a `media_origin` property – inline picker, fullscreen picker, etc.