### PR TITLE
Activity Log: enable for sites hosted on WPCom

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -468,7 +468,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
             return [self supportsRestApi] && [self isAdmin];
         case BlogFeatureActivity:
             // For now Activity is suported only on Jetpack sites for admin users
-            return [self supportsRestApi] && [self isAdmin] && ![self isHostedAtWPcom];
+            return [self supportsRestApi] && [self isAdmin];
         case BlogFeatureCustomThemes:
             return [self supportsRestApi] && [self isAdmin] && ![self isHostedAtWPcom];
         case BlogFeaturePremiumThemes:

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -467,7 +467,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
         case BlogFeatureThemeBrowsing:
             return [self supportsRestApi] && [self isAdmin];
         case BlogFeatureActivity:
-            // For now Activity is suported only on Jetpack sites for admin users
+            // For now Activity is suported for admin users
             return [self supportsRestApi] && [self isAdmin];
         case BlogFeatureCustomThemes:
             return [self supportsRestApi] && [self isAdmin] && ![self isHostedAtWPcom];


### PR DESCRIPTION
Activity Log is rolling out to WPCom now. Let's show the menu item in the app for those sites too.

(Note: the entierety of AL is still only enabled for devs/internal builds, so this doesn't affect external users.)

To test:
1. Open the app
2. Select Hogwarts P2 from the site switcher
3. Verify that the "Activity" menu item is there

