### PR TITLE
Implement Stock Photos from Media Library + button

### DIFF
--- a/WordPress/Classes/Utility/Media/MediaExternalExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaExternalExporter.swift
@@ -34,7 +34,7 @@ class MediaExternalExporter: MediaExporter {
         asset = externalAsset
     }
 
-    /// Downloads and export de external media asset
+    /// Downloads and export the external media asset
     ///
     func export(onCompletion: @escaping OnMediaExport, onError: @escaping OnExportError) -> Progress {
         WPImageSource.shared().downloadImage(for: asset.URL, withSuccess: { (image) in

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMediaPickingCoordinator.swift
@@ -1,24 +1,18 @@
 import MobileCoreServices
 import WPMediaPicker
 
-struct MoreCoordinatorContext {
-    let origin: UIViewController & UIDocumentPickerDelegate
-    let view: UIView
-    let blog: Blog
-}
-
 /// Prepares the alert controller that will be presented when tapping the "more" button in Aztec's Format Bar
-final class AztecMoreCoordinator {
-    private weak var delegate: AztecMoreCoordinatorDelegate?
+final class AztecMediaPickingCoordinator {
+    private weak var delegate: MediaPickingOptionsDelegate?
 
     private let stockPhotos = StockPhotosPicker()
 
-    init(delegate: AztecMoreCoordinatorDelegate & StockPhotosPickerDelegate) {
+    init(delegate: MediaPickingOptionsDelegate & StockPhotosPickerDelegate) {
         self.delegate = delegate
         stockPhotos.delegate = delegate
     }
 
-    func present(context: MoreCoordinatorContext) {
+    func present(context: MediaPickingContext) {
         let origin = context.origin
         let blog = context.blog
         let fromView = context.view
@@ -50,7 +44,7 @@ final class AztecMoreCoordinator {
 
     private func cancelAction() -> UIAlertAction {
         return UIAlertAction(title: .cancelMoreOptions, style: .cancel, handler: { [weak self] action in
-            self?.delegate?.didCancel(coordinator: self)
+            self?.delegate?.didCancel()
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMoreCoordinatorDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMoreCoordinatorDelegate.swift
@@ -1,4 +1,0 @@
-/// Notifies its implementation of lifecycle events in AztecMoreCoordinator
-protocol AztecMoreCoordinatorDelegate: class {
-    func didCancel(coordinator: AztecMoreCoordinator?)
-}

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/MediaPickingContext.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/MediaPickingContext.swift
@@ -1,3 +1,4 @@
+/// Encapsulates context parameters to initiate a flow to pick media from several sources
 struct MediaPickingContext {
     let origin: UIViewController & UIDocumentPickerDelegate
     let view: UIView

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/MediaPickingContext.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/MediaPickingContext.swift
@@ -1,5 +1,13 @@
 struct MediaPickingContext {
     let origin: UIViewController & UIDocumentPickerDelegate
     let view: UIView
+    let barButtonItem: UIBarButtonItem?
     let blog: Blog
+
+    init(origin: UIViewController & UIDocumentPickerDelegate, view: UIView, barButtonItem: UIBarButtonItem? = nil, blog: Blog) {
+        self.origin = origin
+        self.view = view
+        self.barButtonItem = barButtonItem
+        self.blog = blog
+    }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/MediaPickingContext.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/MediaPickingContext.swift
@@ -1,0 +1,5 @@
+struct MediaPickingContext {
+    let origin: UIViewController & UIDocumentPickerDelegate
+    let view: UIView
+    let blog: Blog
+}

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/MediaPickingOptionsDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/MediaPickingOptionsDelegate.swift
@@ -1,0 +1,4 @@
+/// Notifies its implementation of lifecycle events in AztecMoreCoordinator
+protocol MediaPickingOptionsDelegate: class {
+    func didCancel()
+}

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -454,8 +454,8 @@ class AztecPostViewController: UIViewController, PostEditor {
 
 
     /// Presents whatever happens when FormatBar's more button is selected
-    fileprivate lazy var moreCoordinator: AztecMoreCoordinator = {
-        return AztecMoreCoordinator(delegate: self)
+    fileprivate lazy var moreCoordinator: AztecMediaPickingCoordinator = {
+        return AztecMediaPickingCoordinator(delegate: self)
     }()
 
 
@@ -2147,7 +2147,7 @@ extension AztecPostViewController {
         stopListeningToNotifications()
         rememberFirstResponder()
 
-        let moreCoordinatorContext = MoreCoordinatorContext(origin: self, view: view, blog: post.blog)
+        let moreCoordinatorContext = MediaPickingContext(origin: self, view: view, blog: post.blog)
         moreCoordinator.present(context: moreCoordinatorContext)
     }
 
@@ -3593,8 +3593,8 @@ extension AztecPostViewController: UIDocumentPickerDelegate {
     }
 }
 
-extension AztecPostViewController: AztecMoreCoordinatorDelegate {
-    func didCancel(coordinator: AztecMoreCoordinator?) {
+extension AztecPostViewController: MediaPickingOptionsDelegate {
+    func didCancel() {
         startListeningToNotifications()
         restoreFirstResponder()
     }

--- a/WordPress/Classes/ViewRelated/Media/CameraCaptureCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/CameraCaptureCoordinator.swift
@@ -1,0 +1,48 @@
+import MobileCoreServices
+
+final class CameraCaptureCoordinator {
+    private var capturePresenter: WPMediaCapturePresenter?
+
+    func presentMediaCapture(origin: UIViewController, blog: Blog) {
+        capturePresenter = WPMediaCapturePresenter(presenting: origin)
+        capturePresenter!.completionBlock = { [weak self] mediaInfo in
+            if let mediaInfo = mediaInfo as NSDictionary? {
+                self?.processMediaCaptured(mediaInfo, blog: blog)
+            }
+            self?.capturePresenter = nil
+        }
+
+        capturePresenter!.presentCapture()
+    }
+
+    private func processMediaCaptured(_ mediaInfo: NSDictionary, blog: Blog) {
+        let completionBlock: WPMediaAddedBlock = { media, error in
+            if error != nil || media == nil {
+                print("Adding media failed: ", error?.localizedDescription ?? "no media")
+                return
+            }
+            guard let media = media as? PHAsset else {
+                    return
+            }
+
+            let info = MediaAnalyticsInfo(origin: .mediaLibrary, selectionMethod: .fullScreenPicker)
+            MediaCoordinator.shared.addMedia(from: media, to: blog, analyticsInfo: info)
+        }
+
+        guard let mediaType = mediaInfo[UIImagePickerControllerMediaType] as? String else { return }
+
+        switch mediaType {
+        case String(kUTTypeImage):
+            if let image = mediaInfo[UIImagePickerControllerOriginalImage] as? UIImage,
+                let metadata = mediaInfo[UIImagePickerControllerMediaMetadata] as? [AnyHashable: Any] {
+                WPPHAssetDataSource().add(image, metadata: metadata, completionBlock: completionBlock)
+            }
+        case String(kUTTypeMovie):
+            if let mediaURL = mediaInfo[UIImagePickerControllerMediaURL] as? URL {
+                WPPHAssetDataSource().addVideo(from: mediaURL, completionBlock: completionBlock)
+            }
+        default:
+            break
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Media/CameraCaptureCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/CameraCaptureCoordinator.swift
@@ -1,5 +1,6 @@
 import MobileCoreServices
 
+/// Encapsulates capturing media from a device camera
 final class CameraCaptureCoordinator {
     private var capturePresenter: WPMediaCapturePresenter?
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -29,10 +29,7 @@ final class MediaLibraryMediaPickingCoordinator {
             menuAlert.addAction(cameraAction(origin: origin, blog: blog))
         }
 
-        menuAlert.addDefaultActionWithTitle(NSLocalizedString("Photo Library", comment: "Menu option for selecting media from the device's photo library.")) { [weak self] _ in
-            self?.showMediaPicker(origin: origin, blog: blog)
-        }
-
+        menuAlert.addAction(photoLibraryAction(origin: origin, blog: blog))
         menuAlert.addAction(freePhotoAction(origin: origin, blog: blog))
 
         if #available(iOS 11.0, *) {
@@ -52,6 +49,12 @@ final class MediaLibraryMediaPickingCoordinator {
                 return UIAlertAction(title: .takePhotoOrVideo, style: .default, handler: { [weak self] action in
                     self?.showCameraCapture(origin: origin, blog: blog)
                 })
+    }
+
+    private func photoLibraryAction(origin: UIViewController, blog: Blog) -> UIAlertAction {
+        return UIAlertAction(title: .importFromPhotoLibrary, style: .default, handler: { [weak self] action in
+            self?.showMediaPicker(origin: origin, blog: blog)
+        })
     }
 
     private func freePhotoAction(origin: UIViewController, blog: Blog) -> UIAlertAction {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -1,0 +1,80 @@
+import MobileCoreServices
+import WPMediaPicker
+
+final class MediaLibraryMediaPickingCoordinator {
+    private weak var delegate: MediaPickingOptionsDelegate?
+
+    private let stockPhotos = StockPhotosPicker()
+
+    init(delegate: MediaPickingOptionsDelegate & StockPhotosPickerDelegate) {
+        self.delegate = delegate
+        stockPhotos.delegate = delegate
+    }
+
+    func present(context: MediaPickingContext) {
+        let origin = context.origin
+        let blog = context.blog
+        let fromView = context.view
+
+        let menuAlert = UIAlertController(title: nil, message: nil, preferredStyle: UIAlertControllerStyle.actionSheet)
+
+        if let quotaUsageDescription = blog.quotaUsageDescription {
+            menuAlert.title = quotaUsageDescription
+        }
+
+        if WPMediaCapturePresenter.isCaptureAvailable() {
+            menuAlert.addDefaultActionWithTitle(NSLocalizedString("Take Photo or Video", comment: "Menu option for taking an image or video with the device's camera.")) { _ in
+                //self.presentMediaCapture()
+            }
+        }
+
+        menuAlert.addDefaultActionWithTitle(NSLocalizedString("Photo Library", comment: "Menu option for selecting media from the device's photo library.")) { _ in
+            //self.showMediaPicker()
+        }
+
+        if #available(iOS 11.0, *) {
+            menuAlert.addDefaultActionWithTitle(NSLocalizedString("Other Apps", comment: "Menu option used for adding media from other applications.")) { _ in
+                //self.showDocumentPicker()
+            }
+        }
+
+        menuAlert.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Cancel button"))
+
+        // iPad support
+//        menuAlert.popoverPresentationController?.sourceView = fromView
+//        menuAlert.popoverPresentationController?.barButtonItem = navigationItem.rightBarButtonItem
+
+        origin.present(menuAlert, animated: true, completion: nil)
+    }
+
+    private func freePhotoAction(origin: UIViewController, blog: Blog) -> UIAlertAction {
+        return UIAlertAction(title: .freePhotosLibrary, style: .default, handler: { [weak self] action in
+            self?.showStockPhotos(origin: origin, blog: blog)
+        })
+    }
+
+    private func otherAppsAction(origin: UIViewController & UIDocumentPickerDelegate) -> UIAlertAction {
+        return UIAlertAction(title: .files, style: .default, handler: { [weak self] action in
+            self?.showDocumentPicker(origin: origin)
+        })
+    }
+
+    private func cancelAction() -> UIAlertAction {
+        return UIAlertAction(title: .cancelMoreOptions, style: .cancel, handler: { [weak self] action in
+            self?.delegate?.didCancel()
+        })
+    }
+
+    private func showStockPhotos(origin: UIViewController, blog: Blog) {
+        stockPhotos.presentPicker(origin: origin, blog: blog)
+    }
+
+    private func showDocumentPicker(origin: UIViewController & UIDocumentPickerDelegate) {
+        let docTypes = [String(kUTTypeImage), String(kUTTypeMovie)]
+        let docPicker = UIDocumentPickerViewController(documentTypes: docTypes, in: .import)
+        docPicker.delegate = origin
+        WPStyleGuide.configureDocumentPickerNavBarAppearance()
+        origin.present(docPicker, animated: true, completion: nil)
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -6,10 +6,12 @@ final class MediaLibraryMediaPickingCoordinator {
 
     private let stockPhotos = StockPhotosPicker()
     private let cameraCapture = CameraCaptureCoordinator()
+    private let mediaLibrary = MediaLibraryPicker()
 
-    init(delegate: MediaPickingOptionsDelegate & StockPhotosPickerDelegate) {
+    init(delegate: MediaPickingOptionsDelegate & StockPhotosPickerDelegate & WPMediaPickerViewControllerDelegate) {
         self.delegate = delegate
         stockPhotos.delegate = delegate
+        mediaLibrary.delegate = delegate
     }
 
     func present(context: MediaPickingContext) {
@@ -28,7 +30,7 @@ final class MediaLibraryMediaPickingCoordinator {
         }
 
         menuAlert.addDefaultActionWithTitle(NSLocalizedString("Photo Library", comment: "Menu option for selecting media from the device's photo library.")) { [weak self] _ in
-            self?.showMediaPicker(origin: origin)
+            self?.showMediaPicker(origin: origin, blog: blog)
         }
 
         menuAlert.addAction(freePhotoAction(origin: origin, blog: blog))
@@ -86,16 +88,17 @@ final class MediaLibraryMediaPickingCoordinator {
         origin.present(docPicker, animated: true, completion: nil)
     }
 
-    private func showMediaPicker(origin: UIViewController & UIDocumentPickerDelegate) {
-        let options = WPMediaPickerOptions()
-        options.showMostRecentFirst = true
-        options.filter = [.all]
-        options.allowCaptureOfMedia = false
-
-        let picker = WPNavigationMediaPickerViewController(options: options)
-        picker.dataSource = WPPHAssetDataSource()
-        //picker.delegate = self
-
-        origin.present(picker, animated: true, completion: nil)
+    private func showMediaPicker(origin: UIViewController, blog: Blog) {
+//        let options = WPMediaPickerOptions()
+//        options.showMostRecentFirst = true
+//        options.filter = [.all]
+//        options.allowCaptureOfMedia = false
+//
+//        let picker = WPNavigationMediaPickerViewController(options: options)
+//        picker.dataSource = WPPHAssetDataSource()
+//        //picker.delegate = self
+//
+//        origin.present(picker, animated: true, completion: nil)
+        mediaLibrary.presentPicker(origin: origin, blog: blog)
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -18,6 +18,7 @@ final class MediaLibraryMediaPickingCoordinator {
         let origin = context.origin
         let blog = context.blog
         let fromView = context.view
+        let buttonItem = context.barButtonItem
 
         let menuAlert = UIAlertController(title: nil, message: nil, preferredStyle: UIAlertControllerStyle.actionSheet)
 
@@ -38,9 +39,8 @@ final class MediaLibraryMediaPickingCoordinator {
 
         menuAlert.addAction(cancelAction())
 
-        // iPad support
-//        menuAlert.popoverPresentationController?.sourceView = fromView
-//        menuAlert.popoverPresentationController?.barButtonItem = navigationItem.rightBarButtonItem
+        menuAlert.popoverPresentationController?.sourceView = fromView
+        menuAlert.popoverPresentationController?.barButtonItem = buttonItem
 
         origin.present(menuAlert, animated: true, completion: nil)
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -89,16 +89,6 @@ final class MediaLibraryMediaPickingCoordinator {
     }
 
     private func showMediaPicker(origin: UIViewController, blog: Blog) {
-//        let options = WPMediaPickerOptions()
-//        options.showMostRecentFirst = true
-//        options.filter = [.all]
-//        options.allowCaptureOfMedia = false
-//
-//        let picker = WPNavigationMediaPickerViewController(options: options)
-//        picker.dataSource = WPPHAssetDataSource()
-//        //picker.delegate = self
-//
-//        origin.present(picker, animated: true, completion: nil)
         mediaLibrary.presentPicker(origin: origin, blog: blog)
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -1,6 +1,7 @@
 import MobileCoreServices
 import WPMediaPicker
 
+/// Prepares the alert controller that will be presented when tapping the "+" button in Media Library
 final class MediaLibraryMediaPickingCoordinator {
     private weak var delegate: MediaPickingOptionsDelegate?
 
@@ -46,9 +47,9 @@ final class MediaLibraryMediaPickingCoordinator {
     }
 
     private func cameraAction(origin: UIViewController, blog: Blog) -> UIAlertAction {
-                return UIAlertAction(title: .takePhotoOrVideo, style: .default, handler: { [weak self] action in
-                    self?.showCameraCapture(origin: origin, blog: blog)
-                })
+        return UIAlertAction(title: .takePhotoOrVideo, style: .default, handler: { [weak self] action in
+            self?.showCameraCapture(origin: origin, blog: blog)
+        })
     }
 
     private func photoLibraryAction(origin: UIViewController, blog: Blog) -> UIAlertAction {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPicker.swift
@@ -1,0 +1,23 @@
+import WPMediaPicker
+
+final class MediaLibraryPicker: NSObject {
+    private let dataSource = WPPHAssetDataSource()
+
+    weak var delegate: WPMediaPickerViewControllerDelegate?
+    private var blog: Blog?
+
+    func presentPicker(origin: UIViewController, blog: Blog) {
+        self.blog = blog
+        let options = WPMediaPickerOptions()
+        options.showMostRecentFirst = true
+        options.filter = [.all]
+        options.allowCaptureOfMedia = false
+
+
+        let picker = WPNavigationMediaPickerViewController(options: options)
+        picker.dataSource = dataSource
+        picker.delegate = delegate
+
+        origin.present(picker, animated: true, completion: nil)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPicker.swift
@@ -1,5 +1,6 @@
 import WPMediaPicker
 
+/// Encapsulates launching and customization of a media picker to import media from the Photos Library
 final class MediaLibraryPicker: NSObject {
     private let dataSource = WPPHAssetDataSource()
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryStrings.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryStrings.swift
@@ -1,0 +1,5 @@
+extension String {
+    static var takePhotoOrVideo: String {
+        return NSLocalizedString("Take Photo or Video", comment: "Menu option for taking an image or video with the device's camera.")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryStrings.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryStrings.swift
@@ -2,4 +2,8 @@ extension String {
     static var takePhotoOrVideo: String {
         return NSLocalizedString("Take Photo or Video", comment: "Menu option for taking an image or video with the device's camera.")
     }
+
+    static var importFromPhotoLibrary: String {
+        return NSLocalizedString("Photo Library", comment: "Menu option for selecting media from the device's photo library.")
+    }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryStrings.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryStrings.swift
@@ -1,3 +1,4 @@
+// MARK: - Strings specific to media pickers launched from the Media Library
 extension String {
     static var takePhotoOrVideo: String {
         return NSLocalizedString("Take Photo or Video", comment: "Menu option for taking an image or video with the device's camera.")

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -244,18 +244,18 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         showOptionsMenu()
     }
 
-    private func showMediaPicker() {
-        let options = WPMediaPickerOptions()
-        options.showMostRecentFirst = true
-        options.filter = [.all]
-        options.allowCaptureOfMedia = false
-
-        let picker = WPNavigationMediaPickerViewController(options: options)
-        picker.dataSource = WPPHAssetDataSource()
-        picker.delegate = self
-
-        present(picker, animated: true, completion: nil)
-    }
+//    private func showMediaPicker() {
+//        let options = WPMediaPickerOptions()
+//        options.showMostRecentFirst = true
+//        options.filter = [.all]
+//        options.allowCaptureOfMedia = false
+//
+//        let picker = WPNavigationMediaPickerViewController(options: options)
+//        picker.dataSource = WPPHAssetDataSource()
+//        picker.delegate = self
+//
+//        present(picker, animated: true, completion: nil)
+//    }
 
     private func showOptionsMenu() {
         let pickingContext = MediaPickingContext(origin: self, view: view, blog: blog)
@@ -453,49 +453,49 @@ class MediaLibraryViewController: WPMediaPickerViewController {
 
     // MARK: - Upload Media from Camera
 
-    private func presentMediaCapture() {
-        capturePresenter = WPMediaCapturePresenter(presenting: self)
-        capturePresenter!.completionBlock = { [weak self] mediaInfo in
-            if let mediaInfo = mediaInfo as NSDictionary? {
-                self?.processMediaCaptured(mediaInfo)
-            }
-            self?.capturePresenter = nil
-        }
-
-        capturePresenter!.presentCapture()
-    }
-
-    private func processMediaCaptured(_ mediaInfo: NSDictionary) {
-        let completionBlock: WPMediaAddedBlock = { [weak self] media, error in
-            if error != nil || media == nil {
-                print("Adding media failed: ", error?.localizedDescription ?? "no media")
-                return
-            }
-            guard let blog = self?.blog,
-                let media = media as? PHAsset else {
-                return
-            }
-
-            let info = MediaAnalyticsInfo(origin: .mediaLibrary, selectionMethod: .fullScreenPicker)
-            MediaCoordinator.shared.addMedia(from: media, to: blog, analyticsInfo: info)
-        }
-
-        guard let mediaType = mediaInfo[UIImagePickerControllerMediaType] as? String else { return }
-
-        switch mediaType {
-        case String(kUTTypeImage):
-            if let image = mediaInfo[UIImagePickerControllerOriginalImage] as? UIImage,
-                let metadata = mediaInfo[UIImagePickerControllerMediaMetadata] as? [AnyHashable: Any] {
-                WPPHAssetDataSource().add(image, metadata: metadata, completionBlock: completionBlock)
-            }
-        case String(kUTTypeMovie):
-            if let mediaURL = mediaInfo[UIImagePickerControllerMediaURL] as? URL {
-                WPPHAssetDataSource().addVideo(from: mediaURL, completionBlock: completionBlock)
-            }
-        default:
-            break
-        }
-    }
+//    fileprivate func presentMediaCapture() {
+//        capturePresenter = WPMediaCapturePresenter(presenting: self)
+//        capturePresenter!.completionBlock = { [weak self] mediaInfo in
+//            if let mediaInfo = mediaInfo as NSDictionary? {
+//                self?.processMediaCaptured(mediaInfo)
+//            }
+//            self?.capturePresenter = nil
+//        }
+//
+//        capturePresenter!.presentCapture()
+//    }
+//
+//    private func processMediaCaptured(_ mediaInfo: NSDictionary) {
+//        let completionBlock: WPMediaAddedBlock = { [weak self] media, error in
+//            if error != nil || media == nil {
+//                print("Adding media failed: ", error?.localizedDescription ?? "no media")
+//                return
+//            }
+//            guard let blog = self?.blog,
+//                let media = media as? PHAsset else {
+//                return
+//            }
+//
+//            let info = MediaAnalyticsInfo(origin: .mediaLibrary, selectionMethod: .fullScreenPicker)
+//            MediaCoordinator.shared.addMedia(from: media, to: blog, analyticsInfo: info)
+//        }
+//
+//        guard let mediaType = mediaInfo[UIImagePickerControllerMediaType] as? String else { return }
+//
+//        switch mediaType {
+//        case String(kUTTypeImage):
+//            if let image = mediaInfo[UIImagePickerControllerOriginalImage] as? UIImage,
+//                let metadata = mediaInfo[UIImagePickerControllerMediaMetadata] as? [AnyHashable: Any] {
+//                WPPHAssetDataSource().add(image, metadata: metadata, completionBlock: completionBlock)
+//            }
+//        case String(kUTTypeMovie):
+//            if let mediaURL = mediaInfo[UIImagePickerControllerMediaURL] as? URL {
+//                WPPHAssetDataSource().addVideo(from: mediaURL, completionBlock: completionBlock)
+//            }
+//        default:
+//            break
+//        }
+//    }
 }
 
 // MARK: - UIDocumentPickerDelegate

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -451,16 +451,6 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         }
     }
 
-    // MARK: - Document Picker
-
-    private func showDocumentPicker() {
-        let docTypes = [String(kUTTypeImage), String(kUTTypeMovie)]
-        let docPicker = UIDocumentPickerViewController(documentTypes: docTypes, in: .import)
-        docPicker.delegate = self
-        WPStyleGuide.configureDocumentPickerNavBarAppearance()
-        present(docPicker, animated: true, completion: nil)
-    }
-
     // MARK: - Upload Media from Camera
 
     private func presentMediaCapture() {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -644,5 +644,7 @@ extension MediaLibraryViewController: StockPhotosPickerDelegate {
 //        assets.forEach {
 //            self.insert(exportableAsset: $0, source: .stockPhotos)
 //        }
+
+        print("assets received ", assets)
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -244,53 +244,9 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         showOptionsMenu()
     }
 
-//    private func showMediaPicker() {
-//        let options = WPMediaPickerOptions()
-//        options.showMostRecentFirst = true
-//        options.filter = [.all]
-//        options.allowCaptureOfMedia = false
-//
-//        let picker = WPNavigationMediaPickerViewController(options: options)
-//        picker.dataSource = WPPHAssetDataSource()
-//        picker.delegate = self
-//
-//        present(picker, animated: true, completion: nil)
-//    }
-
     private func showOptionsMenu() {
         let pickingContext = MediaPickingContext(origin: self, view: view, blog: blog)
         mediaPickingCoordinator.present(context: pickingContext)
-        /*
-        let menuAlert = UIAlertController(title: nil, message: nil, preferredStyle: UIAlertControllerStyle.actionSheet)
-
-        if let quotaUsageDescription = blog.quotaUsageDescription {
-            menuAlert.title = quotaUsageDescription
-        }
-
-        if WPMediaCapturePresenter.isCaptureAvailable() {
-            menuAlert.addDefaultActionWithTitle(NSLocalizedString("Take Photo or Video", comment: "Menu option for taking an image or video with the device's camera.")) { _ in
-                self.presentMediaCapture()
-            }
-        }
-
-        menuAlert.addDefaultActionWithTitle(NSLocalizedString("Photo Library", comment: "Menu option for selecting media from the device's photo library.")) { _ in
-            self.showMediaPicker()
-        }
-
-        if #available(iOS 11.0, *) {
-            menuAlert.addDefaultActionWithTitle(NSLocalizedString("Other Apps", comment: "Menu option used for adding media from other applications.")) { _ in
-                self.showDocumentPicker()
-            }
-        }
-
-        menuAlert.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Cancel button"))
-
-        // iPad support
-        menuAlert.popoverPresentationController?.sourceView = view
-        menuAlert.popoverPresentationController?.barButtonItem = navigationItem.rightBarButtonItem
-
-        present(menuAlert, animated: true, completion: nil)
-        */
     }
 
     @objc private func editTapped() {
@@ -450,52 +406,6 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             MediaCoordinator.shared.removeObserver(withUUID: uuid)
         }
     }
-
-    // MARK: - Upload Media from Camera
-
-//    fileprivate func presentMediaCapture() {
-//        capturePresenter = WPMediaCapturePresenter(presenting: self)
-//        capturePresenter!.completionBlock = { [weak self] mediaInfo in
-//            if let mediaInfo = mediaInfo as NSDictionary? {
-//                self?.processMediaCaptured(mediaInfo)
-//            }
-//            self?.capturePresenter = nil
-//        }
-//
-//        capturePresenter!.presentCapture()
-//    }
-//
-//    private func processMediaCaptured(_ mediaInfo: NSDictionary) {
-//        let completionBlock: WPMediaAddedBlock = { [weak self] media, error in
-//            if error != nil || media == nil {
-//                print("Adding media failed: ", error?.localizedDescription ?? "no media")
-//                return
-//            }
-//            guard let blog = self?.blog,
-//                let media = media as? PHAsset else {
-//                return
-//            }
-//
-//            let info = MediaAnalyticsInfo(origin: .mediaLibrary, selectionMethod: .fullScreenPicker)
-//            MediaCoordinator.shared.addMedia(from: media, to: blog, analyticsInfo: info)
-//        }
-//
-//        guard let mediaType = mediaInfo[UIImagePickerControllerMediaType] as? String else { return }
-//
-//        switch mediaType {
-//        case String(kUTTypeImage):
-//            if let image = mediaInfo[UIImagePickerControllerOriginalImage] as? UIImage,
-//                let metadata = mediaInfo[UIImagePickerControllerMediaMetadata] as? [AnyHashable: Any] {
-//                WPPHAssetDataSource().add(image, metadata: metadata, completionBlock: completionBlock)
-//            }
-//        case String(kUTTypeMovie):
-//            if let mediaURL = mediaInfo[UIImagePickerControllerMediaURL] as? URL {
-//                WPPHAssetDataSource().addVideo(from: mediaURL, completionBlock: completionBlock)
-//            }
-//        default:
-//            break
-//        }
-//    }
 }
 
 // MARK: - UIDocumentPickerDelegate
@@ -725,8 +635,7 @@ fileprivate extension Blog {
 
 extension MediaLibraryViewController: MediaPickingOptionsDelegate {
     func didCancel() {
-//        startListeningToNotifications()
-//        restoreFirstResponder()
+
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -645,11 +645,9 @@ extension MediaLibraryViewController: StockPhotosPickerDelegate {
             return
         }
 
-        //let info = MediaAnalyticsInfo(origin: .mediaLibrary, selectionMethod: .documentPicker)
         let mediaCoordinator = MediaCoordinator.shared
         assets.forEach {
             mediaCoordinator.addMedia(from: $0, to: blog)
-
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -28,7 +28,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
 
     fileprivate var uploadObserverUUID: UUID?
 
-    fileprivate lazy var optionsCoordinator: MediaLibraryMediaPickingCoordinator = {
+    fileprivate lazy var mediaPickingCoordinator: MediaLibraryMediaPickingCoordinator = {
         return MediaLibraryMediaPickingCoordinator(delegate: self)
     }()
 
@@ -258,6 +258,9 @@ class MediaLibraryViewController: WPMediaPickerViewController {
     }
 
     private func showOptionsMenu() {
+        let pickingContext = MediaPickingContext(origin: self, view: view, blog: blog)
+        mediaPickingCoordinator.present(context: pickingContext)
+        /*
         let menuAlert = UIAlertController(title: nil, message: nil, preferredStyle: UIAlertControllerStyle.actionSheet)
 
         if let quotaUsageDescription = blog.quotaUsageDescription {
@@ -287,6 +290,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         menuAlert.popoverPresentationController?.barButtonItem = navigationItem.rightBarButtonItem
 
         present(menuAlert, animated: true, completion: nil)
+        */
     }
 
     @objc private func editTapped() {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -245,7 +245,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
     }
 
     private func showOptionsMenu() {
-        let pickingContext = MediaPickingContext(origin: self, view: view, blog: blog)
+        let pickingContext = MediaPickingContext(origin: self, view: view, barButtonItem: navigationItem.rightBarButtonItem, blog: blog)
         mediaPickingCoordinator.present(context: pickingContext)
     }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -28,6 +28,10 @@ class MediaLibraryViewController: WPMediaPickerViewController {
 
     fileprivate var uploadObserverUUID: UUID?
 
+    fileprivate lazy var optionsCoordinator: MediaLibraryMediaPickingCoordinator = {
+        return MediaLibraryMediaPickingCoordinator(delegate: self)
+    }()
+
     // MARK: - Initializers
 
     @objc init(blog: Blog) {
@@ -722,5 +726,20 @@ fileprivate extension Blog {
     var userCanUploadMedia: Bool {
         // Self-hosted non-Jetpack blogs have no capabilities, so we'll just assume that users can post media
         return capabilities != nil ? isUploadingFilesAllowed() : true
+    }
+}
+
+extension MediaLibraryViewController: MediaPickingOptionsDelegate {
+    func didCancel() {
+//        startListeningToNotifications()
+//        restoreFirstResponder()
+    }
+}
+
+extension MediaLibraryViewController: StockPhotosPickerDelegate {
+    func stockPhotosPicker(_ picker: StockPhotosPicker, didFinishPicking assets: [StockPhotosMedia]) {
+//        assets.forEach {
+//            self.insert(exportableAsset: $0, source: .stockPhotos)
+//        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -641,12 +641,15 @@ extension MediaLibraryViewController: MediaPickingOptionsDelegate {
 
 extension MediaLibraryViewController: StockPhotosPickerDelegate {
     func stockPhotosPicker(_ picker: StockPhotosPicker, didFinishPicking assets: [StockPhotosMedia]) {
+        guard assets.count > 0 else {
+            return
+        }
+
+        //let info = MediaAnalyticsInfo(origin: .mediaLibrary, selectionMethod: .documentPicker)
+        let mediaCoordinator = MediaCoordinator.shared
         assets.forEach {
-            let _ = $0.image(with: .zero, completionHandler: { [weak self] image, error in
-                if let image = image {
-                    self?.pickerDataSource.add(image, metadata: nil, completionBlock: nil)
-                }
-            })
+            mediaCoordinator.addMedia(from: $0, to: blog)
+
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -641,10 +641,12 @@ extension MediaLibraryViewController: MediaPickingOptionsDelegate {
 
 extension MediaLibraryViewController: StockPhotosPickerDelegate {
     func stockPhotosPicker(_ picker: StockPhotosPicker, didFinishPicking assets: [StockPhotosMedia]) {
-//        assets.forEach {
-//            self.insert(exportableAsset: $0, source: .stockPhotos)
-//        }
-
-        print("assets received ", assets)
+        assets.forEach {
+            let _ = $0.image(with: .zero, completionHandler: { [weak self] image, error in
+                if let image = image {
+                    self?.pickerDataSource.add(image, metadata: nil, completionBlock: nil)
+                }
+            })
+        }
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -886,6 +886,7 @@
 		D80BC79E20746B4100614A59 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79D20746B4100614A59 /* MediaPickingContext.swift */; };
 		D80BC7A02074722000614A59 /* CameraCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79F2074722000614A59 /* CameraCaptureCoordinator.swift */; };
 		D80BC7A22074739400614A59 /* MediaLibraryStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC7A12074739300614A59 /* MediaLibraryStrings.swift */; };
+		D80BC7A4207487F200614A59 /* MediaLibraryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC7A3207487F200614A59 /* MediaLibraryPicker.swift */; };
 		D80EE63A203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */; };
 		D81322B32050F9110067714D /* NotificationName+Names.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81322B22050F9110067714D /* NotificationName+Names.swift */; };
 		D8A3A5AA2069E53900992576 /* AztecMediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5A92069E53900992576 /* AztecMediaPickingCoordinator.swift */; };
@@ -2430,6 +2431,7 @@
 		D80BC79D20746B4100614A59 /* MediaPickingContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
 		D80BC79F2074722000614A59 /* CameraCaptureCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraCaptureCoordinator.swift; sourceTree = "<group>"; };
 		D80BC7A12074739300614A59 /* MediaLibraryStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryStrings.swift; sourceTree = "<group>"; };
+		D80BC7A3207487F200614A59 /* MediaLibraryPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryPicker.swift; sourceTree = "<group>"; };
 		D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderFollowedSitesStreamHeaderTests.swift; sourceTree = "<group>"; };
 		D81322B22050F9110067714D /* NotificationName+Names.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+Names.swift"; sourceTree = "<group>"; };
 		D8A3A5A92069E53900992576 /* AztecMediaPickingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecMediaPickingCoordinator.swift; sourceTree = "<group>"; };
@@ -3866,6 +3868,7 @@
 				D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */,
 				D80BC79F2074722000614A59 /* CameraCaptureCoordinator.swift */,
 				D80BC7A12074739300614A59 /* MediaLibraryStrings.swift */,
+				D80BC7A3207487F200614A59 /* MediaLibraryPicker.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -7751,6 +7754,7 @@
 				5D42A3E0175E7452005CFF05 /* BasePost.m in Sources */,
 				5D000DE11AC0879600A7BAF9 /* PostCardActionBarItem.m in Sources */,
 				E1CB6DA3200F376400945457 /* TimeZoneStore.swift in Sources */,
+				D80BC7A4207487F200614A59 /* MediaLibraryPicker.swift in Sources */,
 				B50C0C511EF429E900372C65 /* HTMLAttachmentRenderer.swift in Sources */,
 				E663D1901C65383E0017F109 /* SharingAccountViewController.swift in Sources */,
 				93DEB88219E5BF7100F9546D /* TodayExtensionService.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -882,16 +882,18 @@
 		CEBD3EAB0FF1BA3B00C1396E /* Blog.m in Sources */ = {isa = PBXBuildFile; fileRef = CEBD3EAA0FF1BA3B00C1396E /* Blog.m */; };
 		D8071631203DA23700B32FD9 /* Accessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8071630203DA23700B32FD9 /* Accessible.swift */; };
 		D809E686203F0215001AA0DE /* ReaderPostCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */; };
+		D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */; };
+		D80BC79E20746B4100614A59 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79D20746B4100614A59 /* MediaPickingContext.swift */; };
 		D80EE63A203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */; };
 		D81322B32050F9110067714D /* NotificationName+Names.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81322B22050F9110067714D /* NotificationName+Names.swift */; };
-		D8A3A5AA2069E53900992576 /* AztecMoreCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5A92069E53900992576 /* AztecMoreCoordinator.swift */; };
+		D8A3A5AA2069E53900992576 /* AztecMediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5A92069E53900992576 /* AztecMediaPickingCoordinator.swift */; };
 		D8A3A5AC2069FE5B00992576 /* StockPhotosStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5AB2069FE5B00992576 /* StockPhotosStrings.swift */; };
 		D8A3A5AF206A442800992576 /* StockPhotosDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5AE206A442800992576 /* StockPhotosDataSource.swift */; };
 		D8A3A5B1206A49A100992576 /* StockPhotosMediaGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5B0206A49A100992576 /* StockPhotosMediaGroup.swift */; };
 		D8A3A5B3206A49BF00992576 /* StockPhotosMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5B2206A49BF00992576 /* StockPhotosMedia.swift */; };
 		D8A3A5B5206A4C7800992576 /* StockPhotosPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5B4206A4C7800992576 /* StockPhotosPicker.swift */; };
 		D8A3A5B7206A563900992576 /* StockPhotosPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5B6206A563900992576 /* StockPhotosPlaceholder.swift */; };
-		D8B43E70206B439F00DDAFAA /* AztecMoreCoordinatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B43E6F206B439F00DDAFAA /* AztecMoreCoordinatorDelegate.swift */; };
+		D8B43E70206B439F00DDAFAA /* MediaPickingOptionsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B43E6F206B439F00DDAFAA /* MediaPickingOptionsDelegate.swift */; };
 		D8B6BEB7203E11F2007C8A19 /* Bundle+LoadFromNib.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6BEB6203E11F2007C8A19 /* Bundle+LoadFromNib.swift */; };
 		D8B9B58F204F4EA1003C6042 /* NetworkAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */; };
 		D8B9B591204F658A003C6042 /* CommentsViewController+NetworkAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B9B590204F658A003C6042 /* CommentsViewController+NetworkAware.swift */; };
@@ -2422,16 +2424,18 @@
 		D61CEAC1CB25AE65B26BDC68 /* Pods-WordPressShareExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		D8071630203DA23700B32FD9 /* Accessible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Accessible.swift; sourceTree = "<group>"; };
 		D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostCardCellTests.swift; sourceTree = "<group>"; };
+		D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryMediaPickingCoordinator.swift; sourceTree = "<group>"; };
+		D80BC79D20746B4100614A59 /* MediaPickingContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
 		D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderFollowedSitesStreamHeaderTests.swift; sourceTree = "<group>"; };
 		D81322B22050F9110067714D /* NotificationName+Names.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+Names.swift"; sourceTree = "<group>"; };
-		D8A3A5A92069E53900992576 /* AztecMoreCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecMoreCoordinator.swift; sourceTree = "<group>"; };
+		D8A3A5A92069E53900992576 /* AztecMediaPickingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecMediaPickingCoordinator.swift; sourceTree = "<group>"; };
 		D8A3A5AB2069FE5B00992576 /* StockPhotosStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosStrings.swift; sourceTree = "<group>"; };
 		D8A3A5AE206A442800992576 /* StockPhotosDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosDataSource.swift; sourceTree = "<group>"; };
 		D8A3A5B0206A49A100992576 /* StockPhotosMediaGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosMediaGroup.swift; sourceTree = "<group>"; };
 		D8A3A5B2206A49BF00992576 /* StockPhotosMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosMedia.swift; sourceTree = "<group>"; };
 		D8A3A5B4206A4C7800992576 /* StockPhotosPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosPicker.swift; sourceTree = "<group>"; };
 		D8A3A5B6206A563900992576 /* StockPhotosPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosPlaceholder.swift; sourceTree = "<group>"; };
-		D8B43E6F206B439F00DDAFAA /* AztecMoreCoordinatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecMoreCoordinatorDelegate.swift; sourceTree = "<group>"; };
+		D8B43E6F206B439F00DDAFAA /* MediaPickingOptionsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingOptionsDelegate.swift; sourceTree = "<group>"; };
 		D8B6BEB6203E11F2007C8A19 /* Bundle+LoadFromNib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+LoadFromNib.swift"; sourceTree = "<group>"; };
 		D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAware.swift; sourceTree = "<group>"; };
 		D8B9B590204F658A003C6042 /* CommentsViewController+NetworkAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentsViewController+NetworkAware.swift"; sourceTree = "<group>"; };
@@ -3855,6 +3859,7 @@
 				7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */,
 				17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */,
 				1750BD6C201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift */,
+				D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -5606,7 +5611,7 @@
 		D8A3A5AD206A059100992576 /* Stock Photos */ = {
 			isa = PBXGroup;
 			children = (
-				D8A3A5A92069E53900992576 /* AztecMoreCoordinator.swift */,
+				D8A3A5A92069E53900992576 /* AztecMediaPickingCoordinator.swift */,
 				D8A3A5AB2069FE5B00992576 /* StockPhotosStrings.swift */,
 				D8A3A5AE206A442800992576 /* StockPhotosDataSource.swift */,
 				7EBB4125206C388100012D98 /* StockPhotosService.swift */,
@@ -5614,7 +5619,8 @@
 				D8A3A5B2206A49BF00992576 /* StockPhotosMedia.swift */,
 				D8A3A5B4206A4C7800992576 /* StockPhotosPicker.swift */,
 				D8A3A5B6206A563900992576 /* StockPhotosPlaceholder.swift */,
-				D8B43E6F206B439F00DDAFAA /* AztecMoreCoordinatorDelegate.swift */,
+				D8B43E6F206B439F00DDAFAA /* MediaPickingOptionsDelegate.swift */,
+				D80BC79D20746B4100614A59 /* MediaPickingContext.swift */,
 			);
 			path = "Stock Photos";
 			sourceTree = "<group>";
@@ -7333,6 +7339,7 @@
 				B56695B01D411EEB007E342F /* KeyboardDismissHelper.swift in Sources */,
 				FF54D4641D6F3FA900A0DC4D /* EditorSettings.swift in Sources */,
 				17D1C22D1EFB16C10076734A /* FancyAlertViewController.swift in Sources */,
+				D80BC79E20746B4100614A59 /* MediaPickingContext.swift in Sources */,
 				E6D2E16C1B8B423B0000ED14 /* ReaderStreamHeader.swift in Sources */,
 				B50C0C571EF42A0000372C65 /* VideoShortcodeProcessor.swift in Sources */,
 				FFD12D5E1FE1998D00F20A00 /* Progress+Helpers.swift in Sources */,
@@ -7383,7 +7390,7 @@
 				E6D3B1431D1C702600008D4B /* ReaderFollowedSitesViewController.swift in Sources */,
 				B5899ADE1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift in Sources */,
 				E6D0EE601F7EF9830064D3FC /* AccountService+SocialService.swift in Sources */,
-				D8A3A5AA2069E53900992576 /* AztecMoreCoordinator.swift in Sources */,
+				D8A3A5AA2069E53900992576 /* AztecMediaPickingCoordinator.swift in Sources */,
 				82FC61241FA8ADAD00A1757E /* ActivityTableViewCell.swift in Sources */,
 				E1ECE34F1FA88DA2007FA37A /* StoreContainer.swift in Sources */,
 				FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */,
@@ -7418,7 +7425,7 @@
 				E6D2E1651B8AAD7E0000ED14 /* ReaderSiteStreamHeader.swift in Sources */,
 				E14B74111C7B16FD00C26E21 /* WPNoResultsView+Model.swift in Sources */,
 				E166FA1B1BB0656B00374B5B /* PeopleCellViewModel.swift in Sources */,
-				D8B43E70206B439F00DDAFAA /* AztecMoreCoordinatorDelegate.swift in Sources */,
+				D8B43E70206B439F00DDAFAA /* MediaPickingOptionsDelegate.swift in Sources */,
 				83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */,
 				B56994451B7A7EF200FF26FA /* WPStyleGuide+Comments.swift in Sources */,
 				74AF4D741FE417D200E3EBFE /* MediaUploadOperation.swift in Sources */,
@@ -7742,6 +7749,7 @@
 				93DEB88219E5BF7100F9546D /* TodayExtensionService.m in Sources */,
 				98D60B9E1FFEE3D800145190 /* SiteCreationThemeSelectionCell.swift in Sources */,
 				5D42A3E2175E7452005CFF05 /* ReaderPost.m in Sources */,
+				D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */,
 				B50C0C561EF42A0000372C65 /* ShortcodeProcessor.swift in Sources */,
 				982A4C3520227D6700B5518E /* NoResultsViewController.swift in Sources */,
 				74EA3B88202A0462004F802D /* ShareNoticeConstants.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -884,6 +884,8 @@
 		D809E686203F0215001AA0DE /* ReaderPostCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */; };
 		D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */; };
 		D80BC79E20746B4100614A59 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79D20746B4100614A59 /* MediaPickingContext.swift */; };
+		D80BC7A02074722000614A59 /* CameraCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC79F2074722000614A59 /* CameraCaptureCoordinator.swift */; };
+		D80BC7A22074739400614A59 /* MediaLibraryStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80BC7A12074739300614A59 /* MediaLibraryStrings.swift */; };
 		D80EE63A203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */; };
 		D81322B32050F9110067714D /* NotificationName+Names.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81322B22050F9110067714D /* NotificationName+Names.swift */; };
 		D8A3A5AA2069E53900992576 /* AztecMediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5A92069E53900992576 /* AztecMediaPickingCoordinator.swift */; };
@@ -2426,6 +2428,8 @@
 		D809E685203F0215001AA0DE /* ReaderPostCardCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostCardCellTests.swift; sourceTree = "<group>"; };
 		D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryMediaPickingCoordinator.swift; sourceTree = "<group>"; };
 		D80BC79D20746B4100614A59 /* MediaPickingContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
+		D80BC79F2074722000614A59 /* CameraCaptureCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraCaptureCoordinator.swift; sourceTree = "<group>"; };
+		D80BC7A12074739300614A59 /* MediaLibraryStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryStrings.swift; sourceTree = "<group>"; };
 		D80EE639203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderFollowedSitesStreamHeaderTests.swift; sourceTree = "<group>"; };
 		D81322B22050F9110067714D /* NotificationName+Names.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationName+Names.swift"; sourceTree = "<group>"; };
 		D8A3A5A92069E53900992576 /* AztecMediaPickingCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecMediaPickingCoordinator.swift; sourceTree = "<group>"; };
@@ -3860,6 +3864,8 @@
 				17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */,
 				1750BD6C201144DB0050F13A /* MediaNoticeNavigationCoordinator.swift */,
 				D80BC79B207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift */,
+				D80BC79F2074722000614A59 /* CameraCaptureCoordinator.swift */,
+				D80BC7A12074739300614A59 /* MediaLibraryStrings.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -7377,6 +7383,7 @@
 				E64384831C628FCC0052ADB5 /* WPStyleGuide+Sharing.swift in Sources */,
 				177074851FB209F100951A4A /* MediaCellProgressView.swift in Sources */,
 				7462BFD42028CD4400B552D8 /* ShareNoticeNavigationCoordinator.swift in Sources */,
+				D80BC7A02074722000614A59 /* CameraCaptureCoordinator.swift in Sources */,
 				74729CAE205722E300D1394D /* AbstractPost+Searchable.swift in Sources */,
 				43B3823C20090AE8008434F4 /* NUXViewControllerBase.swift in Sources */,
 				2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */,
@@ -7789,6 +7796,7 @@
 				FFB1FA9E1BF0EB840090C761 /* UIImage+Exporters.swift in Sources */,
 				E6B84DD51F01BDAA00B1B686 /* SiteInfoHeaderView.swift in Sources */,
 				E1556CF2193F6FE900FC52EA /* CommentService.m in Sources */,
+				D80BC7A22074739400614A59 /* MediaLibraryStrings.swift in Sources */,
 				5DB3BA0518D0E7B600F3F3E9 /* WPPickerView.m in Sources */,
 				B5E94D151FE04815000E7C20 /* UIImageView+SiteIcon.swift in Sources */,
 				5D42A405175E76A7005CFF05 /* WPImageViewController.m in Sources */,


### PR DESCRIPTION
Implements part of  #8954

In this PR: 
- Add support for Stock Photos to the Media Library, according to the following flow:

![37942004-9ce5361a-31a3-11e8-96ed-3954657f13a1](https://user-images.githubusercontent.com/2722505/38291341-1a438be8-3794-11e8-9771-7f9969bd5830.jpg)

I continued piggybacking on the work we had already done on the media picker. I renamed a bunch of the abstractions that we already had created while developing this feature. Turns out some naming was a bit too specific to Aztec. I am terrible at naming things, good thing there are code reviews.

To test:
1. Select a blog > Media
2. Tap the `+` button
3. Taking a Photo or Video should work
4. Importing from the Photo Library should work
5. Importing from Stock Photos should work (although we have not completely finished the implementation of that side of the UI)
6. Importing from Other apps should also work.
