### PR TITLE
Plugin Directory — small fixes.

### DIFF
--- a/WordPress/Classes/Utility/Throttle.swift
+++ b/WordPress/Classes/Utility/Throttle.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+// Based on code by Daniele Margutti — http://www.danielemargutti.com (http://www.danielemargutti.com) and Ignazio Calò:
+// http://danielemargutti.com/2017/10/19/throttle-in-swift/
+
+/// This class provides an easy way to ensure that an operation won't be repeated more often than `seconds` amount of time.
+/// Common use cases include online search — avoiding hitting the backend with a request for every character
+/// the user types.
+
+/// - Note:
+/// Any new block passed to `throttle(:_)` cancels the previous one. If you need to throttle multiple things
+/// (i.e. online search and unrelated background refresh), you'll need to have a separate `Throttle` for each of them.
+public class Throttle {
+    private let queue: DispatchQueue = DispatchQueue.global(qos: .default)
+
+    private var job: DispatchWorkItem = DispatchWorkItem(block: {})
+    private var previousRun: Date = Date.distantPast
+    private var maxInterval: Double
+
+    init(seconds: Double) {
+        self.maxInterval = seconds
+    }
+
+    func throttle(callbackQueue: DispatchQueue = DispatchQueue.main, block: @escaping () -> ()) {
+        job.cancel()
+        job = DispatchWorkItem(){ [weak self] in
+            self?.previousRun = Date()
+            callbackQueue.async {
+                block()
+            }
+        }
+
+        let delay = Date.second(from: previousRun) > maxInterval ? 0 : maxInterval
+        queue.asyncAfter(deadline: .now() + Double(delay), execute: job)
+    }
+
+}
+
+private extension Date {
+    static func second(from referenceDate: Date) -> Double {
+        return Date().timeIntervalSince(referenceDate).rounded()
+    }
+}
+

