### PR TITLE
Add account_created event to magic link signup flow

### DIFF
--- a/WordPress/Classes/Services/SignupService.swift
+++ b/WordPress/Classes/Services/SignupService.swift
@@ -120,7 +120,7 @@ open class SignupService: LocalCoreDataService {
     ///     - status: The status callback
     ///     - success: A success calback
     ///     - failure: A failure callback
-    ///
+    /// - Note: this is only used from the deprecated SignupViewController
     func createWPComUserWithParams(_ params: SignupParams,
                                    status: SignupStatusBlock,
                                    success: @escaping SignupSuccessBlock,

--- a/WordPress/Classes/ViewRelated/NUX/NUXLinkAuthViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXLinkAuthViewController.swift
@@ -32,6 +32,7 @@ class NUXLinkAuthViewController: LoginViewController {
         if let linkSource = loginFields.meta.emailMagicLinkSource {
             switch linkSource {
             case .signup:
+                WordPressAuthenticator.post(event: .createdAccount)
                 WordPressAuthenticator.post(event: .signupMagicLinkSucceeded)
             case .login:
                 WordPressAuthenticator.post(event: .loginMagicLinkSucceeded)

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationTracker.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationTracker.swift
@@ -33,6 +33,8 @@ extension WordPressAuthenticationTracker {
         switch event {
         case .createAccountInitiated:
             WPAppAnalytics.track(.createAccountInitiated)
+        case .createdAccount:
+            WPAppAnalytics.track(.createdAccount)
         case .loginAutoFillCredentialsFilled:
             WPAppAnalytics.track(.loginAutoFillCredentialsFilled)
         case .loginAutoFillCredentialsUpdated:

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator+Events.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator+Events.swift
@@ -6,6 +6,7 @@ import Foundation
 public extension WordPressAuthenticator {
     public enum Event {
         case createAccountInitiated
+        case createdAccount
         case loginAutoFillCredentialsFilled
         case loginAutoFillCredentialsUpdated
         case loginEmailFormViewed


### PR DESCRIPTION
The `account_created` was missing from the email signup flow (was only working for Google).

To test:
- create a new account via email (not Google)
- ensure the `account_created` is being send (either via tracks or breakpoint)

