### PR TITLE
Async Posting: Show Notice on successful posting

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -45,7 +45,7 @@ class PostCoordinator: NSObject {
         let postService = PostService(managedObjectContext: mainContext)
         postService.uploadPost(post, success: { uploadedPost in
             print("Post Coordinator -> upload succesfull: \(String(describing: uploadedPost.content))")
-            let model = PostNoticeViewModel(post: post)
+            let model = PostNoticeViewModel(post: uploadedPost)
             ActionDispatcher.dispatch(NoticeAction.post(model.notice))
         }, failure: { error in
             print("Post Coordinator -> upload error: \(String(describing: error))")

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressFlux
 
 class PostCoordinator: NSObject {
 
@@ -44,6 +45,8 @@ class PostCoordinator: NSObject {
         let postService = PostService(managedObjectContext: mainContext)
         postService.uploadPost(post, success: { uploadedPost in
             print("Post Coordinator -> upload succesfull: \(String(describing: uploadedPost.content))")
+            let model = PostNoticeViewModel(post: post)
+            ActionDispatcher.dispatch(NoticeAction.post(model.notice))
         }, failure: { error in
             print("Post Coordinator -> upload error: \(String(describing: error))")
         })

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -6,6 +6,8 @@ class EditPostViewController: UIViewController {
     @objc var showImmediately: Bool = false
     /// appear with the media picker open
     @objc var openWithMediaPicker: Bool = false
+    /// appear with the post epilogue visible
+    @objc var openWithPostPost: Bool = false
     /// appear with media pre-inserted into the post
     var insertedMedia: [Media]? = nil
 
@@ -81,10 +83,14 @@ class EditPostViewController: UIViewController {
         // show postpost, which will be transparent
         view.isOpaque = false
         view.backgroundColor = .clear
+
+        if openWithPostPost {
+            showPostPost()
+        }
     }
 
     override func viewDidAppear(_ animated: Bool) {
-        if !hasShownEditor {
+        if !openWithPostPost && !hasShownEditor {
             showEditor()
             hasShownEditor = true
         }
@@ -154,17 +160,8 @@ class EditPostViewController: UIViewController {
         onClose?(changesSaved)
 
         var dismissPostPostImmediately = true
-        if showPostEpilogue && shouldShowPostPost(hasChanges: changesSaved), let post = post {
-            postPost.setup(post: post)
-            postPost.onClose = {
-                self.closePostPost(animated: true)
-            }
-            postPost.reshowEditor = {
-                self.showEditor()
-            }
-            postPost.preview = {
-                self.previewPost()
-            }
+        if showPostEpilogue && shouldShowPostPost(hasChanges: changesSaved) {
+            showPostPost()
             dismissPostPostImmediately = false
         }
 
@@ -175,9 +172,29 @@ class EditPostViewController: UIViewController {
         }
     }
 
+    private func showPostPost() {
+        guard let post = post else {
+            return
+        }
+
+        postPost.setup(post: post)
+        postPost.onClose = {
+            self.closePostPost(animated: true)
+        }
+        postPost.reshowEditor = {
+            self.showEditor()
+        }
+        postPost.preview = {
+            self.previewPost()
+        }
+    }
+
     @objc func shouldShowPostPost(hasChanges: Bool) -> Bool {
         guard let post = post else {
             return false
+        }
+        if openWithPostPost {
+            return true
         }
         if editingExistingPost {
             return false

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -3,6 +3,27 @@ import UIKit
 struct PostNoticeViewModel {
     let post: AbstractPost
 
+    /// Returns the Notice represented by this view model.
+    ///
+    var notice: Notice {
+        let action = self.action
+
+        return Notice(title: title,
+                      message: message,
+                      feedbackType: .success,
+                      actionTitle: action.title,
+                      actionHandler: {
+                        switch action {
+                        case .publish:
+                            self.publishPost()
+                        case .view:
+                            self.viewPost()
+                        }
+        })
+    }
+
+    // MARK: - Display values for Notice
+
     private var title: String {
         if let page = post as? Page {
             return title(for: page)
@@ -41,21 +62,86 @@ struct PostNoticeViewModel {
         }
     }
 
-    private var actionTitle: String {
-        if post.status == .draft {
-            return "Publish"
+    private var message: String {
+        let title = post.postTitle ?? ""
+        if title.count > 0 {
+            return title
         }
 
-        return "View"
+        return post.blog.displayURL as String? ?? ""
     }
 
-    var notice: Notice {
-        return Notice(title: title,
-                      message: nil,
-                      feedbackType: .success,
-                      actionTitle: actionTitle,
-                      actionHandler: {
-                        
-        })
+    private enum Action {
+        case publish
+        case view
+
+        var title: String {
+            switch self {
+            case .publish:
+                return NSLocalizedString("Publish", comment: "Button title. Publishes a post.")
+            case .view:
+                return NSLocalizedString("View", comment: "Button title. Displays a summary / sharing screen for a specific post.")
+            }
+        }
+    }
+
+    private var action: Action {
+        return (post.status == .draft) ? .publish : .view
+    }
+
+    // MARK: - Actions
+
+    private func viewPost() {
+        if post is Page {
+            presentViewPage()
+        } else {
+            presentPostPost()
+        }
+    }
+
+    private func presentViewPage() {
+        guard let presenter = UIApplication.shared.delegate?.window??.topmostPresentedViewController,
+            let post = postInContext else {
+                return
+        }
+
+        let controller = PostPreviewViewController(post: post)
+        controller.navigationItem.title = NSLocalizedString("View", comment: "Verb. The screen title shown when viewing a post inside the app.")
+        controller.hidesBottomBarWhenPushed = true
+
+        let navigationController = UINavigationController(rootViewController: controller)
+        navigationController.modalPresentationStyle = .formSheet
+        presenter.present(navigationController, animated: true, completion: nil)
+    }
+
+    private func presentPostPost() {
+        guard let presenter = UIApplication.shared.delegate?.window??.topmostPresentedViewController,
+            let post = postInContext else {
+                return
+        }
+
+        let editor = EditPostViewController(post: post as! Post)
+        editor.modalPresentationStyle = .fullScreen
+        editor.openWithPostPost = true
+        editor.onClose = { _ in
+        }
+        presenter.present(editor, animated: true, completion: nil)
+    }
+
+    private func publishPost() {
+        guard let post = postInContext else {
+            return
+        }
+
+        post.status = .publish
+        PostCoordinator.shared.save(post: post)
+    }
+
+    private var postInContext: AbstractPost? {
+        let context = ContextManager.sharedInstance().mainContext
+        let objectInContext = try? context.existingObject(with: post.objectID)
+        let postInContext = objectInContext as? AbstractPost
+
+        return postInContext
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -4,24 +4,58 @@ struct PostNoticeViewModel {
     let post: AbstractPost
 
     private var title: String {
-        let isPage = post is Page
-        let isDraft = post.isDraft()
-
-        switch (isPage, isDraft) {
-        case (true, true):
-            return NSLocalizedString("Page draft uploaded.", comment: "Title of notification displayed when a page has been successfully saved as a draft.")
-        case (false, true):
-            return NSLocalizedString("Post draft uploaded.", comment: "Title of notification displayed when a post has been successfully saved as a draft.")
-        case (true, false):
-            return NSLocalizedString("Page published.", comment: "Title of notification displayed when a page has been successfully published.")
-        case (false, false):
-            return NSLocalizedString("Post published.", comment: "Title of notification displayed when a post has been successfully published.")
+        if let page = post as? Page {
+            return title(for: page)
+        } else {
+            return title(for: post)
         }
+    }
+
+    private func title(for page: Page) -> String {
+        let status = page.status ?? .publish
+
+        switch status {
+        case .draft:
+            return NSLocalizedString("Page draft uploaded", comment: "Title of notification displayed when a page has been successfully saved as a draft.")
+        case .scheduled:
+            return NSLocalizedString("Page scheduled", comment: "Title of notification displayed when a page has been successfully scheduled.")
+        case .pending:
+            return NSLocalizedString("Page pending review", comment: "Title of notification displayed when a page has been successfully saved as a draft.")
+        default:
+            return NSLocalizedString("Page published", comment: "Title of notification displayed when a page has been successfully published.")
+        }
+    }
+
+    private func title(for post: AbstractPost) -> String {
+        let status = post.status ?? .publish
+
+        switch status {
+        case .draft:
+            return NSLocalizedString("Post draft uploaded", comment: "Title of notification displayed when a post has been successfully saved as a draft.")
+        case .scheduled:
+            return NSLocalizedString("Post scheduled", comment: "Title of notification displayed when a post has been successfully scheduled.")
+        case .pending:
+            return NSLocalizedString("Post pending review", comment: "Title of notification displayed when a post has been successfully saved as a draft.")
+        default:
+            return NSLocalizedString("Post published", comment: "Title of notification displayed when a post has been successfully published.")
+        }
+    }
+
+    private var actionTitle: String {
+        if post.status == .draft {
+            return "Publish"
+        }
+
+        return "View"
     }
 
     var notice: Notice {
         return Notice(title: title,
                       message: nil,
-                      feedbackType: .success)
+                      feedbackType: .success,
+                      actionTitle: actionTitle,
+                      actionHandler: {
+                        
+        })
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -1,0 +1,27 @@
+import UIKit
+
+struct PostNoticeViewModel {
+    let post: AbstractPost
+
+    private var title: String {
+        let isPage = post is Page
+        let isDraft = post.isDraft()
+
+        switch (isPage, isDraft) {
+        case (true, true):
+            return NSLocalizedString("Page draft uploaded.", comment: "Title of notification displayed when a page has been successfully saved as a draft.")
+        case (false, true):
+            return NSLocalizedString("Post draft uploaded.", comment: "Title of notification displayed when a post has been successfully saved as a draft.")
+        case (true, false):
+            return NSLocalizedString("Page published.", comment: "Title of notification displayed when a page has been successfully published.")
+        case (false, false):
+            return NSLocalizedString("Post published.", comment: "Title of notification displayed when a post has been successfully published.")
+        }
+    }
+
+    var notice: Notice {
+        return Notice(title: title,
+                      message: nil,
+                      feedbackType: .success)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -66,6 +66,8 @@ class PostPostViewController: UIViewController {
         editButton.setTitle(NSLocalizedString("Edit Post", comment: "Button label for editing a post"), for: .normal)
         viewButton.setTitle(NSLocalizedString("View Post", comment: "Button label for viewing a post"), for: .normal)
 
+        configureForPost()
+
         if revealPost {
             view.alpha = WPAlphaFull
             animatePostPost()
@@ -130,11 +132,11 @@ class PostPostViewController: UIViewController {
         }) { (context) in }
     }
 
-    @objc func setup(post: Post) {
-        guard let blogSettings = post.blog.settings else {
-            return
+    private func configureForPost() {
+        guard let post = self.post,
+            let blogSettings = post.blog.settings else {
+                return
         }
-        self.post = post
 
         titleLabel.text = post.titleForDisplay().strippingHTML()
 
@@ -153,6 +155,11 @@ class PostPostViewController: UIViewController {
         if isPrivate {
             shareButton.isHidden = true
         }
+
+    }
+
+    @objc func setup(post: Post) {
+        self.post = post
 
         revealPost = true
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		173BCE791CEB780800AE8817 /* Domain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173BCE781CEB780800AE8817 /* Domain.swift */; };
 		174122051EFDCBBF00AFA901 /* FancyAlertPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174122041EFDCBBF00AFA901 /* FancyAlertPresentationController.swift */; };
 		1746D7771D2165AE00B11D77 /* ForcePopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */; };
+		174C9697205A846E00CEEF6E /* PostNoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174C9696205A846E00CEEF6E /* PostNoticeViewModel.swift */; };
 		1750BD6D201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1750BD6C201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift */; };
 		1751E5911CE0E552000CA08D /* KeyValueDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */; };
 		1751E5931CE23801000CA08D /* NSAttributedString+StyledHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */; };
@@ -1459,6 +1460,7 @@
 		173BCE781CEB780800AE8817 /* Domain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Domain.swift; sourceTree = "<group>"; };
 		174122041EFDCBBF00AFA901 /* FancyAlertPresentationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FancyAlertPresentationController.swift; sourceTree = "<group>"; };
 		1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForcePopoverPresenter.swift; sourceTree = "<group>"; };
+		174C9696205A846E00CEEF6E /* PostNoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNoticeViewModel.swift; sourceTree = "<group>"; };
 		1750BD6C201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaNoticeNavigationCoordinator.swift; sourceTree = "<group>"; };
 		1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyValueDatabase.swift; sourceTree = "<group>"; };
 		1751E5921CE23801000CA08D /* NSAttributedString+StyledHTML.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+StyledHTML.swift"; sourceTree = "<group>"; };
@@ -3694,6 +3696,7 @@
 				43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */,
 				E1CECE011E6EC7A8009C6695 /* FakePreviewBuilder.swift */,
 				E1CECE041E6F01CE009C6695 /* PostPreviewGenerator.swift */,
+				174C9696205A846E00CEEF6E /* PostNoticeViewModel.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -7174,6 +7177,7 @@
 				B535209B1AF7BBB800B33BA8 /* PushAuthenticationManager.swift in Sources */,
 				319D6E8119E44C680013871C /* SuggestionsTableView.m in Sources */,
 				40E728851FF3D9070010E7C9 /* PluginDetailViewHeaderCell.swift in Sources */,
+				174C9697205A846E00CEEF6E /* PostNoticeViewModel.swift in Sources */,
 				ACBAB6860E1247F700F38795 /* PostPreviewViewController.m in Sources */,
 				F1D690171F82914200200E30 /* BuildConfiguration.swift in Sources */,
 				5D2FB2861AE98C6600F1D4ED /* RestorePostTableViewCell.m in Sources */,


### PR DESCRIPTION
Partial implementation of #8713

This PR implements notices for the successful path of async posting. Currently these will be triggered when a post is successfully uploaded using the PostCoordinator. There are different messages shown for posts vs pages and for drafts vs published vs scheduled vs pending review statuses.

![post-notices](https://user-images.githubusercontent.com/4780/37534361-8da8cb18-293c-11e8-9536-e0937bc5cde2.png)

**Actions**

* If a post / page is in a state other than 'draft', a **View** action button will be displayed on the notice. Tapping View should show the PostPost view, allowing the post to be shared / edited / viewed.
* If a post / page is in 'draft' state, a **Publish** action button will be displayed on the notice. Tapping Publish should publish the post using the post coordinator.

**To test:**

* Using the new async upload debug option, try the following:
  * Publish a post
  * Publish a page
  * In Post Settings, change a post's status to draft and use the async public option
  * In Post Settings, change a post's status to pending review and use the async public option
  * In Post Settings, change a post's publish date to some time in the future and use the async public option
* Repeat the above for pages too.
* In the event that a post has no title, the site's display domain should be shown.
* Try using the View and Publish buttons on notices, and check they do what you expect. On the PostPost screen, check you can share / edit / view a post.