### PR TITLE
Localizing ‘Back’ button text for Theme Selection page.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationCategoryTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationCategoryTableViewController.swift
@@ -102,6 +102,10 @@ class SiteCreationCategoryTableViewController: NUXTableViewController {
         }
 
         themeVC.siteType = tableRow.siteType
+
+        let backButton = UIBarButtonItem()
+        backButton.title = NSLocalizedString("Back", comment: "Back button title.")
+        navigationItem.backBarButtonItem = backButton
     }
 
     // MARK: - Misc


### PR DESCRIPTION
Fixes #8947 

To test:
- Change device language to something other than English.
- Start the create site process.
- Verify on the Theme Selection page (Step 2 of 4) the nav bar Back button is translated.


@elibud - would you have a minute to look at this? Thanks!