### PR TITLE
Fix media retry options on iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -333,7 +333,8 @@ class MediaLibraryViewController: WPMediaPickerViewController {
     }
 
     fileprivate func presentRetryOptions(for media: Media) {
-        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let style: UIAlertControllerStyle = UIDevice.isPad() ? .alert : .actionSheet
+        let alertController = UIAlertController(title: nil, message: nil, preferredStyle: style)
         alertController.addDestructiveActionWithTitle(NSLocalizedString("Cancel Upload", comment: "Media Library option to cancel an in-progress or failed upload.")) { _ in
             MediaCoordinator.shared.delete(media: [media])
         }


### PR DESCRIPTION
Use an `.alert` style when presenting the retry options on a failed media upload.

Ideally, we'd want to present the popover from the tapped cell, but let's deal with the crash first.

Fixes #8807 

To test:

1. Go to the media library on an iPad
2. Start uploading a picture, then go offline (I turned off wifi while using the simulator)
3. Tap on the thumbnail for the uploading image.
4. The app should show an alert with all the options and not crash