### PR TITLE
Use original username when reselected.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -216,13 +216,14 @@ extension SignupUsernameTableViewController {
         switch indexPath.section {
         case Sections.suggestions.rawValue:
             if indexPath.row == 0 {
-                selectedUsername = ""
+                selectedUsername = currentUsername ?? ""
             } else {
                 selectedUsername = suggestions[indexPath.row - 1]
             }
         default:
             return
         }
+
         delegate?.usernameSelected(selectedUsername)
 
         tableView.deselectSelectedRowWithAnimation(true)

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameViewController.swift
@@ -7,7 +7,6 @@ protocol SignupUsernameViewControllerDelegate {
 class SignupUsernameViewController: NUXViewController {
     // MARK: - Properties
     open var currentUsername: String?
-    private var newUsername: String?
     open var displayName: String?
     open var delegate: SignupUsernameViewControllerDelegate?
 
@@ -51,8 +50,6 @@ class SignupUsernameViewController: NUXViewController {
 
 extension SignupUsernameViewController: SignupUsernameViewControllerDelegate {
     func usernameSelected(_ username: String) {
-        newUsername = username
-
         delegate?.usernameSelected(username)
     }
 }


### PR DESCRIPTION
Fixes #8962

To test:
- Follow the repro steps on #8962 
- Verify the original username is used when re-selected.

@elibud - when you have a moment to review, I'd appreciate it!