### PR TITLE
Reload table after category added.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.m
@@ -327,6 +327,8 @@ static const CGFloat CategoryCellIndentation = 16.0;
             [self.delegate postCategoriesViewController:self didUpdateSelectedCategories:[NSSet setWithArray:self.selectedCategories]];
         }
     }
+
+    [self reloadCategoriesTableViewData];
 }
 
 @end


### PR DESCRIPTION
Fixes #7232, #5905
To test:

On an iPad:
- Go to Site Settings > Default Category.
  - Add a new Category. Save.
  - Verify the new Category appears in the list.
- Edit a blog post.
  - Go to Post Settings > Categories.
  - Add a new Category. Save.
  - Verify the new Category appears in the list.

@frosty , @koke  - if either of you have a moment for a review I'd appreciate it!
