### PR TITLE
Zendesk Mobile: show Zendesk new ticket from App Ratings > Send Feedback.

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -66,6 +66,7 @@ import CoreTelephony
 
         let presentInController = ZendeskUtils.configureViewController(controller)
         ZDKRequests.presentRequestCreation(with: presentInController)
+        createRequest()
     }
 
     func showTicketList(from controller: UIViewController) {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1401,15 +1401,26 @@ extension NotificationsViewController: AppFeedbackPromptViewDelegate {
         WPAnalytics.track(.appReviewsOpenedFeedbackScreen)
         AppRatingUtility.shared.gaveFeedbackForCurrentVersion()
         hideRatingViewWithDelay(0.0)
-        if HelpshiftUtils.isHelpshiftEnabled() {
-            let presenter = HelpshiftPresenter.init()
-            presenter.sourceTag = SupportSourceTag.inAppFeedback
-            presenter.presentHelpshiftConversationWindowFromViewController(self,
-                                                                           refreshUserDetails: true,
-                                                                           completion: nil)
+
+        if FeatureFlag.zendeskMobile.enabled {
+            if ZendeskUtils.sharedInstance.zendeskEnabled {
+                ZendeskUtils.sharedInstance.showNewRequest(from: self)
+            } else {
+                if let contact = URL(string: NotificationsViewController.contactURL) {
+                    UIApplication.shared.open(contact)
+                }
+            }
         } else {
-            if let contact = URL(string: NotificationsViewController.contactURL) {
-                UIApplication.shared.open(contact)
+            if HelpshiftUtils.isHelpshiftEnabled() {
+                let presenter = HelpshiftPresenter.init()
+                presenter.sourceTag = SupportSourceTag.inAppFeedback
+                presenter.presentHelpshiftConversationWindowFromViewController(self,
+                                                                               refreshUserDetails: true,
+                                                                               completion: nil)
+            } else {
+                if let contact = URL(string: NotificationsViewController.contactURL) {
+                    UIApplication.shared.open(contact)
+                }
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -148,13 +148,10 @@ private extension SupportTableViewController {
         return { [unowned self] row in
             self.tableView.deselectSelectedRowWithAnimation(true)
             if ZendeskUtils.sharedInstance.zendeskEnabled {
-
                 guard let controllerToShowFrom = self.controllerToShowFrom() else {
                     return
                 }
-
                 ZendeskUtils.sharedInstance.showNewRequest(from: controllerToShowFrom)
-                ZendeskUtils.sharedInstance.createRequest()
             } else {
                 guard let url = Constants.forumsURL else {
                     return


### PR DESCRIPTION
Fixes #9213 

**NOTES:**
- Your local `.wpcom_app_credentials` must be up-to-date as it contains Zendesk credentials. If you have not, refer to the Field Guide for instructions.
- `SupportSourceTag.inAppFeedback` is not passed on to Zendesk. This will be addressed with a future task that implements SourceTag support.

**To test:**
- Since displaying the App Feedback view is dependent on many conditions, it probably won't just appear. My suggested hack - in `NotificationsViewController:showRatingViewIfApplicable` comment out the first `guard` that checks `shouldPromptForAppReview`. The App Feedback view will _always_ show, but at least you'll see it!
- Go to the Notifications tab.
- Select 'Could Be Better'.
- Select 'Send Feedback'.
- Verify the Zendesk ticket view is displayed.

**Zendesk View** (you should see this):
![zendesk_view](https://user-images.githubusercontent.com/1816888/39333981-1819dbfa-496a-11e8-8cee-fcf5d757bc17.png)


**Helpshift View** (you should _not_ see this):
![helpshift_view](https://user-images.githubusercontent.com/1816888/39333955-0ac13e94-496a-11e8-8096-b0f2b557b514.png)



@etoledom - can I bother you for a review please? Thank you!!
