### PR TITLE
Specify Google Auth is not supported in dev builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In order to use these details, you'll need to create a credential file in your b
 
 Then edit the ~/.wpcom_app_credentials file and change the WPCOM_APP_ID and WPCOM_APP_SECRET fields to the values you got for your app.
 
-Then you can compile and run the app on a device or an emulator and login with a WordPress.com account.
+Then you can compile and run the app on a device or an emulator and log in with a WordPress.com account.  Note that authenticating to WordPress.com via Google is not supported in development builds of the app, only in the offical release.
 
 **Remember the only account you will be able to login in with is the one affiliated with your developer account.** 
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ In order to use these details, you'll need to create a credential file in your b
 
 Then edit the ~/.wpcom_app_credentials file and change the WPCOM_APP_ID and WPCOM_APP_SECRET fields to the values you got for your app.
 
-Then you can compile and run the app on a device or an emulator and log in with a WordPress.com account.  Note that authenticating to WordPress.com via Google is not supported in development builds of the app, only in the offical release.
+Then you can compile and run the app on a device or an emulator and log in with a WordPress.com account.  Note that authenticating to WordPress.com via Google is not supported in development builds of the app, only in the official release.
 
 **Remember the only account you will be able to login in with is the one affiliated with your developer account.** 
 


### PR DESCRIPTION
Updates the README noting that authenticating via Google is not supported in dev builds.
