### PR TITLE
Stock photos: pixelated previews

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosMedia.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosMedia.swift
@@ -54,11 +54,11 @@ final class StockPhotosMedia: NSObject {
 
 extension StockPhotosMedia: WPMediaAsset {
     func image(with size: CGSize, completionHandler: @escaping WPMediaImageBlock) -> WPMediaRequestID {
+        let thumb = thumbURL(with: size)
 
-        //Temporary loading image from URL
         DispatchQueue.global().async {
             do {
-                let data = try Data(contentsOf: self.thumbnails.postThumbnailURL)
+                let data = try Data(contentsOf: thumb)
                 let image = UIImage(data: data)
                 completionHandler(image, nil)
             } catch {
@@ -68,6 +68,11 @@ extension StockPhotosMedia: WPMediaAsset {
 
         let number = Int32(id) ?? 0
         return number as WPMediaRequestID
+    }
+
+    // We assume that if the size passed is .zero, we want the largest possible image
+    private func thumbURL(with size: CGSize) -> URL {
+        return size == .zero ? thumbnails.largeURL : thumbnails.postThumbnailURL
     }
 
     func cancelImageRequest(_ requestID: WPMediaRequestID) {


### PR DESCRIPTION
Fixes #9172 

We were providing the smallest thumbnail to the preview. 

Here is the before and after
![thumbnail_before_after](https://user-images.githubusercontent.com/2722505/39222847-62e24de2-4871-11e8-84c0-554ebd6e2b23.jpg)

To test:
1. Navigate to a blog's Media Library
2. Tap + > Free Photo Library
3. Search for "car"
4. Select one or more images
5. Tap "Preview"