### PR TITLE
Fixes a problem with 'Save as Draft' sometimes publishing.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1136,8 +1136,10 @@ extension AztecPostViewController {
         }
 
         let publishBlock = { [unowned self] in
-            if action == .saveAsDraft {
+            if action == .save || action == .saveAsDraft {
                 self.post.status = .draft
+            } else if action == .publish {
+                self.post.status = .publish
             } else if action == .publishNow {
                 self.post.date_created_gmt = Date()
                 self.post.status = .publish


### PR DESCRIPTION
### Description:

Sometimes posts where being published when saving them as drafts.  This PR fixes that.

Fixes #8920 

### Reproduction steps and testing:

These steps publish the post in `release/9.6` but should save as Draft normally in this PR:

1. Open the editor.
2. Enter a title and content.
3. Tap the "X" to exit the editor.
4. Select "Save Draft."

Result: The post-publish screen appears and the post is published.

