### PR TITLE
Simplifies and fixes post state logic.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -200,7 +200,7 @@ public class PostEditorStateContext {
 
         switch newPostStatus {
         case .draft where originalPostStatus == nil:
-            return .save
+            return publishAction(userCanPublish: userCanPublish)
         case .draft:
             return .update
         case .pending:

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -182,11 +182,10 @@ public class PostEditorStateContext {
     }
 
     private static func initialAction(for originalPostStatus: BasePost.Status?, userCanPublish: Bool) -> PostEditorAction {
-        guard let originalPostStatus = originalPostStatus else {
-            return publishAction(userCanPublish: userCanPublish)
-        }
+        // We assume an initial status of draft if none is set
+        let newPostStatus = originalPostStatus ?? .draft
 
-        return action(for: originalPostStatus, newPostStatus: originalPostStatus, userCanPublish: userCanPublish)
+        return action(for: originalPostStatus, newPostStatus: newPostStatus, userCanPublish: userCanPublish)
     }
 
     private static func action(

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -199,7 +199,7 @@ public class PostEditorStateContext {
         }
 
         switch newPostStatus {
-        case .draft where !isNewOrDraft(originalPostStatus):
+        case .draft where originalPostStatus != nil:
             return .update
         case .draft, .pending:
             return .save

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -178,7 +178,6 @@ public class PostEditorStateContext {
         self.userCanPublish = userCanPublish
         self.currentPublishDate = publishDate
         self.delegate = delegate
-
         self.action = PostEditorStateContext.initialAction(for: originalPostStatus, userCanPublish: userCanPublish)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -199,9 +199,11 @@ public class PostEditorStateContext {
         }
 
         switch newPostStatus {
-        case .draft where originalPostStatus != nil:
+        case .draft where originalPostStatus == nil:
+            return .save
+        case .draft:
             return .update
-        case .draft, .pending:
+        case .pending:
             return .save
         case .publish where isNewOrDraft(originalPostStatus):
             return publishAction(userCanPublish: userCanPublish)

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1453,8 +1453,24 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         if (fabs(interval) < 1.0) {
             return;
         }
+        
         self.apost.dateCreated = selectedDate;
+        
+        if ([self isFutureDated:selectedDate]) {
+            self.apost.status = PostStatusScheduled;
+        }
     }
+}
+
+- (BOOL)isFutureDated:(NSDate *)date {
+    
+    if (date == nil) {
+        return NO;
+    }
+    
+    NSComparisonResult comparison = [NSCalendar.currentCalendar compareDate:[NSDate date] toDate:date toUnitGranularity:NSCalendarUnitMinute];
+    
+    return comparison == NSOrderedAscending;
 }
 
 #pragma mark - WPMediaPickerViewControllerDelegate methods

--- a/WordPress/WordPressTest/PostEditorStateTests.swift
+++ b/WordPress/WordPressTest/PostEditorStateTests.swift
@@ -36,20 +36,6 @@ class PostEditorStateTests: XCTestCase {
         XCTAssertEqual(PostEditorAction.update, context.action, "Existing draft posts should show Update button.")
     }
 
-    func testContextPostSwitchedBetweenFutureAndCurrent() {
-        context = PostEditorStateContext(originalPostStatus: nil, userCanPublish: true, delegate: self)
-
-        XCTAssertEqual(PostEditorAction.publish, context.action)
-
-        context.updated(publishDate: Date.distantFuture)
-
-        XCTAssertEqual(PostEditorAction.schedule, context.action)
-
-        context.updated(publishDate: nil)
-
-        XCTAssertEqual(PostEditorAction.publish, context.action)
-    }
-
     func testContextScheduledPost() {
         context = PostEditorStateContext(originalPostStatus: .scheduled, userCanPublish: true, delegate: self)
 
@@ -82,24 +68,6 @@ extension PostEditorStateTests {
         XCTAssertEqual(PostEditorAction.update, context.action, "should return Update if the post was originally published and is currently reverted to non-published status")
     }
 
-    func testContextPostFutureDatedButNotYetScheduled() {
-        context = PostEditorStateContext(originalPostStatus: .draft, userCanPublish: true, delegate: self)
-
-        context.updated(postStatus: .publish)
-        context.updated(publishDate: Date.distantFuture)
-
-        XCTAssertEqual(PostEditorAction.schedule, context.action, "should return Schedule if the post is dated in the future and not scheduled")
-    }
-
-    func testContextPostFutureDatedAlreadyPublished() {
-        context = PostEditorStateContext(originalPostStatus: .publish, userCanPublish: true, delegate: self)
-
-        context.updated(postStatus: .publish)
-        context.updated(publishDate: Date.distantFuture)
-
-        XCTAssertEqual(PostEditorAction.schedule, context.action, "should return Schedule if the post is dated in the future and published")
-    }
-
     func testContextPostFutureDatedAlreadyScheduled() {
         context = PostEditorStateContext(originalPostStatus: .scheduled, userCanPublish: true, delegate: self)
 
@@ -116,15 +84,6 @@ extension PostEditorStateTests {
         context.updated(postStatus: .draft)
 
         XCTAssertEqual(PostEditorAction.update, context.action, "should return Update if the post is scheduled, dated in the future, and next status is draft")
-    }
-
-    func testContextPostPastDatedAlreadyScheduled() {
-        context = PostEditorStateContext(originalPostStatus: .scheduled, userCanPublish: true, delegate: self)
-
-        context.updated(publishDate: Date.distantPast)
-        context.updated(postStatus: .scheduled)
-
-        XCTAssertEqual(PostEditorAction.publish, context.action, "should return Publish if the post is scheduled and dated in the past")
     }
 
     func testContextDraftPost() {

--- a/WordPress/WordPressTest/PostEditorStateTests.swift
+++ b/WordPress/WordPressTest/PostEditorStateTests.swift
@@ -27,7 +27,7 @@ class PostEditorStateTests: XCTestCase {
 
         context.updated(postStatus: .draft)
 
-        XCTAssertEqual(PostEditorAction.save, context.action, "New posts switched to draft should show Save button.")
+        XCTAssertEqual(PostEditorAction.publish, context.action, "New posts, even if switched to draft, should show Publish button.")
     }
 
     func testContextExistingDraft() {
@@ -93,12 +93,10 @@ extension PostEditorStateTests {
     }
 
     func testContextUserCannotPublish() {
-        context = PostEditorStateContext(originalPostStatus: .draft, userCanPublish: false, delegate: self)
+        context = PostEditorStateContext(originalPostStatus: nil, userCanPublish: false, delegate: self)
 
         XCTAssertEqual(PostEditorAction.submitForReview, context.action, "should return 'Submit for Review' if the post is a draft and user can't publish")
     }
-
-
 
     func testPublishEnabledHasContentAndChangesNotPublishing() {
         context = PostEditorStateContext(originalPostStatus: .draft, userCanPublish: true, delegate: self)


### PR DESCRIPTION
### Description

Fixes an issue that was causing the main action button of the editor to mismatch the post status.

The reason we were having problems is that the logic that turns future posts into scheduled posts inside `PostEditorState` had no mechanism to update the actual post status.  This resulted in the post still showing as draft in the post settings window, if the date was changed before the status was.

This PR also removes some of the code to simplify the state management of the main editor publish action.

### Known issues

Setting a post's status to "Pending review" set the post as draft in my case.  I'm not sure what the rationale behind that option is, but it may need to be restricted to a few specific use-cases.

### Testing:

Test creating a post, saving as draft, publishing, scheduling, etc.
Test in a blog where you don't have posting privileges.
Test changing status of an already saved/scheduled/published post.

/cc @astralbodies - Don't hate me D: