### PR TITLE
Disables paragraph tag stripping for Gutenberg posts.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessor.swift
@@ -5,7 +5,7 @@ protocol CalypsoProcessor: Processor {
 }
 
 extension CalypsoProcessor {
-    
+
     /// HACK: not a very good approach, but our APIs don't offer proper versioning info on `post_content`.
     /// Directly copied from here: https://github.com/WordPress/gutenberg/blob/5a6693589285363341bebad15bd56d9371cf8ecc/lib/register.php#L343
     ///

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessor.swift
@@ -1,0 +1,15 @@
+import Aztec
+import Foundation
+
+protocol CalypsoProcessor: Processor {
+}
+
+extension CalypsoProcessor {
+    
+    /// HACK: not a very good approach, but our APIs don't offer proper versioning info on `post_content`.
+    /// Directly copied from here: https://github.com/WordPress/gutenberg/blob/5a6693589285363341bebad15bd56d9371cf8ecc/lib/register.php#L343
+    ///
+    func wasWrittenWithGutenberg(_ content: String) -> Bool {
+        return content.contains("<!-- wp:")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -4,7 +4,7 @@ import Aztec
 
 // MARK: - CalypsoProcessorIn
 //
-class CalypsoProcessorIn: Processor {
+class CalypsoProcessorIn: CalypsoProcessor {
 
     /// Converts a Calypso-Generated string into Valid HTML that can actually be edited by Aztec.
     ///
@@ -14,9 +14,7 @@ class CalypsoProcessorIn: Processor {
     ///
     func process(_ text: String) -> String {
 
-        // This is awful, but our APIs don't offer any flag to know if the content is Gutenberg content or not.
-        // Directly copied from here: https://github.com/WordPress/gutenberg/blob/5a6693589285363341bebad15bd56d9371cf8ecc/lib/register.php#L343
-        guard !text.contains("<!-- wp:") else {
+        guard !wasWrittenWithGutenberg(text) else {
             return text
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorIn.swift
@@ -13,6 +13,13 @@ class CalypsoProcessorIn: Processor {
     /// Current as of 2017/08/08
     ///
     func process(_ text: String) -> String {
+
+        // This is awful, but our APIs don't offer any flag to know if the content is Gutenberg content or not.
+        // Directly copied from here: https://github.com/WordPress/gutenberg/blob/5a6693589285363341bebad15bd56d9371cf8ecc/lib/register.php#L343
+        guard !text.contains("<!-- wp:") else {
+            return text
+        }
+
         var preserveLinebreaks = false
         var preserveBR = false
         let blocklist = "table|thead|tfoot|caption|col|colgroup|tbody|tr|td|th|div|dl|dd|dt|ul|ol|li|pre" +

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -4,7 +4,7 @@ import Aztec
 
 // MARK: - CalypsoProcessorIn
 //
-class CalypsoProcessorOut: Processor {
+class CalypsoProcessorOut: CalypsoProcessor {
 
     /// Converts the standard-HTML output of Aztec into the hybrid-HTML that WordPress uses to store
     /// posts.
@@ -15,9 +15,7 @@ class CalypsoProcessorOut: Processor {
     ///
     func process(_ text: String) -> String {
 
-        // This is awful, but our APIs don't offer any flag to know if the content is Gutenberg content or not.
-        // Directly copied from here: https://github.com/WordPress/gutenberg/blob/5a6693589285363341bebad15bd56d9371cf8ecc/lib/register.php#L343
-        guard !text.contains("<!-- wp:") else {
+        guard !wasWrittenWithGutenberg(text) else {
             return text
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Processors/CalypsoProcessorOut.swift
@@ -15,6 +15,12 @@ class CalypsoProcessorOut: Processor {
     ///
     func process(_ text: String) -> String {
 
+        // This is awful, but our APIs don't offer any flag to know if the content is Gutenberg content or not.
+        // Directly copied from here: https://github.com/WordPress/gutenberg/blob/5a6693589285363341bebad15bd56d9371cf8ecc/lib/register.php#L343
+        guard !text.contains("<!-- wp:") else {
+            return text
+        }
+
         guard text.count > 0 else {
             return ""
         }

--- a/WordPress/Classes/ViewRelated/Aztec/Renderers/CommentAttachmentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Renderers/CommentAttachmentRenderer.swift
@@ -98,8 +98,8 @@ private extension CommentAttachmentRenderer {
 
     func isGutenbergComment(_ comment: CommentAttachment) -> Bool {
 
-        let openingGutenbergTag = "wp:core/"
-        let closingGutenbergTag = "/wp:core/"
+        let openingGutenbergTag = "wp:"
+        let closingGutenbergTag = "/wp:"
 
         let text = comment.text.trimmingCharacters(in: .whitespacesAndNewlines)
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1202,6 +1202,9 @@
 		E8DEE110E4BC3FA1974AB1BB /* Pods_WordPressTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B921F5DD9A1F257C792EC225 /* Pods_WordPressTest.framework */; };
 		F1049F331F39FCF9004DF0BB /* CalypsoProcessorOut.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */; };
 		F128C31C1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m in Sources */ = {isa = PBXBuildFile; fileRef = F128C31B1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m */; };
+		F162BE0E209266D30085F34D /* CalypsoProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F162BE0D209266D30085F34D /* CalypsoProcessor.swift */; };
+		F162BE0F209268520085F34D /* CalypsoProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F162BE0D209266D30085F34D /* CalypsoProcessor.swift */; };
+		F162BE10209268520085F34D /* CalypsoProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F162BE0D209266D30085F34D /* CalypsoProcessor.swift */; };
 		F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B43771F849F580089B817 /* PostAttachmentTests.swift */; };
 		F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
 		F1D690171F82914200200E30 /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
@@ -1812,8 +1815,8 @@
 		7059CD1F0F332B6500A0660B /* WPCategoryTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = WPCategoryTree.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		7059CD200F332B6500A0660B /* WPCategoryTree.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = WPCategoryTree.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		712D0A17BC83B9730BD7CCC0 /* Pods-WordPressDraftActionExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressDraftActionExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressDraftActionExtension/Pods-WordPressDraftActionExtension.debug.xcconfig"; sourceTree = "<group>"; };
-		740516882087B73400252FD0 /* SearchableActivityConvertable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchableActivityConvertable.swift; sourceTree = "<group>"; };
 		73713582208EA4B900CCDFC8 /* Blog+Files.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Files.swift"; sourceTree = "<group>"; };
+		740516882087B73400252FD0 /* SearchableActivityConvertable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchableActivityConvertable.swift; sourceTree = "<group>"; };
 		740BD8331A0D4C3600F04D18 /* WPUploadStatusButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPUploadStatusButton.h; sourceTree = "<group>"; };
 		740BD8341A0D4C3600F04D18 /* WPUploadStatusButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPUploadStatusButton.m; sourceTree = "<group>"; };
 		740C7C4E202F4CD6001C31B0 /* MainInterface.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MainInterface.storyboard; sourceTree = "<group>"; };
@@ -2898,6 +2901,7 @@
 		F14B5F73208E648300439554 /* WordPress.alpha.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WordPress.alpha.xcconfig; sourceTree = "<group>"; };
 		F14B5F74208E64F900439554 /* Version.public.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.public.xcconfig; sourceTree = "<group>"; };
 		F14B5F75208E64F900439554 /* Version.internal.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.internal.xcconfig; sourceTree = "<group>"; };
+		F162BE0D209266D30085F34D /* CalypsoProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalypsoProcessor.swift; sourceTree = "<group>"; };
 		F18B43771F849F580089B817 /* PostAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostAttachmentTests.swift; path = Posts/PostAttachmentTests.swift; sourceTree = "<group>"; };
 		F1D690141F828FF000200E30 /* BuildConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfiguration.swift; sourceTree = "<group>"; };
 		F1D690151F828FF000200E30 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
@@ -4816,6 +4820,7 @@
 				FF7E51061FBDDFA800AD2918 /* VideoUploadProcessor.swift */,
 				B50C0C541EF42A0000372C65 /* ShortcodeProcessor.swift */,
 				B50C0C551EF42A0000372C65 /* VideoShortcodeProcessor.swift */,
+				F162BE0D209266D30085F34D /* CalypsoProcessor.swift */,
 				B5032DDC1F02B30B00D946DC /* CalypsoProcessorIn.swift */,
 				F1049F321F39FCF9004DF0BB /* CalypsoProcessorOut.swift */,
 			);
@@ -7389,6 +7394,7 @@
 				E1B9128F1BB05B1D003C25B9 /* PeopleCell.swift in Sources */,
 				313AE4A019E3F20400AAFABE /* CommentViewController.m in Sources */,
 				B5015C581D4FDBB300C9449E /* NotificationActionsService.swift in Sources */,
+				F162BE0E209266D30085F34D /* CalypsoProcessor.swift in Sources */,
 				A0E293F10E21027E00C6919C /* WPAddPostCategoryViewController.m in Sources */,
 				E6BDEA731CE4824300682885 /* ReaderSearchTopic.swift in Sources */,
 				5D5A6E931B613CA400DAF819 /* ReaderPostCardCell.swift in Sources */,
@@ -8068,6 +8074,7 @@
 				74E44AD52031E83C00556205 /* ExtensionNotificationManager.swift in Sources */,
 				74448F552044BC7600BD4CDA /* CategoryTree.swift in Sources */,
 				74021A09202E1323006CC39F /* ShareSegueHandler.swift in Sources */,
+				F162BE10209268520085F34D /* CalypsoProcessor.swift in Sources */,
 				74021A01202E12F4006CC39F /* SharedCoreDataStack.swift in Sources */,
 				74021A14202E1393006CC39F /* ShareExtensionEditorViewController.swift in Sources */,
 				74021A0F202E1370006CC39F /* ExtensionTransitioningManager.swift in Sources */,
@@ -8135,6 +8142,7 @@
 				745EAF472003FDAA0066F415 /* ShareExtensionAbstractViewController.swift in Sources */,
 				74448F542044BC7600BD4CDA /* CategoryTree.swift in Sources */,
 				74402F2A200528F200A1D4A2 /* ExtensionPresentationController.swift in Sources */,
+				F162BE0F209268520085F34D /* CalypsoProcessor.swift in Sources */,
 				B5BEA55F1C7CE6D100C8035B /* Constants.m in Sources */,
 				BE6787F51FFF2886005D9F01 /* ShareModularViewController.swift in Sources */,
 				74D06FE61FE075A900AF1788 /* CalypsoProcessorIn.swift in Sources */,

--- a/WordPress/WordPressTest/Aztec/CalypsoProcessorInTests.swift
+++ b/WordPress/WordPressTest/Aztec/CalypsoProcessorInTests.swift
@@ -96,11 +96,11 @@ class CalypsoProcessorInTests: XCTestCase {
         let output = processor.process(input)
         XCTAssertEqual(output, expected)
     }
-    
+
     func testGutenbergPostDoesNotStripParagraphs() {
         let input = "<!-- wp:someblock --><p>Hello there</p><!-- /wp:someblock -->"
         let expected = input
-        
+
         let output = processor.process(input)
         XCTAssertEqual(output, expected)
     }

--- a/WordPress/WordPressTest/Aztec/CalypsoProcessorInTests.swift
+++ b/WordPress/WordPressTest/Aztec/CalypsoProcessorInTests.swift
@@ -96,4 +96,12 @@ class CalypsoProcessorInTests: XCTestCase {
         let output = processor.process(input)
         XCTAssertEqual(output, expected)
     }
+    
+    func testGutenbergPostDoesNotStripParagraphs() {
+        let input = "<!-- wp:someblock --><p>Hello there</p><!-- /wp:someblock -->"
+        let expected = input
+        
+        let output = processor.process(input)
+        XCTAssertEqual(output, expected)
+    }
 }

--- a/WordPress/WordPressTest/Aztec/CalypsoProcessorOutTests.swift
+++ b/WordPress/WordPressTest/Aztec/CalypsoProcessorOutTests.swift
@@ -25,4 +25,12 @@ class CalypsoProcessorOutTests: XCTestCase {
 
         XCTAssertEqual(output, expected)
     }
+    
+    func testGutenbergPostDoesNotStripParagraphs() {
+        let input = "<!-- wp:someblock --><p>Hello there</p><!-- /wp:someblock -->"
+        let expected = input
+        
+        let output = processor.process(input)
+        XCTAssertEqual(output, expected)
+    }
 }

--- a/WordPress/WordPressTest/Aztec/CalypsoProcessorOutTests.swift
+++ b/WordPress/WordPressTest/Aztec/CalypsoProcessorOutTests.swift
@@ -25,11 +25,11 @@ class CalypsoProcessorOutTests: XCTestCase {
 
         XCTAssertEqual(output, expected)
     }
-    
+
     func testGutenbergPostDoesNotStripParagraphs() {
         let input = "<!-- wp:someblock --><p>Hello there</p><!-- /wp:someblock -->"
         let expected = input
-        
+
         let output = processor.process(input)
         XCTAssertEqual(output, expected)
     }


### PR DESCRIPTION
Disables paragraph tag stripping for Gutenberg posts, and hides Gutenberg comment blocks in visual mode (again, because the comment blocks changed it seems).

This won't solve all compatibility issues, but will at least resolve some of them.