### PR TITLE
Adds a confirmation alert when publishing from the post list.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -829,22 +829,22 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
     @objc func publishPost(_ apost: AbstractPost) {
         let title = NSLocalizedString("Are you sure you want to publish?", comment: "Title of the message shown when the user taps Publish in the post list.")
-        
+
         let cancelTitle = NSLocalizedString("Cancel", comment: "Button shown when the author is asked for publishing confirmation.")
         let publishTitle = NSLocalizedString("Publish", comment: "Button shown when the author is asked for publishing confirmation.")
-        
+
         let style: UIAlertControllerStyle = UIDevice.isPad() ? .alert : .actionSheet
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
-        
+
         alertController.addCancelActionWithTitle(cancelTitle)
         alertController.addDefaultActionWithTitle(publishTitle) { [unowned self] _ in
             WPAnalytics.track(.postListPublishAction, withProperties: self.propertiesForAnalytics())
-            
+
             apost.date_created_gmt = Date()
             apost.status = .publish
             self.uploadPost(apost)
         }
-        
+
         present(alertController, animated: true, completion: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -828,11 +828,24 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
     // MARK: - Actions
 
     @objc func publishPost(_ apost: AbstractPost) {
-        WPAnalytics.track(.postListPublishAction, withProperties: propertiesForAnalytics())
-
-        apost.date_created_gmt = Date()
-        apost.status = .publish
-        uploadPost(apost)
+        let title = NSLocalizedString("Are you sure you want to publish?", comment: "Title of the message shown when the user taps Publish in the post list.")
+        
+        let cancelTitle = NSLocalizedString("Cancel", comment: "Button shown when the author is asked for publishing confirmation.")
+        let publishTitle = NSLocalizedString("Publish", comment: "Button shown when the author is asked for publishing confirmation.")
+        
+        let style: UIAlertControllerStyle = UIDevice.isPad() ? .alert : .actionSheet
+        let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
+        
+        alertController.addCancelActionWithTitle(cancelTitle)
+        alertController.addDefaultActionWithTitle(publishTitle) { [unowned self] _ in
+            WPAnalytics.track(.postListPublishAction, withProperties: self.propertiesForAnalytics())
+            
+            apost.date_created_gmt = Date()
+            apost.status = .publish
+            self.uploadPost(apost)
+        }
+        
+        present(alertController, animated: true, completion: nil)
     }
 
     @objc func schedulePost(_ apost: AbstractPost) {


### PR DESCRIPTION
### Description:

Adds a confirmation alert when publishing from the post list.

Allows the user to go ahead and publish the post, or cancel the operation (default action).

### Details:

Publish confirmation alert for iPhone:

![publishconfirmation](https://user-images.githubusercontent.com/1836005/37154148-dab3b0a6-22bd-11e8-8f5f-65f884c31c9e.gif)

Publish confirmation alert for iPad:

![publishconfirmationipad](https://user-images.githubusercontent.com/1836005/37154306-4f40e2ea-22be-11e8-9ac4-4f4c7ef12353.gif)

### Testing:

- Create a new draft post
- Go to the list of posts, pick the "Drafts" filter
- Tap on the publish button for the post you created
- Make sure the alert works as described