### PR TITLE
Media Library: Enable multiple selection for document picker

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -449,6 +449,9 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         let docTypes = [String(kUTTypeImage), String(kUTTypeMovie)]
         let docPicker = UIDocumentPickerViewController(documentTypes: docTypes, in: .import)
         docPicker.delegate = self
+        if #available(iOS 11.0, *) {
+            docPicker.allowsMultipleSelection = true
+        }
         WPStyleGuide.configureDocumentPickerNavBarAppearance()
         present(docPicker, animated: true, completion: nil)
     }


### PR DESCRIPTION
Fixes #9128. This PR modifies the `UIDocumentPickerViewController` instance presented by the Media Library to accommodate selection of multiple document types.

To test: On an iOS 11 device, complete the following sequence:

- Select a Site.
- Navigate to `Publish/Media : Upload Media : Other Apps`
- Observe that the _Browse_ tab presented in the view controller includes a _Select_ bar button item.
- Validate that multiple selections are added to the Media Library.

Alternatively, review the attached screen shots.
![9128_browse](https://user-images.githubusercontent.com/38480191/39017696-c919984c-43d8-11e8-8014-043ec2fa9f9f.png)
![9128_recents](https://user-images.githubusercontent.com/38480191/39017695-c8ffcd90-43d8-11e8-9225-38fbfc0dd58b.png)