### PR TITLE
Activity Log: add swipe action to "Rewind" cells.

### DIFF
--- a/WordPress/Classes/Utility/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable.swift
@@ -346,6 +346,23 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
 
         return nil
     }
+
+    open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        if target.responds(to: #selector(UITableViewDataSource.tableView(_:canEditRowAt:))) {
+            return target.tableView(tableView, canEditRowAt: indexPath)
+        }
+
+        return false
+    }
+
+    open func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+        if target.responds(to: #selector(UITableViewDelegate.tableView(_:editActionsForRowAt:))) {
+            return target.tableView(tableView, editActionsForRowAt: indexPath)
+        }
+
+        return nil
+    }
+
 }
 
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -142,6 +142,25 @@ extension ActivityListViewController {
         return ActivityListSectionHeaderView.height
     }
 
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        guard let row = handler.viewModel.rowAtIndexPath(indexPath) as? ActivityListRow else {
+            return false
+        }
+
+        return (!row.activity.isDiscarded && row.activity.rewindable)
+    }
+
+    override func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
+        let rewindAction = UITableViewRowAction(style: .normal,
+                                                title: NSLocalizedString("Rewind", comment: "Title displayed when user swipes on a rewind cell"),
+                                                handler: { [weak self] _, indexPath in
+                                                    self?.handler.tableView(tableView, didSelectRowAt: indexPath)
+        })
+        rewindAction.backgroundColor = WPStyleGuide.mediumBlue()
+
+        return [rewindAction]
+    }
+
 }
 
 // MARK: - WPNoResultsViewDelegate


### PR DESCRIPTION
Part of #7832.

Adds ability to swipe-to-rewind.

To test:
1. Go to activity log
2. Swipe left on a cell that's "rewindable" — i..e has the rewind icon on the right.
3. Verify that it triggers the rewind dialog.
4. Swipe left on a different cell.
5. Verify that it doesn't do anything.

