### PR TITLE
Async Posting: Don't show PostPost when performing an async publish

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1249,6 +1249,13 @@ private extension AztecPostViewController {
     func displayMoreSheet() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
+        if FeatureFlag.asyncPosting.enabled {
+            alert.addDefaultActionWithTitle("Async Publish (Debug)") { [unowned self]  _ in
+                PostCoordinator.shared.save(post: self.post)
+                self.dismissOrPopView(didSave: true, shouldShowPostEpilogue: false)
+            }
+        }
+
         if postEditorStateContext.isSecondaryPublishButtonShown,
             let buttonTitle = postEditorStateContext.secondaryPublishButtonText {
 
@@ -1279,12 +1286,6 @@ private extension AztecPostViewController {
 
         alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle)
 
-        if FeatureFlag.asyncPosting.enabled {
-            alert.addDefaultActionWithTitle("Async Upload (Debug)") { [unowned self]  _ in
-                PostCoordinator.shared.save(post: self.post)
-                self.dismissOrPopView(didSave: true, shouldShowPostEpilogue: false)
-            }
-        }
         alert.popoverPresentationController?.barButtonItem = moreBarButtonItem
 
         present(alert, animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -14,9 +14,11 @@ import AVKit
 //
 class AztecPostViewController: UIViewController, PostEditor {
 
-    /// Closure to be executed when the editor gets closed
+    /// Closure to be executed when the editor gets closed.
+    /// Pass `false` for `showPostEpilogue` to prevent the post epilogue
+    /// (PostPost) flow being displayed after the editor is closed.
     ///
-    var onClose: ((_ changesSaved: Bool) -> ())?
+    var onClose: ((_ changesSaved: Bool, _ showPostEpilogue: Bool) -> ())?
 
 
     /// Indicates if Aztec was launched for Photo Posting
@@ -1280,7 +1282,7 @@ private extension AztecPostViewController {
         if FeatureFlag.asyncPosting.enabled {
             alert.addDefaultActionWithTitle("Async Upload (Debug)") { [unowned self]  _ in
                 PostCoordinator.shared.save(post: self.post)
-                self.dismissOrPopView(didSave: true)
+                self.dismissOrPopView(didSave: true, shouldShowPostEpilogue: false)
             }
         }
         alert.popoverPresentationController?.barButtonItem = moreBarButtonItem
@@ -2518,13 +2520,13 @@ private extension AztecPostViewController {
         dismissOrPopView(didSave: false)
     }
 
-    func dismissOrPopView(didSave: Bool) {
+    func dismissOrPopView(didSave: Bool, shouldShowPostEpilogue: Bool = true) {
         stopEditing()
 
         WPAppAnalytics.track(.editorClosed, withProperties: [WPAppAnalyticsKeyEditorSource: Analytics.editorSource], with: post)
 
         if let onClose = onClose {
-            onClose(didSave)
+            onClose(didSave, shouldShowPostEpilogue)
         } else if isModal() {
             presentingViewController?.dismiss(animated: true, completion: nil)
         } else {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -336,7 +336,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let filterIndex = filterSettings.currentFilterIndex()
         let editorSettings = EditorSettings()
         let postViewController = editorSettings.instantiatePageEditor(page: post) { (editor, vc) in
-            editor.onClose = { [weak self] changesSaved in
+            editor.onClose = { [weak self] changesSaved, _ in
                 if changesSaved {
                     if let postStatus = editor.post.status {
                         self?.updateFilterWithPostStatus(postStatus)

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -112,7 +112,7 @@ class EditPostViewController: UIViewController {
         let editorSettings = EditorSettings()
         let editor = editorSettings.instantiatePostEditor(post: postToEdit()) { (editor, vc) in
             editor.isOpenedDirectlyForPhotoPost = openWithMediaPicker
-            editor.onClose = { [weak self, weak vc, weak editor] changesSaved in
+            editor.onClose = { [weak self, weak vc, weak editor] changesSaved, showPostEpilogue in
                 guard let strongSelf = self else {
                     vc?.dismiss(animated: true) {}
                     return
@@ -124,7 +124,7 @@ class EditPostViewController: UIViewController {
                 if changesSaved {
                     strongSelf.post = editor?.post as? Post
                 }
-                strongSelf.closeEditor(changesSaved)
+                strongSelf.closeEditor(changesSaved, showPostEpilogue: showPostEpilogue)
             }
         }
         // Neutralize iOS's Restoration:
@@ -150,11 +150,11 @@ class EditPostViewController: UIViewController {
         }
     }
 
-    @objc func closeEditor(_ changesSaved: Bool = true, from presentingViewController: UIViewController? = nil) {
+    @objc func closeEditor(_ changesSaved: Bool = true, showPostEpilogue: Bool, from presentingViewController: UIViewController? = nil) {
         onClose?(changesSaved)
 
         var dismissPostPostImmediately = true
-        if shouldShowPostPost(hasChanges: changesSaved), let post = post {
+        if showPostEpilogue && shouldShowPostPost(hasChanges: changesSaved), let post = post {
             postPost.setup(post: post)
             postPost.onClose = {
                 self.closePostPost(animated: true)

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -13,7 +13,7 @@ import CocoaLumberjack
 
     /// Closure to be executed when the editor gets closed.
     ///
-    var onClose: ((_ changesSaved: Bool) -> Void)? { get set }
+    var onClose: ((_ changesSaved: Bool, _ shouldShowPostPost: Bool) -> Void)? { get set }
 
     /// Whether the editor should open directly to the media picker.
     ///


### PR DESCRIPTION
This PR allows the editor to selectively control whether or not the PostPost screen is displayed. For async posting (currently feature flagged for local dev only), we now disable the PostPost flow. It'll be displayed if the user interacts with a Notice that'll be displayed on successful posting.

This PR also moves the debug option for Async Posting to the top of the action sheet, just so it's more out of the way.

**To test:**

* Publish a post normally, and check that the PostPost screen is still displayed
* Publish a post using the async debug option, and ensure that the PostPost screen is _not_ displayed