--- a/WordPress/Classes/Utility/Throttle.swift
+++ b/WordPress/Classes/Utility/Throttle.swift
@@ -23,7 +23,7 @@ public class Throttle {
 
     func throttle(callbackQueue: DispatchQueue = DispatchQueue.main, block: @escaping () -> ()) {
         job.cancel()
-        job = DispatchWorkItem(){ [weak self] in
+        job = DispatchWorkItem() { [weak self] in
             self?.previousRun = Date()
             callbackQueue.async {
                 block()
@@ -41,4 +41,3 @@ private extension Date {
         return Date().timeIntervalSince(referenceDate).rounded()
     }
 }
-

--- a/WordPress/Classes/Utility/Throttle.swift
+++ b/WordPress/Classes/Utility/Throttle.swift
@@ -1,18 +1,19 @@
 import Foundation
 
-// Based on code by Daniele Margutti — http://www.danielemargutti.com (http://www.danielemargutti.com) and Ignazio Calò:
-// http://danielemargutti.com/2017/10/19/throttle-in-swift/
-
-/// This class provides an easy way to ensure that an operation won't be repeated more often than `seconds` amount of time.
-/// Common use cases include online search — avoiding hitting the backend with a request for every character
-/// the user types.
-
-/// - Note:
+/// Based on code by Daniele Margutti — http://www.danielemargutti.com (http://www.danielemargutti.com)
+/// and Ignazio Calò: http://danielemargutti.com/2017/10/19/throttle-in-swift/
+///
+/// This class provides an easy way to ensure that an operation won't happen more than once in the specified
+/// amount of seconds.
+/// A common use case is when performing an online search, to limit the number of requests made to the backend as well
+/// as the number of (possibly stale) UI updates as the user types.
+///
+/// Note:
 /// Any new block passed to `throttle(:_)` cancels the previous one. If you need to throttle multiple things
 /// (i.e. online search and unrelated background refresh), you'll need to have a separate `Throttle` for each of them.
+///
 public class Throttle {
     private let queue: DispatchQueue = DispatchQueue.global(qos: .default)
-
     private var job: DispatchWorkItem = DispatchWorkItem(block: {})
     private var previousRun: Date = Date.distantPast
     private var maxInterval: Double

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
@@ -9,6 +9,8 @@ class PluginDirectoryViewController: UITableViewController {
     private var tableViewModel: ImmuTable!
     private var searchWrapperView: SearchWrapperView!
 
+    private let searchThrottle = Throttle(seconds: 0.5)
+
     init(site: JetpackSiteRef, store: PluginStore = StoreContainer.shared.plugin) {
         viewModel = PluginDirectoryViewModel(site: site, store: store)
 
@@ -180,8 +182,10 @@ extension PluginDirectoryViewController: UISearchResultsUpdating {
             return
         }
 
-        pluginListViewController.query = .feed(type: .search(term: searchedText))
-        pluginListViewController.tableView.contentInset.top = searchWrapperView.bounds.height
+        searchThrottle.throttle {
+            pluginListViewController.query = .feed(type: .search(term: searchedText))
+            pluginListViewController.tableView.contentInset.top = self.searchWrapperView.bounds.height
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
@@ -14,7 +14,7 @@ class PluginDirectoryViewController: UITableViewController {
     init(site: JetpackSiteRef, store: PluginStore = StoreContainer.shared.plugin) {
         viewModel = PluginDirectoryViewModel(site: site, store: store)
 
-        super.init(style: .grouped)
+        super.init(style: .plain)
         tableViewModel = viewModel.tableViewModel(presenter: self)
         title = NSLocalizedString("Plugins", comment: "Title for the plugin directory")
     }
@@ -50,13 +50,7 @@ class PluginDirectoryViewController: UITableViewController {
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.separatorInset = Constants.separatorInset
 
-        let footerView = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: CGFloat.leastNormalMagnitude))
-        tableView.tableFooterView = footerView
-        // We want the tableView to be in `.grouped` style, but we don't want the additional
-        // padding that comes with it, so we need to have this tiny useless footer.
-
-        ImmuTable.registerRows([CollectionViewContainerRow<PluginDirectoryCollectionViewCell, PluginDirectoryEntry>.self,
-                                TextRow.self],
+        ImmuTable.registerRows([CollectionViewContainerRow<PluginDirectoryCollectionViewCell, PluginDirectoryEntry>.self],
                                tableView: tableView)
 
         tableViewModel = viewModel.tableViewModel(presenter: self)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		40640046200ED30300106789 /* TextWithAccessoryButtonCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 40640045200ED30300106789 /* TextWithAccessoryButtonCell.xib */; };
 		40A2777F20191AA500D078D5 /* PluginDirectoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A2777E20191AA500D078D5 /* PluginDirectoryCollectionViewCell.swift */; };
 		40A2778120191B5E00D078D5 /* PluginDirectoryCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 40A2778020191B5E00D078D5 /* PluginDirectoryCollectionViewCell.xib */; };
+		40D7823A206AEA880015A3A1 /* Throttle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D78238206ABD970015A3A1 /* Throttle.swift */; };
 		40E4698F2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */; };
 		40E469912017EAB10030DB5F /* plugin-directory-jetpack.json in Resources */ = {isa = PBXBuildFile; fileRef = 40E469902017EAB10030DB5F /* plugin-directory-jetpack.json */; };
 		40E469932017F4070030DB5F /* PluginDirectoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E469922017F3D20030DB5F /* PluginDirectoryViewController.swift */; };
@@ -1562,6 +1563,7 @@
 		40640045200ED30300106789 /* TextWithAccessoryButtonCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextWithAccessoryButtonCell.xib; sourceTree = "<group>"; };
 		40A2777E20191AA500D078D5 /* PluginDirectoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		40A2778020191B5E00D078D5 /* PluginDirectoryCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginDirectoryCollectionViewCell.xib; sourceTree = "<group>"; };
+		40D78238206ABD970015A3A1 /* Throttle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Throttle.swift; sourceTree = "<group>"; };
 		40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryEntryStateTests.swift; sourceTree = "<group>"; };
 		40E469902017EAB10030DB5F /* plugin-directory-jetpack.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "plugin-directory-jetpack.json"; path = "../../../WordPressKit/WordPressKitTests/Mock Data/plugin-directory-jetpack.json"; sourceTree = "<group>"; };
 		40E469922017F3D20030DB5F /* PluginDirectoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryViewController.swift; sourceTree = "<group>"; };
@@ -4272,6 +4274,7 @@
 				B526DC241B1E473B002A8C5F /* WebViewController */,
 				E1BEEC621C4E35A8000B4FA0 /* Animator.swift */,
 				E14BCABA1E0BC817002E0603 /* Delay.swift */,
+				40D78238206ABD970015A3A1 /* Throttle.swift */,
 				E1C3C8521CE467A900D5DB36 /* EmailTypoChecker.swift */,
 				E6B046881F0FE85B0079F9FA /* EmailFormatValidator.swift */,
 				E11000981CDB5F1E00E33887 /* KeychainTools.swift */,
@@ -7858,6 +7861,7 @@
 				E19B17AE1E5C6944007517C6 /* BasePost.swift in Sources */,
 				E1EBC36F1C118EA500F638E0 /* ImmuTable.swift in Sources */,
 				B59B18751CC7FB8D0055EB7C /* PersonViewController.swift in Sources */,
+				40D7823A206AEA880015A3A1 /* Throttle.swift in Sources */,
 				E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */,
 				827704F11F607C0E002E8A03 /* JetpackConnectionViewController.swift in Sources */,
 				5D839AAB187F0D8000811F4A /* PostGeolocationCell.m in Sources */,

--- a/WordPressKit/WordPressKit/PluginServiceRemote.swift
+++ b/WordPressKit/WordPressKit/PluginServiceRemote.swift
@@ -24,6 +24,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
                 failure(ResponseError.decodingFailure)
             }
         }, failure: { (error, httpResponse) in
+            DDLogError("[PluginServiceRemoteError] Error fetching featured plugins: \(error)")
             failure(error)
         })
     }
