### PR TITLE
Better offline messages: Extract boilerplate, and preparation for refreshing content when the connection is back up

### DIFF
--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -19,6 +19,7 @@
 
 #import "Comment.h"
 #import "CommentService.h"
+#import "CommentsViewController+Network.h"
 #import "ConfigurablePostView.h"
 #import "Confirmable.h"
 #import "Constants.h"

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Network.h
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Network.h
@@ -4,7 +4,7 @@
 
 
 /**
- Fakes tableViewHandler as a protected property. Only classed importing this header will have access to it
+ Fakes tableViewHandler as a protected property. Only classes importing this header will have access to it
  */
 @interface CommentsViewController (Network)
 @property (nonatomic, strong) WPTableViewHandler *tableViewHandler;

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Network.h
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Network.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+#import "CommentsViewController.h"
+@class WPTableViewHandler;
+
+
+/**
+ Fakes tableViewHandler as a protected property. Only classed importing this header will have access to it
+ */
+@interface CommentsViewController (Network)
+@property (nonatomic, strong) WPTableViewHandler *tableViewHandler;
+@end

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
@@ -1,7 +1,5 @@
 import UIKit
 
-
-// CommentsViewController is an Objective-C class, so in order for interop to work, it looks like we need to override these methods.
 extension CommentsViewController: NetworkAwareUI {
     func contentIsEmpty() -> Bool {
         return tableViewHandler.resultsController.isEmpty()

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
@@ -1,7 +1,17 @@
 import UIKit
 
 extension CommentsViewController: NetworkAwareUI {
-    public func contentIsEmpty() -> Bool {
+    func contentIsEmpty() -> Bool {
         return tableViewHandler.resultsController.isEmpty()
+    }
+
+    @objc
+    func noConnectionMessage() -> String {
+        return ReachabilityUtils.noConnectionMessage()
+    }
+
+    @objc
+    func connectionAvailable() -> Bool {
+        return ReachabilityUtils.isInternetReachable()
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
@@ -1,5 +1,7 @@
 import UIKit
 
+
+// CommentsViewController is an Objective-C class, so in order for interop to work, it looks like we need to override these methods.
 extension CommentsViewController: NetworkAwareUI {
     func contentIsEmpty() -> Bool {
         return tableViewHandler.resultsController.isEmpty()

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+extension CommentsViewController: NetworkAwareUI {
+    public func contentIsEmpty() -> Bool {
+        return tableViewHandler.resultsController.isEmpty()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
@@ -14,4 +14,11 @@ extension CommentsViewController: NetworkAwareUI {
     func connectionAvailable() -> Bool {
         return ReachabilityUtils.isInternetReachable()
     }
+
+    @objc
+    func handleConnectionError() {
+        if shouldPresentAlert() {
+            presentNoNetworkAlert()
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
@@ -7,18 +7,15 @@ extension CommentsViewController: NetworkAwareUI {
         return tableViewHandler.resultsController.isEmpty()
     }
 
-    @objc
-    func noConnectionMessage() -> String {
+    @objc func noConnectionMessage() -> String {
         return ReachabilityUtils.noConnectionMessage()
     }
 
-    @objc
-    func connectionAvailable() -> Bool {
+    @objc func connectionAvailable() -> Bool {
         return ReachabilityUtils.isInternetReachable()
     }
 
-    @objc
-    func handleConnectionError() {
+    @objc func handleConnectionError() {
         if shouldPresentAlert() {
             presentNoNetworkAlert()
         }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -76,6 +76,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     
     // Refresh the UI
     [self refreshNoResultsView];
+    [self handleConnectionError];
 
     [self refreshAndSyncIfNeeded];
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -521,7 +521,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 - (void)refreshNoResultsView
 {
-    BOOL isTableViewEmpty = [self connectionAvailable];
+    BOOL isTableViewEmpty = [self contentIsEmpty];
     BOOL shouldPerformAnimation = self.noResultsView.hidden;
     
     self.noResultsView.hidden = !isTableViewEmpty;

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -429,6 +429,11 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
                                                 failure(error);
                                             });
                                         }
+
+                                        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                                            [weakSelf refreshPullToRefresh];
+                                        });
+                                        
                                         dispatch_async(dispatch_get_main_queue(), ^{
                                             [weakSelf handleConnectionError];
                                         });

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -429,11 +429,9 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
                                                 failure(error);
                                             });
                                         }
-
-                                        if (![self connectionAvailable]) {
-                                            NSString *title = NSLocalizedString(@"Unable to Sync", @"Title of error prompt shown when a sync the user initiated fails.");
-                                            [WPError showNetworkingAlertWithError:error title:title];
-                                        }
+                                        dispatch_async(dispatch_get_main_queue(), ^{
+                                            [weakSelf handleConnectionError];
+                                        });
                                     }];
     }];
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -33,7 +33,6 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 @property (nonatomic, strong) NSCache                   *estimatedRowHeights;
 @end
 
-
 @implementation CommentsViewController
 
 - (void)dealloc
@@ -129,7 +128,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 - (NSString *)noResultsViewTitle
 {
     NSString *noCommentsMessage = NSLocalizedString(@"No comments yet", @"Displayed when the user pulls up the comments view and they have no comments");
-    NSString *noConnectionMessage = [ReachabilityUtils noConnectionMessage];
+    NSString *noConnectionMessage = [self noConnectionMessage];
 
     return [ReachabilityUtils isInternetReachable] ? noCommentsMessage : noConnectionMessage;
 }
@@ -431,7 +430,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
                                             });
                                         }
 
-                                        if (![self isTableViewEmpty]) {
+                                        if (![self connectionAvailable]) {
                                             NSString *title = NSLocalizedString(@"Unable to Sync", @"Title of error prompt shown when a sync the user initiated fails.");
                                             [WPError showNetworkingAlertWithError:error title:title];
                                         }
@@ -476,7 +475,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     [self refreshPullToRefresh];
 }
 
-- (BOOL)isTableViewEmpty
+- (BOOL)contentIsEmpty
 {
     return [self.tableViewHandler.resultsController isEmpty];
 }
@@ -518,7 +517,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 - (void)refreshNoResultsView
 {
-    BOOL isTableViewEmpty = [self isTableViewEmpty];
+    BOOL isTableViewEmpty = [self connectionAvailable];
     BOOL shouldPerformAnimation = self.noResultsView.hidden;
     
     self.noResultsView.hidden = !isTableViewEmpty;

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1085,7 +1085,7 @@ private extension NotificationsViewController {
 
     private func showNoConnectionView() {
         noResultsView.titleText     = NSLocalizedString("No notifications yet.", comment: "Displayed in the Notifications Tab as a title, when there are no notifications")
-        noResultsView.messageText   = ReachabilityUtils.noConnectionMessage()
+        noResultsView.messageText   = noConnectionMessage()
     }
 
     func updateSplitViewAppearanceForNoResultsView() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -738,10 +738,6 @@ private extension NotificationsViewController {
             selectRowForNotification(selectedNotification, animated: false, scrollPosition: .none)
         }
     }
-
-    func isTableViewEmpty() -> Bool {
-        return tableViewHandler.resultsController.isEmpty()
-    }
 }
 
 // MARK: - UIRefreshControl Methods
@@ -770,29 +766,13 @@ extension NotificationsViewController {
             }
         }
     }
