### PR TITLE
Fixed Strings

### DIFF
--- a/WordPress/Classes/Stores/PluginStore.swift
+++ b/WordPress/Classes/Stores/PluginStore.swift
@@ -494,7 +494,7 @@ private extension PluginStore {
                     state.updatesInProgress[site]?.remove(installedPlugin.slug)
                 }
 
-                let message = String(format: NSLocalizedString("Succesfully installed %@.", comment: "Notice displayed after installing a plug-in."), installedPlugin.name)
+                let message = String(format: NSLocalizedString("Successfully installed %@.", comment: "Notice displayed after installing a plug-in."), installedPlugin.name)
                 ActionDispatcher.dispatch(NoticeAction.post(Notice(title: message)))
                 ActionDispatcher.dispatch(PluginAction.activateAndEnableAutoupdates(id: installedPlugin.id, site: site))
             },

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationCreateSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationCreateSiteViewController.swift
@@ -223,7 +223,7 @@ private extension SiteCreationCreateSiteViewController {
         switch validationError {
         case .missingTitle:
             setReturnViewController(for: .details)
-            errorMessage = NSLocalizedString("The site sitle is missing.", comment: "Error shown during site creation process when the site title is missing.")
+            errorMessage = NSLocalizedString("The site title is missing.", comment: "Error shown during site creation process when the site title is missing.")
         case .missingDomain:
             setReturnViewController(for: .domainSuggestion)
             errorMessage = NSLocalizedString("The site domain is missing.", comment: "Error shown during site creation process when the site domain is missing.")

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationCreateSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationCreateSiteViewController.swift
@@ -70,7 +70,7 @@ class SiteCreationCreateSiteViewController: NUXViewController {
         }
 
         if let vc = segue.destination as? NoResultsViewController {
-            let title = NSLocalizedString("Something went wrong...", comment: "Primary message on site creation error page.")
+            let title = NSLocalizedString("Something went wrong…", comment: "Primary message on site creation error page.")
             let errorButtonTitle = NSLocalizedString("Try again", comment: "Button text on site creation error page.")
             let imageName = "site-creation-error"
 

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -95,7 +95,7 @@ class ShareModularViewController: ShareExtensionAbstractViewController {
         if self.originatingExtension == .share {
             title = NSLocalizedString("Publishing post...", comment: "A short message that informs the user a post is being published to the server from the share extension.")
         } else {
-            title = NSLocalizedString("Saving post...", comment: "A short message that informs the user a draft post is being saved to the server from the share extension.")
+            title = NSLocalizedString("Saving post…", comment: "A short message that informs the user a draft post is being saved to the server from the share extension.")
         }
         let activityIndicatorView = UIActivityIndicatorView(activityIndicatorStyle: .gray)
         activityIndicatorView.startAnimating()


### PR DESCRIPTION
Fixes #8831

Two questions for validators;
1. There were many incorrect instances of 'succesfully' throughout in comments and a variable name, I left them unchanged but can go through and correct them all. They can be seen here;
https://github.com/wordpress-mobile/WordPress-iOS/search?p=1&q=Succesfully&type=Code&utf8=%E2%9C%93
2. There were many three dots cases instead of ellipsis', I only went to change these as I found in translating most of the new strings were using the ellipsis character. For consistentcy what's preferred? I can go back through and revert or go and replace all cases of the three dots with ellipsis.
For instance they're strewn throughout these files;
https://github.com/garrett-eclipse/WordPress-iOS/blob/issue/8831-strings/WordPress/Classes/ViewRelated/NUX/SiteCreationCreateSiteViewController.swift
https://github.com/garrett-eclipse/WordPress-iOS/blob/issue/8831-strings/WordPress/WordPressShareExtension/ShareModularViewController.swift

Thanks


