### PR TITLE
Issue/8461 properly display new posts notifications

### DIFF
--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -379,6 +379,7 @@ extension Notification {
         case Follow         = "follow"
         case Like           = "like"
         case Matcher        = "automattcher"
+        case NewPost        = "new_post"
         case Post           = "post"
         case User           = "user"
         case Unknown        = "unknown"

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -845,6 +845,8 @@ private extension NotificationDetailsViewController {
                 fallthrough
             case .Matcher:
                 fallthrough
+            case .NewPost:
+                fallthrough
             case .Post:
                 try displayReaderWithPostId(note.metaPostID, siteID: note.metaSiteID)
             case .Comment:

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -527,7 +527,7 @@ extension NotificationsViewController {
 
         // Display Details
         //
-        if let postID = note.metaPostID, let siteID = note.metaSiteID, note.kind == .Matcher {
+        if let postID = note.metaPostID, let siteID = note.metaSiteID, note.kind == .Matcher || note.kind == .NewPost {
             let readerViewController = ReaderDetailViewController.controllerWithPostID(postID, siteID: siteID)
             showDetailViewController(readerViewController, sender: nil)
             return
@@ -1323,7 +1323,7 @@ extension NotificationsViewController: WPSplitViewControllerDetailProvider {
 
         prepareToShowDetailsForNotification(note)
 
-        if let postID = note.metaPostID, let siteID = note.metaSiteID, note.kind == .Matcher {
+        if let postID = note.metaPostID, let siteID = note.metaSiteID, note.kind == .Matcher || note.kind == .NewPost {
             return ReaderDetailViewController.controllerWithPostID(postID, siteID: siteID)
         }
 


### PR DESCRIPTION
Fixes #8461 

To test:
1. Subscribe to push notifications for new posts for a blog you own.
2. Publish a post. 
3. Check that if you tap on the notification on the notifications list it takes you to Reader, both on IPhone and IPad.