-
-    fileprivate func handleConnectionError() {
-        if shouldPresentAlert() {
-            presentNoNetworkAlert()
-        }
-    }
-
-    private func shouldPresentAlert() -> Bool {
-        return !connectionAvailable() && !isTableViewEmpty()
-    }
-
-    func connectionAvailable() -> Bool {
-        return ReachabilityUtils.isInternetReachable()
-    }
-
-    fileprivate func presentNoNetworkAlert() {
-        let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
-        let message = NSLocalizedString("The Internet connection appears to be offline.", comment: "Message of error prompt shown when a sync the user initiated fails.")
-        WPError.showAlert(withTitle: title, message: message)
-    }
 }
 
-
+extension NotificationsViewController: NetworkAwareUI {
+    func contentIsEmpty() -> Bool {
+        return tableViewHandler.resultsController.isEmpty()
+    }
+}
 
 // MARK: - UISegmentedControl Methods
 //

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -545,7 +545,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     private func showNoConnectionView() {
-        noResultsView.titleText = ReachabilityUtils.noConnectionMessage()
+        noResultsView.titleText = noConnectionMessage()
         noResultsView.messageText = ""
         noResultsView.accessoryView = nil
     }

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -352,27 +352,19 @@ open class PeopleViewController: UITableViewController, NSFetchedResultsControll
     private func noResultsTitle() -> String {
         let noPeopleFormat = NSLocalizedString("No %@ Yet",
             comment: "Empty state message (People Management). %@ can be Users or Followers")
-
         let noPeople = String(format: noPeopleFormat, filter.title)
 
-        let noNetwork = ReachabilityUtils.noConnectionMessage()
+        let noNetwork = noConnectionMessage()
 
-        return ReachabilityUtils.isInternetReachable() ? noPeople : noNetwork
+        return connectionAvailable() ? noPeople : noNetwork
     }
 
     private func handleLoadError(_ forError: Error) {
-        let _ = DispatchDelayedAction(delay: .milliseconds(500)) { [weak self] in
+        let _ = DispatchDelayedAction(delay: .milliseconds(250)) { [weak self] in
             self?.refreshControl?.endRefreshing()
         }
 
-        if !isTableViewEmpty() {
-            let alertTitle = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
-            WPError.showNetworkingAlertWithError(forError, title: alertTitle)
-        }
-    }
-
-    private func isTableViewEmpty() -> Bool {
-        return resultsController.isEmpty()
+        handleConnectionError()
     }
 
     // MARK: - Private Helpers
@@ -507,4 +499,10 @@ open class PeopleViewController: UITableViewController, NSFetchedResultsControll
     }
 
     fileprivate let refreshRowPadding = 4
