### PR TITLE
Reload content when the network connection is back up

### DIFF
--- a/WordPress/Classes/Extensions/Notifications/NotificationName+Names.swift
+++ b/WordPress/Classes/Extensions/Notifications/NotificationName+Names.swift
@@ -1,12 +1,14 @@
 
 import Foundation
 
+/// Declares Notification Names
 extension Foundation.Notification.Name {
     static var reachabilityChanged: Foundation.NSNotification.Name {
         return Foundation.Notification.Name("org.wordpress.reachability.changed")
     }
 }
 
+/// Keys for Notification's userInfo dictionary
 extension Foundation.Notification {
     static var reachabilityKey: String {
         return "org.wordpress.reachability"

--- a/WordPress/Classes/Extensions/Notifications/NotificationName+Names.swift
+++ b/WordPress/Classes/Extensions/Notifications/NotificationName+Names.swift
@@ -1,0 +1,14 @@
+
+import Foundation
+
+extension Foundation.Notification.Name {
+    static var reachabilityChanged: Foundation.NSNotification.Name {
+        return Foundation.Notification.Name("org.wordpress.reachability.changed")
+    }
+}
+
+extension Foundation.Notification {
+    static var reachabilityKey: String {
+        return "org.wordpress.reachability"
+    }
+}

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -54,7 +54,10 @@ extension WordPressAppDelegate {
             let wwan = reachability.isReachableViaWWAN() ? "Y" : "N"
 
             DDLogInfo("Reachability - Internet - WiFi: \(wifi) WWAN: \(wwan)")
-            self?.connectionAvailable = reachability.isReachable()
+            let newValue = reachability.isReachable()
+            self?.connectionAvailable = newValue
+
+            NotificationCenter.default.post(name: .reachabilityChanged, object: self, userInfo: [Foundation.Notification.reachabilityKey: newValue])
         }
 
         internetReachability.reachableBlock = reachabilityBlock

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Network.h
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+Network.h
@@ -8,4 +8,6 @@
  */
 @interface CommentsViewController (Network)
 @property (nonatomic, strong) WPTableViewHandler *tableViewHandler;
+
+- (void)refreshAndSyncIfNeeded;
 @end

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
@@ -21,7 +21,7 @@ extension CommentsViewController: NetworkAwareUI {
 }
 
 extension CommentsViewController: NetworkStatusDelegate {
-    func networdStatusDidChange(active: Bool) {
+    func networkStatusDidChange(active: Bool) {
         refreshAndSyncIfNeeded()
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
@@ -19,3 +19,9 @@ extension CommentsViewController: NetworkAwareUI {
         }
     }
 }
+
+extension CommentsViewController: NetworkStatusDelegate {
+    func networdStatusDidChange(active: Bool) {
+        refreshAndSyncIfNeeded()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -777,7 +777,7 @@ extension NotificationsViewController: NetworkAwareUI {
 }
 
 extension NotificationsViewController: NetworkStatusDelegate {
-    func networdStatusDidChange(active: Bool) {
+    func networkStatusDidChange(active: Bool) {
         reloadResultsControllerIfNeeded()
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -119,6 +119,8 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         setupFiltersSegmentedControl()
 
         reloadTableViewPreservingSelection()
+
+        observeNetworkStatus()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -771,6 +773,12 @@ extension NotificationsViewController {
 extension NotificationsViewController: NetworkAwareUI {
     func contentIsEmpty() -> Bool {
         return tableViewHandler.resultsController.isEmpty()
+    }
+}
+
+extension NotificationsViewController: NetworkStatusDelegate {
+    func networdStatusDidChange(active: Bool) {
+        reloadResultsControllerIfNeeded()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -161,6 +161,8 @@ open class PeopleViewController: UITableViewController, NSFetchedResultsControll
 
         // By default, let's display the Blog's Users
         filter = .Users
+
+        observeNetworkStatus()
     }
 
     open override func viewWillAppear(_ animated: Bool) {
@@ -504,5 +506,11 @@ open class PeopleViewController: UITableViewController, NSFetchedResultsControll
 extension PeopleViewController: NetworkAwareUI {
     func contentIsEmpty() -> Bool {
         return resultsController.isEmpty()
+    }
+}
+
+extension PeopleViewController: NetworkStatusDelegate {
+    func networdStatusDidChange(active: Bool) {
+        refresh()
     }
 }

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -510,7 +510,7 @@ extension PeopleViewController: NetworkAwareUI {
 }
 
 extension PeopleViewController: NetworkStatusDelegate {
-    func networdStatusDidChange(active: Bool) {
+    func networkStatusDidChange(active: Bool) {
         refresh()
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1105,9 +1105,6 @@ extension AbstractPostListViewController: NetworkAwareUI {
 
 extension AbstractPostListViewController: NetworkStatusDelegate {
     func networkStatusDidChange(active: Bool) {
-        // The network status is received from a background thread, only in this view controller
-        DispatchQueue.main.async {
-            self.automaticallySyncIfAppropriate()
-        }
+        automaticallySyncIfAppropriate()
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1105,6 +1105,9 @@ extension AbstractPostListViewController: NetworkAwareUI {
 
 extension AbstractPostListViewController: NetworkStatusDelegate {
     func networdStatusDidChange(active: Bool) {
-        refreshResults()
+        // The network status is received from a background thread, only in this view controller
+        DispatchQueue.main.async {
+            self.automaticallySyncIfAppropriate()
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1104,7 +1104,7 @@ extension AbstractPostListViewController: NetworkAwareUI {
 }
 
 extension AbstractPostListViewController: NetworkStatusDelegate {
-    func networdStatusDidChange(active: Bool) {
+    func networkStatusDidChange(active: Bool) {
         // The network status is received from a background thread, only in this view controller
         DispatchQueue.main.async {
             self.automaticallySyncIfAppropriate()

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -132,6 +132,8 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
         tableView.reloadData()
+
+        observeNetworkStatus()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1100,3 +1100,9 @@ extension AbstractPostListViewController: NetworkAwareUI {
         return tableViewHandler.resultsController.isEmpty()
     }
 }
+
+extension AbstractPostListViewController: NetworkStatusDelegate {
+    func networdStatusDidChange(active: Bool) {
+        refreshResults()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1825,3 +1825,9 @@ extension ReaderStreamViewController: NetworkAwareUI {
         return tableViewHandler.resultsController.isEmpty()
     }
 }
+
+extension ReaderStreamViewController: NetworkStatusDelegate {
+    func networdStatusDidChange(active: Bool) {
+        syncIfAppropriate()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -224,6 +224,8 @@ import WordPressShared
         setupSyncHelper()
         setupResultsStatusView()
 
+        observeNetworkStatus()
+
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
 
         didSetupView = true

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1829,7 +1829,7 @@ extension ReaderStreamViewController: NetworkAwareUI {
 }
 
 extension ReaderStreamViewController: NetworkStatusDelegate {
-    func networdStatusDidChange(active: Bool) {
+    func networkStatusDidChange(active: Bool) {
         syncIfAppropriate()
     }
 }

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -41,10 +41,7 @@ extension NetworkAwareUI {
     }
 }
 
-fileprivate struct NetworkStatusAssociatedKeys {
-    static var associatedObjectKey = "com.later.error.notification.receiver"
-}
-
+/// Implementations of this protocol will be notified when the network connection status changes. Implementations of this protocol must call the observeNetworkStatus method.
 protocol NetworkStatusDelegate: class {
     func observeNetworkStatus()
 
@@ -65,56 +62,11 @@ extension NetworkStatusDelegate where Self: UIViewController {
             objc_setAssociatedObject(self, &NetworkStatusAssociatedKeys.associatedObjectKey, newValue, .OBJC_ASSOCIATION_RETAIN)
         }
     }
-
-//    private(set) var reachabilityObserver: ReachabilityObserver {
-//        get {
-//            guard let value = objc_getAssociatedObject(self, &NetworkStatusAssociatedKeys.observer) as? ReachabilityObserver else {
-//                return ReachabilityObserver(delegate: self)
-//            }
-//            return value
-//        }
-//        set(newValue) {
-//            objc_setAssociatedObject(self, &NetworkStatusAssociatedKeys.observer, newValue, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-//        }
-//    }
-//
-//    func observeNetworkStatus() {
-//        reachabilityObserver = ReachabilityObserver(delegate: self)
-//    }
 }
 
-//@objc final class ReachabilityObserver: NSObject {
-//    private static var observerContext = 0
-//    weak var delegate: NetworkStatusDelegate?
-//
-//    init(delegate: NetworkStatusDelegate) {
-//        self.delegate = delegate
-//        super.init()
-//
-//        configureObserver()
-//    }
-//
-//    private func configureObserver() {
-//        if let appDelegate = UIApplication.shared.delegate as? WordPressAppDelegate {
-//            appDelegate.addObserver(self, forKeyPath: #keyPath(WordPressAppDelegate.connectionAvailable), options: [.old, .new], context: &type(of: self).observerContext)
-//        }
-//    }
-//
-//    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
-//        if keyPath == #keyPath(WordPressAppDelegate.connectionAvailable),
-//            let oldValue = change?[.oldKey] as? Bool,
-//            let newValue = change?[.newKey] as? Bool {
-//            if oldValue != newValue {
-//                delegate?.networdStatusDidChange(active: newValue)
-//            }
-//        }
-//    }
-//
-//    deinit {
-//        removeObserver(self, forKeyPath: #keyPath(WordPressAppDelegate.connectionAvailable))
-//    }
-//}
-
+fileprivate struct NetworkStatusAssociatedKeys {
+    static var associatedObjectKey = "com.later.error.notification.receiver"
+}
 
 fileprivate final class ReachabilityNotificationObserver: NSObject {
     private weak var delegate: NetworkStatusDelegate?
@@ -122,9 +74,10 @@ fileprivate final class ReachabilityNotificationObserver: NSObject {
     init(delegate: NetworkStatusDelegate) {
         self.delegate = delegate
         super.init()
+        observeErrors()
     }
 
-    func observeErrors() {
+    private func observeErrors() {
         NotificationCenter.default.addObserver(self, selector: #selector(receive), name: .reachabilityChanged, object: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -45,7 +45,7 @@ extension NetworkAwareUI {
 protocol NetworkStatusDelegate: class {
     func observeNetworkStatus()
 
-    func networdStatusDidChange(active: Bool)
+    func networkStatusDidChange(active: Bool)
 }
 
 extension NetworkStatusDelegate where Self: UIViewController {
@@ -83,7 +83,7 @@ fileprivate final class ReachabilityNotificationObserver: NSObject {
 
     @objc func receive(notification: Foundation.Notification) {
         if let newValue = notification.userInfo?[Foundation.Notification.reachabilityKey] as? Bool {
-            delegate?.networdStatusDidChange(active: newValue)
+            delegate?.networkStatusDidChange(active: newValue)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -45,6 +45,9 @@ extension NetworkAwareUI {
 protocol NetworkStatusDelegate: class {
     func observeNetworkStatus()
 
+    /// This method will be called, on the main thread, when the network connection changes status.
+    ///
+    /// - Parameter active: the new status of the network connection
     func networkStatusDidChange(active: Bool)
 }
 
@@ -83,7 +86,9 @@ fileprivate final class ReachabilityNotificationObserver: NSObject {
 
     @objc func receive(notification: Foundation.Notification) {
         if let newValue = notification.userInfo?[Foundation.Notification.reachabilityKey] as? Bool {
-            delegate?.networkStatusDidChange(active: newValue)
+            DispatchQueue.main.async {
+                self.delegate?.networkStatusDidChange(active: newValue)
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -116,7 +116,7 @@ extension NetworkStatusDelegate where Self: UIViewController {
 //}
 
 
-final class ReachabilityNotificationReceiver: NSObject {
+fileprivate final class ReachabilityNotificationReceiver: NSObject {
     private weak var delegate: NetworkStatusDelegate?
 
     init(delegate: NetworkStatusDelegate) {

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -65,7 +65,7 @@ extension NetworkStatusDelegate where Self: UIViewController {
 }
 
 fileprivate struct NetworkStatusAssociatedKeys {
-    static var associatedObjectKey = "com.later.error.notification.receiver"
+    static var associatedObjectKey = "org.wordpress.networkstatus.notificationreceiver"
 }
 
 fileprivate final class ReachabilityNotificationObserver: NSObject {

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -53,12 +53,12 @@ protocol NetworkStatusDelegate: class {
 
 extension NetworkStatusDelegate where Self: UIViewController {
     func observeNetworkStatus() {
-        receiver = ReachabilityNotificationReceiver(delegate: self)
+        receiver = ReachabilityNotificationObserver(delegate: self)
     }
 
-    fileprivate var receiver: ReachabilityNotificationReceiver? {
+    fileprivate var receiver: ReachabilityNotificationObserver? {
         get {
-            return objc_getAssociatedObject(self, &NetworkStatusAssociatedKeys.associatedObjectKey) as? ReachabilityNotificationReceiver
+            return objc_getAssociatedObject(self, &NetworkStatusAssociatedKeys.associatedObjectKey) as? ReachabilityNotificationObserver
         }
 
         set {
@@ -116,7 +116,7 @@ extension NetworkStatusDelegate where Self: UIViewController {
 //}
 
 
-fileprivate final class ReachabilityNotificationReceiver: NSObject {
+fileprivate final class ReachabilityNotificationOberver: NSObject {
     private weak var delegate: NetworkStatusDelegate?
 
     init(delegate: NetworkStatusDelegate) {

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -40,3 +40,43 @@ extension NetworkAwareUI {
         return ReachabilityUtils.noConnectionMessage()
     }
 }
+
+protocol NetworkStatusDelegate: class {
+    func observeNetworkStatus()
+    func networdStatusDidChange()
+}
+
+extension NetworkStatusDelegate where Self: UIViewController {
+    func observeNetworkStatus() {
+        let _ = ReachabilityObserver(delegate: self)
+    }
+}
+
+final fileprivate class ReachabilityObserver: NSObject {
+    private static var observerContext = 0
+    private weak var delegate: NetworkStatusDelegate?
+
+    init(delegate: NetworkStatusDelegate) {
+        self.delegate = delegate
+        super.init()
+
+        configureObserver()
+    }
+
+    private func configureObserver() {
+        if let appDelegate = UIApplication.shared.delegate as? WordPressAppDelegate {
+            appDelegate.addObserver(self, forKeyPath: #keyPath(WordPressAppDelegate.connectionAvailable), options: [.new], context: &type(of: self).observerContext)
+        }
+    }
+
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
+        if keyPath == #keyPath(WordPressAppDelegate.connectionAvailable), let newValue = change?[.newKey] as? Bool {
+            //
+            print("======= rechability changed in my observer====")
+        }
+    }
+
+    deinit {
+        removeObserver(self, forKeyPath: #keyPath(WordPressAppDelegate.connectionAvailable))
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -116,7 +116,7 @@ extension NetworkStatusDelegate where Self: UIViewController {
 //}
 
 
-fileprivate final class ReachabilityNotificationOberver: NSObject {
+fileprivate final class ReachabilityNotificationObserver: NSObject {
     private weak var delegate: NetworkStatusDelegate?
 
     init(delegate: NetworkStatusDelegate) {

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -43,7 +43,7 @@ extension NetworkAwareUI {
 
 protocol NetworkStatusDelegate: class {
     func observeNetworkStatus()
-    func networdStatusDidChange()
+    func networdStatusDidChange(active: Bool)
 }
 
 extension NetworkStatusDelegate where Self: UIViewController {
@@ -71,8 +71,8 @@ final fileprivate class ReachabilityObserver: NSObject {
 
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         if keyPath == #keyPath(WordPressAppDelegate.connectionAvailable), let newValue = change?[.newKey] as? Bool {
-            //
             print("======= rechability changed in my observer====")
+            delegate?.networdStatusDidChange(active: newValue)
         }
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -855,6 +855,7 @@
 		D8071631203DA23700B32FD9 /* Accessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8071630203DA23700B32FD9 /* Accessible.swift */; };
 		D809E686203F0215001AA0DE /* ReaderPostCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */; };
 		D80EE63A203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */; };
+		D81322B32050F9110067714D /* NotificationName+Names.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81322B22050F9110067714D /* NotificationName+Names.swift */; };
 		D8B6BEB7203E11F2007C8A19 /* Bundle+LoadFromNib.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6BEB6203E11F2007C8A19 /* Bundle+LoadFromNib.swift */; };
 		D8B9B58F204F4EA1003C6042 /* NetworkAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */; };
 		D8B9B591204F658A003C6042 /* CommentsViewController+NetworkAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B9B590204F658A003C6042 /* CommentsViewController+NetworkAware.swift */; };
@@ -2362,6 +2363,7 @@
 		D8071630203DA23700B32FD9 /* Accessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessible.swift; sourceTree = "<group>"; };
 		D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostCardCellTests.swift; sourceTree = "<group>"; };
 		D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderFollowedSitesStreamHeaderTests.swift; sourceTree = "<group>"; };
+		D81322B22050F9110067714D /* NotificationName+Names.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+Names.swift"; sourceTree = "<group>"; };
 		D8B6BEB6203E11F2007C8A19 /* Bundle+LoadFromNib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+LoadFromNib.swift"; sourceTree = "<group>"; };
 		D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAware.swift; sourceTree = "<group>"; };
 		D8B9B590204F658A003C6042 /* CommentsViewController+NetworkAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentsViewController+NetworkAware.swift"; sourceTree = "<group>"; };
@@ -4949,6 +4951,7 @@
 			children = (
 				B587798419B799EB00E57C5A /* Notification+Interface.swift */,
 				B587798519B799EB00E57C5A /* NotificationBlock+Interface.swift */,
+				D81322B22050F9110067714D /* NotificationName+Names.swift */,
 			);
 			path = Notifications;
 			sourceTree = "<group>";
@@ -7356,6 +7359,7 @@
 				FF7E51071FBDDFA800AD2918 /* ImgUploadProcessor.swift in Sources */,
 				593F26611CAB00CA00F14073 /* PostSharingController.swift in Sources */,
 				FF70A3231FD5840500BC270D /* UIImage+Export.swift in Sources */,
+				D81322B32050F9110067714D /* NotificationName+Names.swift in Sources */,
 				B5DD04741CD3DAB00003DF89 /* NSFetchedResultsController+Helpers.swift in Sources */,
 				B55F1AA81C10936600FD04D4 /* BlogSettings+Discussion.swift in Sources */,
 				E155EC721E9B7DCE009D7F63 /* PostTagPickerViewController.swift in Sources */,


### PR DESCRIPTION
Implements part of #5759

This is the final PR in the implementation of #5759.

- Changes in Reachability status not also post a Foundation.Notification
- That notification is observed in a protocol extension.
- So that view controller that want to be aware of changes in the network availability only need to implement `NetworkStatusDelegate`

To test:
1. Enter flight mode.
2. Navigate to Reader, Post List, Notifications, People
3. Exit flight mode. Wait for the network connection to be re-established. The content should reload

