### PR TITLE
Add missing .createdAccount stat

### DIFF
--- a/WordPress/Classes/Services/SignupService.swift
+++ b/WordPress/Classes/Services/SignupService.swift
@@ -137,6 +137,7 @@ open class SignupService: LocalCoreDataService {
                                             andClientSecret: ApiCredentials.secret(),
                                             success: { (responseDictionary) in
                                                 // Note: User creation is deferred until we have a WPCom auth token.
+                                                WPAppAnalytics.track(.createdAccount)
                                                 success()
                                             },
                                             failure: failure)
@@ -165,6 +166,7 @@ open class SignupService: LocalCoreDataService {
                                                 return
                                         }
 
+                                        WPAppAnalytics.track(.createdAccount)
                                         // create the local account
                                         let service = AccountService(managedObjectContext: self.managedObjectContext)
                                         let account = service.createOrUpdateAccount(withUsername: username, authToken: bearer_token)


### PR DESCRIPTION
This PR brings back one Stat that vanished during `9.4`

**To test:**

1. Check that both email and social sign up fire the `.createdAccount` stat

