### PR TITLE
Sets logging level in every module to prevent loss of detail in logs

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ workspace 'WordPress.xcworkspace'
 
 ## Pods shared between all the targets
 def shared_with_all_pods
-  pod 'CocoaLumberjack', '3.2.1'
+  pod 'CocoaLumberjack', '3.4.1'
   pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
   pod 'NSObject-SafeExpectations', '0.0.2'
   pod 'UIDeviceIdentifier', '~> 0.4'
@@ -51,7 +51,7 @@ target 'WordPress' do
   # --------------------
   # WordPress components
   # --------------------
-  pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.1'
+  pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.2'
   pod 'Gridicons', '0.14'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.27'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -16,16 +16,16 @@ PODS:
   - AFNetworking/UIKit (3.1.0):
     - AFNetworking/NSURLSession
   - Alamofire (4.6.0)
-  - Automattic-Tracks-iOS (0.2.0):
-    - CocoaLumberjack (~> 3.2.0)
+  - Automattic-Tracks-iOS (0.2.2):
+    - CocoaLumberjack (~> 3.4.1)
     - Reachability (~> 3.1)
     - UIDeviceIdentifier (~> 0.4)
   - BuddyBuildSDK (1.0.17)
-  - CocoaLumberjack (3.2.1):
-    - CocoaLumberjack/Default (= 3.2.1)
-    - CocoaLumberjack/Extensions (= 3.2.1)
-  - CocoaLumberjack/Default (3.2.1)
-  - CocoaLumberjack/Extensions (3.2.1):
+  - CocoaLumberjack (3.4.1):
+    - CocoaLumberjack/Default (= 3.4.1)
+    - CocoaLumberjack/Extensions (= 3.4.1)
+  - CocoaLumberjack/Default (3.4.1)
+  - CocoaLumberjack/Extensions (3.4.1):
     - CocoaLumberjack/Default
   - Crashlytics (3.9.3):
     - Fabric (~> 1.7.2)
@@ -121,9 +121,9 @@ DEPENDENCIES:
   - 1PasswordExtension (= 1.8.5)
   - AFNetworking (= 3.1.0)
   - Alamofire (= 4.6.0)
-  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, tag `0.2.1`)
+  - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, tag `0.2.2`)
   - BuddyBuildSDK (= 1.0.17)
-  - CocoaLumberjack (= 3.2.1)
+  - CocoaLumberjack (= 3.4.1)
   - Crashlytics (= 3.9.3)
   - Expecta (= 1.0.6)
   - FLAnimatedImage (= 1.0.12)
@@ -152,7 +152,7 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.2.1
+    :tag: 0.2.2
   WordPress-Aztec-iOS:
     :commit: 1b9e6398f054f8726cf40de9e9a2ace753804502
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
@@ -160,7 +160,7 @@ EXTERNAL SOURCES:
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
-    :tag: 0.2.1
+    :tag: 0.2.2
   WordPress-Aztec-iOS:
     :commit: 1b9e6398f054f8726cf40de9e9a2ace753804502
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
@@ -169,9 +169,9 @@ SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   Alamofire: f41a599bd63041760b26d393ec1069d9d7b917f4
-  Automattic-Tracks-iOS: edc4365d31602490af88dbed181b0b666cbdcf75
+  Automattic-Tracks-iOS: 878edd82f3e535bd94da52facd94fc0bf5542797
   BuddyBuildSDK: 8ae12ee721098b356a961ea7dce70ae55f93a7d2
-  CocoaLumberjack: 2800c03334042fe80589423c8d80e582dcaec482
+  CocoaLumberjack: 2e258a064cacc8eb9a2aca318e24d02a0a7fd56d
   Crashlytics: dbb07d01876c171c5ccbdf7826410380189e452c
   Expecta: 3b6bd90a64b9a1dcb0b70aa0e10a7f8f631667d5
   Fabric: 9cd6a848efcf1b8b07497e0b6a2e7d336353ba15
