### PR TITLE
Reader post spotlight indexing

### DIFF
--- a/WordPress/Classes/Models/AbstractPost+Searchable.swift
+++ b/WordPress/Classes/Models/AbstractPost+Searchable.swift
@@ -47,6 +47,11 @@ extension AbstractPost: SearchableItemConvertable {
     var searchKeywords: [String]? {
         return generateKeywordsFromContent()
     }
+
+    var searchExpirationDate: Date? {
+        // Use the default expiration in spotlight.
+        return nil
+    }
 }
 
 // MARK: - Private Helper Functions

--- a/WordPress/Classes/Models/ReaderPost+Searchable.swift
+++ b/WordPress/Classes/Models/ReaderPost+Searchable.swift
@@ -21,7 +21,10 @@ extension ReaderPost: SearchableItemConvertable {
     }
 
     var searchDomain: String? {
-        return SearchItemType.readerPost.stringValue()
+        guard let siteID = siteID, siteID.intValue > 0 else {
+            return nil
+        }
+        return siteID.stringValue
     }
 
     var searchTitle: String? {

--- a/WordPress/Classes/Models/ReaderPost+Searchable.swift
+++ b/WordPress/Classes/Models/ReaderPost+Searchable.swift
@@ -6,10 +6,6 @@ extension ReaderPost: SearchableItemConvertable {
     }
 
     var isSearchable: Bool {
-        guard let title = searchTitle, !title.isEmpty else {
-            // If the title is empty or nil, don't index it
-            return false
-        }
         return true
     }
 
@@ -28,7 +24,12 @@ extension ReaderPost: SearchableItemConvertable {
     }
 
     var searchTitle: String? {
-        return titleForDisplay()
+        var title = titleForDisplay() ?? ""
+        if title.isEmpty {
+            // If titleForDisplay() happens to be empty, try using the content preview instead...
+            title = contentPreviewForDisplay()
+        }
+        return title
     }
 
     var searchDescription: String? {
@@ -43,8 +44,8 @@ extension ReaderPost: SearchableItemConvertable {
     }
 
     var searchExpirationDate: Date? {
-        let sevenDaysFromNow = Calendar.current.date(byAdding: .day, value: 7, to: Date())
-        return sevenDaysFromNow
+        let oneWeekFromNow = Calendar.current.date(byAdding: .weekOfYear, value: 1, to: Date())
+        return oneWeekFromNow
     }
 }
 

--- a/WordPress/Classes/Models/ReaderPost+Searchable.swift
+++ b/WordPress/Classes/Models/ReaderPost+Searchable.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+extension ReaderPost: SearchableItemConvertable {
+    var searchItemType: SearchItemType {
+        return .readerPost
+    }
+
+    var isSearchable: Bool {
+        guard let title = searchTitle, !title.isEmpty else {
+            // If the title is empty or nil, don't index it
+            return false
+        }
+        return true
+    }
+
+    var searchIdentifier: String? {
+        guard let postID = postID, postID.intValue > 0 else {
+            return nil
+        }
+        return postID.stringValue
+    }
+
+    var searchDomain: String? {
+        return SearchItemType.readerPost.stringValue()
+    }
+
+    var searchTitle: String? {
+        return titleForDisplay()
+    }
+
+    var searchDescription: String? {
+        guard let readerPostPreview = contentPreviewForDisplay(), !readerPostPreview.isEmpty else {
+            return siteURLForDisplay() ?? contentForDisplay()
+        }
+        return readerPostPreview
+    }
+
+    var searchKeywords: [String]? {
+        return generateKeywordsFromContent()
+    }
+
+    var searchExpirationDate: Date? {
+        let sevenDaysFromNow = Calendar.current.date(byAdding: .day, value: 7, to: Date())
+        return sevenDaysFromNow
+    }
+}
+
+// MARK: - Private Helper Functions
+
+fileprivate extension ReaderPost {
+    func generateKeywordsFromContent() -> [String]? {
+        var keywords: [String]? = nil
+        if let postTitle = postTitle {
+            // Try to generate some keywords from the title...
+            keywords = postTitle.components(separatedBy: " ").map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+        } else if !contentPreviewForDisplay().isEmpty {
+            // ...otherwise try to generate some keywords from the content preview
+            keywords = contentPreviewForDisplay().components(separatedBy: " ").map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+        }
+        return keywords
+    }
+}

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1067,6 +1067,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatSpotlightSearchOpenedPage:
             eventName = @"spotlight_search_opened_page";
             break;
+        case WPAnalyticsStatSpotlightSearchOpenedReaderPost:
+            eventName = @"spotlight_search_opened_reader_post";
+            break;
         case WPAnalyticsStatSkippedConnectingToJetpack:
             eventName = @"skipped_connecting_to_jetpack";
             break;

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -166,7 +166,10 @@ import MobileCoreServices
                 DDLogError("Search manager unable to parse postID/siteID for identifier:\(identifier) domain:\(domainString)")
                 return false
         }
