### PR TITLE
Jetpack signup: add signup button

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -491,7 +491,7 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
 
 - (void)showWelcomeScreenAnimated:(BOOL)animated thenEditor:(BOOL)thenEditor
 {
-    [WordPressAuthenticator showLoginFromPresenter:self.window.rootViewController animated:animated thenEditor:thenEditor];
+    [WordPressAuthenticator showLoginFromPresenter:self.window.rootViewController animated:animated];
 }
 
 - (void)customizeAppearance

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -447,7 +447,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         let controller = UIAlertController.init(title: nil, message: nil, preferredStyle: .actionSheet)
 
         if FeatureFlag.socialSignup.enabled {
-            WordPressAuthenticator.showLoginFromPresenter(self, animated: true, thenEditor: false, showCancel: true)
+            WordPressAuthenticator.showLogin(from: self, animated: true, showCancel: true)
         } else {
             controller.addActionWithTitle(NSLocalizedString("Log In",
                                                             comment: "Button title.  Tapping takes the user to the login form."),

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -447,7 +447,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         let controller = UIAlertController.init(title: nil, message: nil, preferredStyle: .actionSheet)
 
         if FeatureFlag.socialSignup.enabled {
-            WordPressAuthenticator.showLogin(from: self, animated: true, showCancel: true)
+            WordPressAuthenticator.showLogin(from: self, animated: true, showCancel: true, restrictToWPCom: true)
         } else {
             controller.addActionWithTitle(NSLocalizedString("Log In",
                                                             comment: "Button title.  Tapping takes the user to the login form."),

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -22,13 +22,6 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     var didFindSafariSharedCredentials = false
     var didRequestSafariSharedCredentials = false
     fileprivate var awaitingGoogle = false
-    override var restrictToWPCom: Bool {
-        didSet {
-            if isViewLoaded {
-                configureForWPComOnlyIfNeeded()
-            }
-        }
-    }
 
     private struct Constants {
         static let alternativeLogInAnimationDuration: TimeInterval = 0.33
@@ -46,7 +39,6 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         setupOnePasswordButtonIfNeeded()
         addGoogleButton()
         addSelfHostedLogInButton()
-        configureForWPComOnlyIfNeeded()
     }
 
     override func didChangePreferredContentSize() {
@@ -67,6 +59,7 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         configureEmailField()
         configureSubmitButton()
         configureViewForEditingIfNeeded()
+        configureForWPComOnlyIfNeeded()
     }
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -10,9 +10,13 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     @IBOutlet var inputStack: UIStackView?
     @IBOutlet var alternativeLoginLabel: UILabel?
 
-    var onePasswordButton: UIButton!
+    //var onePasswordButton: UIButton!
     var googleLoginButton: UIButton?
     var selfHostedLoginButton: UIButton?
+
+    // This signup button isn't for the main flow; it's only shown during Jetpack installation
+    var wpcomSignupButton: UIButton?
+
     override var sourceTag: WordPressSupportSourceTag {
         get {
             return .loginEmail
@@ -39,6 +43,7 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
         setupOnePasswordButtonIfNeeded()
         addGoogleButton()
         addSelfHostedLogInButton()
+        addSignupButton()
     }
 
     override func didChangePreferredContentSize() {
@@ -85,11 +90,9 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     ///
     func configureForWPComOnlyIfNeeded() {
         if restrictToWPCom {
-            selfHostedLoginButton?.isEnabled = false
-            selfHostedLoginButton?.alpha = 0.0
+            selfHostedLoginButton?.isHidden = true
         } else {
-            selfHostedLoginButton?.isEnabled = true
-            selfHostedLoginButton?.alpha = 1.0
+            selfHostedLoginButton?.isHidden = false
         }
     }
 
@@ -180,6 +183,31 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
             ])
 
         selfHostedLoginButton = button
+    }
+
+    /// Add the sign up button
+    ///
+    /// Note: This is only used during Jetpack setup, not the normal flows
+    ///
+    func addSignupButton() {
+        guard let instructionLabel = instructionLabel,
+            let stackView = inputStack else {
+                return
+        }
+
+        let button = WPStyleGuide.wpcomSignupButton()
+        stackView.addArrangedSubview(button)
+        //button.addTarget(self, action: #selector(handleSelfHostedButtonTapped), for: .touchUpInside)
+        button.on(.touchUpInside) { (button) in
+            // pass
+        }
+
+        stackView.addConstraints([
+            button.leadingAnchor.constraint(equalTo: instructionLabel.leadingAnchor),
+            button.trailingAnchor.constraint(equalTo: instructionLabel.trailingAnchor),
+            ])
+
+        wpcomSignupButton = button
     }
 
     /// Configures the email text field, updating its text based on what's stored

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -89,10 +89,15 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     /// Hides the self-hosted login option.
     ///
     func configureForWPComOnlyIfNeeded() {
-        if restrictToWPCom {
+        if loginFields.meta.jetpackLogin {
             selfHostedLoginButton?.isHidden = true
+            wpcomSignupButton?.isHidden = false
+        } else if restrictToWPCom {
+            selfHostedLoginButton?.isHidden = true
+            wpcomSignupButton?.isHidden = true
         } else {
             selfHostedLoginButton?.isHidden = false
+            wpcomSignupButton?.isHidden = true
         }
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginPrologueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginPrologueViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Lottie
 
-class LoginPrologueViewController: UIViewController, UIViewControllerTransitioningDelegate {
+class LoginPrologueViewController: LoginViewController {
 
     private var buttonViewController: NUXButtonViewController?
 
@@ -106,7 +106,7 @@ class LoginPrologueViewController: UIViewController, UIViewControllerTransitioni
         }
     }
 
-    func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+    override func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
         if presented is LoginPrologueSignupMethodViewController {
             return FancyAlertPresentationController(presentedViewController: presented, presenting: presenting)
         }

--- a/WordPress/Classes/ViewRelated/NUX/WPStyleGuide+Login.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WPStyleGuide+Login.swift
@@ -93,7 +93,26 @@ extension WPStyleGuide {
         return UIFont.systemFont(ofSize: maxAllowedFontSize, weight: .medium)
     }
 
-    // MARK: - Google Signin Button Methods
+    /// Creates a attributed string with one underlined section that's surrounded by underscores
+    /// Such as "this _is_ underlined" would under the "is"
+    ///
+    class func underline(formattedString baseString: String, color: UIColor? = nil, underlineColor: UIColor? = nil) -> NSAttributedString {
+        let labelParts = baseString.components(separatedBy: "_")
+        let firstPart = labelParts[0]
+        let underlinePart = labelParts.indices.contains(1) ? labelParts[1] : ""
+        let lastPart = labelParts.indices.contains(2) ? labelParts[2] : ""
+
+        let foregroundColor = color ?? UIColor.black
+        let underlineForegroundColor = underlineColor ?? foregroundColor
+
+        let underlinedString = NSMutableAttributedString(string: firstPart, attributes: [.foregroundColor: foregroundColor])
+        underlinedString.append(NSAttributedString(string: underlinePart, attributes: [.underlineStyle: NSUnderlineStyle.styleSingle.rawValue, .foregroundColor: underlineForegroundColor]))
+        underlinedString.append(NSAttributedString(string: lastPart, attributes: [.foregroundColor: foregroundColor]))
+
+        return underlinedString
+    }
+
+    // MARK: - Login Button Methods
 
     /// Creates a button for Google Sign-in
     ///
@@ -125,6 +144,21 @@ extension WPStyleGuide {
         return textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font)
     }
 
+    /// Creates a button for wpcom signup on the email screen
+    ///
+    /// - Returns: A UIButton styled for wpcom signup
+    /// - Note: This button is only used during Jetpack setup, not the usual flows
+    ///
+    class func wpcomSignupButton() -> UIButton {
+        let baseString = NSLocalizedString("Don't have an account? _Sign up_", comment: "Label for button to log in using your site address.")
+        let attrStrNormal = underline(formattedString: baseString, color: WPStyleGuide.greyDarken20(), underlineColor: WPStyleGuide.wordPressBlue())
+        let attrStrHighlight = underline(formattedString: baseString, color: WPStyleGuide.greyDarken20(), underlineColor: WPStyleGuide.lightBlue())
+
+        let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
+
+        return textButton(normal: attrStrNormal, highlighted: attrStrHighlight, font: font)
+    }
+
     /// Creates a button to open our T&C
     ///
     /// - Returns: A properly styled UIButton
@@ -132,14 +166,7 @@ extension WPStyleGuide {
     class func termsButton() -> UIButton {
         let baseString =  NSLocalizedString("By signing up, you agree to our _Terms of Service_.", comment: "Legal disclaimer for signup buttons, the underscores _..._ denote underline")
 
-        let labelParts = baseString.components(separatedBy: "_")
-        let firstPart = labelParts[0]
-        let underlinePart = labelParts.indices.contains(1) ? labelParts[1] : ""
-        let lastPart = labelParts.indices.contains(2) ? labelParts[2] : ""
-
-        let labelString = NSMutableAttributedString(string: firstPart)
-        labelString.append(NSAttributedString(string: underlinePart, attributes: [.underlineStyle: NSUnderlineStyle.styleSingle.rawValue]))
-        labelString.append(NSAttributedString(string: lastPart))
+        let labelString = underline(formattedString: baseString)
 
         let font = WPStyleGuide.mediumWeightFont(forStyle: .caption2)
         return textButton(normal: labelString, highlighted: labelString, font: font, alignment: .center)

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
@@ -92,7 +92,7 @@ public protocol WordPressAuthenticatorDelegate: class {
         let storyboard = UIStoryboard(name: "Login", bundle: nil)
         if let controller = storyboard.instantiateInitialViewController() {
             if let childController = controller.childViewControllers.first as? LoginPrologueViewController {
-                childController.restrictToWPCom = true
+                childController.restrictToWPCom = restrictToWPCom
                 childController.showCancel = showCancel
             }
             presenter.present(controller, animated: animated, completion: nil)

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
@@ -80,11 +80,11 @@ public protocol WordPressAuthenticatorDelegate: class {
     // MARK: - Helpers for presenting the login flow
 
     /// Used to present the new login flow from the app delegate
-    @objc class func showLoginFromPresenter(_ presenter: UIViewController, animated: Bool, thenEditor: Bool) {
-        showLoginFromPresenter(presenter, animated: animated, thenEditor: thenEditor, showCancel: false)
+    @objc class func showLoginFromPresenter(_ presenter: UIViewController, animated: Bool) {
+        showLogin(from: presenter, animated: animated)
     }
 
-    class func showLoginFromPresenter(_ presenter: UIViewController, animated: Bool, thenEditor: Bool, showCancel: Bool) {
+    class func showLogin(from presenter: UIViewController, animated: Bool, showCancel: Bool = false, restrictToWPCom: Bool = false) {
         defer {
             trackOpenedLogin()
         }
@@ -92,6 +92,7 @@ public protocol WordPressAuthenticatorDelegate: class {
         let storyboard = UIStoryboard(name: "Login", bundle: nil)
         if let controller = storyboard.instantiateInitialViewController() {
             if let childController = controller.childViewControllers.first as? LoginPrologueViewController {
+                childController.restrictToWPCom = true
                 childController.showCancel = showCancel
             }
             presenter.present(controller, animated: animated, completion: nil)


### PR DESCRIPTION
Fixes #9010
Refs #8949

This adds the `sign up` button that will allow the user to signup for a wpcom account while setting up jetpack on a self-hosted site.

To test:
- with a self-hosted site that does not have jetpack, ensure the email entry screen now has a button for signing up
- with a self-hosted site that has jetpack setup but is not configured for the app, also ensure it now has a signup button
- with only a self-hosted site in the app, ensure that tapping 'log in' from the me tab doesn't show the signup button NOR the "site address" button _on the email screen_



