### PR TITLE
Issue/refactor thumbnail generation

### DIFF
--- a/WordPress/Classes/Categories/Media+WPMediaAsset.m
+++ b/WordPress/Classes/Categories/Media+WPMediaAsset.m
@@ -8,16 +8,16 @@
 
 - (WPMediaRequestID)imageWithSize:(CGSize)size completionHandler:(WPMediaImageBlock)completionHandler
 {
-    NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] newDerivedContext];
-    MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:mainContext];
-    mediaService.concurrentThumbnailGeneration = YES;
-    [mediaService thumbnailImageForMedia:self
-                           preferredSize:size
-                              completion:^(UIImage *image, NSError *error){
-                                  dispatch_async(dispatch_get_main_queue(), ^{
-                                      completionHandler(image, error);
-                                  });
-                              }];
+    [MediaCoordinator.shared.mediaThumbnailService thumbnailURLForMedia:self preferredSize:size onCompletion:^(NSURL *url) {
+        UIImage *image = [UIImage imageWithContentsOfFile:url.path];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completionHandler(image, nil);
+        });
+    } onError:^(NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completionHandler(nil, error);
+        });
+    }];
 
     return [self.mediaID intValue];
 }

--- a/WordPress/Classes/Categories/Media+WPMediaAsset.m
+++ b/WordPress/Classes/Categories/Media+WPMediaAsset.m
@@ -8,14 +8,17 @@
 
 - (WPMediaRequestID)imageWithSize:(CGSize)size completionHandler:(WPMediaImageBlock)completionHandler
 {
-    [MediaCoordinator.shared.mediaThumbnailService thumbnailURLForMedia:self preferredSize:size onCompletion:^(NSURL *url) {
-        UIImage *image = [UIImage imageWithContentsOfFile:url.path];
+    [MediaThumbnailCoordinator.shared thumbnailFor:self with:size onCompletion:^(UIImage *image, NSError *error) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            completionHandler(image, nil);
-        });
-    } onError:^(NSError *error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            completionHandler(nil, error);
+            if (error) {
+                if (completionHandler) {
+                    completionHandler(nil, error);
+                }
+                return;
+            }
+            if (completionHandler) {
+                completionHandler(image, nil);
+            }
         });
     }];
 

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -332,6 +332,12 @@ class MediaCoordinator: NSObject {
         return media
     }
 
+    @objc lazy var mediaThumbnailService: MediaThumbnailService = {
+        let mediaThumbnailService = MediaThumbnailService(managedObjectContext: backgroundContext)
+        mediaThumbnailService.exportQueue = DispatchQueue.global(qos: .userInitiated)
+        return mediaThumbnailService
+    }()
+
     /// Returns true if any media is being processed or uploading
     ///
     func isUploadingMedia(for post: AbstractPost) -> Bool {

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -332,12 +332,6 @@ class MediaCoordinator: NSObject {
         return media
     }
 
-    @objc lazy var mediaThumbnailService: MediaThumbnailService = {
-        let mediaThumbnailService = MediaThumbnailService(managedObjectContext: backgroundContext)
-        mediaThumbnailService.exportQueue = DispatchQueue.global(qos: .userInitiated)
-        return mediaThumbnailService
-    }()
-
     /// Returns true if any media is being processed or uploading
     ///
     func isUploadingMedia(for post: AbstractPost) -> Bool {

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -743,10 +743,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
             [self.managedObjectContext deleteObject:deleteMedia];
         }
     }
-    NSError *error;
-    if (![self.managedObjectContext save:&error]){
-        DDLogError(@"Error saving context afer adding media %@", [error localizedDescription]);
-    }
+    [[ContextManager sharedInstance] saveDerivedContext:self.managedObjectContext];
     if (completion) {
         completion();
     }

--- a/WordPress/Classes/Services/MediaThumbnailCoordinator.swift
+++ b/WordPress/Classes/Services/MediaThumbnailCoordinator.swift
@@ -15,7 +15,7 @@ class MediaThumbnailCoordinator: NSObject {
         return context
     }()
 