@@ -47,6 +48,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
                 failure(self.errorFromResponse(response))
             }
         }, failure: { (error, httpResponse) in
+            DDLogError("[PluginServiceRemoteError] Error fetching site plugins: \(error)")
             failure(error)
         })
     }
@@ -75,6 +77,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
                 }
         },
             failure: { (error, _) in
+                DDLogError("[PluginServiceRemoteError] Error updating plugin: \(error)")
                 failure(error)
         })
     }
@@ -134,6 +137,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
                     failure(self.errorFromResponse(response))
                 }
             }, failure: { (error, _) in
+                DDLogError("[PluginServiceRemoteError] Error installing plugin: \(error)")
                 failure(error)
             }
         )
@@ -152,6 +156,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
             success: { _,_  in
                 success()
             }, failure: { (error, _) in
+                DDLogError("[PluginServiceRemoteError] Error removing plugin: \(error)")
                 failure(error)
             }
         )
@@ -171,6 +176,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
                 success()
             },
             failure: { (error, _) in
+                DDLogError("[PluginServiceRemoteError] Error modifying plugin: \(error)")
                 failure(error)
             })
     }


### PR DESCRIPTION
This is a collection of small fixes and touchups for PD, I felt all of them were small enough to warrant rolling them up in a collective PR, instead of 3 tiny ones.

The biggest change should be fairly invisible, except in bad scenarios — sometimes on slower devices (or simulator when your Mac is under a lot of load) the initial screen of Plugin Directory would freeze for a second or two. This was caused because every `PluginDirectoryEntry` that would get downloaded would trigger a full reload — and on a reasonable internet connection, it would mean we'd call `tableView.reloadData` like 20+ times right after each other. We're now throttling those calls, to avoid the freeze.

There should also no longer be a weird gray gap at the bottom of the Plugin Directory. 

Also — fixes #8789, adding error logging to plugin remotes.