### PR TITLE
Hide Jetpack prompt once connected

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+JetpackPrompt.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+JetpackPrompt.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 extension NotificationsViewController {
 
     func promptForJetpackCredentials() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -152,6 +152,13 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
             reloadTableViewPreservingSelection()
         }
 
+        if !AccountHelper.isDotcomAvailable() {
+            promptForJetpackCredentials()
+        } else {
+            jetpackLoginViewController?.view.removeFromSuperview()
+            jetpackLoginViewController?.removeFromParentViewController()
+        }
+
         showNoResultsViewIfNeeded()
     }
 
@@ -160,10 +167,6 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         showRatingViewIfApplicable()
         syncNewNotifications()
         markSelectedNotificationAsRead()
-
-        if !AccountHelper.isDotcomAvailable() {
-            promptForJetpackCredentials()
-        }
 
         registerUserActivity()
     }


### PR DESCRIPTION
Fixes #9235

This fixes the issue of the jetpack connection prompt staying on screen even after Jetpack has been connected.

To test:
- login to a self-hosted site
- flip to the notifications tab
- then flip to my sites > stats
- from stats, login to jetpack
- once done, flip back to the notifications tab
- ensure the jetpack prompt is gone

cc: @elibud you touched this code most recently, but I assume you can't do a review anymore… here's a ping FWIW


