### PR TITLE
UIImageView+Networking: Few Bugfixes!

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationThemeSelectionCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationThemeSelectionCell.swift
@@ -54,8 +54,7 @@ class SiteCreationThemeSelectionCell: UICollectionViewCell {
     private func refreshScreenshot(url imageUrl: String) {
         themeImageView.backgroundColor = Styles.placeholderColor
         activityView.startAnimating()
-        themeImageView.downloadImage(from: URL(string: imageUrl), success: { [weak self, weak themeImageView] image in
-            themeImageView?.image = image
+        themeImageView.downloadImage(from: URL(string: imageUrl), success: { [weak self] _ in
             self?.showScreenshot()
         }, failure: { [weak self] error in
                 if let error = error as NSError?, error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockImageTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockImageTableViewCell.swift
@@ -24,9 +24,8 @@ class NoteBlockImageTableViewCell: NoteBlockTableViewCell {
 
         imageURL = url
 
-        blockImageView.downloadImage(from: url, success: { image in
-            self.blockImageView.image = image
-            self.blockImageView.expandSpringAnimation()
+        blockImageView.downloadImage(from: url, success: { [weak blockImageView] _ in
+            blockImageView?.expandSpringAnimation()
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
@@ -196,8 +196,7 @@ open class ThemeBrowserCell: UICollectionViewCell {
 
         imageView.backgroundColor = Styles.placeholderColor
         activityView.startAnimating()
-        imageView.downloadImage(from: screenshotUrl, success: { [weak self, weak imageView] image in
-            imageView?.image = image
+        imageView.downloadImage(from: screenshotUrl, success: { [weak self] _ in
             self?.showScreenshot()
         }, failure: { [weak self] error in
                 if let error = error as NSError?, error.domain == NSURLErrorDomain && error.code == NSURLErrorCancelled {

--- a/WordPressUI/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -98,11 +98,10 @@ public extension UIImageView {
     ///
     private var downloadTask: URLSessionDataTask? {
         get {
-            return objc_getAssociatedObject(self, Downloader.taskKey) as? URLSessionDataTask
+            return objc_getAssociatedObject(self, &Downloader.taskKey) as? URLSessionDataTask
         }
         set {
-            let policy = objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC
-            objc_setAssociatedObject(self, Downloader.taskKey, newValue, policy)
+            objc_setAssociatedObject(self, &Downloader.taskKey, newValue as AnyObject, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
 
@@ -117,6 +116,6 @@ public extension UIImageView {
 
         /// Key used to associate a Download task to the current instance
         ///
-        static let taskKey = "downloadTaskKey"
+        static var taskKey = "downloadTaskKey"
     }
 }

--- a/WordPressUI/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -30,7 +30,6 @@ public extension UIImageView {
     ///     -   failure: Closure to be executed upon failure.
     ///
     public func downloadImage(from url: URL?, placeholderImage: UIImage? = nil, success: ((UIImage) -> ())? = nil, failure: ((Error?) -> ())? = nil) {
-        // Placeholder?
         if let placeholderImage = placeholderImage {
             image = placeholderImage
         }
@@ -44,19 +43,16 @@ public extension UIImageView {
 
         downloadURL = url
 
-        // By default, onSuccess we just set the image instance
         let internalOnSuccess = { [weak self] (image: UIImage) in
             self?.image = image
             success?(image)
         }
 
-        // Hit the cache
         if let cachedImage = Downloader.cache.object(forKey: url as AnyObject) as? UIImage {
             internalOnSuccess(cachedImage)
             return
         }
 
-        // Hit the Backend
         let request = self.request(for: url)
 
         let task = URLSession.shared.dataTask(with: request, completionHandler: { [weak self] data, response, error in
@@ -66,15 +62,12 @@ public extension UIImageView {
             }
 
             DispatchQueue.main.async {
-                // Update the Cache
                 Downloader.cache.setObject(image, forKey: url as AnyObject)
 
-                // Yet another failsafe
                 if response?.url == self?.downloadURL {
                     internalOnSuccess(image)
                 }
 
-                // Cleanup
                 self?.downloadTask = nil
             }
         })

--- a/WordPressUI/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -26,7 +26,7 @@ public extension UIImageView {
     /// - Parameters:
     ///     -   url: The URL of the target image
     ///     -   placeholderImage: Image to be displayed while the actual asset gets downloaded.
-    ///     -   success: Closure to be executed on success. If it's nil, we'll simply update `self.image`
+    ///     -   success: Closure to be executed on success.
     ///     -   failure: Closure to be executed upon failure.
     ///
     public func downloadImage(from url: URL?, placeholderImage: UIImage? = nil, success: ((UIImage) -> ())? = nil, failure: ((Error?) -> ())? = nil) {
@@ -45,11 +45,10 @@ public extension UIImageView {
         downloadURL = url
 
         // By default, onSuccess we just set the image instance
-        let defaultOnSuccess = { [weak self] (image: UIImage) in
+        let internalOnSuccess = { [weak self] (image: UIImage) in
             self?.image = image
+            success?(image)
         }
-
-        let internalOnSuccess = success ?? defaultOnSuccess
 
         // Hit the cache
         if let cachedImage = Downloader.cache.object(forKey: url as AnyObject) as? UIImage {


### PR DESCRIPTION
### Details:
I've found few issues in the *UIImageView+Networking* extension (which is now part of WordPressUI, and hits NSURLSession, directly):

- ObjectiveC's Object Association was broken / malfunctioning. You've got to pass the pointer!
- Added a failsafe: upon completion we make sure the image we're about to set is the one we should (`response?.url == self?.downloadURL`)
- Updated the 'onSuccess' behavior. Now, by default, we'll always set the image, and hit the callback.

@diegoreymendez Maaaay i bug you with this one?
(Thanks in advance!!!)

### To test:
1. Verify the Gravatars in the Notifications List show up correctly
2. Verify your Site's Blavatars (My Sites Tab) show up fine!
3. Verify that your gravatar shows up as expected (Me Tab), and that you look as pretty as ever

