### PR TITLE
Fix - Post/Page - Search Spinner Hidden When Active Search Bar

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -59,6 +59,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
     @objc var refreshControl: UIRefreshControl? {
         get {
+            self.tableViewController.refreshControl?.backgroundColor = .clear
             return self.tableViewController.refreshControl
         }
     }


### PR DESCRIPTION
Fixes #8980 

For some reason the fix for this is to make sure that the refreshControl had a background. I set it to clear and it worked fine. iOS 11 wants the searchBarController to be a part of the navigationHeader, and not part of the tableHeaderView. This table though has a filter bar which would also need to be changed in order to support that. Not sure if another ticket would need to be made for that though.

To test:
1. My Sites -> Sites
2. Go to either Site Pages or Site Posts
3. Tap into Search Bar
4. Pull down to refresh -> Refresh spinner now visible


