### PR TITLE
Show sign up epilogue for Jetpack logins

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginViewController.swift
@@ -63,19 +63,10 @@ class LoginViewController: NUXViewController, SigninWPComSyncHandler, LoginFacad
     }
 
     fileprivate func shouldShowEpilogue() -> Bool {
-        if !isJetpackLogin {
-            return true
+        if isJetpackLogin && !isSignUp() {
+            return false
         }
-        let context = ContextManager.sharedInstance().mainContext
-        let accountService = AccountService(managedObjectContext: context)
-        guard
-            let objectID = loginFields.meta.jetpackBlogID,
-            let blog = context.object(with: objectID) as? Blog,
-            let account = blog.account
-            else {
-                return false
-        }
-        return accountService.isDefaultWordPressComAccount(account)
+        return true
     }
 
     func showLoginEpilogue() {
@@ -91,9 +82,8 @@ class LoginViewController: NUXViewController, SigninWPComSyncHandler, LoginFacad
     func dismiss() {
         if shouldShowEpilogue() {
 
-            if let linkSource = loginFields.meta.emailMagicLinkSource,
-                linkSource == .signup {
-                    performSegue(withIdentifier: .showSignupEpilogue, sender: self)
+            if isSignUp() {
+                performSegue(withIdentifier: .showSignupEpilogue, sender: self)
             } else {
                 showLoginEpilogue()
             }
@@ -103,6 +93,14 @@ class LoginViewController: NUXViewController, SigninWPComSyncHandler, LoginFacad
 
         dismissBlock?(false)
         navigationController?.dismiss(animated: true, completion: nil)
+    }
+
+    private func isSignUp() -> Bool {
+        if let linkSource = loginFields.meta.emailMagicLinkSource,
+            linkSource == .signup {
+            return true
+        }
+        return false
     }
 
     /// Validates what is entered in the various form fields and, if valid,


### PR DESCRIPTION
**Fixes** #8949 

**To test:**

1. Add a self-hosted site to the app and then sign up from Stats or Notifications. Verify that the sing up epilogue is displayed.
2. Add a self-hosted site to the app and then log in with an existing account from Stats or Notifications. Verify that the log in epilogue is *not* displayed.
3. Check that I didn't' break anything else.

