### PR TITLE
Dismiss Google sign up flow according to user status

### DIFF
--- a/WordPress/Classes/Services/SignupService.swift
+++ b/WordPress/Classes/Services/SignupService.swift
@@ -173,8 +173,17 @@ open class SignupService: LocalCoreDataService {
                                         }
 
                                         let createdAccount = (responseDictionary?[ResponseKeys.createdAccount] as? Int ?? 0) == 1
-                                        success(createdAccount)
-
+                                        if createdAccount {
+                                            success(createdAccount)
+                                        } else {
+                                            // we need to sync the blogs for existing accounts to be able to display the Login Epilogue
+                                            BlogSyncFacade().syncBlogs(for: account, success: {
+                                                success(createdAccount)
+                                            }, failure: { (_) in
+                                                // the blog sync failed but the user is already logged in
+                                                success(createdAccount)
+                                            })
+                                        }
                                     },
                                     failure: failure)
     }

--- a/WordPress/Classes/Services/SignupService.swift
+++ b/WordPress/Classes/Services/SignupService.swift
@@ -15,6 +15,7 @@ enum SignupStatus: Int {
 
 typealias SignupStatusBlock = (_ status: SignupStatus) -> Void
 typealias SignupSuccessBlock = () -> Void
+typealias SignupSocialSuccessBlock = (_ newAccount: Bool) -> Void
 typealias SignupFailureBlock = (_ error: Error?) -> Void
 
 
@@ -149,7 +150,7 @@ open class SignupService: LocalCoreDataService {
     ///   - success: block called when account is created successfully
     ///   - failure: block called when account creation fails
     func createWPComeUserWithGoogle(token: String,
-                                   success: @escaping SignupSuccessBlock,
+                                   success: @escaping SignupSocialSuccessBlock,
                                    failure: @escaping SignupFailureBlock) {
         let remote = WordPressComServiceRemote(wordPressComRestApi: self.anonymousApi())
 
@@ -171,7 +172,9 @@ open class SignupService: LocalCoreDataService {
                                             service.setDefaultWordPressComAccount(account)
                                         }
 
-                                        success()
+                                        let createdAccount = (responseDictionary?[ResponseKeys.createdAccount] as? Int ?? 0) == 1
+                                        success(createdAccount)
+
                                     },
                                     failure: failure)
     }
@@ -322,5 +325,6 @@ open class SignupService: LocalCoreDataService {
     private struct ResponseKeys {
         static let bearerToken = "bearer_token"
         static let username = "username"
+        static let createdAccount = "created_account"
     }
 }