-
+        var properties = [AnyHashable: Any]()
+        properties[WPAppAnalyticsKeyBlogID] = siteID
+        properties[WPAppAnalyticsKeyPostID] = readerPostID
+        WPAppAnalytics.track(.spotlightSearchOpenedReaderPost, withProperties: properties)
         openReader(for: readerPostID, siteID: siteID, onFailure: {
             DDLogError("Search manager unable to open reader for readerPostID:\(readerPostID) siteID:\(siteID)")
         })

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -127,25 +127,50 @@ import MobileCoreServices
         }
 
         let (itemType, domainString, identifier) = SearchIdentifierGenerator.decomposeFromUniqueIdentifier(compositeIdentifier)
-        guard itemType == .abstractPost, let postID = NumberFormatter().number(from: identifier) else {
-            // We are only handling posts for now.
-            DDLogError("Search manager unable to open post - postID:\(identifier) siteID:\(domainString)")
+        switch itemType {
+        case .abstractPost:
+            return handleAbstractPost(domainString: domainString, identifier: identifier)
+        case .readerPost:
+            return handleReaderPost(domainString: domainString, identifier: identifier)
+        default:
+            return false
+        }
+    }
+
+    fileprivate func handleAbstractPost(domainString: String, identifier: String) -> Bool {
+        guard let postID = NumberFormatter().number(from: identifier) else {
+            DDLogError("Search manager unable to parse postID/siteID for identifier:\(identifier) domain:\(domainString)")
             return false
         }
 
         if let siteID = validWPComSiteID(with: domainString) {
             fetchPost(postID, blogID: siteID, onSuccess: { [weak self] apost in
                 self?.navigateToScreen(for: apost)
-            }, onFailure: {
-                DDLogError("Search manager unable to open post - postID:\(postID) siteID:\(siteID)")
+                }, onFailure: {
+                    DDLogError("Search manager unable to open post - postID:\(postID) siteID:\(siteID)")
             })
         } else {
             fetchSelfHostedPost(postID, blogXMLRpcString: domainString, onSuccess: { [weak self] apost in
                 self?.navigateToScreen(for: apost, isDotCom: false)
-            }, onFailure: {
-                DDLogError("Search manager unable to open self hosted post - postID:\(postID) xmlrpc:\(domainString)")
+                }, onFailure: {
+                    DDLogError("Search manager unable to open self hosted post - postID:\(postID) xmlrpc:\(domainString)")
             })
         }
+
+        return true
+    }
+
+    fileprivate func handleReaderPost(domainString: String, identifier: String) -> Bool {
+        guard let siteID = validWPComSiteID(with: domainString),
+            let readerPostID = NumberFormatter().number(from: identifier) else {
+                DDLogError("Search manager unable to parse postID/siteID for identifier:\(identifier) domain:\(domainString)")
+                return false
+        }
+
+        openReader(for: readerPostID, siteID: siteID, onFailure: {
+            DDLogError("Search manager unable to open reader for readerPostID:\(readerPostID) siteID:\(siteID)")
+        })
+
         return true
     }
 }
@@ -258,6 +283,15 @@ fileprivate extension SearchManager {
         WPTabBarController.sharedInstance().showReaderTab(forPost: postID, onBlog: blogID)
     }
 
