### PR TITLE
Issue/8978 Async Feature Flag Removal

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -94,6 +94,9 @@ class PostCoordinator: NSObject {
         let postService = PostService(managedObjectContext: mainContext)
         postService.uploadPost(post, success: { uploadedPost in
             print("Post Coordinator -> upload succesfull: \(String(describing: uploadedPost.content))")
+
+            SearchManager.shared.indexItem(uploadedPost)
+
             let model = PostNoticeViewModel(post: uploadedPost)
             ActionDispatcher.dispatch(NoticeAction.post(model.notice))
         }, failure: { error in

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -8,7 +8,6 @@ enum FeatureFlag: Int {
     case jetpackSignup
     case activity
     case usernameChanging
-    case asyncPosting
     case zendeskMobile
 
     /// Returns a boolean indicating if the feature is enabled
@@ -25,8 +24,6 @@ enum FeatureFlag: Int {
         case .activity:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .usernameChanging:
-            return BuildConfiguration.current == .localDeveloper
-        case .asyncPosting:
             return BuildConfiguration.current == .localDeveloper
         case .zendeskMobile:
             return BuildConfiguration.current == .localDeveloper

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1164,7 +1164,7 @@ extension AztecPostViewController {
             }
 
             if action.isAsync || dismissWhenDone {
-                self.asyncUploadPost(action: action, dismissWhenDone: dismissWhenDone)
+                self.asyncUploadPost(action: action)
             } else {
                 self.uploadPost(action: action, dismissWhenDone: dismissWhenDone)
             }
@@ -2623,7 +2623,7 @@ private extension AztecPostViewController {
 
     /// Starts the publishing process.
     ///
-    func asyncUploadPost(action: PostEditorAction, dismissWhenDone: Bool) {
+    func asyncUploadPost(action: PostEditorAction) {
         postEditorStateContext.updated(isBeingPublished: true)
 
         mapUIContentToPostAndSave()
@@ -2632,11 +2632,7 @@ private extension AztecPostViewController {
 
         PostCoordinator.shared.save(post: post)
 
-        if dismissWhenDone {
-            dismissOrPopView(didSave: true, shouldShowPostEpilogue: false)
-        } else {
-            self.createRevisionOfPost()
-        }
+        dismissOrPopView(didSave: true, shouldShowPostEpilogue: false)
 
         self.postEditorStateContext.updated(isBeingPublished: false)
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1069,7 +1069,9 @@ extension AztecPostViewController {
         let title = NSLocalizedString("You have unsaved changes.", comment: "Title of message with options that shown when there are unsaved changes and the author is trying to move away from the post.")
         let cancelTitle = NSLocalizedString("Keep Editing", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
         let saveTitle = NSLocalizedString("Save Draft", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
-        let updateTitle = NSLocalizedString("Update Draft", comment: "Button shown if there are unsaved changes and the author is trying to move away from an already published/saved post.")
+        let updateTitle = NSLocalizedString("Update Draft", comment: "Button shown if there are unsaved changes and the author is trying to move away from an already saved draft.")
+        let updatePostTitle = NSLocalizedString("Update Post", comment: "Button shown if there are unsaved changes and the author is trying to move away from an already published post.")
+        let updatePageTitle = NSLocalizedString("Update Page", comment: "Button shown if there are unsaved changes and the author is trying to move away from an already published page.")
         let discardTitle = NSLocalizedString("Discard", comment: "Button shown if there are unsaved changes and the author is trying to move away from the post.")
 
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
@@ -1080,16 +1082,23 @@ extension AztecPostViewController {
         // Button: Save Draft/Update Draft
         if post.hasLocalChanges() {
             let title: String = {
-                if !post.hasRemote() || post.status == .draft {
-                    return saveTitle
+                if post.status == .draft {
+                    if !post.hasRemote() {
+                        return saveTitle
+                    } else {
+                        return updateTitle
+                    }
+                } else if post is Page {
+                    return updatePageTitle
                 } else {
-                    return updateTitle
+                    return updatePostTitle
                 }
             }()
 
             // The post is a local or remote draft
             alertController.addDefaultActionWithTitle(title) { _ in
-                self.publishPost(action: .save, dismissWhenDone: true, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
+                let action: PostEditorAction = (self.post.status == .draft) ? .saveAsDraft : .publish
+                self.publishPost(action: action, dismissWhenDone: true, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1148,7 +1148,7 @@ extension AztecPostViewController {
                 self.trackPostSave(stat: analyticsStat)
             }
 
-            if action == .publish || action == .publishNow {
+            if action.isAsync || dismissWhenDone {
                 self.asyncUploadPost(action: action, dismissWhenDone: dismissWhenDone)
             } else {
                 self.uploadPost(action: action, dismissWhenDone: dismissWhenDone)
@@ -1156,7 +1156,7 @@ extension AztecPostViewController {
         }
 
         let promoBlock = { [unowned self] in
-            if (action == .publish || action == .publishNow) && !UserDefaults.standard.asyncPromoWasDisplayed {
+            if action.isAsync && !UserDefaults.standard.asyncPromoWasDisplayed {
                 UserDefaults.standard.asyncPromoWasDisplayed = true
 
                 let controller = FancyAlertViewController.makeAsyncPostingAlertController(publishAction: publishBlock)
@@ -1170,7 +1170,7 @@ extension AztecPostViewController {
             }
         }
 
-        if action == .publish || action == .publishNow {
+        if action.isAsync {
             displayPublishConfirmationAlert(onPublish: promoBlock)
         } else {
             promoBlock()

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2617,7 +2617,6 @@ private extension AztecPostViewController {
                 self.post = uploadedPost
 
                 generator.notificationOccurred(.success)
-                SearchManager.shared.indexItem(uploadedPost)
             }
 
             if dismissWhenDone {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1251,43 +1251,6 @@ private extension AztecPostViewController {
     func displayMoreSheet() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-        if FeatureFlag.asyncPosting.enabled {
-            let publishAction = { [unowned self] in
-                self.mapUIContentToPostAndSave()
-
-                let action = self.postEditorStateContext.action
-                if action == .save || action == .saveAsDraft {
-                    self.post.status = .draft
-                } else if action == .publish {
-                    if self.post.date_created_gmt == nil {
-                        self.post.date_created_gmt = Date()
-                    }
-                    self.post.status = .publish
-                } else if action == .publishNow {
-                    self.post.date_created_gmt = Date()
-                    self.post.status = .publish
-                }
-                self.post.updatePathForDisplayImageBasedOnContent()
-                PostCoordinator.shared.save(post: self.post)
-                self.dismissOrPopView(didSave: true, shouldShowPostEpilogue: false)
-            }
-
-            alert.addDefaultActionWithTitle("Async Publish (Debug)") { [unowned self]  _ in
-                if !UserDefaults.standard.asyncPromoWasDisplayed {
-                    UserDefaults.standard.asyncPromoWasDisplayed = true
-
-                    let controller = FancyAlertViewController.makeAsyncPostingAlertController(publishAction: publishAction)
-                    controller.modalPresentationStyle = .custom
-                    controller.transitioningDelegate = self
-                    self.present(controller, animated: true, completion: nil)
-
-                    return
-                }
-
-                publishAction()
-            }
-        }
-
         if postEditorStateContext.isSecondaryPublishButtonShown,
             let buttonTitle = postEditorStateContext.secondaryPublishButtonText {
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1116,6 +1116,12 @@ extension AztecPostViewController {
         dismissWhenDone: Bool,
         analyticsStat: WPAnalyticsStat?) {
 
+        // Cancel publishing if media is currently being uploaded
+        if !action.isAsync && !dismissWhenDone && mediaCoordinator.isUploadingMedia(for: post) {
+            displayMediaIsUploadingAlert()
+            return
+        }
+
         // If there is any failed media allow it to be removed or cancel publishing
         if hasFailedMedia {
             displayHasFailedMediaAlert(then: {
@@ -1184,6 +1190,12 @@ extension AztecPostViewController {
         } else {
             promoBlock()
         }
+    }
+
+    func displayMediaIsUploadingAlert() {
+        let alertController = UIAlertController(title: MediaUploadingAlert.title, message: MediaUploadingAlert.message, preferredStyle: .alert)
+        alertController.addDefaultActionWithTitle(MediaUploadingAlert.acceptTitle)
+        present(alertController, animated: true, completion: nil)
     }
 
     @IBAction func closeWasPressed() {
@@ -3690,6 +3702,12 @@ extension AztecPostViewController {
 
         static let acceptTitle              = NSLocalizedString("OK", comment: "Accept Action")
         static let cancelTitle              = NSLocalizedString("Cancel", comment: "Cancel Action")
+    }
+
+    struct MediaUploadingAlert {
+        static let title = NSLocalizedString("Uploading media", comment: "Title for alert when trying to save/exit a post before media upload process is complete.")
+        static let message = NSLocalizedString("You are currently uploading media. Please wait until this completes.", comment: "This is a notification the user receives if they are trying to save a post (or exit) before the media upload process is complete.")
+        static let acceptTitle  = NSLocalizedString("OK", comment: "Accept Action")
     }
 
     struct FailedMediaRemovalAlert {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1089,7 +1089,7 @@ extension AztecPostViewController {
 
             // The post is a local or remote draft
             alertController.addDefaultActionWithTitle(title) { _ in
-                self.publishPost(action: .save, dismissWhenDone: true, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
+                self.asyncPublishPost(action: .save, dismissWhenDone: true, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
             }
         }
 
@@ -1205,7 +1205,7 @@ extension AztecPostViewController {
         }
 
         let promoBlock = { [unowned self] in
-            if !UserDefaults.standard.asyncPromoWasDisplayed {
+            if (action == .publish || action == .publishNow) && !UserDefaults.standard.asyncPromoWasDisplayed {
                 UserDefaults.standard.asyncPromoWasDisplayed = true
 
                 let controller = FancyAlertViewController.makeAsyncPostingAlertController(publishAction: publishBlock)

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -873,6 +873,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
             apost.date_created_gmt = Date()
             apost.status = .publish
             self.uploadPost(apost)
+            self.updateFilterWithPostStatus(.publish)
         }
 
         present(alertController, animated: true, completion: nil)
@@ -883,26 +884,11 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
         apost.status = .scheduled
         uploadPost(apost)
+        updateFilterWithPostStatus(.scheduled)
     }
 
     fileprivate func uploadPost(_ apost: AbstractPost) {
-        let postService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-
-        postService.uploadPost(apost, success: nil) { [weak self] (error: Error?) in
-
-            let error = error as NSError?
-            guard let strongSelf = self else {
-                return
-            }
-
-            if error?.code == type(of: strongSelf).HTTPErrorCodeForbidden {
-                strongSelf.promptForPassword()
-            } else {
-                WPError.showXMLRPCErrorAlert(error)
-            }
-
-            strongSelf.syncItemsWithUserInteraction(false)
-        }
+        PostCoordinator.shared.save(post: apost)
     }
 
     @objc func viewPost(_ apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -421,7 +421,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 - (void)configureActionBar
 {
     NSString *status = [self.post status];
-    if ([Feature enabled:FeatureFlagAsyncPosting] && self.post.isFailed) {
+    if (self.post.isFailed) {
         [self configureFailedActionBar];
     } else if ([status isEqualToString:PostStatusPublish] || [status isEqualToString:PostStatusPrivate]) {
         [self configurePublishedActionBar];

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -16,7 +16,16 @@ public enum PostEditorAction {
 
     var dismissesEditor: Bool {
         switch self {
-        case .publish, .publishNow, .schedule:
+        case .publish, .publishNow, .schedule, .submitForReview:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var isAsync: Bool {
+        switch self {
+        case .publish, .publishNow, .schedule, .submitForReview:
             return true
         default:
             return false
@@ -69,12 +78,7 @@ public enum PostEditorAction {
     }
 
     fileprivate var isPostPostShown: Bool {
-        switch self {
-        case .publish:
-            return true
-        default:
-            return false
-        }
+        return false
     }
 
     fileprivate var secondaryPublishAction: PostEditorAction? {
@@ -348,8 +352,7 @@ public class PostEditorStateContext {
     /// Indicates whether the Publish Action should be allowed, or not
     ///
     private func updatePublishActionAllowed() {
-        let actionIsPublish = action == .publish || action == .publishNow
-        publishActionAllowed = hasContent && hasChanges && !isBeingPublished && (actionIsPublish || !isUploadingMedia)
+        publishActionAllowed = hasContent && hasChanges && !isBeingPublished && (action.isAsync || !isUploadingMedia)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -348,7 +348,8 @@ public class PostEditorStateContext {
     /// Indicates whether the Publish Action should be allowed, or not
     ///
     private func updatePublishActionAllowed() {
-        publishActionAllowed = hasContent && hasChanges && !isBeingPublished && !isUploadingMedia
+        let actionIsPublish = action == .publish || action == .publishNow
+        publishActionAllowed = hasContent && hasChanges && !isBeingPublished && (actionIsPublish || !isUploadingMedia)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -67,12 +67,7 @@ import Foundation
         let filterType: Status = .published
         let statuses: [BasePost.Status] = [.publish, .publishPrivate]
 
-        let predicate: NSPredicate
-        if FeatureFlag.asyncPosting.enabled {
-            predicate = NSPredicate(format: "status IN %@", statuses.strings)
-        } else {
-            predicate = NSPredicate(format: "status IN %@ AND remoteStatusNumber <> %d", statuses.strings, AbstractPostRemoteStatus.local.rawValue)
-        }
+        let predicate = NSPredicate(format: "status IN %@", statuses.strings)
 
         let title = NSLocalizedString("Published", comment: "Title of the published filter. This filter shows a list of posts that the user has published.")
 
@@ -84,12 +79,7 @@ import Foundation
         let statuses: [BasePost.Status] = [.draft, .pending]
         let statusesExcluded: [BasePost.Status] = [.publish, .publishPrivate, .scheduled, .trash]
 
-        let predicate: NSPredicate
-        if FeatureFlag.asyncPosting.enabled {
-            predicate = NSPredicate(format: "NOT status IN %@", statusesExcluded.strings)
-        } else {
-            predicate = NSPredicate(format: "NOT status IN %@ OR remoteStatusNumber = %d", statusesExcluded.strings, AbstractPostRemoteStatus.local.rawValue)
-        }
+        let predicate = NSPredicate(format: "NOT status IN %@", statusesExcluded.strings)
 
         let title = NSLocalizedString("Drafts", comment: "Title of the drafts filter.  This filter shows a list of draft posts.")
 


### PR DESCRIPTION
Fixes #8976.

This PR removes the feature flag for async posting, and switches over most of the UI uploading actions to use the new asynchronous methods:

* Tapping Publish or Schedule on a draft in the Posts / Pages list.
* Starting a new post, adding some content, then tapping Publish in the navigation bar.
* Starting a new post, adding some content, then tapping the X and choosing Save Draft.
* Publishing an existing draft using the Publish Now quick action in the `...` menu.

These will all post asynchronously whether or not the post has media uploading or not. If there is media, the post will be uploaded once media completes.

Here's a couple of gifs of these in action:

![async-1-publish-new-post](https://user-images.githubusercontent.com/4780/38447960-b8b0857c-39f8-11e8-81ba-d77691e13d5a.gif)

![async-1-publish-save-draft](https://user-images.githubusercontent.com/4780/38447962-ba25c552-39f8-11e8-9150-3b20117e1cd5.gif)

![async-1-publish-draft](https://user-images.githubusercontent.com/4780/38447965-bc812bd4-39f8-11e8-8e31-616999527c81.gif)

There are a few cases where we're currently still using synchronous posting, due to complexities with revisions. I'd like to tackle these, but didn't want them to make this PR more complex. Essentially, it's any situation where you save a post but remain in the editor:

* Create a new post, add some content, tap `...` and choose "Save as Draft"
* Edit an existing post or draft and tap Save / Update.

Both of these will still show a HUD, as they keep the user in the editor.

**To test:**

* Check each of the scenarios listed above works as expected: 
  * Publishing / scheduling new posts
  * Saving drafts when exiting the editor
  * Publishing existing drafts, both in the editor ("Publish Now") and in the Posts list