### PR TITLE
Image loader

### DIFF
--- a/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
@@ -1,0 +1,10 @@
+
+extension AbstractPost: PostInformation {
+    var isPrivateSite: Bool {
+        return isPrivate() && blog.isHostedAtWPcom
+    }
+
+    var isBlogSelfHostedWithCredentials: Bool {
+        return !blog.isHostedAtWPcom && blog.isBasicAuthCredentialStored()
+    }
+}

--- a/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
@@ -1,6 +1,6 @@
 
 extension AbstractPost: PostInformation {
-    var isPostPrivate: Bool {
+    var isPrivateOnWPCom: Bool {
         return isPrivate() && blog.isHostedAtWPcom
     }
 

--- a/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
@@ -1,6 +1,6 @@
 
 extension AbstractPost: PostInformation {
-    var isPrivateSite: Bool {
+    var isPostPrivate: Bool {
         return isPrivate() && blog.isHostedAtWPcom
     }
 

--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -109,7 +109,11 @@ extension URL {
     }
 
     var isGif: Bool {
-        return pathExtension == "gif"
+        if let uti = typeIdentifier {
+            return UTTypeConformsTo(uti as CFString, kUTTypeGIF)
+        } else {
+            return pathExtension.lowercased() == "gif"
+        }
     }
 }
 

--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -107,6 +107,10 @@ extension URL {
 
         return UTTypeConformsTo(uti as CFString, kUTTypeImage)
     }
+
+    var isGif: Bool {
+        return pathExtension == "gif"
+    }
 }
 
 extension NSURL {

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -77,7 +77,8 @@
         let scale = UIScreen.main.scale
         let scaledSize = CGSize(width: size.width * scale, height: size.height * scale)
         let scaledURL = WPImageURLHelper.imageURLWithSize(scaledSize, forImageURL: url)
-        imageView.downloadImage(from: scaledURL)
+        let request = PrivateSiteURLProtocol.requestForPrivateSite(from: scaledURL)
+        imageView.setImageWith(request, placeholderImage: nil, success: nil, failure: nil)
     }
 
     private func loadProtonUrl(with url: URL, preferedSize size: CGSize) {

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -13,6 +13,9 @@
     var isBlogSelfHostedWithCredentials: Bool { get }
 }
 
+/// Class used together with `CachedAnimatedImageView` to facilitate the loading of both
+/// still images and animated gifs.
+///
 @objc class ImageLoader: NSObject {
 
     private let imageView: CachedAnimatedImageView

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -82,7 +82,7 @@
 
     private func loadProtonUrl(with url: URL, preferedSize size: CGSize) {
         guard let protonURL = PhotonImageURLHelper.photonURL(with: size, forImageURL: url) else {
-            imageView.setImageWith(url)
+            imageView.downloadImage(from: url)
             return
         }
         imageView.downloadImage(from: protonURL)

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -13,7 +13,7 @@
     var isBlogSelfHostedWithCredentials: Bool { get }
 }
 
-@objc class MediaLoader: NSObject {
+@objc class ImageLoader: NSObject {
 
     private let imageView: CachedAnimatedImageView
 
@@ -22,14 +22,12 @@
         super.init()
     }
 
-
     /// Call this in a table/collection cell's `prepareForReuse()`
     ///
     @objc func prepareForReuse() {
         imageView.image = nil
         imageView.prepForReuse()
     }
-
 
     @objc(loadImageWithURL:fromPost:andPreferedSize:)
     /// Load an image from a specific post, using the given URL. Supports animated images (gifs) as well.

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -63,11 +63,11 @@
 
     private func loadStillImage(with url: URL, from post: PostInformation, preferedSize size: CGSize) {
         if url.isFileURL {
-            imageView.downloadImage(from:url)
+            imageView.downloadImage(from: url)
         } else if post.isPrivateOnWPCom {
             loadImage(with: url, fromPrivatePost: post, preferedSize: size)
         } else if post.isBlogSelfHostedWithCredentials {
-            imageView.downloadImage(from:url)
+            imageView.downloadImage(from: url)
         } else {
             loadProtonUrl(with: url, preferedSize: size)
         }
@@ -77,7 +77,7 @@
         let scale = UIScreen.main.scale
         let scaledSize = CGSize(width: size.width * scale, height: size.height * scale)
         let scaledURL = WPImageURLHelper.imageURLWithSize(scaledSize, forImageURL: url)
-        imageView.downloadImage(from:scaledURL)
+        imageView.downloadImage(from: scaledURL)
     }
 
     private func loadProtonUrl(with url: URL, preferedSize size: CGSize) {
@@ -85,6 +85,6 @@
             imageView.setImageWith(url)
             return
         }
-        imageView.downloadImage(from:protonURL)
+        imageView.downloadImage(from: protonURL)
     }
 }

--- a/WordPress/Classes/Utility/Media/MediaLoader.swift
+++ b/WordPress/Classes/Utility/Media/MediaLoader.swift
@@ -1,0 +1,85 @@
+
+@objc protocol PostInformation {
+    var isPrivateSite: Bool { get }
+    var isBlogSelfHostedWithCredentials: Bool { get }
+}
+
+extension AbstractPost: PostInformation {
+    var isPrivateSite: Bool {
+        return isPrivate() && blog.isHostedAtWPcom
+    }
+
+    var isBlogSelfHostedWithCredentials: Bool {
+        return !blog.isHostedAtWPcom && blog.isBasicAuthCredentialStored()
+    }
+}
+
+extension URL {
+    var isGif: Bool {
+        return pathExtension == "gif"
+    }
+}
+
+@objc class MediaLoader: NSObject {
+
+    private let imageView: CachedAnimatedImageView
+
+    @objc init(imageView: CachedAnimatedImageView) {
+        self.imageView = imageView
+        super.init()
+    }
+
+    @objc func prepareForReuse() {
+        imageView.image = nil
+        imageView.prepForReuse()
+    }
+
+    @objc(loadImageWithURL:fromPost:andPreferedSize:)
+    func loadImage(with url: URL, from post: PostInformation, preferedSize size: CGSize = .zero) {
+        if url.isGif {
+            loadGif(with: url, from: post)
+        } else {
+            loadStillImage(with: url, from: post, preferedSize: size)
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func loadGif(with url: URL, from post: PostInformation) {
+        let request: URLRequest
+        if post.isPrivateSite {
+            request = PrivateSiteURLProtocol.requestForPrivateSite(from: url)
+        } else {
+            request = URLRequest(url: url)
+        }
+
+        imageView.setAnimatedImage(request, placeholderImage: nil, success: nil, failure: nil)
+    }
+
+    private func loadStillImage(with url: URL, from post: PostInformation, preferedSize size: CGSize) {
+        if url.isFileURL {
+            imageView.setImageWith(url)
+        } else if post.isPrivateSite {
+            loadImage(with: url, fromPrivatePost: post, preferedSize: size)
+        } else if post.isBlogSelfHostedWithCredentials {
+            imageView.setImageWith(url)
+        } else {
+            loadProtonUrl(with: url, preferedSize: size)
+        }
+    }
+
+    private func loadImage(with url: URL, fromPrivatePost post: PostInformation, preferedSize size: CGSize) {
+        let scale = UIScreen.main.scale
+        let scaledSize = CGSize(width: size.width * scale, height: size.height * scale)
+        let scaledURL = WPImageURLHelper.imageURLWithSize(scaledSize, forImageURL: url)
+        imageView.setImageWith(scaledURL)
+    }
+
+    private func loadProtonUrl(with url: URL, preferedSize size: CGSize) {
+        guard let protonURL = PhotonImageURLHelper.photonURL(with: size, forImageURL: url) else {
+            imageView.setImageWith(url)
+            return
+        }
+        imageView.setImageWith(protonURL)
+    }
+}

--- a/WordPress/Classes/Utility/Media/MediaLoader.swift
+++ b/WordPress/Classes/Utility/Media/MediaLoader.swift
@@ -62,11 +62,11 @@
 
     private func loadStillImage(with url: URL, from post: PostInformation, preferedSize size: CGSize) {
         if url.isFileURL {
-            imageView.setImageWith(url)
+            imageView.downloadImage(from:url)
         } else if post.isPrivateOnWPCom {
             loadImage(with: url, fromPrivatePost: post, preferedSize: size)
         } else if post.isBlogSelfHostedWithCredentials {
-            imageView.setImageWith(url)
+            imageView.downloadImage(from:url)
         } else {
             loadProtonUrl(with: url, preferedSize: size)
         }
@@ -76,7 +76,7 @@
         let scale = UIScreen.main.scale
         let scaledSize = CGSize(width: size.width * scale, height: size.height * scale)
         let scaledURL = WPImageURLHelper.imageURLWithSize(scaledSize, forImageURL: url)
-        imageView.setImageWith(scaledURL)
+        imageView.downloadImage(from:scaledURL)
     }
 
     private func loadProtonUrl(with url: URL, preferedSize size: CGSize) {
@@ -84,6 +84,6 @@
             imageView.setImageWith(url)
             return
         }
-        imageView.setImageWith(protonURL)
+        imageView.downloadImage(from:protonURL)
     }
 }

--- a/WordPress/Classes/Utility/Media/MediaLoader.swift
+++ b/WordPress/Classes/Utility/Media/MediaLoader.swift
@@ -1,23 +1,15 @@
 
+/// Protocol used to abstract the information needed to load post related images
+///
 @objc protocol PostInformation {
+
+    /// The post is privated, and hosted in WPcom
+    ///
     var isPrivateSite: Bool { get }
+
+    /// The blog is self-hosted and there is already a basic auth credential stored.
+    ///
     var isBlogSelfHostedWithCredentials: Bool { get }
-}
-
-extension AbstractPost: PostInformation {
-    var isPrivateSite: Bool {
-        return isPrivate() && blog.isHostedAtWPcom
-    }
-
-    var isBlogSelfHostedWithCredentials: Bool {
-        return !blog.isHostedAtWPcom && blog.isBasicAuthCredentialStored()
-    }
-}
-
-extension URL {
-    var isGif: Bool {
-        return pathExtension == "gif"
-    }
 }
 
 @objc class MediaLoader: NSObject {
@@ -29,12 +21,23 @@ extension URL {
         super.init()
     }
 
+
+    /// Call this in a table/collection cell's `prepareForReuse()`
+    ///
     @objc func prepareForReuse() {
         imageView.image = nil
         imageView.prepForReuse()
     }
 
+
     @objc(loadImageWithURL:fromPost:andPreferedSize:)
+    /// Load an image from a specific post, using the given URL. Supports animated images (gifs) as well.
+    ///
+    /// - Parameters:
+    ///   - url: The URL to load the image from.
+    ///   - post: The post where the image is loaded from.
+    ///   - size: The prefered size of the image to load.
+    ///
     func loadImage(with url: URL, from post: PostInformation, preferedSize size: CGSize = .zero) {
         if url.isGif {
             loadGif(with: url, from: post)

--- a/WordPress/Classes/Utility/Media/MediaLoader.swift
+++ b/WordPress/Classes/Utility/Media/MediaLoader.swift
@@ -6,7 +6,7 @@
     /// The post is private and hosted on WPcom.
     /// Redundant name due to naming conflict.
     ///
-    var isPostPrivate: Bool { get }
+    var isPrivateOnWPCom: Bool { get }
 
     /// The blog is self-hosted and there is already a basic auth credential stored.
     ///
@@ -51,7 +51,7 @@
 
     private func loadGif(with url: URL, from post: PostInformation) {
         let request: URLRequest
-        if post.isPostPrivate {
+        if post.isPrivateOnWPCom {
             request = PrivateSiteURLProtocol.requestForPrivateSite(from: url)
         } else {
             request = URLRequest(url: url)
@@ -63,7 +63,7 @@
     private func loadStillImage(with url: URL, from post: PostInformation, preferedSize size: CGSize) {
         if url.isFileURL {
             imageView.setImageWith(url)
-        } else if post.isPostPrivate {
+        } else if post.isPrivateOnWPCom {
             loadImage(with: url, fromPrivatePost: post, preferedSize: size)
         } else if post.isBlogSelfHostedWithCredentials {
             imageView.setImageWith(url)

--- a/WordPress/Classes/Utility/Media/MediaLoader.swift
+++ b/WordPress/Classes/Utility/Media/MediaLoader.swift
@@ -3,9 +3,10 @@
 ///
 @objc protocol PostInformation {
 
-    /// The post is privated, and hosted in WPcom
+    /// The post is privated, and hosted in WPcom.
+    /// Redundant name due to naming conflict.
     ///
-    var isPrivateSite: Bool { get }
+    var isPostPrivate: Bool { get }
 
     /// The blog is self-hosted and there is already a basic auth credential stored.
     ///
@@ -50,7 +51,7 @@
 
     private func loadGif(with url: URL, from post: PostInformation) {
         let request: URLRequest
-        if post.isPrivateSite {
+        if post.isPostPrivate {
             request = PrivateSiteURLProtocol.requestForPrivateSite(from: url)
         } else {
             request = URLRequest(url: url)
@@ -62,7 +63,7 @@
     private func loadStillImage(with url: URL, from post: PostInformation, preferedSize size: CGSize) {
         if url.isFileURL {
             imageView.setImageWith(url)
-        } else if post.isPrivateSite {
+        } else if post.isPostPrivate {
             loadImage(with: url, fromPrivatePost: post, preferedSize: size)
         } else if post.isBlogSelfHostedWithCredentials {
             imageView.setImageWith(url)

--- a/WordPress/Classes/Utility/Media/MediaLoader.swift
+++ b/WordPress/Classes/Utility/Media/MediaLoader.swift
@@ -3,7 +3,7 @@
 ///
 @objc protocol PostInformation {
 
-    /// The post is privated, and hosted in WPcom.
+    /// The post is private and hosted on WPcom.
     /// Redundant name due to naming conflict.
     ///
     var isPostPrivate: Bool { get }

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -59,7 +59,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 @property (nonatomic, weak) id<InteractivePostViewDelegate> delegate;
 @property (nonatomic, strong) Post *post;
 @property (nonatomic, strong) PostCardStatusViewModel *viewModel;
-@property (nonatomic, strong) MediaLoader *mediaLoader;
+@property (nonatomic, strong) ImageLoader *imageLoader;
 @property (nonatomic) CGFloat headerViewHeight;
 @property (nonatomic) CGFloat headerViewLowerMargin;
 @property (nonatomic) CGFloat titleViewLowerMargin;
@@ -164,20 +164,20 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
                      } completion:nil];
 }
 
-- (MediaLoader *)mediaLoader
+- (ImageLoader *)imageLoader
 {
-    if (!_mediaLoader && self.postCardImageView) {
-        _mediaLoader = [[MediaLoader alloc] initWithImageView:self.postCardImageView];
+    if (!_imageLoader && self.postCardImageView) {
+        _imageLoader = [[ImageLoader alloc] initWithImageView:self.postCardImageView];
     }
 
-    return _mediaLoader;
+    return _imageLoader;
 }
 
 - (void)prepareForReuse
 {
     [super prepareForReuse];
-    if (self.mediaLoader) {
-        [self.mediaLoader prepareForReuse];
+    if (self.imageLoader) {
+        [self.imageLoader prepareForReuse];
     }
     [self setNeedsDisplay];
 }
@@ -275,7 +275,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 - (void)configureCardImage
 {
-    if (!self.mediaLoader) {
+    if (!self.imageLoader) {
         return;
     }
 
@@ -290,7 +290,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
     CGFloat desiredHeight = self.postCardImageViewHeightConstraint.constant;
     CGSize imageSize = CGSizeMake(desiredWidth, desiredHeight);
 
-    [self.mediaLoader loadImageWithURL:url fromPost:post andPreferedSize:imageSize];
+    [self.imageLoader loadImageWithURL:url fromPost:post andPreferedSize:imageSize];
 }
 
 - (void)configureTitle

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -59,6 +59,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 @property (nonatomic, weak) id<InteractivePostViewDelegate> delegate;
 @property (nonatomic, strong) Post *post;
 @property (nonatomic, strong) PostCardStatusViewModel *viewModel;
+@property (nonatomic, strong) MediaLoader *mediaLoader;
 @property (nonatomic) CGFloat headerViewHeight;
 @property (nonatomic) CGFloat headerViewLowerMargin;
 @property (nonatomic) CGFloat titleViewLowerMargin;
@@ -163,11 +164,20 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
                      } completion:nil];
 }
 
+- (MediaLoader *)mediaLoader
+{
+    if (!_mediaLoader && self.postCardImageView) {
+        _mediaLoader = [[MediaLoader alloc] initWithImageView:self.postCardImageView];
+    }
+
+    return _mediaLoader;
+}
+
 - (void)prepareForReuse
 {
     [super prepareForReuse];
-    if (self.postCardImageView) {
-        [self.postCardImageView prepForReuse];
+    if (self.mediaLoader) {
+        [self.mediaLoader prepareForReuse];
     }
     [self setNeedsDisplay];
 }
@@ -265,51 +275,22 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
 
 - (void)configureCardImage
 {
-    if (!self.postCardImageView) {
+    if (!self.mediaLoader) {
         return;
     }
 
     AbstractPost *post = [self.post latest];
-    // Clear the image so we know its not stale.
-    self.postCardImageView.image = nil;
     NSURL *url = [post featuredImageURLForDisplay];
     if (url == nil) {
         // no feature image available.
         return;
     }
 
-    BOOL isAnimatedGIF = [[url pathExtension] isEqual:@"gif"];
-
-    if (isAnimatedGIF) {
-        NSURLRequest *request = [[NSURLRequest alloc] initWithURL:url];
-        if ([post isPrivate] && [post.blog isHostedAtWPcom]) {
-            request = [PrivateSiteURLProtocol requestForPrivateSiteFromURL:url];
-        }
-        [self.postCardImageView setAnimatedImage:request
-                                        placeholderImage:nil
-                                                 success:nil
-                                                 failure:nil];
-        return;
-    }
-    
     CGFloat desiredWidth = [UIApplication  sharedApplication].keyWindow.frame.size.width;
     CGFloat desiredHeight = self.postCardImageViewHeightConstraint.constant;
     CGSize imageSize = CGSizeMake(desiredWidth, desiredHeight);
-    if ([url isFileURL]) {
-        [self.postCardImageView setImageWithURL:url placeholderImage:nil];
-    } else if ([post isPrivate] && [post.blog isHostedAtWPcom]) {
-        CGFloat scale = [[UIScreen mainScreen] scale];
-        CGSize scaledSize = CGSizeMake(desiredWidth * scale, desiredHeight * scale);
-        url = [WPImageURLHelper imageURLWithSize:scaledSize forImageURL:url];
-        NSURLRequest *request = [PrivateSiteURLProtocol requestForPrivateSiteFromURL:url];
-        [self.postCardImageView setImageWithURLRequest:request placeholderImage:nil success:nil failure:nil];
-    } else if (!post.blog.isHostedAtWPcom && post.blog.isBasicAuthCredentialStored) {
-        [self.postCardImageView setImageWithURL:url placeholderImage:nil];
-    } else {
-        // if not private create photon url
-        url = [PhotonImageURLHelper photonURLWithSize:imageSize forImageURL:url];
-        [self.postCardImageView setImageWithURL:url placeholderImage:nil];
-    }
+
+    [self.mediaLoader loadImageWithURL:url fromPost:post andPreferedSize:imageSize];
 }
 
 - (void)configureTitle

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -470,7 +470,7 @@
 		7E21C761202BBC8E00837CF5 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E21C760202BBC8D00837CF5 /* iAd.framework */; };
 		7E21C765202BBF4400837CF5 /* SearchAdsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E21C764202BBF4400837CF5 /* SearchAdsAttribution.swift */; };
 		7E52B7181FC89F2400B55EB8 /* MediaNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */; };
-		7E729C28209A087300F76599 /* MediaLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C27209A087200F76599 /* MediaLoader.swift */; };
+		7E729C28209A087300F76599 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C27209A087200F76599 /* ImageLoader.swift */; };
 		7E729C2A209A241100F76599 /* AbstractPost+PostInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */; };
 		7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */; };
 		7EAD7CD0206D761200BEDCFD /* MediaExternalExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */; };
@@ -1845,7 +1845,7 @@
 		7E21C760202BBC8D00837CF5 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
 		7E21C764202BBF4400837CF5 /* SearchAdsAttribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SearchAdsAttribution.swift; path = iAds/SearchAdsAttribution.swift; sourceTree = "<group>"; };
 		7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaNoResultsView.swift; sourceTree = "<group>"; };
-		7E729C27209A087200F76599 /* MediaLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLoader.swift; sourceTree = "<group>"; };
+		7E729C27209A087200F76599 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+PostInformation.swift"; sourceTree = "<group>"; };
 		7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonHeaderCell.swift; sourceTree = "<group>"; };
 		7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExternalExporter.swift; sourceTree = "<group>"; };
@@ -3187,7 +3187,7 @@
 				08F8CD381EBD2C970049D0C0 /* MediaURLExporter.swift */,
 				08E77F441EE87FCF006F9515 /* MediaThumbnailExporter.swift */,
 				7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */,
-				7E729C27209A087200F76599 /* MediaLoader.swift */,
+				7E729C27209A087200F76599 /* ImageLoader.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -7465,7 +7465,7 @@
 				9872CB30203B8A730066A293 /* SignupEpilogueTableViewController.swift in Sources */,
 				E1B23B081BFB3B370006559B /* MyProfileViewController.swift in Sources */,
 				B5CC05F61962150600975CAC /* Constants.m in Sources */,
-				7E729C28209A087300F76599 /* MediaLoader.swift in Sources */,
+				7E729C28209A087300F76599 /* ImageLoader.swift in Sources */,
 				5D146EBB189857ED0068FDC6 /* FeaturedImageViewController.m in Sources */,
 				31EC15081A5B6675009FC8B3 /* WPStyleGuide+Suggestions.m in Sources */,
 				FF5371631FDFF64F00619A3F /* MediaService.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -470,6 +470,7 @@
 		7E21C761202BBC8E00837CF5 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E21C760202BBC8D00837CF5 /* iAd.framework */; };
 		7E21C765202BBF4400837CF5 /* SearchAdsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E21C764202BBF4400837CF5 /* SearchAdsAttribution.swift */; };
 		7E52B7181FC89F2400B55EB8 /* MediaNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */; };
+		7E729C28209A087300F76599 /* MediaLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C27209A087200F76599 /* MediaLoader.swift */; };
 		7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */; };
 		7EAD7CD0206D761200BEDCFD /* MediaExternalExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */; };
 		7EBB4126206C388100012D98 /* StockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBB4125206C388100012D98 /* StockPhotosService.swift */; };
@@ -1843,6 +1844,7 @@
 		7E21C760202BBC8D00837CF5 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
 		7E21C764202BBF4400837CF5 /* SearchAdsAttribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SearchAdsAttribution.swift; path = iAds/SearchAdsAttribution.swift; sourceTree = "<group>"; };
 		7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaNoResultsView.swift; sourceTree = "<group>"; };
+		7E729C27209A087200F76599 /* MediaLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLoader.swift; sourceTree = "<group>"; };
 		7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonHeaderCell.swift; sourceTree = "<group>"; };
 		7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExternalExporter.swift; sourceTree = "<group>"; };
 		7EBB4125206C388100012D98 /* StockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosService.swift; sourceTree = "<group>"; };
@@ -3183,6 +3185,7 @@
 				08F8CD381EBD2C970049D0C0 /* MediaURLExporter.swift */,
 				08E77F441EE87FCF006F9515 /* MediaThumbnailExporter.swift */,
 				7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */,
+				7E729C27209A087200F76599 /* MediaLoader.swift */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -7459,6 +7462,7 @@
 				9872CB30203B8A730066A293 /* SignupEpilogueTableViewController.swift in Sources */,
 				E1B23B081BFB3B370006559B /* MyProfileViewController.swift in Sources */,
 				B5CC05F61962150600975CAC /* Constants.m in Sources */,
+				7E729C28209A087300F76599 /* MediaLoader.swift in Sources */,
 				5D146EBB189857ED0068FDC6 /* FeaturedImageViewController.m in Sources */,
 				31EC15081A5B6675009FC8B3 /* WPStyleGuide+Suggestions.m in Sources */,
 				FF5371631FDFF64F00619A3F /* MediaService.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -471,6 +471,7 @@
 		7E21C765202BBF4400837CF5 /* SearchAdsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E21C764202BBF4400837CF5 /* SearchAdsAttribution.swift */; };
 		7E52B7181FC89F2400B55EB8 /* MediaNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */; };
 		7E729C28209A087300F76599 /* MediaLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C27209A087200F76599 /* MediaLoader.swift */; };