+    func openReader(for postID: NSNumber, siteID: NSNumber, onFailure: () -> Void) {
+        closeAnyOpenPreview()
+        guard postID.intValue > 0, siteID.intValue > 0 else {
+            onFailure()
+            return
+        }
+        WPTabBarController.sharedInstance().showReaderTab(forPost: postID, onBlog: siteID)
+    }
+
     func openEditor(for post: Post) {
         closePreviewIfNeeded(for: post)
         openListView(for: post)
@@ -295,6 +329,9 @@ fileprivate extension SearchManager {
         openListView(for: apost)
     }
 
+    /// If there is a PostPreviewViewController window open and it is already displaying the provided
+    /// AbstractPost, leave it open, otherwise close it.
+    ///
     func closePreviewIfNeeded(for apost: AbstractPost) {
         guard let navController = WPTabBarController.sharedInstance().presentedViewController as? UINavigationController,
             let previewVC = navController.topViewController as? PostPreviewViewController,
@@ -302,8 +339,16 @@ fileprivate extension SearchManager {
                 // Do nothing — post is already loaded or PostPreviewViewController isn't visible
                 return
         }
+        navController.dismiss(animated: true, completion: nil)
+    }
 
-        // Close the current nav controller containing the post preview
+    /// If there is any PostPreviewViewController window open, close it.
+    ///
+    func closeAnyOpenPreview() {
+        guard let navController = WPTabBarController.sharedInstance().presentedViewController as? UINavigationController,
+            let _ = navController.topViewController as? PostPreviewViewController else {
+                return
+        }
         navController.dismiss(animated: true, completion: nil)
     }
 }

--- a/WordPress/Classes/Utility/Spotlight/SearchableItem.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchableItem.swift
@@ -65,6 +65,12 @@ import MobileCoreServices
     /// *Local* URL to image that should be displayed in spotlight search
     ///
     @objc optional var searchLocalImageURL: URL? {get}
+
+    /// Expiration date for an indexed search item. If not set, the expiration
+    /// date will use the spotlight default: "the system automatically expires the
+    /// item after a period of time."
+    ///
+    @objc optional var searchExpirationDate: Date? {get}
 }
 
 extension SearchableItemConvertable {
@@ -95,8 +101,14 @@ extension SearchableItemConvertable {
             searchableItemAttributeSet.thumbnailURL = imgURL
         }
 
-        return CSSearchableItem(uniqueIdentifier: uniqueIdentifier,
-                                domainIdentifier: searchDomain,
-                                attributeSet: searchableItemAttributeSet)
+        let searchableItem = CSSearchableItem(uniqueIdentifier: uniqueIdentifier,
+                                              domainIdentifier: searchDomain,
+                                              attributeSet: searchableItemAttributeSet)
+
+        if let expirationDate = searchExpirationDate {
+            searchableItem.expirationDate = expirationDate
+        }
+
+        return searchableItem
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -211,6 +211,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
         bumpStats()
         bumpPageViewsForPost()
+        indexReaderPostInSpotlight()
     }
 
 
