### PR TITLE
Remove unused buttons from login prologue

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Login.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/Login.storyboard
@@ -97,47 +97,6 @@
                                     <segue destination="TP5-re-Ncg" kind="embed" id="mLC-uB-YYS"/>
                                 </connections>
                             </containerView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="22" translatesAutoresizingMaskIntoConstraints="NO" id="Icw-wp-UXX" userLabel="Button Stack View">
-                                <rect key="frame" x="20" y="523" width="335" height="122"/>
-                                <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Lhb-JH-DQG" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="335" height="50"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="utn-AU-aRl"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <state key="normal" title="Log In">
-                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
-                                        </userDefinedRuntimeAttributes>
-                                        <connections>
-                                            <segue destination="fwZ-QE-5et" kind="show" identifier="showEmailLogin" id="ttc-1d-dkK"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5na-fB-S4z" customClass="NUXButton" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="72" width="335" height="50"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="nextButton"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="bid-K8-ZUQ"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <state key="normal" title="Create a WordPress site">
-                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
-                                        </userDefinedRuntimeAttributes>
-                                        <connections>
-                                            <action selector="signupTapped" destination="xro-OF-z8b" eventType="touchUpInside" id="VG3-SL-8DF"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <variation key="widthClass=regular" axis="horizontal"/>
-                                <variation key="heightClass=compact-widthClass=compact" axis="horizontal"/>
-                            </stackView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G3G-Ap-6ix">
                                 <rect key="frame" x="0.0" y="501" width="375" height="166"/>
                                 <constraints>
@@ -147,37 +106,24 @@
                                     <segue destination="A3H-HK-nmU" kind="embed" id="swV-lc-6gI"/>
                                 </connections>
                             </containerView>
-                            <imageView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="darkgrey-shadow" translatesAutoresizingMaskIntoConstraints="NO" id="X1p-73-aGm">
-                                <rect key="frame" x="0.0" y="491" width="375" height="10"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="10" id="5fL-Mc-SKT"/>
-                                </constraints>
-                            </imageView>
                         </subviews>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="Icw-wp-UXX" secondAttribute="trailing" constant="20" id="1Nu-oS-ZG5"/>
-                            <constraint firstItem="dPr-Tg-feW" firstAttribute="top" secondItem="Icw-wp-UXX" secondAttribute="bottom" constant="22" id="7IO-0C-0w6"/>
                             <constraint firstItem="6cw-FO-hjb" firstAttribute="leading" secondItem="EnO-7f-1yO" secondAttribute="leading" id="7Z8-mD-FWN"/>
                             <constraint firstAttribute="trailing" secondItem="G3G-Ap-6ix" secondAttribute="trailing" id="96a-eB-JlD"/>
                             <constraint firstItem="G3G-Ap-6ix" firstAttribute="top" secondItem="6cw-FO-hjb" secondAttribute="bottom" id="Cuw-sd-C5k"/>
                             <constraint firstAttribute="trailing" secondItem="6cw-FO-hjb" secondAttribute="trailing" id="Hgo-qC-AqF"/>
-                            <constraint firstItem="X1p-73-aGm" firstAttribute="leading" secondItem="EnO-7f-1yO" secondAttribute="leading" id="bvL-2u-7AR"/>
                             <constraint firstItem="6cw-FO-hjb" firstAttribute="top" secondItem="EnO-7f-1yO" secondAttribute="top" id="dXg-NZ-hRY"/>
-                            <constraint firstItem="X1p-73-aGm" firstAttribute="bottom" secondItem="6cw-FO-hjb" secondAttribute="bottom" id="jeg-wN-ua6"/>
                             <constraint firstAttribute="bottom" secondItem="G3G-Ap-6ix" secondAttribute="bottom" id="lOP-Up-00c"/>
