### PR TITLE
Make sure the navbar is blue for username changing screen

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
@@ -160,7 +160,7 @@ import WordPressShared
             }
         }
 
-        let navController = NUXNavigationController(rootViewController: controller)
+        let navController = LoginNavigationController(rootViewController: controller)
 
         // The way the magic link flow works some view controller might
         // still be presented when the app is resumed by tapping on the auth link.


### PR DESCRIPTION
Fixes #8865 

The username screen now has a blue navbar ✅

To test:
- signup for a new account
- change the username
- ensure the navbar is blue