@@ -866,6 +867,14 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     @objc func isScrollViewAtBottom() -> Bool {
         return textView.contentOffset.y + textView.frame.height == textView.contentSize.height
+    }
+
+    @objc func indexReaderPostInSpotlight() {
+        guard let post = post else {
+            return
+        }
+
+        SearchManager.shared.indexItem(post)
     }
 
     // MARK: - Analytics

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -500,25 +500,20 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (void)showReaderTabForPost:(NSNumber *)postId onBlog:(NSNumber *)blogId
 {
     [self showReaderTab];
-    
-    if (self.selectedIndex == WPTabReader) {
-        UIViewController *topViewController = (ReaderDetailViewController *)self.readerNavigationController.topViewController;
-        if ([topViewController isKindOfClass:[ReaderDetailViewController class]]) {
-            ReaderDetailViewController *readerDetailVC = (ReaderDetailViewController *)topViewController;
-            ReaderPost *readerPost = readerDetailVC.post;
-            if ([readerPost.postID isEqual:postId] && [readerPost.siteID isEqual: blogId]) {
-                 // The desired reader detail VC is already the top VC for the tab. Move along.
-                return;
-            } else {
-                // Close the existing detail tab before opening another one.
-                [self.readerSplitViewController popToRootViewControllersAnimated:YES];
-            }
+
+    UIViewController *topDetailVC = (ReaderDetailViewController *)self.readerSplitViewController.topDetailViewController;
+    if ([topDetailVC isKindOfClass:[ReaderDetailViewController class]]) {
+        ReaderDetailViewController *readerDetailVC = (ReaderDetailViewController *)topDetailVC;
+        ReaderPost *readerPost = readerDetailVC.post;
+        if ([readerPost.postID isEqual:postId] && [readerPost.siteID isEqual: blogId]) {
+             // The desired reader detail VC is already the top VC for the tab. Move along.
+            return;
         }
     }
 
-    ReaderMenuViewController *readerMenuViewController = (ReaderMenuViewController *)[self.readerNavigationController.viewControllers firstObject];
-    if ([readerMenuViewController isKindOfClass:[ReaderMenuViewController class]]) {
-        [readerMenuViewController openPost:postId onBlog:blogId];
+    if (topDetailVC && topDetailVC.navigationController) {
+        ReaderDetailViewController *readerPostDetailVC = [ReaderDetailViewController controllerWithPostID:postId siteID:blogId];
+        [topDetailVC.navigationController pushFullscreenViewController:readerPostDetailVC animated:YES];
     }
 }
 
@@ -545,8 +540,8 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (void)switchTabToPagesListForPost:(AbstractPost *)post
 {
     UIViewController *topVC = [self.blogListSplitViewController topDetailViewController];
-    if ([topVC isKindOfClass:[PostListViewController class]]) {
-        Blog *blog = ((PostListViewController *)topVC).blog;
+    if ([topVC isKindOfClass:[PageListViewController class]]) {
+        Blog *blog = ((PageListViewController *)topVC).blog;
         if ([post.blog.objectID isEqual:blog.objectID]) {
             // The desired post view controller is already the top viewController for the tab.
             // Nothing to see here.  Move along.

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -422,6 +422,7 @@
 		74585B991F0D58F300E7E667 /* DomainsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74585B981F0D58F300E7E667 /* DomainsServiceTests.swift */; };
 		74585B9C1F0D591D00E7E667 /* domain-service-valid-domains.json in Resources */ = {isa = PBXBuildFile; fileRef = 74585B9A1F0D591D00E7E667 /* domain-service-valid-domains.json */; };
 		74585B9D1F0D591D00E7E667 /* domain-service-all-domain-types.json in Resources */ = {isa = PBXBuildFile; fileRef = 74585B9B1F0D591D00E7E667 /* domain-service-all-domain-types.json */; };
+		745A41B02065405600299D75 /* ReaderPost+Searchable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745A41AF2065405600299D75 /* ReaderPost+Searchable.swift */; };
 		745EAF452003FD050066F415 /* ShareSegueHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745EAF442003FD050066F415 /* ShareSegueHandler.swift */; };
 		745EAF472003FDAA0066F415 /* ShareExtensionAbstractViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745EAF462003FDAA0066F415 /* ShareExtensionAbstractViewController.swift */; };
 		745EAF4A20040B220066F415 /* ShareData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 745EAF4920040B220066F415 /* ShareData.swift */; };
@@ -1808,6 +1809,7 @@
 		74585B981F0D58F300E7E667 /* DomainsServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsServiceTests.swift; sourceTree = "<group>"; };
 		74585B9A1F0D591D00E7E667 /* domain-service-valid-domains.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "domain-service-valid-domains.json"; sourceTree = "<group>"; };
 		74585B9B1F0D591D00E7E667 /* domain-service-all-domain-types.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "domain-service-all-domain-types.json"; sourceTree = "<group>"; };
+		745A41AF2065405600299D75 /* ReaderPost+Searchable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPost+Searchable.swift"; sourceTree = "<group>"; };
 		745EAF442003FD050066F415 /* ShareSegueHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareSegueHandler.swift; sourceTree = "<group>"; };
 		745EAF462003FDAA0066F415 /* ShareExtensionAbstractViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareExtensionAbstractViewController.swift; sourceTree = "<group>"; };
 		745EAF4920040B220066F415 /* ShareData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareData.swift; sourceTree = "<group>"; };
@@ -3316,7 +3318,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				E1B34C091CCDFFCE00889709 /* Credentials */,
@@ -3493,6 +3495,7 @@
 				E6374DBE1C444D8B00F24720 /* PublicizeService.swift */,
 				5D42A3DC175E7452005CFF05 /* ReaderPost.h */,
 				5D42A3DD175E7452005CFF05 /* ReaderPost.m */,
+				745A41AF2065405600299D75 /* ReaderPost+Searchable.swift */,
 				E6C09B3D1BF0FDEB003074CB /* ReaderCrossPostMeta.swift */,
 				5DE471B71B4C710E00665C44 /* ReaderPostContentProvider.h */,
 				E6A3384A1BB08E3F00371587 /* ReaderGapMarker.h */,
@@ -6541,7 +6544,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -7543,6 +7546,7 @@
 				E6E57CD51D0F08B200C22E3E /* ReaderMenuViewController.swift in Sources */,
 				08D978591CD2AF7D0054F19A /* MenuItemSourceTextBar.m in Sources */,
 				40E469952017FB1F0030DB5F /* PluginDirectoryViewModel.swift in Sources */,
+				745A41B02065405600299D75 /* ReaderPost+Searchable.swift in Sources */,
 				E1A8CACB1C22FF7C0038689E /* MeViewController.swift in Sources */,
 				17A28DC52050404C00EA6D9E /* AuthorFilterButton.swift in Sources */,
 				08216FD31CDBF96000304BA7 /* MenuItemTagsViewController.m in Sources */,
@@ -8959,7 +8963,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_alpha_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_alpha_app_credentials;
 			};
 			name = "Release-Alpha";
 		};
