### PR TITLE
Fixed font (not changing size) for nav bar title and search bar

### DIFF
--- a/WordPress/Classes/Extensions/WPStyleGuide+Search.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+Search.swift
@@ -30,7 +30,7 @@ extension WPStyleGuide {
 
     @objc public class func configureSearchBarTextAppearance() {
         // Cancel button
-        let barButtonTitleAttributes: [NSAttributedStringKey: Any] = [.font: WPStyleGuide.fontForTextStyle(.headline),
+        let barButtonTitleAttributes: [NSAttributedStringKey: Any] = [.font: WPStyleGuide.fixedFont(for: .headline),
                                                                       .foregroundColor: WPStyleGuide.darkGrey()]
         let barButtonItemAppearance = UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self])
         barButtonItemAppearance.setTitleTextAttributes(barButtonTitleAttributes, for: UIControlState())

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -540,7 +540,10 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
 - (void)customizeAppearanceForTextElements
 {
     CGFloat maximumPointSize = [WPStyleGuide maxFontSize];
-    [[UINavigationBar appearance] setTitleTextAttributes:@{NSForegroundColorAttributeName: [UIColor whiteColor], NSFontAttributeName: [WPStyleGuide fontForTextStyle:UIFontTextStyleHeadline symbolicTraits:UIFontDescriptorTraitBold maximumPointSize:maximumPointSize]} ];
+    [[UINavigationBar appearance] setTitleTextAttributes:@{
+                                                           NSForegroundColorAttributeName: [UIColor whiteColor],
+                                                           NSFontAttributeName: [WPStyleGuide fixedFontFor:UIFontTextStyleHeadline weight:UIFontWeightBold]
+                                                           }];
     // Search
     [WPStyleGuide configureSearchBarTextAppearance];
     // SVProgressHUD styles

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+ReaderComments.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+ReaderComments.swift
@@ -11,7 +11,7 @@ extension WPStyleGuide {
     class func defaultSearchBarTextAttributesSwifted(_ color: UIColor) -> [NSAttributedStringKey: Any] {
         return [
             .foregroundColor: color,
-            .font: WPStyleGuide.fontForTextStyle(.footnote)
+            .font: WPStyleGuide.fixedFont(for: .footnote)
         ]
     }
 }

--- a/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
+++ b/WordPressShared/WordPressShared/Core/Views/WPStyleGuide+DynamicType.swift
@@ -142,6 +142,20 @@ extension WPStyleGuide {
         return font.pointSize
     }
 
+    /// Creates a UIFont with fixed size, equal to the size of the given text style, assuming a default content size category.
+    /// This font will never change its size.
+    ///
+    /// - Parameters:
+    ///   - for: The base UIFontTextStyle to take the size from.
+    ///   - weight: The desired font weight
+    /// - Returns: The created font.
+    ///
+    @objc public class func fixedFont(for style: UIFontTextStyle, weight: UIFont.Weight = .regular) -> UIFont {
+        let defaultContentSizeCategory = UITraitCollection(preferredContentSizeCategory: .large) // .large is the default
+        let fontSize = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style, compatibleWith: defaultContentSizeCategory).pointSize
+        return UIFont.systemFont(ofSize: fontSize, weight: weight)
+    }
+
     /// Creates a NotoSerif UIFont for the user current text size settings.
     ///
     /// - Parameters:


### PR DESCRIPTION
Looking at Apple/system apps, the navigation bar title won't change its font size when the user selects a different content size category.

The same happens with the search bar text and cancel button

Currently, both elements will adopt the system font size when the view is loaded, but it won't resize when the user changes it. This can create awkward situations like this:
![img_2443](https://user-images.githubusercontent.com/9772967/37606813-25706c46-2b75-11e8-8c26-5484567ea7fa.png)

This PR fixes this problem by giving to this elements a fixed font that won't change its size according to content size category, but will assume the size of the default category.

## Testing:
**To reproduce the issue:**
- Open the app
- Change the system font size
- Navigation bar title and search bar text will remain with the previous
- Change tab to reset the font size of those elements

**This PR:**
Following the previous steps, the navigation bar title and search bar text will remain with a fixed font size for any system font size change.
