### PR TITLE
Decoupling Authentication Flow: Mark XXIV

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Login2FAViewController.swift
@@ -19,6 +19,9 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
         }
     }
 
+    private enum Constants {
+        static let headsUpDismissDelay = TimeInterval(1)
+    }
 
     // MARK: - Lifecycle Methods
 
@@ -240,7 +243,8 @@ class Login2FAViewController: LoginViewController, NUXKeyboardResponder, UITextF
 
     @IBAction func handleSendVerificationButtonTapped(_ sender: UIButton) {
         let message = NSLocalizedString("SMS Sent", comment: "One Time Code has been sent via SMS")
-        SVProgressHUD.showDismissibleSuccess(withStatus: message)
+        SVProgressHUD.showSuccess(withStatus: message)
+        SVProgressHUD.dismiss(withDelay: Constants.headsUpDismissDelay)
 
         if let _ = loginFields.nonceInfo {
             // social login


### PR DESCRIPTION
### Details:
I've been finding a proper solution to this... but ended up with a compromise one.

**SVProgressHUD**'s category, implemented in ObjectiveC, brings the method `showDismissibleSuccess` to the table. This is used in the whole app, quite extensively. However: the Authentication flow only calls that method in a single spot.

I've analyzed the following alternatives:

- Moving the category over to WordPressUI. Disregarded, because that means a third party dependency to a framework that was meant to be... pristine?
- Moving the category over to WordPressShared. Felt... definitely wrong.
- Duplicating the code (keeping a copy of `SVProgressHUD+Dismiss.{h, m}` in the Authenticator) doesn't feel good either.

Ultimately, i figured we can simply alter the way the HUD is used. `SMS Sent` is meant to be a split second message, rendered by the app, before you actually get the 2FA message.

(Hopefully that's acceptable!!).

### Testing
1. Fresh Install
2. Log into a WordPress.com account that requires 2FA
3. In the `Verification Code` UI, press over the `Text me a code instead` button

A. Verify that the `SMS Sent!` alert goes away after a second, automatically.
B. Verify that the user interaction doesn't get blocked anyhow by the overlay.

@frosty May i bug you with a super quick PR?

Thank you!!!
