### PR TITLE
Post upload cancel when editing again

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -468,7 +468,7 @@ class MediaCoordinator: NSObject {
     /// including any 'wildcard' observers that are observing _all_ media items.
     ///
     private func observersForMedia(_ media: Media) -> [MediaObserver] {
-        let mediaObservers = self.mediaObservers.values.filter({ $0.media?.mediaID == media.mediaID })
+        let mediaObservers = self.mediaObservers.values.filter({ $0.media?.uploadID == media.uploadID })
 
         let postObservers = self.mediaObservers.values.filter({
             guard let posts = media.posts,

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -26,7 +26,7 @@ class PostCoordinator: NSObject {
 
         if mediaCoordinator.isUploadingMedia(for: post) {
             // Only observe if we're not already
-            guard !areWeObserving(post: post) else {
+            guard !isObserving(post: post) else {
                 return
             }
 
@@ -112,7 +112,7 @@ class PostCoordinator: NSObject {
         }
     }
 
-    private func areWeObserving(post: AbstractPost) -> Bool {
+    private func isObserving(post: AbstractPost) -> Bool {
         var result = false
         queue.sync {
             result = observerUUIDs[post] != nil

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -52,6 +52,10 @@ class PostCoordinator: NSObject {
         upload(post: post)
     }
 
+    func isUploading(post: AbstractPost) -> Bool {
+        return post.remoteStatus == .pushing
+    }
+
     private func upload(post: AbstractPost) {
         let postService = PostService(managedObjectContext: mainContext)
         postService.uploadPost(post, success: { uploadedPost in

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -52,6 +52,10 @@ class PostCoordinator: NSObject {
         upload(post: post)
     }
 
+    func cancelAnyPendingSaveOf(post: AbstractPost) {
+        removeObserver(for: post)
+    }
+
     func isUploading(post: AbstractPost) -> Bool {
         return post.remoteStatus == .pushing
     }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -26,7 +26,7 @@ class PostCoordinator: NSObject {
 
         if mediaCoordinator.isUploadingMedia(for: post) {
             // Only observe if we're not already
-            guard observerUUIDs[post] == nil else {
+            guard !areWeObserving(post: post) else {
                 return
             }
 
@@ -44,8 +44,7 @@ class PostCoordinator: NSObject {
                     print("Post Coordinator -> Media state: \(state)")
                 }
             }, forMediaFor: post)
-
-            observerUUIDs[post] = uuid
+            trackObserver(receipt: uuid, for: post)
             return
         }
 
@@ -95,13 +94,29 @@ class PostCoordinator: NSObject {
         post.content = postContent
     }
 
-    private func removeObserver(for post: AbstractPost) {
-        let uuid = observerUUIDs[post]
-
-        observerUUIDs.removeValue(forKey: post)
-
-        if let uuid = uuid {
-            MediaCoordinator.shared.removeObserver(withUUID: uuid)
+    private func trackObserver(receipt: UUID, for post: AbstractPost) {
+        queue.sync {
+            observerUUIDs[post] = receipt
         }
+    }
+
+    private func removeObserver(for post: AbstractPost) {
+        queue.sync {
+            let uuid = observerUUIDs[post]
+
+            observerUUIDs.removeValue(forKey: post)
+
+            if let uuid = uuid {
+                MediaCoordinator.shared.removeObserver(withUUID: uuid)
+            }
+        }
+    }
+
+    private func areWeObserving(post: AbstractPost) -> Bool {
+        var result = false
+        queue.sync {
+            result = observerUUIDs[post] != nil
+        }
+        return result
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -471,6 +471,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         self.restorationClass = type(of: self)
         self.shouldRemovePostOnDismiss = post.shouldRemoveOnDismiss
 
+        PostCoordinator.shared.cancelAnyPendingSaveOf(post: post)
         addObservers(toPost: post)
     }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -361,7 +361,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func presentAlertForPageBeingUploaded() {
-        let message = NSLocalizedString("Page is being uploaded, please wait until this is done", comment: "Prompts the user that the post is being uploaded and cannot be restored post was moved to the drafts list.")
+        let message = NSLocalizedString("Page is being uploaded, please wait until this is done", comment: "Prompts the user that the page is being uploaded and cannot be edited while that process is ongoing.")
 
         let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -328,6 +328,10 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     fileprivate func editPage(_ apost: AbstractPost) {
+        guard !PostCoordinator.shared.isUploading(post: apost) else {
+            presentAlertForPageBeingUploaded()
+            return
+        }
         WPAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics())
         showEditor(post: apost)
     }
@@ -354,6 +358,16 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         present(navController, animated: true, completion: { [weak self] in
             self?.updateFilterWithPostStatus(.draft)
         })
+    }
+
+    func presentAlertForPageBeingUploaded() {
+        let message = NSLocalizedString("Page is being uploaded, please wait until this is done", comment: "Prompts the user that the post is being uploaded and cannot be restored post was moved to the drafts list.")
+
+        let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
+
+        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(alertCancel, handler: nil)
+        alertController.presentFromRootViewController()
     }
 
     fileprivate func draftPage(_ apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -361,7 +361,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func presentAlertForPageBeingUploaded() {
-        let message = NSLocalizedString("Page is being uploaded, please wait until this is done", comment: "Prompts the user that the page is being uploaded and cannot be edited while that process is ongoing.")
+        let message = NSLocalizedString("This page is currently uploading. It won't take long -- try again soon and you'll be able to edit it.", comment: "Prompts the user that the page is being uploaded and cannot be edited while that process is ongoing.")
 
         let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -261,7 +261,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
         let page = pageAtIndexPath(indexPath)
 
-        if page.remoteStatus != .pushing && page.status != .trash {
+        if page.status != .trash {
             editPage(page)
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -438,7 +438,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func presentAlertForPostBeingUploaded() {
-        let message = NSLocalizedString("Post is being uploaded, please wait until this is done", comment: "Prompts the user that the post is being uploaded and cannot be edited while that process is ongoing.")
+        let message = NSLocalizedString("This post is currently uploading. It won't take long -- try again soon and you'll be able to edit it.", comment: "Prompts the user that the post is being uploaded and cannot be edited while that process is ongoing.")
 
         let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -438,7 +438,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func presentAlertForPostBeingUploaded() {
-        let message = NSLocalizedString("Post is being uploaded, please wait until this is done", comment: "Prompts the user that the post is being uploaded and cannot be restored post was moved to the drafts list.")
+        let message = NSLocalizedString("Post is being uploaded, please wait until this is done", comment: "Prompts the user that the post is being uploaded and cannot be edited while that process is ongoing.")
 
         let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -425,6 +425,10 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         guard let post = apost as? Post else {
             return
         }
+        guard !PostCoordinator.shared.isUploading(post: post) else {
+            presentAlertForPostBeingUploaded()
+            return
+        }
         let editor = EditPostViewController(post: post)
         editor.onClose = { [weak self] changesSaved in
             if changesSaved {
@@ -436,6 +440,16 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         editor.modalPresentationStyle = .fullScreen
         present(editor, animated: false, completion: nil)
         WPAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics())
+    }
+
+    func presentAlertForPostBeingUploaded() {
+        let message = NSLocalizedString("Post is being uploaded, please wait until this is done", comment: "Prompts the user that the post is being uploaded and cannot be restored post was moved to the drafts list.")
+
+        let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
+
+        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(alertCancel, handler: nil)
+        alertController.presentFromRootViewController()
     }
 
     override func promptThatPostRestoredToFilter(_ filter: PostListFilter) {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -342,11 +342,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
         let post = postAtIndexPath(indexPath)
 
-        if post.remoteStatus == .pushing {
-            // Don't allow editing while pushing changes
-            return
-        }
-
         if post.status == .trash {
             // No editing posts that are trashed.
             return


### PR DESCRIPTION
This PR implements check for post status before reopening a pending to upload post.

It introduces checks to see if a Post is pending media upload and if a post being uploaded at the moment.

To test:
 - Create a new Post
 - Add some media to it
 - Exit the editor by selecting the Async Publish option
 - Before it uploads the media
 - go back inside the post
 - insert more media
 - Tap Async Publish again.



