### PR TITLE
Fix padding for site description

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -26,7 +26,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="320" height="136"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Qis-1y-KvO">
-                            <rect key="frame" x="16" y="16" width="288" height="35.5"/>
+                            <rect key="frame" x="16" y="16" width="288" height="32"/>
                             <subviews>
                                 <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="sng-2e-9Fd">
                                     <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
@@ -79,8 +79,12 @@
                                 </button>
                             </subviews>
                         </stackView>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BDq-6m-YPX">
+                            <rect key="frame" x="16" y="64" width="288" height="0.0"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Site description" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uvZ-h9-MUU">
-                            <rect key="frame" x="16" y="67.5" width="288" height="19.5"/>
+                            <rect key="frame" x="16" y="80" width="288" height="7"/>
                             <fontDescription key="fontDescription" type="system" pointSize="16"/>
                             <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>


### PR DESCRIPTION
Fixes #8855 

To test:

Before | After
-|-
![34966050-b171f3e8-fa0d-11e7-8bf0-7f139f9466bc](https://user-images.githubusercontent.com/5558824/37163237-03bfb2ac-22d6-11e8-937e-ecc1465d975d.jpg) | ![simulator screen shot - iphone 8 - 2018-03-08 at 13 39 19](https://user-images.githubusercontent.com/5558824/37163297-2c983fbe-22d6-11e8-893a-c5282799635f.png)


