### PR TITLE
Issue/8937 Make post status filter bar visible on iOS 10

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -23,6 +23,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
     fileprivate let animatedBox = WPAnimatedBox()
 
+    @IBOutlet weak var filterTabBarTopConstraint: NSLayoutConstraint!
+    @IBOutlet weak var filterTabBariOS10TopConstraint: NSLayoutConstraint!
     @IBOutlet weak var filterTabBarBottomConstraint: NSLayoutConstraint!
     @IBOutlet weak var tableViewTopConstraint: NSLayoutConstraint!
 
@@ -80,9 +82,26 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         super.viewDidLoad()
 
         title = NSLocalizedString("Site Pages", comment: "Title of the screen showing the list of pages for a blog.")
+
+        configureFilterBarTopConstraint()
     }
 
     // MARK: - Configuration
+
+    private func configureFilterBarTopConstraint() {
+        // Not an ideal solution, but fixes an issue where the filter bar
+        // wasn't showing up on iOS 10: https://github.com/wordpress-mobile/WordPress-iOS/issues/8937
+        if #available(iOS 11.0, *) {
+            filterTabBariOS10TopConstraint.isActive = false
+        } else {
+            extendedLayoutIncludesOpaqueBars = false
+            edgesForExtendedLayout = []
+
+            filterTabBarTopConstraint.isActive = false
+
+            view.layoutIfNeeded()
+        }
+    }
 
     override func configureTableView() {
         tableView.accessibilityIdentifier = "PagesTable"

--- a/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
+++ b/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
@@ -42,6 +42,7 @@
                             <constraint firstAttribute="trailing" secondItem="LM5-dj-tFF" secondAttribute="trailing" id="AVm-wb-6M1"/>
                             <constraint firstAttribute="bottomMargin" secondItem="LM5-dj-tFF" secondAttribute="bottom" id="Icj-Cf-hTM"/>
                             <constraint firstItem="kb7-5Y-cyY" firstAttribute="top" secondItem="MiP-YM-poS" secondAttribute="topMargin" id="Iu4-wT-NJl"/>
+                            <constraint firstItem="kb7-5Y-cyY" firstAttribute="top" secondItem="zEU-W1-HEN" secondAttribute="bottom" priority="999" id="N3R-GK-VXe"/>
                             <constraint firstItem="LM5-dj-tFF" firstAttribute="top" secondItem="kb7-5Y-cyY" secondAttribute="bottom" id="VTs-hm-pCI"/>
                             <constraint firstAttribute="trailing" secondItem="kb7-5Y-cyY" secondAttribute="trailing" id="bVD-D5-qun"/>
                             <constraint firstItem="LM5-dj-tFF" firstAttribute="top" secondItem="MiP-YM-poS" secondAttribute="topMargin" id="hqa-P7-bPN"/>
@@ -63,6 +64,8 @@
                         <outlet property="addButton" destination="AUi-GI-97s" id="D1f-jZ-iVb"/>
                         <outlet property="filterTabBar" destination="kb7-5Y-cyY" id="yfM-1V-Kgn"/>
                         <outlet property="filterTabBarBottomConstraint" destination="VTs-hm-pCI" id="8xw-da-7bY"/>
+                        <outlet property="filterTabBarTopConstraint" destination="Iu4-wT-NJl" id="ncb-1g-VsV"/>
+                        <outlet property="filterTabBariOS10TopConstraint" destination="N3R-GK-VXe" id="qgA-sx-Yrb"/>
                         <outlet property="rightBarButtonView" destination="eMR-fX-0uB" id="tkm-aq-s67"/>
                         <outlet property="tableViewTopConstraint" destination="hqa-P7-bPN" id="Mas-aT-2OZ"/>
                     </connections>

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -331,21 +331,25 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
     fileprivate func configureSearchBackingView() {
         // This mask view is required to cover the area between the top of the search
-        // bar and the top of the screen on an iPhone X.
+        // bar and the top of the screen on an iPhone X and on iOS 10.
+        var topAnchor = topLayoutGuide.bottomAnchor
+
         if #available(iOS 11.0, *) {
-            let backingView = UIView()
-            view.addSubview(backingView)
-
-            backingView.backgroundColor = searchController.searchBar.barTintColor
-            backingView.translatesAutoresizingMaskIntoConstraints = false
-
-            NSLayoutConstraint.activate([
-                backingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                backingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                backingView.topAnchor.constraint(equalTo: view.topAnchor),
-                backingView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
-                ])
+            topAnchor = view.safeAreaLayoutGuide.topAnchor
         }
+
+        let backingView = UIView()
+        view.addSubview(backingView)
+
+        backingView.backgroundColor = searchController.searchBar.barTintColor
+        backingView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            backingView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backingView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            backingView.topAnchor.constraint(equalTo: view.topAnchor),
+            backingView.bottomAnchor.constraint(equalTo: topAnchor)
+            ])
     }
 
     @objc func configureSearchHelper() {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -112,6 +112,16 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
         title = NSLocalizedString("Blog Posts", comment: "Title of the screen showing the list of posts for a blog.")
 
+        configureFilterBarTopConstraint()
+    }
+
+    // MARK: - Configuration
+
+    override func heightForFooterView() -> CGFloat {
+        return type(of: self).postListHeightForFooterView
+    }
+
+    private func configureFilterBarTopConstraint() {
         // Not an ideal solution, but fixes an issue where the filter bar
         // wasn't showing up on iOS 10: https://github.com/wordpress-mobile/WordPress-iOS/issues/8937
         if #available(iOS 11.0, *) {
@@ -124,12 +134,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
             view.layoutIfNeeded()
         }
