### PR TITLE
Issue/8977 Pages List: Show uploading and failed pages

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -60,6 +60,9 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 - (BOOL)hasCategories;
 - (BOOL)hasTags;
 
+/// True if either the post failed to upload, or the post has media that failed to upload.
+@property (nonatomic, assign, readonly) BOOL isFailed;
+
 @property (nonatomic, assign, readonly) BOOL hasFailedMedia;
 
 /**

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -380,6 +380,11 @@
     return NO;
 }
 
+- (BOOL)isFailed
+{
+    return self.remoteStatus == AbstractPostRemoteStatusFailed || [[MediaCoordinator shared] hasFailedMediaFor:self] || self.hasFailedMedia;
+}
+
 - (BOOL)hasFailedMedia
 {
     if ([self.media count] == 0) {

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -347,6 +347,7 @@ class MediaCoordinator: NSObject {
 
     /// Returns true if there is any media with a fail state
     ///
+    @objc
     func hasFailedMedia(for post: AbstractPost) -> Bool {
         return cachedCoordinator(for: post)?.hasFailedMedia ?? false
     }

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -75,8 +75,8 @@ class MediaCoordinator: NSObject {
     }
 
     private func removeCoordinator(_ progressCoordinator: MediaProgressCoordinator) {
-        if let index = postMediaProgressCoordinators.index(where: { $0.value == progressCoordinator }) {
-            progressCoordinatorQueue.async(flags: .barrier) {
+        progressCoordinatorQueue.async(flags: .barrier) {
+            if let index = postMediaProgressCoordinators.index(where: { $0.value == progressCoordinator }) {
                 self.postMediaProgressCoordinators.remove(at: index)
             }
         }

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -76,7 +76,7 @@ class MediaCoordinator: NSObject {
 
     private func removeCoordinator(_ progressCoordinator: MediaProgressCoordinator) {
         progressCoordinatorQueue.async(flags: .barrier) {
-            if let index = postMediaProgressCoordinators.index(where: { $0.value == progressCoordinator }) {
+            if let index = self.postMediaProgressCoordinators.index(where: { $0.value == progressCoordinator }) {
                 self.postMediaProgressCoordinators.remove(at: index)
             }
         }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -14,6 +14,14 @@
 - (void)awakeFromNib
 {
     [super awakeFromNib];
+
+    [self applyStyles];
+}
+
+- (void)prepareForReuse
+{
+    [super prepareForReuse];
+    
     [self applyStyles];
 }
 
@@ -23,6 +31,7 @@
 {
     [super setPost:post];
     [self configureTitle];
+    [self configureForStatus];
 }
 
 #pragma mark - Configuration
@@ -30,6 +39,7 @@
 - (void)applyStyles
 {
     [WPStyleGuide applyPageTitleStyle:self.titleLabel];
+    self.menuButton.tintColor = [WPStyleGuide wordPressBlue];
 }
 
 - (void)configureTitle
@@ -37,6 +47,14 @@
     AbstractPost *post = [self.post hasRevision] ? [self.post revision] : self.post;
     NSString *str = [post titleForDisplay] ?: [NSString string];
     self.titleLabel.attributedText = [[NSAttributedString alloc] initWithString:str attributes:[WPStyleGuide pageCellTitleAttributes]];
+}
+
+- (void)configureForStatus
+{
+    if (self.post.isFailed) {
+        self.titleLabel.textColor = [WPStyleGuide errorRed];
+        self.menuButton.tintColor = [WPStyleGuide errorRed];
+    }
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -355,6 +355,10 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         showEditor(post: apost)
     }
 
+    fileprivate func retryPage(_ apost: AbstractPost) {
+        PostCoordinator.shared.retrySave(of: apost)
+    }
+
     fileprivate func showEditor(post: AbstractPost) {
         let filterIndex = filterSettings.currentFilterIndex()
         let editorSettings = EditorSettings()
@@ -380,7 +384,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func presentAlertForPageBeingUploaded() {
-        let message = NSLocalizedString("This page is currently uploading. It won't take long -- try again soon and you'll be able to edit it.", comment: "Prompts the user that the page is being uploaded and cannot be edited while that process is ongoing.")
+        let message = NSLocalizedString("This page is currently uploading. It won't take long – try again soon and you'll be able to edit it.", comment: "Prompts the user that the page is being uploaded and cannot be edited while that process is ongoing.")
 
         let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
 
@@ -435,6 +439,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     fileprivate func handleMenuAction(fromCell cell: UITableViewCell, fromButton button: UIButton, forPage page: AbstractPost) {
         let objectID = page.objectID
 
+        let retryButtonTitle = NSLocalizedString("Retry", comment: "Label for a button that attempts to re-upload a page that previously failed to upload.")
         let viewButtonTitle = NSLocalizedString("View", comment: "Label for a button that opens the page when tapped.")
         let draftButtonTitle = NSLocalizedString("Move to Draft", comment: "Label for a button that moves a page to the draft folder")
         let publishButtonTitle = NSLocalizedString("Publish Immediately", comment: "Label for a button that moves a page to the published folder, publishing with the current date/time.")
@@ -475,23 +480,34 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
                 strongSelf.deletePost(page)
             })
         } else if filter == .published {
-            alertController.addActionWithTitle(viewButtonTitle, style: .default, handler: { [weak self] (action) in
-                guard let strongSelf = self,
-                    let page = strongSelf.pageForObjectID(objectID) else {
-                        return
-                }
+            if page.isFailed {
+                alertController.addActionWithTitle(retryButtonTitle, style: .default, handler: { [weak self] (action) in
+                    guard let strongSelf = self,
+                        let page = strongSelf.pageForObjectID(objectID) else {
+                            return
+                    }
 
-                strongSelf.viewPost(page)
-            })
+                    strongSelf.retryPage(page)
+                })
+            } else {
+                alertController.addActionWithTitle(viewButtonTitle, style: .default, handler: { [weak self] (action) in
+                    guard let strongSelf = self,
+                        let page = strongSelf.pageForObjectID(objectID) else {
+                            return
+                    }
 
-            alertController.addActionWithTitle(draftButtonTitle, style: .default, handler: { [weak self] (action) in
-                guard let strongSelf = self,
-                    let page = strongSelf.pageForObjectID(objectID) else {
-                        return
-                }
+                    strongSelf.viewPost(page)
+                })
 
-                strongSelf.draftPage(page)
-            })
+                alertController.addActionWithTitle(draftButtonTitle, style: .default, handler: { [weak self] (action) in
+                    guard let strongSelf = self,
+                        let page = strongSelf.pageForObjectID(objectID) else {
+                            return
+                    }
+
+                    strongSelf.draftPage(page)
+                })
+            }
 
             alertController.addActionWithTitle(trashButtonTitle, style: .default, handler: { [weak self] (action) in
                 guard let strongSelf = self,
@@ -502,23 +518,34 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
                 strongSelf.deletePost(page)
             })
         } else {
-            alertController.addActionWithTitle(viewButtonTitle, style: .default, handler: { [weak self] (action) in
-                guard let strongSelf = self,
-                    let page = strongSelf.pageForObjectID(objectID) else {
-                        return
-                }
+            if page.isFailed {
+                alertController.addActionWithTitle(retryButtonTitle, style: .default, handler: { [weak self] (action) in
+                    guard let strongSelf = self,
+                        let page = strongSelf.pageForObjectID(objectID) else {
+                            return
+                    }
 
-                strongSelf.viewPost(page)
-            })
+                    strongSelf.retryPage(page)
+                })
+            } else {
+                alertController.addActionWithTitle(viewButtonTitle, style: .default, handler: { [weak self] (action) in
+                    guard let strongSelf = self,
+                        let page = strongSelf.pageForObjectID(objectID) else {
+                            return
+                    }
 
-            alertController.addActionWithTitle(publishButtonTitle, style: .default, handler: { [weak self] (action) in
-                guard let strongSelf = self,
-                    let page = strongSelf.pageForObjectID(objectID) else {
-                        return
-                }
+                    strongSelf.viewPost(page)
+                })
 
-                strongSelf.publishPost(page)
-            })
+                alertController.addActionWithTitle(publishButtonTitle, style: .default, handler: { [weak self] (action) in
+                    guard let strongSelf = self,
+                        let page = strongSelf.pageForObjectID(objectID) else {
+                            return
+                    }
+
+                    strongSelf.publishPost(page)
+                })
+            }
 
             alertController.addActionWithTitle(trashButtonTitle, style: .default, handler: { [weak self] (action) in
                 guard let strongSelf = self,

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -939,7 +939,15 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
         let postService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext)
 
-        postService.trashPost(apost, success: nil) { [weak self] (error) in
+        let trashed = (apost.status == .trash)
+
+        postService.trashPost(apost, success: {
+            // If we permanently deleted the post
+            if trashed {
+                PostCoordinator.shared.cancelAnyPendingSaveOf(post: apost)
+                MediaCoordinator.shared.cancelUploadOfAllMedia(for: apost)
+            }
+        }, failure: { [weak self] (error) in
 
             guard let strongSelf = self else {
                 return
@@ -960,7 +968,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
                     strongSelf.updateAndPerformFetchRequestRefreshingResults()
                 }
             }
-        }
+        })
     }
 
     @objc func restorePost(_ apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -32,7 +32,7 @@ class PostCardStatusViewModel: NSObject {
     var status: String? {
         if MediaCoordinator.shared.isUploadingMedia(for: post) {
             return NSLocalizedString("Uploading media...", comment: "Message displayed on a post's card while the post is uploading media")
-        } else if postIsFailed {
+        } else if post.isFailed {
             return NSLocalizedString("Upload failed", comment: "Message displayed on a post's card when the post has failed to upload")
         } else if post.remoteStatus == .pushing {
             return NSLocalizedString("Uploading post...", comment: "Message displayed on a post's card when the post has failed to upload")
@@ -65,7 +65,7 @@ class PostCardStatusViewModel: NSObject {
             return Gridicon.iconOfType(.cloudUpload)
         }
 
-        if postIsFailed {
+        if post.isFailed {
             return Gridicon.iconOfType(.cloudUpload)
         }
 
@@ -91,7 +91,7 @@ class PostCardStatusViewModel: NSObject {
             return WPStyleGuide.grey()
         }
 
-        if postIsFailed {
+        if post.isFailed {
             return WPStyleGuide.errorRed()
         }
 
@@ -119,10 +119,5 @@ class PostCardStatusViewModel: NSObject {
         } else {
             return MediaCoordinator.shared.totalProgress(for: post)
         }
-    }
-
-    @objc
-    var postIsFailed: Bool {
-        return post.remoteStatus == .failed || MediaCoordinator.shared.hasFailedMedia(for: post) || post.hasFailedMedia
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -421,7 +421,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 - (void)configureActionBar
 {
     NSString *status = [self.post status];
-    if ([Feature enabled:FeatureFlagAsyncPosting] && [self.viewModel postIsFailed]) {
+    if ([Feature enabled:FeatureFlagAsyncPosting] && self.post.isFailed) {
         [self configureFailedActionBar];
     } else if ([status isEqualToString:PostStatusPublish] || [status isEqualToString:PostStatusPrivate]) {
         [self configurePublishedActionBar];

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -461,7 +461,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func presentAlertForPostBeingUploaded() {
-        let message = NSLocalizedString("This post is currently uploading. It won't take long -- try again soon and you'll be able to edit it.", comment: "Prompts the user that the post is being uploaded and cannot be edited while that process is ongoing.")
+        let message = NSLocalizedString("This post is currently uploading. It won't take long – try again soon and you'll be able to edit it.", comment: "Prompts the user that the post is being uploaded and cannot be edited while that process is ongoing.")
 
         let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
 

--- a/WordPress/Resources/AppImages.xcassets/icon-post-actionbar-more.imageset/Contents.json
+++ b/WordPress/Resources/AppImages.xcassets/icon-post-actionbar-more.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
Implements #8977. 

This PR implements the updated requirements for #8977:

* Currently uploading pages will be shown in the pages list
* Failed page uploads in the pages list will have red text / `...` icon
* Failed page uploads will have a Retry option in their `...` menu

![img_ed6334d0f96a-1](https://user-images.githubusercontent.com/4780/38309373-d39b5dbe-3811-11e8-85b2-67b24069a72b.jpeg)

![img_ed6334d0f96a-2](https://user-images.githubusercontent.com/4780/38309375-d5ae9c42-3811-11e8-9353-dc9525c476e4.jpeg)

**To test:**

**Publishing a Page**

* Go to Site Pages, and tap the + in the navigation bar to start creating a page
* Add some text and a few images
* Before the images finish uploading, tap `...` in the editor and choose **Async Publish (Debug)**
* If you see an alert, tap **Publish Now**
* Ensure that you see the new page appear in the pages list under the Published filter

**Saving a Page Draft**

* Perform the same steps, but before you add images to the post go to Post Settings and toggle the status to Published and then back to Draft. This will change the Publish button to Save, which will save the post as a Draft. Ensure the post appears in the Drafts list while uploading.

**Failed Pages**

* Perform the same steps as **Publishing a Page**, but test on a device and turn on airplane mode while the page is uploading on the pages list. You should see an error, and the page text and `...` button should turn red.
* Check that the `...` menu has a `Retry` option
* Turn off airplane mode, and check the `Retry` option works