### PR TITLE
Adding device locale to signup email request.

### DIFF
--- a/WordPressKit/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/WordPressKit/AccountServiceRemoteREST.m
@@ -243,6 +243,7 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
                                                                                   @"email": email,
                                                                                   @"client_id": clientID,
                                                                                   @"client_secret": clientSecret,
+                                                                                  @"locale": [[WordPressComLanguageDatabase new] deviceLanguageSlug],
                                                                                   }];
     if (![@"wordpress" isEqualToString:scheme]) {
         [params setObject:scheme forKey:@"scheme"];


### PR DESCRIPTION
Ref #8109

To test:
- Change device language to something other than English.
- Create a new WP account.
- Verify the Reader shows in the correct language.

@elibud , @nheagy - could one of you look at this please?