### PR TITLE
Async Posting: Show 100% progress while a post is uploading

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -112,8 +112,13 @@ class PostCardStatusViewModel: NSObject {
         return !(MediaCoordinator.shared.isUploadingMedia(for: post) || post.remoteStatus == .pushing)
     }
 
+    @objc
     var progress: Double {
-        return MediaCoordinator.shared.totalProgress(for: post)
+        if post.remoteStatus == .pushing {
+            return 1.0
+        } else {
+            return MediaCoordinator.shared.totalProgress(for: post)
+        }
     }
 
     @objc

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -401,6 +401,8 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
         self.progressView.hidden = shouldHide;
     }
 
+    self.progressView.progress = self.viewModel.progress;
+
     if (!shouldHide && !self.viewModel.progressBlock) {
         __weak __typeof(self) weakSelf = self;
         self.viewModel.progressBlock = ^(double progress){


### PR DESCRIPTION
This PR updates post cells to show 100% progress while the final part of the upload process (uploading the post itself) is happening. Previously it was showing 0%.

![img_3084dcd4e61d-1](https://user-images.githubusercontent.com/4780/38144208-bac30438-343b-11e8-95de-3858e89fd648.jpeg)

**To test:**

* Upload a post with images, using async
* After the images complete, check the cell progress bar continues to show 100%

