### PR TITLE
Send user’s locale as an endpoint param when creating a Google account.

### DIFF
--- a/WordPress/Classes/Services/SignupService.swift
+++ b/WordPress/Classes/Services/SignupService.swift
@@ -153,12 +153,15 @@ open class SignupService: LocalCoreDataService {
     func createWPComUserWithGoogle(token: String,
                                    success: @escaping SignupSocialSuccessBlock,
                                    failure: @escaping SignupFailureBlock) {
+
         let remote = WordPressComServiceRemote(wordPressComRestApi: self.anonymousApi())
+        let locale = WordPressComLanguageDatabase().deviceLanguage.slug
 
         remote?.createWPComAccount(withGoogle: token,
-                                    andClientID: ApiCredentials.client(),
-                                    andClientSecret: ApiCredentials.secret(),
-                                    success: { (responseDictionary) in
+                                   andLocale: locale,
+                                   andClientID: ApiCredentials.client(),
+                                   andClientSecret: ApiCredentials.secret(),
+                                   success: { (responseDictionary) in
                                         guard let username = responseDictionary?[ResponseKeys.username] as? String,
                                             let bearer_token = responseDictionary?[ResponseKeys.bearerToken] as? String else {
                                                 // without these we can't proceed.

--- a/WordPressKit/WordPressKit/WordPressComServiceRemote.h
+++ b/WordPressKit/WordPressKit/WordPressComServiceRemote.h
@@ -45,6 +45,7 @@ typedef void(^WordPressComServiceFailureBlock)(NSError *error);
  @param failure failure block
  */
 - (void)createWPComAccountWithGoogle:(NSString *)token
+                           andLocale:(NSString *)locale
                          andClientID:(NSString *)clientID
                      andClientSecret:(NSString *)clientSecret
                              success:(WordPressComServiceSuccessBlock)success

--- a/WordPressKit/WordPressKit/WordPressComServiceRemote.m
+++ b/WordPressKit/WordPressKit/WordPressComServiceRemote.m
@@ -70,6 +70,7 @@
 
 // API v1 POST /users/social/new
 - (void)createWPComAccountWithGoogle:(NSString *)token
+                           andLocale:(NSString *)locale
                          andClientID:(NSString *)clientID
                      andClientSecret:(NSString *)clientSecret
                              success:(WordPressComServiceSuccessBlock)success
@@ -88,6 +89,7 @@
                              @"client_id": clientID,
                              @"client_secret": clientSecret,
                              @"id_token": token,
+                             @"locale": locale,
                              @"service": @"google",
                              @"signup_flow_name": @"social",
                              };


### PR DESCRIPTION
Ref #8109 

To test:
Verify you can create a wp account using a Google account.


