### PR TITLE
Fix the layout when the post header view is hidden.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardImageCell.xib
@@ -62,11 +62,11 @@
                                 </constraints>
                             </view>
                             <view clipsSubviews="YES" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="9Kf-3e-Bni" customClass="CachedAnimatedImageView" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="64" width="308" height="196"/>
+                                <rect key="frame" x="0.0" y="61" width="308" height="196"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </view>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Y9d-Yk-F4X">
-                                <rect key="frame" x="0.0" y="64" width="308" height="196"/>
+                                <rect key="frame" x="0.0" y="61" width="308" height="196"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="196" id="0wl-TX-0Ed">
                                         <variation key="heightClass=regular-widthClass=regular" constant="226"/>
@@ -74,21 +74,21 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="E9Y-IT-TUt">
-                                <rect key="frame" x="16" y="274" width="276" height="24"/>
+                                <rect key="frame" x="16" y="271" width="276" height="24"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="Cbe-bm-gnv">
-                                <rect key="frame" x="16" y="307" width="276" height="17"/>
+                                <rect key="frame" x="16" y="304" width="276" height="17"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zle-VU-ygo">
-                                <rect key="frame" x="16" y="333" width="196" height="18"/>
+                                <rect key="frame" x="16" y="330" width="196" height="18"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-clock" translatesAutoresizingMaskIntoConstraints="NO" id="ed0-E7-1lw">
                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -118,7 +118,7 @@
                                 </constraints>
                             </view>
                             <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="2OR-ox-Csb">
-                                <rect key="frame" x="16" y="357" width="276" height="18"/>
+                                <rect key="frame" x="16" y="354" width="276" height="18"/>
                                 <subviews>
                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-status-pending" translatesAutoresizingMaskIntoConstraints="NO" id="WhA-sd-qfz">
                                         <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
@@ -148,7 +148,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U6E-MB-03K">
-                                <rect key="frame" x="212" y="333" width="80" height="18"/>
+                                <rect key="frame" x="212" y="330" width="80" height="18"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="U4X-fn-9uf" customClass="PostMetaButton">
                                         <rect key="frame" x="50" y="0.0" width="30" height="18"/>
@@ -237,7 +237,6 @@
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
                             <constraint firstItem="U6E-MB-03K" firstAttribute="centerY" secondItem="zle-VU-ygo" secondAttribute="centerY" id="NCb-6E-SND"/>
-                            <constraint firstItem="Y9d-Yk-F4X" firstAttribute="top" secondItem="rIp-IY-Ng4" secondAttribute="bottom" constant="15" id="QbH-qP-NR7"/>
                             <constraint firstItem="rIp-IY-Ng4" firstAttribute="leading" secondItem="b5E-yQ-veP" secondAttribute="leading" constant="16" id="SmN-xb-mWD">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
@@ -250,6 +249,7 @@
                             <constraint firstItem="s3z-0r-RPP" firstAttribute="top" secondItem="2OR-ox-Csb" secondAttribute="bottom" priority="900" constant="13" id="VIq-Lu-L4K">
                                 <variation key="heightClass=regular-widthClass=regular" constant="16"/>
                             </constraint>
+                            <constraint firstItem="Y9d-Yk-F4X" firstAttribute="top" secondItem="b5E-yQ-veP" secondAttribute="top" constant="61" id="WPG-cJ-Wdq"/>
                             <constraint firstItem="2OR-ox-Csb" firstAttribute="top" secondItem="zle-VU-ygo" secondAttribute="bottom" constant="6" id="cCR-ch-CxK">
                                 <variation key="heightClass=regular-widthClass=regular" constant="8"/>
                             </constraint>
@@ -298,7 +298,8 @@
                 <outlet property="headerView" destination="rIp-IY-Ng4" id="7zf-me-hFG"/>
                 <outlet property="headerViewHeightConstraint" destination="hQY-s6-IDE" id="JE0-4W-dHL"/>
                 <outlet property="headerViewLeftConstraint" destination="SmN-xb-mWD" id="sB9-to-eqY"/>
