### PR TITLE
API: Update connect/site-info API call

### DIFF
--- a/WordPressKit/WordPressKit/JetpackServiceRemote.m
+++ b/WordPressKit/WordPressKit/JetpackServiceRemote.m
@@ -71,16 +71,10 @@ static NSString * const GetUsersBlogsApiPath = @"https://public-api.wordpress.co
                     success:(void (^)(BOOL isJetpack))success
                     failure:(void (^)(NSError *error))failure
 {
-    NSString *siteStr = [NSString stringWithFormat:@"%@%@", siteURL.host, siteURL.path];
-    siteStr = [siteStr stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
-    siteStr = [siteStr stringByReplacingOccurrencesOfString:@"/" withString:@"::"];
-    NSString *scheme = siteURL.scheme ?: @"http";
-
-    NSString *endpoint = [NSString stringWithFormat:@"connect/site-info/%@/%@", scheme, siteStr];
-    NSString *path = [self pathForEndpoint:endpoint withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    NSString *path = [self pathForEndpoint:@"connect/site-info" withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
     [self.wordPressComRestApi GET:path
-                       parameters:nil
+                       parameters:@{ @"url": siteURL.absoluteString }
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                               NSDictionary *dict = (NSDictionary *)responseObject;
                               BOOL hasJetpack = [[dict numberForKey:@"hasJetpack"] boolValue];


### PR DESCRIPTION
A new site-info endpoint has been added that receives the URL as a query
parameter rather than parts of the path (D11731-code)

This simplifies the API call and is less error-prone.

What was in the path, with `/` -> `::` (slug-style) encoding:

`https://public-api.wordpress.com/rest/v1.1/connect/site-info/https/example.com::site::path`

Is now a query param (no need to think about encoding):

`https://public-api.wordpress.com/rest/v1.1/connect/site-info?url=https%3A//example.com/site/path`


Aligns with https://github.com/Automattic/wp-calypso/pull/24034

The API logic and response are unchanged.

cc: @seear

## To test
1. Add a new self-hosted site from the app
1. Enter a URL with a non-WordPress site and verify you're not allowed to continue
1. Enter a WordPress.org site and verify you are allowed to continue
1. Inspect the request and verify that the new endpoint is used:
   - old: `https://public-api.wordpress.com/rest/v1.1/connect/site-info/https/example.com::site::path?locale=en`
   - new: `https://public-api.wordpress.com/rest/v1.1/connect/site-info?locale=en&url=https%3A//example.com/site/path`
