### PR TITLE
Add spotlight user activity analytics

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1153,6 +1153,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatSiteSettingsStartOverContactSupportClicked:
             eventName = @"site_settings_start_over_contact_support_clicked";
             break;
+        case WPAnalyticsStatSpotlightSearchOpenedApp:
+            eventName = @"spotlight_search_opened_app";
+            break;
         case WPAnalyticsStatSpotlightSearchOpenedPost:
             eventName = @"spotlight_search_opened_post";
             break;
@@ -1326,7 +1329,6 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatDefaultAccountChanged:
         case WPAnalyticsStatNoStat:
         case WPAnalyticsStatPerformedCoreDataMigrationFixFor45:
-        case WPAnalyticsStatSpotlightSearchOpenedApp:
         case WPAnalyticsStatMaxValue:
             return nil;
     }

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -131,20 +131,28 @@ import MobileCoreServices
             // This activityType is related to a CoreSpotlight search (SearchableItemConvertable)
             return handleCoreSpotlightSearchableActivityType(activity: activity)
         case WPActivityType.siteList.rawValue:
+            WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.siteList.rawValue])
             return openMySitesTab()
         case WPActivityType.siteDetails.rawValue:
+            WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.siteDetails.rawValue])
             return handleSite(activity: activity)
         case WPActivityType.reader.rawValue:
+            WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.reader.rawValue])
             return openReaderTab()
         case WPActivityType.me.rawValue:
+            WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.me.rawValue])
             return openMeTab()
         case WPActivityType.appSettings.rawValue:
+            WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.appSettings.rawValue])
             return openAppSettingsScreen()
         case WPActivityType.notificationSettings.rawValue:
+            WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.notificationSettings.rawValue])
             return openNotificationSettingsScreen()
         case WPActivityType.support.rawValue:
+            WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.support.rawValue])
             return openSupportScreen()
         case WPActivityType.notifications.rawValue:
+            WPAppAnalytics.track(.spotlightSearchOpenedApp, withProperties: ["via": WPActivityType.notifications.rawValue])
             return openNotificationsTab()
         default:
             return false


### PR DESCRIPTION
This simple PR adds some missing analytics to the new spotlight user activity indexing.

ref: #9148 

**To test:**

0. Make sure WPiOS builds and runs.
1. Navigate around the app a little bit (open the main tabs, open app settings, open notification settings)
2. Dismiss the WPiOS and open spotlight search on iOS. Search for things like "WordPress" or "Settings"
3. Verify you are seeing log statments like this in the console:

* `🔵 Tracked: spotlight_search_opened_app, properties: {
    via = "org.wordpress.mysites";}`
* `🔵 Tracked: spotlight_search_opened_app, properties: {via = "org.wordpress.notifications";}`
* `🔵 Tracked: spotlight_search_opened_app, properties: {via = "org.wordpress.me.notificationsettings";}`

@diegoreymendez could you take a quick peek at this for me?

