### PR TITLE
Remove jetpackSignup feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -4,7 +4,6 @@
 enum FeatureFlag: Int {
     case exampleFeature
     case jetpackDisconnect
-    case jetpackSignup
     case activity
     case usernameChanging
     case zendeskMobile
@@ -15,8 +14,6 @@ enum FeatureFlag: Int {
         case .exampleFeature:
             return true
         case .jetpackDisconnect:
-            return BuildConfiguration.current == .localDeveloper
-        case .jetpackSignup:
             return BuildConfiguration.current == .localDeveloper
         case .activity:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]

--- a/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEmailViewController.swift
@@ -188,10 +188,6 @@ class LoginEmailViewController: LoginViewController, NUXKeyboardResponder {
     /// Note: This is only used during Jetpack setup, not the normal flows
     ///
     func addSignupButton() {
-        guard WordPressAuthenticator.shared.configuration.supportsJetpackSignup else {
-            return
-        }
-
         guard let instructionLabel = instructionLabel,
             let stackView = inputStack else {
                 return

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -26,8 +26,7 @@ class WordPressAuthenticationManager: NSObject {
                                                                 wpcomTermsOfServiceURL: WPAutomatticTermsOfServiceURL,
                                                                 googleLoginClientId: ApiCredentials.googleLoginClientId(),
                                                                 googleLoginServerClientId: ApiCredentials.googleLoginServerClientId(),
-                                                                userAgent: WPUserAgent.wordPress(),
-                                                                supportsJetpackSignup: Feature.enabled(.jetpackSignup))
+                                                                userAgent: WPUserAgent.wordPress())
 
         WordPressAuthenticator.initialize(configuration: configuration)
     }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
@@ -133,10 +133,6 @@ public struct WordPressAuthenticatorConfiguration {
     /// UserAgent
     ///
     let userAgent: String
-
-    /// Indicates if Jetpack Signup is allowed, or not.
-    ///
-    let supportsJetpackSignup: Bool
 }
 
 


### PR DESCRIPTION
Fixes #8883

This closes out #8883 by removing the feature flag it was behind 🎉 With this, signup during Jetpack setup will ship!

To test:
- Make sure the signup option still appears in the Jetpack setup flow

