### PR TITLE
Issue/9112 crash on thumbnail generation

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -631,7 +631,12 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 {
     NSManagedObjectID *mediaID = [mediaInRandomContext objectID];
     [self.managedObjectContext performBlock:^{
-        Media *media = (Media *)[self.managedObjectContext objectWithID: mediaID];
+        NSError *error;
+        Media *media = (Media *)[self.managedObjectContext existingObjectWithID:mediaID error:&error];
+        if (media == nil) {
+            completion(nil, error);
+            return;
+        }
         [self.thumbnailService thumbnailURLForMedia:media
                                       preferredSize:preferredSize
                                        onCompletion:^(NSURL *url) {
@@ -649,7 +654,12 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 {
     NSManagedObjectID *mediaID = [mediaInRandomContext objectID];
     [self.managedObjectContext performBlock:^{
-        Media *media = (Media *)[self.managedObjectContext objectWithID: mediaID];
+        NSError *error;
+        Media *media = (Media *)[self.managedObjectContext existingObjectWithID:mediaID error:&error];
+        if (media == nil) {
+            completion(nil, error);
+            return;
+        }
         [self.thumbnailService thumbnailURLForMedia:media
                                       preferredSize:preferredSize
                                        onCompletion:^(NSURL *url) {

--- a/WordPress/Classes/Services/MediaThumbnailService.swift
+++ b/WordPress/Classes/Services/MediaThumbnailService.swift
@@ -32,8 +32,14 @@ class MediaThumbnailService: LocalCoreDataService {
     ///
     @objc func thumbnailURL(forMedia media: Media, preferredSize: CGSize, onCompletion: @escaping OnThumbnailURL, onError: OnError?) {
         managedObjectContext.perform {
-            guard let objectInContext = try? self.managedObjectContext.existingObject(with: media.objectID),
-                let mediaInContext =  objectInContext as? Media else {
+            var objectInContext: NSManagedObject?
+            do {
+                objectInContext = try self.managedObjectContext.existingObject(with: media.objectID)
+            } catch {
+                onError?(error)
+                return
+            }
+            guard let mediaInContext = objectInContext as? Media else {
                 return
             }
             // Configure a thumbnail exporter.


### PR DESCRIPTION
Fixes #9112 

While I was not able to reproduce the crash, on this PR I added some extra safe guards to make sure no nil Media object is sent to the thumbnail service.

To test:
 - Test scenarios where thumbnail generation is made like: add images to post, set featured image, media library browsing


