### PR TITLE
Allow 2FA codes to have spaces

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -266,7 +266,7 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
             pasteString != pasteboardBeforeBackground else {
                 return
         }
-        
+
         switch isValidCode(code: pasteString) {
         case .valid(let cleanedCode):
             displayError(message: "")

--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -184,8 +184,10 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         if isOnlyNumbers && isShortEnough {
             displayError(message: "")
 
-            // because the string was stripped of whitespace, we can't return true. But we can do the change ourselves
+            // because the string was stripped of whitespace, we can't return true and we update the textfield ourselves
             textField.text = resultStringStripped
+            loginFields.multifactorCode = resultStringStripped
+            configureSubmitButton(animating: false)
         } else if let pasteString = UIPasteboard.general.string, pasteString == replacementString {
             displayError(message: NSLocalizedString("That doesn't appear to be a valid verification code.", comment: "Shown when a user pastes a code into the two factor field that contains letters or is the wrong length"))
         } else if !isOnlyNumbers {
@@ -202,13 +204,6 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
 
 
     // MARK: - Actions
-
-    @IBAction func handleTextFieldDidChange(_ sender: UITextField) {
-        loginFields.multifactorCode = verificationCodeField.nonNilTrimmedText()
-
-        configureSubmitButton(animating: false)
-    }
-
 
     @IBAction func handleSubmitForm() {
         validateForm()


### PR DESCRIPTION
We should be slightly more permissive for the formatting of 2FA codes by allowing white space.

This updates our support to match https://github.com/Automattic/wp-calypso/pull/23176

To test:
- ensure normal 2FA codes still work
- ensure typing in a 2FA code with or without a space (such as `123 456`) works
- ensure pasting codes with/without white space works
- ensure that really wrong codes still don't work eg `12as56`; `password`; `😂`

Also tagging @diegoreymendez for release management.