### PR TITLE
Fix Aztec editor constraints and scrolling issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -613,6 +613,19 @@ class AztecPostViewController: UIViewController, PostEditor {
         contentInset.top = (titleHeightConstraint.constant + separatorView.frame.height)
         referenceView.contentInset = contentInset
         referenceView.setContentOffset(CGPoint(x: 0, y: -contentInset.top), animated: false)
+
+        updateScrollInsets()
+    }
+
+    func updateScrollInsets() {
+        let referenceView: UITextView = mode == .richText ? richTextView : htmlTextView
+        var scrollInsets = referenceView.contentInset
+        var rightMargin = (view.frame.maxX - referenceView.frame.maxX)
+        if #available(iOS 11.0, *) {
+            rightMargin -= view.safeAreaInsets.right
+        }
+        scrollInsets.right = -rightMargin
+        referenceView.scrollIndicatorInsets = scrollInsets
     }
 
 
@@ -967,14 +980,12 @@ class AztecPostViewController: UIViewController, PostEditor {
     fileprivate func refreshInsets(forKeyboardFrame keyboardFrame: CGRect) {
         let referenceView: UIScrollView = mode == .richText ? richTextView : htmlTextView
 
-        let scrollInsets = UIEdgeInsets(top: referenceView.scrollIndicatorInsets.top, left: 0, bottom: view.frame.maxY - (keyboardFrame.minY + self.view.layoutMargins.bottom), right: referenceView.frame.maxX - view.frame.maxX)
         let contentInsets  = UIEdgeInsets(top: referenceView.contentInset.top, left: 0, bottom: view.frame.maxY - (keyboardFrame.minY + self.view.layoutMargins.bottom), right: 0)
 
-        htmlTextView.scrollIndicatorInsets = scrollInsets
         htmlTextView.contentInset = contentInsets
-
-        richTextView.scrollIndicatorInsets = scrollInsets
         richTextView.contentInset = contentInsets
+
+        updateScrollInsets()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -499,6 +499,8 @@ class AztecPostViewController: UIViewController, PostEditor {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        richTextView.isScrollEnabled = false
+        htmlTextView.isScrollEnabled = false
         // This needs to called first
         configureMediaAppearance()
 
@@ -542,6 +544,9 @@ class AztecPostViewController: UIViewController, PostEditor {
 
         // Handles refreshing controls with state context after options screen is dismissed
         editorContentWasUpdated()
+
+        richTextView.isScrollEnabled = true
+        htmlTextView.isScrollEnabled = true
     }
 
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -517,6 +517,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         refreshInterface()
 
         // Setup Autolayout
+        configureConstraints()
         view.setNeedsUpdateConstraints()
 
         if isOpenedDirectlyForPhotoPost {
@@ -636,8 +637,12 @@ class AztecPostViewController: UIViewController, PostEditor {
     // MARK: - Configuration Methods
 
     override func updateViewConstraints() {
-
+        refreshTitlePosition()
+        updateTitleHeight()
         super.updateViewConstraints()
+    }
+
+    func configureConstraints() {
 
         titleHeightConstraint = titleTextField.heightAnchor.constraint(equalToConstant: titleTextField.font!.lineHeight)
         titleTopConstraint = titleTextField.topAnchor.constraint(equalTo: view.topAnchor, constant: -richTextView.contentOffset.y)


### PR DESCRIPTION
This PR ports the changes made on this Aztec PR https://github.com/wordpress-mobile/AztecEditor-iOS/pull/940 to the main app.

This fixes a lot of constraints warning and some scrolling issues we where seeing.

To test:
 - Open the Aztec editor with a big post
 - Scroll up and down on it and see if everything is work ok.
 - Check on phones and tablets on the multiple multitasks mode.


