### PR TITLE
Site Creation: Using `localizedUppercase` for all step labels.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationCategoryTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationCategoryTableViewController.swift
@@ -40,8 +40,7 @@ class SiteCreationCategoryTableViewController: NUXTableViewController {
     // MARK: - Table Model
 
     private func tableViewModel() -> ImmuTable {
-
-        let step = NSLocalizedString("STEP 1 OF 4", comment: "Step for view.")
+        let step = NSLocalizedString("Step 1 of 4", comment: "Title for first step in the site creation process.").localizedUppercase
         let instr1 = NSLocalizedString("What kind of site do you need?", comment: "Site type question.")
         let instr2 = NSLocalizedString("Choose an option below:", comment: "Choose site type prompt.")
         let instructionRow = InstructionRow(step: step, instr1: instr1, instr2: instr2, action: nil)

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationSiteDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationSiteDetailsViewController.swift
@@ -85,7 +85,7 @@ class SiteCreationSiteDetailsViewController: NUXViewController, NUXKeyboardRespo
     }
 
     private func setLabelText() {
-        stepLabel.text = NSLocalizedString("STEP 3 OF 4", comment: "Step for view.")
+        stepLabel.text = NSLocalizedString("Step 3 of 4", comment: "Title for third step in the site creation process.").localizedUppercase
         stepDescriptionLabel1.text = NSLocalizedString("Tell us more about the site you're creating.", comment: "Shown during the site details step of the site creation flow.")
         stepDescriptionLabel2.text = NSLocalizedString("What's the title and tagline?", comment: "Prompts the user for Site details information.")
 

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationThemeSelectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationThemeSelectionHeaderView.swift
@@ -6,7 +6,7 @@ class SiteCreationThemeSelectionHeaderView: UICollectionReusableView {
 
     static let reuseIdentifier = "themeSelectionHeader"
 
-    static let stepLabelText = NSLocalizedString("STEP 2 OF 4", comment: "Step for view.")
+    static let stepLabelText = NSLocalizedString("Step 2 of 4", comment: "Title for second step in the site creation process.").localizedUppercase
     static let stepDescrLabelText = NSLocalizedString("Get started fast with one of our popular themes. Once your site is created, you can browse and choose from hundreds more.", comment: "Shown during the theme selection step of the site creation flow.")
 
     @IBOutlet weak var stepLabel: UILabel!


### PR DESCRIPTION
Fixes # n/a (brought up by @elibud on https://github.com/wordpress-mobile/WordPress-iOS/pull/8952)

To test:
Verify in the Site Creation process the step labels for steps 1 - 3 are still uppercase (e.g. STEP 1 OF 4).

