### PR TITLE
Stock Photos: Adding WPStyle to search bar

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPicker.swift
@@ -89,6 +89,12 @@ extension StockPhotosPicker: WPMediaPickerViewControllerDelegate {
         return searchHint
     }
 
+    func mediaPickerControllerDidEndLoadingData(_ picker: WPMediaPickerViewController) {
+        if let searchBar = picker.searchBar {
+            WPStyleGuide.configureSearchBar(searchBar)
+        }
+    }
+
     func mediaPickerControllerDidCancel(_ picker: WPMediaPickerViewController) {
         picker.dismiss(animated: true)
         dataSource.clearSearch(notifyObservers: false)


### PR DESCRIPTION
Fixes #9168 

This PR adds styling to the Stock Photos search bar.

![searchbar](https://user-images.githubusercontent.com/9772967/39204003-ddfc0590-47cc-11e8-9ad8-61bb184cc17b.png)

To test from Media Library:
- Go to your favorite blog's Media Library.
- Press the `+` button at the top right.
- Choose `Free Photo Library`.
- Check that the search bar color is the same than the other ones in the app.

Test from editor:
- Open the editor.
- Press the `+` button in the style bar.
- Press the `...` button.
- Choose `Free Photo Library`.
- Check that the search bar color is the same than the other ones in the app.

cc: @diegoreymendez 