### PR TITLE
Zendesk Mobile: show Zendesk new ticket when `presentLivechat` called.

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -9,7 +9,7 @@ import CoreTelephony
     static var sharedInstance: ZendeskUtils = ZendeskUtils()
     private override init() {}
 
-    var zendeskEnabled = false
+    static var zendeskEnabled = false
 
     private var userName: String?
     private var userEmail: String?
@@ -77,7 +77,7 @@ import CoreTelephony
 private extension ZendeskUtils {
 
     static func toggleZendesk(enabled: Bool) {
-        ZendeskUtils.sharedInstance.zendeskEnabled = enabled
+        ZendeskUtils.zendeskEnabled = enabled
         DDLogInfo("Zendesk Enabled: \(enabled)")
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/FancyAlertViewController+LoginError.swift
+++ b/WordPress/Classes/ViewRelated/NUX/FancyAlertViewController+LoginError.swift
@@ -23,13 +23,13 @@ extension FancyAlertViewController {
         let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
             controller.dismiss(animated: true) {
                 // Find the topmost view controller that we can present from
-                guard WordPressAuthenticator.shared.delegate?.livechatActionEnabled == true,
+                guard WordPressAuthenticator.shared.delegate?.supportEnabled == true,
                     let viewController = UIApplication.shared.delegate?.window??.topmostPresentedViewController
                 else {
                     return
                 }
 
-                WordPressAuthenticator.shared.delegate?.presentLivechat(from: viewController, sourceTag: sourceTag, options: loginFields.helpshiftLoginOptions())
+                WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: viewController, sourceTag: sourceTag, options: loginFields.helpshiftLoginOptions())
             }
         }
 
@@ -69,7 +69,7 @@ extension FancyAlertViewController {
         DDLogError(message)
 
         if sourceTag == .jetpackLogin && error.domain == WordPressAuthenticator.errorDomain && error.code == NSURLErrorBadURL {
-            if WordPressAuthenticator.shared.delegate?.livechatActionEnabled == true {
+            if WordPressAuthenticator.shared.delegate?.supportEnabled == true {
                 // TODO: Placeholder Jetpack login error message. Needs updating with final wording. 2017-06-15 Aerych.
                 message = NSLocalizedString("We're not able to connect to the Jetpack site at that URL.  Contact us for assistance.", comment: "Error message shown when having trouble connecting to a Jetpack site.")
                 return alertForGenericErrorMessageWithHelpshiftButton(message, loginFields: loginFields, sourceTag: sourceTag)
@@ -77,7 +77,7 @@ extension FancyAlertViewController {
         }
 
         if error.domain != WPXMLRPCFaultErrorDomain && error.code != NSURLErrorBadURL {
-            if WordPressAuthenticator.shared.delegate?.livechatActionEnabled == true {
+            if WordPressAuthenticator.shared.delegate?.supportEnabled == true {
                 return alertForGenericErrorMessageWithHelpshiftButton(message, loginFields: loginFields, sourceTag: sourceTag)
             }
 
@@ -144,12 +144,12 @@ extension FancyAlertViewController {
                 guard let appDelegate = UIApplication.shared.delegate,
                     let window = appDelegate.window,
                     let viewController = window?.topmostPresentedViewController,
-                    WordPressAuthenticator.shared.delegate?.livechatActionEnabled == true
+                    WordPressAuthenticator.shared.delegate?.supportEnabled == true
                 else {
                     return
                 }
 
-                WordPressAuthenticator.shared.delegate?.presentLivechat(from: viewController, sourceTag: sourceTag, options: loginFields.helpshiftLoginOptions())
+                WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: viewController, sourceTag: sourceTag, options: loginFields.helpshiftLoginOptions())
             }
         }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginLinkRequestViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginLinkRequestViewController.swift
@@ -89,7 +89,7 @@ class LoginLinkRequestViewController: LoginViewController {
             // However, let's make sure we give the user some useful feedback just in case.
             DDLogError("Attempted to request authentication link, but the email address did not appear valid.")
             let alert = UIAlertController(title: NSLocalizedString("Can Not Request Link", comment: "Title of an alert letting the user know"), message: NSLocalizedString("A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address.", comment: "An error message."), preferredStyle: .alert)
-            alert.addActionWithTitle(NSLocalizedString("Need help?", comment: "Takes the user to get help"), style: .cancel, handler: { _ in WordPressAuthenticator.shared.delegate?.presentLivechat(from: self, sourceTag: .loginEmail, options: [:]) })
+            alert.addActionWithTitle(NSLocalizedString("Need help?", comment: "Takes the user to get help"), style: .cancel, handler: { _ in WordPressAuthenticator.shared.delegate?.presentSupportRequest(from: self, sourceTag: .loginEmail, options: [:]) })
             alert.addActionWithTitle(NSLocalizedString("OK", comment: "Dismisses the alert"), style: .default, handler: nil)
             self.present(alert, animated: true, completion: nil)
             return

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -144,17 +144,6 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         }
     }
 
-    /// Presents Helpshift, with the specified ViewController as a source. Additional metadata is supplied, such as the sourceTag and Login details.
-    ///
-    func presentLivechat(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag, options: [String: Any]) {
-        let presenter = HelpshiftPresenter()
-        presenter.sourceTag = sourceTag.toSupportSourceTag()
-        presenter.optionsDictionary = options
-        presenter.presentHelpshiftConversationWindowFromViewController(sourceViewController,
-                                                                       refreshUserDetails: true,
-                                                                       completion: nil)
-    }
-
     /// Presents Support new request, with the specified ViewController as a source.
     /// Additional metadata is supplied, such as the sourceTag and Login details.
     ///

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -98,9 +98,12 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         return true
     }
 
-    /// Indicates if Helpshift is Enabled.
+    /// Indicates if Support is Enabled.
     ///
-    var livechatActionEnabled: Bool {
+    var supportEnabled: Bool {
+        if FeatureFlag.zendeskMobile.enabled {
+            return ZendeskUtils.zendeskEnabled
+        }
         return HelpshiftUtils.isHelpshiftEnabled()
     }
 
@@ -150,6 +153,23 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         presenter.presentHelpshiftConversationWindowFromViewController(sourceViewController,
                                                                        refreshUserDetails: true,
                                                                        completion: nil)
+    }
+
+    /// Presents Support new request, with the specified ViewController as a source.
+    /// Additional metadata is supplied, such as the sourceTag and Login details.
+    ///
+    func presentSupportRequest(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag, options: [String: Any]) {
+
+        if FeatureFlag.zendeskMobile.enabled {
+            ZendeskUtils.sharedInstance.showNewRequest(from: sourceViewController)
+        } else {
+            let presenter = HelpshiftPresenter()
+            presenter.sourceTag = sourceTag.toSupportSourceTag()
+            presenter.optionsDictionary = options
+            presenter.presentHelpshiftConversationWindowFromViewController(sourceViewController,
+                                                                           refreshUserDetails: true,
+                                                                           completion: nil)
+        }
     }
 
     /// Presents the Login Epilogue, in the specified NavigationController.

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
@@ -58,11 +58,6 @@ public protocol WordPressAuthenticatorDelegate: class {
     ///
     func createdWordPressComAccount(username: String, authToken: String)
 
-    /// Presents the Livechat Interface, from a given ViewController, with a specified SourceTag, and additional metadata,
-    /// such as all of the User's Login details.
-    ///
-    func presentLivechat(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag, options: [String: Any])
-
     /// Presents the Support new request, from a given ViewController, with a specified SourceTag, and additional metadata,
     /// such as all of the User's Login details.
     ///

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticator.swift
@@ -41,9 +41,9 @@ public protocol WordPressAuthenticatorDelegate: class {
     ///
     var supportActionEnabled: Bool { get }
 
-    /// Indicates if the Livechat Action should be enabled, or not.
+    /// Indicates if Support is available or not.
     ///
-    var livechatActionEnabled: Bool { get }
+    var supportEnabled: Bool { get }
 
     /// Returns the Support's Badge Count.
     ///
@@ -62,6 +62,11 @@ public protocol WordPressAuthenticatorDelegate: class {
     /// such as all of the User's Login details.
     ///
     func presentLivechat(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag, options: [String: Any])
+
+    /// Presents the Support new request, from a given ViewController, with a specified SourceTag, and additional metadata,
+    /// such as all of the User's Login details.
+    ///
+    func presentSupportRequest(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag, options: [String: Any])
 
     /// Presents the Login Epilogue, in the specified NavigationController.
     ///

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1403,7 +1403,7 @@ extension NotificationsViewController: AppFeedbackPromptViewDelegate {
         hideRatingViewWithDelay(0.0)
 
         if FeatureFlag.zendeskMobile.enabled {
-            if ZendeskUtils.sharedInstance.zendeskEnabled {
+            if ZendeskUtils.zendeskEnabled {
                 ZendeskUtils.sharedInstance.showNewRequest(from: self)
             } else {
                 if let contact = URL(string: NotificationsViewController.contactURL) {

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -96,7 +96,7 @@ private extension SupportTableViewController {
         var helpSectionRows = [HelpRow]()
         helpSectionRows.append(HelpRow(title: LocalizedText.wpHelpCenter, action: helpCenterSelected()))
 
-        if ZendeskUtils.sharedInstance.zendeskEnabled {
+        if ZendeskUtils.zendeskEnabled {
             helpSectionRows.append(HelpRow(title: LocalizedText.contactUs, action: contactUsSelected()))
             helpSectionRows.append(HelpRow(title: LocalizedText.myTickets, action: myTicketsSelected()))
         } else {
@@ -129,7 +129,7 @@ private extension SupportTableViewController {
     func helpCenterSelected() -> ImmuTableAction {
         return { [unowned self] row in
             self.tableView.deselectSelectedRowWithAnimation(true)
-            if ZendeskUtils.sharedInstance.zendeskEnabled {
+            if ZendeskUtils.zendeskEnabled {
                 guard let controllerToShowFrom = self.controllerToShowFrom() else {
                     return
                 }
@@ -147,7 +147,7 @@ private extension SupportTableViewController {
     func contactUsSelected() -> ImmuTableAction {
         return { [unowned self] row in
             self.tableView.deselectSelectedRowWithAnimation(true)
-            if ZendeskUtils.sharedInstance.zendeskEnabled {
+            if ZendeskUtils.zendeskEnabled {
                 guard let controllerToShowFrom = self.controllerToShowFrom() else {
                     return
                 }


### PR DESCRIPTION
Fixes #9222 

**Notes:**
- Zendesk does not work yet if you are not logged in.
- The `sourceTag` is not passed on to Zendesk. That will be addressed in a future task to add `sourceTag` support.

**To test:**

---
Hack to get this error to show: in `SiteCreationSiteDetailsViewController:toggleNextButton` - always set `nextButton.isEnabled = true`.
- Go to My Sites > Create WordPress.com site > select Category > select Theme.
- If you've enacted the hack, tap in the 'Site Title' field to enable the Next button. Tap it.
- On the error, select 'Need more help?'
- Verify Zendesk view is displayed.
---
- Go to My Sites > Add self-hosted site.
- Tap 'Need help finding your site address?'
- On the error, select 'Need more help?'
- Verify Zendesk view is displayed.
---
Hack to get this error to show: in `LoginLinkRequestViewController:requestAuthenticationLink` - comment out the first `guard` that validates the email.
- Go to Log In > enter your email address > tap 'Send Link'.
- On the error, select 'Need help?'
- Verify Zendesk view is displayed.
---

**Zendesk view** (you should see this):
![zendesk_view](https://user-images.githubusercontent.com/1816888/39388567-4c38a716-4a3e-11e8-9746-5c477036b71a.png)

**Helpshift view** (you should _not_ see this):
![helpshift_view](https://user-images.githubusercontent.com/1816888/39388572-5108717c-4a3e-11e8-9d2d-b3f3306f433d.png)
