### PR TITLE
Stock Photos: Avoid reload images when typing in search bar

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -66,7 +66,7 @@ target 'WordPress' do
   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
   pod 'Gridicons', '0.15'
   pod 'NSURL+IDN', '0.3'
-  pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '5c487e4e4a7a42ae9d6999613e6e5195351fddf4'
+  pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '9811f962361b4eed378750d9d85b432e0b6a3a3b'
   pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'52849f1be62bc6a6316f3828d56e8fc32f5fa8e4'
 
   target 'WordPressTest' do

--- a/Podfile
+++ b/Podfile
@@ -66,7 +66,7 @@ target 'WordPress' do
   pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
   pod 'Gridicons', '0.15'
   pod 'NSURL+IDN', '0.3'
-  pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '9811f962361b4eed378750d9d85b432e0b6a3a3b'
+  pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '177e6773395a77ba01e3851c38372b8bff8723c0'
   pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'52849f1be62bc6a6316f3828d56e8fc32f5fa8e4'
 
   target 'WordPressTest' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -157,7 +157,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `52849f1be62bc6a6316f3828d56e8fc32f5fa8e4`)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `f7051f3b32fae3dadda267e725288d9f212fcc55`)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `9811f962361b4eed378750d9d85b432e0b6a3a3b`)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `177e6773395a77ba01e3851c38372b8bff8723c0`)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
 
@@ -172,7 +172,7 @@ EXTERNAL SOURCES:
     :commit: f7051f3b32fae3dadda267e725288d9f212fcc55
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WPMediaPicker:
-    :commit: 9811f962361b4eed378750d9d85b432e0b6a3a3b
+    :commit: 177e6773395a77ba01e3851c38372b8bff8723c0
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
@@ -186,7 +186,7 @@ CHECKOUT OPTIONS:
     :commit: f7051f3b32fae3dadda267e725288d9f212fcc55
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WPMediaPicker:
-    :commit: 9811f962361b4eed378750d9d85b432e0b6a3a3b
+    :commit: 177e6773395a77ba01e3851c38372b8bff8723c0
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
@@ -226,6 +226,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 3f78e9a6fa7438b8506dc5332b3339b521a9e59a
+PODFILE CHECKSUM: 8e309e60f4327436f1a52e570782c21344916ebb
 
 COCOAPODS: 1.4.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -157,7 +157,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `52849f1be62bc6a6316f3828d56e8fc32f5fa8e4`)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `f7051f3b32fae3dadda267e725288d9f212fcc55`)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `5c487e4e4a7a42ae9d6999613e6e5195351fddf4`)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `9811f962361b4eed378750d9d85b432e0b6a3a3b`)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
 
@@ -172,7 +172,7 @@ EXTERNAL SOURCES:
     :commit: f7051f3b32fae3dadda267e725288d9f212fcc55
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WPMediaPicker:
-    :commit: 5c487e4e4a7a42ae9d6999613e6e5195351fddf4
+    :commit: 9811f962361b4eed378750d9d85b432e0b6a3a3b
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
@@ -186,7 +186,7 @@ CHECKOUT OPTIONS:
     :commit: f7051f3b32fae3dadda267e725288d9f212fcc55
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WPMediaPicker:
-    :commit: 5c487e4e4a7a42ae9d6999613e6e5195351fddf4
+    :commit: 9811f962361b4eed378750d9d85b432e0b6a3a3b
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
@@ -226,6 +226,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 06e6b8f067bd538751dce79e446fd2fd404b0d1c
+PODFILE CHECKSUM: 3f78e9a6fa7438b8506dc5332b3339b521a9e59a
 
 COCOAPODS: 1.4.0

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -75,6 +75,7 @@
 
         _fetchController = nil;
         [self.fetchController performFetch:nil];
+        [self notifyObserversReloadData];
     }
 }
 
@@ -148,6 +149,15 @@
     for ( WPMediaChangesBlock callback in [self.observers allValues]) {
         callback(incrementalChanges, removed, inserted, changed, moved);
     }
+}
+
+- (void)notifyObserversReloadData
+{
+    [self notifyObserversWithIncrementalChanges:NO
+                                        removed:[NSIndexSet new]
+                                       inserted:[NSIndexSet new]
+                                        changed:[NSIndexSet new]
+                                          moved:@[]];
 }
 
 -(id<NSObject>)registerChangeObserverBlock:(WPMediaChangesBlock)callback


### PR DESCRIPTION
Fixes #9178 

The reloading issue was solved internally in the [MediaPicker project](https://github.com/wordpress-mobile/MediaPicker-iOS/pull/290).

This PR adapts the project to the changes made in the Media Picker project to solve the reloading issue. Basically, reloading the Media Library manually after the search phrase has changed.

![sp_images_not_shuffling](https://user-images.githubusercontent.com/9772967/39258362-391d4912-488a-11e8-9c0b-cf8f5df1d4f9.gif)

(The loading indicator is coming soon)

*To test:*

- `pod install`
- Test searching in:
    - Blog's Media Library
    - Free Photo Library (from `+` butting in the media library)
    - Editor: WordPress Media (from `W` in the style bar)
    - Editor: Free Photo Library (from `...` button in the style bar)
    - Any other media picker with search bar you could think of
