### PR TITLE
Fix crash on WebKitViewController

### DIFF
--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -32,6 +32,7 @@ class WebKitViewController: UIViewController {
         navigationDelegate = configuration.navigationDelegate
         super.init(nibName: nil, bundle: nil)
         hidesBottomBarWhenPushed = true
+        startObservingWebView()
     }
 
     fileprivate init(url: URL, parent: WebKitViewController) {
@@ -45,6 +46,7 @@ class WebKitViewController: UIViewController {
         navigationDelegate = parent.navigationDelegate
         super.init(nibName: nil, bundle: nil)
         hidesBottomBarWhenPushed = true
+        startObservingWebView()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -56,6 +58,13 @@ class WebKitViewController: UIViewController {
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
         webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.isLoading))
+    }
+
+    private func startObservingWebView() {
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.title), options: [.new], context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: [.new], context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: [.new], context: nil)
+        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.isLoading), options: [], context: nil)
     }
 
     override func loadView() {
@@ -72,10 +81,6 @@ class WebKitViewController: UIViewController {
 
         configureNavigation()
         configureToolbar()
-        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.title), options: [.new], context: nil)
-        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: [.new], context: nil)
-        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: [.new], context: nil)
-        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.isLoading), options: [], context: nil)
         webView.customUserAgent = WPUserAgent.wordPress()
         webView.navigationDelegate = self
         webView.uiDelegate = self


### PR DESCRIPTION
The previous implementation was adding observers on viewDidLoad, which
meant there were some odd cases where the controller could be
deallocated before the view was loaded, leading to a crash.

Since removeObserver is called on deinit, we are calling addObserver
from init

Fixes #8801 

To test:

- Present a web vc (view site, view reader article,...)
- Notice that the title and progress update as the web page loads.