### PR TITLE
Blog selector button arrow

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPBlogSelectorButton.m
@@ -15,6 +15,8 @@
     [button setImage:[UIImage imageNamed:@"icon-nav-chevron"] forState:UIControlStateNormal];
     [button setAccessibilityHint:NSLocalizedString(@"Tap to select which blog to post to", @"This is the blog picker in the editor")];
 
+    [button invertLayout];
+
     BOOL isLayoutLeftToRight = [button userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight;
     switch (button.buttonStyle) {
         case WPBlogSelectorButtonTypeSingleLine:
@@ -23,9 +25,9 @@
             button.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
             button.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
             if (isLayoutLeftToRight) {
-                [button setTitleEdgeInsets:UIEdgeInsetsMake(0, -4, 0, 0)];
-            } else {
                 [button setImageEdgeInsets:UIEdgeInsetsMake(0, -4, 0, 0)];
+            } else {
+                [button setTitleEdgeInsets:UIEdgeInsetsMake(0, -4, 0, 0)];
             }
             break;
         case WPBlogSelectorButtonTypeStacked:
@@ -33,11 +35,11 @@
             button.titleLabel.textAlignment = NSTextAlignmentNatural;
             button.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
             if (isLayoutLeftToRight) {
-                [button setImageEdgeInsets:UIEdgeInsetsMake(0, -4, 0, -10)];
-                [button setTitleEdgeInsets:UIEdgeInsetsMake(0, -10, 0, 0)];
-            } else {
                 [button setImageEdgeInsets:UIEdgeInsetsMake(0, -10, 0, 0)];
                 [button setTitleEdgeInsets:UIEdgeInsetsMake(0, -4, 0, -10)];
+            } else {
+                [button setImageEdgeInsets:UIEdgeInsetsMake(0, -4, 0, -10)];
+                [button setTitleEdgeInsets:UIEdgeInsetsMake(0, -10, 0, 0)];
             }
             break;
     }
@@ -45,23 +47,13 @@
     return button;
 }
 
-- (void)didMoveToSuperview
-{
-    [super didMoveToSuperview];
-    [self invertLayout];
-}
-
 /// Inverts the layout to show the image on the trailing side
 ///
 - (void)invertLayout
 {
-    BOOL isLayoutLeftToRight = [self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionLeftToRight;
-
-    if (isLayoutLeftToRight) {
-        self.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    } else {
-        self.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
-    }
+    self.transform = CGAffineTransformMakeScale(-1.0, 1.0);
+    self.titleLabel.transform = CGAffineTransformMakeScale(-1.0, 1.0);
+    self.imageView.transform = CGAffineTransformMakeScale(-1.0, 1.0);
 }
 
 - (void)setButtonMode:(WPBlogSelectorButtonMode)value


### PR DESCRIPTION
Fixes #8791 

This PR implements a different approach to change the arrow image to the trailing position in the `WPBlogSelectorButton` class.

This approach seems to work better, solving both #8791 and #8707 without the need of workarounds.

![1](https://user-images.githubusercontent.com/9772967/36978259-a6f79c94-2062-11e8-82fb-89b24f229c67.png)

**To test for #8791:**

1. Start a new post
2. Look at site selector
2. Open post options
3. Close post options
4. Look at site selector (The arrow must stay in the same trailing position)

**To test for #8707 (avoid regression):**

1. Build and run the app in Xcode
2. Open the editor
3. Exit to the home screen
4. Stop the app in Xcode
5. Re-run the app  (The arrow must stay in the same trailing position)