### PR TITLE
Add tracks events to Xcode console

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -62,7 +62,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         DDLogInfo(@"WPAnalyticsStat not supported by WPAnalyticsTrackerAutomatticTracks: %@", @(stat));
         return;
     }
-    
+
+    DDLogInfo(@"🔵 Tracked: %@", eventPair.eventName);
+
     NSMutableDictionary *mergedProperties = [NSMutableDictionary new];
 
     [mergedProperties addEntriesFromDictionary:eventPair.properties];

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -63,12 +63,16 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         return;
     }
 
-    DDLogInfo(@"🔵 Tracked: %@", eventPair.eventName);
-
     NSMutableDictionary *mergedProperties = [NSMutableDictionary new];
 
     [mergedProperties addEntriesFromDictionary:eventPair.properties];
     [mergedProperties addEntriesFromDictionary:properties];
+
+    if (eventPair.properties == nil && properties == nil) {
+        DDLogInfo(@"🔵 Tracked: %@", eventPair.eventName);
+    } else {
+        DDLogInfo(@"🔵 Tracked: %@, properties: %@", eventPair.eventName, mergedProperties);
+    }
 
     [self.tracksService trackEventName:eventPair.eventName withCustomProperties:mergedProperties];
 }


### PR DESCRIPTION
This is a small change for developers to make it easier to keep track of our analytics events.

During the development of login and social signup several analytics events were missed or modified in annoying ways. Also, during the development of new features, analytics is often an after thought. This is a simple change to try and help developers both think about analytics earlier, and to make it easier to see how events are currently working.

<img width="933" alt="screen shot 2018-04-12 at 1 37 07 pm" src="https://user-images.githubusercontent.com/517257/38694199-ff77bf40-3e56-11e8-93b9-c39dc918f9aa.png">

To test:
- Build and the run the app in Xcode (if you can build it elsewhere, congrats, but I didn't consider that possibility)
- Open the developer console/output window
- Look for blue dots calling attention to analytics events

Asking for a few reviews to find out if this would be considered useful.