+}
+
+extension PeopleViewController: NetworkAwareUI {
+    func contentIsEmpty() -> Bool {
+        return resultsController.isEmpty()
+    }
 }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -272,6 +272,10 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
             return
         }
 
+        let _ = DispatchDelayedAction(delay: .milliseconds(500)) { [weak self] in
+            self?.refreshControl?.endRefreshing()
+        }
+
         if tableViewHandler.resultsController.fetchedObjects?.count > 0 {
             hideNoResultsView()
             presentNoNetworkAlert()

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -585,18 +585,6 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         }
     }
 
-    private func shouldPresentAlert() -> Bool {
-        return !connectionAvailable() && !isTableViewEmpty()
-    }
-
-    private func isTableViewEmpty() -> Bool {
-        return self.tableViewHandler.resultsController.isEmpty()
-    }
-
-    func connectionAvailable() -> Bool {
-        return ReachabilityUtils.isInternetReachable()
-    }
-
     @objc func syncItemsWithUserInteraction(_ userInteraction: Bool) {
         syncHelper.syncContentWithUserInteraction(userInteraction)
         refreshResults()
@@ -1100,5 +1088,11 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
     func updateSearchResults(for searchController: UISearchController) {
         resetTableViewContentOffset()
         searchHelper.searchUpdated(searchController.searchBar.text)
+    }
+}
+
+extension AbstractPostListViewController: NetworkAwareUI {
+    func contentIsEmpty() -> Bool {
+        return tableViewHandler.resultsController.isEmpty()
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -556,7 +556,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     private func showNoConnectionView() {
-        noResultsView.titleText = ReachabilityUtils.noConnectionMessage()
+        noResultsView.titleText = noConnectionMessage()
         noResultsView.messageText = ""
         noResultsView.accessoryView = nil
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -997,34 +997,16 @@ import WordPressShared
     @objc func handleRefresh(_ sender: UIRefreshControl) {
         if !canSync() {
             cleanupAfterSync()
-            handleConnectionError()
+
+            /// Delay presenting the alert, so that the refreshControl can end its own dismissal animation, and the table view scroll back to its original offset
+            let _ = DispatchDelayedAction(delay: .milliseconds(200)) { [weak self] in
+                self?.handleConnectionError()
+            }
+
             return
         }
         syncHelper.syncContentWithUserInteraction(true)
     }
-
-    private func handleConnectionError() {
-        if shouldPresentAlert() {
-            _ = DispatchDelayedAction(delay: .milliseconds(500)) {[weak self] in
-                self?.presentNoNetworkAlert()
-            }
-        }
-    }
-
-    private func shouldPresentAlert() -> Bool {
-        return !connectionAvailable() && !isTableViewEmpty()
-    }
-
-    private func presentNoNetworkAlert() {
-        let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
-        let message = NSLocalizedString("The Internet connection appears to be offline.", comment: "Message of error prompt shown when a sync the user initiated fails.")
-        WPError.showAlert(withTitle: title, message: message)
-    }
-
-    private func isTableViewEmpty() -> Bool {
-        return self.tableViewHandler.resultsController.isEmpty()
-    }
-
 
     /// Handle's the user tapping the search button.  Displays the search controller
     ///

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -461,7 +461,7 @@ import WordPressShared
 
     private func displayNoConnectionView(_ topic: ReaderAbstractTopic) {
         resultsStatusView.titleText = ReaderStreamViewController.responseForNoResults(topic).title
-        resultsStatusView.messageText = ReachabilityUtils.noConnectionMessage()
+        resultsStatusView.messageText = noConnectionMessage()
         resultsStatusView.accessoryView = nil
         displayResultsStatus()
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1832,9 +1832,14 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
 
 }
 
-
 extension ReaderStreamViewController: WPNoResultsViewDelegate {
     public func didTap(_ noResultsView: WPNoResultsView!) {
         showManageSites()
+    }
+}
+
+extension ReaderStreamViewController: NetworkAwareUI {
+    func contentIsEmpty() -> Bool {
+        return tableViewHandler.resultsController.isEmpty()
     }
 }

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -28,7 +28,7 @@ extension NetworkAwareUI {
         }
     }
 
-    func presentNetworkAlert() {
+    func presentNoNetworkAlert() {
         let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
         let message = NSLocalizedString("The Internet connection appears to be offline.", comment: "Message of error prompt shown when a sync the user initiated fails.")
         WPError.showAlert(withTitle: title, message: message)

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -1,0 +1,36 @@
+
+/// Abstracts UI elements that need to be aware of the network connection status.
+protocol NetworkAware {
+    func connectionAvailable() -> Bool
+    func handleConnectionError()
+}
+
+protocol NetworkAwareUI: NetworkAware {
+    func shouldPresentAlert() -> Bool
+    func contentIsEmpty() -> Bool
+    func presentNoNetworkAlert()
+}
+
+extension NetworkAware {
+    func connectionAvailable() -> Bool {
+        return ReachabilityUtils.isInternetReachable()
+    }
+}
+
+extension NetworkAwareUI {
+    func shouldPresentAlert() -> Bool {
+        return !connectionAvailable() && !contentIsEmpty()
+    }
+
+    func handleConnectionError() {
+        if shouldPresentAlert() {
+            presentNoNetworkAlert()
+        }
+    }
+
+    func presentNetworkAlert() {
+        let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
+        let message = NSLocalizedString("The Internet connection appears to be offline.", comment: "Message of error prompt shown when a sync the user initiated fails.")
+        WPError.showAlert(withTitle: title, message: message)
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -1,10 +1,11 @@
 
-/// Abstracts UI elements that need to be aware of the network connection status.
+/// Abstracts elements that need to be aware of the network connection status.
 protocol NetworkAware {
     func connectionAvailable() -> Bool
     func handleConnectionError()
 }
 
+/// Abstracts UI elements that need to be aware of the network connection status, and present user facing alerts.
 protocol NetworkAwareUI: NetworkAware {
     func shouldPresentAlert() -> Bool
     func contentIsEmpty() -> Bool

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -9,6 +9,7 @@ protocol NetworkAwareUI: NetworkAware {
     func shouldPresentAlert() -> Bool
     func contentIsEmpty() -> Bool
     func presentNoNetworkAlert()
+    func noConnectionMessage() -> String
 }
 
 extension NetworkAware {
@@ -32,5 +33,9 @@ extension NetworkAwareUI {
         let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
         let message = NSLocalizedString("The Internet connection appears to be offline.", comment: "Message of error prompt shown when a sync the user initiated fails.")
         WPError.showAlert(withTitle: title, message: message)
+    }
+
+    func noConnectionMessage() -> String {
+        return ReachabilityUtils.noConnectionMessage()
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -856,6 +856,7 @@
 		D809E686203F0215001AA0DE /* ReaderPostCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */; };
 		D80EE63A203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */; };
 		D8B6BEB7203E11F2007C8A19 /* Bundle+LoadFromNib.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6BEB6203E11F2007C8A19 /* Bundle+LoadFromNib.swift */; };
+		D8B9B58F204F4EA1003C6042 /* NetworkAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */; };
 		E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */; };
 		E10290741F30615A00DAC588 /* Role.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10290731F30615A00DAC588 /* Role.swift */; };
 		E102B7901E714F24007928E8 /* RecentSitesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E102B78F1E714F24007928E8 /* RecentSitesService.swift */; };
@@ -2361,6 +2362,7 @@
 		D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostCardCellTests.swift; sourceTree = "<group>"; };
 		D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderFollowedSitesStreamHeaderTests.swift; sourceTree = "<group>"; };
 		D8B6BEB6203E11F2007C8A19 /* Bundle+LoadFromNib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+LoadFromNib.swift"; sourceTree = "<group>"; };
+		D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAware.swift; sourceTree = "<group>"; };
 		DA67DF58196D8F6A005B5BC8 /* WordPress 20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 20.xcdatamodel"; sourceTree = "<group>"; };
 		E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-11-12.xcmappingmodel"; sourceTree = "<group>"; };
 		E10290731F30615A00DAC588 /* Role.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Role.swift; sourceTree = "<group>"; };
@@ -3250,7 +3252,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				E1B34C091CCDFFCE00889709 /* Credentials */,
@@ -4219,6 +4221,7 @@
 				176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */,
 				310186691A373B01008F7DF6 /* WPTabBarController.h */,
 				3101866A1A373B01008F7DF6 /* WPTabBarController.m */,
