### PR TITLE
Issue/9182 Fix Page List crash

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -6,7 +6,7 @@ data model as well as any custom migrations.
 ## WordPress 74
 
 - @sergioestevao 2018-04-18
-- ``AbstractPost` added `featuredImage` a relationship to Media for the media featured in a post  and removed 'post_thumbnail' that used to store a Int with the mediaID information.
+- `AbstractPost` added `featuredImage` a relationship to Media for the media featured in a post  and removed 'post_thumbnail' that used to store a Int with the mediaID information.
 
 ## WordPress 73
 

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -53,6 +53,9 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     page.blog = blog;
     page.date_created_gmt = [NSDate date];
     page.remoteStatus = AbstractPostRemoteStatusSync;
+
+    [[ContextManager sharedInstance] obtainPermanentIDForObject:page];
+
     return page;
 }
 

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 74.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 74.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14133" systemVersion="17E199" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14133" systemVersion="17C88" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AbstractPost" representedClassName="AbstractPost" isAbstract="YES" parentEntity="BasePost">
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
         <attribute name="metaIsLocal" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
@@ -345,7 +345,7 @@
         <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="media" inverseEntity="Blog" indexed="YES">
             <userInfo/>
         </relationship>
-        <relationship name="featuredOnPosts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Post" inverseName="featuredImage" inverseEntity="AbstractPost" syncable="YES"/>
+        <relationship name="featuredOnPosts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AbstractPost" inverseName="featuredImage" inverseEntity="AbstractPost" syncable="YES"/>
         <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AbstractPost" inverseName="media" inverseEntity="AbstractPost" indexed="YES">
             <userInfo/>
         </relationship>


### PR DESCRIPTION
Fixes #9182 

I was unable to recreate the original crash, but I could create the Core Data errors. @aerych discovered that the `featuredOnPosts` relationship from `Media` was referencing `Post` objects instead of `AbstractPost`, which could've been causing an issue. I've fixed that in this PR, but it didn't remove the Core Data errors for me. 

The errors seemed to be appearing during the creation / merging of all of the remote pages when they're first loaded, so I looked through the code in `PostService` to see there were any obvious differences between Posts and Pages.

I noticed that in `createPostForBlog`, we call

```
[[ContextManager sharedInstance] obtainPermanentIDForObject:post];
```

after creating the post, before returning. This was added some time ago by @astralbodies, to "prevent any Core Data issues with temp IDs for new posts". `createPageForBlog` was lacking this line, so I've added that in and it's resolved the Core Data errors I was seeing. 

**To test:**

* Fresh install the app
* Log in, and go to the Pages list
* Ensure there are no Core Data errors, and the app doesn't crash