-    }
-
-    // MARK: - Configuration
-
-    override func heightForFooterView() -> CGFloat {
-        return type(of: self).postListHeightForFooterView
     }
 
     override func configureTableView() {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -46,6 +46,8 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     static fileprivate let postListHeightForFooterView = CGFloat(34.0)
 
     @IBOutlet var searchWrapperView: UIView!
+    @IBOutlet weak var filterTabBarTopConstraint: NSLayoutConstraint!
+    @IBOutlet weak var filterTabBariOS10TopConstraint: NSLayoutConstraint!
     @IBOutlet weak var filterTabBarBottomConstraint: NSLayoutConstraint!
     @IBOutlet weak var tableViewTopConstraint: NSLayoutConstraint!
 
@@ -109,6 +111,19 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         super.viewDidLoad()
 
         title = NSLocalizedString("Blog Posts", comment: "Title of the screen showing the list of posts for a blog.")
+
+        // Not an ideal solution, but fixes an issue where the filter bar
+        // wasn't showing up on iOS 10: https://github.com/wordpress-mobile/WordPress-iOS/issues/8937
+        if #available(iOS 11.0, *) {
+            filterTabBariOS10TopConstraint.isActive = false
+        } else {
+            extendedLayoutIncludesOpaqueBars = false
+            edgesForExtendedLayout = []
+
+            filterTabBarTopConstraint.isActive = false
+
+            view.layoutIfNeeded()
+        }
     }
 
     // MARK: - Configuration
@@ -163,7 +178,11 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     fileprivate func updateTableHeaderSize() {
         if searchController.isActive {
             // Account for the search bar being moved to the top of the screen.
-            searchWrapperView.frame.size.height = (searchController.searchBar.bounds.height + searchController.searchBar.frame.origin.y) - topLayoutGuide.length
+            if #available(iOS 11.0, *) {
+                searchWrapperView.frame.size.height = (searchController.searchBar.bounds.height + searchController.searchBar.frame.origin.y) - topLayoutGuide.length
+            } else {
+                searchWrapperView.frame.size.height = (searchController.searchBar.bounds.height + searchController.searchBar.frame.origin.y)
+            }
         } else {
             searchWrapperView.frame.size.height = searchController.searchBar.bounds.height
         }

--- a/WordPress/Classes/ViewRelated/Post/Posts.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Posts.storyboard
@@ -42,7 +42,8 @@
                             <constraint firstItem="cnu-9z-5GZ" firstAttribute="top" secondItem="Nmf-Iz-jkG" secondAttribute="bottom" id="Hb8-6N-iSm"/>
                             <constraint firstAttribute="trailing" secondItem="Nmf-Iz-jkG" secondAttribute="trailing" id="KGt-NK-T3O"/>
                             <constraint firstItem="cnu-9z-5GZ" firstAttribute="top" secondItem="Zhd-4n-wcm" secondAttribute="topMargin" id="UwE-7o-GHb"/>
-                            <constraint firstItem="Nmf-Iz-jkG" firstAttribute="top" secondItem="Zhd-4n-wcm" secondAttribute="topMargin" id="fGy-cf-WIB"/>
+                            <constraint firstItem="Nmf-Iz-jkG" firstAttribute="top" secondItem="Zhd-4n-wcm" secondAttribute="topMargin" id="ZFh-Do-F2v"/>
+                            <constraint firstItem="Nmf-Iz-jkG" firstAttribute="top" secondItem="rUe-TB-81b" secondAttribute="bottom" priority="999" id="fGy-cf-WIB"/>
                             <constraint firstAttribute="trailing" secondItem="cnu-9z-5GZ" secondAttribute="trailing" id="hEd-mB-ZfB"/>
                             <constraint firstItem="Nmf-Iz-jkG" firstAttribute="leading" secondItem="Zhd-4n-wcm" secondAttribute="leading" id="npO-qQ-WgT"/>
                             <constraint firstItem="cnu-9z-5GZ" firstAttribute="leading" secondItem="Zhd-4n-wcm" secondAttribute="leading" id="phA-Qk-kzl"/>
@@ -63,6 +64,8 @@
                         <outlet property="addButton" destination="9Az-zB-Hwe" id="r4s-oX-gyT"/>
                         <outlet property="filterTabBar" destination="Nmf-Iz-jkG" id="Ydz-ff-EUy"/>
                         <outlet property="filterTabBarBottomConstraint" destination="Hb8-6N-iSm" id="GsJ-Hc-dE5"/>
+                        <outlet property="filterTabBarTopConstraint" destination="ZFh-Do-F2v" id="hq3-Iz-dZu"/>
+                        <outlet property="filterTabBariOS10TopConstraint" destination="fGy-cf-WIB" id="2s9-pa-9Ee"/>
                         <outlet property="rightBarButtonView" destination="8Ph-e4-iOe" id="V4F-lw-glT"/>
                         <outlet property="searchWrapperView" destination="sFK-WP-z2Z" id="CJ1-ul-bLt"/>
                         <outlet property="tableViewTopConstraint" destination="UwE-7o-GHb" id="4mJ-Ry-6Xa"/>


### PR DESCRIPTION
Fixes #8937. The new post status filter bar wasn't showing up at all on iOS 10 due to some difference in the top margin of the superview. I'd prefer a cleaner solution, but after spending a while trying things out I couldn't currently come up with anything better and this needs to be fixed for 9.7. 

There's still a slight issue on iOS 10 when the keyboard appears – the tableview is scrolled ever so slightly too far up. But it's almost not noticeable, and it's still better than no filter bar appearing at all!

**To test:**

* Build and run the app, and check that the filter bar is visible in both the Posts and Pages VCs on both iOS 10 and 11.
* Check that the search bar animates to the top of the screen (and back again when cancelled) as expected.

@jleandroperez Can I trouble you with a quick review please?!