### PR TITLE
Signup Epilogue: Fix username changer issues

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -35,7 +35,7 @@ class SignupEpilogueViewController: NUXViewController {
         }
 
         if let vc = segue.destination as? SignupUsernameViewController {
-            vc.currentUsername = epilogueUserInfo?.username
+            vc.currentUsername = updatedUsername ?? epilogueUserInfo?.username
             vc.displayName = updatedDisplayName ?? epilogueUserInfo?.fullName
             vc.delegate = self
         }

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
@@ -3,6 +3,7 @@ import SVProgressHUD
 protocol SignupUsernameViewControllerDelegate {
     func usernameSelected(_ username: String)
 }
+
 class SignupUsernameViewController: NUXViewController {
     // MARK: - Properties
     open var currentUsername: String?
@@ -30,38 +31,6 @@ class SignupUsernameViewController: NUXViewController {
         _ = addHelpButtonToNavController()
         navigationItem.title = NSLocalizedString("Change Username", comment: "Change Username title.")
         WPStyleGuide.configureColors(for: view, andTableView: nil)
-    }
-
-    private func changeUsername() {
-        guard let newUsername = newUsername, newUsername != "" else {
-            navigationController?.popViewController(animated: true)
-            return
-        }
-
-        SVProgressHUD.show(withStatus: NSLocalizedString("Changing username", comment: "Shown while the app waits for the username changing web service to return."))
-
-        let context = ContextManager.sharedInstance().mainContext
-        let accountService = AccountService(managedObjectContext: context)
-        guard let account = accountService.defaultWordPressComAccount(),
-            let api = account.wordPressComRestApi else {
-                navigationController?.popViewController(animated: true)
-                return
-        }
-
-        let settingsService = AccountSettingsService(userID: account.userID.intValue, api: api)
-        settingsService.changeUsername(to: newUsername, success: { [weak self] in
-            // now we refresh the account to get the new username
-            accountService.updateUserDetails(for: account, success: { [weak self] in
-                SVProgressHUD.dismiss()
-                self?.navigationController?.popViewController(animated: true)
-            }, failure: { [weak self] (error) in
-                SVProgressHUD.dismiss()
-                self?.navigationController?.popViewController(animated: true)
-            })
-        }) { [weak self] in
-            SVProgressHUD.showDismissibleError(withStatus: NSLocalizedString("Username change failed", comment: "Shown when an attempt to change the username fails."))
-            self?.navigationController?.popViewController(animated: true)
-        }
     }
 
     // MARK: - Segue


### PR DESCRIPTION
Fixes #8866 

To test:
- Create an account.
- On the epilogue, select the username to bring up the username changer.
- Select a username other than the default.
- Return to the epilogue. The username is now the one selected.
- Select the username again.
- Verify:
  - The username in the top description is the one just selected (not the default one).
  - The selected username is first in the suggestion list and has a checkmark.
- Press 'Continue' on the epilogue.
- Verify the account's username is what you selected.


