### PR TITLE
Stock Photos: Implementing MediaPicker updates

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -54,7 +54,7 @@ target 'WordPress' do
   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.2'
   pod 'Gridicons', '0.15'
   pod 'NSURL+IDN', '0.3'
-  pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '906c757c062adcb4f5a49c955d92a210136caa9c'
+  pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '5c487e4e4a7a42ae9d6999613e6e5195351fddf4'
   pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'52849f1be62bc6a6316f3828d56e8fc32f5fa8e4'
 
   target 'WordPressTest' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -146,7 +146,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `52849f1be62bc6a6316f3828d56e8fc32f5fa8e4`)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `906c757c062adcb4f5a49c955d92a210136caa9c`)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `5c487e4e4a7a42ae9d6999613e6e5195351fddf4`)
   - wpxmlrpc (= 0.8.3)
 
 EXTERNAL SOURCES:
@@ -157,7 +157,7 @@ EXTERNAL SOURCES:
     :commit: 52849f1be62bc6a6316f3828d56e8fc32f5fa8e4
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WPMediaPicker:
-    :commit: 906c757c062adcb4f5a49c955d92a210136caa9c
+    :commit: 5c487e4e4a7a42ae9d6999613e6e5195351fddf4
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
@@ -168,7 +168,7 @@ CHECKOUT OPTIONS:
     :commit: 52849f1be62bc6a6316f3828d56e8fc32f5fa8e4
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WPMediaPicker:
-    :commit: 906c757c062adcb4f5a49c955d92a210136caa9c
+    :commit: 5c487e4e4a7a42ae9d6999613e6e5195351fddf4
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
@@ -206,6 +206,6 @@ SPEC CHECKSUMS:
   WPMediaPicker: 1fe532b4ff215a9dd259f08439376fc0dbab1039
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: d54a3cb6bd3e6c17ca8eecf5f80f57532721515b
+PODFILE CHECKSUM: 8dae8b5cd538259ebcbffed1756fced1d09c9b32
 
 COCOAPODS: 1.4.0

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
@@ -76,7 +76,10 @@ extension StockPhotosPicker: WPMediaPickerViewControllerDelegate {
 
     private func hideKeyboard(from view: UIView?) {
         if let view = view, view.isFirstResponder {
-            view.resignFirstResponder()
+            //Fix animation conflict between dismissing the keyboard and showing the accessory input view
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                view.resignFirstResponder()
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -70,6 +70,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         options.allowMultipleSelection = false
         options.allowCaptureOfMedia = false
         options.showSearchBar = true
+        options.showActionBar = false
 
         return options
     }


### PR DESCRIPTION
This PR implements the update of the MediaPicker-iOS library. This update includes:

- Image Carousel to preview many assets.
- Bottom action bar with a `preview` and an `add` action.

An example video [here](https://www.dropbox.com/s/kf0vo7lj6yrchit/stock_photos.mov?dl=0)

Fixes part of #8954 

**To test:**
1. From the editor:
- Tap the + button over the keyboard.
- Tap the … button.
- Open the `Free Photo Library`.
- Search for kittens (or pizza).
- Play selecting, deselecting, previewing, showing and dismissing the keyboard, etc...

2. Repeat the test from the Media Library:
- From the Media Library, tap the top right `+` button.
- Choose `Free Photo Library`.
- Repeat previous tests.
