### PR TITLE
Jetpack setup/login: Removed ScrollView, corrected layout for orientations.

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
@@ -24,7 +24,6 @@ class JetpackLoginViewController: UIViewController {
 
     @IBOutlet fileprivate weak var jetpackImage: UIImageView!
     @IBOutlet fileprivate weak var descriptionLabel: UILabel!
-    @IBOutlet fileprivate weak var scrollView: UIScrollView!
     @IBOutlet fileprivate weak var signinButton: WPNUXMainButton!
     @IBOutlet fileprivate weak var installJetpackButton: WPNUXMainButton!
 

--- a/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.xib
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="ipad9_7" orientation="landscape">
+    <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -14,72 +14,63 @@
                 <outlet property="descriptionLabel" destination="5EX-8b-0NL" id="D6j-Vu-Grr"/>
                 <outlet property="installJetpackButton" destination="Qm1-Pi-98R" id="nNU-KI-fYA"/>
                 <outlet property="jetpackImage" destination="GNi-Lj-sLf" id="OLq-eC-Ez8"/>
-                <outlet property="scrollView" destination="BSZ-Dy-TNX" id="GHi-Th-IDj"/>
                 <outlet property="signinButton" destination="lMy-o2-gd3" id="9I4-sr-k0G"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view autoresizesSubviews="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <scrollView multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" bounces="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BSZ-Dy-TNX">
-                    <rect key="frame" x="0.0" y="0.0" width="1024" height="768"/>
+                <stackView autoresizesSubviews="NO" opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="wZ5-Fs-qlA">
+                    <rect key="frame" x="57" y="185" width="300" height="365"/>
                     <subviews>
-                        <stackView autoresizesSubviews="NO" opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="wZ5-Fs-qlA">
-                            <rect key="frame" x="361.5" y="201" width="300" height="365"/>
-                            <subviews>
-                                <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="wp-illustration-stats" translatesAutoresizingMaskIntoConstraints="NO" id="GNi-Lj-sLf">
-                                    <rect key="frame" x="0.0" y="0.0" width="300" height="179"/>
-                                </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Looks like you have Jetpack set up on your site." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5EX-8b-0NL">
-                                    <rect key="frame" x="0.0" y="209" width="300" height="36"/>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lMy-o2-gd3" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="275" width="300" height="30"/>
-                                    <state key="normal" title="Log in"/>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                    </userDefinedRuntimeAttributes>
-                                    <connections>
-                                        <action selector="didTouchSignInButton:" destination="-1" eventType="touchUpInside" id="4XZ-kZ-sw4"/>
-                                    </connections>
-                                </button>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qm1-Pi-98R" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="335" width="300" height="30"/>
-                                    <state key="normal" title="Set up Jetpack"/>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                    </userDefinedRuntimeAttributes>
-                                    <connections>
-                                        <action selector="didTouchInstallJetpackButton:" destination="-1" eventType="touchUpInside" id="jig-Gw-45O"/>
-                                    </connections>
-                                </button>
-                            </subviews>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="300" id="Gku-Cz-guL"/>
-                            </constraints>
-                        </stackView>
+                        <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="wp-illustration-stats" translatesAutoresizingMaskIntoConstraints="NO" id="GNi-Lj-sLf">
+                            <rect key="frame" x="0.0" y="0.0" width="300" height="179"/>
+                        </imageView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Looks like you have Jetpack set up on your site." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5EX-8b-0NL">
+                            <rect key="frame" x="0.0" y="209" width="300" height="36"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lMy-o2-gd3" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="275" width="300" height="30"/>
+                            <state key="normal" title="Log in"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                            </userDefinedRuntimeAttributes>
+                            <connections>
+                                <action selector="didTouchSignInButton:" destination="-1" eventType="touchUpInside" id="4XZ-kZ-sw4"/>
+                            </connections>
+                        </button>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qm1-Pi-98R" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="335" width="300" height="30"/>
+                            <state key="normal" title="Set up Jetpack"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                            </userDefinedRuntimeAttributes>
+                            <connections>
+                                <action selector="didTouchInstallJetpackButton:" destination="-1" eventType="touchUpInside" id="jig-Gw-45O"/>
+                            </connections>
+                        </button>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="wZ5-Fs-qlA" firstAttribute="centerY" secondItem="BSZ-Dy-TNX" secondAttribute="centerY" id="5oL-bf-Gwx"/>
-                        <constraint firstAttribute="bottom" secondItem="wZ5-Fs-qlA" secondAttribute="bottom" constant="59" id="7Ei-oc-fY5"/>
-                        <constraint firstItem="wZ5-Fs-qlA" firstAttribute="centerX" secondItem="BSZ-Dy-TNX" secondAttribute="centerX" id="HMu-Jj-Vos"/>
-                        <constraint firstAttribute="trailing" secondItem="wZ5-Fs-qlA" secondAttribute="trailing" constant="184" id="WOE-e7-1Th"/>
+                        <constraint firstAttribute="width" constant="300" id="Gku-Cz-guL"/>
                     </constraints>
-                </scrollView>
+                    <variation key="heightClass=compact" spacing="10"/>
+                </stackView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="BSZ-Dy-TNX" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="648-rM-vJ1"/>
-                <constraint firstAttribute="bottom" secondItem="BSZ-Dy-TNX" secondAttribute="bottom" id="O5r-Py-9gh"/>
-                <constraint firstAttribute="trailing" secondItem="BSZ-Dy-TNX" secondAttribute="trailing" id="jqi-JB-UTa"/>
-                <constraint firstItem="BSZ-Dy-TNX" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="mO0-Fz-rbn"/>
+                <constraint firstAttribute="trailing" secondItem="wZ5-Fs-qlA" secondAttribute="trailing" constant="57" id="0Js-9m-Blr"/>
+                <constraint firstItem="wZ5-Fs-qlA" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="57" id="Dxb-er-ZaS"/>
+                <constraint firstItem="wZ5-Fs-qlA" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="L7X-Kp-l86"/>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="wZ5-Fs-qlA" secondAttribute="bottom" constant="10" id="QJ4-zJ-Y1h"/>
+                <constraint firstItem="wZ5-Fs-qlA" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="uM1-5X-YF1"/>
+                <constraint firstItem="wZ5-Fs-qlA" firstAttribute="top" relation="greaterThanOrEqual" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="10" id="xL7-0Z-D7p"/>
             </constraints>
             <point key="canvasLocation" x="-1606.5" y="-689.5"/>
         </view>


### PR DESCRIPTION
Fixes #8948 

To test:
- Sign into self-hosted site with and without a Jetpack site.
- Verify the setup/login view does not scroll.
- Verify the view renders correctly in portrait and landscape (this was unrelated to the scrolling, but it was overflowing in landscape.)

