### PR TITLE
Update Async Promo link for release

### DIFF
--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+Async.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+Async.swift
@@ -23,17 +23,13 @@ extension FancyAlertViewController {
         }
 
         let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
-            let presenter = controller.presentingViewController
-            controller.dismiss(animated: true) {
-                // TODO: Add a relevant URL when we have a page up for this feature
-                guard let url = URL(string: "https://apps.wordpress.org/") else {
-                    return
-                }
-
-                let safariViewController = SFSafariViewController(url: url)
-                safariViewController.modalPresentationStyle = .pageSheet
-                presenter?.present(safariViewController, animated: true, completion: nil)
+            guard let url = URL(string: "http://en.blog.wordpress.com/2018/04/23/ios-nine-point-eight/") else {
+                return
             }
+
+            let safariViewController = SFSafariViewController(url: url)
+            safariViewController.modalPresentationStyle = .pageSheet
+            controller.present(safariViewController, animated: true, completion: nil)
         }
 
         let image = UIImage(named: "wp-illustration-easy-async")


### PR DESCRIPTION
This PR updates the URL launched from the "How does it work?" link in the async promo displayed in Aztec. It also updates the promo logic so that the promo alert itself isn't dismissed when the safari view controller is displayed.

**To test:**

* Either test with a fresh install, or modify the `if` statement at the end of `publishPost(action:dismissWhenDone:analyticsStat:)` in `AztecPostViewController` so that `promoBlock()` is always called (You can just replace `if !UserDefaults.standard.asyncPromoWasDisplayed {` with `if true {`).
* Verify that the "How does it work?" link takes you to en.blog.
* Verify that after closing the web view controller that the promo alert is still visible.