### PR TITLE
Stock photos: Cancel previous throttled jobs when the search string is empty

### DIFF
--- a/WordPress/Classes/Utility/Scheduler.swift
+++ b/WordPress/Classes/Utility/Scheduler.swift
@@ -47,6 +47,8 @@ public class Scheduler {
         }
     }
 
+    /// Cancels the current scheduled job, if any.
+    ///
     func cancel() {
         job.cancel()
     }

--- a/WordPress/Classes/Utility/Throttle.swift
+++ b/WordPress/Classes/Utility/Throttle.swift
@@ -35,6 +35,9 @@ public class Throttle {
         queue.asyncAfter(deadline: .now() + Double(delay), execute: job)
     }
 
+    func cancel() {
+        job.cancel()
+    }
 }
 
 private extension Date {

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
@@ -148,7 +148,7 @@ extension StockPhotosDataSource {
 
 extension StockPhotosDataSource: StockPhotosDataLoaderDelegate {
     func didLoad(media: [StockPhotosMedia], reset: Bool) {
-        guard media.count > 0 else {
+        guard media.count > 0 && searchQuery.count > 0 else {
             clearSearch(notifyObservers: true)
             return
         }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
@@ -34,7 +34,7 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
 
         guard searchText?.isEmpty == false else {
             clearSearch(notifyObservers: true)
-            throttle.cancel()
+            scheduler.cancel()
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
@@ -31,6 +31,7 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
     func search(for searchText: String?) {
         guard searchText?.isEmpty == false else {
             clearSearch(notifyObservers: true)
+            throttle.cancel()
             return
         }
 


### PR DESCRIPTION
Implements part of #8954 

Fixes a bug when deleting a preexisting search term, character by character, until all characters were removed. After a second, a new search request containing the last character removed will be performed. It will be easy to understand with one example.

0. Launch Stock Photos
1. Search for "car" (without quotes)
2. Wait until the search results are populated
3. Delete characters one by one.
4. After deleting the "c", the "no results" placeholder will be presented
5. Wait for a second
6. A new search will be triggered, and some results will be presented (corresponding to the letter c)

To test:
Follow the instructions in the bug description.
After step 4, wait for a couple of seconds. No new searches should be triggered, and the "no results view" should not be removed from screen.
