### PR TITLE
Fix clipping in FancyButton

### DIFF
--- a/WordPressUI/WordPressUI/FancyAlert/FancyButton.swift
+++ b/WordPressUI/WordPressUI/FancyAlert/FancyButton.swift
@@ -202,8 +202,8 @@ private extension FancyButton {
             var bounds = renderer.format.bounds
             bounds.origin.x += lineWidthInPixels
             bounds.origin.y += lineWidthInPixels
-            bounds.size.height -= lineWidthInPixels * 2
-            bounds.size.width -= lineWidthInPixels * 2
+            bounds.size.height -= lineWidthInPixels * 2 + shadowOffset.height
+            bounds.size.width -= lineWidthInPixels * 2 + shadowOffset.width
 
             let path = UIBezierPath(roundedRect: bounds, cornerRadius: cornerRadius)
 


### PR DESCRIPTION
This fixes some slight clipping for `FancyButton`s, which appear in our fancy alerts (such as site address info screen and [async announcement](https://github.com/wordpress-mobile/WordPress-iOS/pull/8999)).

![fancy button fix](https://user-images.githubusercontent.com/517257/39275116-4f2d4bbe-48a1-11e8-969e-5f92ca6df57f.png)

To test:
- open a fancy alert
  - for example, Log In > Log in by entering your site address. > Need help finding…
- ensure the bottom of the buttons aren't cut off
