### PR TITLE
Fix two rotatable Signup screens 

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginPrologueSignupMethodViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginPrologueSignupMethodViewController.swift
@@ -1,4 +1,4 @@
-class LoginPrologueSignupMethodViewController: UIViewController {
+class LoginPrologueSignupMethodViewController: NUXViewController {
     /// Buttons at bottom of screen
     private var buttonViewController: NUXButtonViewController?
 

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
@@ -160,7 +160,7 @@ import WordPressShared
             }
         }
 
-        let navController = UINavigationController(rootViewController: controller)
+        let navController = NUXNavigationController(rootViewController: controller)
 
         // The way the magic link flow works some view controller might
         // still be presented when the app is resumed by tapping on the auth link.


### PR DESCRIPTION
Fixes  #8833

Signup epilogue can no longer rotate. Also found that the signup method selection screen (Email vs. Google) was rotatable, too.

This has likely been a problem with the magic link flow since 2016 😉

To test:
- signup to a new account
- ensure the Email vs Gmail screen can't rotate
- ensure the epilogue screen can't rotate
