### PR TITLE
Signup Epilogue changes username instead of 

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Signup.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Signup.storyboard
@@ -191,49 +191,32 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="inn-oe-jvt">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <connections>
                                     <segue destination="zr7-F4-cJb" kind="embed" id="FSB-2z-SdS"/>
-                                </connections>
-                            </containerView>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rjJ-Oz-vCa">
-                                <rect key="frame" x="0.0" y="583" width="375" height="84"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="84" placeholder="YES" id="LPh-li-yRa"/>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="84" id="gSs-ae-WjU"/>
-                                </constraints>
-                                <connections>
-                                    <segue destination="1ez-ur-Wce" kind="embed" id="4Xr-qK-MYW"/>
                                 </connections>
                             </containerView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="inn-oe-jvt" firstAttribute="top" secondItem="IqI-1c-b2S" secondAttribute="topMargin" constant="-20" id="4Qy-07-V8Y"/>
-                            <constraint firstItem="rjJ-Oz-vCa" firstAttribute="bottom" secondItem="IqI-1c-b2S" secondAttribute="bottom" id="gXB-2t-wqt"/>
                             <constraint firstItem="inn-oe-jvt" firstAttribute="leading" secondItem="nKx-sI-ahu" secondAttribute="leading" id="jez-ad-Ryr"/>
                             <constraint firstItem="inn-oe-jvt" firstAttribute="trailing" secondItem="nKx-sI-ahu" secondAttribute="trailing" id="kam-4m-1ir"/>
-                            <constraint firstItem="rjJ-Oz-vCa" firstAttribute="trailing" secondItem="nKx-sI-ahu" secondAttribute="trailing" id="lQI-xx-833"/>
-                            <constraint firstItem="rjJ-Oz-vCa" firstAttribute="leading" secondItem="nKx-sI-ahu" secondAttribute="leading" id="oow-zG-Ij0"/>
-                            <constraint firstItem="rjJ-Oz-vCa" firstAttribute="top" secondItem="inn-oe-jvt" secondAttribute="bottom" id="uOC-yy-qEc"/>
+                            <constraint firstItem="inn-oe-jvt" firstAttribute="bottom" secondItem="nKx-sI-ahu" secondAttribute="bottom" id="wM0-jM-BSi"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="nKx-sI-ahu"/>
                     </view>
-                    <connections>
-                        <outlet property="buttonContainerHeightConstraint" destination="gSs-ae-WjU" id="Ljd-MJ-p8V"/>
-                        <outlet property="buttonContainerViewBottomConstraint" destination="gXB-2t-wqt" id="Bk0-BR-GCA"/>
-                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gP7-8o-YtF" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-145" y="-739"/>
+            <point key="canvasLocation" x="-146.40000000000001" y="-739.88005997001505"/>
         </scene>
         <!--Signup Username Table View Controller-->
         <scene sceneID="6JI-EP-aNd">
             <objects>
                 <tableViewController id="zr7-F4-cJb" customClass="SignupUsernameTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="cfa-qK-cgc">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="583"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -285,7 +268,7 @@
                             <constraint firstItem="Ae9-4j-PcF" firstAttribute="trailing" secondItem="Pfn-Ox-xPa" secondAttribute="trailing" id="9lO-lg-WIO"/>
                             <constraint firstItem="P1I-3a-oLv" firstAttribute="trailing" secondItem="Ae9-4j-PcF" secondAttribute="trailing" id="DBe-AY-pLB"/>
                             <constraint firstItem="Ae9-4j-PcF" firstAttribute="top" secondItem="Pfn-Ox-xPa" secondAttribute="top" id="fxp-bT-e4a"/>
-                            <constraint firstItem="P1I-3a-oLv" firstAttribute="bottom" secondItem="Ae9-4j-PcF" secondAttribute="bottom" id="maZ-1x-gSB"/>
+                            <constraint firstItem="P1I-3a-oLv" firstAttribute="bottom" secondItem="5jy-Z9-HSJ" secondAttribute="bottom" id="maZ-1x-gSB"/>
                             <constraint firstItem="Pfn-Ox-xPa" firstAttribute="leading" secondItem="Ae9-4j-PcF" secondAttribute="leading" id="qMk-VK-ZUv"/>
                             <constraint firstItem="P1I-3a-oLv" firstAttribute="leading" secondItem="Ae9-4j-PcF" secondAttribute="leading" id="yGX-fn-rqf"/>
                             <constraint firstItem="P1I-3a-oLv" firstAttribute="top" secondItem="Pfn-Ox-xPa" secondAttribute="bottom" id="yMT-vg-j6M"/>
