### PR TITLE
Stock photos UX fixes

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
@@ -13,6 +13,13 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
         super.init()
     }
 
+    func clearSearch(notifyObservers shouldNotify: Bool) {
+        photosMedia.removeAll()
+        if shouldNotify {
+            notifyObservers()
+        }
+    }
+
     func numberOfGroups() -> Int {
         return 1
     }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
@@ -77,6 +77,10 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
         return true
     }
 
+    func searchCancelled() {
+        clearSearch(notifyObservers: true)
+    }
+
     // MARK: Unnused protocol methods
 
     func setSelectedGroup(_ group: WPMediaGroup) {

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
@@ -61,4 +61,18 @@ extension StockPhotosPicker: WPMediaPickerViewControllerDelegate {
     func mediaPickerControllerDidCancel(_ picker: WPMediaPickerViewController) {
         picker.dismiss(animated: true, completion: nil)
     }
+
+    func mediaPickerController(_ picker: WPMediaPickerViewController, didSelect asset: WPMediaAsset) {
+        hideKeyboard(from: picker.searchBar)
+    }
+
+    func mediaPickerController(_ picker: WPMediaPickerViewController, didDeselect asset: WPMediaAsset) {
+        hideKeyboard(from: picker.searchBar)
+    }
+
+    private func hideKeyboard(from view: UIView?) {
+        if let view = view, view.isFirstResponder {
+            view.resignFirstResponder()
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
@@ -36,7 +36,9 @@ final class StockPhotosPicker: NSObject {
         picker.showGroupSelector = false
         picker.dataSource = dataSource
 
-        origin.present(picker, animated: true)
+        origin.present(picker, animated: true) {
+            picker.mediaPicker.searchBar?.becomeFirstResponder()
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
@@ -49,7 +49,9 @@ extension StockPhotosPicker: WPMediaPickerViewControllerDelegate {
             return
         }
         delegate?.stockPhotosPicker(self, didFinishPicking: stockPhotosMedia)
-        picker.dismiss(animated: true, completion: nil)
+        picker.dismiss(animated: true)
+        dataSource.clearSearch(notifyObservers: false)
+        hideKeyboard(from: picker.searchBar)
     }
 
     func emptyView(forMediaPickerController picker: WPMediaPickerViewController) -> UIView? {
@@ -59,7 +61,9 @@ extension StockPhotosPicker: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerControllerDidCancel(_ picker: WPMediaPickerViewController) {
-        picker.dismiss(animated: true, completion: nil)
+        picker.dismiss(animated: true)
+        dataSource.clearSearch(notifyObservers: false)
+        hideKeyboard(from: picker.searchBar)
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, didSelect asset: WPMediaAsset) {


### PR DESCRIPTION
Fixes parts of #8954 

This PR implement the following improvements:

- Open Stock Photos with the keyboard present.
- Dismiss the keyboard when selecting/deselecting images.
- Clear last search when dismissing the picker.
- Better keyboard animation when dismissing the picker.
- Clear search when cancel search button is pressed.

To test:
- Start a new post.
- Add photos using Stock Photos.
- Test the previews improvements.