### PR TITLE
Fix a failing test for following sites by ID in the Reader

### DIFF
--- a/WordPressKit/WordPressKitTests/ReaderSiteServiceRemoteTests.swift
+++ b/WordPressKit/WordPressKitTests/ReaderSiteServiceRemoteTests.swift
@@ -39,9 +39,10 @@ class ReaderSiteServiceRemoteTests: XCTestCase {
                                                         withVersion: ._1_1)
         readerSiteServiceRemote.followSite(withID: 1, success: nil, failure: nil)
         XCTAssertTrue(mockRemoteApi.postMethodCalled, "Wrong method")
-        XCTAssertEqual(mockRemoteApi.URLStringPassedIn, expectedPath, "Wrong path")
-        let parameters: NSDictionary = mockRemoteApi.parametersPassedIn as! NSDictionary
-        XCTAssertEqual(parameters["source"] as! String?, "ios", "incorrect source parameter")
+
+        let url = URL(string: mockRemoteApi.URLStringPassedIn!)!
+        XCTAssertEqual(url.path, expectedPath, "Wrong path")
+        XCTAssertEqual(url.query, "source=ios", "incorrect source parameter")
     }
 
     func testFollowSiteWithID() {


### PR DESCRIPTION
This PR fixes a unit test that started failing as a result of changes made in https://github.com/wordpress-mobile/WordPress-iOS/pull/9022. My fault, as I forgot to run unit tests before merging.

The call to follow a site by ID in the Reader originally passed the `source` of the follow as a parameter of the `POST` (where it was being added to the request's JSON body). The PR switched this up to add the `source` to the request's query string. The unit test wasn't expecting this change, so I've updated it to look for the source in the correct place.

There are two force unwraps in there, but neither of those things should ever be nil, and we want the test to fail if they are.

**To test:**

* Build and run tests, ensure they pass.