### PR TITLE
Adds a mode toggle option to the ellipsis menu.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Helpers/AztecVerificationPromptHelper.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Helpers/AztecVerificationPromptHelper.swift
@@ -39,7 +39,7 @@ class AztecVerificationPromptHelper: NSObject {
         NotificationCenter.default.removeObserver(self)
     }
 
-    func neeedsVerification(before action: PostEditorAction) -> Bool {
+    func needsVerification(before action: PostEditorAction) -> Bool {
         guard action == .publish else {
             return false
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1221,14 +1221,6 @@ private extension AztecPostViewController {
     func displayMoreSheet() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-        if postEditorStateContext.isSecondaryPublishButtonShown,
-            let buttonTitle = postEditorStateContext.secondaryPublishButtonText {
-            let dismissWhenDone = postEditorStateContext.secondaryPublishButtonAction == .publish
-            alert.addActionWithTitle(buttonTitle, style: dismissWhenDone ? .destructive : .default ) { _ in
-                self.secondaryPublishButtonTapped(dismissWhenDone: dismissWhenDone)
-            }
-        }
-        
         let toggleModeTitle: String = {
             if mode == .richText {
                 return MoreSheetAlert.htmlTitle

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1147,7 +1147,7 @@ extension AztecPostViewController {
             self.uploadPost(action: action, dismissWhenDone: dismissWhenDone)
         }
 
-        if action == .publish {
+        if action == .publish || action == .publishNow {
             displayPublishConfirmationAlert(onPublish: publishBlock)
         } else {
             publishBlock()

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1221,6 +1221,15 @@ private extension AztecPostViewController {
     func displayMoreSheet() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
+        if postEditorStateContext.isSecondaryPublishButtonShown,
+            let buttonTitle = postEditorStateContext.secondaryPublishButtonText {
+            let dismissWhenDone = postEditorStateContext.secondaryPublishButtonAction == .publish
+            
+            alert.addDefaultActionWithTitle(buttonTitle) { _ in
+                self.secondaryPublishButtonTapped(dismissWhenDone: dismissWhenDone)
+            }
+        }
+        
         let toggleModeTitle: String = {
             if mode == .richText {
                 return MoreSheetAlert.htmlTitle

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1030,14 +1030,17 @@ extension AztecPostViewController {
 //
 extension AztecPostViewController {
     @IBAction func publishButtonTapped(sender: UIBarButtonItem) {
+
+        let action = self.postEditorStateContext.action
+
         publishPost(
-            action: self.postEditorStateContext.action,
-            dismissWhenDone: postEditorStateContext.publishActionDismissesEditor,
+            action: action,
+            dismissWhenDone: action.dismissesEditor,
             analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
     }
 
-    @IBAction func secondaryPublishButtonTapped(dismissWhenDone: Bool = true) {
-        guard let secondaryPublishAction = self.postEditorStateContext.secondaryPublishButtonAction else {
+    @IBAction func secondaryPublishButtonTapped() {
+        guard let action = self.postEditorStateContext.secondaryPublishButtonAction else {
             // If the user tapped on the secondary publish action button, it means we should have a secondary publish action.
             let error = NSError(domain: errorDomain, code: ErrorCode.expectedSecondaryAction.rawValue, userInfo: nil)
             Crashlytics.sharedInstance().recordError(error)
@@ -1048,8 +1051,8 @@ extension AztecPostViewController {
 
         let publishPostClosure = { [unowned self] in
             self.publishPost(
-                action: secondaryPublishAction,
-                dismissWhenDone: dismissWhenDone,
+                action: action,
+                dismissWhenDone: action.dismissesEditor,
                 analyticsStat: secondaryStat)
         }
 
@@ -1246,10 +1249,9 @@ private extension AztecPostViewController {
 
         if postEditorStateContext.isSecondaryPublishButtonShown,
             let buttonTitle = postEditorStateContext.secondaryPublishButtonText {
-            let dismissWhenDone = postEditorStateContext.secondaryPublishButtonAction == .publish
 
             alert.addDefaultActionWithTitle(buttonTitle) { _ in
-                self.secondaryPublishButtonTapped(dismissWhenDone: dismissWhenDone)
+                self.secondaryPublishButtonTapped()
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1245,8 +1245,8 @@ private extension AztecPostViewController {
             self.displayPreview()
         }
 
-        alert.addDefaultActionWithTitle(MoreSheetAlert.optionsTitle) { [unowned self]  _ in
-            self.displayPostOptions()
+        alert.addDefaultActionWithTitle(MoreSheetAlert.postSettingsTitle) { [unowned self]  _ in
+            self.displayPostSettings()
         }
 
         alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle)
@@ -1267,7 +1267,7 @@ private extension AztecPostViewController {
         present(alert, animated: true, completion: nil)
     }
 
-    func displayPostOptions() {
+    func displayPostSettings() {
         let settingsViewController: PostSettingsViewController
         if post is Page {
             settingsViewController = PageSettingsViewController(post: post)
@@ -3554,7 +3554,7 @@ extension AztecPostViewController {
         static let htmlTitle = NSLocalizedString("Switch to HTML Mode", comment: "Switches the Editor to HTML Mode")
         static let richTitle = NSLocalizedString("Switch to Visual Mode", comment: "Switches the Editor to Rich Text Mode")
         static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")
-        static let optionsTitle = NSLocalizedString("Options", comment: "Displays the Post's Options")
+        static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1224,12 +1224,12 @@ private extension AztecPostViewController {
         if postEditorStateContext.isSecondaryPublishButtonShown,
             let buttonTitle = postEditorStateContext.secondaryPublishButtonText {
             let dismissWhenDone = postEditorStateContext.secondaryPublishButtonAction == .publish
-            
+
             alert.addDefaultActionWithTitle(buttonTitle) { _ in
                 self.secondaryPublishButtonTapped(dismissWhenDone: dismissWhenDone)
             }
         }
-        
+
         let toggleModeTitle: String = {
             if mode == .richText {
                 return MoreSheetAlert.htmlTitle
@@ -1237,7 +1237,7 @@ private extension AztecPostViewController {
                 return MoreSheetAlert.richTitle
             }
         }()
-        
+
         alert.addDefaultActionWithTitle(toggleModeTitle) { [unowned self] _ in
             self.toggleEditingMode()
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1133,10 +1133,8 @@ extension AztecPostViewController {
         }
 
         let publishBlock = { [unowned self] in
-            if action == .save {
+            if action == .saveAsDraft {
                 self.post.status = .draft
-            } else if action == .publish {
-                self.post.status = .publish
             } else if action == .publishNow {
                 self.post.date_created_gmt = Date()
                 self.post.status = .publish

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1144,7 +1144,7 @@ extension AztecPostViewController {
                 self.trackPostSave(stat: analyticsStat)
             }
 
-            self.uploadPost(dismissWhenDone: dismissWhenDone)
+            self.uploadPost(action: action, dismissWhenDone: dismissWhenDone)
         }
 
         if action == .publish {
@@ -2552,9 +2552,9 @@ private extension AztecPostViewController {
 
     /// Shows the publishing overlay and starts the publishing process.
     ///
-    func uploadPost(dismissWhenDone: Bool) {
+    func uploadPost(action: PostEditorAction, dismissWhenDone: Bool) {
         SVProgressHUD.setDefaultMaskType(.clear)
-        SVProgressHUD.show(withStatus: postEditorStateContext.publishVerbText)
+        SVProgressHUD.show(withStatus: action.publishingActionLabel)
         postEditorStateContext.updated(isBeingPublished: true)
 
         uploadPost() { uploadedPost, error in
@@ -2567,7 +2567,7 @@ private extension AztecPostViewController {
             if let error = error {
                 DDLogError("Error publishing post: \(error.localizedDescription)")
 
-                SVProgressHUD.showDismissibleError(withStatus: self.postEditorStateContext.publishErrorText)
+                SVProgressHUD.showDismissibleError(withStatus: action.publishingErrorLabel)
                 generator.notificationOccurred(.error)
             } else if let uploadedPost = uploadedPost {
                 self.post = uploadedPost

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1228,12 +1228,24 @@ private extension AztecPostViewController {
                 self.secondaryPublishButtonTapped(dismissWhenDone: dismissWhenDone)
             }
         }
+        
+        let toggleModeTitle: String = {
+            if mode == .richText {
+                return MoreSheetAlert.htmlTitle
+            } else {
+                return MoreSheetAlert.richTitle
+            }
+        }()
+        
+        alert.addDefaultActionWithTitle(toggleModeTitle) { [unowned self] _ in
+            self.toggleEditingMode()
+        }
 
-        alert.addDefaultActionWithTitle(MoreSheetAlert.previewTitle) { _ in
+        alert.addDefaultActionWithTitle(MoreSheetAlert.previewTitle) { [unowned self]  _ in
             self.displayPreview()
         }
 
-        alert.addDefaultActionWithTitle(MoreSheetAlert.optionsTitle) { _ in
+        alert.addDefaultActionWithTitle(MoreSheetAlert.optionsTitle) { [unowned self]  _ in
             self.displayPostOptions()
         }
 
@@ -3539,8 +3551,8 @@ extension AztecPostViewController {
     }
 
     struct MoreSheetAlert {
-        static let htmlTitle = NSLocalizedString("Switch to HTML", comment: "Switches the Editor to HTML Mode")
-        static let richTitle = NSLocalizedString("Switch to Rich Text", comment: "Switches the Editor to Rich Text Mode")
+        static let htmlTitle = NSLocalizedString("Switch to HTML Mode", comment: "Switches the Editor to HTML Mode")
+        static let richTitle = NSLocalizedString("Switch to Visual Mode", comment: "Switches the Editor to Rich Text Mode")
         static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")
         static let optionsTitle = NSLocalizedString("Options", comment: "Displays the Post's Options")
         static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1097,7 +1097,11 @@ extension AztecPostViewController {
         present(alertController, animated: true, completion: nil)
     }
 
-    private func publishPost(action: PostEditorAction, dismissWhenDone: Bool, analyticsStat: WPAnalyticsStat?) {
+    private func publishPost(
+        action: PostEditorAction,
+        dismissWhenDone: Bool,
+        analyticsStat: WPAnalyticsStat?) {
+
         // Cancel publishing if media is currently being uploaded
         if mediaCoordinator.isUploadingMedia(for: post) {
             displayMediaIsUploadingAlert()
@@ -1115,7 +1119,7 @@ extension AztecPostViewController {
         }
 
         // If the user is trying to publish to WP.com and they haven't verified their account, prompt them to do so.
-        if let verificationHelper = verificationPromptHelper, verificationHelper.neeedsVerification(before: postEditorStateContext.action) {
+        if let verificationHelper = verificationPromptHelper, verificationHelper.needsVerification(before: postEditorStateContext.action) {
             verificationHelper.displayVerificationPrompt(from: self) { [unowned self] verifiedInBackground in
                 // User could've been plausibly silently verified in the background.
                 // If so, proceed to publishing the post as normal, otherwise save it as a draft.
@@ -1132,6 +1136,8 @@ extension AztecPostViewController {
             if action == .save {
                 self.post.status = .draft
             } else if action == .publish {
+                self.post.status = .publish
+            } else if action == .publishNow {
                 self.post.date_created_gmt = Date()
                 self.post.status = .publish
             }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -31,7 +31,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     }()
 
     private let errorDomain = "AztecPostViewController.errorDomain"
-    
+
     private enum ErrorCode: Int {
         case expectedSecondaryAction = 1
     }
@@ -1043,9 +1043,9 @@ extension AztecPostViewController {
             Crashlytics.sharedInstance().recordError(error)
             return
         }
-        
+
         let secondaryStat = self.postEditorStateContext.secondaryPublishActionAnalyticsStat
-        
+
         let publishPostClosure = { [unowned self] in
             self.publishPost(
                 action: secondaryPublishAction,
@@ -1081,7 +1081,7 @@ extension AztecPostViewController {
                     return updateTitle
                 }
             }()
-            
+
             // The post is a local or remote draft
             alertController.addDefaultActionWithTitle(title) { _ in
                 self.publishPost(action: .save, dismissWhenDone: true, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
@@ -1127,7 +1127,7 @@ extension AztecPostViewController {
             }
             return
         }
-        
+
         let publishBlock = { [unowned self] in
             if action == .save {
                 self.post.status = .draft
@@ -1135,11 +1135,11 @@ extension AztecPostViewController {
                 self.post.date_created_gmt = Date()
                 self.post.status = .publish
             }
-            
+
             if let analyticsStat = analyticsStat {
                 self.trackPostSave(stat: analyticsStat)
             }
-            
+
             self.uploadPost(dismissWhenDone: dismissWhenDone)
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -33,7 +33,7 @@ public enum PostEditorAction {
         }
     }
 
-    fileprivate var publishingActionLabel: String {
+    var publishingActionLabel: String {
         switch self {
         case .publish, .publishNow:
             return NSLocalizedString("Publishing...", comment: "Text displayed in HUD while a post is being published.")
@@ -48,7 +48,7 @@ public enum PostEditorAction {
         }
     }
 
-    fileprivate var publishingErrorLabel: String {
+    var publishingErrorLabel: String {
         switch self {
         case .publish, .publishNow:
             return NSLocalizedString("Error occurred\nduring publishing", comment: "Text displayed in HUD while a post is being published.")
@@ -255,19 +255,6 @@ public class PostEditorStateContext {
     ///
     var publishButtonText: String {
         return editorState.action.publishActionLabel
-    }
-
-    /// Returns appropriate publishing UI text text for the current action
-    /// e.g. Publishing...
-    ///
-    var publishVerbText: String {
-        return editorState.action.publishingActionLabel
-    }
-
-    /// Returns the Error Text for the current active action
-    ///
-    var publishErrorText: String {
-        return editorState.action.publishingErrorLabel
     }
 
     /// Returns the WPAnalyticsStat enum to be tracked when this post is published

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -71,7 +71,7 @@ public enum PostEditorAction {
     fileprivate var secondaryPublishAction: PostEditorAction? {
         switch self {
         case .publish:
-            return .save
+            return .saveAsDraft
         case .update:
             return .publishNow
         default:

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -7,8 +7,10 @@ import WordPressShared
 ///
 public enum PostEditorAction {
     case save
+    case saveAsDraft
     case schedule
     case publish
+    case publishNow
     case update
     case submitForReview
 
@@ -16,8 +18,12 @@ public enum PostEditorAction {
         switch self {
         case .publish:
             return NSLocalizedString("Publish", comment: "Label for the publish (verb) button. Tapping publishes a draft post.")
+        case .publishNow:
+            return NSLocalizedString("Publish Now", comment: "Title of button allowing the user to immediately publish the post they are editing.")
         case .save:
             return NSLocalizedString("Save", comment: "Save button label (saving content, ex: Post, Page, Comment).")
+        case .saveAsDraft:
+            return NSLocalizedString("Save as Draft", comment: "Title of button allowing users to change the status of the post they are currently editing to Draft.")
         case .schedule:
             return NSLocalizedString("Schedule", comment: "Schedule button, this is what the Publish button changes to in the Post Editor if the post has been scheduled for posting later.")
         case .submitForReview:
@@ -29,9 +35,9 @@ public enum PostEditorAction {
 
     fileprivate var publishingActionLabel: String {
         switch self {
-        case .publish:
+        case .publish, .publishNow:
             return NSLocalizedString("Publishing...", comment: "Text displayed in HUD while a post is being published.")
-        case .save:
+        case .save, .saveAsDraft:
             return NSLocalizedString("Saving...", comment: "Text displayed in HUD while a post is being saved as a draft.")
         case .schedule:
             return NSLocalizedString("Scheduling...", comment: "Text displayed in HUD while a post is being scheduled to be published.")
@@ -44,23 +50,12 @@ public enum PostEditorAction {
 
     fileprivate var publishingErrorLabel: String {
         switch self {
-        case .publish:
+        case .publish, .publishNow:
             return NSLocalizedString("Error occurred\nduring publishing", comment: "Text displayed in HUD while a post is being published.")
         case .schedule:
             return NSLocalizedString("Error occurred\nduring scheduling", comment: "Text displayed in HUD while a post is being scheduled to be published.")
-        case .save, .submitForReview, .update:
+        case .save, .saveAsDraft, .submitForReview, .update:
             return NSLocalizedString("Error occurred\nduring saving", comment: "Text displayed in HUD after attempting to save a draft post and an error occurred.")
-        }
-    }
-
-    fileprivate var secondaryPublishActionLabel: String? {
-        switch self {
-        case .publish:
-            return NSLocalizedString("Publish Now", comment: "Title of button allowing the user to immediately publish the post they are editing.")
-        case .save:
-            return NSLocalizedString("Save as Draft", comment: "Title of button allowing users to change the status of the post they are currently editing to Draft.")
-        default:
-            return nil
         }
     }
 
@@ -78,7 +73,7 @@ public enum PostEditorAction {
         case .publish:
             return .save
         case .update:
-            return .publish
+            return .publishNow
         default:
             return nil
         }
@@ -88,26 +83,19 @@ public enum PostEditorAction {
         switch self {
         case .save:
             return .editorSavedDraft
+        case .saveAsDraft:
+            return .editorQuickSavedDraft
         case .schedule:
             return .editorScheduledPost
         case .publish:
             return .editorPublishedPost
+        case .publishNow:
+            return .editorQuickPublishedPost
         case .update:
             return .editorUpdatedPost
         case .submitForReview:
             // TODO: When support is added for submit for review, add a new stat to support it
             return .editorPublishedPost
-        }
-    }
-
-    fileprivate var secondaryPublishActionAnalyticsStat: WPAnalyticsStat? {
-        switch self {
-        case .save:
-            return .editorQuickSavedDraft
-        case .publish:
-            return .editorQuickPublishedPost
-        default:
-            return nil
         }
     }
 }
@@ -337,7 +325,7 @@ public class PostEditorStateContext {
             return nil
         }
 
-        return editorState.action.secondaryPublishAction?.secondaryPublishActionLabel
+        return editorState.action.secondaryPublishAction?.publishActionLabel
     }
 
     /// Returns the WPAnalyticsStat enum to be tracked when this post is published with the secondary action
@@ -346,7 +334,7 @@ public class PostEditorStateContext {
             return nil
         }
 
-        return editorState.action.secondaryPublishAction?.secondaryPublishActionAnalyticsStat
+        return editorState.action.secondaryPublishAction?.publishActionAnalyticsStat
     }
 
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -14,6 +14,15 @@ public enum PostEditorAction {
     case update
     case submitForReview
 
+    var dismissesEditor: Bool {
+        switch self {
+        case .publish, .publishNow, .schedule:
+            return true
+        default:
+            return false
+        }
+    }
+
     fileprivate var publishActionLabel: String {
         switch self {
         case .publish:

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -120,7 +120,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 {
     [super viewDidLoad];
     
-    self.title = NSLocalizedString(@"Options", nil);
+    self.title = NSLocalizedString(@"Post Settings", @"The title of the Post Settings screen.");
 
     DDLogInfo(@"%@ %@", self, NSStringFromSelector(_cmd));
 


### PR DESCRIPTION
### Description:

This PR modifies the ellipsis menu in the editor:
- Adds an editor-mode-toggle button.
- Removes the red coloring from the "Save as Draft" / "Publish Button" (since that's for destructive actions).
- Renames "Options" to "Post Settings".

This PR also re-titles the post's "Options" view controller as "Post Settings".

### Details:

Example of it in action in iPhone:

![savepublishsecondary](https://user-images.githubusercontent.com/1836005/37178536-8d9f1bc2-2301-11e8-9084-5bceca3f3bd5.gif)

### Testing:

Just repeat the steps shown in the GIFs above.
Make sure to test in both iPhone and iPad.
Run the unit tests.
