### PR TITLE
Remove display of no networking alert.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -292,7 +292,6 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
         if tableViewHandler.resultsController.fetchedObjects?.count > 0 {
             hideNoResultsView()
-            presentNoNetworkAlert()
         } else {
             showNoResultsView()
         }


### PR DESCRIPTION
Fixes #9081 

To test:
 - Start the app
 - Switch the device to offline/airplane mode 
 - Create a new post
- write content on the post
- See if  alerts about No Internet connection **don't** show up


