### PR TITLE
Initialize post draft status as `PostStatusDraft`.

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -425,6 +425,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
 - (void)initializeDraft:(AbstractPost *)post {
     post.remoteStatus = AbstractPostRemoteStatusLocal;
     post.dateModified = [NSDate date];
+    post.status = PostStatusDraft;
 }
 
 - (void)mergePosts:(NSArray <RemotePost *> *)remotePosts


### PR DESCRIPTION
Fixes #8382

To test:
- Start a post.
- Go to the Post Settings (... in the upper right corner).
- Verify Publish > Status is 'Draft'.

<img width="415" alt="status" src="https://user-images.githubusercontent.com/1816888/38055721-c65103ea-3297-11e8-8446-a7b6ab988ba6.png">


@SergioEstevao , @diegoreymendez - if either of you have a moment to review, I'd greatly appreciate it!
