### PR TITLE
Fixing Shaky ReplyTextView

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -364,7 +364,7 @@ private extension ReplyTextView {
 // MARK: - Settings
 //
 private extension ReplyTextView {
-    
+
     enum Settings {
 
         /// Maximum number of *visible* lines

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -53,13 +53,18 @@ import WordPressShared.WPStyleGuide
             return placeholderLabel.text
         }
     }
-
     @objc open var replyText: String! {
         set {
             replyButton.setTitle(newValue, for: UIControlState())
         }
         get {
             return replyButton.title(for: UIControlState())
+        }
+    }
+
+    open var maximumNumberOfVisibleLines = Settings.maximumNumberOfVisibleLines {
+        didSet {
+            invalidateIntrinsicContentSize()
         }
     }
 
@@ -202,15 +207,8 @@ import WordPressShared.WPStyleGuide
         textView.layoutIfNeeded()
 
         // Calculate the entire control's size
-        let topMargin = bezierContainerView.layoutMargins.top
-        let bottomMargin = bezierContainerView.layoutMargins.bottom
-
-        let contentHeight = textView.contentSize.height
-        let fullWidth = frame.width
-        let textHeight = floor(contentHeight + topMargin + bottomMargin)
-
-        let newHeight = min(max(textHeight, textViewMinHeight), textViewMaxHeight)
-        let intrinsicSize = CGSize(width: fullWidth, height: newHeight)
+        let newHeight = min(max(contentHeight, minimumHeight), maximumHeight)
+        let intrinsicSize = CGSize(width: frame.width, height: newHeight)
 
         return intrinsicSize
     }
@@ -218,22 +216,20 @@ import WordPressShared.WPStyleGuide
 
     // MARK: - Setup Helpers
     fileprivate func setupView() {
-        self.frame.size.height = textViewMinHeight
-
         // Load the nib + add its container view
         bundle = Bundle.main.loadNibNamed("ReplyTextView", owner: self, options: nil) as NSArray?
         addSubview(contentView)
 
         // Setup Layout
-        self.translatesAutoresizingMaskIntoConstraints = false
+        translatesAutoresizingMaskIntoConstraints = false
         contentView.translatesAutoresizingMaskIntoConstraints = false
         pinSubviewToAllEdges(contentView)
 
         // Setup the TextView
         textView.delegate = self
         textView.scrollsToTop = false
-        textView.contentInset = UIEdgeInsets.zero
-        textView.textContainerInset = UIEdgeInsets.zero
+        textView.contentInset = .zero
+        textView.textContainerInset = .zero
         textView.font = WPStyleGuide.Reply.textFont
         textView.textColor = WPStyleGuide.Reply.textColor
         textView.textContainer.lineFragmentPadding = 0
@@ -260,6 +256,7 @@ import WordPressShared.WPStyleGuide
 
         // Bezier
         bezierContainerView.bezierColor = WPStyleGuide.Reply.separatorColor
+        bezierContainerView.translatesAutoresizingMaskIntoConstraints = false
 
         // Separators
         separatorsView.topColor = WPStyleGuide.Reply.separatorColor
@@ -268,6 +265,10 @@ import WordPressShared.WPStyleGuide
         // Recognizers
         let recognizer = UITapGestureRecognizer(target: self, action: #selector(ReplyTextView.backgroundWasTapped))
         gestureRecognizers = [recognizer]
+
+        /// Initial Sizing: Final step, since this depends on other control(s) initialization
+        ///
+        frame.size.height = minimumHeight
     }
 
 
@@ -307,10 +308,6 @@ import WordPressShared.WPStyleGuide
     }
 
 
-    // MARK: - Constants
-    fileprivate let textViewMaxHeight = CGFloat(86)   // Fits 3 lines onscreen
-    fileprivate let textViewMinHeight = CGFloat(50)
-
     // MARK: - Private Properties
     fileprivate var bundle: NSArray?
 
@@ -323,4 +320,59 @@ import WordPressShared.WPStyleGuide
     @IBOutlet private var contentView: UIView!
     @IBOutlet private var bezierTopConstraint: NSLayoutConstraint!
     @IBOutlet private var bezierBottomConstraint: NSLayoutConstraint!