+				D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -6419,7 +6422,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -6785,7 +6788,7 @@
 			inputPaths = (
 				"${SRCROOT}/../Pods/Target Support Files/Pods-WordPress/Pods-WordPress-resources.sh",
 				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
-				"$PODS_CONFIGURATION_BUILD_DIR/HockeySDK/HockeySDKResources.bundle",
+				$PODS_CONFIGURATION_BUILD_DIR/HockeySDK/HockeySDKResources.bundle,
 			);
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
@@ -7248,6 +7251,7 @@
 				E66969E21B9E67A000EC9C00 /* ReaderTopicToReaderSiteTopic37to38.swift in Sources */,
 				E14A52371E39F43E00EE203E /* AppRatingsUtility.swift in Sources */,
 				8350E49611D2C71E00A7B073 /* Media.m in Sources */,
+				D8B9B58F204F4EA1003C6042 /* NetworkAware.swift in Sources */,
 				B54346961C6A707D0010B3AD /* LanguageViewController.swift in Sources */,
 				E6805D321DCD399600168E4F /* WPRichTextMediaAttachment.swift in Sources */,
 				B53AD9BC1BE95687009AB87E /* SettingsTextViewController.m in Sources */,
@@ -8802,7 +8806,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_alpha_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_alpha_app_credentials;
 			};
 			name = "Release-Alpha";
 		};
