### PR TITLE
Post and Pages List: Do not present network alert when composing posts / pages

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -281,7 +281,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: abstractPostWindowlessCellIdenfitier)
     }
 
-    fileprivate func refreshResults(_ userInteraction: Bool = false) {
+    fileprivate func refreshResults(ignoringNetworkAlerts: Bool = true) {
         guard isViewLoaded == true else {
             return
         }
@@ -292,7 +292,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
         if tableViewHandler.resultsController.fetchedObjects?.count > 0 {
             hideNoResultsView()
-            if userInteraction {
+            if ignoringNetworkAlerts {
                 presentNoNetworkAlert()
             }
         } else {
@@ -611,7 +611,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
     @objc func syncItemsWithUserInteraction(_ userInteraction: Bool) {
         syncHelper.syncContentWithUserInteraction(userInteraction)
-        refreshResults(userInteraction)
+        refreshResults(ignoringNetworkAlerts: userInteraction)
     }
 
     @objc func updateFilter(_ filter: PostListFilter, withSyncedPosts posts: [AbstractPost], syncOptions options: PostServiceSyncOptions) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -281,7 +281,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: abstractPostWindowlessCellIdenfitier)
     }
 
-    fileprivate func refreshResults() {
+    fileprivate func refreshResults(_ userInteraction: Bool = false) {
         guard isViewLoaded == true else {
             return
         }
@@ -292,7 +292,9 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
         if tableViewHandler.resultsController.fetchedObjects?.count > 0 {
             hideNoResultsView()
-            presentNoNetworkAlert()
+            if userInteraction {
+                presentNoNetworkAlert()
+            }
         } else {
             showNoResultsView()
         }
@@ -603,9 +605,13 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         }
     }
 
+    func shouldPresentAlert() -> Bool {
+        return !connectionAvailable() && !contentIsEmpty() && !isViewOnScreen()
+    }
+
     @objc func syncItemsWithUserInteraction(_ userInteraction: Bool) {
         syncHelper.syncContentWithUserInteraction(userInteraction)
-        refreshResults()
+        refreshResults(userInteraction)
     }
 
     @objc func updateFilter(_ filter: PostListFilter, withSyncedPosts posts: [AbstractPost], syncOptions options: PostServiceSyncOptions) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -281,7 +281,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: abstractPostWindowlessCellIdenfitier)
     }
 
-    fileprivate func refreshResults(ignoringNetworkAlerts: Bool = true) {
+    fileprivate func refreshResults(forcingNetworkAlerts: Bool = true) {
         guard isViewLoaded == true else {
             return
         }
@@ -292,7 +292,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
         if tableViewHandler.resultsController.fetchedObjects?.count > 0 {
             hideNoResultsView()
-            if ignoringNetworkAlerts {
+            if forcingNetworkAlerts {
                 presentNoNetworkAlert()
             }
         } else {
@@ -611,7 +611,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
     @objc func syncItemsWithUserInteraction(_ userInteraction: Bool) {
         syncHelper.syncContentWithUserInteraction(userInteraction)
-        refreshResults(ignoringNetworkAlerts: userInteraction)
+        refreshResults(forcingNetworkAlerts: userInteraction)
     }
 
     @objc func updateFilter(_ filter: PostListFilter, withSyncedPosts posts: [AbstractPost], syncOptions options: PostServiceSyncOptions) {


### PR DESCRIPTION
Fixes #9025 , as suggested, by:

1. AbstractPostListViewController should only display an alert if it's topmost
2. It should only attempt to display an alert if the refresh was user initiated. We should pass a parameter to the refresh method to indicate whether the refresh was caused by the user (pull to refresh) – only in that situation should we display the alert.
To test:

Navigate to the Post list
1. Start composing a post.
2. Turn on airplane mode. There should be one and only one alert.
It should be possible to compose a post and save it as draft (locally)

First discussion here: #9038 
