### PR TITLE
Fix account verification crash when email is missing

### DIFF
--- a/WordPress/Classes/Models/WPAccount+AccountSettings.swift
+++ b/WordPress/Classes/Models/WPAccount+AccountSettings.swift
@@ -1,6 +1,12 @@
 import Foundation
 
 extension WPAccount {
+    enum VerificationStatus: String {
+        case unknown
+        case verified
+        case unverified
+    }
+
     func applyChange(_ change: AccountSettingsChange) {
         switch change {
         case .displayName(let value):
@@ -11,5 +17,16 @@ extension WPAccount {
         default:
             break
         }
+    }
+
+    var verificationStatus: VerificationStatus {
+        guard let verified = emailVerified?.boolValue else {
+            return .unknown
+        }
+        return verified ? .verified : .unverified
+    }
+
+    var needsEmailVerification: Bool {
+        return verificationStatus == .unverified
     }
 }

--- a/WordPress/Classes/Models/WPAccount.h
+++ b/WordPress/Classes/Models/WPAccount.h
@@ -39,11 +39,6 @@
  */
 @property (nonatomic, readonly) WordPressComRestApi *wordPressComRestApi;
 
-/**
- A string with the email verification status. Can be "verified", "unverified", or "unknown".
- */
-- (NSString *)verificationStatus;
-
 @end
 
 @interface WPAccount (CoreDataGeneratedAccessors)

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -124,16 +124,6 @@ static NSString * const WordPressComOAuthKeychainServiceName = @"public-api.word
     return [visibleBlogs sortedArrayUsingDescriptors:@[descriptor]];
 }
 
-- (NSString *)verificationStatus {
-    if (!self.emailVerified) {
-        return @"unknown";
-    } else if ([self.emailVerified boolValue]) {
-        return @"verified";
-    } else {
-        return @"unverified";
-    }
-}
-
 #pragma mark - API Helpers
 
 - (WordPressComRestApi *)wordPressComRestApi

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -162,9 +162,8 @@ extension WordPressAppDelegate {
 
         if let account = account,
             let username = account.username,
-            let userID = account.userID,
-            let verificationStatus = account.verificationStatus() {
-            DDLogInfo("wp.com account: \(username) (ID: \(userID)) (\(verificationStatus))")
+            let userID = account.userID {
+            DDLogInfo("wp.com account: \(username) (ID: \(userID)) (\(account.verificationStatus.rawValue))")
         }
 
         if let blogs = blogs as? [Blog], blogs.count > 0 {

--- a/WordPress/Classes/ViewRelated/Aztec/Helpers/AztecVerificationPromptHelper.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Helpers/AztecVerificationPromptHelper.swift
@@ -19,7 +19,7 @@ class AztecVerificationPromptHelper: NSObject {
         accountService = AccountService(managedObjectContext: managedObjectContext)
 
         guard accountService.isDefaultWordPressComAccount(passedAccount),
-              !passedAccount.emailVerified.boolValue else {
+              passedAccount.needsEmailVerification else {
                 // if the post the user is trying to compose isn't on a WP.com account,
                 // or they're already verified, then the verification prompt is irrelevant.
                 return nil
@@ -44,7 +44,7 @@ class AztecVerificationPromptHelper: NSObject {
             return false
         }
 
-        return !wpComAccount.emailVerified.boolValue
+        return wpComAccount.needsEmailVerification
     }
 
     /// - parameter presentingViewController: UIViewController that the prompt should be presented from.
@@ -54,7 +54,8 @@ class AztecVerificationPromptHelper: NSObject {
                                    then: AztecVerificationPromptCompletion?) {
 
         let fancyAlert = FancyAlertViewController.verificationPromptController { [weak self] in
-            then?(self?.wpComAccount.emailVerified.boolValue ?? false)
+            let needsVerification = self?.wpComAccount.needsEmailVerification ?? true
+            then?(!needsVerification)
         }
 
         fancyAlert.modalPresentationStyle = .custom
@@ -78,12 +79,12 @@ class AztecVerificationPromptHelper: NSObject {
                                             // the verification status has changed, before we call the callback.
                                             guard let displayedAlert = self?.displayedAlert,
                                                   let updatedAccount = self?.accountService.defaultWordPressComAccount(),
-                                                  updatedAccount.emailVerified.boolValue else {
+                                                  !updatedAccount.needsEmailVerification else {
                                                         return
                                             }
 
                                             displayedAlert.dismiss(animated: true, completion: nil)
-                                            self?.completionBlock?(updatedAccount.emailVerified.boolValue)
+                                            self?.completionBlock?(!updatedAccount.needsEmailVerification)
             }, failure: nil)
     }
 


### PR DESCRIPTION
I refactored the emailVerified a bit to use an enum. @jklausa I'm a bit confused by the logic in `AztecVerificationPromptHelper`, does this make sense?

Fixes #8837 