### PR TITLE
Crasher fix: Removed a forced unwrap in AztecPostViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2537,10 +2537,14 @@ private extension AztecPostViewController {
     }
 
     func mapUIContentToPostAndSave() {
+        guard let context = post.managedObjectContext else {
+            return
+        }
+
         post.postTitle = titleTextField.text
         post.content = getHTML()
 
-        ContextManager.sharedInstance().save(post.managedObjectContext!)
+        ContextManager.sharedInstance().save(context)
     }
 
     func publishPost(completion: ((_ post: AbstractPost?, _ error: Error?) -> Void)? = nil) {


### PR DESCRIPTION
Fixes #8816 

I never was able to repro this issue, however looking at the specific line throwing an exception (in each of the versions) there was a forced unwrap of the post context:

`ContextManager.sharedInstance().save(post.managedObjectContext!)`

Not sure if this will fix things 100%, but it should help. 🤷‍♂️ 

**To test:**
Open up a new post, edit the content (in both the title and body), and verify the post is being saved as one would expect.

@koke would you mind taking a look? Thanks!!