-                <outlet property="headerViewLowerConstraint" destination="QbH-qP-NR7" id="yVA-nc-yCf"/>
+                <outlet property="headerViewLowerConstraint" destination="WPG-cJ-Wdq" id="Idl-e3-thG"/>
+                <outlet property="headerViewTopConstraint" destination="Af8-lU-jWg" id="2pD-FE-Whs"/>
                 <outlet property="metaButtonLeft" destination="f2K-8g-nnA" id="6Rd-TT-m9U"/>
                 <outlet property="metaButtonRight" destination="U4X-fn-9uf" id="SHw-FM-KL3"/>
                 <outlet property="metaView" destination="U6E-MB-03K" id="XZt-Fn-PJ2"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -44,6 +44,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 @property (nonatomic, strong) IBOutlet UIButton *metaButtonLeft;
 @property (nonatomic, strong) IBOutlet UIProgressView *progressView;
 @property (nonatomic, strong) IBOutlet PostCardActionBar *actionBar;
+@property (nonatomic, strong) IBOutlet NSLayoutConstraint *headerViewTopConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *headerViewLeftConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *headerViewHeightConstraint;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *headerViewLowerConstraint;
@@ -232,11 +233,13 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 {
     if (![self.post isMultiAuthorBlog]) {
         self.headerViewHeightConstraint.constant = 0;
-        self.headerViewLowerConstraint.constant = 0;
+        // Move the next element up to where the header was.
+        self.headerViewLowerConstraint.constant = self.headerViewTopConstraint.constant;
         // If not visible, just return and don't bother setting the text or loading the avatar.
         self.headerView.hidden = YES;
         return;
     }
+
     self.headerView.hidden = NO;
     self.headerViewHeightConstraint.constant = self.headerViewHeight;
     self.headerViewLowerConstraint.constant = self.headerViewLowerMargin;

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -213,6 +213,7 @@
                             <constraint firstItem="O28-fP-tpX" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" constant="16" id="EvA-em-Rnw">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
+                            <constraint firstItem="xIT-FJ-g43" firstAttribute="top" secondItem="Lk7-nZ-b0t" secondAttribute="top" constant="64" id="Kyi-5t-RfN"/>
                             <constraint firstItem="OuO-i7-2Ds" firstAttribute="top" secondItem="Lk7-nZ-b0t" secondAttribute="top" constant="15" id="Seu-o3-dkG"/>
                             <constraint firstAttribute="trailing" secondItem="POV-pe-wu8" secondAttribute="trailing" constant="16" id="SjY-e4-XWL">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
@@ -223,7 +224,6 @@
                             <constraint firstItem="Z3W-ou-g2J" firstAttribute="top" secondItem="POV-pe-wu8" secondAttribute="bottom" constant="9" id="cgz-3E-MrQ">
                                 <variation key="heightClass=regular-widthClass=regular" constant="9"/>
                             </constraint>
-                            <constraint firstItem="xIT-FJ-g43" firstAttribute="top" secondItem="OuO-i7-2Ds" secondAttribute="bottom" constant="12" id="gXH-oU-BWB"/>
                             <constraint firstAttribute="trailing" secondItem="O28-fP-tpX" secondAttribute="trailing" constant="16" id="hDs-3W-qUQ">
                                 <variation key="heightClass=regular-widthClass=regular" constant="24"/>
                             </constraint>
@@ -279,7 +279,8 @@
                 <outlet property="headerView" destination="OuO-i7-2Ds" id="E0y-NW-njY"/>
                 <outlet property="headerViewHeightConstraint" destination="XPo-Pz-YMq" id="Hrp-nb-6G0"/>
                 <outlet property="headerViewLeftConstraint" destination="2pB-iJ-nFa" id="1Ha-rq-koT"/>
-                <outlet property="headerViewLowerConstraint" destination="gXH-oU-BWB" id="DR5-aJ-6Ye"/>
+                <outlet property="headerViewLowerConstraint" destination="Kyi-5t-RfN" id="blu-Sb-eNo"/>
+                <outlet property="headerViewTopConstraint" destination="Seu-o3-dkG" id="zaE-GJ-3WH"/>
                 <outlet property="metaButtonLeft" destination="uDE-AO-Rii" id="NHd-hW-Cag"/>
                 <outlet property="metaButtonRight" destination="Ovg-ci-Pfb" id="dCB-Tf-ED7"/>
                 <outlet property="metaView" destination="YwV-AJ-Nvl" id="KYr-Rj-rfE"/>


### PR DESCRIPTION
Fixes #8963 

To test:
- Create a new account in the app.
- Create a new site for your new account.
- Go to My Sites > Blog Posts.
- Verify there is no longer a gap at the top of the post.

To note, the header is hidden when the post is **_not_** `isMultiAuthor`.

@frosty - would you mind please kind sir? (Sorry for the dupe, I messed up the first one.). Also, this is going in `9.7`, so I kept the changes minimal. Please keep that in mind when reviewing. 😄 


