### PR TITLE
First draft of Stock Photos Service

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMoreCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMoreCoordinator.swift
@@ -1,6 +1,12 @@
 import MobileCoreServices
 import WPMediaPicker
 
+struct MoreCoordinatorContext {
+    let origin: UIViewController & UIDocumentPickerDelegate
+    let view: UIView
+    let blog: Blog
+}
+
 /// Prepares the alert controller that will be presented when tapping the "more" button in Aztec's Format Bar
 final class AztecMoreCoordinator {
     private weak var delegate: AztecMoreCoordinatorDelegate?
@@ -12,15 +18,18 @@ final class AztecMoreCoordinator {
         stockPhotos.delegate = delegate
     }
 
-    func present(origin: UIViewController & UIDocumentPickerDelegate, view: UIView) {
+    func present(context: MoreCoordinatorContext) {
+        let origin = context.origin
+        let fromView = context.view
+
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
         alertController.addAction(freePhotoAction(origin: origin))
         alertController.addAction(otherAppsAction(origin: origin))
         alertController.addAction(cancelAction())
 
-        alertController.popoverPresentationController?.sourceView = view
-        alertController.popoverPresentationController?.sourceRect = CGRect(origin: view.frame.origin, size: CGSize(width: 1, height: 1))
+        alertController.popoverPresentationController?.sourceView = fromView
+        alertController.popoverPresentationController?.sourceRect = CGRect(origin: fromView.frame.origin, size: CGSize(width: 1, height: 1))
         alertController.popoverPresentationController?.permittedArrowDirections = .any
 
         origin.present(alertController, animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMoreCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMoreCoordinator.swift
@@ -20,11 +20,12 @@ final class AztecMoreCoordinator {
 
     func present(context: MoreCoordinatorContext) {
         let origin = context.origin
+        let blog = context.blog
         let fromView = context.view
 
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-        alertController.addAction(freePhotoAction(origin: origin))
+        alertController.addAction(freePhotoAction(origin: origin, blog: blog))
         alertController.addAction(otherAppsAction(origin: origin))
         alertController.addAction(cancelAction())
 
@@ -35,9 +36,9 @@ final class AztecMoreCoordinator {
         origin.present(alertController, animated: true, completion: nil)
     }
 
-    private func freePhotoAction(origin: UIViewController) -> UIAlertAction {
+    private func freePhotoAction(origin: UIViewController, blog: Blog) -> UIAlertAction {
         return UIAlertAction(title: .freePhotosLibrary, style: .default, handler: { [weak self] action in
-            self?.showStockPhotos(origin: origin)
+            self?.showStockPhotos(origin: origin, blog: blog)
         })
     }
 
@@ -53,8 +54,8 @@ final class AztecMoreCoordinator {
         })
     }
 
-    private func showStockPhotos(origin: UIViewController) {
-        stockPhotos.presentPicker(origin: origin)
+    private func showStockPhotos(origin: UIViewController, blog: Blog) {
+        stockPhotos.presentPicker(origin: origin, blog: blog)
     }
 
     private func showDocumentPicker(origin: UIViewController & UIDocumentPickerDelegate) {

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
@@ -18,7 +18,8 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
     }
 
     func search(for searchText: String?) {
-        service.search(text: searchText ?? "") { (result) in
+        let params = StockPhotosSearchParams(text: searchText ?? "")
+        service.search(params: params) { (result) in
             self.searchCompleted(result: result)
         }
     }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
@@ -6,9 +6,9 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
 
     var photosMedia = [StockPhotosMedia]()
     var observers = [String: WPMediaChangesBlock]()
-    let service: StockPhotosServiceProtocol
+    let service: StockPhotosService
 
-    init(service: StockPhotosServiceProtocol) {
+    init(service: StockPhotosService) {
         self.service = service
         super.init()
     }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosMedia.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosMedia.swift
@@ -28,18 +28,6 @@ struct ThumbnailCollection {
     private(set) var mediumURL: URL
     private(set) var postThumbnailURL: URL
     private(set) var thumbnailURL: URL
-
-    init() {
-        let mock = URL(string: "http://nil")!
-        self.init(largeURL: mock, mediumURL: mock, postThumbnailURL: mock, thumbnailURL: mock)
-    }
-
-    init(largeURL: URL, mediumURL: URL, postThumbnailURL: URL, thumbnailURL: URL) {
-        self.largeURL = largeURL
-        self.mediumURL = mediumURL
-        self.postThumbnailURL = postThumbnailURL
-        self.thumbnailURL = thumbnailURL
-    }
 }
 
 /// Models a Stock Photo
@@ -140,16 +128,14 @@ extension StockPhotosMedia: Decodable {
     }
 
     convenience init(from decoder: Decoder) throws {
-        let url = Foundation.URL(string: "http://elpais.com")!
-
-        self.init(id: "", URL: url, title: "", name: "", size: .zero, thumbnails: ThumbnailCollection())
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        id = try values.decode(String.self, forKey: .ID)
-        URL = try values.decode(String.self, forKey: .URL).asURL()
-        title = try values.decode(String.self, forKey: .title)
-        name = try values.decode(String.self, forKey: .name)
-        size = .zero
+        let id = try values.decode(String.self, forKey: .ID)
+        let URL = try values.decode(String.self, forKey: .URL).asURL()
+        let title = try values.decode(String.self, forKey: .title)
+        let name = try values.decode(String.self, forKey: .name)
+        let size: CGSize = .zero
+        let thumbnails = try values.decode(ThumbnailCollection.self, forKey: .thumbnails)
 
-        thumbnails = try values.decode(ThumbnailCollection.self, forKey: .thumbnails)
+        self.init(id: id, URL: URL, title: title, name: name, size: size, thumbnails: thumbnails)
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosMedia.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosMedia.swift
@@ -141,6 +141,7 @@ extension StockPhotosMedia: Decodable {
 
     convenience init(from decoder: Decoder) throws {
         let url = Foundation.URL(string: "http://elpais.com")!
+
         self.init(id: "", URL: url, title: "", name: "", size: .zero, thumbnails: ThumbnailCollection())
         let values = try decoder.container(keyedBy: CodingKeys.self)
         id = try values.decode(String.self, forKey: .ID)
@@ -149,9 +150,6 @@ extension StockPhotosMedia: Decodable {
         name = try values.decode(String.self, forKey: .name)
         size = .zero
 
-        //let thumbnailsInfo = try values.nestedContainer(keyedBy: CodingKeys.self, forKey: .thumbnails)
         thumbnails = try values.decode(ThumbnailCollection.self, forKey: .thumbnails)
-
-        //self.init(id: id, URL: URL, title: title, name: name, size: size, thumbnails: thumbnails)
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosMedia.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosMedia.swift
@@ -76,7 +76,7 @@ extension StockPhotosMedia: WPMediaAsset {
             }
         }
 
-        let number = Int32(id)!
+        let number = Int32(id) ?? 0
         return number as WPMediaRequestID
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosMedia.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosMedia.swift
@@ -1,3 +1,4 @@
+import Foundation
 import WPMediaPicker
 
 /*** JSON Structure of a StockPhoto object coming from the API ***
@@ -23,26 +24,36 @@ import WPMediaPicker
 */
 
 struct ThumbnailCollection {
-    let largeURL: URL
-    let mediumURL: URL
-    let postThumbnailURL: URL
-    let thumbnailURL: URL
+    private(set) var largeURL: URL
+    private(set) var mediumURL: URL
+    private(set) var postThumbnailURL: URL
+    private(set) var thumbnailURL: URL
+
+    init() {
+        let mock = URL(string: "http://nil")!
+        self.init(largeURL: mock, mediumURL: mock, postThumbnailURL: mock, thumbnailURL: mock)
+    }
+
+    init(largeURL: URL, mediumURL: URL, postThumbnailURL: URL, thumbnailURL: URL) {
+        self.largeURL = largeURL
+        self.mediumURL = mediumURL
+        self.postThumbnailURL = postThumbnailURL
+        self.thumbnailURL = thumbnailURL
+    }
 }
 
 /// Models a Stock Photo
 ///
 final class StockPhotosMedia: NSObject {
-    let id: Int
-    let guid: String
-    let URL: URL
-    let title: String
-    let name: String
-    let size: CGSize
-    let thumbnails: ThumbnailCollection
+    private(set) var id: String
+    private(set) var URL: URL
+    private(set) var title: String
+    private(set) var name: String
+    private(set) var size: CGSize
+    private(set) var thumbnails: ThumbnailCollection
 
-    init(id: Int, guid: String, URL: URL, title: String, name: String, size: CGSize, thumbnails: ThumbnailCollection) {
+    init(id: String, URL: URL, title: String, name: String, size: CGSize, thumbnails: ThumbnailCollection) {
         self.id = id
-        self.guid = guid
         self.URL = URL
         self.title = title
         self.name = name
@@ -65,8 +76,8 @@ extension StockPhotosMedia: WPMediaAsset {
             }
         }
 
-        let number = NSNumber(value: id)
-        return number.int32Value as WPMediaRequestID
+        let number = Int32(id)!
+        return number as WPMediaRequestID
     }
 
     func cancelImageRequest(_ requestID: WPMediaRequestID) {
@@ -90,7 +101,7 @@ extension StockPhotosMedia: WPMediaAsset {
     }
 
     func identifier() -> String {
-        return guid
+        return id
     }
 
     func date() -> Date {
@@ -99,5 +110,48 @@ extension StockPhotosMedia: WPMediaAsset {
 
     func pixelSize() -> CGSize {
         return size
+    }
+}
+
+extension ThumbnailCollection: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case large
+        case medium
+        case postThumbnail = "post-thumbnail"
+        case thumbnail
+    }
+
+    init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        largeURL = try values.decode(String.self, forKey: .large).asURL()
+        mediumURL = try values.decode(String.self, forKey: .medium).asURL()
+        postThumbnailURL = try values.decode(String.self, forKey: .large).asURL()
+        thumbnailURL = try values.decode(String.self, forKey: .large).asURL()
+    }
+}
+
+extension StockPhotosMedia: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case ID
+        case URL
+        case title
+        case name
+        case thumbnails
+    }
+
+    convenience init(from decoder: Decoder) throws {
+        let url = Foundation.URL(string: "http://elpais.com")!
+        self.init(id: "", URL: url, title: "", name: "", size: .zero, thumbnails: ThumbnailCollection())
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        id = try values.decode(String.self, forKey: .ID)
+        URL = try values.decode(String.self, forKey: .URL).asURL()
+        title = try values.decode(String.self, forKey: .title)
+        name = try values.decode(String.self, forKey: .name)
+        size = .zero
+
+        //let thumbnailsInfo = try values.nestedContainer(keyedBy: CodingKeys.self, forKey: .thumbnails)
+        thumbnails = try values.decode(ThumbnailCollection.self, forKey: .thumbnails)
+
+        //self.init(id: id, URL: URL, title: title, name: name, size: size, thumbnails: thumbnails)
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
@@ -11,11 +11,12 @@ final class StockPhotosPicker: NSObject {
     }()
 
     private lazy var stockPhotosService: StockPhotosService = {
-        guard let blog = self.blog else {
+        guard let api = self.blog?.wordPressComRestApi() else {
+            //TO DO. Present a user facing error (although in theory we shoul dnever reach this case if we limit Stock Photos to Jetpack blogs only
             return StockPhotosServiceMock()
         }
 
-        return DefaultStockPhotosService()
+        return DefaultStockPhotosService(api: api)
     }()
 
     weak var delegate: StockPhotosPickerDelegate?

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
@@ -7,7 +7,15 @@ protocol StockPhotosPickerDelegate: AnyObject {
 /// Presents the Stock Photos main interface
 final class StockPhotosPicker: NSObject {
     private lazy var dataSource: StockPhotosDataSource = {
-        return StockPhotosDataSource(service: StockPhotosServiceMock())
+        return StockPhotosDataSource(service: self.stockPhotosService)
+    }()
+
+    private lazy var stockPhotosService: StockPhotosService = {
+        guard let blog = self.blog else {
+            return StockPhotosServiceMock()
+        }
+
+        return DefaultStockPhotosService()
     }()
 
     weak var delegate: StockPhotosPickerDelegate?

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
@@ -9,7 +9,7 @@ final class StockPhotosPicker: NSObject {
     private let dataSource = StockPhotosDataSource(service: StockPhotosServiceMock())
     weak var delegate: StockPhotosPickerDelegate?
 
-    func presentPicker(origin: UIViewController) {
+    func presentPicker(origin: UIViewController, blog: Blog) {
         let options = WPMediaPickerOptions()
         options.showMostRecentFirst = true
         options.filter = [.all]

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
@@ -6,10 +6,15 @@ protocol StockPhotosPickerDelegate: AnyObject {
 
 /// Presents the Stock Photos main interface
 final class StockPhotosPicker: NSObject {
-    private let dataSource = StockPhotosDataSource(service: StockPhotosServiceMock())
+    private lazy var dataSource: StockPhotosDataSource = {
+        return StockPhotosDataSource(service: StockPhotosServiceMock())
+    }()
+
     weak var delegate: StockPhotosPickerDelegate?
+    private var blog: Blog?
 
     func presentPicker(origin: UIViewController, blog: Blog) {
+        self.blog = blog
         let options = WPMediaPickerOptions()
         options.showMostRecentFirst = true
         options.filter = [.all]

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -13,7 +13,6 @@ protocol StockPhotosService {
     func search(params: StockPhotosSearchParams, completion: @escaping ([StockPhotosMedia]) -> Void)
 }
 
-
 /// Default implementation of the Stock Photos Service, attacking a blog's restful api
 final class DefaultStockPhotosService: StockPhotosService {
     private let endPoint = "/rest/v1/meta/external-media/pexels"
@@ -36,9 +35,7 @@ final class DefaultStockPhotosService: StockPhotosService {
             print("//////// response! ====")
             // success
         }) { error, response in
-            // Fail!
-            print("========= failure! ==== ", error)
-            print("========= response! ==== ", response)
+            completion([])
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -21,6 +21,10 @@ final class DefaultStockPhotosService: StockPhotosService {
         static let search = "search"
     }
 
+    private struct ParsingKeys {
+        static let media = "media"
+    }
+
     private let api: WordPressComRestApi
 
     init(api: WordPressComRestApi) {
@@ -29,7 +33,7 @@ final class DefaultStockPhotosService: StockPhotosService {
 
     func search(params: StockPhotosSearchParams, completion: @escaping ([StockPhotosMedia]) -> Void) {
         api.GET(endPoint, parameters: parameters(params: params), success: { results, response in
-            if let media = results["media"] {
+            if let media = results[ParsingKeys.media] {
                 do {
                     let json = try JSONSerialization.data(withJSONObject: media)
                     let parsedResponse = try JSONDecoder().decode([StockPhotosMedia].self, from: json)

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -5,6 +5,12 @@ protocol StockPhotosService {
     func search(text: String, completion: @escaping ([StockPhotosMedia]) -> Void)
 }
 
+final class DefaultStockPhotosService: StockPhotosService {
+    func search(text: String, completion: @escaping ([StockPhotosMedia]) -> Void) {
+        StockPhotosServiceMock().search(text: text, completion: completion)
+    }
+}
+
 // MARK: - Temporary mock for testing
 
 final class StockPhotosServiceMock: StockPhotosService {

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -6,15 +6,32 @@ protocol StockPhotosService {
 }
 
 final class DefaultStockPhotosService: StockPhotosService {
+    private let endPoint = "/rest/v1/meta/external-media/pexels"
+
+    private struct Parameters {
+        static let search = "search"
+    }
+
     private let api: WordPressComRestApi
 
     init(api: WordPressComRestApi) {
-        print("=== initializing with API===")
         self.api = api
     }
 
     func search(text: String, completion: @escaping ([StockPhotosMedia]) -> Void) {
-        StockPhotosServiceMock().search(text: text, completion: completion)
+        api.GET(endPoint, parameters: parameters(text: text), success: { something, response in
+            print("========= success! ====")
+            // success
+        }) { error, response in
+            // Fail!
+            print("========= failure! ==== ", error)
+            print("========= response! ==== ", response)
+        }
+        //StockPhotosServiceMock().search(text: text, completion: completion)
+    }
+
+    private func parameters(text: String) -> [String: AnyObject] {
+        return [Parameters.search: text as! AnyObject]
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -6,6 +6,13 @@ protocol StockPhotosService {
 }
 
 final class DefaultStockPhotosService: StockPhotosService {
+    private let api: WordPressComRestApi
+
+    init(api: WordPressComRestApi) {
+        print("=== initializing with API===")
+        self.api = api
+    }
+
     func search(text: String, completion: @escaping ([StockPhotosMedia]) -> Void) {
         StockPhotosServiceMock().search(text: text, completion: completion)
     }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -55,14 +55,14 @@ final class StockPhotosServiceMock: StockPhotosService {
         }
         DispatchQueue.global().async {
             let totalMedia = text.count
-            let mediaResult = (1...totalMedia).map { self.crateStockPhotosMedia(id: $0 as Int) }
+            let mediaResult = (1...totalMedia).map { self.crateStockPhotosMedia(id: "\($0)") }
             DispatchQueue.main.async {
                 completion(mediaResult)
             }
         }
     }
 
-    private func crateStockPhotosMedia(id: Int) -> StockPhotosMedia {
+    private func crateStockPhotosMedia(id: String) -> StockPhotosMedia {
         let url = "https://images.pexels.com/photos/710916/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940".toURL()!
         let thumbs = ThumbnailCollection(
             largeURL: "https://images.pexels.com/photos/710916/pexels-photo-710916.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=650&w=940".toURL()!,
@@ -72,7 +72,6 @@ final class StockPhotosServiceMock: StockPhotosService {
         )
         return StockPhotosMedia(
             id: id,
-            guid: "\(id)",
             URL: url,
             title: "pexels-photo-710916.jpeg",
             name: "pexels-photo-710916.jpeg",

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -31,7 +31,7 @@ final class DefaultStockPhotosService: StockPhotosService {
     }
 
     private func parameters(text: String) -> [String: AnyObject] {
-        return [Parameters.search: text as! AnyObject]
+        return [Parameters.search: text as AnyObject]
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -1,14 +1,20 @@
 
 import Foundation
 
+
+/// Encapsulates search parameters (text, pagination, etc)
 struct StockPhotosSearchParams {
     let text: String
 }
 
+
+/// Abstracts the serive used to fetch Stock Photos
 protocol StockPhotosService {
     func search(params: StockPhotosSearchParams, completion: @escaping ([StockPhotosMedia]) -> Void)
 }
 
+
+/// Default implementation of the Stock Photos Service, attacking a blog's restful api
 final class DefaultStockPhotosService: StockPhotosService {
     private let endPoint = "/rest/v1/meta/external-media/pexels"
 
@@ -34,7 +40,6 @@ final class DefaultStockPhotosService: StockPhotosService {
             print("========= failure! ==== ", error)
             print("========= response! ==== ", response)
         }
-        //StockPhotosServiceMock().search(text: text, completion: completion)
     }
 
     private func parameters(params: StockPhotosSearchParams) -> [String: AnyObject] {

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -1,8 +1,12 @@
 
 import Foundation
 
+struct StockPhotosSearchParams {
+    let text: String
+}
+
 protocol StockPhotosService {
-    func search(text: String, completion: @escaping ([StockPhotosMedia]) -> Void)
+    func search(params: StockPhotosSearchParams, completion: @escaping ([StockPhotosMedia]) -> Void)
 }
 
 final class DefaultStockPhotosService: StockPhotosService {
@@ -18,8 +22,8 @@ final class DefaultStockPhotosService: StockPhotosService {
         self.api = api
     }
 
-    func search(text: String, completion: @escaping ([StockPhotosMedia]) -> Void) {
-        api.GET(endPoint, parameters: parameters(text: text), success: { results, response in
+    func search(params: StockPhotosSearchParams, completion: @escaping ([StockPhotosMedia]) -> Void) {
+        api.GET(endPoint, parameters: parameters(params: params), success: { results, response in
             print("========= success! ====")
             print("========= response! ====")
             print(results)
@@ -33,15 +37,16 @@ final class DefaultStockPhotosService: StockPhotosService {
         //StockPhotosServiceMock().search(text: text, completion: completion)
     }
 
-    private func parameters(text: String) -> [String: AnyObject] {
-        return [Parameters.search: text as AnyObject]
+    private func parameters(params: StockPhotosSearchParams) -> [String: AnyObject] {
+        return [Parameters.search: params.text as AnyObject]
     }
 }
 
 // MARK: - Temporary mock for testing
 
 final class StockPhotosServiceMock: StockPhotosService {
-    func search(text: String, completion: @escaping ([StockPhotosMedia]) -> Void) {
+    func search(params: StockPhotosSearchParams, completion: @escaping ([StockPhotosMedia]) -> Void) {
+        let text = params.text
         guard text.count > 0 else {
             completion([])
             return

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -29,11 +29,16 @@ final class DefaultStockPhotosService: StockPhotosService {
 
     func search(params: StockPhotosSearchParams, completion: @escaping ([StockPhotosMedia]) -> Void) {
         api.GET(endPoint, parameters: parameters(params: params), success: { results, response in
-            print("========= success! ====")
-            print("========= response! ====")
-            print(results)
-            print("//////// response! ====")
-            // success
+            if let media = results["media"] {
+                do {
+                    let json = try JSONSerialization.data(withJSONObject: media)
+                    let parsedResponse = try JSONDecoder().decode([StockPhotosMedia].self, from: json)
+
+                    completion(parsedResponse)
+                } catch {
+                    completion([])
+                }
+            }
         }) { error, response in
             completion([])
         }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -19,8 +19,11 @@ final class DefaultStockPhotosService: StockPhotosService {
     }
 
     func search(text: String, completion: @escaping ([StockPhotosMedia]) -> Void) {
-        api.GET(endPoint, parameters: parameters(text: text), success: { something, response in
+        api.GET(endPoint, parameters: parameters(text: text), success: { results, response in
             print("========= success! ====")
+            print("========= response! ====")
+            print(results)
+            print("//////// response! ====")
             // success
         }) { error, response in
             // Fail!

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosService.swift
@@ -1,13 +1,13 @@
 
 import Foundation
 
-protocol StockPhotosServiceProtocol {
+protocol StockPhotosService {
     func search(text: String, completion: @escaping ([StockPhotosMedia]) -> Void)
 }
 
 // MARK: - Temporary mock for testing
 
-final class StockPhotosServiceMock: StockPhotosServiceProtocol {
+final class StockPhotosServiceMock: StockPhotosService {
     func search(text: String, completion: @escaping ([StockPhotosMedia]) -> Void) {
         guard text.count > 0 else {
             completion([])

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2119,7 +2119,9 @@ extension AztecPostViewController {
     private func showMore(from: FormatBarItem) {
         stopListeningToNotifications()
         rememberFirstResponder()
-        moreCoordinator.present(origin: self, view: from)
+
+        let moreCoordinatorContext = MoreCoordinatorContext(origin: self, view: view, blog: post.blog)
+        moreCoordinator.present(context: moreCoordinatorContext)
     }
 
     // MARK: - Present Toolbar related VC


### PR DESCRIPTION
This is a very first draft of an implementation of the Stock Photos Service.

Things I have assumed, and I am not sure I should have assumed 😊 
- Stock Photos are available only to jetpack blogs
- That means that the blog object contains a restful api client that I can use
- Therefore I use that client.

Things kind of seem to work, so here we are 😛 

Implements part of #8954 

I have made a few other changes:
- Renamed the service protocol
- Added an implementation of the StockPhotosService that attacks the remote API
- Touched the model objects a little bit to make them implement Decodable
- Added a couple of lightweight model objects to pass parameters around

Open questions and next steps:
- First, this might not be the best possible implementation, considering everything I have assumed.
- If stock photos are only available for jetpack blogs, we should touch `AztecMoreCoordinator` to bypass the alert for non-jetpack blogs and present directly Files.
- Are we going to paginate the queries to the api?
- Shall we consider adding an extra layer between `StockPhotosPicker` and `StockPhotosService` that implements some business logic, like decide when a new page of data needs to be loaded, or maybe even throttling the requests to the service?

To test:

1. Start a new post or edit an existing one
2. Tap the + button in the lower Format Bar.
3. Tap the ellipsis in the Format Bar
4. Select "Free Photos Library".
5. Search for your pizzas.

For jetpack blogs, this should happen:
![simulator screen shot - iphone 8 - 2018-03-29 at 16 10 10](https://user-images.githubusercontent.com/2722505/38077582-069e7f16-336c-11e8-82aa-3e8016bf2e64.png)
