### PR TITLE
Update Zendesk pod to 1.11.2.1.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -57,7 +57,7 @@ target 'WordPress' do
   pod 'lottie-ios', '1.5.1'
   pod 'Starscream', '3.0.4'
   pod 'GoogleSignIn', '4.1.2'
-  pod 'ZendeskSDK', '1.11.0.1'
+  pod 'ZendeskSDK', '1.11.2.1'
 
 
   ## Automattic libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -120,11 +120,11 @@ PODS:
     - NSObject-SafeExpectations (= 0.0.2)
   - WPMediaPicker (0.27)
   - wpxmlrpc (0.8.3)
-  - ZendeskSDK (1.11.0.1):
-    - ZendeskSDK/Providers (= 1.11.0.1)
-    - ZendeskSDK/UI (= 1.11.0.1)
-  - ZendeskSDK/Providers (1.11.0.1)
-  - ZendeskSDK/UI (1.11.0.1):
+  - ZendeskSDK (1.11.2.1):
+    - ZendeskSDK/Providers (= 1.11.2.1)
+    - ZendeskSDK/UI (= 1.11.2.1)
+  - ZendeskSDK/Providers (1.11.2.1)
+  - ZendeskSDK/UI (1.11.2.1):
     - ZendeskSDK/Providers
 
 DEPENDENCIES:
@@ -159,7 +159,7 @@ DEPENDENCIES:
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`)
   - WPMediaPicker (= 0.27)
   - wpxmlrpc (= 0.8.3)
-  - ZendeskSDK (= 1.11.0.1)
+  - ZendeskSDK (= 1.11.2.1)
 
 EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
@@ -217,8 +217,8 @@ SPEC CHECKSUMS:
   WordPressShared: b1bed3aa4db4438fd9fe78ccd0be58c8fee19c17
   WPMediaPicker: 1fe532b4ff215a9dd259f08439376fc0dbab1039
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
-  ZendeskSDK: 4e075d7610e74755c576188886a073cfc5810145
+  ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 07a9bfc29f8ad350956e5d57126b99ccbba47ea7
+PODFILE CHECKSUM: 7d93b2d776338a843024e0d74797f58109137069
 
 COCOAPODS: 1.4.0


### PR DESCRIPTION
Ref #9020 

**To test:**
- Do a pod install, build and run the project.
- To verify Zendesk components:
  - NOTE: Right now, the new Support view is only accessible if you are logged in with a WP or social account. And only via the navigation bar > Help. (Tip: I usually do Create Site > Help)
  - Sign in with a WP/social account.
  - Go to the Support page.
  - Verify 'WordPress Help Center' shows the FAQ.
  - Verify 'Contact Us' displays the new ticket view. 
  - Verify 'My Tickets' shows the ticket list view.

**Help Center view:**
<img width="250" alt="help_center" src="https://user-images.githubusercontent.com/1816888/39007133-50818a5e-43c2-11e8-8470-458ac9d54ed5.png">

**Contact Us view:**
<img width="250" alt="contact_us" src="https://user-images.githubusercontent.com/1816888/39007163-6276a3e8-43c2-11e8-81d7-b4684d97b5a6.png">

**My Tickets view:**
<img width="250" alt="my_tickets" src="https://user-images.githubusercontent.com/1816888/39007192-769297e2-43c2-11e8-9f9b-4e8d6477eee9.png">


@etoledom , @jleandroperez - can I bother one of you for a quick review please? Thank you!!

