### PR TITLE
Improve Voiceover accessibility for FilterTabBar + Author Filter Button

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterButton.swift
@@ -6,6 +6,17 @@ enum AuthorFilterType {
     case user(gravatarEmail: String?)
 }
 
+private extension AuthorFilterType {
+    var accessibilityValue: String {
+        switch self {
+        case .everyone:
+            return NSLocalizedString("Showing everyone's posts", comment: "Voiceover description for the post list filter which shows posts for all users on a site.")
+        case .user:
+            return NSLocalizedString("Showing just my posts", comment: "Voiceover description for the post list filter which shows posts for just the current user on a site.")
+        }
+    }
+}
+
 /// Displays an author gravatar image with a dropdown arrow.
 ///
 class AuthorFilterButton: UIControl {
@@ -57,6 +68,8 @@ class AuthorFilterButton: UIControl {
                     authorImageView.image = gravatarPlaceholder
                 }
             }
+
+            prepareForVoiceOver()
         }
     }
 
@@ -86,6 +99,8 @@ class AuthorFilterButton: UIControl {
             ])
 
         authorImageView.image = gravatarPlaceholder
+
+        prepareForVoiceOver()
     }
 
     private let gravatarPlaceholder: UIImage = Gridicon.iconOfType(.user, withSize: Metrics.gravatarSize)
@@ -98,6 +113,16 @@ class AuthorFilterButton: UIControl {
         static let stackViewSpacing: CGFloat = 7.0
         static let chevronVerticalPadding: CGFloat = 2.0
         static let leadingPadding: CGFloat = 12.0
+    }
+}
+
+extension AuthorFilterButton: Accessible {
+    func prepareForVoiceOver() {
+        isAccessibilityElement = true
+        accessibilityTraits = UIAccessibilityTraitButton
+        accessibilityLabel = NSLocalizedString("Author Filter", comment: "Voiceover description of a button that allows the user to filter posts by author.")
+        accessibilityHint = NSLocalizedString("Select to change the current author filter.", comment: "Voiceover hint for a button that allows the user to filter posts by author.")
+        accessibilityValue = filterType.accessibilityValue
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
@@ -199,6 +199,7 @@ private class AuthorFilterCell: UITableViewCell {
             case .everyone:
                 gravatarImageView.image = Gridicon.iconOfType(.multipleUsers, withSize: Metrics.multipleGravatarSize)
                 gravatarImageView.contentMode = .center
+                accessibilityHint = NSLocalizedString("Select to show everyone's posts.", comment: "Voiceover accessibility hint, informing the user they can select an item to show posts written by all users on the site")
             case .user(let email):
                 gravatarImageView.contentMode = .scaleAspectFill
 
@@ -208,6 +209,8 @@ private class AuthorFilterCell: UITableViewCell {
                 } else {
                     gravatarImageView.image = placeholder
                 }
+
+                accessibilityHint = NSLocalizedString("Select to just show my posts.", comment: "Voiceover accessibility hint, informing the user they can select an item to filter a list of posts to show only their own posts.")
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -236,6 +236,10 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     private func showAuthorSelectionPopover(_ sender: UIView) {
         let filterController = AuthorFilterViewController(initialSelection: filterSettings.currentPostAuthorFilter(),
                                                           gravatarEmail: blog.account?.email) { [weak self] filter in
+                                                            if filter != self?.filterSettings.currentPostAuthorFilter() {
+                                                                UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, sender)
+                                                            }
+
                                                             self?.filterSettings.setCurrentPostAuthorFilter(filter)
                                                             self?.updateAuthorFilter()
                                                             self?.refreshAndReload()

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -302,3 +302,10 @@ class FilterTabBar: UIControl {
         static let size: CGFloat = 14.0
     }
 }
+
+extension FilterTabBar: Accessible {
+    func prepareForVoiceOver() {
+        isAccessibilityElement = false
+        accessibilityTraits = super.accessibilityTraits | UIAccessibilityTraitTabBar
+    }
+}


### PR DESCRIPTION
This PR improves the voiceover support for the new pages / posts list filter bar and author filter button. Previously, Voiceover didn't even recognise the author filter button, so it couldn't be selected. I've added some more helpful descriptions for it, and posted a notification once the user changes the option.

<img width="379" alt="screen shot 2018-03-16 at 20 00 56" src="https://user-images.githubusercontent.com/4780/37542067-c3ad3592-2954-11e8-8385-f87cfa9e5a32.png">

@ctarda As you recently worked on Voiceover improvements, would you mind taking a look at this? If you have any suggestions for how to make it better, please let me know! Thanks!

**To test:**

* With Voiceover enabled, try scrolling through and using the items at the top of the Posts screen. Ensure that items can be interacted with, and make sense using Voiceover.