### PR TITLE
Publish confirmation and other post alert changes.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1149,8 +1149,11 @@ extension AztecPostViewController {
             return
         }
         
-        // Confirmation
-        displayPublishConfirmationAlert(dismissWhenDone: dismissWhenDone)
+        if postEditorStateContext.action == .publish {
+            displayPublishConfirmationAlert(dismissWhenDone: dismissWhenDone)
+        } else {
+            publishPost(dismissWhenDone: dismissWhenDone)
+        }
     }
 
     @IBAction func closeWasPressed() {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1268,7 +1268,7 @@ private extension AztecPostViewController {
             self.displayPostOptions()
         }
 
-        alert.addCancelActionWithTitle(MoreSheetAlert.cancelTitle)
+        alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle)
         alert.popoverPresentationController?.barButtonItem = moreBarButtonItem
 
         present(alert, animated: true, completion: nil)
@@ -3565,11 +3565,11 @@ extension AztecPostViewController {
     }
 
     struct MoreSheetAlert {
-        static let htmlTitle                = NSLocalizedString("Switch to HTML", comment: "Switches the Editor to HTML Mode")
-        static let richTitle                = NSLocalizedString("Switch to Rich Text", comment: "Switches the Editor to Rich Text Mode")
-        static let previewTitle             = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")
-        static let optionsTitle             = NSLocalizedString("Options", comment: "Displays the Post's Options")
-        static let cancelTitle              = NSLocalizedString("Cancel", comment: "Dismisses the Alert from Screen")
+        static let htmlTitle = NSLocalizedString("Switch to HTML", comment: "Switches the Editor to HTML Mode")
+        static let richTitle = NSLocalizedString("Switch to Rich Text", comment: "Switches the Editor to Rich Text Mode")
+        static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")
+        static let optionsTitle = NSLocalizedString("Options", comment: "Displays the Post's Options")
+        static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
     }
 
     struct MediaAttachmentActionSheet {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1148,7 +1148,7 @@ extension AztecPostViewController {
             }
             return
         }
-        
+
         if postEditorStateContext.action == .publish {
             displayPublishConfirmationAlert(dismissWhenDone: dismissWhenDone)
         } else {
@@ -1337,17 +1337,17 @@ private extension AztecPostViewController {
     ///
     func displayPublishConfirmationAlert(dismissWhenDone: Bool) {
         let title = NSLocalizedString("Are you sure you want to publish?", comment: "Title of the message shown when the user taps Publish while editing a post.  Options will be Publish and Keep Editing.")
-        
+
         let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Button shown when the author is asked for publishing confirmation.")
         let publishTitle = NSLocalizedString("Publish", comment: "Button shown when the author is asked for publishing confirmation.")
-        
+
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
-        
+
         alertController.addCancelActionWithTitle(keepEditingTitle)
         alertController.addDefaultActionWithTitle(publishTitle) { [unowned self] _ in
             self.publishPost(dismissWhenDone: dismissWhenDone)
         }
-        
+
         present(alertController, animated: true, completion: nil)
     }
 }
@@ -2543,33 +2543,33 @@ private extension AztecPostViewController {
 // MARK: - Publishing
 
 private extension AztecPostViewController {
-    
+
     /// Shows the publishing overlay and starts the publishing process.
     ///
     func publishPost(dismissWhenDone: Bool) {
         SVProgressHUD.setDefaultMaskType(.clear)
         SVProgressHUD.show(withStatus: postEditorStateContext.publishVerbText)
         postEditorStateContext.updated(isBeingPublished: true)
-        
+
         // Finally, publish the post.
         publishPost() { uploadedPost, error in
             self.postEditorStateContext.updated(isBeingPublished: false)
             SVProgressHUD.dismiss()
-            
+
             let generator = UINotificationFeedbackGenerator()
             generator.prepare()
-            
+
             if let error = error {
                 DDLogError("Error publishing post: \(error.localizedDescription)")
-                
+
                 SVProgressHUD.showDismissibleError(withStatus: self.postEditorStateContext.publishErrorText)
                 generator.notificationOccurred(.error)
             } else if let uploadedPost = uploadedPost {
                 self.post = uploadedPost
-                
+
                 generator.notificationOccurred(.success)
             }
-            
+
             if dismissWhenDone {
                 self.dismissOrPopView(didSave: true)
             } else {
@@ -2577,7 +2577,7 @@ private extension AztecPostViewController {
             }
         }
     }
-    
+
     /// Published the post
     ///
     /// - Parameters:
@@ -2585,7 +2585,7 @@ private extension AztecPostViewController {
     ///
     private func publishPost(completion: ((_ post: AbstractPost?, _ error: Error?) -> Void)?) {
         mapUIContentToPostAndSave()
-        
+
         let managedObjectContext = ContextManager.sharedInstance().mainContext
         let postService = PostService(managedObjectContext: managedObjectContext)
         postService.uploadPost(post, success: { uploadedPost in

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1341,7 +1341,8 @@ private extension AztecPostViewController {
         let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Button shown when the author is asked for publishing confirmation.")
         let publishTitle = NSLocalizedString("Publish", comment: "Button shown when the author is asked for publishing confirmation.")
 
-        let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
+        let style: UIAlertControllerStyle = UIDevice.isPad() ? .alert : .actionSheet
+        let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
 
         alertController.addCancelActionWithTitle(keepEditingTitle)
         alertController.addDefaultActionWithTitle(publishTitle) { [unowned self] _ in
@@ -2578,7 +2579,7 @@ private extension AztecPostViewController {
         }
     }
 
-    /// Published the post
+    /// Publish the post
     ///
     /// - Parameters:
     ///     - completion: the closure to execute when the publish operation completes.


### PR DESCRIPTION
### Description:

Improves the publishing experience by adding a confirmation alert.

Also renames the cancel button within "More".  It's now named "Keep Editing".

Includes some minor code cleanup.

Fixes #6397 

### Screenshots:

- **Publish confirmation alert**:

<img width="487" alt="screen shot 2018-03-05 at 13 53 16" src="https://user-images.githubusercontent.com/1836005/36988091-a97dfb88-207c-11e8-9c0f-3b1491ea5753.png">

- **More button alert**:

<img width="487" alt="screen shot 2018-03-05 at 13 53 29" src="https://user-images.githubusercontent.com/1836005/36988130-c9afc2d8-207c-11e8-852e-b33004b08c4f.png">

### Testing:

**Test 1:**

- Create a new post.
- Write a title and some content.
- Tap publish and make sure there's a confirmation alert as described.

**Test 2:**

- Create a new post.
- Tap X
- When the alert comes up, pick "Save as Draft".
- Make sure the publish confirmation alert does not come up.

**Test 3:**

- Create a new post.
- Tap on "..."
- Make sure the default action is now named "Keep Editing".

