### PR TITLE
Fix More button image insets on post list

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
@@ -2,7 +2,7 @@
 #import "PostCardActionBarItem.h"
 #import <WordPressShared/UIDevice+Helpers.h>
 #import <WordPressShared/WPStyleGuide.h>
-#import <WordPressUI/UIImage+Util.h>
+#import <WordPressUI/WordPressUI.h>
 #import "WordPress-Swift.h"
 
 static NSInteger ActionBarMoreButtonIndex = 999;
@@ -317,7 +317,13 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
         item = [PostCardActionBarItem itemWithTitle:NSLocalizedString(@"More", @"")
                                               image:[UIImage imageNamed:@"icon-post-actionbar-more"]
                                    highlightedImage:nil];
-        item.imageInsets = [InsetsHelper flipForRightToLeftLayoutDirection:MoreButtonImageInsets];
+
+        UIEdgeInsets imageInsets = MoreButtonImageInsets;
+        if ([self userInterfaceLayoutDirection] == UIUserInterfaceLayoutDirectionRightToLeft) {
+            imageInsets = [InsetsHelper flipForRightToLeftLayoutDirection:imageInsets];
+        }
+
+        item.imageInsets = imageInsets;
     }
     return item;
 }


### PR DESCRIPTION
**Fixes** #8211 

**To test:**

Check that the More button looks good on RTL and LTR languages 🤦‍♀️ 

| Left to Right  | Right to Left |
-|-
![simulator screen shot - iphone 8 - 2018-03-06 at 10 24 08](https://user-images.githubusercontent.com/5558824/37035458-61e6f72a-212b-11e8-9372-4decfee19909.png) |![simulator screen shot - iphone 8 - 2018-03-06 at 10 22 20](https://user-images.githubusercontent.com/5558824/37035461-6414cc0c-212b-11e8-9228-ab68c4ebdf2f.png)
