### PR TITLE
Plugin Directory: add "auto-managed" status for sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryAccessoryItem.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryAccessoryItem.swift
@@ -8,6 +8,10 @@ struct PluginDirectoryAccessoryItem {
     }
 
     static func accessoryView(pluginState: PluginState) -> UIView {
+        guard !pluginState.automanaged else {
+            return PluginDirectoryAccessoryItem.automanaged()
+        }
+
         guard pluginState.active else {
             return PluginDirectoryAccessoryItem.inactive()
         }
@@ -20,6 +24,14 @@ struct PluginDirectoryAccessoryItem {
         case .updated:
             return PluginDirectoryAccessoryItem.active()
         }
+    }
+
+    private static func automanaged() -> UIView {
+        let icon = Gridicon.iconOfType(.domains, withSize: Constants.imageSize)
+        let color = WPStyleGuide.validGreen()
+        let text = NSLocalizedString("Auto-managed", comment: "Describes a status of a plugin")
+
+        return PluginDirectoryAccessoryItem.label(with: icon, tintColor: color, text: text)
     }
 
     private static func active() -> UIView {


### PR DESCRIPTION
Calypso hides active/inactive status of `automanaged` plug-ins, since their states are somewhat of a implementation detail. We weren't respecting it. Now we are:

@mattmiklic I improvised on the icon to use here (the globe), let me know if you'd prefer something else.

![simulator screen shot - iphone 8 plus - 2018-03-01 at 21 19 27](https://user-images.githubusercontent.com/1594081/36851595-244be6f6-1d9c-11e8-807b-6baf8b0ff6b7.png)


Fixes #8772 (and I'm pretty sure also #8755).

To test:
1. Go to plugin directory
2. Make sure that the `automanaged` plugins (Akismet, JPOP, VP...) now display "Auto-managed" in their status label.


