### PR TITLE
Stock Photos: Add loading indicator

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
@@ -152,8 +152,9 @@ extension StockPhotosDataSource {
 
 extension StockPhotosDataSource: StockPhotosDataLoaderDelegate {
     func didLoad(media: [StockPhotosMedia], reset: Bool) {
-        
-        onStopLoading?()
+        defer {
+            onStopLoading?()
+        }
 
         guard media.count > 0 && searchQuery.count > 0 else {
             clearSearch(notifyObservers: true)

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosDataSource.swift
@@ -9,6 +9,9 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
     var observers = [String: WPMediaChangesBlock]()
     private var dataLoader: StockPhotosDataLoader?
 
+    var onStartLoading: (() -> Void)?
+    var onStopLoading: (() -> Void)?
+
     private let scheduler = Scheduler(seconds: 0.5)
 
     private(set) var searchQuery: String = ""
@@ -41,6 +44,7 @@ final class StockPhotosDataSource: NSObject, WPMediaCollectionDataSource {
         scheduler.debounce { [weak self] in
             let params = StockPhotosSearchParams(text: searchText, pageable: StockPhotosPageable.first())
             self?.search(params)
+            self?.onStartLoading?()
         }
     }
 
@@ -148,6 +152,9 @@ extension StockPhotosDataSource {
 
 extension StockPhotosDataSource: StockPhotosDataLoaderDelegate {
     func didLoad(media: [StockPhotosMedia], reset: Bool) {
+        
+        onStopLoading?()
+
         guard media.count > 0 && searchQuery.count > 0 else {
             clearSearch(notifyObservers: true)
             return

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosPlaceholder.swift
@@ -21,12 +21,29 @@ final class StockPhotosPlaceholder: WPNoResultsView {
         configureSubtitle()
     }
 
+    func configureAsLoading() {
+        configureLoadingIndicator()
+        titleText = " " // empty strings are ignored.
+        messageText = ""
+    }
+
     func configureAsNoSearchResults(for string: String) {
+        configureImage()
+        configureSearchResultTitle(for: string)
+        messageText = ""
+    }
+
+    private func configureSearchResultTitle(for string: String) {
         //Translators could add an empty space at the end of this phrase.
         let sanitizedNoResultString = String.freePhotosSearchNoResult.trimmingCharacters(in: .whitespaces)
-
         titleText = sanitizedNoResultString + " " + string
-        messageText = ""
+    }
+
+    private func configureLoadingIndicator() {
+        let activity = UIActivityIndicatorView(activityIndicatorStyle: .whiteLarge)
+        activity.color = UIColor.gray
+        accessoryView = activity
+        activity.startAnimating()
     }
 
     private func configureImage() {


### PR DESCRIPTION
Fixes #9176 

This PR adds a loading indicator to the Stock Photos search query.
This loading indicator was added in the background, so it won't be visible when there are images showing.

![sp_loading_indicator](https://user-images.githubusercontent.com/9772967/39260277-5e43dbde-488f-11e8-8705-35aae1ed4305.gif)


To test:
1. Go to My Sites > Blog Posts > +.
2. In the body of the post, go to Add Media > {ellipsis menu} > Free Photo Library.
3. Enter a search term.
