### PR TITLE
Add completion handlers to ImageLoader

### DIFF
--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -1,5 +1,5 @@
 
-/// Protocol used to abstract the information needed to load post related images
+/// Protocol used to abstract the information needed to load post related images.
 ///
 @objc protocol PostInformation {
 
@@ -18,14 +18,17 @@
 ///
 @objc class ImageLoader: NSObject {
 
-    private let imageView: CachedAnimatedImageView
+    private unowned let imageView: CachedAnimatedImageView
+    private var successHandler: (() -> Void)?
+    private var errorHandler: ((Error?) -> Void)?
+    private var placeholder: UIImage?
 
     @objc init(imageView: CachedAnimatedImageView) {
         self.imageView = imageView
         super.init()
     }
 
-    /// Call this in a table/collection cell's `prepareForReuse()`
+    /// Call this in a table/collection cell's `prepareForReuse()`.
     ///
     @objc func prepareForReuse() {
         imageView.image = nil
@@ -48,8 +51,28 @@
         }
     }
 
+    @objc(loadImageWithURL:fromPost:preferedSize:placeholder:success:error:)
+    /// Load an image from a specific post, using the given URL. Supports animated images (gifs) as well.
+    ///
+    /// - Parameters:
+    ///   - url: The URL to load the image from.
+    ///   - post: The post where the image is loaded from.
+    ///   - size: The prefered size of the image to load.
+    ///   - placeholder: A placeholder to show while the image is loading.
+    ///   - success: A closure to be called if the image was loaded successfully.
+    ///   - error: A closure to be called if there was an error loading the image.
+    func loadImage(with url: URL, from post: PostInformation, preferedSize size: CGSize = .zero, placeholder: UIImage?, success: (() -> Void)?, error: ((Error?) -> Void)?) {
+        self.placeholder = placeholder
+        successHandler = success
+        errorHandler = error
+
+        loadImage(with: url, from: post, preferedSize: size)
+    }
+
     // MARK: - Private helpers
 
+    /// Load an animated image from the given URL.
+    ///
     private func loadGif(with url: URL, from post: PostInformation) {
         let request: URLRequest
         if post.isPrivateOnWPCom {
@@ -57,35 +80,89 @@
         } else {
             request = URLRequest(url: url)
         }
-
-        imageView.setAnimatedImage(request, placeholderImage: nil, success: nil, failure: nil)
+        downloadGif(from: request)
     }
 
+    /// Load a static image from the given URL.
+    ///
     private func loadStillImage(with url: URL, from post: PostInformation, preferedSize size: CGSize) {
         if url.isFileURL {
-            imageView.downloadImage(from: url)
+            downloadImage(from: url)
         } else if post.isPrivateOnWPCom {
-            loadImage(with: url, fromPrivatePost: post, preferedSize: size)
+            loadPrivateImage(with: url, from: post, preferedSize: size)
         } else if post.isBlogSelfHostedWithCredentials {
-            imageView.downloadImage(from: url)
+            downloadImage(from: url)
         } else {
             loadProtonUrl(with: url, preferedSize: size)
         }
     }
 
-    private func loadImage(with url: URL, fromPrivatePost post: PostInformation, preferedSize size: CGSize) {
+    /// Loads the image from a private post hosted in WPCom.
+    ///
+    private func loadPrivateImage(with url: URL, from post: PostInformation, preferedSize size: CGSize) {
         let scale = UIScreen.main.scale
         let scaledSize = CGSize(width: size.width * scale, height: size.height * scale)
         let scaledURL = WPImageURLHelper.imageURLWithSize(scaledSize, forImageURL: url)
         let request = PrivateSiteURLProtocol.requestForPrivateSite(from: scaledURL)
-        imageView.setImageWith(request, placeholderImage: nil, success: nil, failure: nil)
+
+        downloadImage(from: request)
     }
 
+    /// Loads the image from the Proton API with the given size.
+    ///
     private func loadProtonUrl(with url: URL, preferedSize size: CGSize) {
         guard let protonURL = PhotonImageURLHelper.photonURL(with: size, forImageURL: url) else {
-            imageView.downloadImage(from: url)
+            downloadImage(from: url)
             return
         }
-        imageView.downloadImage(from: protonURL)
+        downloadImage(from: protonURL)
+    }
+
+    /// Download the animated image from the given URL Request.
+    ///
+    private func downloadGif(from request: URLRequest) {
+        imageView.setAnimatedImage(request, placeholderImage: placeholder, success: { [weak self] in
+            self?.callSuccessHandler()
+        }) { [weak self] (error) in
+            self?.callErrorHandler(with: error)
+        }
+    }
+
+    /// Downloads the image from the given URL Request.
+    ///
+    private func downloadImage(from request: URLRequest) {
+        imageView.setImageWith(request, placeholderImage: placeholder, success: { [weak self] (_, _, _) in
+            self?.successHandler?()
+        }) { [weak self] (_, _, error) in
+            self?.errorHandler?(error)
+        }
+    }
+
+    /// Downloads the image from the given URL.
+    ///
+    private func downloadImage(from url: URL) {
+        imageView.downloadImage(from: url, placeholderImage: placeholder, success: { [weak self] (_) in
+            self?.callSuccessHandler()
+        }) { [weak self] (error) in
+            self?.callErrorHandler(with: error)
+        }
+    }
+
+    private func callSuccessHandler() {
+        guard successHandler != nil else {
+            return
+        }
+        DispatchQueue.main.async {
+            self.successHandler?()
+        }
+    }
+
+    private func callErrorHandler(with error: Error?) {
+        guard errorHandler != nil else {
+            return
+        }
+        DispatchQueue.main.async {
+            self.errorHandler?(error)
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
@@ -86,7 +86,11 @@ class AnimatedImageCache {
             }
             // check if there is an error
             if let error = error {
-                failure?(error as NSError)
+                let nsError = error as NSError
+                // task.cancel() triggers an error that we don't want to send to the error handler.
+                if nsError.code != NSURLErrorCancelled {
+                    failure?(nsError)
+                }
                 return
             }
             // check if data is here and is animated gif


### PR DESCRIPTION
Fixes #9259 

This PR adds a `success` and a `error` handler to the `loadImage()` function in the `ImageLoader` class. This also adds a image placeholder to be shown while the image is being loaded. 

To test:
- Be sure to have plenty of featured images/gifs in your post lists.
- Add a breakpoint on `callSuccessHandler():151` and `callErrorHandler(with:):160` in the `ImageLoader` class.
- Check that the breakpoints are triggered when they should.
