### PR TITLE
Media Library: Remove redundant code and reinstate multiple document selection

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -88,6 +88,9 @@ final class MediaLibraryMediaPickingCoordinator {
         let docTypes = [String(kUTTypeImage), String(kUTTypeMovie)]
         let docPicker = UIDocumentPickerViewController(documentTypes: docTypes, in: .import)
         docPicker.delegate = origin
+        if #available(iOS 11.0, *) {
+            docPicker.allowsMultipleSelection = true
+        }
         WPStyleGuide.configureDocumentPickerNavBarAppearance()
         origin.present(docPicker, animated: true, completion: nil)
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -407,65 +407,6 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             MediaCoordinator.shared.removeObserver(withUUID: uuid)
         }
     }
-
-    // MARK: - Document Picker
-
-    private func showDocumentPicker() {
-        let docTypes = [String(kUTTypeImage), String(kUTTypeMovie)]
-        let docPicker = UIDocumentPickerViewController(documentTypes: docTypes, in: .import)
-        docPicker.delegate = self
-        if #available(iOS 11.0, *) {
-            docPicker.allowsMultipleSelection = true
-        }
-        WPStyleGuide.configureDocumentPickerNavBarAppearance()
-        present(docPicker, animated: true, completion: nil)
-    }
-
-    // MARK: - Upload Media from Camera
-
-    private func presentMediaCapture() {
-        capturePresenter = WPMediaCapturePresenter(presenting: self)
-        capturePresenter!.completionBlock = { [weak self] mediaInfo in
-            if let mediaInfo = mediaInfo as NSDictionary? {
-                self?.processMediaCaptured(mediaInfo)
-            }
-            self?.capturePresenter = nil
-        }
-
-        capturePresenter!.presentCapture()
-    }
-
-    private func processMediaCaptured(_ mediaInfo: NSDictionary) {
-        let completionBlock: WPMediaAddedBlock = { [weak self] media, error in
-            if error != nil || media == nil {
-                print("Adding media failed: ", error?.localizedDescription ?? "no media")
-                return
-            }
-            guard let blog = self?.blog,
-                let media = media as? PHAsset else {
-                return
-            }
-
-            let info = MediaAnalyticsInfo(origin: .mediaLibrary(.wpMediaLibrary), selectionMethod: .fullScreenPicker)
-            MediaCoordinator.shared.addMedia(from: media, to: blog, analyticsInfo: info)
-        }
-
-        guard let mediaType = mediaInfo[UIImagePickerControllerMediaType] as? String else { return }
-
-        switch mediaType {
-        case String(kUTTypeImage):
-            if let image = mediaInfo[UIImagePickerControllerOriginalImage] as? UIImage,
-                let metadata = mediaInfo[UIImagePickerControllerMediaMetadata] as? [AnyHashable: Any] {
-                WPPHAssetDataSource().add(image, metadata: metadata, completionBlock: completionBlock)
-            }
-        case String(kUTTypeMovie):
-            if let mediaURL = mediaInfo[UIImagePickerControllerMediaURL] as? URL {
-                WPPHAssetDataSource().addVideo(from: mediaURL, completionBlock: completionBlock)
-            }
-        default:
-            break
-        }
-    }
 }
 
 // MARK: - UIDocumentPickerDelegate


### PR DESCRIPTION
While reviewing #9161, I noticed that changes to `showDocumentPicker` in `MediaLibraryViewController` didn't seem to be having any effect. It looks as though `showDocumentPicker` was moved to `MediaLibraryMediaPickingCoordinator` as part of the recent stock photos changes, but the original method wasn't removed from `MediaLibraryViewController`. 

The camera capture presentation and processing methods were also still present, so I've removed those too.

This also meant that the stock photos merge removed functionality added in #9147 (multiple selection in the document picker). I've re-added this to `MediaLibraryMediaPickingCoordinator`.

**To test:**

* Check the app builds and runs.
* In the media library, choose + and Other Apps. Ensure you can see the Select button in the navigation bar, and that you can select multiple items to upload.

cc @ctarda and @a8c-sab-trial