+}
+
+
+// MARK: - Layout Calculated Properties
+//
+private extension ReplyTextView {
+
+    /// Padding: Bezier Margins (Top / Bottom) + Bezier Constraints (Top / Bottom)
+    ///
+    var contentPadding: CGFloat {
+        return bezierContainerView.layoutMargins.top + bezierContainerView.layoutMargins.bottom
+                + bezierTopConstraint.constant + bezierBottomConstraint.constant
+    }
+
+    /// Returns the Content Height (non capped).
+    ///
+    var contentHeight: CGFloat {
+        return ceil(textView.contentSize.height) + contentPadding
+    }
+
+    /// Returns the current Font's LineHeight.
+    ///
+    var lineHeight: CGFloat {
+        let lineHeight = textView.font?.lineHeight ?? Settings.defaultLineHeight
+        return ceil(lineHeight)
+    }
+
+    /// Returns the Minimum component Height.
+    ///
+    var minimumHeight: CGFloat {
+        return lineHeight + contentPadding
+    }
+
+    /// Returns the Maximum component Height.
+    ///
+    var maximumHeight: CGFloat {
+        return lineHeight * CGFloat(maximumNumberOfVisibleLines) + contentPadding
+    }
+}
+
+
+// MARK: - Settings
+//
+private extension ReplyTextView {
+    
+    enum Settings {
+
+        /// Maximum number of *visible* lines
+        ///
+        static let maximumNumberOfVisibleLines = 3
+
+        /// Default Line Height. Used as a safety measure, in case the actual font is not yet loaded.
+        ///
+        static let defaultLineHeight = CGFloat(21)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -315,10 +315,12 @@ import WordPressShared.WPStyleGuide
     fileprivate var bundle: NSArray?
 
     // MARK: - IBOutlets
-    @IBOutlet fileprivate var textView: UITextView!
-    @IBOutlet fileprivate var placeholderLabel: UILabel!
-    @IBOutlet fileprivate var replyButton: UIButton!
-    @IBOutlet fileprivate var bezierContainerView: ReplyBezierView!
-    @IBOutlet fileprivate var separatorsView: SeparatorsView!
-    @IBOutlet fileprivate var contentView: UIView!
+    @IBOutlet private var textView: UITextView!
+    @IBOutlet private var placeholderLabel: UILabel!
+    @IBOutlet private var replyButton: UIButton!
+    @IBOutlet private var bezierContainerView: ReplyBezierView!
+    @IBOutlet private var separatorsView: SeparatorsView!
+    @IBOutlet private var contentView: UIView!
+    @IBOutlet private var bezierTopConstraint: NSLayoutConstraint!
+    @IBOutlet private var bezierBottomConstraint: NSLayoutConstraint!
 }

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.xib
@@ -1,17 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ReplyTextView" customModule="WordPress">
             <connections>
+                <outlet property="bezierBottomConstraint" destination="Ocu-Gu-5Xw" id="PCv-Aq-cAs"/>
                 <outlet property="bezierContainerView" destination="t6q-rh-Bzh" id="eED-vb-5Ix"/>
+                <outlet property="bezierTopConstraint" destination="7Fj-lO-ua1" id="oJu-iL-iS9"/>
                 <outlet property="contentView" destination="iN0-l3-epB" id="4IS-I7-JV9"/>
                 <outlet property="placeholderLabel" destination="6Lf-XI-exE" id="vNK-7w-Wk1"/>
                 <outlet property="replyButton" destination="8sg-79-AsR" id="z4S-0x-kJt"/>
@@ -29,10 +32,10 @@
                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </view>
                 <view multipleTouchEnabled="YES" contentMode="scaleToFill" horizontalHuggingPriority="240" horizontalCompressionResistancePriority="740" translatesAutoresizingMaskIntoConstraints="NO" id="t6q-rh-Bzh" customClass="ReplyBezierView" customModule="WordPress">
-                    <rect key="frame" x="7" y="1" width="231" height="73"/>
+                    <rect key="frame" x="15" y="1" width="215" height="73"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Placeholder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Lf-XI-exE" userLabel="Placeholder">
-                            <rect key="frame" x="8" y="14" width="219" height="45"/>
+                            <rect key="frame" x="8" y="33" width="203" height="26"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -40,7 +43,7 @@
                             <size key="shadowOffset" width="-1" height="-1"/>
                         </label>
                         <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" showsHorizontalScrollIndicator="NO" bouncesZoom="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="gfH-NN-dph">
-                            <rect key="frame" x="8" y="14" width="219" height="45"/>
+                            <rect key="frame" x="8" y="33" width="203" height="26"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <fontDescription key="fontDescription" type="system" pointSize="13"/>
                             <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -60,7 +63,7 @@
                     <edgeInsets key="layoutMargins" top="14" left="8" bottom="14" right="4"/>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="VGi-tL-gUc">
-                    <rect key="frame" x="238" y="1" width="74" height="73"/>
+                    <rect key="frame" x="230" y="1" width="74" height="73"/>
                     <subviews>
                         <view contentMode="scaleToFill" horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="Chg-FI-dzN" userLabel="Spacer View">
                             <rect key="frame" x="0.0" y="0.0" width="74" height="21"/>


### PR DESCRIPTION
### Details:
1. Launch WPiOS and log into a dotcom account
2. Open the Notifications tab
3. Open any Notification that allows for Text Entry at the bottom
4. Type some random text in the reply component

Verify that the ReplyTextView doesn't get resized every single time you hit a button.

Closes #8847

Needs Review: @frosty 
Sir, you game for a review?. (Thanks!!!)