-    private let queue = DispatchQueue(label: "org.wordpress.media_thumbnail_coordinator", attributes: .concurrent)
+    private let queue = DispatchQueue(label: "org.wordpress.media_thumbnail_coordinator", qos: .default)
 
     typealias ThumbnailBlock = (UIImage?, Error?) -> Void
 

--- a/WordPress/Classes/Services/MediaThumbnailCoordinator.swift
+++ b/WordPress/Classes/Services/MediaThumbnailCoordinator.swift
@@ -1,0 +1,53 @@
+import Foundation
+import UIKit
+
+/// MediaThumbnailCoordinator is responsible for generating thumbnails for media
+/// items, independently of a specific view controller. It should be accessed
+/// via the `shared` singleton.
+///
+class MediaThumbnailCoordinator: NSObject {
+
+    @objc static let shared = MediaThumbnailCoordinator()
+
+    private(set) var backgroundContext: NSManagedObjectContext = {
+        let context = ContextManager.sharedInstance().newDerivedContext()
+        context.automaticallyMergesChangesFromParent = true
+        return context
+    }()
+
+    private let queue = DispatchQueue(label: "org.wordpress.media_thumbnail_coordinator", attributes: .concurrent)
+
+    typealias ThumbnailBlock = (UIImage?, Error?) -> Void
+
+    private lazy var mediaThumbnailService: MediaThumbnailService = {
+        let mediaThumbnailService = MediaThumbnailService(managedObjectContext: backgroundContext)
+        mediaThumbnailService.exportQueue = queue
+        return mediaThumbnailService
+    }()
+
+    /// Tries to generate a thumbnail for the specified media object with the size requested
+    ///
+    /// - Parameters:
+    ///   - media: the media object to generate the thumbail representation
+    ///   - size: the size of the thumbnail
+    ///   - onCompletion: a block that is invoked when the thumbnail generatio is completed with success or failure.
+    @objc func thumbnail(for media: Media, with size: CGSize, onCompletion: @escaping ThumbnailBlock) {
+        mediaThumbnailService.thumbnailURL(forMedia: media, preferredSize: size, onCompletion: { (url) in
+            guard let imageURL = url else {
+                DispatchQueue.main.async {
+                    onCompletion(nil, MediaThumbnailExporter.ThumbnailExportError.failedToGenerateThumbnailFileURL)
+                }
+                return
+            }
+            let image = UIImage(contentsOfFile: imageURL.path)
+            DispatchQueue.main.async {
+                onCompletion(image, nil)
+            }
+        }) { (error) in
+            DispatchQueue.main.async {
+                onCompletion(nil, error)
+            }
+        }
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
@@ -215,15 +215,12 @@ extension SiteIconPickerPresenter: WPMediaPickerViewControllerDelegate {
         case let media as Media:
             showLoadingMessage()
             originalMedia = media
-            let mediaService = MediaService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-            mediaService.thumbnailImage(for: media,
-                                        preferredSize: CGSize.zero,
-                                        completion: { [weak self] (image, error) in
-                                            guard let image = image else {
-                                                self?.showErrorLoadingImageMessage()
-                                                return
-                                            }
-                                            self?.showImageCropViewController(image)
+            MediaThumbnailCoordinator.shared.thumbnail(for: media, with: CGSize.zero, onCompletion: { [weak self] (image, error) in
+                guard let image = image else {
+                    self?.showErrorLoadingImageMessage()
+                    return
+                }
+                self?.showImageCropViewController(image)
             })
         default:
             break

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1289,7 +1289,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         width = width - (PostFeaturedImageCellMargin * 2); // left and right cell margins
         CGFloat height = ceilf(width * 0.66);
         CGSize imageSize = CGSizeMake(width, height);
-        [mediaService thumbnailImageForMedia:featuredMedia preferredSize:imageSize completion:^(UIImage *image, NSError *error) {
+        [MediaThumbnailCoordinator.shared thumbnailFor:media with:imageSize onCompletion:^(UIImage * image, NSError * error) {
             self.featuredImage = image;
             [self.tableView reloadData];
         }];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1206,6 +1206,7 @@
 		FF28B3F11AEB251200E11AAE /* InfoPListTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = FF28B3F01AEB251200E11AAE /* InfoPListTranslator.m */; };
 		FF355D981FB492DD00244E6D /* ExportableAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF355D971FB492DD00244E6D /* ExportableAsset.swift */; };
 		FF4258501BA092EE00580C68 /* RelatedPostsSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FF42584F1BA092EE00580C68 /* RelatedPostsSettingsViewController.m */; };
+		FF4C069F206560E500E0B2BC /* MediaThumbnailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4C069E206560E500E0B2BC /* MediaThumbnailCoordinator.swift */; };
 		FF5371631FDFF64F00619A3F /* MediaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5371621FDFF64F00619A3F /* MediaService.swift */; };
 		FF54D4641D6F3FA900A0DC4D /* EditorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF54D4631D6F3FA900A0DC4D /* EditorSettings.swift */; };
 		FF619DD51C75246900903B65 /* CLPlacemark+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF619DD41C75246900903B65 /* CLPlacemark+Formatting.swift */; };
