### PR TITLE
Username search crash

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -109,7 +109,7 @@ extension SignupUsernameTableViewController {
         case Sections.titleAndDescription.rawValue:
             return 1
         case Sections.searchField.rawValue:
-            return suggestions.count > 0 ? 1 : 0
+            return 1
         case Sections.suggestions.rawValue:
             return suggestions.count + 1
         default:


### PR DESCRIPTION
Fixes #8777 

This PR fixes a crash when searching for a new Username with a short text, assuming that we don't want to ever hide the search field cell.

![no-crash](https://user-images.githubusercontent.com/9772967/36854844-c86b7a86-1d50-11e8-80d5-f4a989cf3929.gif)

cc @elibud 