### PR TITLE
Decoupling Authentication Flow: Mark XIV

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginSiteAddressViewController.swift
@@ -242,7 +242,7 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
         alert.modalPresentationStyle = .custom
         alert.transitioningDelegate = self
         present(alert, animated: true, completion: nil)
-        WPAnalytics.track(.loginURLHelpScreenViewed)
+        WordPressAuthenticator.post(event: .loginURLHelpScreenViewed)
     }
 
     @IBAction func handleTextFieldDidChange(_ sender: UITextField) {

--- a/WordPress/Classes/ViewRelated/NUX/SignupEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEmailViewController.swift
@@ -188,14 +188,14 @@ class SignupEmailViewController: LoginViewController, NUXKeyboardResponder {
 
             }, failure: { [weak self] (error: Error) in
                 DDLogError("Request for signup link email failed.")
-                WPAppAnalytics.track(.signupMagicLinkFailed)
+                WordPressAuthenticator.post(event: .signupMagicLinkFailed)
                 self?.displayError(message: ErrorMessage.magicLinkRequestFail.description())
                 self?.configureSubmitButton(animating: false)
         })
     }
 
     private func didRequestSignupLink() {
-        WPAppAnalytics.track(.signupMagicLinkRequested)
+        WordPressAuthenticator.post(event: .signupMagicLinkRequested)
         WordPressAuthenticator.storeLoginInfoForTokenAuth(loginFields)
         performSegue(withIdentifier: "showLinkMailView", sender: nil)
     }

--- a/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupGoogleViewController.swift
@@ -45,7 +45,7 @@ class SignupGoogleViewController: LoginViewController {
 
         GIDSignIn.sharedInstance().signIn()
 
-        WPAppAnalytics.track(.loginSocialButtonClick)
+        WordPressAuthenticator.post(event: .loginSocialButtonClick)
     }
 
     // MARK: - Navigation
@@ -86,10 +86,10 @@ extension SignupGoogleViewController: GIDSignInDelegate {
             SVProgressHUD.dismiss()
             if accountCreated {
                 self?.performSegue(withIdentifier: .showSignupEpilogue, sender: self)
-                WPAnalytics.track(.signupSocialSuccess)
+                WordPressAuthenticator.post(event: .signupSocialSuccess)
             } else {
                 self?.showLoginEpilogue()
-                WPAnalytics.track(.loginSocialSuccess)
+                WordPressAuthenticator.post(event: .loginSocialSuccess)
             }
         }) { [weak self] (error) in
             SVProgressHUD.dismiss()

--- a/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupViewController.swift
@@ -448,7 +448,7 @@ import SafariServices
             self.usernameField.text = username
             self.passwordField.text = password
 
-            WPAnalytics.track(.onePasswordSignup)
+            WordPressAuthenticator.post(event: .onePasswordSignup)
 
             // Note: Since the Site field is right below the 1Password field, let's continue with the edition flow
             // and make the SiteAddress Field the first responder.
@@ -459,7 +459,7 @@ import SafariServices
             }
 
             DDLogError("Failed to use 1Password App Extension to save a new Login: \(error)")
-            WPAnalytics.track(.onePasswordFailed)
+            WordPressAuthenticator.post(event: .onePasswordFailed)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationTracker.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationTracker.swift
@@ -91,12 +91,16 @@ extension WordPressAuthenticationTracker {
             WPAppAnalytics.track(.loginTwoFactorFormViewed)
         case .loginURLFormViewed:
             WPAppAnalytics.track(.loginURLFormViewed)
+        case .loginURLHelpScreenViewed:
+            WPAppAnalytics.track(.loginURLHelpScreenViewed)
         case .loginUsernamePasswordFormViewed:
             WPAppAnalytics.track(.loginUsernamePasswordFormViewed)
         case .onePasswordFailed:
             WPAppAnalytics.track(.onePasswordFailed)
         case .onePasswordLogin:
             WPAppAnalytics.track(.onePasswordLogin)
+        case .onePasswordSignup:
+            WPAppAnalytics.track(.onePasswordSignup)
         case .openedLogin:
             WPAppAnalytics.track(.openedLogin)
         case .signupMagicLinkOpenEmailClientViewed:
@@ -105,6 +109,12 @@ extension WordPressAuthenticationTracker {
             WPAppAnalytics.track(.signupMagicLinkOpened)
         case .signupMagicLinkSucceeded:
             WPAppAnalytics.track(.signupMagicLinkSucceeded)
+        case .signupMagicLinkFailed:
+            WPAppAnalytics.track(.signupMagicLinkFailed)
+        case .signupMagicLinkRequested:
+            WPAppAnalytics.track(.signupMagicLinkRequested)
+        case .signupSocialSuccess:
+            WPAppAnalytics.track(.signupSocialSuccess)
         case .signedIn(let properties):
             WPAppAnalytics.track(.signedIn, withProperties: properties)
         case .twoFactorCodeRequested:

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator+Events.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator+Events.swift
@@ -34,13 +34,18 @@ public extension WordPressAuthenticator {
         case loginSocialSuccess
         case loginTwoFactorFormViewed
         case loginURLFormViewed
+        case loginURLHelpScreenViewed
         case loginUsernamePasswordFormViewed
         case onePasswordFailed
         case onePasswordLogin
+        case onePasswordSignup
         case openedLogin
         case signupMagicLinkOpenEmailClientViewed
         case signupMagicLinkOpened
         case signupMagicLinkSucceeded
+        case signupMagicLinkFailed
+        case signupMagicLinkRequested
+        case signupSocialSuccess
         case signedIn(properties: [String: String])
         case twoFactorCodeRequested
     }


### PR DESCRIPTION
### Details:

In this PR we're simply mapping the new **Signup WPAnalytics** calls via the **WordPressAuthenticator**'s event delegate.

This way, it's up to the Host App to actually track the events (the login library won't have access to **WPAppAnalytics** // **WPAnalytics**.

### Testing:
Please verify the app builds correctly, and the unit tests look green!.

@ScoutHarris may i bug you with a relatively quick review?
Thanks in advance!!
