### PR TITLE
Prevent accidental post deletion.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1315,7 +1315,7 @@ private extension AztecPostViewController {
 
         let style: UIAlertControllerStyle = UIDevice.isPad() ? .alert : .actionSheet
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
-        
+
         alertController.addCancelActionWithTitle(keepEditingTitle)
         alertController.addDefaultActionWithTitle(publishTitle) { [unowned self] _ in
             self.publishPost(dismissWhenDone: dismissWhenDone)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1315,7 +1315,7 @@ private extension AztecPostViewController {
 
         let style: UIAlertControllerStyle = UIDevice.isPad() ? .alert : .actionSheet
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
-
+        
         alertController.addCancelActionWithTitle(keepEditingTitle)
         alertController.addDefaultActionWithTitle(publishTitle) { [unowned self] _ in
             self.publishPost(dismissWhenDone: dismissWhenDone)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -523,14 +523,14 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
             if post.status == .trash {
                 cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
-                deleteText = NSLocalizedString("Delete", comment: "Deletes post permanently")
-                titleText = NSLocalizedString("Delete this post permanently?", comment: "Deletes post permanently")
-                messageText = NSLocalizedString("Once deleted you won't be able to restore this post.", comment: "Details about what would happen if the user decided to permanently delete a post.")
+                deleteText = NSLocalizedString("Delete Permanently", comment: "Delete option in the confirmation alert when deleting a post from the trash.")
+                titleText = NSLocalizedString("Delete Permanently?", comment: "Title of the confirmation alert when deleting a post from the trash.")
+                messageText = NSLocalizedString("Are you sure you want to permanently delete this post?", comment: "Message of the confirmation alert when deleting a post from the trash.")
             } else {
                 cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
-                deleteText = NSLocalizedString("Delete", comment: "Deletes post")
-                titleText = NSLocalizedString("Delete this post?", comment: "Deletes post")
-                messageText = NSLocalizedString("This post will be deleted and sent to the Trash", comment: "Details about what would happen if the user decided to delete a post.")
+                deleteText = NSLocalizedString("Move to Trash", comment: "Trash option in the trash confirmation alert.")
+                titleText = NSLocalizedString("Trash this post?", comment: "Title of the trash confirmation alert.")
+                messageText = NSLocalizedString("Are you sure you want to trash this post?", comment: "Message of the trash confirmation alert.")
             }
 
             let alertController = UIAlertController(title: titleText, message: messageText, preferredStyle: .alert)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -519,7 +519,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             let cancelText: String
             let deleteText: String
             let messageText: String
-            
+
             if post.status == .trash {
                 cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
                 deleteText = NSLocalizedString("Delete", comment: "Deletes post permanently")
@@ -529,9 +529,9 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
                 deleteText = NSLocalizedString("Delete", comment: "Deletes post")
                 messageText = NSLocalizedString("Delete this post?", comment: "Deletes post")
             }
-            
+
             let alertController = UIAlertController(title: nil, message: messageText, preferredStyle: .alert)
-            
+
             alertController.addCancelActionWithTitle(cancelText)
             alertController.addDestructiveActionWithTitle(deleteText) { [weak self] action in
                 self?.deletePost(post)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -516,22 +516,27 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
     func cell(_ cell: UITableViewCell, handleTrashPost post: AbstractPost) {
         ReachabilityUtils.onAvailableInternetConnectionDo {
+            let cancelText: String
+            let deleteText: String
+            let messageText: String
+            
             if post.status == .trash {
-
-                let cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
-                let deleteText = NSLocalizedString("Delete", comment: "Deletes post permanently")
-                let messageText = NSLocalizedString("Delete this post permanently?", comment: "Deletes post permanently")
-                let alertController = UIAlertController(title: nil, message: messageText, preferredStyle: .alert)
-
-                alertController.addCancelActionWithTitle(cancelText)
-                alertController.addDestructiveActionWithTitle(deleteText) { [weak self] action in
-                    self?.deletePost(post)
-                }
-                alertController.presentFromRootViewController()
-
+                cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
+                deleteText = NSLocalizedString("Delete", comment: "Deletes post permanently")
+                messageText = NSLocalizedString("Delete this post permanently?", comment: "Deletes post permanently")
             } else {
-                deletePost(post)
+                cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
+                deleteText = NSLocalizedString("Delete", comment: "Deletes post")
+                messageText = NSLocalizedString("Delete this post?", comment: "Deletes post")
             }
+            
+            let alertController = UIAlertController(title: nil, message: messageText, preferredStyle: .alert)
+            
+            alertController.addCancelActionWithTitle(cancelText)
+            alertController.addDestructiveActionWithTitle(deleteText) { [weak self] action in
+                self?.deletePost(post)
+            }
+            alertController.presentFromRootViewController()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -519,18 +519,21 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             let cancelText: String
             let deleteText: String
             let messageText: String
+            let titleText: String
 
             if post.status == .trash {
                 cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
                 deleteText = NSLocalizedString("Delete", comment: "Deletes post permanently")
-                messageText = NSLocalizedString("Delete this post permanently?", comment: "Deletes post permanently")
+                titleText = NSLocalizedString("Delete this post permanently?", comment: "Deletes post permanently")
+                messageText = NSLocalizedString("Once deleted you won't be able to restore this post.", comment: "Details about what would happen if the user decided to permanently delete a post.")
             } else {
                 cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
                 deleteText = NSLocalizedString("Delete", comment: "Deletes post")
-                messageText = NSLocalizedString("Delete this post?", comment: "Deletes post")
+                titleText = NSLocalizedString("Delete this post?", comment: "Deletes post")
+                messageText = NSLocalizedString("This post will be deleted and sent to the Trash", comment: "Details about what would happen if the user decided to delete a post.")
             }
 
-            let alertController = UIAlertController(title: nil, message: messageText, preferredStyle: .alert)
+            let alertController = UIAlertController(title: titleText, message: messageText, preferredStyle: .alert)
 
             alertController.addCancelActionWithTitle(cancelText)
             alertController.addDestructiveActionWithTitle(deleteText) { [weak self] action in


### PR DESCRIPTION
### Description:

Prevent accidental post deletion by adding a confirmation alert.

Fixes #8798 

### Screenshots:

The alert was changed from the one proposed in #8798 because post deletion is NOT permanent unless you're deleting a post from the trash.

<img width="433" alt="screen shot 2018-03-06 at 16 45 51" src="https://user-images.githubusercontent.com/1836005/37054599-133298c2-215e-11e8-8838-f588b6d3f6b9.png">

### Testing:

- Go to the list of published posts for a site
- Tap the trash icon to delete a post
- Make sure a confirmation alert comes up.
- Try the same with deleted posts, make sure the alert mentions the deletion would be permanent.