### PR TITLE
Don't allow multiple items being pushed in PluginDirectory.

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
@@ -64,11 +64,7 @@ class PluginDirectoryViewController: UITableViewController {
     private func reloadTable() {
         tableViewModel = viewModel.tableViewModel(presenter: self)
 
-        if tableView.numberOfRows(inSection: 0) != tableViewModel.sections.first?.rows.count {
-            tableView.reloadData()
-        } else {
-            tableView.reloadSections([0], with: .none)
-        }
+        tableView.reloadData()
     }
 
     private func setupSearchBar() {

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
@@ -193,11 +193,23 @@ extension PluginDirectoryViewController: WPNoResultsViewDelegate {
 
 extension PluginDirectoryViewController: PluginPresenter {
     func present(plugin: Plugin, capabilities: SitePluginCapabilities) {
+        guard navigationController?.topViewController == self else {
+            // because of some work we're doing when presenting the VC, there might be a slight lag
+            // between when a user taps on a plugin, and when it appears on screen — unfortunately enough
+            // for users to not be sure whether the tap "registered".
+            // this prevents from pushing the same screen multiple times when users taps again.
+            return
+        }
+
         let pluginVC = PluginViewController(plugin: plugin, capabilities: capabilities, site: viewModel.site)
         navigationController?.pushViewController(pluginVC, animated: true)
     }
 
     func present(directoryEntry: PluginDirectoryEntry) {
+        guard navigationController?.topViewController == self else {
+            return
+        }
+
         let pluginVC = PluginViewController(directoryEntry: directoryEntry, site: viewModel.site)
         navigationController?.pushViewController(pluginVC, animated: true)
     }


### PR DESCRIPTION
"Fixes" #8741. I tried actually making everything be reasonably fast so this doesn't ever happen, but I couldn't find any easy wins here — and I didn't want to spend too much time on this, so here it goes.

To test:
1. Go to plugin directory.
2. Tap on a item really fast
3. Verify that only one VC is pushed onto the stack


