### PR TITLE
Media Library : Allow document types to be selected in the doc picker

### DIFF
--- a/WordPress/Classes/Models/Blog+Files.swift
+++ b/WordPress/Classes/Models/Blog+Files.swift
@@ -1,0 +1,24 @@
+import MobileCoreServices
+
+
+extension Blog {
+    var allowedTypeIdentifiers: [String] {
+        guard let allowedFileExtensions = allowedFileTypes as? Set<String> else {
+            return [String(kUTTypeContent), String(kUTTypeZipArchive)]
+        }
+
+        var typeIdentifiers = [String]()
+        for pathExtension in allowedFileExtensions {
+            let uti = UTTypeCreatePreferredIdentifierForTag(
+                kUTTagClassFilenameExtension,
+                pathExtension as CFString,
+                nil)?.takeUnretainedValue() as String?
+
+            if let validUTI = uti {
+                typeIdentifiers.append(validUTI)
+            }
+        }
+
+        return typeIdentifiers
+    }
+}

--- a/WordPress/Classes/Models/Blog+Files.swift
+++ b/WordPress/Classes/Models/Blog+Files.swift
@@ -1,9 +1,25 @@
 import MobileCoreServices
 
 
+// MARK: - Support for Files-based functionality
+
 extension Blog {
+    /// In conjunction with `allowedFileExtensions`, reports the
+    /// [Uniform Type Identifiers](https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_intro/understand_utis_intro.html#//apple_ref/doc/uid/TP40001319-CH201-SW1)
+    /// supported by this particular `Blog` instance. Supported files differ between
+    /// [Wordpress.org](https://codex.wordpress.org/Uploading_Files)
+    /// and [Wordpress.com](https://en.support.wordpress.com/accepted-filetypes/).
+    ///
+    /// This computed property is intended for use with `UIDocumentPickerController`.
+    ///
+    /// - returns: The collection of UTIs supported by this blog instance.
+    ///
     var allowedTypeIdentifiers: [String] {
         guard let allowedFileExtensions = allowedFileTypes as? Set<String> else {
+            /**
+                NB: For self-hosted plans, this collection has been observed to be empty. In that
+                case, we fall back to base [System-Declared Uniform Type Identifiers](https://developer.apple.com/library/content/documentation/Miscellaneous/Reference/UTIRef/Articles/System-DeclaredUniformTypeIdentifiers.html).
+             */
             return [String(kUTTypeContent), String(kUTTypeZipArchive)]
         }
 

--- a/WordPress/Classes/Services/MediaImportService.swift
+++ b/WordPress/Classes/Services/MediaImportService.swift
@@ -20,6 +20,9 @@ open class MediaImportService: LocalCoreDataService {
     ///
     @objc static let preferredImageCompressionQuality = 0.9
 
+    /// Allows the caller to designate supported import file types
+    @objc var allowableFileExtensions = [String]()
+
     /// Completion handler for a created Media object.
     ///
     public typealias MediaCompletion = (Media) -> Void
@@ -78,6 +81,7 @@ open class MediaImportService: LocalCoreDataService {
             let exporter = MediaURLExporter(url: url)
             exporter.imageOptions = self.exporterImageOptions
             exporter.videoOptions = self.exporterVideoOptions
+            exporter.urlOptions = self.exporterURLOptions
             return exporter
         case let stockPhotosMedia as StockPhotosMedia:
             let exporter = MediaExternalExporter(externalAsset: stockPhotosMedia)
@@ -136,6 +140,13 @@ open class MediaImportService: LocalCoreDataService {
         var options = MediaVideoExporter.Options()
         options.stripsGeoLocationIfNeeded = MediaSettings().removeLocationSetting
         options.exportPreset = MediaSettings().maxVideoSizeSetting.videoPreset
+        return options
+    }
+
+    fileprivate var exporterURLOptions: MediaURLExporter.Options {
+        var options = MediaURLExporter.Options()
+        options.allowableFileExtensions = allowableFileExtensions
+        options.stripsGeoLocationIfNeeded = MediaSettings().removeLocationSetting
         return options
     }
 

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -43,6 +43,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 {
     NSProgress *createProgress = [NSProgress discreteProgressWithTotalUnitCount:1];
     __block Media *media;
+    __block NSArray *allowedFileTypes = [NSArray array];
     [self.managedObjectContext performBlockAndWait:^{
         AbstractPost *post = nil;
         Blog *blog = nil;
@@ -59,6 +60,10 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
                 completion(nil, error);
             }
             return;
+        }
+        
+        if (blog.allowedFileTypes != nil) {
+            allowedFileTypes = blog.allowedFileTypes.allObjects;
         }
 
         if (post != nil) {
@@ -102,6 +107,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 
         // Export based on the type of the exportable.
         MediaImportService *importService = [[MediaImportService alloc] initWithManagedObjectContext:self.managedObjectContext];
+        importService.allowableFileExtensions = allowedFileTypes;
         NSProgress *importProgress = [importService importResource:exportable toMedia:media onCompletion:completionWithMedia onError:completionWithError];
         [createProgress addChild:importProgress withPendingUnitCount:1];
     }];

--- a/WordPress/Classes/Services/MediaThumbnailService.swift
+++ b/WordPress/Classes/Services/MediaThumbnailService.swift
@@ -99,11 +99,13 @@ class MediaThumbnailService: LocalCoreDataService {
             }
 
             // If the Media asset is available locally, export thumbnails from the local asset.
-            if let localAssetURL = mediaInContext.absoluteLocalURL, exporter.supportsThumbnailExport(forFile: localAssetURL) {
-                self.exportQueue.async {
-                    exporter.exportThumbnail(forFile: localAssetURL,
-                                             onCompletion: onThumbnailExport,
-                                             onError: onThumbnailExportError)
+            if let localAssetURL = mediaInContext.absoluteLocalURL {
+                if exporter.supportsThumbnailExport(forFile: localAssetURL) {
+                    self.exportQueue.async {
+                        exporter.exportThumbnail(forFile: localAssetURL,
+                                                 onCompletion: onThumbnailExport,
+                                                 onError: onThumbnailExportError)
+                    }
                 }
                 return
             }

--- a/WordPress/Classes/Utility/Media/MediaThumbnailExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaThumbnailExporter.swift
@@ -120,6 +120,8 @@ class MediaThumbnailExporter: MediaExporter {
             switch expected {
             case .image, .video, .gif:
                 return true
+            case .other:
+                return false
             }
         } catch {
             return false
@@ -154,6 +156,8 @@ class MediaThumbnailExporter: MediaExporter {
                 return exportImageThumbnail(at: url, onCompletion: onCompletion, onError: onError)
             case .video:
                 return exportVideoThumbnail(at: url, onCompletion: onCompletion, onError: onError)
+            case .other:
+                return Progress.discreteCompletedProgress()
             }
         } catch {
             onError(exporterErrorWith(error: error))

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -35,7 +35,7 @@ final class MediaLibraryMediaPickingCoordinator {
         menuAlert.addAction(freePhotoAction(origin: origin, blog: blog))
 
         if #available(iOS 11.0, *) {
-            menuAlert.addAction(otherAppsAction(origin: origin))
+            menuAlert.addAction(otherAppsAction(origin: origin, blog: blog))
         }
 
         menuAlert.addAction(cancelAction())
@@ -64,9 +64,9 @@ final class MediaLibraryMediaPickingCoordinator {
         })
     }
 
-    private func otherAppsAction(origin: UIViewController & UIDocumentPickerDelegate) -> UIAlertAction {
+    private func otherAppsAction(origin: UIViewController & UIDocumentPickerDelegate, blog: Blog) -> UIAlertAction {
         return UIAlertAction(title: .files, style: .default, handler: { [weak self] action in
-            self?.showDocumentPicker(origin: origin)
+            self?.showDocumentPicker(origin: origin, blog: blog)
         })
     }
 
@@ -84,8 +84,8 @@ final class MediaLibraryMediaPickingCoordinator {
         stockPhotos.presentPicker(origin: origin, blog: blog)
     }
 
-    private func showDocumentPicker(origin: UIViewController & UIDocumentPickerDelegate) {
-        let docTypes = [String(kUTTypeImage), String(kUTTypeMovie)]
+    private func showDocumentPicker(origin: UIViewController & UIDocumentPickerDelegate, blog: Blog) {
+        let docTypes = blog.allowedTypeIdentifiers
         let docPicker = UIDocumentPickerViewController(documentTypes: docTypes, in: .import)
         docPicker.delegate = origin
         if #available(iOS 11.0, *) {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -411,7 +411,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
     // MARK: - Document Picker
 
     private func showDocumentPicker() {
-        let docTypes = [String(kUTTypeImage), String(kUTTypeMovie)]
+        let docTypes = blog.allowedTypeIdentifiers
         let docPicker = UIDocumentPickerViewController(documentTypes: docTypes, in: .import)
         docPicker.delegate = self
         if #available(iOS 11.0, *) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -353,6 +353,7 @@
 		6867C0633E597372235CB5E0 /* Pods_WordPressDraftActionExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7E3CC306AECBBCB71D2E19C /* Pods_WordPressDraftActionExtension.framework */; };
 		7059CD210F332B6500A0660B /* WPCategoryTree.m in Sources */ = {isa = PBXBuildFile; fileRef = 7059CD200F332B6500A0660B /* WPCategoryTree.m */; };
 		722F5726ACB4A276B0CF3C83 /* Pods_WordPress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */; };
+		73713583208EA4B900CCDFC8 /* Blog+Files.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73713582208EA4B900CCDFC8 /* Blog+Files.swift */; };
 		740219FE202E12F4006CC39F /* UploadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741E22441FC0CC55007967AB /* UploadOperation.swift */; };
 		740219FF202E12F4006CC39F /* PostUploadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AF4D711FE417D200E3EBFE /* PostUploadOperation.swift */; };
 		74021A00202E12F4006CC39F /* MediaUploadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AF4D6D1FE417D200E3EBFE /* MediaUploadOperation.swift */; };
@@ -1812,6 +1813,7 @@
 		7059CD200F332B6500A0660B /* WPCategoryTree.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = WPCategoryTree.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		712D0A17BC83B9730BD7CCC0 /* Pods-WordPressDraftActionExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressDraftActionExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressDraftActionExtension/Pods-WordPressDraftActionExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		740516882087B73400252FD0 /* SearchableActivityConvertable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchableActivityConvertable.swift; sourceTree = "<group>"; };
+		73713582208EA4B900CCDFC8 /* Blog+Files.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Files.swift"; sourceTree = "<group>"; };
 		740BD8331A0D4C3600F04D18 /* WPUploadStatusButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPUploadStatusButton.h; sourceTree = "<group>"; };
 		740BD8341A0D4C3600F04D18 /* WPUploadStatusButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUploadStatusButton.m; sourceTree = "<group>"; };
 		740C7C4E202F4CD6001C31B0 /* MainInterface.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MainInterface.storyboard; sourceTree = "<group>"; };
@@ -4875,6 +4877,7 @@
 				CEBD3EA90FF1BA3B00C1396E /* Blog.h */,
 				CEBD3EAA0FF1BA3B00C1396E /* Blog.m */,
 				B518E1641CCAA19200ADFE75 /* Blog+Capabilities.swift */,
+				73713582208EA4B900CCDFC8 /* Blog+Files.swift */,
 				B5EEDB961C91F10400676B2B /* Blog+Interface.swift */,
 				E11C4B6F2010930B00A6619C /* Blog+Jetpack.swift */,
 				B5D889401BEBE30A007C4684 /* BlogSettings.swift */,
@@ -7946,6 +7949,7 @@
 				43D54D131DCAA070007F575F /* PostPostViewController.swift in Sources */,
 				B54E1DF41A0A7BBF00807537 /* NotificationMediaDownloader.swift in Sources */,
 				178EDE701C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift in Sources */,
+				73713583208EA4B900CCDFC8 /* Blog+Files.swift in Sources */,
 				E174F6E6172A73960004F23A /* WPAccount.m in Sources */,
 				E1718EA01CAD0800006F9E2D /* HockeyManager.m in Sources */,
 				FF619DD51C75246900903B65 /* CLPlacemark+Formatting.swift in Sources */,


### PR DESCRIPTION
Fixes #9129, which requests support for adding additional document types to the _Media Library_ via `UIDocumentPickerViewController`. It accomplishes this with the following changes:

- Leverages an existing property on `Blog` called `allowedFileTypes` to identify the file types associated with the blog's plan.
- Extends `Blog` to translate those file types into corresponding [Uniform Type Identifiers](https://developer.apple.com/library/content/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_intro/understand_utis_intro.html#//apple_ref/doc/uid/TP40001319-CH201-SW1).
- Enforces `allowedFileTypes` injected into `MediaURLExporter`.
- Defines a new case for `URLExportExpectation`, and propagates support for that.

To test:

- *Manually* attempt to add various files into the _Media Library_ for an assortment of plans & files. Keep in mind that file support differs between [Wordpress.org](https://codex.wordpress.org/Uploading_Files) & [Wordpress.com](https://en.support.wordpress.com/accepted-filetypes/).
- Inspect the screenshots below:
<img width="487" alt="9129_docpickerselection_free" src="https://user-images.githubusercontent.com/38480191/39099913-d8733446-4636-11e8-8fd6-a52f015968bc.png">
<img width="487" alt="9129_import_success" src="https://user-images.githubusercontent.com/38480191/39099915-df2f0c42-4636-11e8-9ad6-148dbf2ae54c.png">