### PR TITLE
Zendesk Mobile: register devices for push notifications

### DIFF
--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -78,12 +78,18 @@ final public class PushNotificationsManager: NSObject {
 
     /// Registers the Device Token agains WordPress.com backend, if there's a default account.
     ///
-    /// - Note: Helpshift will also be initialized. The token will be persisted across App Sessions.
+    /// - Note: Support will also be initialized. The token will be persisted across App Sessions.
     ///
     @objc func registerDeviceToken(_ tokenData: Data) {
-        if HelpshiftUtils.isHelpshiftEnabled() {
-            // We want to register Helpshift regardless so that way if a user isn't logged in
-            // they can still get push notifications that we replied to their support ticket.
+
+        // Token Cleanup
+        let newToken = tokenData.hexString
+
+        // We want to register with Support regardless so that way if a user isn't logged in
+        // they can still get push notifications that we replied to their support ticket.
+        if FeatureFlag.zendeskMobile.enabled {
+            ZendeskUtils.registerDevice(newToken)
+        } else if HelpshiftUtils.isHelpshiftEnabled() {
             HelpshiftCore.registerDeviceToken(tokenData)
         }
 
@@ -91,9 +97,6 @@ final public class PushNotificationsManager: NSObject {
         guard AccountHelper.isDotcomAvailable() else {
             return
         }
-
-        // Token Cleanup
-        let newToken = tokenData.hexString
 
         if deviceToken != newToken {
             DDLogInfo("Device Token has changed! OLD Value: \(String(describing: deviceToken)), NEW value: \(newToken)")

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -85,6 +85,34 @@ import CoreTelephony
         })
     }
 
+    static func registerDevice(_ identifier: String) {
+        if ZDKConfig.instance().userIdentity == nil {
+            ZendeskUtils.createZendeskIdentity(withUser: false)
+        }
+
+        ZDKConfig.instance().enablePush(withDeviceID: identifier) { pushResponse, error in
+            if let error = error {
+                DDLogInfo("Zendesk couldn't register device: \(identifier). Error: \(error)")
+            } else {
+                DDLogDebug("Zendesk successfully registered device: \(identifier)")
+            }
+        }
+    }
+
+    static func unregisterDevice(_ identifier: String) {
+        if ZDKConfig.instance().userIdentity == nil {
+            ZendeskUtils.createZendeskIdentity(withUser: false)
+        }
+
+        ZDKConfig.instance().disablePush(identifier) { status, error in
+            if let error = error {
+                print("Zendesk couldn't unregistered device: \(identifier). Error: \(error)")
+            } else {
+                print("Zendesk successfully unregistered device: \(identifier)")
+            }
+        }
+    }
+
 }
 
 // MARK: - Private Extension
@@ -156,10 +184,12 @@ private extension ZendeskUtils {
         }
     }
 
-    static func createZendeskIdentity() {
+    static func createZendeskIdentity(withUser: Bool = true) {
         let zendeskIdentity = ZDKAnonymousIdentity()
-        zendeskIdentity.email = ZendeskUtils.sharedInstance.userEmail
-        zendeskIdentity.name = ZendeskUtils.sharedInstance.userName
+        if withUser {
+            zendeskIdentity.email = ZendeskUtils.sharedInstance.userEmail
+            zendeskIdentity.name = ZendeskUtils.sharedInstance.userName
+        }
         ZDKConfig.instance().userIdentity = zendeskIdentity
         DDLogDebug("Zendesk identity created with email '\(zendeskIdentity.email)' and name '\(zendeskIdentity.name)'.")
     }


### PR DESCRIPTION
Fixes #9242 

To test:
- Launch the app. 
- Login.
- Agree to notifications if necessary.
- Verify you see this message in the logs:
`Zendesk successfully registered device:<device_id>`

I did add a method to un-register devices. At this time it is not called. However, I believe it will be used in the future, so I'm adding it now. If you feel spunky and want to test it:
- Add this code to `PushNotificationsManager:unregisterDeviceToken`
```
        if let deviceToken = deviceToken {
            ZendeskUtils.unregisterDevice(deviceToken)
        }
```
- Logout.
- Notice the log message `Zendesk successfully unregistered device:<device_id>`

