### PR TITLE
Gravatar: Wiring our new Image Downloader

### DIFF
--- a/WordPress/Classes/Extensions/UIImage+Assets.swift
+++ b/WordPress/Classes/Extensions/UIImage+Assets.swift
@@ -8,7 +8,7 @@ extension UIImage {
     /// Returns the Default SiteIcon Placeholder Image.
     ///
     @objc
-    static var siteIconPlaceholderImage: UIImage {
+    public static var siteIconPlaceholderImage: UIImage {
         return UIImage(named: "blavatar-default")!
     }
 
@@ -16,7 +16,7 @@ extension UIImage {
     /// Returns the Default Gravatar Placeholder Image.
     ///
     @objc
-    static var gravatarPlaceholderImage: UIImage {
+    public static var gravatarPlaceholderImage: UIImage {
         return UIImage(named: "gravatar.png")!
     }
 
@@ -24,7 +24,7 @@ extension UIImage {
     /// Returns the Gravatar's "Unapproved" Image.
     ///
     @objc
-    static var gravatarUnapprovedImage: UIImage {
+    public static var gravatarUnapprovedImage: UIImage {
         return UIImage(named: "gravatar-unapproved")!
     }
 }

--- a/WordPress/Classes/Extensions/UIImageView+Gravatar.swift
+++ b/WordPress/Classes/Extensions/UIImageView+Gravatar.swift
@@ -52,7 +52,7 @@ extension UIImageView {
     ///
     @objc
     public func downloadGravatarWithEmail(_ email: String, rating: GravatarRatings = .`default`, placeholderImage: UIImage = .gravatarPlaceholderImage) {
-        let gravatarURL = gravatarUrlForEmail(email, size: gravatarDefaultSize(), rating: rating.stringValue())
+        let gravatarURL = gravatarUrl(for: email, size: gravatarDefaultSize(), rating: rating.stringValue())
 
         downloadImage(from: gravatarURL, placeholderImage: placeholderImage)
     }
@@ -112,7 +112,7 @@ extension UIImageView {
     ///
     @objc
     public func overrideGravatarImageCache(_ image: UIImage, rating: GravatarRatings, email: String) {
-        guard let gravatarURL = gravatarUrlForEmail(email, size: gravatarDefaultSize(), rating: rating.stringValue()) else {
+        guard let gravatarURL = gravatarUrl(for: email, size: gravatarDefaultSize(), rating: rating.stringValue()) else {
             return
         }
 
@@ -131,11 +131,11 @@ extension UIImageView {
     ///
     /// - Returns: Gravatar's URL
     ///
-    private func gravatarUrlForEmail(_ email: String, size: Int, rating: String) -> URL? {
+    private func gravatarUrl(for email: String, size: Int, rating: String) -> URL? {
         let sanitizedEmail = email
             .lowercased()
             .trimmingCharacters(in: .whitespaces)
-        let targetURL = String(format: "%@/%@?d=404&s=%d&r=%@", WPGravatarBaseURL, sanitizedEmail.md5(), size, rating)
+        let targetURL = String(format: "%@/%@?d=404&s=%d&r=%@", Defaults.baseURL, sanitizedEmail.md5(), size, rating)
         return URL(string: targetURL)
     }
 
@@ -154,5 +154,6 @@ extension UIImageView {
     ///
     private struct Defaults {
         static let imageSize = 80
+        static let baseURL = "http://gravatar.com/avatar"
     }
 }

--- a/WordPress/Classes/Extensions/UIImageView+Gravatar.swift
+++ b/WordPress/Classes/Extensions/UIImageView+Gravatar.swift
@@ -42,12 +42,10 @@ extension UIImageView {
     ///     - rating: expected image rating
     ///     - placeholderImage: Image to be used as Placeholder
     ///
-    @objc func downloadGravatarWithEmail(_ email: String, rating: GravatarRatings = GravatarDefaults.rating, placeholderImage: UIImage) {
-        let targetSize = gravatarDefaultSize()
-        let targetURL = gravatarUrlForEmail(email, size: targetSize, rating: rating.stringValue())
-        let targetRequest = URLRequest(url: targetURL!)
+    @objc func downloadGravatarWithEmail(_ email: String, rating: GravatarRatings = GravatarDefaults.rating, placeholderImage: UIImage = .gravatarPlaceholderImage) {
+        let gravatarURL = gravatarUrlForEmail(email, size: gravatarDefaultSize(), rating: rating.stringValue())
 
-        setImageWith(targetRequest, placeholderImage: placeholderImage, success: nil, failure: nil)
+        downloadImage(from: gravatarURL, placeholderImage: placeholderImage)
     }
 
     /// Downloads the provided Gravatar.
@@ -104,21 +102,12 @@ extension UIImageView {
     /// Hope buddah, and the code reviewer, can forgive me for this hack.
     ///
     @objc func overrideGravatarImageCache(_ image: UIImage, rating: GravatarRatings, email: String) {
-        guard let targetURL = gravatarUrlForEmail(email, size: gravatarDefaultSize(), rating: rating.stringValue()) else {
+        guard let gravatarURL = gravatarUrlForEmail(email, size: gravatarDefaultSize(), rating: rating.stringValue()) else {
             return
         }
 
-        let request = URLRequest(url: targetURL)
-
-        type(of: self).sharedImageDownloader().imageCache?.removeImageforRequest(request, withAdditionalIdentifier: nil)
-        type(of: self).sharedImageDownloader().imageCache?.add(image, for: request, withAdditionalIdentifier: nil)
-
-        // Remove all cached responses - removing an individual response does not work since iOS 7.
-        // This feels hacky to do but what else can we do...
-        let sessionConfiguration = type(of: self).sharedImageDownloader().sessionManager.value(forKey: "sessionConfiguration") as? URLSessionConfiguration
-        sessionConfiguration?.urlCache?.removeAllCachedResponses()
+        overrideImageCache(for: gravatarURL, with: image)
     }
-
 
 
     // MARK: - Private Helpers

--- a/WordPress/Classes/Extensions/UIImageView+Gravatar.swift
+++ b/WordPress/Classes/Extensions/UIImageView+Gravatar.swift
@@ -13,13 +13,20 @@ extension UIImageView {
         case pg
         case r
         case x
+        case `default`
 
         func stringValue() -> String {
             switch self {
-                case .g:    return "g"
-                case .pg:   return "pg"
-                case .r:    return "r"
-                case .x:    return "x"
+            case .default:
+                fallthrough
+            case .g:
+                return "g"
+            case .pg:
+                return "pg"
+            case .r:
+                return "r"
+            case .x:
+                return "x"
             }
         }
     }
@@ -31,7 +38,8 @@ extension UIImageView {
     ///     - email: the user's email
     ///     - rating: expected image rating
     ///
-    @objc func downloadGravatarWithEmail(_ email: String, rating: GravatarRatings) {
+    @objc
+    public func downloadGravatarWithEmail(_ email: String, rating: GravatarRatings) {
         downloadGravatarWithEmail(email, rating: rating, placeholderImage: .gravatarPlaceholderImage)
     }
 
@@ -42,7 +50,8 @@ extension UIImageView {
     ///     - rating: expected image rating
     ///     - placeholderImage: Image to be used as Placeholder
     ///
-    @objc func downloadGravatarWithEmail(_ email: String, rating: GravatarRatings = GravatarDefaults.rating, placeholderImage: UIImage = .gravatarPlaceholderImage) {
+    @objc
+    public func downloadGravatarWithEmail(_ email: String, rating: GravatarRatings = .`default`, placeholderImage: UIImage = .gravatarPlaceholderImage) {
         let gravatarURL = gravatarUrlForEmail(email, size: gravatarDefaultSize(), rating: rating.stringValue())
 
         downloadImage(from: gravatarURL, placeholderImage: placeholderImage)
@@ -56,7 +65,7 @@ extension UIImageView {
     ///     - animate: enable/disable fade in animation
     ///     - failure: Callback block to be invoked when an error occurs while fetching the Gravatar image
     ///
-    func downloadGravatar(_ gravatar: Gravatar?, placeholder: UIImage, animate: Bool, failure: ((Error?) -> ())? = nil) {
+    public func downloadGravatar(_ gravatar: Gravatar?, placeholder: UIImage, animate: Bool, failure: ((Error?) -> ())? = nil) {
         guard let gravatar = gravatar else {
             self.image = placeholder
             return
@@ -101,7 +110,8 @@ extension UIImageView {
     /// P.s.:
     /// Hope buddah, and the code reviewer, can forgive me for this hack.
     ///
-    @objc func overrideGravatarImageCache(_ image: UIImage, rating: GravatarRatings, email: String) {
+    @objc
+    public func overrideGravatarImageCache(_ image: UIImage, rating: GravatarRatings, email: String) {
         guard let gravatarURL = gravatarUrlForEmail(email, size: gravatarDefaultSize(), rating: rating.stringValue()) else {
             return
         }
@@ -121,19 +131,19 @@ extension UIImageView {
     ///
     /// - Returns: Gravatar's URL
     ///
-    fileprivate func gravatarUrlForEmail(_ email: String, size: Int, rating: String) -> URL? {
+    private func gravatarUrlForEmail(_ email: String, size: Int, rating: String) -> URL? {
         let sanitizedEmail = email
             .lowercased()
-            .trimmingCharacters(in: CharacterSet.whitespaces)
+            .trimmingCharacters(in: .whitespaces)
         let targetURL = String(format: "%@/%@?d=404&s=%d&r=%@", WPGravatarBaseURL, sanitizedEmail.md5(), size, rating)
         return URL(string: targetURL)
     }
 
     /// Returns the required gravatar size. If the current view's size is zero, falls back to the default size.
     ///
-    fileprivate func gravatarDefaultSize() -> Int {
-        guard bounds.size.equalTo(CGSize.zero) == false else {
-            return GravatarDefaults.imageSize
+    private func gravatarDefaultSize() -> Int {
+        guard bounds.size.equalTo(.zero) == false else {
+            return Defaults.imageSize
         }
 
         let targetSize = max(bounds.width, bounds.height) * UIScreen.main.scale
@@ -142,8 +152,7 @@ extension UIImageView {
 
     /// Private helper structure: contains the default Gravatar parameters
     ///
-    fileprivate struct GravatarDefaults {
+    private struct Defaults {
         static let imageSize = 80
-        static let rating = GravatarRatings.g
     }
 }

--- a/WordPress/Classes/Extensions/UIImageView+Gravatar.swift
+++ b/WordPress/Classes/Extensions/UIImageView+Gravatar.swift
@@ -154,6 +154,6 @@ extension UIImageView {
     ///
     private struct Defaults {
         static let imageSize = 80
-        static let baseURL = "http://gravatar.com/avatar"
+        static let baseURL = "https://gravatar.com/avatar"
     }
 }

--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -21,7 +21,6 @@ extern NSString *const WPTwitterWordPressMobileURL;
 /// Gravatar Constants
 ///
 extern NSString *const WPBlavatarBaseURL;
-extern NSString *const WPGravatarBaseURL;
 
 /// Notifications Constants
 ///

--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -18,10 +18,6 @@ extern NSString *const WPGithubMainURL;
 extern NSString *const WPTwitterWordPressHandle;
 extern NSString *const WPTwitterWordPressMobileURL;
 
-/// Gravatar Constants
-///
-extern NSString *const WPBlavatarBaseURL;
-
 /// Notifications Constants
 ///
 extern NSString *const WPPushNotificationAppId;

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -21,7 +21,6 @@ NSString *const WPTwitterWordPressMobileURL                         = @"https://
 /// Gravatar Constants
 ///
 NSString *const WPBlavatarBaseURL                                   = @"http://gravatar.com/blavatar";
-NSString *const WPGravatarBaseURL                                   = @"http://gravatar.com/avatar";
 
 /// Notifications Constants
 ///

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -18,10 +18,6 @@ NSString *const WPGithubMainURL                                     = @"https://
 NSString *const WPTwitterWordPressHandle                            = @"@WordPressiOS";
 NSString *const WPTwitterWordPressMobileURL                         = @"https://twitter.com/WordPressiOS";
 
-/// Gravatar Constants
-///
-NSString *const WPBlavatarBaseURL                                   = @"http://gravatar.com/blavatar";
-
 /// Notifications Constants
 ///
 #ifdef DEBUG

--- a/WordPressUI/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -78,6 +78,21 @@ public extension UIImageView {
     }
 
 
+    /// Overrides the cached UIImage, for a given URL. This is useful for whenever we've just updated a remote resource,
+    /// and we need to prevent returning the (old) cached entry.
+    ///
+    public func overrideImageCache(for url: URL, with image: UIImage) {
+        Downloader.cache.setObject(image, forKey: url as AnyObject)
+
+        // Remove all cached responses - removing an individual response does not work since iOS 7.
+        // This feels hacky to do but what else can we do...
+        //
+        // Update: Years have gone by (iOS 11 era). Still broken. Still ashamed about this. Thank you, Apple.
+        //
+        URLSession.shared.configuration.urlCache?.removeAllCachedResponses()
+    }
+
+
     /// Returns a URLRequest for an image, hosted at the specified URL.
     ///
     private func request(for url: URL) -> URLRequest {

--- a/WordPressUI/WordPressUI/Extensions/UIImageView+Networking.swift
+++ b/WordPressUI/WordPressUI/Extensions/UIImageView+Networking.swift
@@ -30,8 +30,14 @@ public extension UIImageView {
     ///     -   failure: Closure to be executed upon failure.
     ///
     public func downloadImage(from url: URL?, placeholderImage: UIImage? = nil, success: ((UIImage) -> ())? = nil, failure: ((Error?) -> ())? = nil) {
-        if let placeholderImage = placeholderImage {
-            image = placeholderImage
+        let internalOnSuccess = { [weak self] (image: UIImage) in
+            self?.image = image
+            success?(image)
+        }
+
+        if let cachedImage = Downloader.cache.object(forKey: url as AnyObject) as? UIImage {
+            internalOnSuccess(cachedImage)
+            return
         }
 
         // Ideally speaking, this method should *not* receive an Optional URL. But we're doing so, for convenience.
@@ -43,14 +49,8 @@ public extension UIImageView {
 
         downloadURL = url
 
-        let internalOnSuccess = { [weak self] (image: UIImage) in
-            self?.image = image
-            success?(image)
-        }
-
-        if let cachedImage = Downloader.cache.object(forKey: url as AnyObject) as? UIImage {
-            internalOnSuccess(cachedImage)
-            return
+        if let placeholderImage = placeholderImage {
+            image = placeholderImage
         }
 
         let request = self.request(for: url)


### PR DESCRIPTION
### Details:
In this PR we're replacing AFNetworking usage (in our UIImageView+Gravatar extension) with the new UIImageView+Networking.

This is a multi-staged approach to move UIImageView+Gravatar over to WordPressUI (required by the upcoming WordPressAuthentication.framework).

**Plus** we're updating UIImageView+Networking's callback sequence:

- **Before**: the placeholder would be set, and if the URL was the same, nothing else would have happened.
- **Now**: we only check if the URL differs before firing a new Networking request. This effectively prevents a UI glitch we've seen around!

### Scenario: Notifications List
1. Open the Notifications List. 
Try scrolling upwards / downwards. Verify nothing odd happens, and the gravatar(s) load correctly.

### Scenario: Uploading a gravatar!
1. Press `Me`
2. Upload a new Gravatar
3. Try scrolling the gravatar offscreen (so that the Header is forced to reload). Verify the _new_ gravatar always shows up.
4. Relaunch the app
5. Verify that the *new* gravatar shows up
