### PR TITLE
Added second check to rememberFirstResponder()

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -771,13 +771,14 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     func rememberFirstResponder() {
-        lastFirstResponder = view.findFirstResponder()
+        lastFirstResponder = view.findFirstResponder() ?? lastFirstResponder
         lastFirstResponder?.resignFirstResponder()
     }
 
     func restoreFirstResponder() {
         let nextFirstResponder = lastFirstResponder ?? titleTextField
         nextFirstResponder.becomeFirstResponder()
+        lastFirstResponder = nil
     }
 
     func refreshInterface() {
@@ -2144,7 +2145,6 @@ extension AztecPostViewController {
     }
 
     private func showMore(from: FormatBarItem) {
-        stopListeningToNotifications()
         rememberFirstResponder()
 
         let moreCoordinatorContext = MediaPickingContext(origin: self, view: view, blog: post.blog)
@@ -3595,7 +3595,6 @@ extension AztecPostViewController: UIDocumentPickerDelegate {
 
 extension AztecPostViewController: MediaPickingOptionsDelegate {
     func didCancel() {
-        startListeningToNotifications()
         restoreFirstResponder()
     }
 }


### PR DESCRIPTION
Fixes part of #8954 

This PR prevents losing the first responder in the text view when the Stock Photos picker is dismissed.

I also removed `stopListeningToNotifications()` from `func showMore(from: FormatBarItem)`, since seems to not affect the crash that we saw previously when dismissing the action sheet.

**To test:**

- Pick and add images to the editor from the Stock Photos library.
- After dismissing the picker, the focus should stay in the text view.
- Test presenting and dismissing the action sheet and the picker many times to be sure that the crash is still not present.