@@ -9277,7 +9281,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_internal_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_internal_app_credentials;
 			};
 			name = "Release-Internal";
 		};
@@ -9620,7 +9624,7 @@
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 3.0;
-				WPCOM_CONFIG = "$HOME/.wpcom_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
 			};
 			name = Debug;
 		};
@@ -9670,7 +9674,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
 			};
 			name = Release;
 		};

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -857,6 +857,7 @@
 		D80EE63A203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */; };
 		D8B6BEB7203E11F2007C8A19 /* Bundle+LoadFromNib.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6BEB6203E11F2007C8A19 /* Bundle+LoadFromNib.swift */; };
 		D8B9B58F204F4EA1003C6042 /* NetworkAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */; };
+		D8B9B591204F658A003C6042 /* CommentsViewController+NetworkAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B9B590204F658A003C6042 /* CommentsViewController+NetworkAware.swift */; };
 		E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */; };
 		E10290741F30615A00DAC588 /* Role.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10290731F30615A00DAC588 /* Role.swift */; };
 		E102B7901E714F24007928E8 /* RecentSitesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E102B78F1E714F24007928E8 /* RecentSitesService.swift */; };
@@ -2363,6 +2364,8 @@
 		D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderFollowedSitesStreamHeaderTests.swift; sourceTree = "<group>"; };
 		D8B6BEB6203E11F2007C8A19 /* Bundle+LoadFromNib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+LoadFromNib.swift"; sourceTree = "<group>"; };
 		D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAware.swift; sourceTree = "<group>"; };
+		D8B9B590204F658A003C6042 /* CommentsViewController+NetworkAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentsViewController+NetworkAware.swift"; sourceTree = "<group>"; };
+		D8B9B592204F6C93003C6042 /* CommentsViewController+Network.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CommentsViewController+Network.h"; sourceTree = "<group>"; };
 		DA67DF58196D8F6A005B5BC8 /* WordPress 20.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 20.xcdatamodel"; sourceTree = "<group>"; };
 		E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-11-12.xcmappingmodel"; sourceTree = "<group>"; };
 		E10290731F30615A00DAC588 /* Role.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Role.swift; sourceTree = "<group>"; };
@@ -4869,6 +4872,8 @@
 				5D6C4AFD1B603CE9005E3C43 /* EditCommentViewController.xib */,
 				2906F80F110CDA8900169D56 /* EditCommentViewController.h */,
 				2906F810110CDA8900169D56 /* EditCommentViewController.m */,
