### PR TITLE
MediaCoordinator: Use original posts when observing / reporting progress

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3070,7 +3070,7 @@ extension AztecPostViewController {
                 alertController.addActionWithTitle(MediaAttachmentActionSheet.stopUploadActionTitle,
                                                    style: .destructive,
                                                    handler: { (action) in
-                                                    self.mediaCoordinator.delete(media)
+                                                    self.mediaCoordinator.cancelUpload(of: media)
                 })
             }
         } else {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -348,7 +348,8 @@ class AztecPostViewController: UIViewController, PostEditor {
         didSet {
             removeObservers(fromPost: oldValue)
             addObservers(toPost: post)
-
+            unregisterMediaObserver()
+            registerMediaObserver()
             postEditorStateContext = createEditorStateContext(for: post)
             refreshInterface()
         }
@@ -515,8 +516,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         if isOpenedDirectlyForPhotoPost {
             presentMediaPickerFullScreen(animated: false)
         }
-
-        registerMediaObserver()
     }
 
 


### PR DESCRIPTION
This PR fixes an issue where media progress fails to be reported to Aztec after a post has been saved. The issue seems to be due to a revision being created on save, which means the observers were pointing to an old Post object. This PR updates the MediaCoordinator to always use the post's `original` post when creating or fetching a progress coordinator.

**To test:**

* Open the editor, enter a title / text
* From the `...` menu choose Save as Draft
* Add some images to the post, and check the actual images appear in the post (not placeholders) and that their progress is reported