--- a/WordPress/Classes/Services/SignupService.swift
+++ b/WordPress/Classes/Services/SignupService.swift
@@ -149,7 +149,7 @@ open class SignupService: LocalCoreDataService {
     ///   - token: the token from a successful Google login
     ///   - success: block called when account is created successfully
     ///   - failure: block called when account creation fails
-    func createWPComeUserWithGoogle(token: String,
+    func createWPComUserWithGoogle(token: String,
                                    success: @escaping SignupSocialSuccessBlock,
                                    failure: @escaping SignupFailureBlock) {
         let remote = WordPressComServiceRemote(wordPressComRestApi: self.anonymousApi())

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
@@ -14,8 +14,12 @@ struct LoginEpilogueUserInfo {
         if let name = account.username {
             username = name
         }
-        email = account.email
-        fullName = account.displayName
+        if let accountEmail = account.email {
+            email = accountEmail
+        }
+        if let displayName = account.displayName {
+            fullName = displayName
+        }
     }
 
     init(account: WPAccount, loginFields: LoginFields) {

--- a/WordPress/Classes/ViewRelated/NUX/NUXViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXViewController.swift
@@ -39,6 +39,7 @@ class NUXViewController: UIViewController, NUXViewControllerBase, UIViewControll
         case showSiteCreationEpilogue
         case showSiteCreationError
         case showSignupEpilogue
+        case showLoginEpilogue
         case showUsernames
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/Signup.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Signup.storyboard
@@ -177,6 +177,7 @@
                     <connections>
                         <outlet property="titleLabel" destination="fiA-2f-xfj" id="gJJ-nI-Zmw"/>
                         <segue destination="xt0-gh-hzg" kind="show" identifier="showSignupEpilogue" id="LGz-VK-bVX"/>
+                        <segue destination="CN5-i0-0hC" kind="show" identifier="showLoginEpilogue" id="zgv-9q-Usa"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5UK-0h-9ZC" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -327,6 +328,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="GCN-8K-LcG" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="165" y="784"/>
+        </scene>
+        <!--LoginEpilogue-->
+        <scene sceneID="t07-8v-Z85">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Login" referencedIdentifier="LoginEpilogue" id="CN5-i0-0hC" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="2cP-Rt-jfP" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-286" y="1097"/>
         </scene>
         <!--ButtonView-->
         <scene sceneID="S07-eQ-m0X">

--- a/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
@@ -75,7 +75,7 @@ extension SignupGoogleViewController: GIDSignInDelegate {
                 self?.performSegue(withIdentifier: .showSignupEpilogue, sender: self)
                 WPAnalytics.track(.signupSocialSuccess)
             } else {
-                self?.navigationController?.dismiss(animated: true, completion: nil)
+                self?.performSegue(withIdentifier: .showLoginEpilogue, sender: self)
                 WPAnalytics.track(.loginSocialSuccess)
             }
         }) { [weak self] (error) in

--- a/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
@@ -85,6 +85,8 @@ extension SignupGoogleViewController: GIDSignInDelegate {
                 self?.navigationController?.popViewController(animated: true)
                 return
             }
+            self?.titleLabel?.text = NSLocalizedString("Google sign up failed.",
+                                                       comment: "Message shown on screen after the Google sign up process failed.")
             self?.displayError(error as NSError, sourceTag: .wpComSignup)
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
@@ -69,10 +69,15 @@ extension SignupGoogleViewController: GIDSignInDelegate {
 
         let context = ContextManager.sharedInstance().mainContext
         let service = SignupService(managedObjectContext: context)
-        service.createWPComeUserWithGoogle(token: token, success: { [weak self] in
+        service.createWPComeUserWithGoogle(token: token, success: { [weak self] (accountCreated) in
             SVProgressHUD.dismiss()
-            self?.performSegue(withIdentifier: .showSignupEpilogue, sender: self)
-            WPAnalytics.track(.signupSocialSuccess)
+            if accountCreated {
+                self?.performSegue(withIdentifier: .showSignupEpilogue, sender: self)
+                WPAnalytics.track(.signupSocialSuccess)
+            } else {
+                self?.navigationController?.dismiss(animated: true, completion: nil)
+                WPAnalytics.track(.loginSocialSuccess)
+            }
         }) { [weak self] (error) in
             SVProgressHUD.dismiss()
             WPAnalytics.track(.signupSocialFailure)

--- a/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
@@ -69,7 +69,7 @@ extension SignupGoogleViewController: GIDSignInDelegate {
 
         let context = ContextManager.sharedInstance().mainContext
         let service = SignupService(managedObjectContext: context)
-        service.createWPComeUserWithGoogle(token: token, success: { [weak self] (accountCreated) in
+        service.createWPComUserWithGoogle(token: token, success: { [weak self] (accountCreated) in
             SVProgressHUD.dismiss()
             if accountCreated {
                 self?.performSegue(withIdentifier: .showSignupEpilogue, sender: self)

--- a/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
@@ -85,6 +85,7 @@ extension SignupGoogleViewController: GIDSignInDelegate {
                 self?.navigationController?.popViewController(animated: true)
                 return
             }
+            self?.titleLabel?.textColor = WPStyleGuide.errorRed()
             self?.titleLabel?.text = NSLocalizedString("Google sign up failed.",
                                                        comment: "Message shown on screen after the Google sign up process failed.")
             self?.displayError(error as NSError, sourceTag: .wpComSignup)


### PR DESCRIPTION
**Fixes** #8775 

In this PR we are adding a check for the `created_account` value when doing a Google SignUp. If it's not a new account the user is logged in and the flow dismissed.

**To test:**

Both from a fresh install and from the Me tab perform the following actions and check that everything behaves as expected.

1. Sign up with a new Google account.
2. Sign up with an existing Google account.
3. Log in with a Google account.