+				D8B9B590204F658A003C6042 /* CommentsViewController+NetworkAware.swift */,
+				D8B9B592204F6C93003C6042 /* CommentsViewController+Network.h */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -7396,6 +7401,7 @@
 				E1E4CE0B1773C59B00430844 /* WPAvatarSource.m in Sources */,
 				85D239AE1AE5A5FC0074768D /* BlogSyncFacade.m in Sources */,
 				5D97C2F315CAF8D8009B44DD /* UINavigationController+KeyboardFix.m in Sources */,
+				D8B9B591204F658A003C6042 /* CommentsViewController+NetworkAware.swift in Sources */,
 				4034FDEA2007C42400153B87 /* ExpandableCell.swift in Sources */,
 				40E469932017F4070030DB5F /* PluginDirectoryViewController.swift in Sources */,
 				E1D28E931F2F6EB500A5DAFD /* RoleService.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -8812,7 +8812,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = $HOME/.wpcom_alpha_app_credentials;
+				WPCOM_CONFIG = "$HOME/.wpcom_alpha_app_credentials";
 			};
 			name = "Release-Alpha";
 		};


### PR DESCRIPTION
Implements part of #5759 

This PR assumes the rest of PRs open against #5759 will be approved eventually. It takes where the last one ends, and attempts to remove all the boilerplate introduced to present alerts and user facing messages when the network is down.

This is the first step to refresh content when the connection comes back up (which will be implemented in a follow-up PR)

To test:
1. Enter flight mode
2. Navigate the app (Sites,Sites > Pages, Sites > Blog Posts, Sites > Comments, Sites > People, Reader, Notifications)

The diff in this PR, as it is, contains only the effort to remove the aforementioned boilerplate.

Changing the base branch to iOS-5759-better-offline would allow a review of the full implementation of the feature (which has been already reviewed and approved, except the changes in `CommentsViewController` and `PeopleViewController`)
