### PR TITLE
Fix alerts blocking composing posts when offline

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -281,7 +281,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: abstractPostWindowlessCellIdenfitier)
     }
 
-    fileprivate func refreshResults(forcingNetworkAlerts: Bool = true) {
+    fileprivate func refreshResults(forcingNetworkAlerts: Bool = false) {
         guard isViewLoaded == true else {
             return
         }
@@ -606,7 +606,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
     }
 
     func shouldPresentAlert() -> Bool {
-        return !connectionAvailable() && !contentIsEmpty() && !isViewOnScreen()
+        return !connectionAvailable() && !contentIsEmpty() && isViewOnScreen()
     }
 
     @objc func syncItemsWithUserInteraction(_ userInteraction: Bool) {


### PR DESCRIPTION
Fixes #9025 

Composing a new post was blocked by the network alert when:
1. Navigate to Me tab
2. Navigate to any of the sections in the Me tab (i.e. Account Settings) (this is the key step)
3. Enter flight mode
4. Start composing a post.

To test:
Attempt to compose a post when flight mode is on. Launch the editor from:
1. Me > My Profile
2. Reader > Followed sites
3. My Site > Blog posts
