### PR TITLE
Aztec: Enable multiple selection for document picker

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2139,6 +2139,9 @@ extension AztecPostViewController {
         let docTypes = [String(kUTTypeImage), String(kUTTypeMovie)]
         let docPicker = UIDocumentPickerViewController(documentTypes: docTypes, in: .import)
         docPicker.delegate = self
+        if #available(iOS 11.0, *) {
+            docPicker.allowsMultipleSelection = true
+        }
         WPStyleGuide.configureDocumentPickerNavBarAppearance()
         present(docPicker, animated: true, completion: nil)
     }


### PR DESCRIPTION
Fixes #9130. This PR modifies the `UIDocumentPickerViewController` instance presented by Aztec to accommodate selection of multiple document types. A similar change was applied to the [Media Library](https://github.com/wordpress-mobile/WordPress-iOS/pull/9147).

To test: On an iOS 11 device (or Simulator), complete the following sequence:

- Select a Site.
- Navigate to `Publish/Site Pages : Start A Page : + (Add Content) : ... (Present the Document Picker)`
- Observe that the _Browse_ tab presented in the view controller includes a _Select_ bar button item.
- Validate that multiple selections are added to the Media Library.

Alternatively, review the attached screen shot.
![9130_browse](https://user-images.githubusercontent.com/38480191/39029841-e3630c08-4412-11e8-971e-a3cd13c6da30.png)