@@ -2886,6 +2887,7 @@
 		FF355D971FB492DD00244E6D /* ExportableAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportableAsset.swift; sourceTree = "<group>"; };
 		FF42584E1BA092EE00580C68 /* RelatedPostsSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RelatedPostsSettingsViewController.h; sourceTree = "<group>"; };
 		FF42584F1BA092EE00580C68 /* RelatedPostsSettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RelatedPostsSettingsViewController.m; sourceTree = "<group>"; };
+		FF4C069E206560E500E0B2BC /* MediaThumbnailCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaThumbnailCoordinator.swift; sourceTree = "<group>"; };
 		FF5371621FDFF64F00619A3F /* MediaService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaService.swift; sourceTree = "<group>"; };
 		FF54D4631D6F3FA900A0DC4D /* EditorSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorSettings.swift; sourceTree = "<group>"; };
 		FF619DD41C75246900903B65 /* CLPlacemark+Formatting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CLPlacemark+Formatting.swift"; sourceTree = "<group>"; };
@@ -3316,7 +3318,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				E1B34C091CCDFFCE00889709 /* Credentials */,
@@ -4555,6 +4557,7 @@
 				93DEB88119E5BF7100F9546D /* TodayExtensionService.m */,
 				E6311C401EC9FF4A00122529 /* UsersService.swift */,
 				17876B1C1F9A131200F774C7 /* MediaCoordinator.swift */,
+				FF4C069E206560E500E0B2BC /* MediaThumbnailCoordinator.swift */,
 				FF0D8145205809C8000EE505 /* PostCoordinator.swift */,
 			);
 			path = Services;
@@ -6541,7 +6544,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -7333,6 +7336,7 @@
 				98B24D5A2017E2520082BA78 /* NUXButtonViewController.swift in Sources */,
 				98C87E9C2003FA3E0052AF32 /* NUXLinkMailViewController.swift in Sources */,
 				E1CB6DA7200F661900945457 /* TimeZoneSelectorViewController.swift in Sources */,
+				FF4C069F206560E500E0B2BC /* MediaThumbnailCoordinator.swift in Sources */,
 				E151C0C61F3889DF00710A83 /* PluginListRow.swift in Sources */,
 				8217380B1FE05EE600BEC94C /* BlogSettings+DateAndTimeFormat.swift in Sources */,
 				313692791A5D6F7900EBE645 /* HelpshiftUtils.m in Sources */,
@@ -8959,7 +8963,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_alpha_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_alpha_app_credentials;
 			};
 			name = "Release-Alpha";
 		};
@@ -9434,7 +9438,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_internal_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_internal_app_credentials;
 			};
 			name = "Release-Internal";
 		};
@@ -9777,7 +9781,7 @@
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 3.0;
-				WPCOM_CONFIG = "$HOME/.wpcom_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
 			};
 			name = Debug;
 		};
@@ -9827,7 +9831,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This PR is just a refactor on the way we access the generation of thumbnails for Media.

Instead of using the MediaService method for generating thumbmails, it adds a new MediaThumbnailCoordinator that keeps the generation oft thumbnail inside a background context. 

This avoid the creation of multiple Derived Context for just for browsing the Media Library.

To test:
- Open a Site
- Scroll inside it's media library
- Check if thumbnails are generated correct
- Check the same for the site icon picker and for featured image on posts.


