### PR TITLE
Fix loss of custom display name and password in SignupEpilogueTableViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -191,9 +191,13 @@ private extension SignupEpilogueTableViewController {
             userInfo = LoginEpilogueUserInfo(account: account, loginFields: loginFields)
         } else {
             userInfo = LoginEpilogueUserInfo(account: account)
-            let autoDisplayName = generateDisplayName(from: userInfo.email)
-            userInfo.fullName = autoDisplayName
-            delegate?.displayNameUpdated(newDisplayName: autoDisplayName)
+            if let customDisplayName = dataSource?.customDisplayName {
+                userInfo.fullName = customDisplayName
+            } else {
+                let autoDisplayName = generateDisplayName(from: userInfo.email)
+                userInfo.fullName = autoDisplayName
+                delegate?.displayNameUpdated(newDisplayName: autoDisplayName)
+            }
         }
         epilogueUserInfo = userInfo
     }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -6,10 +6,18 @@ protocol SignupEpilogueTableViewControllerDelegate {
     func usernameTapped(userInfo: LoginEpilogueUserInfo?)
 }
 
+/// Data source to get updated temporary user info, not yet saved in the user account.
+///
+protocol SignupEpilogueTableViewControllerDataSource {
+    var customDisplayName: String? { get }
+    var password: String? { get }
+}
+
 class SignupEpilogueTableViewController: NUXTableViewController {
 
     // MARK: - Properties
 
+    open var dataSource: SignupEpilogueTableViewControllerDataSource?
     open var delegate: SignupEpilogueTableViewControllerDelegate?
 
     private var epilogueUserInfo: LoginEpilogueUserInfo?
@@ -214,7 +222,7 @@ private extension SignupEpilogueTableViewController {
         case .displayName:
             cell.configureCell(forType: .displayName,
                                labelText: NSLocalizedString("Display Name", comment: "Display Name label text."),
-                               fieldValue: epilogueUserInfo?.fullName)
+                               fieldValue: dataSource?.customDisplayName ?? epilogueUserInfo?.fullName)
         case .username:
             cell.configureCell(forType: .username,
                                labelText: NSLocalizedString("Username", comment: "Username label text."),
@@ -222,7 +230,7 @@ private extension SignupEpilogueTableViewController {
         case .password:
             cell.configureCell(forType: .password,
                                labelText: NSLocalizedString("Password", comment: "Password label text."),
-                               fieldValue: nil,
+                               fieldValue: dataSource?.password,
                                fieldPlaceholder: NSLocalizedString("Optional", comment: "Password field placeholder text"))
         }
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -6,7 +6,7 @@ protocol SignupEpilogueTableViewControllerDelegate {
     func usernameTapped(userInfo: LoginEpilogueUserInfo?)
 }
 
-/// Data source to get updated temporary user info, not yet saved in the user account.
+/// Data source to get the temporary user info, not yet saved in the user account.
 ///
 protocol SignupEpilogueTableViewControllerDataSource {
     var customDisplayName: String? { get }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -29,6 +29,7 @@ class SignupEpilogueViewController: NUXViewController {
 
         if let vc = segue.destination as? SignupEpilogueTableViewController {
             vc.loginFields = loginFields
+            vc.dataSource = self
             vc.delegate = self
         }
 
@@ -54,6 +55,18 @@ extension SignupEpilogueViewController: NUXButtonViewControllerDelegate {
         } else {
             navigationController?.dismiss(animated: true, completion: nil)
         }
+    }
+}
+
+// MARK: - SignupEpilogueTableViewControllerDataSource
+
+extension SignupEpilogueViewController: SignupEpilogueTableViewControllerDataSource {
+    var customDisplayName: String? {
+        return updatedDisplayName
+    }
+
+    var password: String? {
+        return updatedPassword
     }
 }
 


### PR DESCRIPTION
Fixes #8749 

Not just the display name but also the password field were lost when coming back to the `SignupEpilogueTableViewController` from other controllers.

This PR fixes both issues.

To test:

1. Select the Signup button.
2. Select "Sign up with email."
3. Enter a new email address and tap "Next."
4. Open the mail app and tap the button in the magic link email.
5. On the New Account screen, change your Display Name.
6. Write a password
7. Tap on Username to open the Change Username screen.
8. Tap "Back" (you don't have to make any username changes).

Result: Both Display Name and password should be the same you just wrote, and not go back to the default.
