### PR TITLE
Readable margins in editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -531,15 +531,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         rememberFirstResponder()
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-
-        var safeInsets = self.view.layoutMargins
-        safeInsets.top = richTextView.textContainerInset.top
-        richTextView.textContainerInset = safeInsets
-        htmlTextView.textContainerInset = safeInsets
-    }
-
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
@@ -670,10 +661,10 @@ class AztecPostViewController: UIViewController, PostEditor {
             htmlTextView.topAnchor.constraint(equalTo: richTextView.topAnchor),
             htmlTextView.bottomAnchor.constraint(equalTo: richTextView.bottomAnchor)
             ])
-
+        
         NSLayoutConstraint.activate([
-            placeholderLabel.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor, constant: Constants.placeholderPadding.left),
-            placeholderLabel.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor, constant: -(Constants.placeholderPadding.right + richTextView.textContainer.lineFragmentPadding)),
+            placeholderLabel.leftAnchor.constraint(equalTo: richTextView.leftAnchor, constant: insets.left + richTextView.textContainer.lineFragmentPadding),
+            placeholderLabel.rightAnchor.constraint(equalTo: richTextView.rightAnchor, constant: -insets.right - richTextView.textContainer.lineFragmentPadding),
             textPlaceholderTopConstraint,
             placeholderLabel.bottomAnchor.constraint(lessThanOrEqualTo: richTextView.bottomAnchor, constant: Constants.placeholderPadding.bottom)
             ])

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -635,8 +635,8 @@ class AztecPostViewController: UIViewController, PostEditor {
         let layoutGuide = view.layoutMarginsGuide
 
         NSLayoutConstraint.activate([
-            titleTextField.leadingAnchor.constraint(equalTo: layoutGuide.leadingAnchor),
-            titleTextField.trailingAnchor.constraint(equalTo: layoutGuide.trailingAnchor),
+            titleTextField.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor),
+            titleTextField.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor),
             titleTopConstraint,
             titleHeightConstraint
             ])
@@ -651,15 +651,15 @@ class AztecPostViewController: UIViewController, PostEditor {
             ])
 
         NSLayoutConstraint.activate([
-            separatorView.leftAnchor.constraint(equalTo: layoutGuide.leftAnchor),
-            separatorView.rightAnchor.constraint(equalTo: layoutGuide.rightAnchor),
+            separatorView.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor),
+            separatorView.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor),
             separatorView.topAnchor.constraint(equalTo: titleTextField.bottomAnchor),
             separatorView.heightAnchor.constraint(equalToConstant: separatorView.frame.height)
             ])
 
         NSLayoutConstraint.activate([
-            richTextView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            richTextView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            richTextView.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor),
+            richTextView.trailingAnchor.constraint(equalTo: view.readableContentGuide.trailingAnchor),
             richTextView.topAnchor.constraint(equalTo: view.topAnchor),
             richTextView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             ])

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -68,6 +68,9 @@ class AztecPostViewController: UIViewController, PostEditor {
             textView.smartQuotesType = .no
         }
 
+        // We need this false to be able to set negative `scrollInset` values.
+        textView.clipsToBounds = false
+        
         return textView
     }()
 
@@ -112,6 +115,9 @@ class AztecPostViewController: UIViewController, PostEditor {
             textView.smartDashesType = .no
             textView.smartQuotesType = .no
         }
+
+        // We need this false to be able to set negative `scrollInset` values.
+        textView.clipsToBounds = false
 
         return textView
 
@@ -936,8 +942,8 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     fileprivate func refreshInsets(forKeyboardFrame keyboardFrame: CGRect) {
         let referenceView: UIScrollView = mode == .richText ? richTextView : htmlTextView
-
-        let scrollInsets = UIEdgeInsets(top: referenceView.scrollIndicatorInsets.top, left: 0, bottom: view.frame.maxY - (keyboardFrame.minY + self.view.layoutMargins.bottom), right: 0)
+        
+        let scrollInsets = UIEdgeInsets(top: referenceView.scrollIndicatorInsets.top, left: 0, bottom: view.frame.maxY - (keyboardFrame.minY + self.view.layoutMargins.bottom), right: referenceView.frame.maxX - view.frame.maxX)
         let contentInsets  = UIEdgeInsets(top: referenceView.contentInset.top, left: 0, bottom: view.frame.maxY - (keyboardFrame.minY + self.view.layoutMargins.bottom), right: 0)
 
         htmlTextView.scrollIndicatorInsets = scrollInsets

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -661,7 +661,7 @@ class AztecPostViewController: UIViewController, PostEditor {
             htmlTextView.topAnchor.constraint(equalTo: richTextView.topAnchor),
             htmlTextView.bottomAnchor.constraint(equalTo: richTextView.bottomAnchor)
             ])
-        
+
         NSLayoutConstraint.activate([
             placeholderLabel.leftAnchor.constraint(equalTo: richTextView.leftAnchor, constant: insets.left + richTextView.textContainer.lineFragmentPadding),
             placeholderLabel.rightAnchor.constraint(equalTo: richTextView.rightAnchor, constant: -insets.right - richTextView.textContainer.lineFragmentPadding),

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -70,7 +70,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
         // We need this false to be able to set negative `scrollInset` values.
         textView.clipsToBounds = false
-        
+
         return textView
     }()
 
@@ -942,7 +942,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     fileprivate func refreshInsets(forKeyboardFrame keyboardFrame: CGRect) {
         let referenceView: UIScrollView = mode == .richText ? richTextView : htmlTextView
-        
+
         let scrollInsets = UIEdgeInsets(top: referenceView.scrollIndicatorInsets.top, left: 0, bottom: view.frame.maxY - (keyboardFrame.minY + self.view.layoutMargins.bottom), right: referenceView.frame.maxX - view.frame.maxX)
         let contentInsets  = UIEdgeInsets(top: referenceView.contentInset.top, left: 0, bottom: view.frame.maxY - (keyboardFrame.minY + self.view.layoutMargins.bottom), right: 0)
 


### PR DESCRIPTION
### Description:

Modifies the editor to have readable margins (as defined by Apple).

### Screenshots:

<img width="433" alt="screen shot 2018-03-06 at 16 25 02" src="https://user-images.githubusercontent.com/1836005/37053555-38cc662e-215b-11e8-85c0-4451759a85a5.png">

<img width="612" alt="screen shot 2018-03-06 at 16 26 45" src="https://user-images.githubusercontent.com/1836005/37053573-452239c6-215b-11e8-9f59-aeb20f537f58.png">


### Testing:

- Launch the editor in both iPhone and ipad.
- Create a new post.  Check the margins for the placeholders.
- Type in some content.  Check the margins for the inserted content.
- Rotate the device.