### PR TITLE
ActivityList, TimeZoneSelector: Fix issue where the WPNoResultsView ould be misaligned after rotation.

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -120,8 +120,8 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
         noResultsView.removeFromSuperview()
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
         noResultsView.centerInSuperview()
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -120,6 +120,11 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
         noResultsView.removeFromSuperview()
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        noResultsView.centerInSuperview()
+    }
+
 }
 
 // MARK: - UITableViewDelegate

--- a/WordPress/Classes/ViewRelated/Tools/TimeZoneSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/TimeZoneSelectorViewController.swift
@@ -206,6 +206,12 @@ class TimeZoneSelectorViewController: UITableViewController, UISearchResultsUpda
         }
         return searchController.searchBar.text?.nonEmptyString()
     }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        noResultsView.centerInSuperview()
+    }
+
 }
 
 // MARK: - WPNoResultsViewDelegate

--- a/WordPress/Classes/ViewRelated/Tools/TimeZoneSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/TimeZoneSelectorViewController.swift
@@ -207,8 +207,8 @@ class TimeZoneSelectorViewController: UITableViewController, UISearchResultsUpda
         return searchController.searchBar.text?.nonEmptyString()
     }
 
-    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.viewWillTransition(to: size, with: coordinator)
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
         noResultsView.centerInSuperview()
     }
 


### PR DESCRIPTION
I'm somewhat conflicted if this is the "right" way to fix this — I don't think adding the four lines of code in every view controller ever is exactly a scalable solution. I'm somewhat afraid of rewriting `WPNoResultsView` to use AutoLayout though, especially if there's `NoResultsViewController` coming soon (?). 

I'm leaning towards fixing this where it pops up, and then maybe it would make for a nice HackWeek project to migrate away from `WPNoResultsView`? Totally up for discussion, curious to hear your thoughts!

Fixes #9144.

To test:
1. Open the app on an iPad (or simulator thereof)
2. Cut off your network connection
3. Wait for the empty/error state to appear.
4. Rotate the device to/from landscape
5. Rotate the device back to previous orientation
6. Verify that the content is properly centered.

