### PR TITLE
Stock Photos: Add Pexel link to NoResultsView

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
@@ -30,7 +30,7 @@ final class StockPhotosPlaceholder: WPNoResultsView {
         do {
             attributedMessageText = try createStringWithLinkAttributes(from: .freePhotosPlaceholderSubtitle)
         } catch {
-            // A translation error could make the link attributes to fail. (i.e. removing the '{')
+            // A translation error could make the creation of link attributes to fail. (i.e. removing the '{')
             // This will make sure that the message is still present, without any {}, but without the link.
             messageText = removeCurlybraces(from: .freePhotosPlaceholderSubtitle)
         }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
@@ -28,7 +28,7 @@ final class StockPhotosPlaceholder: WPNoResultsView {
 
     private func configureSubtitle() {
         do {
-            attributedMessageText = try createStringWIthLinkAttributes(in: .freePhotosPlaceholderSubtitle)
+            attributedMessageText = try createStringWithLinkAttributes(from: .freePhotosPlaceholderSubtitle)
         } catch {
             // A translation error could make the link attributes to fail. (i.e. removing the '{')
             // This will make sure that the message is still present, without any {}, but without the link.
@@ -36,7 +36,7 @@ final class StockPhotosPlaceholder: WPNoResultsView {
         }
     }
 
-    private func createStringWIthLinkAttributes(in subtitle: String) throws -> NSAttributedString {
+    private func createStringWithLinkAttributes(from subtitle: String) throws -> NSAttributedString {
         let htmlTaggedString = subtitle.replacingOccurrences(of: "{", with: "<a href=\"\(pexelsUrl)\">")
             .replacingOccurrences(of: "}", with: "</a>")
 

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
@@ -1,5 +1,8 @@
 // Empty state for Stock Photos
 final class StockPhotosPlaceholder: WPNoResultsView {
+
+    private let pexelsUrl = "https://www.pexels.com"
+
     init() {
         super.init(frame: .zero)
         configure()
@@ -24,6 +27,32 @@ final class StockPhotosPlaceholder: WPNoResultsView {
     }
 
     private func configureSubtitle() {
-        messageText = .freePhotosPlaceholderSubtitle
+        do {
+            attributedMessageText = try createStringWIthLinkAttributes(in: .freePhotosPlaceholderSubtitle)
+        } catch {
+            // A translation error could make the link attributes to fail. (i.e. removing the '{')
+            // This will make sure that the message is still present, without any {}, but without the link.
+            messageText = removeCurlybraces(from: .freePhotosPlaceholderSubtitle)
+        }
+    }
+
+    private func createStringWIthLinkAttributes(in subtitle: String) throws -> NSAttributedString {
+        let htmlTaggedString = subtitle.replacingOccurrences(of: "{", with: "<a href=\"\(pexelsUrl)\">")
+            .replacingOccurrences(of: "}", with: "</a>")
+
+        guard let htmlTaggedData = htmlTaggedString.data(using: .utf8) else {
+            throw NSError()
+        }
+
+        let attributedString = try NSMutableAttributedString(
+            data: htmlTaggedData,
+            options:[.documentType: NSAttributedString.DocumentType.html, .characterEncoding: String.Encoding.utf8.rawValue],
+            documentAttributes: nil)
+
+        return attributedString
+    }
+
+    private func removeCurlybraces(from string: String) -> String {
+        return string.replacingOccurrences(of: "{", with: "").replacingOccurrences(of: "}", with: "")
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
@@ -1,8 +1,10 @@
 // Empty state for Stock Photos
 final class StockPhotosPlaceholder: WPNoResultsView {
 
-    private let companyUrl = "https://www.pexels.com"
-    private let companyName = "Pexels"
+    private enum Constants {
+        static let companyUrl = "https://www.pexels.com"
+        static let companyName = "Pexels"
+    }
 
     init() {
         super.init(frame: .zero)
@@ -32,8 +34,8 @@ final class StockPhotosPlaceholder: WPNoResultsView {
     }
 
     private func createStringWithLinkAttributes(from subtitle: String) -> NSAttributedString {
-        let htmlTaggedLink = "<a href=\"\(companyUrl)\">\(companyName)</a>"
-        let htmlTaggedText = subtitle.replacingOccurrences(of: companyName, with: htmlTaggedLink)
+        let htmlTaggedLink = "<a href=\"\(Constants.companyUrl)\">\(Constants.companyName)</a>"
+        let htmlTaggedText = subtitle.replacingOccurrences(of: Constants.companyName, with: htmlTaggedLink)
 
         return NSAttributedString.attributedStringWithHTML(htmlTaggedText, attributes: nil)
     }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
@@ -1,7 +1,8 @@
 // Empty state for Stock Photos
 final class StockPhotosPlaceholder: WPNoResultsView {
 
-    private let pexelsUrl = "https://www.pexels.com"
+    private let companyUrl = "https://www.pexels.com"
+    private let companyName = "Pexels"
 
     init() {
         super.init(frame: .zero)
@@ -27,32 +28,13 @@ final class StockPhotosPlaceholder: WPNoResultsView {
     }
 
     private func configureSubtitle() {
-        do {
-            attributedMessageText = try createStringWithLinkAttributes(from: .freePhotosPlaceholderSubtitle)
-        } catch {
-            // A translation error could make the creation of link attributes to fail. (i.e. removing the '{')
-            // This will make sure that the message is still present, without any {}, but without the link.
-            messageText = removeCurlybraces(from: .freePhotosPlaceholderSubtitle)
-        }
+        attributedMessageText = createStringWithLinkAttributes(from: .freePhotosPlaceholderSubtitle)
     }
 
-    private func createStringWithLinkAttributes(from subtitle: String) throws -> NSAttributedString {
-        let htmlTaggedString = subtitle.replacingOccurrences(of: "{", with: "<a href=\"\(pexelsUrl)\">")
-            .replacingOccurrences(of: "}", with: "</a>")
+    private func createStringWithLinkAttributes(from subtitle: String) -> NSAttributedString {
+        let htmlTaggedLink = "<a href=\"\(companyUrl)\">\(companyName)</a>"
+        let htmlTaggedText = subtitle.replacingOccurrences(of: companyName, with: htmlTaggedLink)
 
-        guard let htmlTaggedData = htmlTaggedString.data(using: .utf8) else {
-            throw NSError()
-        }
-
-        let attributedString = try NSMutableAttributedString(
-            data: htmlTaggedData,
-            options:[.documentType: NSAttributedString.DocumentType.html, .characterEncoding: String.Encoding.utf8.rawValue],
-            documentAttributes: nil)
-
-        return attributedString
-    }
-
-    private func removeCurlybraces(from string: String) -> String {
-        return string.replacingOccurrences(of: "{", with: "").replacingOccurrences(of: "}", with: "")
+        return NSAttributedString.attributedStringWithHTML(htmlTaggedText, attributes: nil)
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosStrings.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosStrings.swift
@@ -19,6 +19,6 @@ extension String {
     }
 
     static var freePhotosPlaceholderSubtitle: String {
-        return NSLocalizedString("Photos provided by Pexels", comment: "Subtitle for placeholder in Free Photos")
+        return NSLocalizedString("Photos provided by {Pexels}", comment: "Subtitle for placeholder in Free Photos. The {} won't be visible, but they are important to make that word a link to the Pexels website.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosStrings.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosStrings.swift
@@ -19,6 +19,6 @@ extension String {
     }
 
     static var freePhotosPlaceholderSubtitle: String {
-        return NSLocalizedString("Photos provided by {Pexels}", comment: "Subtitle for placeholder in Free Photos. The {} won't be visible, but they are important to make that word a link to the Pexels website.")
+        return NSLocalizedString("Photos provided by Pexels", comment: "Subtitle for placeholder in Free Photos. The company name 'Pexels' should always be written as it is.")
     }
 }

--- a/WordPressShared/WordPressShared/Core/Views/WPNoResultsView.h
+++ b/WordPressShared/WordPressShared/Core/Views/WPNoResultsView.h
@@ -11,6 +11,7 @@
 
 @property (nonatomic, strong) NSString                      *titleText;
 @property (nonatomic, strong) NSString                      *messageText;
+@property (nonatomic, strong) NSAttributedString            *attributedMessageText;
 @property (nonatomic, strong) NSString                      *buttonTitle;
 @property (nonatomic, strong) UIView                        *accessoryView;
 @property (nonatomic, strong) UIButton                      *button;

--- a/WordPressShared/WordPressShared/Core/Views/WPNoResultsView.m
+++ b/WordPressShared/WordPressShared/Core/Views/WPNoResultsView.m
@@ -222,6 +222,7 @@
 {
     NSAttributedString * finalAttributedText = [self applyMessageStylesToAttributedString:attributedMessageText];
     self.messageTextView.attributedText = finalAttributedText;
+    self.messageTextView.selectable = YES;
 }
 
 - (NSAttributedString *)applyMessageStylesToAttributedString:(NSAttributedString *)attributedString

--- a/WordPressShared/WordPressShared/Core/Views/WPNoResultsView.m
+++ b/WordPressShared/WordPressShared/Core/Views/WPNoResultsView.m
@@ -82,6 +82,7 @@
     _messageTextView.textAlignment   = NSTextAlignmentCenter;
     _messageTextView.adjustsFontForContentSizeCategory = YES;
     _messageTextView.editable = NO;
+    _messageTextView.selectable = NO;
     _messageTextView.textContainerInset = UIEdgeInsetsZero;
     _messageTextView.textContainer.lineFragmentPadding = 0;
     [self addSubview:_messageTextView];

--- a/WordPressShared/WordPressShared/Core/Views/WPNoResultsView.m
+++ b/WordPressShared/WordPressShared/Core/Views/WPNoResultsView.m
@@ -7,8 +7,8 @@
 
 
 @interface WPNoResultsView ()
-@property (nonatomic, strong) UILabel   *titleLabel;
-@property (nonatomic, strong) UILabel   *messageLabel;
+@property (nonatomic, strong) UILabel       *titleLabel;
+@property (nonatomic, strong) UITextView    *messageTextView;
 @end
 
 @implementation WPNoResultsView
@@ -75,13 +75,16 @@
 
 - (void)configureMessageLabel
 {
-    _messageLabel               = [[UILabel alloc] init];
-    _messageLabel.font          = [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
-    _messageLabel.textColor     = [WPStyleGuide allTAllShadeGrey];
-    _messageLabel.numberOfLines = 0;
-    _messageLabel.textAlignment = NSTextAlignmentCenter;
-    _messageLabel.adjustsFontForContentSizeCategory = YES;
-    [self addSubview:_messageLabel];
+    _messageTextView                 = [[UITextView alloc] init];
+    _messageTextView.font            = [UIFont preferredFontForTextStyle:UIFontTextStyleSubheadline];
+    _messageTextView.textColor       = [WPStyleGuide allTAllShadeGrey];
+    _messageTextView.backgroundColor = [UIColor clearColor];
+    _messageTextView.textAlignment   = NSTextAlignmentCenter;
+    _messageTextView.adjustsFontForContentSizeCategory = YES;
+    _messageTextView.editable = NO;
+    _messageTextView.textContainerInset = UIEdgeInsetsZero;
+    _messageTextView.textContainer.lineFragmentPadding = 0;
+    [self addSubview:_messageTextView];
 }
 
 - (void)configureButton
@@ -116,25 +119,25 @@
 
     _titleLabel.frame = CGRectMake(0.0f, (CGRectGetMaxY(_accessoryView.frame) > 0 && _accessoryView.hidden != YES ? CGRectGetMaxY(_accessoryView.frame) + 10.0 : 0) , width, titleSize.height);
     
-    CGSize messageSize = [_messageLabel.text boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX)
+    CGSize messageSize = [_messageTextView.text boundingRectWithSize:CGSizeMake(width, CGFLOAT_MAX)
                                                           options:NSStringDrawingUsesLineFragmentOrigin
-                                                       attributes:@{NSFontAttributeName: _messageLabel.font}
+                                                       attributes:@{NSFontAttributeName: _messageTextView.font}
                                                           context:nil].size;
 
-    _messageLabel.frame = CGRectMake(0.0f, CGRectGetMaxY(_titleLabel.frame) + 8.0, width, messageSize.height);
+    _messageTextView.frame = CGRectMake(0.0f, CGRectGetMaxY(_titleLabel.frame) + 8.0, width, messageSize.height);
     
     [_button sizeToFit];
     CGSize buttonSize = _button.frame.size;
     buttonSize.width += 40.0;
-    CGFloat buttonYOrigin = (CGRectGetHeight(_messageLabel.frame) > 0 ? CGRectGetMaxY(_messageLabel.frame) : CGRectGetMaxY(_titleLabel.frame)) + 17.0 ;
+    CGFloat buttonYOrigin = (CGRectGetHeight(_messageTextView.frame) > 0 ? CGRectGetMaxY(_messageTextView.frame) : CGRectGetMaxY(_titleLabel.frame)) + 17.0 ;
     _button.frame = CGRectMake((width - buttonSize.width) / 2, buttonYOrigin, MIN(buttonSize.width, width), buttonSize.height);
     
     
     CGRect bottomViewRect;
     if (_button != nil) {
         bottomViewRect = _button.frame;
-    } else if (_messageLabel.text.length > 0) {
-        bottomViewRect = _messageLabel.frame;
+    } else if (_messageTextView.text.length > 0) {
+        bottomViewRect = _messageTextView.frame;
     } else if (_titleLabel.text.length > 0) {
         bottomViewRect = _titleLabel.frame;
     } else {
@@ -201,12 +204,38 @@
 }
 
 - (NSString *)messageText {
-    return _messageLabel.text;
+    return _messageTextView.text;
 }
 
 - (void)setMessageText:(NSString *)message {
-    _messageLabel.text = message;
+    _messageTextView.text = message;
     [self setNeedsLayout];
+}
+
+- (NSAttributedString *)attributedMessageText
+{
+    return self.messageTextView.attributedText;
+}
+
+- (void)setAttributedMessageText:(NSAttributedString *)attributedMessageText
+{
+    NSAttributedString * finalAttributedText = [self applyMessageStylesToAttributedString:attributedMessageText];
+    self.messageTextView.attributedText = finalAttributedText;
+}
+
+- (NSAttributedString *)applyMessageStylesToAttributedString:(NSAttributedString *)attributedString
+{
+    NSRange fullTextRange = NSMakeRange(0, attributedString.string.length);
+    NSMutableAttributedString *mutableAttributedText = [attributedString mutableCopy];
+
+    [mutableAttributedText addAttribute:NSFontAttributeName value:self.messageTextView.font range:fullTextRange];
+    [mutableAttributedText addAttribute:NSForegroundColorAttributeName value:self.messageTextView.textColor range:fullTextRange];
+
+    NSMutableParagraphStyle *paragraphStyle = [NSMutableParagraphStyle new];
+    paragraphStyle.alignment = self.messageTextView.textAlignment;
+    [mutableAttributedText addAttribute:NSParagraphStyleAttributeName value:paragraphStyle range:fullTextRange];
+
+    return mutableAttributedText;
 }
 
 - (void)setAccessoryView:(UIView *)accessoryView {


### PR DESCRIPTION
Fixes part of #8954 

This PR adds support for attributed text in `WPNoResultsView`'s message label.
Using that, now the Stock Photos `WPNoResultsView` has a tappable link to the Pexel website.

To add tappable links to `UILabel` or even to `UITextField` is fairly complicated, so I decided to replace the `UILabel` with a `UITextView` that already manages opening links by default. In this way the implementation became much simpler.

![pexel_link](https://user-images.githubusercontent.com/9772967/38956028-c9b2af8e-432c-11e8-8fa7-7c4ee930d7ac.png)

@bummytime  could you help us to review this?

**To test:**

1. Open Stock Photos (Blog -> Media -> + up right corner -> Free Photo Library).
2. In the `Photos provided by Pexel` message, the `Pexel` word should me highlighted as a link.
3. By tapping the link, it should open the Pexel website.
4. Please inspect the NoResultViews across the app to be sure they are displaying as they should.