### PR TITLE
Check available size before uploads

### DIFF
--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -110,4 +110,11 @@ extension NSURL {
     @objc var isVideo: Bool {
         return (self as URL).isVideo
     }
+
+    @objc var fileSize: NSNumber? {
+        guard let fileSize = (self as URL).fileSize else {
+            return nil
+        }
+        return NSNumber(value: fileSize)
+    }
 }

--- a/WordPress/Classes/Models/Blog+Quota.swift
+++ b/WordPress/Classes/Models/Blog+Quota.swift
@@ -64,7 +64,7 @@ extension Blog {
 
     /// Returns true if the site has disk quota available to for the file size of the URL provided.
     ///
-    /// If not quota information is available for the site this method returns true.
+    /// If no quota information is available for the site this method returns true.
     /// - Parameter url: the file URL to check the filesize
     /// - Returns: true if there is space available
     @objc func hasSpaceAvailable(for url: URL) -> Bool {

--- a/WordPress/Classes/Models/Blog+Quota.swift
+++ b/WordPress/Classes/Models/Blog+Quota.swift
@@ -36,6 +36,14 @@ extension Blog {
         return quotaPercentageUsedDescription
     }
 
+    @objc var quotaUsageDescription: String? {
+        guard isQuotaAvailable, let quotaPercentageUsedDescription = self.quotaPercentageUsedDescription, let quotaSpaceAllowedDescription = self.quotaSpaceAllowedDescription else {
+            return nil
+        }
+        let formatString = NSLocalizedString("%@ of %@ used", comment: "Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used.")
+        return String(format: formatString, quotaPercentageUsedDescription, quotaSpaceAllowedDescription)
+    }
+
     @objc var quotaSpaceAvailable: NSNumber? {
         guard let quotaSpaceAllowed = quotaSpaceAllowed?.doubleValue, let quotaSpaceUsed = quotaSpaceUsed?.doubleValue else {
             return nil

--- a/WordPress/Classes/Models/Blog+Quota.swift
+++ b/WordPress/Classes/Models/Blog+Quota.swift
@@ -36,6 +36,7 @@ extension Blog {
         return quotaPercentageUsedDescription
     }
 
+    /// Returns an human readable message indicating the percentage of disk quota space available in regard to the maximum allowed.Ex: 10% of 15 GB used
     @objc var quotaUsageDescription: String? {
         guard isQuotaAvailable, let quotaPercentageUsedDescription = self.quotaPercentageUsedDescription, let quotaSpaceAllowedDescription = self.quotaSpaceAllowedDescription else {
             return nil
@@ -44,6 +45,7 @@ extension Blog {
         return String(format: formatString, quotaPercentageUsedDescription, quotaSpaceAllowedDescription)
     }
 
+    /// Returns the disk space quota still available to use in the site.
     @objc var quotaSpaceAvailable: NSNumber? {
         guard let quotaSpaceAllowed = quotaSpaceAllowed?.doubleValue, let quotaSpaceUsed = quotaSpaceUsed?.doubleValue else {
             return nil
@@ -52,6 +54,7 @@ extension Blog {
         return NSNumber(value: quotaSpaceAvailable)
     }
 
+    /// Returns the maximum upload byte size supported for a media file on the site.
     @objc var maxUploadSize: NSNumber? {
         guard let maxUploadSize = getOptionValue("max_upload_size") as? NSNumber else {
             return nil
@@ -59,6 +62,11 @@ extension Blog {
         return maxUploadSize
     }
 
+    /// Returns true if the site has disk quota available to for the file size of the URL provided.
+    ///
+    /// If not quota information is available for the site this method returns true.
+    /// - Parameter url: the file URL to check the filesize
+    /// - Returns: true if there is space available
     @objc func hasSpaceAvailable(for url: URL) -> Bool {
         guard let fileSize = url.fileSize,
               let spaceAvailable = quotaSpaceAvailable?.intValue
@@ -69,6 +77,10 @@ extension Blog {
         return fileSize < spaceAvailable
     }
 
+    /// Returns true if the site is able to support the file size of an upload made with the specified URL.
+    ///
+    /// - Parameter url: the file URL to check the filesize.
+    /// - Returns: true if the site is able to support the URL file size.
     @objc func isAbleToHandleFileSizeOf(url: URL) -> Bool {
         guard let fileSize = url.fileSize,
             let maxUploadSize = maxUploadSize?.intValue

--- a/WordPress/Classes/Models/Blog+Quota.swift
+++ b/WordPress/Classes/Models/Blog+Quota.swift
@@ -45,7 +45,7 @@ extension Blog {
     }
 
     @objc var maxUploadSize: NSNumber? {
-        guard let maxUploadSize = options?["max_upload_size"] as? NSNumber else {
+        guard let maxUploadSize = getOptionValue("max_upload_size") as? NSNumber else {
             return nil
         }
         return maxUploadSize

--- a/WordPress/Classes/Models/Blog+Quota.swift
+++ b/WordPress/Classes/Models/Blog+Quota.swift
@@ -35,4 +35,39 @@ extension Blog {
         }
         return quotaPercentageUsedDescription
     }
+
+    @objc var quotaSpaceAvailable: NSNumber? {
+        guard let quotaSpaceAllowed = quotaSpaceAllowed?.doubleValue, let quotaSpaceUsed = quotaSpaceUsed?.doubleValue else {
+            return nil
+        }
+        let quotaSpaceAvailable = quotaSpaceAllowed - quotaSpaceUsed
+        return NSNumber(value: quotaSpaceAvailable)
+    }
+
+    @objc var maxUploadSize: NSNumber? {
+        guard let maxUploadSize = options?["max_upload_size"] as? NSNumber else {
+            return nil
+        }
+        return maxUploadSize
+    }
+
+    @objc func hasSpaceAvailable(for url: URL) -> Bool {
+        guard let fileSize = url.fileSize,
+              let spaceAvailable = quotaSpaceAvailable?.intValue
+        else {
+            // let's assume the site can handle it if we don't know any of quota or fileSize information.
+            return true
+        }
+        return fileSize < spaceAvailable
+    }
+
+    @objc func isAbleToHandleFileSizeOf(url: URL) -> Bool {
+        guard let fileSize = url.fileSize,
+            let maxUploadSize = maxUploadSize?.intValue
+            else {
+                // let's assume the site can handle it.
+                return true
+        }
+        return fileSize < maxUploadSize
+    }
 }

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -8,6 +8,13 @@
 @class Blog;
 @protocol ExportableAsset;
 
+extern NSErrorDomain _Nonnull const MediaServiceErrorDomain;
+typedef NS_ERROR_ENUM(MediaServiceErrorDomain, MediaServiceError) {
+    MediaServiceErrorFileDoesNotExist = 0,
+    MediaServiceErrorFileLargerThanDiskQuotaAvailable = 1,
+    MediaServiceErrorFileLargerThanMaxFileSize = 2
+};
+
 @interface MediaService : LocalCoreDataService
 
 /**

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -14,7 +14,7 @@
 @import WordPressUI;
 @import WordPressShared;
 
-
+NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 
 @interface MediaService ()
 
@@ -145,6 +145,38 @@
 
 #pragma mark - Uploading media
 
+- (BOOL)isValidFileInMedia:(Media *)media error:(NSError **)error {
+    Blog *blog = media.blog;
+    if (media.absoluteLocalURL == nil) {
+        if (error){
+            *error = [NSError errorWithDomain:MediaServiceErrorDomain
+                                         code:MediaServiceErrorFileDoesNotExist
+                                     userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Media doesn't have an associated file to upload.", @"Error message to show to users when trying to upload a media object with no local file associated")}];
+        }
+        return NO;
+    }
+
+    if (![blog hasSpaceAvailableFor:media.absoluteLocalURL]) {
+        if (error) {
+            *error = [NSError errorWithDomain:MediaServiceErrorDomain
+                                         code:MediaServiceErrorFileLargerThanDiskQuotaAvailable
+                                     userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Not enought space to upload", @"Error message to show to users when trying to upload a media object wich file size is larger than the available site disk quota")}];
+        }
+        return NO;
+    }
+
+    if (![blog isAbleToHandleFileSizeOfUrl:media.absoluteLocalURL]) {
+        if (error) {
+            *error = [NSError errorWithDomain:MediaServiceErrorDomain
+                                         code:MediaServiceErrorFileLargerThanMaxFileSize
+                                     userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"File too large to upload", @"Error message to show to users when trying to upload a media object with file size ir larger than the max file size allowed in the site")}];
+        }
+        return NO;
+    }
+
+    return YES;
+}
+
 - (void)uploadMedia:(Media *)media
            progress:(NSProgress **)progress
             success:(void (^)(void))success
@@ -153,19 +185,39 @@
     Blog *blog = media.blog;
     id<MediaServiceRemote> remote = [self remoteForBlog:blog];
     RemoteMedia *remoteMedia = [self remoteMediaFromMedia:media];
-    if (media.absoluteLocalURL == nil) {
-        if (failure) {
-            failure([NSError errorWithDomain:NSURLErrorDomain
-                                        code:NSURLErrorFileDoesNotExist
-                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Media doesn't have an associated file to upload.", @"Error message to show to users when trying to upload a media object with no local file associated")}]);
-        }
-        return;
-    }
     // Even though jpeg is a valid extension, use jpg instead for the widest possible
     // support.  Some third-party image related plugins prefer the .jpg extension.
     // See https://github.com/wordpress-mobile/WordPress-iOS/issues/4663
     remoteMedia.file = [remoteMedia.file stringByReplacingOccurrencesOfString:@".jpeg" withString:@".jpg"];
     NSManagedObjectID *mediaObjectID = media.objectID;
+
+    void (^failureBlock)(NSError *error) = ^(NSError *error) {
+        [self.managedObjectContext performBlock:^{
+            if (error) {
+                [self trackUploadError:error];
+            }
+            NSError *customError = [self customMediaUploadError:error remote:remote];
+            Media *mediaInContext = (Media *)[self.managedObjectContext existingObjectWithID:mediaObjectID error:nil];
+            if (mediaInContext) {
+                mediaInContext.remoteStatus = MediaRemoteStatusFailed;
+                mediaInContext.error = customError;
+                [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+            }
+            if (failure) {
+                failure(customError);
+            }
+        }];
+    };
+
+    NSError *mediaValidationError = nil;
+    if (![self isValidFileInMedia:media error: &mediaValidationError]) {
+        if(progress) {
+            *progress = [NSProgress discreteProgressWithTotalUnitCount:1];
+        }
+        failureBlock(mediaValidationError);
+        return;
+    }
+
     [self.managedObjectContext performBlock:^{
         Media *mediaInContext = (Media *)[self.managedObjectContext existingObjectWithID:mediaObjectID error:nil];
         if (mediaInContext) {
@@ -196,23 +248,7 @@
             }];
         }];
     };
-    void (^failureBlock)(NSError *error) = ^(NSError *error) {
-        [self.managedObjectContext performBlock:^{
-            if (error) {
-                [self trackUploadError:error];
-            }
-            NSError *customError = [self customMediaUploadError:error remote:remote];
-            Media *mediaInContext = (Media *)[self.managedObjectContext existingObjectWithID:mediaObjectID error:nil];
-            if (mediaInContext) {
-                mediaInContext.remoteStatus = MediaRemoteStatusFailed;
-                mediaInContext.error = customError;                
-                [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-            }
-            if (failure) {
-                failure(customError);
-            }
-        }];
-    };
+
     [self.managedObjectContext performBlock:^{
         [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadStarted withBlog:blog];
     }];

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -207,6 +207,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
         [self.managedObjectContext performBlock:^{
             if (error) {
                 [self trackUploadError:error];
+                DDLogError(@"Error uploading media: %@", error);
             }
             NSError *customError = [self customMediaUploadError:error remote:remote];
             Media *mediaInContext = (Media *)[self.managedObjectContext existingObjectWithID:mediaObjectID error:nil];

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -158,7 +158,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 
     if (![blog hasSpaceAvailableFor:media.absoluteLocalURL]) {
         if (error) {
-            NSString *errorReason = NSLocalizedString(@"Not enough space to upload", @"Error message to show to users when trying to upload a media object wich file size is larger than the available site disk quota");
+            NSString *errorReason = NSLocalizedString(@"Not enough space to upload", @"Error message to show to users when trying to upload a media object with file size is larger than the available site disk quota");
             NSString *quotaInfo = blog.quotaUsageDescription;
             NSString *errorMessage = errorReason;
             if (quotaInfo != nil) {
@@ -177,7 +177,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
             NSString *fileSizeDescription = [NSByteCountFormatter stringFromByteCount:fileSize.longLongValue countStyle:NSByteCountFormatterCountStyleBinary];
             NSNumber *maxFileSize = blog.maxUploadSize;
             NSString *maxFileSizeDescription = [NSByteCountFormatter stringFromByteCount:maxFileSize.longLongValue countStyle:NSByteCountFormatterCountStyleBinary];
-            NSString *errorLocalized = NSLocalizedString(@"Media filesize (%@) is too large to upload. Maximum allowed is %@", @"Error message to show to users when trying to upload a media object with file size ir larger than the max file size allowed in the site");
+            NSString *errorLocalized = NSLocalizedString(@"Media filesize (%@) is too large to upload. Maximum allowed is %@", @"Error message to show to users when trying to upload a media object with file size is larger than the max file size allowed in the site");
             NSString *errorMessage = [NSString stringWithFormat:errorLocalized, fileSizeDescription, maxFileSizeDescription];
             *error = [NSError errorWithDomain:MediaServiceErrorDomain
                                          code:MediaServiceErrorFileLargerThanMaxFileSize

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -158,18 +158,30 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 
     if (![blog hasSpaceAvailableFor:media.absoluteLocalURL]) {
         if (error) {
+            NSString *errorReason = NSLocalizedString(@"Not enough space to upload", @"Error message to show to users when trying to upload a media object wich file size is larger than the available site disk quota");
+            NSString *quotaInfo = blog.quotaUsageDescription;
+            NSString *errorMessage = errorReason;
+            if (quotaInfo != nil) {
+                errorMessage = [NSString stringWithFormat:@"%@\n%@", errorReason, quotaInfo];
+            }
             *error = [NSError errorWithDomain:MediaServiceErrorDomain
                                          code:MediaServiceErrorFileLargerThanDiskQuotaAvailable
-                                     userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Not enought space to upload", @"Error message to show to users when trying to upload a media object wich file size is larger than the available site disk quota")}];
+                                     userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
         }
         return NO;
     }
 
     if (![blog isAbleToHandleFileSizeOfUrl:media.absoluteLocalURL]) {
         if (error) {
+            NSNumber *fileSize = media.absoluteLocalURL.fileSize;
+            NSString *fileSizeDescription = [NSByteCountFormatter stringFromByteCount:fileSize.longLongValue countStyle:NSByteCountFormatterCountStyleBinary];
+            NSNumber *maxFileSize = blog.maxUploadSize;
+            NSString *maxFileSizeDescription = [NSByteCountFormatter stringFromByteCount:maxFileSize.longLongValue countStyle:NSByteCountFormatterCountStyleBinary];
+            NSString *errorLocalized = NSLocalizedString(@"Media filesize (%@) is too large to upload. Maximum allowed is %@", @"Error message to show to users when trying to upload a media object with file size ir larger than the max file size allowed in the site");
+            NSString *errorMessage = [NSString stringWithFormat:errorLocalized, fileSizeDescription, maxFileSizeDescription];
             *error = [NSError errorWithDomain:MediaServiceErrorDomain
                                          code:MediaServiceErrorFileLargerThanMaxFileSize
-                                     userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"File too large to upload", @"Error message to show to users when trying to upload a media object with file size ir larger than the max file size allowed in the site")}];
+                                     userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
         }
         return NO;
     }

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -397,7 +397,8 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     _mediaQuotaCell = (MediaQuotaCell *)[self.tableView dequeueReusableCellWithIdentifier:MediaQuotaCell.defaultReuseIdentifier];
 
     _mediaQuotaCell.title = NSLocalizedString(@"Space used", @"Label for showing the available disk space quota available for media");
-
+    _mediaQuotaCell.selectionStyle = UITableViewCellSelectionStyleNone;
+    
     return _mediaQuotaCell;
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -256,9 +256,8 @@ class MediaLibraryViewController: WPMediaPickerViewController {
     private func showOptionsMenu() {
         let menuAlert = UIAlertController(title: nil, message: nil, preferredStyle: UIAlertControllerStyle.actionSheet)
 
-        if blog.isQuotaAvailable, let quotaPercentageUsedDescription = blog.quotaPercentageUsedDescription, let quotaSpaceAllowedDescription = blog.quotaSpaceAllowedDescription {
-            let formatString = NSLocalizedString("%@ of %@ used", comment: "Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used.")
-            menuAlert.title = String(format: formatString, quotaPercentageUsedDescription, quotaSpaceAllowedDescription)
+        if let quotaUsageDescription = blog.quotaUsageDescription {
+            menuAlert.title = quotaUsageDescription
         }
 
         if WPMediaCapturePresenter.isCaptureAvailable() {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -416,7 +416,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         uploadObserverUUID = MediaCoordinator.shared.addObserver({ [weak self] (media, state) in
             switch state {
             case .progress(let progress) :
-	                self?.updateCellProgress(progress, for: media)
+                self?.updateCellProgress(progress, for: media)
                 break
             case .processing, .uploading:
                 self?.showUploadingStateForCell(for: media)

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -360,7 +360,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             }
         }
 
-        alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: ""))
+        alertController.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: ""))
 
         present(alertController, animated: true, completion: nil)
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -217,6 +217,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         visibleCells(for: media).forEach { cell in
             if let overlayView = cell.overlayView as? MediaCellProgressView {
                 overlayView.state = .retry
+                configureAppearance(for: overlayView, with: media)
             }
         }
     }
@@ -416,7 +417,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         uploadObserverUUID = MediaCoordinator.shared.addObserver({ [weak self] (media, state) in
             switch state {
             case .progress(let progress) :
-                self?.updateCellProgress(progress, for: media)
+	                self?.updateCellProgress(progress, for: media)
                 break
             case .processing, .uploading:
                 self?.showUploadingStateForCell(for: media)
@@ -425,7 +426,11 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             case .failed:
                 self?.showFailedStateForCell(for: media)
             case .thumbnailReady:
-                self?.showUploadingStateForCell(for: media)
+                if media.remoteStatus == .failed {
+                    self?.showFailedStateForCell(for: media)
+                } else {
+                    self?.showUploadingStateForCell(for: media)
+                }
             }
             }, for: nil)
     }

--- a/WordPressKit/WordPressKit/RemoteBlogOptionsHelper.m
+++ b/WordPressKit/WordPressKit/RemoteBlogOptionsHelper.m
@@ -29,7 +29,8 @@
                                           @"frame_nonce",
                                           @"jetpack_version",
                                           @"is_automated_transfer",
-                                          @"blog_public"
+                                          @"blog_public",
+                                          @"max_upload_size"
                                           ];
 
         for (NSString *key in optionsDirectMapKeys) {


### PR DESCRIPTION
Fixes #5077

This PR uses the disk quota information and max file upload size information to check for possible upload errors even before the uploads are started.
<img width="385" alt="screen shot 2018-03-06 at 23 37 08" src="https://user-images.githubusercontent.com/651601/37065083-62515f86-2197-11e8-9071-bd7d04b23d33.png">

To test:
 - Try to add a new large media object (big video)to an on site that is reaching the limits of it's disk quota
 - Check if upload fails even before up the upload start
 - Check if an appropriate error message shows up
 - Try start an media upload on site that has a limited max file upload size (self-hosted site with Jetpack)
 - Check if upload fails even before up the upload start
 - Check if an appropriate error message shows up



