### PR TITLE
Ensuring Notification is onScreen

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -563,7 +563,7 @@ extension NotificationsViewController {
     ///     -   noteObjectID: The Core Data ObjectID associated to a given notification.
     ///     -   request: A DeletionRequest Struct
     ///
-    func showUndeleteForNoteWithID(_ noteObjectID: NSManagedObjectID, request: NotificationDeletionRequest) {
+    fileprivate func showUndeleteForNoteWithID(_ noteObjectID: NSManagedObjectID, request: NotificationDeletionRequest) {
         // Mark this note as Pending Deletion and Reload
         notificationDeletionRequests[noteObjectID] = request
         reloadRowForNotificationWithID(noteObjectID)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1411,6 +1411,17 @@ private extension NotificationsViewController {
         }
     }
 
+    var filter: Filter {
+        get {
+            let selectedIndex = filtersSegmentedControl?.selectedSegmentIndex ?? Filter.none.rawValue
+            return Filter(rawValue: selectedIndex) ?? .none
+        }
+        set {
+            filtersSegmentedControl?.selectedSegmentIndex = newValue.rawValue
+            reloadResultsController()
+        }
+    }
+
     static let contactURL = "https://support.wordpress.com/contact/"
 
     enum Filter: Int {


### PR DESCRIPTION
### Description:
This PR fixes a Split Screen scenario (iPad) in which the selected notification isn't actually displayed on the left hand side of the UI.

Fixes #7718

### Scenario A: (Previously) Non Empty List
1. Make sure push notifications are enabled on your device.
2. Launch WPiOS on an iPad
3. Open the app and go to the Notifications.
4. Select a notification.
5. Leave the app.
6. Trigger a push notification (e.g. leave a comment on your site using a different account).
7. Tap on the push notification to open the app. 

Verify that the Notification selected on the left is visible.

### Scenario B: (Previously) Empty List
1. Repeat steps 1-3 of Scenario A
2. Select a tab with no notifications in the list.
3. Leave the app.
4. Trigger another push notification.
5. Tap on the push notification to open the app. 

Verify that the selected Notification is visible on the left hand side.
