### PR TITLE
Avoid to create an alert controller when presenting LoginPrologueViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -444,11 +444,12 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
     /// into a self-hosted site the ability to create a WordPress.com account.
     ///
     fileprivate func promptForLoginOrSignup() {
-        let controller = UIAlertController.init(title: nil, message: nil, preferredStyle: .actionSheet)
 
         if FeatureFlag.socialSignup.enabled {
             WordPressAuthenticator.showLoginFromPresenter(self, animated: true, thenEditor: false, showCancel: true)
         } else {
+            let controller = UIAlertController.init(title: nil, message: nil, preferredStyle: .actionSheet)
+
             controller.addActionWithTitle(NSLocalizedString("Log In",
                                                             comment: "Button title.  Tapping takes the user to the login form."),
                                           style: .default,
@@ -464,17 +465,17 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
                                             let navController = NUXNavigationController(rootViewController: controller)
                                             self.present(navController, animated: true, completion: nil)
                                           })
-        }
 
-        controller.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Cancel"))
-        controller.modalPresentationStyle = .popover
-        present(controller, animated: true, completion: nil)
+            controller.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Cancel"))
+            controller.modalPresentationStyle = .popover
+            present(controller, animated: true, completion: nil)
 
-        if let presentationController = controller.popoverPresentationController,
-            let cell = tableView.visibleCells.last {
-            presentationController.permittedArrowDirections = .any
-            presentationController.sourceView = cell
-            presentationController.sourceRect = cell.bounds
+            if let presentationController = controller.popoverPresentationController,
+                let cell = tableView.visibleCells.last {
+                presentationController.permittedArrowDirections = .any
+                presentationController.sourceView = cell
+                presentationController.sourceRect = cell.bounds
+            }
         }
     }
 }


### PR DESCRIPTION
This PR prevents the creation of the old `UIAlertController` to show login/signup options when the feature flag `socialSignup` is `true`.

Fixes #9007

![fix_](https://user-images.githubusercontent.com/9772967/38209494-f04a6e74-368a-11e8-910e-7f3ad484812d.gif)


To test:
- Follow the steps in the gif.
