### PR TITLE
MediaCoordinator: Use original posts when observing / reporting progress (develop)

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3070,7 +3070,7 @@ extension AztecPostViewController {
                 alertController.addActionWithTitle(MediaAttachmentActionSheet.stopUploadActionTitle,
                                                    style: .destructive,
                                                    handler: { (action) in
-                                                    self.mediaCoordinator.delete(media)
+                                                    self.mediaCoordinator.cancelUpload(of: media)
                 })
             }
         } else {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -348,7 +348,8 @@ class AztecPostViewController: UIViewController, PostEditor {
         didSet {
             removeObservers(fromPost: oldValue)
             addObservers(toPost: post)
-
+            unregisterMediaObserver()
+            registerMediaObserver()
             postEditorStateContext = createEditorStateContext(for: post)
             refreshInterface()
         }
@@ -515,8 +516,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         if isOpenedDirectlyForPhotoPost {
             presentMediaPickerFullScreen(animated: false)
         }
-
-        registerMediaObserver()
     }
 
 


### PR DESCRIPTION
This PR pulls the changes from #8986 into `develop`.

**To test:**

* Check all the right changes have been pulled over.
* Same as the original PR:
* Open the editor, enter a title / text
* From the ... menu choose Save as Draft
* Add some images to the post, and check the actual images appear in the post (not placeholders) and that their progress is reported