@@ -9434,7 +9438,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_internal_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_internal_app_credentials;
 			};
 			name = "Release-Internal";
 		};
@@ -9777,7 +9781,7 @@
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 3.0;
-				WPCOM_CONFIG = "$HOME/.wpcom_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
 			};
 			name = Debug;
 		};
@@ -9827,7 +9831,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
 			};
 			name = Release;
 		};

--- a/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
+++ b/WordPressShared/WordPressShared/Core/Analytics/WPAnalytics.h
@@ -292,6 +292,7 @@ typedef NS_ENUM(NSUInteger, WPAnalyticsStat) {
     WPAnalyticsStatSiteSettingsStartOverContactSupportClicked,
     WPAnalyticsStatSpotlightSearchOpenedPost,
     WPAnalyticsStatSpotlightSearchOpenedPage,
+    WPAnalyticsStatSpotlightSearchOpenedReaderPost,
     WPAnalyticsStatSkippedConnectingToJetpack,
     WPAnalyticsStatStatsAccessed,
     WPAnalyticsStatStatsInsightsAccessed,


### PR DESCRIPTION
![reader_indexing](https://user-images.githubusercontent.com/154014/37913321-3641dc84-30da-11e8-80f5-6ae5a4a6d648.gif)

This PR builds on top of the work done in  #8781 by indexing and posts opened in the reader. Unlike post/page indexing we only index posts if the user drills into a specific post (vs. scrolling through a topic tableview). In addition, the reader post `CSSearchableItem` is set to expire after 7 days.

(Note that featured image thumbnails are out of scope for this PR)

Fixes #8785 
Fixes #8786 

**To test:**
_You will want to test this PR on a device because the sim is not reliable when working with spotlight._

Should be straight-forward to test:
1. Open Me -> App Settings and clear the spotlight index
2. Browse around in reader and drill into a few articles. 
3. Search in spotlight for various keywords verifying articles show up
4. Tap on search results and make sure appropriate article appears in the reader

@frosty would you mind taking a peek?




