### PR TITLE
Redirect to login on signup when email is already registered

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Signup.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Signup.storyboard
@@ -133,6 +133,7 @@
                         <outlet property="instructionLabel" destination="CPF-7g-0y5" id="Urr-Xa-YNp"/>
                         <outlet property="submitButton" destination="4Su-Zc-Omp" id="amJ-9P-tcO"/>
                         <segue destination="Je3-5O-NYu" kind="show" identifier="showLinkMailView" id="Yop-RV-xJa"/>
+                        <segue destination="J8B-jx-UJD" kind="show" identifier="showEmailLogin" id="1cg-nu-IEn"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="OAN-7g-PQl" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -334,6 +335,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="XrP-NU-nZR" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-147" y="-315"/>
+        </scene>
+        <!--emailEntry-->
+        <scene sceneID="JU2-CA-QR6">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Login" referencedIdentifier="emailEntry" id="J8B-jx-UJD" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Y5k-uW-muf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-346" y="-127"/>
         </scene>
     </scenes>
     <resources>

--- a/WordPress/Classes/ViewRelated/NUX/SignupEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEmailViewController.swift
@@ -146,8 +146,8 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         remote.isEmailAvailable(loginFields.emailAddress, success: { available in
             if !available {
-                // If email address is unavailable, display appropriate message.
-                self.displayError(message: ErrorMessage.emailUnavailable.description())
+                // If the user has already signed up redirect to the Login flow
+                self.performSegue(withIdentifier: .showEmailLogin, sender: self)
             }
             completion(available)
         }, failure: { error in
@@ -158,6 +158,15 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
             self.displayError(message: ErrorMessage.availabilityCheckFail.description())
             completion(false)
         })
+    }
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        super.prepare(for: segue, sender: sender)
+        // Configure login flow to allow only .com login and prefill the email
+        if let destination = segue.destination as? LoginEmailViewController {
+            destination.restrictToWPCom = true
+            destination.loginFields.username = loginFields.emailAddress
+        }
     }
 
     // MARK: - Send email


### PR DESCRIPTION
**Fixes** #8748 

**To test:**

Test both from a fresh install and from the Me tab:
1. Try to sign up with an already registered email.
2. Check that you are redirected to the login flow and the email field is pre-filled.
3. Check that you can login with password, magic link and google.
4. Check that canceling the flow works as expected.

@nheagy @ScoutHarris I'm not sure if this is how you would've implemented this one, feel free to commit to this branch with any changes/improvements as you see fit.


