### PR TITLE
Fix for confusing publish button and title when scheduling post

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1201,6 +1201,7 @@ extension AztecPostViewController {
                 }
             }
 
+
             if let analyticsStat = analyticsStat {
                 self.trackPostSave(stat: analyticsStat)
             }
@@ -1225,7 +1226,7 @@ extension AztecPostViewController {
             if !UserDefaults.standard.asyncPromoWasDisplayed {
                 promoBlock()
             } else {
-                displayPublishConfirmationAlert(onPublish: publishBlock)
+                displayPublishConfirmationAlert(for: action, onPublish: publishBlock)
             }
         } else {
             publishBlock()
@@ -1413,15 +1414,16 @@ private extension AztecPostViewController {
         return
     }
 
-    /// Displays a publish confirmation alert with two options: "Keep Editing" and "Publish".
+    /// Displays a publish confirmation alert with two options: "Keep Editing" and String for Action.
     ///
     /// - Parameters:
+    ///     - action: Publishing action being performed
     ///     - dismissWhenDone: if `true`, the VC will be dismissed if the user picks "Publish".
     ///
-    func displayPublishConfirmationAlert(onPublish publishAction: @escaping () -> ()) {
-        let title = postEditorStateContext.publishQuestionTitleText
+    func displayPublishConfirmationAlert(for action: PostEditorAction, onPublish publishAction: @escaping () -> ()) {
+        let title = action.publishingActionQuestionLabel
         let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Button shown when the author is asked for publishing confirmation.")
-        let publishTitle = postEditorStateContext.publishButtonText
+        let publishTitle = action.publishActionLabel
         let style: UIAlertControllerStyle = UIDevice.isPad() ? .alert : .actionSheet
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1419,11 +1419,9 @@ private extension AztecPostViewController {
     ///     - dismissWhenDone: if `true`, the VC will be dismissed if the user picks "Publish".
     ///
     func displayPublishConfirmationAlert(onPublish publishAction: @escaping () -> ()) {
-        let title = NSLocalizedString("Are you sure you want to publish?", comment: "Title of the message shown when the user taps Publish while editing a post.  Options will be Publish and Keep Editing.")
-
+        let title = postEditorStateContext.publishQuestionTitleText
         let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Button shown when the author is asked for publishing confirmation.")
-        let publishTitle = NSLocalizedString("Publish", comment: "Button shown when the author is asked for publishing confirmation.")
-
+        let publishTitle = postEditorStateContext.publishButtonText
         let style: UIAlertControllerStyle = UIDevice.isPad() ? .alert : .actionSheet
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: style)
 
@@ -1431,7 +1429,6 @@ private extension AztecPostViewController {
         alertController.addDefaultActionWithTitle(publishTitle) { _ in
             publishAction()
         }
-
         present(alertController, animated: true, completion: nil)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -53,16 +53,16 @@ public enum PostEditorAction {
 
     fileprivate var publishingActionQuestionLabel: String {
         switch self {
-        case .publish, .publishNow:
+        case .publish:
             return NSLocalizedString("Are you sure you want to publish?", comment: "Title of the message shown when the user taps Publish while editing a post.  Options will be Publish and Keep Editing.")
-        case .save, .saveAsDraft:
-            return NSLocalizedString("Are you sure you want to save?", comment: "Title of message shown when user taps save or saveAsDraft.")
+        case .publishNow:
+            return NSLocalizedString("Are you sure you want to publish now?", comment: "Title of the message shown when the user taps Publish Now while editing a post.  Options will be Publish Now and Keep Editing.")
         case .schedule:
             return NSLocalizedString("Are you sure you want to schedule?", comment: "Title of message shown when the user taps Schedule while editing a post. Options will be Schedule and Keep Editing")
         case .submitForReview:
             return NSLocalizedString("Are you sure you want to submit for review?", comment: "Title of message shown when user taps submit for review.")
-        case .update:
-            return NSLocalizedString("Are you sure you want to update?", comment: "Title of message shown when user taps update.")
+        default:
+            return ""
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -32,7 +32,7 @@ public enum PostEditorAction {
         }
     }
 
-    fileprivate var publishActionLabel: String {
+    var publishActionLabel: String {
         switch self {
         case .publish:
             return NSLocalizedString("Publish", comment: "Label for the publish (verb) button. Tapping publishes a draft post.")
@@ -51,18 +51,22 @@ public enum PostEditorAction {
         }
     }
 
-    fileprivate var publishingActionQuestionLabel: String {
+    var publishingActionQuestionLabel: String {
         switch self {
         case .publish:
             return NSLocalizedString("Are you sure you want to publish?", comment: "Title of the message shown when the user taps Publish while editing a post.  Options will be Publish and Keep Editing.")
         case .publishNow:
             return NSLocalizedString("Are you sure you want to publish now?", comment: "Title of the message shown when the user taps Publish Now while editing a post.  Options will be Publish Now and Keep Editing.")
+        case .save:
+            return NSLocalizedString("Are you sure you want to save?", comment: "Title of the message shown when the user taps Save while editing a post.  Options will be Save Now and Keep Editing.")
+        case .saveAsDraft:
+            return NSLocalizedString("Are you sure you want to save as draft?", comment: "Title of the message shown when the user taps Save as Draft while editing a post.  Options will be Save Now and Keep Editing.")
         case .schedule:
             return NSLocalizedString("Are you sure you want to schedule?", comment: "Title of message shown when the user taps Schedule while editing a post. Options will be Schedule and Keep Editing")
         case .submitForReview:
             return NSLocalizedString("Are you sure you want to submit for review?", comment: "Title of message shown when user taps submit for review.")
-        default:
-            return ""
+        case .update:
+            return NSLocalizedString("Are you sure you want to update?", comment: "Title of message shown when user taps update.")
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -51,6 +51,21 @@ public enum PostEditorAction {
         }
     }
 
+    fileprivate var publishingActionQuestionLabel: String {
+        switch self {
+        case .publish, .publishNow:
+            return NSLocalizedString("Are you sure you want to publish?", comment: "Title of the message shown when the user taps Publish while editing a post.  Options will be Publish and Keep Editing.")
+        case .save, .saveAsDraft:
+            return NSLocalizedString("Are you sure you want to save?", comment: "Title of message shown when user taps save or saveAsDraft.")
+        case .schedule:
+            return NSLocalizedString("Are you sure you want to schedule?", comment: "Title of message shown when the user taps Schedule while editing a post. Options will be Schedule and Keep Editing")
+        case .submitForReview:
+            return NSLocalizedString("Are you sure you want to submit for review?", comment: "Title of message shown when user taps submit for review.")
+        case .update:
+            return NSLocalizedString("Are you sure you want to update?", comment: "Title of message shown when user taps update.")
+        }
+    }
+
     var publishingActionLabel: String {
         switch self {
         case .publish, .publishNow:
@@ -295,6 +310,10 @@ public class PostEditorStateContext {
     ///
     var publishButtonText: String {
         return action.publishActionLabel
+    }
+
+    var publishQuestionTitleText: String {
+        return action.publishingActionQuestionLabel
     }
 
     /// Returns the WPAnalyticsStat enum to be tracked when this post is published


### PR DESCRIPTION
Fixes #9224 

To test:
1. Create new post
2. Change its publish options to scheduling
3. Tap on “Schedule” button or attempt to exit
4. Alert action sheet will now display text and title for "schedule" or "publish" according to the `postEditorStatContext`

