### PR TITLE
Moves the event postEpilogueDisplayed so it's only triggered once.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -46,6 +46,12 @@ class PostPostViewController: UIViewController {
         return .lightContent
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        WPAnalytics.track(.postEpilogueDisplayed)
+    }
+
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -70,11 +76,6 @@ class PostPostViewController: UIViewController {
             view.alpha = WPAlphaFull
             animatePostPost()
         }
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        WPAnalytics.track(.postEpilogueDisplayed)
     }
 
     @objc func animatePostPost() {


### PR DESCRIPTION
The `postEpilogueDisplayed` was being tracked on `viewDidAppear`, meaning that if the user tapped on the "View" option, and then "Done", the VC would be shown again triggering a second tracking of the event.

After discussing this with @iamthomasbishop, I'm moving it to a location where it'll only be triggered once.