### PR TITLE
Remembering Notifications Reply Text

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -458,11 +458,11 @@ extension NotificationDetailsViewController {
     }
 
     func storeNotificationReplyIfNeeded() {
-        guard let reply = replyTextView.text, !reply.isEmpty else {
+        guard let reply = replyTextView?.text, let notificationId = note?.notificationId, !reply.isEmpty else {
             return
         }
 
-        NotificationReplyStore.shared.store(reply: reply, for: note.notificationId)
+        NotificationReplyStore.shared.store(reply: reply, for: notificationId)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -152,6 +152,7 @@ class NotificationDetailsViewController: UIViewController {
         super.viewWillDisappear(animated)
         keyboardManager?.stopListeningToKeyboardNotifications()
         tearDownNotificationListeners()
+        storeNotificationReplyIfNeeded()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -379,9 +380,12 @@ extension NotificationDetailsViewController {
     }
 
     func setupReplyTextView() {
+        let previousReply = NotificationReplyStore.shared.loadReply(for: note.notificationId)
         let replyTextView = ReplyTextView(width: view.frame.width)
+
         replyTextView.placeholder = NSLocalizedString("Write a reply…", comment: "Placeholder text for inline compose view")
         replyTextView.replyText = NSLocalizedString("Reply", comment: "").localizedUppercase
+        replyTextView.text = previousReply
         replyTextView.accessibilityIdentifier = NSLocalizedString("Reply Text", comment: "Notifications Reply Accessibility Identifier")
         replyTextView.delegate = self
         replyTextView.onReply = { [weak self] content in
@@ -451,6 +455,14 @@ extension NotificationDetailsViewController {
         }
 
         return block.isActionOn(.Reply)
+    }
+
+    func storeNotificationReplyIfNeeded() {
+        guard let reply = replyTextView.text, !reply.isEmpty else  {
+            return
+        }
+
+        NotificationReplyStore.shared.store(reply: reply, for: note.notificationId)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -458,7 +458,7 @@ extension NotificationDetailsViewController {
     }
 
     func storeNotificationReplyIfNeeded() {
-        guard let reply = replyTextView.text, !reply.isEmpty else  {
+        guard let reply = replyTextView.text, !reply.isEmpty else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -70,11 +70,11 @@ class NotificationDetailsViewController: UIViewController {
 
     /// Previous NavBar Navigation Button
     ///
-    @objc var previousNavigationButton: UIButton!
+    var previousNavigationButton: UIButton!
 
     /// Next NavBar Navigation Button
     ///
-    @objc var nextNavigationButton: UIButton!
+    var nextNavigationButton: UIButton!
 
     /// Arrows Navigation Datasource
     ///
@@ -82,7 +82,7 @@ class NotificationDetailsViewController: UIViewController {
 
     /// Notification to-be-displayed
     ///
-    @objc var note: Notification! {
+    var note: Notification! {
         didSet {
             guard oldValue != note && isViewLoaded else {
                 return
@@ -103,7 +103,7 @@ class NotificationDetailsViewController: UIViewController {
     /// Closure to be executed whenever the notification that's being currently displayed, changes.
     /// This happens due to Navigation Events (Next / Previous)
     ///
-    @objc var onSelectedNoteChange: ((Notification) -> Void)?
+    var onSelectedNoteChange: ((Notification) -> Void)?
 
 
     deinit {
@@ -325,7 +325,7 @@ extension NotificationDetailsViewController: UITableViewDelegate, UITableViewDat
 // MARK: - Setup Helpers
 //
 extension NotificationDetailsViewController {
-    @objc func setupNavigationBar() {
+    func setupNavigationBar() {
         // Don't show the notification title in the next-view's back button
         let backButton = UIBarButtonItem(title: String(),
                                          style: .plain,
@@ -348,11 +348,11 @@ extension NotificationDetailsViewController {
         enableNavigationRightBarButtonItems()
     }
 
-    @objc func setupMainView() {
+    func setupMainView() {
         view.backgroundColor = WPStyleGuide.itsEverywhereGrey()
     }
 
-    @objc func setupTableView() {
+    func setupTableView() {
         tableView.separatorStyle            = .none
         tableView.keyboardDismissMode       = .interactive
         tableView.backgroundColor           = WPStyleGuide.greyLighten30()
@@ -360,7 +360,7 @@ extension NotificationDetailsViewController {
         tableView.backgroundColor           = WPStyleGuide.itsEverywhereGrey()
     }
 
-    @objc func setupTableViewCells() {
+    func setupTableViewCells() {
         let cellClassNames: [NoteBlockTableViewCell.Type] = [
             NoteBlockHeaderTableViewCell.self,
             NoteBlockTextTableViewCell.self,
@@ -378,7 +378,7 @@ extension NotificationDetailsViewController {
         }
     }
 
-    @objc func setupReplyTextView() {
+    func setupReplyTextView() {
         let replyTextView = ReplyTextView(width: view.frame.width)
         replyTextView.placeholder = NSLocalizedString("Write a reply…", comment: "Placeholder text for inline compose view")
         replyTextView.replyText = NSLocalizedString("Reply", comment: "").localizedUppercase
@@ -396,14 +396,14 @@ extension NotificationDetailsViewController {
         self.replyTextView = replyTextView
     }
 
-    @objc func setupSuggestionsView() {
+    func setupSuggestionsView() {
         suggestionsTableView = SuggestionsTableView()
         suggestionsTableView.siteID = note.metaSiteID
         suggestionsTableView.suggestionsDelegate = self
         suggestionsTableView.translatesAutoresizingMaskIntoConstraints = false
     }
 
-    @objc func setupKeyboardManager() {
+    func setupKeyboardManager() {
         precondition(replyTextView != nil)
         precondition(bottomLayoutConstraint != nil)
 
@@ -413,7 +413,7 @@ extension NotificationDetailsViewController {
                                                 bottomLayoutConstraint: bottomLayoutConstraint)
     }
 
-    @objc func setupNotificationListeners() {
+    func setupNotificationListeners() {
         let nc = NotificationCenter.default
         nc.addObserver(self,
                        selector: #selector(notificationWasUpdated),
@@ -421,7 +421,7 @@ extension NotificationDetailsViewController {
                        object: note.managedObjectContext)
     }
 
-    @objc func tearDownNotificationListeners() {
+    func tearDownNotificationListeners() {
         let nc = NotificationCenter.default
         nc.removeObserver(self,
                           name: .NSManagedObjectContextObjectsDidChange,
@@ -434,7 +434,7 @@ extension NotificationDetailsViewController {
 // MARK: - Reply View Helpers
 //
 extension NotificationDetailsViewController {
-    @objc func attachReplyViewIfNeeded() {
+    func attachReplyViewIfNeeded() {
         guard shouldAttachReplyView else {
             replyTextView.removeFromSuperview()
             return
@@ -443,7 +443,7 @@ extension NotificationDetailsViewController {
         stackView.addArrangedSubview(replyTextView)
     }
 
-    @objc var shouldAttachReplyView: Bool {
+    var shouldAttachReplyView: Bool {
         // Attach the Reply component only if the noficiation has a comment, and it can be replied-to
         //
         guard let block = note.blockGroupOfKind(.comment)?.blockOfKind(.comment) else {
@@ -1257,11 +1257,11 @@ extension NotificationDetailsViewController {
         note = next
     }
 
-    @objc var shouldEnablePreviousButton: Bool {
+    var shouldEnablePreviousButton: Bool {
         return dataSource?.notification(preceding: note) != nil
     }
 
-    @objc var shouldEnableNextButton: Bool {
+    var shouldEnableNextButton: Bool {
         return dataSource?.notification(succeeding: note) != nil
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationReplyStore.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationReplyStore.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+
+// MARK: - NotificationReplyStore
+//
+class NotificationReplyStore {
+
+    /// Shared Instance.
+    ///
+    static let shared = NotificationReplyStore()
+
+    /// Unit Testing Helper: Allows us to hack the current date.
+    ///
+    private var overridenNow: Date?
+
+    /// Our beautiful and private Initializer. In here we'll trigger the cleanup sequence, which removes outdated replies!.
+    ///
+    private init() {
+        purgeOldReplies()
+    }
+
+    /// Unit Testing Helper: Allows us to hack the current date.
+    ///
+    init(now: Date) {
+        overridenNow = now
+        purgeOldReplies(now: now)
+    }
+
+
+    /// Retrieves the cached reply, for the specified notificationID (if any).
+    ///
+    func loadReply(for notificationID: String) -> String? {
+        return replies[notificationID]
+    }
+
+    /// Stores a given reply, for the specified notificationID.
+    ///
+    func store(reply: String, for notificationID: String) {
+        replies[notificationID] = reply
+        timestamps[notificationID] = overridenNow?.normalizedDate() ?? Date().normalizedDate()
+    }
+
+    /// Meant for unit testing purposes. Effectively nukes the cached replies.
+    ///
+    func reset() {
+        replies = [:]
+        timestamps = [:]
+    }
+}
+
+
+// MARK: - Private Methods
+//
+private extension NotificationReplyStore {
+
+    /// Nukes entries older than `Settings.timeToLiveInDays`.
+    ///
+    func purgeOldReplies(now: Date = Date()) {
+        guard let expiredKeys = findExpiredKeys(inRelationTo: now) else {
+            return
+        }
+
+        removeEntries(with: expiredKeys)
+    }
+
+    /// Returns the collection of expired keys, when compared to the specified Date.
+    ///
+    private func findExpiredKeys(inRelationTo now: Date) -> Set<String>? {
+        var expiredKeys = Set<String>()
+        for (key, timestamp) in timestamps where deltaInDays(between: now, and: timestamp) > Settings.timeToLiveInDays {
+            expiredKeys.insert(key)
+        }
+
+        return expiredKeys.isEmpty ? nil : expiredKeys
+    }
+
+    /// Returns the difference, in days, between the two specified dates.
+    ///
+    private func deltaInDays(between lhs: Date, and rhs: Date) -> Int {
+        return Calendar.current.dateComponents([.day], from: lhs, to: rhs).day ?? .min
+    }
+
+    /// Removes the specified collection of Keys.
+    ///
+    private func removeEntries(with keys: Set<String>) {
+        replies = replies.filter { keys.contains($0.key) == false }
+        timestamps = timestamps.filter { keys.contains($0.key) == false }
+    }
+}
+
+
+// MARK: - Private Calculated Properties
+//
+private extension NotificationReplyStore {
+
+    /// Returns the Replies Dictionary.
+    ///
+    var replies: [String: String] {
+        get {
+            let replies = UserDefaults.standard.dictionary(forKey: Settings.contentsKey) as? [String: String]
+            return replies ?? [String: String]()
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: Settings.contentsKey)
+        }
+    }
+
+    /// Returns the Timestamps Dictionary.
+    ///
+    var timestamps: [String: Date] {
+        get {
+            let timestamps = UserDefaults.standard.dictionary(forKey: Settings.timestampsKey) as? [String: Date]
+            return timestamps ?? [String: Date]()
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: Settings.timestampsKey)
+        }
+    }
+}
+
+
+// MARK: - Private Structures
+//
+private extension NotificationReplyStore {
+
+    /// Settings
+    ///
+    enum Settings {
+        static let contentsKey = "NotificationsReplyContents"
+        static let timestampsKey = "NotificationsReplyTimestamps"
+        static let timeToLiveInDays = 7
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -786,6 +786,8 @@
 		B5BEA057202E342700903044 /* OnePasswordFacade.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BEA056202E342700903044 /* OnePasswordFacade.swift */; };
 		B5BEA55F1C7CE6D100C8035B /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CC05F51962150600975CAC /* Constants.m */; };
 		B5BEA5601C7CE6D700C8035B /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		B5C0CF3D204DA41000DB0362 /* NotificationReplyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C0CF3C204DA41000DB0362 /* NotificationReplyStore.swift */; };
+		B5C0CF3F204DB92F00DB0362 /* NotificationReplyStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C0CF3E204DB92F00DB0362 /* NotificationReplyStoreTests.swift */; };
 		B5C66B701ACF06CA00F68370 /* NoteBlockHeaderTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5C66B6F1ACF06CA00F68370 /* NoteBlockHeaderTableViewCell.xib */; };
 		B5C66B721ACF071100F68370 /* NoteBlockTextTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5C66B711ACF071000F68370 /* NoteBlockTextTableViewCell.xib */; };
 		B5C66B741ACF071F00F68370 /* NoteBlockActionsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5C66B731ACF071F00F68370 /* NoteBlockActionsTableViewCell.xib */; };
@@ -2270,6 +2272,8 @@
 		B5BEA052202E0B6100903044 /* WordPressAuthenticator+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAuthenticator+Events.swift"; sourceTree = "<group>"; };
 		B5BEA054202E109300903044 /* WordPressAuthenticationTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticationTracker.swift; sourceTree = "<group>"; };
 		B5BEA056202E342700903044 /* OnePasswordFacade.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnePasswordFacade.swift; sourceTree = "<group>"; };
+		B5C0CF3C204DA41000DB0362 /* NotificationReplyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationReplyStore.swift; sourceTree = "<group>"; };
+		B5C0CF3E204DB92F00DB0362 /* NotificationReplyStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationReplyStoreTests.swift; sourceTree = "<group>"; };
 		B5C66B6F1ACF06CA00F68370 /* NoteBlockHeaderTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NoteBlockHeaderTableViewCell.xib; sourceTree = "<group>"; };
 		B5C66B711ACF071000F68370 /* NoteBlockTextTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NoteBlockTextTableViewCell.xib; sourceTree = "<group>"; };
 		B5C66B731ACF071F00F68370 /* NoteBlockActionsTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NoteBlockActionsTableViewCell.xib; sourceTree = "<group>"; };
@@ -3250,7 +3254,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				E1B34C091CCDFFCE00889709 /* Credentials */,
@@ -4781,6 +4785,7 @@
 			isa = PBXGroup;
 			children = (
 				B5882C461D5297D1008E0EAA /* NotificationTests.swift */,
+				B5C0CF3E204DB92F00DB0362 /* NotificationReplyStoreTests.swift */,
 				85B125401B028E34008A3D95 /* PushAuthenticationManagerTests.swift */,
 				85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */,
 				B5416CFD1C1756B900006DD8 /* PushNotificationsManagerTests.m */,
@@ -5156,6 +5161,7 @@
 				B54E1DF31A0A7BBF00807537 /* NotificationMediaDownloader.swift */,
 				B54075D31D3D7D5B0095C318 /* IntrinsicTableView.swift */,
 				B56695AF1D411EEB007E342F /* KeyboardDismissHelper.swift */,
+				B5C0CF3C204DA41000DB0362 /* NotificationReplyStore.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -6419,7 +6425,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -6785,7 +6791,7 @@
 			inputPaths = (
 				"${SRCROOT}/../Pods/Target Support Files/Pods-WordPress/Pods-WordPress-resources.sh",
 				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
-				"$PODS_CONFIGURATION_BUILD_DIR/HockeySDK/HockeySDKResources.bundle",
+				$PODS_CONFIGURATION_BUILD_DIR/HockeySDK/HockeySDKResources.bundle,
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -7250,6 +7256,7 @@
 				8350E49611D2C71E00A7B073 /* Media.m in Sources */,
 				B54346961C6A707D0010B3AD /* LanguageViewController.swift in Sources */,
 				E6805D321DCD399600168E4F /* WPRichTextMediaAttachment.swift in Sources */,
+				B5C0CF3D204DA41000DB0362 /* NotificationReplyStore.swift in Sources */,
 				B53AD9BC1BE95687009AB87E /* SettingsTextViewController.m in Sources */,
 				E1389ADB1C59F7C200FB2466 /* PlanListViewController.swift in Sources */,
 				8370D10A11FA499A009D650F /* WPTableViewActivityCell.m in Sources */,
@@ -7911,6 +7918,7 @@
 				FF8032661EE9E22200861F28 /* MediaProgressCoordinatorTests.swift in Sources */,
 				E6B0468B1F0FEC410079F9FA /* EmailFormatValidatorTests.swift in Sources */,
 				E63C897C1CB9A0D700649C8F /* UITextFieldTextHelperTests.swift in Sources */,
+				B5C0CF3F204DB92F00DB0362 /* NotificationReplyStoreTests.swift in Sources */,
 				E15027651E03E54100B847E3 /* PinghubTests.swift in Sources */,
 				E1B642131EFA5113001DC6D7 /* ModelTestHelper.swift in Sources */,
 				B566EC751B83867800278395 /* NSMutableAttributedStringTests.swift in Sources */,
@@ -8802,7 +8810,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_alpha_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_alpha_app_credentials;
 			};
 			name = "Release-Alpha";
 		};
@@ -9277,7 +9285,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_internal_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_internal_app_credentials;
 			};
 			name = "Release-Internal";
 		};
@@ -9620,7 +9628,7 @@
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 3.0;
-				WPCOM_CONFIG = "$HOME/.wpcom_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
 			};
 			name = Debug;
 		};
@@ -9670,7 +9678,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
 			};
 			name = Release;
 		};

--- a/WordPress/WordPressTest/NotificationReplyStoreTests.swift
+++ b/WordPress/WordPressTest/NotificationReplyStoreTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import XCTest
+@testable import WordPress
+
+
+// MARK: - NotificationReplyStore Unit Tests!
+//
+class NotificationReplyStoreTests: XCTestCase {
+
+    /// Testing Keys
+    ///
+    struct Testing {
+        static let text1 = "This is a sample reply"
+        static let text2 = "This is the second sample!"
+        static let key1 = "1234"
+        static let key2 = "4321"
+    }
+
+    /// Reset Reply Storage everytime!
+    ///
+    override func tearDown() {
+        NotificationReplyStore.shared.reset()
+    }
+
+    /// Verifies that `loadReply` returns *nil* for keys never seen before.
+    ///
+    func testLoadReplyReturnsNilWheneverThereIsNoReplyStored() {
+        let store = NotificationReplyStore(now: Date())
+        XCTAssertNil(store.loadReply(for: Testing.key1))
+    }
+
+    /// Verifies that `loadReply` returns previously stored replies.
+    ///
+    func testLoadEffectivelyRetrievesStoredEntries() {
+        let store = NotificationReplyStore(now: Date())
+
+        store.store(reply: Testing.text1, for: Testing.key1)
+        store.store(reply: Testing.text2, for: Testing.key2)
+
+        XCTAssertEqual(store.loadReply(for: Testing.key1), Testing.text1)
+        XCTAssertEqual(store.loadReply(for: Testing.key2), Testing.text2)
+    }
+
+    /// Verifies that replies "younger" than 7 days do not get nuked.
+    ///
+    func testNonOudatedEntriesArePreserved() {
+        let sevenDaysAgoInSeconds = TimeInterval(3600 * 24 * -6)
+        let sevenDaysAgoAsDate = Date(timeIntervalSinceNow: sevenDaysAgoInSeconds)
+
+        let sometimeInThePast = NotificationReplyStore(now: sevenDaysAgoAsDate)
+        sometimeInThePast.store(reply: Testing.text1, for: Testing.key1)
+        sometimeInThePast.store(reply: Testing.text2, for: Testing.key2)
+
+        let nowadays = NotificationReplyStore(now: Date())
+        XCTAssertEqual(nowadays.loadReply(for: Testing.key1), Testing.text1)
+        XCTAssertEqual(nowadays.loadReply(for: Testing.key2), Testing.text2)
+    }
+
+    /// Verifies that replies older than 7 days get nucked.
+    ///
+    func testOudatedEntriesAreNuked() {
+        let sevenDaysAgoInSeconds = TimeInterval(3600 * 24 * -7)
+        let sevenDaysAgoAsDate = Date(timeIntervalSinceNow: sevenDaysAgoInSeconds)
+
+        let sometimeInThePast = NotificationReplyStore(now: sevenDaysAgoAsDate)
+        sometimeInThePast.store(reply: Testing.key1, for: Testing.text1)
+        sometimeInThePast.store(reply: Testing.key2, for: Testing.text2)
+
+        let nowadays = NotificationReplyStore(now: Date())
+        XCTAssertNil(nowadays.loadReply(for: Testing.key1))
+        XCTAssertNil(nowadays.loadReply(for: Testing.key2))
+    }
+}
+

--- a/WordPress/WordPressTest/NotificationReplyStoreTests.swift
+++ b/WordPress/WordPressTest/NotificationReplyStoreTests.swift
@@ -71,4 +71,3 @@ class NotificationReplyStoreTests: XCTestCase {
         XCTAssertNil(nowadays.loadReply(for: Testing.key2))
     }
 }
-


### PR DESCRIPTION
### Details:
This PR implements a Notification Reply cache, which preserved any entered text for 7 days.

Closes #6003

### To test:
1. Verify the (new) unit tests are green
2. Launch WPiOS and log into your account
3. Open any Comment-Y Notification
4. Press over the ReplyTextView component
5. Enter some random text
6. Hit back
7. Kill the app, and relaunch
8. Reopen the same notofication opened in (3)

Verify that the Reply Text is pre-populated with the text you've written in (5).

Needs Review: @SergioEstevao 
Sir, may i bug you with a fun review?

Thanks in advance!!

