### PR TITLE
Async posting: Add system notifications for upload success / failure

### DIFF
--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -119,6 +119,22 @@ final class InteractiveNotificationsManager: NSObject {
                         break
                     }
                 }
+            case .postUploadSuccess, .postUploadFailure:
+                if identifier == UNNotificationDefaultActionIdentifier {
+                    ShareNoticeNavigationCoordinator.navigateToPostList(with: userInfo)
+                    return true
+                }
+
+                if let action = NoteActionDefinition(rawValue: identifier) {
+                    switch action {
+                    case .postRetry:
+                        PostNoticeNavigationCoordinator.retryPostUpload(with: userInfo)
+                    case .postView:
+                        PostNoticeNavigationCoordinator.presentPostEpilogue(with: userInfo)
+                    default:
+                        break
+                    }
+                }
             case .shareUploadSuccess:
                 if identifier == UNNotificationDefaultActionIdentifier {
                     ShareNoticeNavigationCoordinator.navigateToPostList(with: userInfo)
@@ -236,6 +252,8 @@ private extension InteractiveNotificationsManager {
         case commentReplyWithLike   = "replyto-like-comment"
         case mediaUploadSuccess     = "media-upload-success"
         case mediaUploadFailure     = "media-upload-failure"
+        case postUploadSuccess      = "post-upload-success"
+        case postUploadFailure      = "post-upload-failure"
         case shareUploadSuccess     = "share-upload-success"
         case shareUploadFailure     = "share-upload-failure"
 
@@ -253,6 +271,10 @@ private extension InteractiveNotificationsManager {
                 return [.mediaWritePost]
             case .mediaUploadFailure:
                 return [.mediaRetry]
+            case .postUploadSuccess:
+                return [.postView]
+            case .postUploadFailure:
+                return [.postRetry]
             case .shareUploadSuccess:
                 return [.shareEditPost]
             case .shareUploadFailure:
@@ -276,8 +298,8 @@ private extension InteractiveNotificationsManager {
                 options: [])
         }
 
-        static var allDefinitions = [commentApprove, commentLike, commentReply, commentReplyWithLike, mediaUploadSuccess, mediaUploadFailure, shareUploadSuccess, shareUploadFailure]
-        static var localDefinitions = [mediaUploadSuccess, mediaUploadFailure, shareUploadSuccess, shareUploadFailure]
+        static var allDefinitions = [commentApprove, commentLike, commentReply, commentReplyWithLike, mediaUploadSuccess, mediaUploadFailure, postUploadSuccess, postUploadFailure, shareUploadSuccess, shareUploadFailure]
+        static var localDefinitions = [mediaUploadSuccess, mediaUploadFailure, postUploadSuccess, postUploadFailure, shareUploadSuccess, shareUploadFailure]
     }
 
 
@@ -290,6 +312,8 @@ private extension InteractiveNotificationsManager {
         case commentReply     = "COMMENT_REPLY"
         case mediaWritePost   = "MEDIA_WRITE_POST"
         case mediaRetry       = "MEDIA_RETRY"
+        case postRetry        = "POST_RETRY"
+        case postView         = "POST_VIEW"
         case shareEditPost    = "SHARE_EDIT_POST"
 
         var description: String {
@@ -304,6 +328,10 @@ private extension InteractiveNotificationsManager {
                 return NSLocalizedString("Write Post", comment: "Opens the editor to write a new post.")
             case .mediaRetry:
                 return NSLocalizedString("Retry", comment: "Opens the media library .")
+            case .postRetry:
+                return NSLocalizedString("Retry", comment: "Retries the upload of a user's post.")
+            case .postView:
+                return NSLocalizedString("View", comment: "Opens the post epilogue screen to allow sharing / viewing of a post.")
             case .shareEditPost:
                 return NSLocalizedString("Edit Post", comment: "Opens the editor to edit an existing post.")
             }
@@ -323,7 +351,7 @@ private extension InteractiveNotificationsManager {
 
         var requiresForeground: Bool {
             switch self {
-            case .mediaWritePost, .mediaRetry, .shareEditPost:
+            case .mediaWritePost, .mediaRetry, .postView, .shareEditPost:
                 return true
             default: return false
             }
@@ -356,7 +384,7 @@ private extension InteractiveNotificationsManager {
             }
         }
 
-        static var allDefinitions = [commentApprove, commentLike, commentReply, mediaWritePost, mediaRetry, shareEditPost]
+        static var allDefinitions = [commentApprove, commentLike, commentReply, mediaWritePost, mediaRetry, postRetry, postView, shareEditPost]
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeNavigationCoordinator.swift
@@ -1,0 +1,67 @@
+import UIKit
+
+/// This class simply exists to coordinate the display of various sections of
+/// the app in response to actions taken by the user from Post notifications.
+///
+class PostNoticeNavigationCoordinator {
+    static func presentPostEpilogue(with userInfo: NSDictionary) {
+        if let post = self.post(from: userInfo) {
+            presentPostEpilogue(for: post)
+        }
+    }
+
+    static func presentPostEpilogue(for post: AbstractPost) {
+        if let page = post as? Page {
+            presentViewPage(for: page)
+        } else if let post = post as? Post {
+            presentPostEpilogue(for: post)
+        }
+    }
+
+    private static func presentViewPage(for page: Page) {
+        guard let presenter = UIApplication.shared.delegate?.window??.topmostPresentedViewController else {
+                return
+        }
+
+        let controller = PostPreviewViewController(post: page)
+        controller.navigationItem.title = NSLocalizedString("View", comment: "Verb. The screen title shown when viewing a post inside the app.")
+        controller.hidesBottomBarWhenPushed = true
+
+        let navigationController = UINavigationController(rootViewController: controller)
+        navigationController.modalPresentationStyle = .formSheet
+        presenter.present(navigationController, animated: true, completion: nil)
+    }
+
+    private static func presentPostEpilogue(for post: Post) {
+        guard let presenter = UIApplication.shared.delegate?.window??.topmostPresentedViewController else {
+                return
+        }
+
+        let editor = EditPostViewController(post: post)
+        editor.modalPresentationStyle = .fullScreen
+        editor.openWithPostPost = true
+        editor.onClose = { _ in
+        }
+        presenter.present(editor, animated: true, completion: nil)
+    }
+
+    static func retryPostUpload(with userInfo: NSDictionary) {
+        if let post = self.post(from: userInfo) {
+            PostCoordinator.shared.save(post: post)
+        }
+    }
+
+    private static func post(from userInfo: NSDictionary) -> AbstractPost? {
+        let context = ContextManager.sharedInstance().mainContext
+
+        guard let postID = userInfo[PostNoticeUserInfoKey.postID] as? String,
+            let URIRepresentation = URL(string: postID),
+            let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: URIRepresentation),
+            let managedObject = try? context.existingObject(with: objectID),
+            let post = managedObject as? AbstractPost else {
+                return nil
+        }
+
+        return post
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		1702BBDC1CEDEA6B00766A33 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */; };
 		1702BBE01CF3034E00766A33 /* DomainsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDF1CF3034E00766A33 /* DomainsService.swift */; };
 		1707CE421F3121750020B7FE /* UICollectionViewCell+Tint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1707CE411F3121750020B7FE /* UICollectionViewCell+Tint.swift */; };
+		170CE7402064478600A48191 /* PostNoticeNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170CE73F2064478600A48191 /* PostNoticeNavigationCoordinator.swift */; };
 		171795831D1C65E8002F1EB2 /* FlingableViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171795821D1C65E8002F1EB2 /* FlingableViewHandler.swift */; };
 		171963401D378D5100898E8B /* SearchWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1719633F1D378D5100898E8B /* SearchWrapperView.swift */; };
 		1724DDC81C60F1200099D273 /* PlanDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1724DDC71C60F1200099D273 /* PlanDetailViewController.swift */; };