@@ -326,14 +309,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="GCN-8K-LcG" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="165" y="784"/>
-        </scene>
-        <!--ButtonView-->
-        <scene sceneID="S07-eQ-m0X">
-            <objects>
-                <viewControllerPlaceholder storyboardName="NUXButtonView" referencedIdentifier="ButtonView" id="1ez-ur-Wce" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="XrP-NU-nZR" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-147" y="-315"/>
         </scene>
     </scenes>
     <resources>

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -11,6 +11,7 @@ protocol SignupEpilogueTableViewControllerDelegate {
 protocol SignupEpilogueTableViewControllerDataSource {
     var customDisplayName: String? { get }
     var password: String? { get }
+    var username: String? { get }
 }
 
 class SignupEpilogueTableViewController: NUXTableViewController {
@@ -231,7 +232,7 @@ private extension SignupEpilogueTableViewController {
         case .username:
             cell.configureCell(forType: .username,
                                labelText: NSLocalizedString("Username", comment: "Username label text."),
-                               fieldValue: epilogueUserInfo?.username)
+                               fieldValue: dataSource?.username ?? epilogueUserInfo?.username)
         case .password:
             cell.configureCell(forType: .password,
                                labelText: NSLocalizedString("Password", comment: "Password label text."),

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -1,4 +1,4 @@
-import UIKit
+import SVProgressHUD
 
 class SignupEpilogueViewController: NUXViewController {
 
@@ -7,6 +7,7 @@ class SignupEpilogueViewController: NUXViewController {
     private var buttonViewController: NUXButtonViewController?
     private var updatedDisplayName: String?
     private var updatedPassword: String?
+    private var updatedUsername: String?
     private var epilogueUserInfo: LoginEpilogueUserInfo?
 
     // MARK: - View
@@ -36,6 +37,7 @@ class SignupEpilogueViewController: NUXViewController {
         if let vc = segue.destination as? SignupUsernameViewController {
             vc.currentUsername = epilogueUserInfo?.username
             vc.displayName = updatedDisplayName ?? epilogueUserInfo?.fullName
+            vc.delegate = self
         }
     }
 
@@ -45,16 +47,7 @@ class SignupEpilogueViewController: NUXViewController {
 
 extension SignupEpilogueViewController: NUXButtonViewControllerDelegate {
     func primaryButtonPressed() {
-        // If the Display Name needs updating, start the update process there.
-        // If not, if the Password needs updating, start there.
-        // If nothing needs updating, just dismiss.
-        if updatedDisplayName != nil {
-            updateUserInfo()
-        } else if updatedPassword != nil {
-            updatePassword()
-        } else {
-            navigationController?.dismiss(animated: true, completion: nil)
-        }
+        saveChanges()
     }
 }
 
@@ -90,56 +83,104 @@ extension SignupEpilogueViewController: SignupEpilogueTableViewControllerDelegat
 // MARK: - Private Extension
 
 private extension SignupEpilogueViewController {
+    func saveChanges() {
+        if let newUsername = updatedUsername {
+            SVProgressHUD.show(withStatus: NSLocalizedString("Changing username", comment: "Shown while the app waits for the username changing web service to return."))
+            changeUsername(to: newUsername) {
+                self.updatedUsername = nil
+                self.saveChanges()
+            }
+        } else if let newDisplayName = updatedDisplayName {
+            SVProgressHUD.show(withStatus: NSLocalizedString("Changing display name", comment: "Shown while the app waits for the display name changing web service to return."))
+            changeDisplayName(to: newDisplayName) {
+                self.updatedDisplayName = nil
+                self.saveChanges()
+            }
+        } else if let newPassword = updatedPassword {
+            SVProgressHUD.show(withStatus: NSLocalizedString("Changing password", comment: "Shown while the app waits for the password changing web service to return."))
+            changePassword(to: newPassword) {
+                self.updatedPassword = nil
+                self.saveChanges()
+            }
+        } else {
+            self.refreshAccountDetails() {
+                SVProgressHUD.dismiss()
+                self.navigationController?.dismiss(animated: true, completion: nil)
+            }
+        }
+    }
 
-    func updateUserInfo() {
-
-        guard let updatedDisplayName = updatedDisplayName else {
+    private func changeUsername(to newUsername: String, finished: @escaping (() -> Void)) {
+        guard newUsername != "" else {
+            finished()
             return
         }
+
+        let context = ContextManager.sharedInstance().mainContext
+        let accountService = AccountService(managedObjectContext: context)
+        guard let account = accountService.defaultWordPressComAccount(),
+            let api = account.wordPressComRestApi else {
+                navigationController?.popViewController(animated: true)
+                return
+        }
+
+        let settingsService = AccountSettingsService(userID: account.userID.intValue, api: api)
+        settingsService.changeUsername(to: newUsername, success: { [weak self] in
+            // now we refresh the account to get the new username
+//            accountService.updateUserDetails(for: account, success: { [weak self] in
+//                    finished()
+//                }, failure: { [weak self] (error) in
+//                    finished()
+//            })
+            finished()
+        }) { [weak self] in
+            finished()
+        }
+    }
+
+    func changeDisplayName(to newDisplayName: String, finished: @escaping (() -> Void)) {
 
         let context = ContextManager.sharedInstance().mainContext
 
         guard let defaultAccount = AccountService(managedObjectContext: context).defaultWordPressComAccount(),
         let restApi = defaultAccount.wordPressComRestApi else {
+            finished()
             return
         }
 
         let accountSettingService = AccountSettingsService(userID: defaultAccount.userID.intValue, api: restApi)
-        let accountSettingsChange = AccountSettingsChange.displayName(updatedDisplayName)
+        let accountSettingsChange = AccountSettingsChange.displayName(newDisplayName)
 
         accountSettingService.saveChange(accountSettingsChange) {
+            finished()
             // If the password needs updating, do that.
             // If not, refresh the account so 'Me' tab info is correct.
-            if let _ = self.updatedPassword {
-                self.updatePassword()
-            } else {
-                self.refreshAccountDetails()
-            }
+//            if let _ = self.updatedPassword {
+//                self.updatePassword()
+//            } else {
+//                self.refreshAccountDetails()
+//            }
         }
     }
 
-    func updatePassword() {
-
-        guard let updatedPassword = updatedPassword else {
-            return
-        }
+    func changePassword(to newPassword: String, finished: @escaping () -> Void) {
 
         let context = ContextManager.sharedInstance().mainContext
 
         guard let defaultAccount = AccountService(managedObjectContext: context).defaultWordPressComAccount(),
             let restApi = defaultAccount.wordPressComRestApi else {
+                finished()
                 return
         }
 
         let accountSettingService = AccountSettingsService(userID: defaultAccount.userID.intValue, api: restApi)
 
-        accountSettingService.updatePassword(updatedPassword) {
-            // Refresh the account so 'Me' tab info is correct.
-            self.refreshAccountDetails()
+        accountSettingService.updatePassword(newPassword) {
+            finished()
         }
     }
 
-    func refreshAccountDetails() {
+    func refreshAccountDetails(finished: @escaping () -> Void) {
         let context = ContextManager.sharedInstance().mainContext
         let service = AccountService(managedObjectContext: context)
         guard let account = service.defaultWordPressComAccount() else {
@@ -147,10 +188,20 @@ private extension SignupEpilogueViewController {
             return
         }
         service.updateUserDetails(for: account, success: { () in
-            self.navigationController?.dismiss(animated: true, completion: nil)
+            finished()
         }, failure: { _ in
-            self.navigationController?.dismiss(animated: true, completion: nil)
+            finished()
         })
     }
 
+}
+
+extension SignupEpilogueViewController: SignupUsernameViewControllerDelegate {
+    func usernameSelected(_ username: String) {
+        if !username.isEmpty {
+            updatedUsername = username
+        } else {
+            updatedUsername = nil
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -61,6 +61,10 @@ extension SignupEpilogueViewController: SignupEpilogueTableViewControllerDataSou
     var password: String? {
         return updatedPassword
     }
+
+    var username: String? {
+        return updatedUsername
+    }
 }
 
 // MARK: - SignupEpilogueTableViewControllerDelegate
@@ -125,15 +129,9 @@ private extension SignupEpilogueViewController {
         }
 
         let settingsService = AccountSettingsService(userID: account.userID.intValue, api: api)
-        settingsService.changeUsername(to: newUsername, success: { [weak self] in
-            // now we refresh the account to get the new username
-//            accountService.updateUserDetails(for: account, success: { [weak self] in
-//                    finished()
-//                }, failure: { [weak self] (error) in
-//                    finished()
-//            })
+        settingsService.changeUsername(to: newUsername, success: {
             finished()
-        }) { [weak self] in
+        }) {
             finished()
         }
     }
@@ -153,13 +151,6 @@ private extension SignupEpilogueViewController {
 
         accountSettingService.saveChange(accountSettingsChange) {
             finished()
-            // If the password needs updating, do that.
-            // If not, refresh the account so 'Me' tab info is correct.
-//            if let _ = self.updatedPassword {
-//                self.updatePassword()
-//            } else {
-//                self.refreshAccountDetails()
-//            }
         }
     }
 
@@ -200,8 +191,6 @@ extension SignupEpilogueViewController: SignupUsernameViewControllerDelegate {
     func usernameSelected(_ username: String) {
         if !username.isEmpty {
             updatedUsername = username
-        } else {
-            updatedUsername = nil
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -1,14 +1,9 @@
 import SVProgressHUD
 
-protocol SignupUsernameTableViewControllerDelegate {
-    func usernameSelected(_ username: String)
-    func newSearchStarted()
-}
-
 class SignupUsernameTableViewController: NUXTableViewController {
     open var currentUsername: String?
     open var displayName: String?
-    open var delegate: SignupUsernameTableViewControllerDelegate?
+    open var delegate: SignupUsernameViewControllerDelegate?
     private var service: AccountSettingsService?
     private var suggestions: [String] = []
     private var isSearching: Bool = false
@@ -251,7 +246,7 @@ extension SignupUsernameTableViewController {
 extension SignupUsernameTableViewController: SiteCreationDomainSearchTableViewCellDelegate {
     func startSearch(for searchTerm: String) {
 
-        delegate?.newSearchStarted()
+//        delegate?.newSearchStarted()
 
         guard searchTerm.count > 0 else {
             return

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -246,8 +246,6 @@ extension SignupUsernameTableViewController {
 extension SignupUsernameTableViewController: SiteCreationDomainSearchTableViewCellDelegate {
     func startSearch(for searchTerm: String) {
 
-//        delegate?.newSearchStarted()
-
         guard searchTerm.count > 0 else {
             return
         }

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
@@ -1,10 +1,14 @@
 import SVProgressHUD
 
+protocol SignupUsernameViewControllerDelegate {
+    func usernameSelected(_ username: String)
+}
 class SignupUsernameViewController: NUXViewController {
     // MARK: - Properties
     open var currentUsername: String?
     private var newUsername: String?
     open var displayName: String?
+    open var delegate: SignupUsernameViewControllerDelegate?
 
     // Used to hide/show the Buttom View
     @IBOutlet weak var buttonContainerViewBottomConstraint: NSLayoutConstraint!
@@ -118,22 +122,27 @@ class SignupUsernameViewController: NUXViewController {
             }
             showButtonView(show: false, withAnimation: false)
         }
+
+
     }
 }
 
 // MARK: - SignupUsernameTableViewControllerDelegate
 
-extension SignupUsernameViewController: SignupUsernameTableViewControllerDelegate {
+extension SignupUsernameViewController: SignupUsernameViewControllerDelegate {
     func usernameSelected(_ username: String) {
         newUsername = username
-        if username == "" {
-            showButtonView(show: false, withAnimation: true)
-        } else {
-            showButtonView(show: true, withAnimation: true)
-        }
+
+        delegate?.usernameSelected(username)
+
+//        if username == "" {
+//            showButtonView(show: false, withAnimation: true)
+//        } else {
+//            showButtonView(show: true, withAnimation: true)
+//        }
     }
 
     func newSearchStarted() {
-        showButtonView(show: false, withAnimation: true)
+        //showButtonView(show: false, withAnimation: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
@@ -134,15 +134,5 @@ extension SignupUsernameViewController: SignupUsernameViewControllerDelegate {
         newUsername = username
 
         delegate?.usernameSelected(username)
-
-//        if username == "" {
-//            showButtonView(show: false, withAnimation: true)
-//        } else {
-//            showButtonView(show: true, withAnimation: true)
-//        }
-    }
-
-    func newSearchStarted() {
-        //showButtonView(show: false, withAnimation: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
@@ -10,10 +10,6 @@ class SignupUsernameViewController: NUXViewController {
     open var displayName: String?
     open var delegate: SignupUsernameViewControllerDelegate?
 
-    // Used to hide/show the Buttom View
-    @IBOutlet weak var buttonContainerViewBottomConstraint: NSLayoutConstraint!
-    @IBOutlet weak var buttonContainerHeightConstraint: NSLayoutConstraint!
-
     override var sourceTag: SupportSourceTag {
         get {
             return .wpComCreateSiteUsername
@@ -21,7 +17,6 @@ class SignupUsernameViewController: NUXViewController {
     }
 
     private var usernamesTableViewController: SignupUsernameTableViewController?
-    private var buttonViewController: NUXButtonViewController?
 
     // MARK: - View
 
@@ -31,44 +26,10 @@ class SignupUsernameViewController: NUXViewController {
         navigationController?.setNavigationBarHidden(false, animated: false)
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        addConfirmationWarning()
-    }
-
     private func configureView() {
         _ = addHelpButtonToNavController()
         navigationItem.title = NSLocalizedString("Change Username", comment: "Change Username title.")
         WPStyleGuide.configureColors(for: view, andTableView: nil)
-    }
-
-    private func addConfirmationWarning() {
-        let warningLabel = UILabel()
-        warningLabel.text = NSLocalizedString("Once you change your username, it will no longer be available for future use.", comment: "Warning shown before a user changes their username.")
-        warningLabel.numberOfLines = 0
-        warningLabel.textAlignment = .center
-        warningLabel.textColor = WPStyleGuide.darkGrey()
-        buttonViewController?.stackView?.insertArrangedSubview(warningLabel, at: 0)
-    }
-
-    private func showButtonView(show: Bool, withAnimation: Bool) {
-
-        let duration = withAnimation ? WPAnimationDurationDefault : 0
-
-        UIView.animate(withDuration: duration, animations: {
-            if show {
-                self.buttonContainerViewBottomConstraint.constant = 0
-            }
-            else {
-                // Move the view down double the height to ensure it's off the screen.
-                // i.e. to defy iPhone X bottom gap.
-                self.buttonContainerViewBottomConstraint.constant +=
-                    self.buttonContainerHeightConstraint.constant * 2
-            }
-
-            // Since the Button View uses auto layout, need to call this so the animation works properly.
-            self.view.layoutIfNeeded()
-        }, completion: nil)
     }
 
     private func changeUsername() {
@@ -114,16 +75,6 @@ class SignupUsernameViewController: NUXViewController {
             vc.displayName = displayName
             vc.currentUsername = currentUsername
         }
-
-        if let vc = segue.destination as? NUXButtonViewController {
-            buttonViewController = vc
-            vc.setupButtomButton(title: NSLocalizedString("Change Username", comment: "Button text for changing the user's username."), isPrimary: true) { [weak self] in
-                self?.changeUsername()
-            }
-            showButtonView(show: false, withAnimation: false)
-        }
-
-
     }
 }
 


### PR DESCRIPTION
The username selection screen no longer changes the username immediately. Now the username will be changed when the epilogue itself submits all changes to the new account.

![username changing epilogue](https://user-images.githubusercontent.com/517257/36967456-266ed114-20a3-11e8-862d-641877e40ff7.gif)

To test:
- Create a new account
- Change the username
- Ensure the username has changed

