### PR TITLE
Jetpack signup: show signup flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackConnectionWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackConnectionWebViewController.swift
@@ -285,7 +285,6 @@ private extension JetpackConnectionWebViewController {
 
     func stopObservingLoginNotifications() {
         NotificationCenter.default.removeObserver(self, name: .wordpressLoginFinishedJetpackLogin, object: nil)
-
     }
 
     @objc func handleLoginCancelled() {

--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -209,6 +209,14 @@
             </objects>
             <point key="canvasLocation" x="362" y="717"/>
         </scene>
+        <!--Signup Email Entry-->
+        <scene sceneID="gjg-iE-qSx">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Signup" referencedIdentifier="emailEntry" id="klu-4U-PyL" userLabel="Signup Email Entry" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="OWM-SL-SwW" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2125" y="46"/>
+        </scene>
         <!--Login Email View Controller-->
         <scene sceneID="w6Y-pB-a3f">
             <objects>
@@ -398,6 +406,7 @@
                         <segue destination="Mwz-tq-5A8" kind="custom" identifier="showEpilogue" customClass="EpilogueSegue" customModule="WordPress" customModuleProvider="target" id="gAE-di-Wyf"/>
                         <segue destination="bAd-Df-IzS" kind="show" identifier="show2FA" id="kRR-qz-Hu2"/>
                         <segue destination="anK-hg-K4j" kind="show" identifier="showSelfHostedLogin" id="bK1-J1-hfT"/>
+                        <segue destination="klu-4U-PyL" kind="show" identifier="showSignupEmail" id="dh4-9P-l8W"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wWl-qb-1Yp" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1618,8 +1627,8 @@
         <image name="icon-wp" width="50" height="52"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="7lv-19-h36"/>
-        <segue reference="qLI-qX-rkG"/>
+        <segue reference="gAE-di-Wyf"/>
+        <segue reference="kRR-qz-Hu2"/>
         <segue reference="ySQ-EM-6JI"/>
         <segue reference="1xT-tL-sp6"/>
         <segue reference="swV-lc-6gI"/>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -198,8 +198,8 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
 
         let button = WPStyleGuide.wpcomSignupButton()
         stackView.addArrangedSubview(button)
-        button.on(.touchUpInside) { (button) in
-            // pass
+        button.on(.touchUpInside) { [weak self] (button) in
+            self?.performSegue(withIdentifier: .showSignupEmail, sender: self)
         }
 
         stackView.addConstraints([

--- a/WordPress/Classes/ViewRelated/NUX/NUXViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/NUXViewController.swift
@@ -38,6 +38,7 @@ class NUXViewController: UIViewController, NUXViewControllerBase, UIViewControll
         case showSiteCreationEpilogue
         case showSiteCreationError
         case showSignupEpilogue
+        case showSignupEmail
         case showUsernames
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/Signup.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Signup.storyboard
@@ -40,16 +40,16 @@
                                 <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="19Z-ie-Qfz">
-                                        <rect key="frame" x="0.0" y="223.5" width="375" height="100"/>
+                                        <rect key="frame" x="0.0" y="221.5" width="375" height="102"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" verticalCompressionResistancePriority="1000" text="Log in to WordPress.com using an email address to manage all your WordPress sites." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CPF-7g-0y5">
-                                                <rect key="frame" x="20" y="0.0" width="335" height="36"/>
+                                                <rect key="frame" x="20" y="0.0" width="335" height="38"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Email address" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HTy-KJ-his" customClass="LoginTextField" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="56" width="375" height="44"/>
+                                                <rect key="frame" x="0.0" y="58" width="375" height="44"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="usernameField"/>
                                                 <constraints>
@@ -68,7 +68,7 @@
                                                 </connections>
                                             </textField>
                                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EYw-oM-W1K">
-                                                <rect key="frame" x="20" y="100" width="335" height="40"/>
+                                                <rect key="frame" x="20" y="102" width="335" height="40"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="40" placeholder="YES" id="li2-jI-jeL"/>
                                                 </constraints>


### PR DESCRIPTION
Fixes #8949 

With this second PR (first #9012) the login screen will offer the ability to sign up to a new account during the Jetpack setup flow. 

To test:
- ensure that the jetpack setup flow now allows for signing up to a new wpcom account

Review note:
This is a relatively simple change: the button opens the sign up flow. at the end, the notification for successful jetpack login fires and the process completes. Are their any implications I've missed?

cc: @elibud for your reference