### PR TITLE
Adding `createAccountInitiated` track in for new Signup flow.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEmailViewController.swift
@@ -43,6 +43,7 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
         super.viewDidLoad()
         WPStyleGuide.configureColors(for: view, andTableView: nil)
         localizeControls()
+        WordPressAuthenticator.post(event: .createAccountInitiated)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
@@ -20,6 +20,7 @@ class SignupGoogleViewController: LoginViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         titleLabel?.text = NSLocalizedString("Waiting for Google to complete…", comment: "Message shown on screen while waiting for Google to finish its signup process.")
+        WordPressAuthenticator.post(event: .createAccountInitiated)
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
Fixes # n/a

To test: Nothing really. This just adds the `account_create_initiated` track in the new Signup flow.


