### PR TITLE
Xcode 9.3 support

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -55,7 +55,7 @@ target 'WordPress' do
   pod 'Gridicons', '0.15'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '0.27'
-  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'1b9e6398f054f8726cf40de9e9a2ace753804502'
+  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'fb2043c04a0c2868480f11797383acb8130636ae'
 
   target 'WordPressTest' do
     inherit! :search_paths
@@ -72,7 +72,7 @@ target 'WordPress' do
     shared_with_all_pods
     shared_with_networking_pods
 
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'1b9e6398f054f8726cf40de9e9a2ace753804502'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'fb2043c04a0c2868480f11797383acb8130636ae'
     pod 'Gridicons', '0.15'
   end
 
@@ -82,7 +82,7 @@ target 'WordPress' do
     shared_with_all_pods
     shared_with_networking_pods
 
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'1b9e6398f054f8726cf40de9e9a2ace753804502'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'fb2043c04a0c2868480f11797383acb8130636ae'
     pod 'Gridicons', '0.15'
   end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -145,7 +145,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.4)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `1b9e6398f054f8726cf40de9e9a2ace753804502`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `fb2043c04a0c2868480f11797383acb8130636ae`)
   - WPMediaPicker (= 0.27)
   - wpxmlrpc (= 0.8.3)
 
@@ -154,7 +154,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.2
   WordPress-Aztec-iOS:
-    :commit: 1b9e6398f054f8726cf40de9e9a2ace753804502
+    :commit: fb2043c04a0c2868480f11797383acb8130636ae
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 CHECKOUT OPTIONS:
@@ -162,7 +162,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.2
   WordPress-Aztec-iOS:
-    :commit: 1b9e6398f054f8726cf40de9e9a2ace753804502
+    :commit: fb2043c04a0c2868480f11797383acb8130636ae
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 SPEC CHECKSUMS:
@@ -196,10 +196,10 @@ SPEC CHECKSUMS:
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 2e99ee80c61ba9d5f5a38560043b273830f2c9d6
+  WordPress-Aztec-iOS: 7ff072186e0ab6093ac9a494f5d1c4f84b9128ca
   WPMediaPicker: 1fe532b4ff215a9dd259f08439376fc0dbab1039
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: ecec6a14bddbdd1bf7303d6f6b00af2a21f70404
+PODFILE CHECKSUM: 88b5ac56b7c8515eac2a11b950891d456ef51fc5
 
 COCOAPODS: 1.4.0

--- a/WordPress.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/WordPress.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -67,7 +67,7 @@ class Post: AbstractPost {
 
     fileprivate func buildContentPreview() {
         if let excerpt = mt_excerpt, excerpt.count > 0 {
-            storedContentPreviewForDisplay = String.makePlainText(excerpt)
+            storedContentPreviewForDisplay = NSString.makePlainText(excerpt)
         } else if let content = content {
             storedContentPreviewForDisplay = NSString.summary(fromContent: content)
         }


### PR DESCRIPTION
Includes fixes to our Aztec pod so that it'll work with Xcode 9.3.

Aztec PR is: `https://github.com/wordpress-mobile/AztecEditor-iOS/pull/928`