### PR TITLE
Stock Photos design review

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -541,6 +541,8 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     [[WPMediaCollectionViewCell appearanceWhenContainedInInstancesOfClasses:@[ [WPMediaPickerViewController class] ]] setPlaceholderTintColor:[WPStyleGuide greyLighten30]];
     [[WPMediaCollectionViewCell appearanceWhenContainedInInstancesOfClasses:@[ [WPMediaPickerViewController class] ]] setCellTintColor:[WPStyleGuide wordPressBlue]];
 
+    [[UIButton appearanceWhenContainedInInstancesOfClasses:@[ [WPActionBar class] ]] setTintColor:[WPStyleGuide wordPressBlue]];
+
     // Customize the appearence of the text elements
     [self customizeAppearanceForTextElements];
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryStrings.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryStrings.swift
@@ -5,6 +5,6 @@ extension String {
     }
 
     static var importFromPhotoLibrary: String {
-        return NSLocalizedString("Photo Library", comment: "Menu option for selecting media from the device's photo library.")
+        return NSLocalizedString("Choose from My Device", comment: "Menu option for selecting media from the device's photo library.")
     }
 }


### PR DESCRIPTION
Fixes #9186 

- Media library's "Add asset picker": Rename "Device library" option.

![pickername](https://user-images.githubusercontent.com/9772967/39217306-d19b8036-47f5-11e8-8caf-6e586604d70f.png)

- The actions/links on the Free Photo Library action bar should be set in `wordPressBlue`.

![actionbat](https://user-images.githubusercontent.com/9772967/39217301-c87a4eec-47f5-11e8-9058-c67ac9263e55.png)


To test:

- First point:
  - Go to the Media Library.
  - Press the `+` button at the top right corner.
  - The second option should say: "Choose from My Device".

- Second point:
  - From that same picker, choose `Free Photo Library`.
  - Search for `car`.
  - Select items.
  - Check that the color of the buttons in the bottom bar are `wordPressBlue` (like in the screenshot).
