### PR TITLE
Use explicit Int64 type for file sizes and site quota variables.

### DIFF
--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -5,12 +5,15 @@ extension URL {
 
     /// The URLResource fileSize of the file at the URL in bytes, if available.
     ///
-    var fileSize: Int? {
+    var fileSize: Int64? {
         guard isFileURL else {
             return nil
         }
         let values = try? resourceValues(forKeys: [.fileSizeKey])
-        return values?.fileSize
+        guard let fileSize = values?.allValues[.fileSizeKey] as? NSNumber else {
+            return nil
+        }
+        return fileSize.int64Value
     }
 
     /// The URLResource uniform type identifier for the file at the URL, if available.

--- a/WordPress/Classes/Models/Blog+Quota.swift
+++ b/WordPress/Classes/Models/Blog+Quota.swift
@@ -47,7 +47,7 @@ extension Blog {
 
     /// Returns the disk space quota still available to use in the site.
     @objc var quotaSpaceAvailable: NSNumber? {
-        guard let quotaSpaceAllowed = quotaSpaceAllowed?.doubleValue, let quotaSpaceUsed = quotaSpaceUsed?.doubleValue else {
+        guard let quotaSpaceAllowed = quotaSpaceAllowed?.int64Value, let quotaSpaceUsed = quotaSpaceUsed?.int64Value else {
             return nil
         }
         let quotaSpaceAvailable = quotaSpaceAllowed - quotaSpaceUsed
@@ -69,7 +69,7 @@ extension Blog {
     /// - Returns: true if there is space available
     @objc func hasSpaceAvailable(for url: URL) -> Bool {
         guard let fileSize = url.fileSize,
-              let spaceAvailable = quotaSpaceAvailable?.intValue
+              let spaceAvailable = quotaSpaceAvailable?.int64Value
         else {
             // let's assume the site can handle it if we don't know any of quota or fileSize information.
             return true
@@ -83,7 +83,7 @@ extension Blog {
     /// - Returns: true if the site is able to support the URL file size.
     @objc func isAbleToHandleFileSizeOf(url: URL) -> Bool {
         guard let fileSize = url.fileSize,
-            let maxUploadSize = maxUploadSize?.intValue
+            let maxUploadSize = maxUploadSize?.int64Value
             else {
                 // let's assume the site can handle it.
                 return true

--- a/WordPress/Classes/Utility/Media/MediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaExporter.swift
@@ -13,7 +13,7 @@ class MediaExport {
     ///
     let url: URL
     /// The resulting file size in bytes of the export.
-    let fileSize: Int?
+    let fileSize: Int64?
     /// The pixel width of the media exported.
     let width: CGFloat?
     /// The pixel height of the media exported.
@@ -21,7 +21,7 @@ class MediaExport {
     /// The duration of a media file, this is only available if the asset is a video.
     let duration: TimeInterval?
 
-    init(url: URL, fileSize: Int?, width: CGFloat?, height: CGFloat?, duration: TimeInterval?) {
+    init(url: URL, fileSize: Int64?, width: CGFloat?, height: CGFloat?, duration: TimeInterval?) {
         self.url = url
         self.fileSize = fileSize
         self.height = height


### PR DESCRIPTION
Fixes #9090 

This PR changes the type on URL filesize and quota variable to use Int64 explicitly, this fix the error on 32 bits devices (iPhone 5) where values for this variables where overloading the limit and being returned as negative values.

To test:
 - Start the app on a iPhone 5 (32bits)  running iOS 10 ( simulator is ok for this)
 - Start a new post on a WP.com site
 - Insert a new media file and see if upload works correctly
 - Test the same on a iOS11 device to see if all works correctly there too

**Note**: if it's too late for 9.7.1 I can retarget this PR for 9.8
