### PR TITLE
Add NSPhotoLibraryAddUsageDescription to Info.plist

### DIFF
--- a/WordPress/Classes/Utility/InfoPListTranslator.m
+++ b/WordPress/Classes/Utility/InfoPListTranslator.m
@@ -8,6 +8,7 @@
     NSLocalizedString(@"WordPress would like to add your location to posts on sites where you have enabled geotagging.", @"NSLocationWhenInUseUsageDescription: this sentence is show when the app asks permission from the user to use is location.");
     NSLocalizedString(@"To take photos or videos to use in your posts.", @"NSCameraUsageDescription: Sentence to justify why the app is asking permission from the user to use is camera.");
     NSLocalizedString(@"To add photos or videos to your posts.", @"NSPhotoLibraryUsageDescription: Sentence to justify why the app asks permission from the user to access is Media Library.");
+    NSLocalizedString(@"To add photos or videos to your posts.", @"NSPhotoLibraryAddUsageDescription: Sentence to justify why the app asks permission from the user to access is Media Library.");
     NSLocalizedString(@"For your videos to have sound on them.", @"NSMicrophoneUsageDescription: Sentence to justify why the app asks permission from the user to access the device microphone.");
 }
 

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -89,6 +89,8 @@
 	<string>For your videos to have sound on them.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>To add photos or videos to your posts.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>To add photos or videos to your posts.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Noticons.ttf</string>

--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -94,6 +94,8 @@
 	<string>For your videos to have sound on them.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>To add photos or videos to your posts.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>To add photos or videos to your posts.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Noticons.ttf</string>

--- a/WordPress/Wordpress-Alpha-Info.plist
+++ b/WordPress/Wordpress-Alpha-Info.plist
@@ -95,6 +95,8 @@
 	<string>For your videos to have sound on them.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>To add photos or videos to your posts.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>To add photos or videos to your posts.</string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Noticons.ttf</string>


### PR DESCRIPTION
As I understood it, we should not be needing this since we have
NSPhotoLibraryUsageDescription already, but we're getting a number of
crashes for privacy violations with this as the reason:

  Termination Reason: TCC, This app has crashed because it attempted to
  access privacy-sensitive data without a usage description. The app's
  Info.plist must contain an NSPhotoLibraryAddUsageDescription key with a
  string value explaining to the user how the app uses this data.

Fixes #8795