### PR TITLE
Notifications: Move comment + approve feedback generation pre-animation

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1028,8 +1028,6 @@ private extension NotificationDetailsViewController {
     }
 
     func likeCommentWithBlock(_ block: NotificationBlock) {
-        UINotificationFeedbackGenerator().notificationOccurred(.success)
-
         actionsService.likeCommentWithBlock(block)
         WPAppAnalytics.track(.notificationsCommentLiked, withBlogID: block.metaSiteID)
     }
@@ -1040,8 +1038,6 @@ private extension NotificationDetailsViewController {
     }
 
     func approveCommentWithBlock(_ block: NotificationBlock) {
-        UINotificationFeedbackGenerator().notificationOccurred(.success)
-
         actionsService.approveCommentWithBlock(block)
         WPAppAnalytics.track(.notificationsCommentApproved, withBlogID: block.metaSiteID)
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -242,6 +242,10 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
             let onClick = isLikeOn ? onUnlikeClick : onLikeClick
             isLikeOn = !isLikeOn
 
+            if isLikeOn {
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+            }
+
             animateLikeButton(btnLike) {
                 onClick?(sender)
             }
@@ -252,6 +256,10 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
         ReachabilityUtils.onAvailableInternetConnectionDo {
             let onClick = isApproveOn ? onUnapproveClick : onApproveClick
             isApproveOn = !isApproveOn
+
+            if isApproveOn {
+                UINotificationFeedbackGenerator().notificationOccurred(.success)
+            }
 
             animateApproveButton(btnApprove) {
                 onClick?(sender)


### PR DESCRIPTION
Fixes #8753 

So the original issue was caused because the feedback was triggered in the details view controller, in methods that were only called after the button animations were completed. I've moved the feedback generation forward, so that it happens before the animations.

**To test:**

* From a comment notification, try liking a comment and approving a comment. Check the Taptic feedback happens as soon as you tap the button.