### PR TITLE
Activity log: feed design v2

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityListSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListSectionHeaderView.xib
@@ -22,8 +22,8 @@
                 </view>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rTR-ms-4m0">
                     <rect key="frame" x="16" y="12" width="288" height="26"/>
-                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                    <color key="textColor" red="0.37623882293701172" green="0.47978341579437256" blue="0.57279956340789795" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                    <color key="textColor" red="0.30980392156862746" green="0.45490196078431372" blue="0.55686274509803924" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -34,7 +34,7 @@ open class ActivityTableViewCell: WPTableViewCell {
             rewindIcon.isHidden = true
         } else {
             contentView.backgroundColor = Style.backgroundColor()
-            rewindIcon.isHidden = !activity.rewindable
+            rewindIconContainer.isHidden  = !activity.rewindable
         }
     }
 
@@ -51,5 +51,6 @@ open class ActivityTableViewCell: WPTableViewCell {
     @IBOutlet fileprivate var iconImageView: UIImageView!
     @IBOutlet fileprivate var contentLabel: UILabel!
     @IBOutlet fileprivate var summaryLabel: UILabel!
+    @IBOutlet fileprivate var rewindIconContainer: UIView!
     @IBOutlet fileprivate var rewindIcon: UIImageView!
 }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.xib
@@ -6,68 +6,87 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="Upg-EE-wRd" customClass="ActivityTableViewCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="74"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="61" id="Upg-EE-wRd" customClass="ActivityTableViewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="61"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Upg-EE-wRd" id="p6H-P7-J7f">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="73.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="60.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0Gm-n3-CNm" userLabel="icon" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="10" y="13" width="46" height="46"/>
-                    </imageView>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="TCy-wp-wTe">
-                        <rect key="frame" x="64" y="16.5" width="211" height="40.5"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wDk-1k-6n4">
-                                <rect key="frame" x="0.0" y="0.0" width="211" height="20.5"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wVX-To-MrZ">
-                                <rect key="frame" x="0.0" y="22.5" width="211" height="18"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                <color key="textColor" red="0.4349169135093689" green="0.55408048629760742" blue="0.65517556667327881" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
-                        <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
-                    </stackView>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0lh-9o-ekV">
-                        <rect key="frame" x="281" y="24" width="24" height="24"/>
+                        <rect key="frame" x="16" y="11" width="38" height="38"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="24" id="LgG-Ii-fpv"/>
-                            <constraint firstAttribute="width" constant="24" id="mV7-T4-hKK"/>
+                            <constraint firstAttribute="height" constant="38" id="2gR-WZ-UxT"/>
+                            <constraint firstAttribute="width" constant="38" id="DVY-mp-ll8"/>
                         </constraints>
                     </imageView>
-                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RzG-YS-PIa">
-                        <rect key="frame" x="21" y="24" width="24" height="24"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="myo-BJ-PwG">
+                        <rect key="frame" x="64" y="11" width="240" height="38"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="TCy-wp-wTe">
+                                <rect key="frame" x="0.0" y="0.0" width="218" height="38"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wDk-1k-6n4">
+                                        <rect key="frame" x="0.0" y="0.0" width="218" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wVX-To-MrZ">
+                                        <rect key="frame" x="0.0" y="22.5" width="218" height="15.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                        <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
+                            </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mPY-S3-ymc">
+                                <rect key="frame" x="222" y="0.0" width="18" height="38"/>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0lh-9o-ekV">
+                                        <rect key="frame" x="0.0" y="10" width="18" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="18" id="LgG-Ii-fpv"/>
+                                            <constraint firstAttribute="width" constant="18" id="mV7-T4-hKK"/>
+                                        </constraints>
+                                    </imageView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="18" id="60X-ML-RFP"/>
+                                    <constraint firstItem="0lh-9o-ekV" firstAttribute="centerY" secondItem="mPY-S3-ymc" secondAttribute="centerY" id="Ago-3T-bGB"/>
+                                    <constraint firstItem="0lh-9o-ekV" firstAttribute="centerX" secondItem="mPY-S3-ymc" secondAttribute="centerX" id="K83-tQ-VsU"/>
+                                </constraints>
+                            </view>
+                        </subviews>
                         <constraints>
-                            <constraint firstAttribute="width" constant="24" id="QMf-o8-jUg"/>
-                            <constraint firstAttribute="height" constant="24" id="v1f-H3-n69"/>
+                            <constraint firstItem="mPY-S3-ymc" firstAttribute="top" secondItem="myo-BJ-PwG" secondAttribute="top" id="8P5-cK-CoR"/>
+                            <constraint firstAttribute="trailing" secondItem="mPY-S3-ymc" secondAttribute="trailing" id="zH1-KX-1aB"/>
+                        </constraints>
+                    </stackView>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RzG-YS-PIa">
+                        <rect key="frame" x="23" y="18" width="24" height="24"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="24" id="Paz-2X-1nw"/>
+                            <constraint firstAttribute="width" constant="24" id="wQf-nD-j4p"/>
                         </constraints>
                     </imageView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailing" secondItem="TCy-wp-wTe" secondAttribute="trailing" constant="45" id="0oE-5U-SQT"/>
