### PR TITLE
Fix list layouting issue in Plugin Details

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -479,7 +479,7 @@ class PluginViewModel: Observable {
     }
 
     var title: String {
-        return plugin?.name ?? directoryEntry?.name ?? "foo"
+        return plugin?.name ?? directoryEntry?.name ?? ""
     }
 
     private var descriptionExpandedStatus: Bool = true

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -473,7 +473,7 @@ class PluginViewModel: Observable {
                 if index + 1 < paragraphAttributes.endIndex,
                     paragraphAttributes[index + 1].paragraph.tabStops.isEmpty {
                     // this means that the next paragraph is _not_ a list.
-                    // we need to add paragraphSpacing, so that there's a nice gap between the list and next paragraph.
+                    // we need to add paragraphSpacingBefore, so that there's a nice gap between the list and next paragraph.
 
                     let nextItem = paragraphAttributes[index + 1]
 

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -446,8 +446,18 @@ class PluginViewModel: Observable {
             copy.addAttribute(.foregroundColor, value: WPStyleGuide.darkGrey(), range: range)
         }
 
-        copy.enumerateAttribute(NSAttributedStringKey.paragraphStyle, in: NSMakeRange(0, copy.length), options: NSAttributedString.EnumerationOptions(rawValue: 0)) { (value, range, stop) in
+
+        var paragraphAttributes: [(paragraph: NSParagraphStyle, range: NSRange)] = []
+
+        copy.enumerateAttribute(NSAttributedStringKey.paragraphStyle, in: NSMakeRange(0, copy.length), options: [.longestEffectiveRangeNotRequired]) { (value, range, stop) in
             guard let paragraphStyle = value as? NSParagraphStyle else { return }
+
+            paragraphAttributes.append((paragraphStyle, range))
+        }
+
+        for (index, item) in paragraphAttributes.enumerated() {
+            let paragraphStyle = item.paragraph
+            let range = item.range
 
             var mutableParagraphStyle: NSMutableParagraphStyle?
 
@@ -459,6 +469,19 @@ class PluginViewModel: Observable {
                 mutableParagraphStyle?.defaultTabInterval = 5
                 mutableParagraphStyle?.firstLineHeadIndent = 0
                 mutableParagraphStyle?.headIndent = 15
+
+                if index + 1 < paragraphAttributes.endIndex,
+                    paragraphAttributes[index + 1].paragraph.tabStops.isEmpty {
+                    // this means that the next paragraph is _not_ a list.
+                    // we need to add paragraphSpacing, so that there's a nice gap between the list and next paragraph.
+
+                    let nextItem = paragraphAttributes[index + 1]
+
+                    let nextMutableParagraph = nextItem.paragraph.mutableCopy() as! NSMutableParagraphStyle
+                    nextMutableParagraph.paragraphSpacingBefore = 12
+
+                    copy.addAttribute(.paragraphStyle, value: nextMutableParagraph, range: nextItem.range)
+                }
             }
 
             if ceil(paragraphStyle.paragraphSpacing) == 16 {


### PR DESCRIPTION
Fixes #8746 — there was an issue where a paragraph immediately after a bulleted list had no space between the list and the text. This fixes it.

Quick before: 
![simulator screen shot - iphone 8 plus - 2018-03-23 at 00 03 46](https://user-images.githubusercontent.com/1594081/37803356-9049eeb4-2e2e-11e8-9183-07d245efea8f.png)

and after shots:
![simulator screen shot - iphone 8 plus - 2018-03-23 at 00 01 33](https://user-images.githubusercontent.com/1594081/37803359-95af88b4-2e2e-11e8-84a9-265e07a865e6.png)


To test:
1. Open plugin directory
2. Go to a plugin that has bullet list in description, like Akismet
3. Verify there's a space below the bulleted list.