### PR TITLE
Implemented a working StockPhotos data source

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMoreCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMoreCoordinator.swift
@@ -7,8 +7,9 @@ final class AztecMoreCoordinator {
 
     private let stockPhotos = StockPhotosPicker()
 
-    init(delegate: AztecMoreCoordinatorDelegate) {
+    init(delegate: AztecMoreCoordinatorDelegate & StockPhotosPickerDelegate) {
         self.delegate = delegate
+        stockPhotos.delegate = delegate
     }
 
     func present(origin: UIViewController & UIDocumentPickerDelegate, view: UIView) {

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
@@ -3,9 +3,24 @@ import WPMediaPicker
 
 /// Data Source for Stock Photos
 final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
+
+    var photosMedia = [StockPhotosMedia]()
+    var observers = [String: WPMediaChangesBlock]()
+    let service: StockPhotosServiceProtocol
+
+    init(service: StockPhotosServiceProtocol) {
+        self.service = service
+        super.init()
+    }
+    
     func numberOfGroups() -> Int {
-        print("==== number of groups ====")
         return 1
+    }
+
+    func search(for searchText: String?) {
+        service.search(text: searchText ?? "") { (result) in
+            self.searchCompleted(result: result)
+        }
     }
 
     func group(at index: Int) -> WPMediaGroup {
@@ -16,33 +31,47 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
         return StockPhotosMediaGroup()
     }
 
-    func setSelectedGroup(_ group: WPMediaGroup) {
-        //
-    }
-
     func numberOfAssets() -> Int {
-        print("==== number of assets ===")
-        return 0
+        return photosMedia.count
     }
 
     func media(at index: Int) -> WPMediaAsset {
-        return StockPhotosMedia()
+        return photosMedia[index]
     }
 
     func media(withIdentifier identifier: String) -> WPMediaAsset? {
-        return StockPhotosMedia()
+        return photosMedia.filter { $0.identifier() == identifier }.first
     }
 
     func registerChangeObserverBlock(_ callback: @escaping WPMediaChangesBlock) -> NSObjectProtocol {
-        //
-        return NSObject()
+        let blockKey = UUID().uuidString
+        observers[blockKey] = callback
+        return blockKey as NSString
     }
 
     func unregisterChangeObserver(_ blockKey: NSObjectProtocol) {
-        //
+        guard let key = blockKey as? String else {
+            assertionFailure("blockKey must be of type String")
+            return
+        }
+        observers.removeValue(forKey: key)
     }
 
     func loadData(with options: WPMediaLoadOptions, success successBlock: WPMediaSuccessBlock?, failure failureBlock: WPMediaFailureBlock? = nil) {
+        successBlock?()
+    }
+
+    func mediaTypeFilter() -> WPMediaType {
+        return .image
+    }
+
+    func ascendingOrdering() -> Bool {
+        return true
+    }
+
+    //MARK: Unnused protocol methods
+
+    func setSelectedGroup(_ group: WPMediaGroup) {
         //
     }
 
@@ -58,15 +87,22 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
         //
     }
 
-    func mediaTypeFilter() -> WPMediaType {
-        return .image
-    }
-
     func setAscendingOrdering(_ ascending: Bool) {
         //
     }
+}
 
-    func ascendingOrdering() -> Bool {
-        return true
+//MARK: - Helpers
+
+extension StockPhotosDataSource {
+    private func searchCompleted(result: [StockPhotosMedia]) {
+        self.photosMedia = result
+        self.notifyObservers()
+    }
+
+    private func notifyObservers() {
+        observers.forEach {
+            $0.value(false, IndexSet(), IndexSet(), IndexSet(), [])
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosMedia.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosMedia.swift
@@ -1,10 +1,72 @@
 import WPMediaPicker
 
+/*** JSON Structure of a StockPhoto object coming from the API ***
+{
+    "ID": "PEXELS-710916",
+    "URL": "https://images.pexels.com/photos/710916/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+    "title": "pexels-photo-710916.jpeg",
+    "date": "2018-03-28 00:00:00",
+    "name": "pexels-photo-710916.jpeg",
+    "file": "pexels-photo-710916.jpeg",
+    "guid": "{\"url\":\"https:\\/\\/images.pexels.com\\/photos\\/710916\\/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940\",\"name\":\"pexels-photo-710916.jpeg\",\"title\":\"pexels-photo-710916.jpeg\"}",
+    "height": 1253,
+    "width": 1880,
+    "thumbnails": {
+        "large": "https://images.pexels.com/photos/710916/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940",
+        "medium": "https://images.pexels.com/photos/710916/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&h=350",
+        "post-thumbnail": "https://images.pexels.com/photos/710916/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&h=130",
+        "thumbnail": "https://images.pexels.com/photos/710916/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=200&w=280"
+    },
+    "type": "image",
+    "extension": "jpeg"
+}
+*/
+
+struct ThumbnailCollection {
+    let largeURL: URL
+    let mediumURL: URL
+    let postThumbnailURL: URL
+    let thumbnailURL: URL
+}
 
 /// Models a Stock Photo
-final class StockPhotosMedia: NSObject, WPMediaAsset {
+///
+final class StockPhotosMedia: NSObject {
+    let id: Int
+    let guid: String
+    let URL: URL
+    let title: String
+    let name: String
+    let size: CGSize
+    let thumbnails: ThumbnailCollection
+
+    init(id: Int, guid: String, URL: URL, title: String, name: String, size: CGSize, thumbnails: ThumbnailCollection) {
+        self.id = id
+        self.guid = guid
+        self.URL = URL
+        self.title = title
+        self.name = name
+        self.size = size
+        self.thumbnails = thumbnails
+    }
+}
+
+extension StockPhotosMedia: WPMediaAsset {
     func image(with size: CGSize, completionHandler: @escaping WPMediaImageBlock) -> WPMediaRequestID {
-        return 0
+
+        //Temporary loading image from URL
+        DispatchQueue.global().async {
+            do {
+                let data = try Data(contentsOf: self.thumbnails.postThumbnailURL)
+                let image = UIImage(data: data)
+                completionHandler(image, nil)
+            } catch {
+                completionHandler(nil, error)
+            }
+        }
+
+        let number = NSNumber(value: id)
+        return number.int32Value as WPMediaRequestID
     }
 
     func cancelImageRequest(_ requestID: WPMediaRequestID) {
@@ -24,11 +86,11 @@ final class StockPhotosMedia: NSObject, WPMediaAsset {
     }
 
     func baseAsset() -> Any {
-        return ""
+        return self
     }
 
     func identifier() -> String {
-        return "image"
+        return guid
     }
 
     func date() -> Date {
@@ -36,6 +98,6 @@ final class StockPhotosMedia: NSObject, WPMediaAsset {
     }
 
     func pixelSize() -> CGSize {
-        return .zero
+        return size
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
@@ -1,9 +1,13 @@
 import WPMediaPicker
 
+protocol StockPhotosPickerDelegate: AnyObject {
+    func stockPhotosPicker(_ picker: StockPhotosPicker, didFinishPicking assets: [StockPhotosMedia])
+}
 
 /// Presents the Stock Photos main interface
 final class StockPhotosPicker: NSObject {
-    private let dataSource = StockPhotosDataSource()
+    private let dataSource = StockPhotosDataSource(service: StockPhotosServiceMock())
+    weak var delegate: StockPhotosPickerDelegate?
 
     func presentPicker(origin: UIViewController) {
         let options = WPMediaPickerOptions()
@@ -24,7 +28,12 @@ final class StockPhotosPicker: NSObject {
 
 extension StockPhotosPicker: WPMediaPickerViewControllerDelegate {
     func mediaPickerController(_ picker: WPMediaPickerViewController, didFinishPicking assets: [WPMediaAsset]) {
-        //
+        guard let stockPhotosMedia = assets as? [StockPhotosMedia] else {
+            assertionFailure("assets should be of type `[StockPhotosMedia]`")
+            return
+        }
+        delegate?.stockPhotosPicker(self, didFinishPicking: stockPhotosMedia)
+        picker.dismiss(animated: true, completion: nil)
     }
 
     func emptyView(forMediaPickerController picker: WPMediaPickerViewController) -> UIView? {

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -1,0 +1,50 @@
+
+import Foundation
+
+protocol StockPhotosServiceProtocol {
+    func search(text: String, completion: @escaping ([StockPhotosMedia]) -> Void)
+}
+
+// MARK: - Temporary mock for testing
+
+final class StockPhotosServiceMock: StockPhotosServiceProtocol {
+    func search(text: String, completion: @escaping ([StockPhotosMedia]) -> Void) {
+        guard text.count > 0 else {
+            completion([])
+            return
+        }
+        DispatchQueue.global().async {
+            let totalMedia = text.count
+            let mediaResult = (1...totalMedia).map { self.crateStockPhotosMedia(id: $0 as Int) }
+            DispatchQueue.main.async {
+                completion(mediaResult)
+            }
+        }
+    }
+
+    private func crateStockPhotosMedia(id: Int) -> StockPhotosMedia {
+        let url = "https://images.pexels.com/photos/710916/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940".toURL()!
+        let thumbs = ThumbnailCollection(
+            largeURL: "https://images.pexels.com/photos/710916/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940".toURL()!,
+            mediumURL: "https://images.pexels.com/photos/710916/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&h=350".toURL()!,
+            postThumbnailURL: "https://images.pexels.com/photos/710916/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&h=130".toURL()!,
+            thumbnailURL: "https://images.pexels.com/photos/710916/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&fit=crop&h=200&w=280".toURL()!
+        )
+        return StockPhotosMedia(
+            id: id,
+            guid: "\(id)",
+            URL: url,
+            title: "pexels-photo-710916.jpeg",
+            name: "pexels-photo-710916.jpeg",
+            size:
+            CGSize(width: 1880, height: 1253),
+            thumbnails: thumbs
+        )
+    }
+}
+
+private extension String {
+    func toURL() -> URL? {
+        return URL(string: self)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3567,6 +3567,13 @@ extension AztecPostViewController: AztecMoreCoordinatorDelegate {
     }
 }
 
+extension AztecPostViewController: StockPhotosPickerDelegate {
+    func stockPhotosPicker(_ picker: StockPhotosPicker, didFinishPicking assets: [StockPhotosMedia]) {
+        ///TODO:  Insert picked assets
+        ///Hint: Follow `mediaPickerController(_:didFinishPicking:)`
+    }
+}
+
 // MARK: - Constants
 //
 extension AztecPostViewController {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -492,6 +492,7 @@
 		7E21C765202BBF4400837CF5 /* SearchAdsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E21C764202BBF4400837CF5 /* SearchAdsAttribution.swift */; };
 		7E52B7181FC89F2400B55EB8 /* MediaNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */; };
 		7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */; };
+		7EBB4126206C388100012D98 /* StockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBB4125206C388100012D98 /* StockPhotosService.swift */; };
 		820ADD701F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */; };
 		820ADD721F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */; };
 		821738091FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821738081FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift */; };
@@ -1904,6 +1905,7 @@
 		7E21C764202BBF4400837CF5 /* SearchAdsAttribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SearchAdsAttribution.swift; path = iAds/SearchAdsAttribution.swift; sourceTree = "<group>"; };
 		7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaNoResultsView.swift; sourceTree = "<group>"; };
 		7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonHeaderCell.swift; sourceTree = "<group>"; };
+		7EBB4125206C388100012D98 /* StockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosService.swift; sourceTree = "<group>"; };
 		820ADD6C1F3A0DA0002D7F93 /* WordPress 64.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 64.xcdatamodel"; sourceTree = "<group>"; };
 		820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ThemeBrowserSectionHeaderView.xib; sourceTree = "<group>"; };
 		820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSectionHeaderView.swift; sourceTree = "<group>"; };
@@ -5631,6 +5633,7 @@
 				D8A3A5A92069E53900992576 /* AztecMoreCoordinator.swift */,
 				D8A3A5AB2069FE5B00992576 /* StockPhotosStrings.swift */,
 				D8A3A5AE206A442800992576 /* StockPhotosDataSource.swift */,
+				7EBB4125206C388100012D98 /* StockPhotosService.swift */,
 				D8A3A5B0206A49A100992576 /* StockPhotosMediaGroup.swift */,
 				D8A3A5B2206A49BF00992576 /* StockPhotosMedia.swift */,
 				D8A3A5B4206A4C7800992576 /* StockPhotosPicker.swift */,
@@ -7670,6 +7673,7 @@
 				BE87E1A01BD4054F0075D45B /* WP3DTouchShortcutCreator.swift in Sources */,
 				37EAAF4D1A11799A006D6306 /* CircularImageView.swift in Sources */,
 				B50C0C501EF429E900372C65 /* CommentAttachmentRenderer.swift in Sources */,
+				7EBB4126206C388100012D98 /* StockPhotosService.swift in Sources */,
 				E69551F61B8B6AE200CB8E4F /* ReaderStreamViewController+Helper.swift in Sources */,
 				E61084BE1B9B47BA008050C5 /* ReaderAbstractTopic.swift in Sources */,
 				E61084BF1B9B47BA008050C5 /* ReaderDefaultTopic.swift in Sources */,


### PR DESCRIPTION
This PR implements the `StockPhotosDataSource` with fake data using `StockPhotosServiceMock`. The real API call is yet to be developed.

Fixes partially #8954

The sample will show one tasty pizza image for each character of the search word. 🍕 

☠️  There is a crash when dismissing the "Free Photos Library" picker. I believe this is an issue in the Media picker library and I already sent a PR there addressing it.

![pizza](https://user-images.githubusercontent.com/9772967/38059832-7433cc42-32be-11e8-9bb6-021c67674567.gif)

To test:
1. Start creating a new post
2. Tap the + button in the lower Format Bar.
3. Tap the ellipsis in the Format Bar
4. Select "Free Photos Library".
5. Search for your pizzas.