-                            <constraint firstAttribute="trailing" secondItem="X1p-73-aGm" secondAttribute="trailing" id="u95-1f-lmm"/>
-                            <constraint firstItem="Icw-wp-UXX" firstAttribute="leading" secondItem="EnO-7f-1yO" secondAttribute="leading" constant="20" id="uOW-oB-IHd"/>
                             <constraint firstItem="G3G-Ap-6ix" firstAttribute="leading" secondItem="EnO-7f-1yO" secondAttribute="leading" id="uzT-mw-eJq"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="42E-2e-kOq"/>
                     <connections>
-                        <outlet property="loginButton" destination="Lhb-JH-DQG" id="RIH-uM-wDl"/>
-                        <outlet property="signupButton" destination="5na-fB-S4z" id="3Bd-jn-IhO"/>
                         <segue destination="IwV-3R-6dB" kind="presentation" identifier="showSignupMethod" id="gD5-d0-X3t"/>
                         <segue destination="T5n-nb-cOW" kind="show" identifier="showSigninV2" id="nCA-u7-fKm"/>
                         <segue destination="MEg-KS-Afs" kind="show" identifier="showGoogle" id="aSC-hU-lzE"/>
+                        <segue destination="fwZ-QE-5et" kind="show" identifier="showEmailLogin" id="D3h-Su-Jwk"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ieq-Ar-5OF" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -1228,7 +1174,6 @@
         </scene>
     </scenes>
     <resources>
-        <image name="darkgrey-shadow" width="10" height="10"/>
         <image name="icon-password-field" width="18" height="22"/>
         <image name="icon-url-field" width="18" height="22"/>
         <image name="icon-username-field" width="18" height="18"/>
@@ -1236,7 +1181,7 @@
     <inferredMetricsTieBreakers>
         <segue reference="fWM-mD-lXg"/>
         <segue reference="ySQ-EM-6JI"/>
-        <segue reference="ttc-1d-dkK"/>
-        <segue reference="swV-lc-6gI"/>
+        <segue reference="D3h-Su-Jwk"/>
+        <segue reference="iD4-VS-n3M"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/WordPress/Classes/ViewRelated/NUX/LoginPrologueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginPrologueViewController.swift
@@ -4,9 +4,6 @@ import Lottie
 class LoginPrologueViewController: LoginViewController {
 
     private var buttonViewController: NUXButtonViewController?
-
-    @IBOutlet var loginButton: UIButton!
-    @IBOutlet var signupButton: UIButton!
     var showCancel = false
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
@@ -14,12 +11,6 @@ class LoginPrologueViewController: LoginViewController {
     }
 
     // MARK: - Lifecycle Methods
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        localizeControls()
-    }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -82,18 +73,6 @@ class LoginPrologueViewController: LoginViewController {
             }
         }
         buttonViewController.backgroundColor = WPStyleGuide.lightGrey()
-    }
-
-    // MARK: - Setup and Config
-
-    @objc func localizeControls() {
-        loginButton.setTitle(NSLocalizedString("Log In", comment: "Button title.  Tapping takes the user to the login form."),
-                             for: .normal)
-        loginButton.accessibilityIdentifier = "Log In"
-
-        signupButton.setTitle(NSLocalizedString("Create a WordPress site", comment: "Button title. Tapping takes the user to a form where they can create a new WordPress site."),
-                              for: .normal)
-
     }
 
     // MARK: - Actions


### PR DESCRIPTION
This is code cleanup to remove two buttons from the Login prologue that were covered up and not being used anymore. The only noticeable result beyond the code is that the shadow above the button's container is lighter, since before there were actually _two_ shadows on top of one another:

![login shadow before after](https://user-images.githubusercontent.com/517257/38948663-68fad1a0-42fd-11e8-8c2b-6c0bfdf11b42.jpg)

*Code note*:
One of the buttons was the origin for a storyboard segue, which had to be recreated.

To test:
- Logout of all accounts, or use a fresh install, so that the login prologue appears
- Ensure that both login and signup flows still work (that they've started should be enough, no need to test every case)

