### PR TITLE
Throttle: Remove delay condition.

### DIFF
--- a/WordPress/Classes/Utility/Throttle.swift
+++ b/WordPress/Classes/Utility/Throttle.swift
@@ -31,8 +31,7 @@ public class Throttle {
             }
         }
 
-        let delay = Date.second(from: previousRun) > maxInterval ? 0 : maxInterval
-        queue.asyncAfter(deadline: .now() + Double(delay), execute: job)
+        queue.asyncAfter(deadline: .now() + maxInterval, execute: job)
     }
 
 }


### PR DESCRIPTION
This PR fixes an issue that made the request be sent every time the user started typing immediately.
It also sent the request constantly every time the `maxInterval` was reached. 

**I'm not sure if this was intended or not**, but it felt kind of buggy.
This might not be too noticeable in the plugins section, but using it in StockPhotos search (still in develop), it's a lot more noticeable and kind of weird.

@jklausa Could you please check this out?

**Before**
![before](https://user-images.githubusercontent.com/9772967/38904088-b12ffaec-427e-11e8-9ebb-418d81a23fb1.gif)

**After**
![after](https://user-images.githubusercontent.com/9772967/38904091-b69e2558-427e-11e8-8a32-71c2dc4ded4a.gif)


## How to test:

- Go to a blog with the plugins feature enabled.
- Go to the Plugins sections.
- Start search for something (like `SEO`).

 **Before the change:**
- You will see the 'Loading plugins..' interface right after tapping the first key.
- Start deleting and taping one letter repeatedly.
- You will notice that exactly every 0.5 seconds, a search will be performed

 **After the change:**
- You will see the list of plugins while typing.
- Then you will see the loading interface right 0.5 seconds after stop typing.
- Start deleting and taping one letter repeatedly.
- You will see that nothing happens after 0.5 seconds after stopping.

