### PR TITLE
Fixes auto rotate cell configuration

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -33,14 +33,13 @@ class SignupEpilogueCell: UITableViewCell {
         cellField.text = fieldValue
         cellField.placeholder = fieldPlaceholder
         cellField.delegate = self
+        cellField.isSecureTextEntry = (cellType == .password)
         selectionStyle = .none
-
-        if cellType == .password {
-            cellField.isSecureTextEntry = true
-        }
 
         if cellType == .username {
             accessoryType = .disclosureIndicator
+        } else {
+            accessoryType = .none
         }
     }
 


### PR DESCRIPTION
Fixes #8752 

To test:

1. Create a new WordPress.com account
2. Open the magic link that gets sent
3. Rotate the screen when you're shown a possible username/password

@elibud we may want to just disable rotation as well (no other login screen allows rotation)

But this fix works for now.

