### PR TITLE
Fixes private publishing.

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/WordPress.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/WordPress.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/WordPress.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1142,10 +1142,15 @@ extension AztecPostViewController {
             if action == .save || action == .saveAsDraft {
                 self.post.status = .draft
             } else if action == .publish {
-                self.post.status = .publish
+                if self.post.status != .publishPrivate {
+                    self.post.status = .publish
+                }
             } else if action == .publishNow {
                 self.post.date_created_gmt = Date()
-                self.post.status = .publish
+
+                if self.post.status != .publishPrivate {
+                    self.post.status = .publish
+                }
             }
 
             if let analyticsStat = analyticsStat {

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -293,7 +293,7 @@ public class PostEditorStateContext {
 
         guard originalPostStatus != .publish
             && originalPostStatus != .publishPrivate
-            && originalPostStatus == .scheduled else {
+            && originalPostStatus != .scheduled else {
                 return false
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -291,9 +291,10 @@ public class PostEditorStateContext {
             return false
         }
 
-        // Don't show Publish Now for an already published or scheduled post with the update button as primary
-        guard !((currentPostStatus == .publish || currentPostStatus == .scheduled) && editorState.action == .update) else {
-            return false
+        guard originalPostStatus != .publish
+            && originalPostStatus != .publishPrivate
+            && originalPostStatus == .scheduled else {
+                return false
         }
 
         // Don't show Publish Now for a draft with a future date


### PR DESCRIPTION
Fixes a high-priority bug that was causing private posts to be published as public.

See [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/8989).

### Additional notes:

The other [post status changes](https://github.com/wordpress-mobile/WordPress-iOS/pull/9057) are not necessary in 9.7 because it fixes issues only present in 9.8.

### Testing:

1. Create a new post.
2. Set it's visibility to private.
3. Publish it.
4. Check the post is private.
5. Edit the post and make it public.
6. Publish and check the status again.
7. Play with the visibility.

NOTE: this PR is intentionally very specific, since it's going to be included in 9.7.1 for direct release to the App store.