### PR TITLE
Stock Photos: Added no result message when search returns empty

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
@@ -11,6 +11,7 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
 
     private let throttle = Throttle(seconds: 1)
 
+    var searchQuery: String = ""
 
     init(service: StockPhotosService) {
         super.init()
@@ -29,6 +30,8 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
     }
 
     func search(for searchText: String?) {
+        searchQuery = searchText ?? ""
+
         guard searchText?.isEmpty == false else {
             clearSearch(notifyObservers: true)
             return
@@ -92,6 +95,7 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
     }
 
     func searchCancelled() {
+        searchQuery = ""
         clearSearch(notifyObservers: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
@@ -21,6 +21,7 @@ final class StockPhotosPicker: NSObject {
 
     weak var delegate: StockPhotosPickerDelegate?
     private var blog: Blog?
+    private var observerToken: NSObjectProtocol?
 
     private let searchHint = StockPhotosPlaceholder()
 
@@ -42,7 +43,32 @@ final class StockPhotosPicker: NSObject {
             picker.mediaPicker.searchBar?.becomeFirstResponder()
         }
 
+        observeDataSource()
         trackAccess()
+    }
+
+    private func observeDataSource() {
+        observerToken = dataSource.registerChangeObserverBlock { [weak self] (_, _, _, _, assets) in
+            self?.updateHintView()
+        }
+    }
+
+    private func shouldShowNoResults() -> Bool {
+        return dataSource.searchQuery.count > 0 && dataSource.numberOfAssets() == 0
+    }
+
+    private func updateHintView() {
+        if shouldShowNoResults() {
+            searchHint.configureAsNoSearchResults(for: dataSource.searchQuery)
+        } else {
+            searchHint.configureAsIntro()
+        }
+    }
+
+    deinit {
+        if let token = observerToken {
+            dataSource.unregisterChangeObserver(token)
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
@@ -8,17 +8,25 @@ final class StockPhotosPlaceholder: WPNoResultsView {
 
     init() {
         super.init(frame: .zero)
-        configure()
+        configureAsIntro()
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func configure() {
+    func configureAsIntro() {
         configureImage()
         configureTitle()
         configureSubtitle()
+    }
+
+    func configureAsNoSearchResults(for string: String) {
+        //Translators could add an empty space at the end of this phrase.
+        let sanitizedNoResultString = String.freePhotosSearchNoResult.trimmingCharacters(in: .whitespaces)
+
+        titleText = sanitizedNoResultString + " " + string
+        messageText = ""
     }
 
     private func configureImage() {

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosStrings.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosStrings.swift
@@ -21,4 +21,8 @@ extension String {
     static var freePhotosPlaceholderSubtitle: String {
         return NSLocalizedString("Photos provided by Pexels", comment: "Subtitle for placeholder in Free Photos. The company name 'Pexels' should always be written as it is.")
     }
+
+    static var freePhotosSearchNoResult: String {
+        return NSLocalizedString("No media files match your search for", comment: "Phrase to show when the user search for images but there are no result to show. This will be followed by the phrase the user used to search. (i.e. No media files match your search for Ugly kitten). This search phrase will be always appended at the end.")
+    }
 }


### PR DESCRIPTION
Fixes parts of #8954 

This PR adds a 'No search results' message when the user search for Free Photos and it returns empty.

![kittens](https://user-images.githubusercontent.com/9772967/39022556-7d19b9d4-440c-11e8-940d-94cb117e6c79.png)

Since this version is not merged with [the debouncing search](#9146), it will behave a little bit weird, updating the no result message in unexpected moments (as the throttle algorithm fire the requests)

@iamthomasbishop could you take a fast look at this?

To test:

- Free Photos search from the Media Library or the Editor.
- Search with a phrase that won't return results.
- You will see the No Results phrase as shown in the images.
- Test many phrases with and without phrases.
- Test learning the phrases string and cancelling search.
- Be sure that the No Results view is always consistent.
