### PR TITLE
If the maxUpload size is zero assume that uploads can go forward.

### DIFF
--- a/WordPress/Classes/Models/Blog+Quota.swift
+++ b/WordPress/Classes/Models/Blog+Quota.swift
@@ -83,7 +83,8 @@ extension Blog {
     /// - Returns: true if the site is able to support the URL file size.
     @objc func isAbleToHandleFileSizeOf(url: URL) -> Bool {
         guard let fileSize = url.fileSize,
-            let maxUploadSize = maxUploadSize?.int64Value
+            let maxUploadSize = maxUploadSize?.int64Value,
+            maxUploadSize > 0
             else {
                 // let's assume the site can handle it.
                 return true


### PR DESCRIPTION
Fixes #9237 

This PR add a simple test for the max upload size variable set for the site, if it's set to zero we are assuming some kind of server/api issue and allowing the upload to go forward.

To test:
 - There are have been some users sites reporting this, but I wasn't able to reproduce it on my own servers, so the only thing is to see if the uploads are working normally for the regular sites.


