### PR TITLE
Adding SupportSourceTag for Signup Epilogue and Signup Google pages.

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/SupportViewController.h
+++ b/WordPress/Classes/ViewRelated/Me/SupportViewController.h
@@ -9,6 +9,7 @@ extern SupportSourceTag const SupportSourceTagGeneralLogin;
 extern SupportSourceTag const SupportSourceTagInAppFeedback;
 extern SupportSourceTag const SupportSourceTagLoginEmail;
 extern SupportSourceTag const SupportSourceTagLoginMagicLink;
+extern SupportSourceTag const SupportSourceTagSignupMagicLink;
 extern SupportSourceTag const SupportSourceTagLoginWPComPassword;
 extern SupportSourceTag const SupportSourceTagLogin2FA;
 extern SupportSourceTag const SupportSourceTagLoginSiteAddress;
@@ -20,6 +21,7 @@ extern SupportSourceTag const SupportSourceTagWPComCreateSiteDomain;
 extern SupportSourceTag const SupportSourceTagWPComCreateSiteUsername;
 extern SupportSourceTag const SupportSourceTagWPComCreateSiteCreation;
 extern SupportSourceTag const SupportSourceTagWPComSignupEmail;
+extern SupportSourceTag const SupportSourceTagSignupWaitingForGoogle;
 
 @interface SupportViewController : UITableViewController
 @property (nonatomic, strong) SupportSourceTag sourceTag;

--- a/WordPress/Classes/ViewRelated/Me/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/SupportViewController.m
@@ -24,6 +24,7 @@ SupportSourceTag const SupportSourceTagGeneralLogin = @"origin:login-screen";
 SupportSourceTag const SupportSourceTagInAppFeedback = @"origin:in-app-feedback";
 SupportSourceTag const SupportSourceTagLoginEmail = @"origin:login-email";
 SupportSourceTag const SupportSourceTagLoginMagicLink = @"origin:login-magic-link";
+SupportSourceTag const SupportSourceTagSignupMagicLink = @"origin:signup-magic-link";
 SupportSourceTag const SupportSourceTagLoginWPComPassword = @"origin:login-wpcom-password";
 SupportSourceTag const SupportSourceTagLogin2FA = @"origin:login-2fa";
 SupportSourceTag const SupportSourceTagLoginSiteAddress = @"origin:login-site-address";
@@ -35,6 +36,7 @@ SupportSourceTag const SupportSourceTagWPComCreateSiteDomain = @"origin:wpcom-cr
 SupportSourceTag const SupportSourceTagWPComCreateSiteUsername = @"origin:wpcom-create-site-username";
 SupportSourceTag const SupportSourceTagWPComCreateSiteCreation = @"origin:wpcom-create-site-creation";
 SupportSourceTag const SupportSourceTagWPComSignupEmail = @"origin:wpcom-signup-email-entry";
+SupportSourceTag const SupportSourceTagSignupWaitingForGoogle = @"origin:signup-waiting-for-google";
 
 static NSString *const WPSupportRestorationID = @"WPSupportRestorationID";
 

--- a/WordPress/Classes/ViewRelated/NUX/NUXLinkMailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXLinkMailViewController.swift
@@ -11,6 +11,14 @@ class NUXLinkMailViewController: LoginViewController {
     var emailMagicLinkSource: EmailMagicLinkSource?
     override var sourceTag: SupportSourceTag {
         get {
+            if let emailMagicLinkSource = emailMagicLinkSource {
+                switch emailMagicLinkSource {
+                case .login:
+                    return .loginMagicLink
+                case .signup:
+                    return .signupMagicLink
+                }
+            }
             return .loginMagicLink
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/NUXLinkMailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXLinkMailViewController.swift
@@ -11,13 +11,9 @@ class NUXLinkMailViewController: LoginViewController {
     var emailMagicLinkSource: EmailMagicLinkSource?
     override var sourceTag: SupportSourceTag {
         get {
-            if let emailMagicLinkSource = emailMagicLinkSource {
-                switch emailMagicLinkSource {
-                case .login:
-                    return .loginMagicLink
-                case .signup:
-                    return .signupMagicLink
-                }
+            if let emailMagicLinkSource = emailMagicLinkSource,
+                emailMagicLinkSource == .signup {
+                return .signupMagicLink
             }
             return .loginMagicLink
         }

--- a/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
@@ -4,8 +4,18 @@ import SVProgressHUD
 /// View controller that handles the google signup code
 class SignupGoogleViewController: LoginViewController {
 
+    // MARK: - Properties
+
     private var hasShownGoogle = false
     @IBOutlet var titleLabel: UILabel?
+
+    override var sourceTag: SupportSourceTag {
+        get {
+            return .signupWaitingForGoogle
+        }
+    }
+
+    // MARK: - View
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -48,6 +58,8 @@ class SignupGoogleViewController: LoginViewController {
 
 }
 
+// MARK: - GIDSignInDelegate
+
 extension SignupGoogleViewController: GIDSignInDelegate {
     func sign(_ signIn: GIDSignIn?, didSignInFor user: GIDGoogleUser?, withError error: Error?) {
         GIDSignIn.sharedInstance().disconnect()
@@ -84,6 +96,8 @@ extension SignupGoogleViewController: GIDSignInDelegate {
         }
     }
 }
+
+// MARK: - GIDSignInUIDelegate
 
 /// This is needed to set self as uiDelegate, even though none of the methods are called
 extension SignupGoogleViewController: GIDSignInUIDelegate {


### PR DESCRIPTION
Ref #8314

To test: Nothing really. This just add two signup SupportSourceTags. If you feel spunky, you could log out the soureTag in `NUXViewControllerBase.displaySupportViewController` to ensure the tag is correct for the Epilogue and waiting for google page (you have to click fast on this one).


