### PR TITLE
Aztec: Don't show publish confirmation when showing async promo

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1177,24 +1177,22 @@ extension AztecPostViewController {
         }
 
         let promoBlock = { [unowned self] in
-            if action.isAsync && !UserDefaults.standard.asyncPromoWasDisplayed {
-                UserDefaults.standard.asyncPromoWasDisplayed = true
+            UserDefaults.standard.asyncPromoWasDisplayed = true
 
-                let controller = FancyAlertViewController.makeAsyncPostingAlertController(publishAction: publishBlock)
-                controller.modalPresentationStyle = .custom
-                controller.transitioningDelegate = self
-                self.present(controller, animated: true, completion: nil)
-
-                return
-            } else {
-                publishBlock()
-            }
+            let controller = FancyAlertViewController.makeAsyncPostingAlertController(publishAction: publishBlock)
+            controller.modalPresentationStyle = .custom
+            controller.transitioningDelegate = self
+            self.present(controller, animated: true, completion: nil)
         }
 
         if action.isAsync {
-            displayPublishConfirmationAlert(onPublish: promoBlock)
+            if !UserDefaults.standard.asyncPromoWasDisplayed {
+                promoBlock()
+            } else {
+                displayPublishConfirmationAlert(onPublish: publishBlock)
+            }
         } else {
-            promoBlock()
+            publishBlock()
         }
     }
 


### PR DESCRIPTION
This PR fixes a small issue with async publishing, where we were showing both the standard 'Are you sure you want to publish?' alert and then the promotional 'fancy alert' for the new async publishing feature right afterwards. The two alerts both prompt the user to confirm that they want to publish their post, so it's confusing to see both.

With this PR, the first time the user tries to publish with async they'll *only* see the async promo:

![img_2391](https://user-images.githubusercontent.com/4780/38824208-6c48e1fc-41a0-11e8-98f0-6dca899f9bd6.PNG)

On subsequent publishes they'll *only* see the standard publishing alert:

![img_2392](https://user-images.githubusercontent.com/4780/38824212-6effae08-41a0-11e8-92e9-37915fac340d.PNG)

**To test:**

* With a fresh install, open the editor, add some content, and tap Publish. You should see the promo alert shown above.
  * Ensure that "Keep Editing" keeps you in the editor. If you tap Publish again, you should see the standard alert.
  * Ensure that Publish Now publishes the post.
* After publishing, start another post, add some content, tap Publish, and check you see the standard alert and that the Publish button works as expected.

cc @elibud – just a small fix for 9.8