@@ -1446,6 +1447,7 @@
 		1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
 		1702BBDF1CF3034E00766A33 /* DomainsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsService.swift; sourceTree = "<group>"; };
 		1707CE411F3121750020B7FE /* UICollectionViewCell+Tint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+Tint.swift"; sourceTree = "<group>"; };
+		170CE73F2064478600A48191 /* PostNoticeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNoticeNavigationCoordinator.swift; sourceTree = "<group>"; };
 		171795821D1C65E8002F1EB2 /* FlingableViewHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FlingableViewHandler.swift; sourceTree = "<group>"; };
 		1719633F1D378D5100898E8B /* SearchWrapperView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchWrapperView.swift; sourceTree = "<group>"; };
 		1724DDC71C60F1200099D273 /* PlanDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanDetailViewController.swift; sourceTree = "<group>"; };
@@ -3697,6 +3699,7 @@
 				E1CECE011E6EC7A8009C6695 /* FakePreviewBuilder.swift */,
 				E1CECE041E6F01CE009C6695 /* PostPreviewGenerator.swift */,
 				174C9696205A846E00CEEF6E /* PostNoticeViewModel.swift */,
+				170CE73F2064478600A48191 /* PostNoticeNavigationCoordinator.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -7268,6 +7271,7 @@
 				E6D2E16C1B8B423B0000ED14 /* ReaderStreamHeader.swift in Sources */,
 				B50C0C571EF42A0000372C65 /* VideoShortcodeProcessor.swift in Sources */,
 				FFD12D5E1FE1998D00F20A00 /* Progress+Helpers.swift in Sources */,
+				170CE7402064478600A48191 /* PostNoticeNavigationCoordinator.swift in Sources */,
 				B59DCB05202A1E3200BEBD8A /* NUXHelpBadgeLabel.swift in Sources */,
 				B5F641B31E37C36700B7819F /* AdaptiveNavigationController.swift in Sources */,
 				74BC35B820499EEB00AC1525 /* RemotePostCategory+Extensions.swift in Sources */,


### PR DESCRIPTION
The last part of #8713! This PR follows on from #8935, by showing system notifications for async posting notices that are posted while the app is in the background. I've also extracted some of the navigation logic from the `PostNoticeViewModel` into a new navigation coordinator.

<img width="904" alt="screen shot 2018-03-23 at 11 00 12" src="https://user-images.githubusercontent.com/4780/37825916-6726cf4c-2e89-11e8-9c12-db077dee461e.png">

**To test:**

* Start an async post uploading and leave the app. Test the following cases:
  * The post uploads successfully. You should see a success notification, which will have a View action (you'll need to interact with the notification to show the action). Tap View to be taken into the app and shown PostPost.
  * The post fails to upload. You should see the failure notification with a Retry action. The Retry button should retry the upload in the background.
  * Try async saving a draft post, and check you see the different text in the notification.
* Check that the actions for notices displayed within the app still work as expected, because I moved that logic.