### PR TITLE
PluginDirectory: change how "Auto-managed" label is displayed.

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryAccessoryItem.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryAccessoryItem.swift
@@ -27,11 +27,10 @@ struct PluginDirectoryAccessoryItem {
     }
 
     private static func automanaged() -> UIView {
-        let icon = Gridicon.iconOfType(.domains, withSize: Constants.imageSize)
-        let color = WPStyleGuide.validGreen()
+        let color = WPStyleGuide.greyDarken10()
         let text = NSLocalizedString("Auto-managed", comment: "Describes a status of a plugin")
 
-        return PluginDirectoryAccessoryItem.label(with: icon, tintColor: color, text: text)
+        return PluginDirectoryAccessoryItem.label(with: nil, tintColor: color, text: text)
     }
 
     private static func active() -> UIView {
@@ -66,12 +65,13 @@ struct PluginDirectoryAccessoryItem {
         return PluginDirectoryAccessoryItem.label(with: icon, tintColor: color, text: text)
     }
 
-    private static func label(with icon: UIImage, tintColor: UIColor, text: String) -> UIView {
-        let container = UIView(frame: .zero)
+    private static func label(with icon: UIImage?, tintColor: UIColor, text: String) -> UIView {
+        let container = UIStackView(frame: .zero)
         container.translatesAutoresizingMaskIntoConstraints = false
 
         let imageView = UIImageView(image: icon)
         imageView.tintColor = tintColor
+        imageView.translatesAutoresizingMaskIntoConstraints = false
 
         let label = UILabel(frame: .zero)
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -79,17 +79,16 @@ struct PluginDirectoryAccessoryItem {
         label.textColor = tintColor
         label.text = text
 
-        container.addSubview(imageView)
-        container.addSubview(label)
+        container.axis = .horizontal
+        container.distribution = .fillProportionally
+        container.spacing = Constants.trailingSpacing
 
-        label.topAnchor.constraint(equalTo: container.topAnchor).isActive = true
-        label.bottomAnchor.constraint(equalTo: container.bottomAnchor).isActive = true
-        label.trailingAnchor.constraint(equalTo: container.trailingAnchor).isActive = true
+        if icon == nil {
+            imageView.isHidden = true
+        }
 
-        imageView.leadingAnchor.constraint(equalTo: container.leadingAnchor).isActive = true
-        imageView.trailingAnchor.constraint(equalTo: label.leadingAnchor, constant: -Constants.trailingSpacing).isActive = true
-
-        imageView.centerYAnchor.constraint(equalTo: label.centerYAnchor).isActive = true
+        container.addArrangedSubview(imageView)
+        container.addArrangedSubview(label)
 
         return container
     }


### PR DESCRIPTION
This addresses design comment by @mattmiklic left in #8780, which I missed before, but caught when catching up on notifications after my AFK. 

(tl;dr remove the icon for the "automanaged" state and change the text color)

Here's how it looks like now:
![simulator screen shot - iphone 8 plus - 2018-03-22 at 21 50 39](https://user-images.githubusercontent.com/1594081/37797786-163a1828-2e1b-11e8-8727-46d059e15848.png)

To test:

1. Go to plugin directory
2. Verify that the "automanaged" label doesn't have an icon and is in the correct color (grey).
