### PR TITLE
Issue/9234 hide stockphotos from selfhosted nonjetpack sites

### DIFF
--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -65,7 +65,9 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     /// Does the blog support editing media metadata?
     BlogFeatureMediaMetadataEditing,
     /// Does the blog support deleting media?
-    BlogFeatureMediaDeletion
+    BlogFeatureMediaDeletion,
+    /// Does the blog support Stock Photos feature (free photos library)
+    BlogFeatureStockPhotos
 };
 
 typedef NS_ENUM(NSInteger, SiteVisibility) {

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -447,6 +447,7 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
         case BlogFeatureWPComRESTAPI:
         case BlogFeatureCommentLikes:
         case BlogFeatureStats:
+        case BlogFeatureStockPhotos:
             return [self supportsRestApi];
         case BlogFeatureSharing:
             return [self supportsSharing];

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMediaPickingCoordinator.swift
@@ -19,7 +19,9 @@ final class AztecMediaPickingCoordinator {
 
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
 
-        alertController.addAction(freePhotoAction(origin: origin, blog: blog))
+        if blog.supports(.stockPhotos) {
+            alertController.addAction(freePhotoAction(origin: origin, blog: blog))
+        }
         alertController.addAction(otherAppsAction(origin: origin))
         alertController.addAction(cancelAction())
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -32,7 +32,10 @@ final class MediaLibraryMediaPickingCoordinator {
         }
 
         menuAlert.addAction(photoLibraryAction(origin: origin, blog: blog))
-        menuAlert.addAction(freePhotoAction(origin: origin, blog: blog))
+
+        if blog.supports(.stockPhotos) {
+            menuAlert.addAction(freePhotoAction(origin: origin, blog: blog))
+        }
 
         if #available(iOS 11.0, *) {
             menuAlert.addAction(otherAppsAction(origin: origin))


### PR DESCRIPTION
Fixes #9234 

This PR hides the Stock Photos action from the picker in the Aztec Editor and in the Media Library for Self-Hosted sites without Jetpack.

![no-stock-photos](https://user-images.githubusercontent.com/9772967/39481518-1ea54fdc-4d42-11e8-85ed-6c0f2e46d599.png)

The picker in the editor will show just one option. Personally I prefer it in that way than pressing the ellipse button (`...`) and not knowing what to expect. I remember having that sensation of unexpected behavior before the picker was implemented, specially when I first started using the app.

To test:
- Open a self-hosted site without Jetpack.
  - Go to the media library.
  - Add media (top right `+` button).
  - The picker should **not** show the `Free Photos Library` option. 
  - Go to the Aztec Editor.
  - Add media (`+` button in the style bar).
  - Press the ellipse button `...`.
  - The picker should **not** show the `Free Photos Library` option. 
- Test the same in self-hosted site with Jetpack connected and in a WPcom site. 
  - The picker **should** show the `Free Photos Library` option. 