@@ -200,6 +200,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 1fe532b4ff215a9dd259f08439376fc0dbab1039
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: e332228a2ce171e91ef3322c378b68d83239df4d
+PODFILE CHECKSUM: 5667931d6024a338d49feed1338fc681e938b4d5
 
 COCOAPODS: 1.3.1

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -190,7 +190,7 @@ extension WordPressAppDelegate {
             UserDefaults.standard.set(origExtraDebug, forKey: "orig_extra_debug")
             UserDefaults.standard.set(true, forKey: "extra_debug")
             WordPressAppDelegate.setLogLevel(.verbose)
-            UserDefaults.resetStandardUserDefaults()
+            UserDefaults.standard.synchronize()
         } else {
             guard let origExtraDebug = UserDefaults.standard.string(forKey: "orig_extra_debug") else {
                 return
@@ -201,7 +201,7 @@ extension WordPressAppDelegate {
             // Restore the original setting and remove orig_extra_debug
             UserDefaults.standard.set(origExtraDebugValue, forKey: "extra_debug")
             UserDefaults.standard.removeObject(forKey: "orig_extra_debug")
-            UserDefaults.resetStandardUserDefaults()
+            UserDefaults.standard.synchronize()
 
             if origExtraDebugValue {
                 WordPressAppDelegate.setLogLevel(.verbose)

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -22,6 +22,8 @@
 
 // Logging
 #import "WPLogger.h"
+#import <AutomatticTracks/TracksLogging.h>
+#import <WordPressComStatsiOS/WPStatsLogging.h>
 
 // Misc managers, helpers, utilities
 #import "ContextManager.h"
@@ -610,6 +612,11 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
 + (void)setLogLevel:(DDLogLevel)logLevel
 {
     ddLogLevel = logLevel;
+
+    int logLevelInt = (int)logLevel;
+    WPSharedSetLoggingLevel(logLevelInt);
+    TracksSetLoggingLevel(logLevelInt);
+    WPStatsSetLoggingLevel(logLevelInt);
 }
 
 @end

--- a/WordPress/Classes/Utility/Logging/WPLogger.h
+++ b/WordPress/Classes/Utility/Logging/WPLogger.h
@@ -21,4 +21,6 @@
  */
 - (NSString *)getLogFilesContentWithMaxSize:(NSInteger)maxSize;
 
++ (void)configureLoggerLevelWithExtraDebug;
+
 @end

--- a/WordPress/Classes/Utility/Logging/WPLogger.m
+++ b/WordPress/Classes/Utility/Logging/WPLogger.m
@@ -2,6 +2,7 @@
 
 @import CocoaLumberjack;
 #import "WPCrashlyticsLogger.h"
+#import "WordPressAppDelegate.h"
 
 @interface WPLogger ()
 @property (nonatomic, strong, readwrite) DDFileLogger *fileLogger;
@@ -46,11 +47,8 @@
 #endif
     
     [DDLog addLogger:self.fileLogger];
-    
-    BOOL extraDebug = [[NSUserDefaults standardUserDefaults] boolForKey:@"extra_debug"];
-    if (extraDebug) {
-        ddLogLevel = DDLogLevelVerbose;
-    }
+
+    [WPLogger configureLoggerLevelWithExtraDebug];
 }
 
 #pragma mark - Getters
@@ -97,6 +95,17 @@
     }
     
     return description;
+}
+
+#pragma mark - Public static methods
+
++ (void)configureLoggerLevelWithExtraDebug {
+    BOOL extraDebug = [[NSUserDefaults standardUserDefaults] boolForKey:@"extra_debug"];
+    if (extraDebug) {
+        [WordPressAppDelegate setLogLevel:DDLogLevelVerbose];
+    } else {
+        [WordPressAppDelegate setLogLevel:DDLogLevelInfo];
+    }
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Me/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/SupportViewController.m
@@ -385,6 +385,8 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
     if (aSwitch.tag == SettingsSectionSettingsRowExtraDebug) {
         [[NSUserDefaults standardUserDefaults] setBool:aSwitch.on forKey:kExtraDebugDefaultsKey];
         [[NSUserDefaults standardUserDefaults] synchronize];
+
+        [WPLogger configureLoggerLevelWithExtraDebug];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Me/SupportViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/SupportViewController.m
@@ -384,7 +384,7 @@ typedef NS_ENUM(NSInteger, SettingsSectionActivitySettingsRows)
 
     if (aSwitch.tag == SettingsSectionSettingsRowExtraDebug) {
         [[NSUserDefaults standardUserDefaults] setBool:aSwitch.on forKey:kExtraDebugDefaultsKey];
-        [NSUserDefaults resetStandardUserDefaults];
+        [[NSUserDefaults standardUserDefaults] synchronize];
     }
 }
 


### PR DESCRIPTION
Fixes #8876 

This resolves a few things.

1. Bumps CocoaLumberjack to the latest version.
2. Sets logging level on each module's `ddLogLevel` when the app's level is set.
3. Properly persists the "Extra Debug" bool by synchronizing to user defaults.
4. Changes the log level immediately when the "Extra Debug" switch is changed.

To test follow the procedures outlined in the reported issue.

@jleandroperez can you check this over?
