### PR TITLE
Async Posting: Show notices for failed uploads

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -573,9 +573,9 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
     }
 
     func mediaProgressCoordinatorDidFinishUpload(_ mediaProgressCoordinator: MediaProgressCoordinator) {
-        // Currently, we only want to show a successful upload notice for uploads
-        // initiated within the media library.
-        if mediaProgressCoordinator == mediaLibraryProgressCoordinator {
+        // We only want to show an upload notice for uploads initiated within
+        // the media library, or if there's been a failure.
+        if mediaProgressCoordinator == mediaLibraryProgressCoordinator || mediaProgressCoordinator.hasFailedMedia {
             let model = MediaProgressCoordinatorNoticeViewModel(mediaProgressCoordinator: mediaProgressCoordinator)
             if let notice = model?.notice {
                 ActionDispatcher.dispatch(NoticeAction.post(notice))

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -88,6 +88,12 @@ class PostCoordinator: NSObject {
     }
 
     private func removeObserver(for post: AbstractPost) {
+        let uuid = observerUUIDs[post]
+
         observerUUIDs.removeValue(forKey: post)
+
+        if let uuid = uuid {
+            MediaCoordinator.shared.removeObserver(withUUID: uuid)
+        }
     }
 }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -59,6 +59,9 @@ class PostCoordinator: NSObject {
             let model = PostNoticeViewModel(post: uploadedPost)
             ActionDispatcher.dispatch(NoticeAction.post(model.notice))
         }, failure: { error in
+            let model = PostNoticeViewModel(post: post)
+            ActionDispatcher.dispatch(NoticeAction.post(model.notice))
+
             print("Post Coordinator -> upload error: \(String(describing: error))")
         })
     }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -15,6 +15,8 @@ class PostCoordinator: NSObject {
 
     private let queue = DispatchQueue(label: "org.wordpress.postcoordinator")
 
+    private var observerUUIDs: [AbstractPost: UUID] = [:]
+
     /// Saves the post to both the local database and the server if available.
     /// If media is still uploading it keeps track of the ongoing media operations and updates the post content when they finish
     ///
@@ -23,18 +25,27 @@ class PostCoordinator: NSObject {
         let mediaCoordinator = MediaCoordinator.shared
 
         if mediaCoordinator.isUploadingMedia(for: post) {
-            mediaCoordinator.addObserver({ (media, state) in
+            // Only observe if we're not already
+            guard observerUUIDs[post] == nil else {
+                return
+            }
+
+            let uuid = mediaCoordinator.addObserver({ (media, state) in
                 switch state {
                 case .ended:
                     self.updateReferences(to: media, in: post)
+
                     // Let's check if media uploading is still going, if all finished with success then we can upload the post
                     if !mediaCoordinator.isUploadingMedia(for: post) && !post.hasFailedMedia {
+                        self.removeObserver(for: post)
                         self.upload(post: post)
                     }
                 default:
                     print("Post Coordinator -> Media state: \(state)")
                 }
             }, forMediaFor: post)
+
+            observerUUIDs[post] = uuid
             return
         }
 
@@ -71,5 +82,9 @@ class PostCoordinator: NSObject {
         }
 
         post.content = postContent
+    }
+
+    private func removeObserver(for post: AbstractPost) {
+        observerUUIDs.removeValue(forKey: post)
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -9,12 +9,18 @@ struct MediaProgressCoordinatorNoticeViewModel {
     private let successfulMedia: [Media]
     private let failedMedia: [Media]
 
-    init?(mediaProgressCoordinator: MediaProgressCoordinator) {
+    // Is the media progress related to a post?
+    // Only failed post media should be reported through this view model.
+    // Successful post media uploads should be reported via a PostNoticeViewModel.
+    private let isPostMedia: Bool
+
+    init?(mediaProgressCoordinator: MediaProgressCoordinator, isPostMedia: Bool = false) {
         guard !mediaProgressCoordinator.isRunning else {
                 return nil
         }
 
         self.mediaProgressCoordinator = mediaProgressCoordinator
+        self.isPostMedia = isPostMedia
 
         successfulMedia = mediaProgressCoordinator.successfulMedia
         failedMedia = mediaProgressCoordinator.failedMedia
@@ -128,9 +134,15 @@ struct MediaProgressCoordinatorNoticeViewModel {
     }
 
     private var failedMediaDescription: String {
-        return pluralize(mediaProgressCoordinator.failedMediaIDs.count,
-                         singular: NSLocalizedString("1 file not uploaded", comment: "Alert displayed to the user when a single media item has failed to upload."),
-                         plural: NSLocalizedString("%ld files not uploaded", comment: "Alert displayed to the user when multiple media items have failed to upload."))
+        if isPostMedia {
+            return pluralize(mediaProgressCoordinator.failedMediaIDs.count,
+                             singular: NSLocalizedString("1 file not uploaded", comment: "Alert displayed to the user when a single media item has failed to upload."),
+                             plural: NSLocalizedString("%ld files not uploaded", comment: "Alert displayed to the user when multiple media items have failed to upload."))
+        } else {
+            return pluralize(mediaProgressCoordinator.failedMediaIDs.count,
+                             singular: NSLocalizedString("1 post, 1 file not uploaded", comment: "Alert displayed to the user when a single media item attached to a post has failed to upload."),
+                             plural: NSLocalizedString("1 post, %ld files not uploaded", comment: "Alert displayed to the user when multiple media items attached to a post have failed to upload."))
+        }
     }
 
     var actionTitle: String {


### PR DESCRIPTION
Partial implementation of #8713. This PR follows on from #8921, by adding notices for failure cases when either media or posts fail to upload.

Note that the messages differ slightly from the designs, as the circumstances under which uploads can fail are I think a little different to what we first thought. There are two cases in which these failures might be displayed:

1. Media for a post fails to upload. In this case, we haven't yet tried to upload the post, so we can just display a normal media failure notice (except we mention that the post has failed). The retry button on the notice will retry the uploads, which will still be observed by the `PostCoordinator`. If the media uploads then complete, the post coordinator will upload the post as normal.

![img_2017](https://user-images.githubusercontent.com/4780/37723586-aab35ae6-2d26-11e8-8cd0-8deb0dafad19.PNG)

2. If the media has uploaded, but the post itself fails to upload, we'll display a new variation on the Post upload notice:

![img_2021](https://user-images.githubusercontent.com/4780/37723654-cd5e88ae-2d26-11e8-8dcb-11b6077a33e9.PNG)

The Retry button will simply retry the upload through the `PostCoordinator`.

**To test:**

* To test both of these cases, it's easiest to turn on the Very Bad Network link conditioner, so that you have more time to perform actions before the posts complete.
* For notice 1, you can do the following:
  * Open the editor, and add a couple of media items
  * Before they finish uploading, use the Async Publish button
  * Switch airplane mode on, and the notice should appear. Quickly switch airplane mode off and then tap the Retry button to test that. You could increase the hide duration in NoticePresenter if you need more time.
* For notice 2, you can do the following:
  * Open the editor, and don't add any media items
  * Use the Async Publish button
  * Switch airplane mode on before the publish completes. You should see the notice. Quickly switch airplane mode off and then tap the Retry button to test that. You could increase the hide duration in NoticePresenter if you need more time.