+		7E729C2A209A241100F76599 /* AbstractPost+PostInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */; };
 		7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */; };
 		7EAD7CD0206D761200BEDCFD /* MediaExternalExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */; };
 		7EBB4126206C388100012D98 /* StockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBB4125206C388100012D98 /* StockPhotosService.swift */; };
@@ -1845,6 +1846,7 @@
 		7E21C764202BBF4400837CF5 /* SearchAdsAttribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SearchAdsAttribution.swift; path = iAds/SearchAdsAttribution.swift; sourceTree = "<group>"; };
 		7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaNoResultsView.swift; sourceTree = "<group>"; };
 		7E729C27209A087200F76599 /* MediaLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLoader.swift; sourceTree = "<group>"; };
+		7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+PostInformation.swift"; sourceTree = "<group>"; };
 		7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonHeaderCell.swift; sourceTree = "<group>"; };
 		7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExternalExporter.swift; sourceTree = "<group>"; };
 		7EBB4125206C388100012D98 /* StockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosService.swift; sourceTree = "<group>"; };
@@ -4937,6 +4939,7 @@
 				B55FFCF91F034F1A0070812C /* String+Ranges.swift */,
 				B54C02231F38F50100574572 /* String+RegEx.swift */,
 				FFD12D5D1FE1998D00F20A00 /* Progress+Helpers.swift */,
+				7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -7671,6 +7674,7 @@
 				E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */,
 				827704F11F607C0E002E8A03 /* JetpackConnectionViewController.swift in Sources */,
 				5D839AAB187F0D8000811F4A /* PostGeolocationCell.m in Sources */,
+				7E729C2A209A241100F76599 /* AbstractPost+PostInformation.swift in Sources */,
 				8236EB502024ED8C007C7CF9 /* NotificationsViewController+JetpackPrompt.swift in Sources */,
 				5D732F971AE84E3C00CD89E7 /* PostListFooterView.m in Sources */,
 				1767494E1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift in Sources */,


### PR DESCRIPTION
Fixes #9250 

This PR introduce a new class `MediaLoader`. The intent is to facilitate loading images across the app. Specially those images that could be animated (gifs).

This PR also implements this `MediaLoader` in the `PostCardTableViewCell`, so it can be tested in action in the Posts list.

To test:

- Be sure to have plenty of images/gifs in your blog posts's feature images.
- Open the Blog list and check that all featured images are loading properly.
- Test in a WPcom sites, a self-hosted site and public/private posts.

