### PR TITLE
Sync reader feed and header after site follow/unfollow

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -779,6 +779,7 @@ import WordPressShared
                                             success: { [weak self] in
                                                 SVProgressHUD.showDismissibleSuccess(withStatus: successMessage)
                                                 self?.syncHelper.syncContent()
+                                                self?.updateStreamHeaderIfNeeded()
                                             },
                                             failure: { (error: Error?) in
                                                 SVProgressHUD.dismiss()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -776,8 +776,9 @@ import WordPressShared
         SVProgressHUD.show()
         let postService = ReaderPostService(managedObjectContext: managedObjectContext())
         postService.toggleFollowing(for: post,
-                                            success: {
+                                            success: { [weak self] in
                                                 SVProgressHUD.showDismissibleSuccess(withStatus: successMessage)
+                                                self?.syncHelper.syncContent()
                                             },
                                             failure: { (error: Error?) in
                                                 SVProgressHUD.dismiss()
@@ -1439,9 +1440,11 @@ import WordPressShared
         }
 
         let service = ReaderTopicService(managedObjectContext: topic.managedObjectContext!)
-        service.toggleFollowing(forTag: topic, success: nil, failure: { (error: Error?) in
+        service.toggleFollowing(forTag: topic, success: { [weak self] in
+            self?.syncHelper.syncContent()
+        }, failure: { [weak self] (error: Error?) in
             generator.notificationOccurred(.error)
-            self.updateStreamHeaderIfNeeded()
+            self?.updateStreamHeaderIfNeeded()
         })
 
         updateStreamHeaderIfNeeded()
@@ -1457,9 +1460,11 @@ import WordPressShared
         }
 
         let service = ReaderTopicService(managedObjectContext: topic.managedObjectContext!)
-        service.toggleFollowing(forSite: topic, success: nil, failure: { (error: Error?) in
+        service.toggleFollowing(forSite: topic, success: { [weak self] in
+            self?.syncHelper.syncContent()
+        }, failure: { [weak self] (error: Error?) in
             generator.notificationOccurred(.error)
-            self.updateStreamHeaderIfNeeded()
+            self?.updateStreamHeaderIfNeeded()
         })
 
         updateStreamHeaderIfNeeded()


### PR DESCRIPTION
**Fixes** #8352 #8212 and the looping inconsistent part of #8352

This PR adds two things:
- A feed refresh after the site has been followed/unfollowed from the header.
- A header refresh after the site has been followed/unfollowed from any cell on the feed.

**To test:**

1. First check that you can replicate the issues mentioned above in `develop`
2. Then check that you can't on this branch ;)

Note that the updates won't be instant as we are making a network request not faking the update.

@mindgraffiti I think this is a nice PR to get some more Swift exposure.