-                    <constraint firstItem="TCy-wp-wTe" firstAttribute="centerY" secondItem="p6H-P7-J7f" secondAttribute="centerY" id="C8d-4Z-PfM"/>
-                    <constraint firstItem="RzG-YS-PIa" firstAttribute="centerX" secondItem="0Gm-n3-CNm" secondAttribute="centerX" id="L3r-zV-wCL"/>
-                    <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="topMargin" constant="2" id="L9J-ix-0rd"/>
-                    <constraint firstItem="RzG-YS-PIa" firstAttribute="centerY" secondItem="0Gm-n3-CNm" secondAttribute="centerY" id="OWl-vB-Ogj"/>
-                    <constraint firstItem="0Gm-n3-CNm" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leadingMargin" constant="-6" id="WWd-O4-jdV"/>
-                    <constraint firstItem="0Gm-n3-CNm" firstAttribute="centerY" secondItem="p6H-P7-J7f" secondAttribute="centerY" id="XJ7-jd-HAr"/>
-                    <constraint firstItem="TCy-wp-wTe" firstAttribute="leading" secondItem="0Gm-n3-CNm" secondAttribute="trailing" constant="8" symbolic="YES" id="Z4j-ub-4hK"/>
-                    <constraint firstItem="0lh-9o-ekV" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="topMargin" constant="13" id="iFV-eU-vyW"/>
-                    <constraint firstItem="0lh-9o-ekV" firstAttribute="centerY" secondItem="p6H-P7-J7f" secondAttribute="centerY" id="mWj-F5-WNl"/>
-                    <constraint firstItem="TCy-wp-wTe" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leading" constant="64" id="s8e-8L-e8s"/>
-                    <constraint firstAttribute="trailing" secondItem="0lh-9o-ekV" secondAttribute="trailing" constant="15" id="wXY-aQ-Z2t"/>
+                    <constraint firstAttribute="bottom" secondItem="myo-BJ-PwG" secondAttribute="bottom" constant="11" id="4vx-5J-w77"/>
+                    <constraint firstItem="myo-BJ-PwG" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="top" constant="11" id="9zi-nz-6mI"/>
+                    <constraint firstItem="RzG-YS-PIa" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leading" constant="23" id="DE5-Er-mqx"/>
+                    <constraint firstItem="0Gm-n3-CNm" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="top" constant="11" id="Dia-4Q-RmS"/>
+                    <constraint firstItem="myo-BJ-PwG" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leading" constant="64" id="KNm-Ex-SA7"/>
+                    <constraint firstAttribute="trailing" secondItem="myo-BJ-PwG" secondAttribute="trailing" constant="16" id="XpT-mQ-lI9"/>
+                    <constraint firstItem="0Gm-n3-CNm" firstAttribute="leading" secondItem="p6H-P7-J7f" secondAttribute="leading" constant="16" id="esq-dG-6ro"/>
+                    <constraint firstItem="RzG-YS-PIa" firstAttribute="top" secondItem="p6H-P7-J7f" secondAttribute="top" constant="18" id="ycT-xN-l9w"/>
                 </constraints>
             </tableViewCellContentView>
             <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -76,9 +95,10 @@
                 <outlet property="iconBackgroundImageView" destination="0Gm-n3-CNm" id="fGa-Im-Uyk"/>
                 <outlet property="iconImageView" destination="RzG-YS-PIa" id="ipG-B7-oYT"/>
                 <outlet property="rewindIcon" destination="0lh-9o-ekV" id="VWL-O9-f2T"/>
+                <outlet property="rewindIconContainer" destination="mPY-S3-ymc" id="qaR-1A-xJG"/>
                 <outlet property="summaryLabel" destination="wVX-To-MrZ" id="mTZ-pq-Wt4"/>
             </connections>
-            <point key="canvasLocation" x="34" y="56"/>
+            <point key="canvasLocation" x="34" y="49.5"/>
         </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
**Another step in** #7832 

**To test:**

Check that the activity log feed looks as specified by MT on the v2 design. 

Before | After
-|-
![albefore](https://user-images.githubusercontent.com/5558824/36806201-0a7c07f0-1c9e-11e8-881a-44c85810f288.png)|![alafter](https://user-images.githubusercontent.com/5558824/36806204-0c91671a-1c9e-11e8-8a7a-003a1d98b471.png)




