### PR TITLE
Scan featured media for a suitable image on reader

### DIFF
--- a/WordPressKit/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/WordPressKit/ReaderPostServiceRemote.m
@@ -676,6 +676,14 @@ static const NSUInteger ReaderPostTitleLength = 30;
         featuredImage = [dict stringForKey:PostRESTKeyFeaturedImage];
     }
 
+    // If there's no featured image look for a suitable one in the post featured media
+    if ([featuredImage length] == 0) {
+        NSDictionary *featuredMedia = [dict dictionaryForKey:PostRESTKeyFeaturedMedia];
+        if ([[featuredMedia stringForKey:@"type"] isEqualToString:@"image"]) {
+            featuredImage = [featuredMedia stringForKey:@"uri"];
+        }
+    }
+
     // If there's no featured image look for a suitable one in the post content
     NSString *content = [dict stringForKey:PostRESTKeyContent];
     if ([featuredImage length] == 0) {


### PR DESCRIPTION
**Fixes** #8393 

This PR adds another level of scanning for featured images on the reader feed to match Calypso's behavior.

**To test:**

Follow `b19y.blog` and check that the post `Lap dog #goldendoodle` from December 23rd has an image in the feed.
Also check that Reader images look reasonable by comparing it to develop or the web.

