### PR TITLE
Restores the help nudge for Jetpack users.

### DIFF
--- a/WordPressAuthenticator/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/Signin/LoginSiteAddressViewController.swift
@@ -160,11 +160,11 @@ class LoginSiteAddressViewController: LoginViewController, NUXKeyboardResponder 
 
             let err = strongSelf.originalErrorOrError(error: error as NSError)
 
-            if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
-                strongSelf.displayError(message: xmlrpcValidatorError.localizedDescription)
-
-            } else if strongSelf.errorDiscoveringJetpackSite(error: err) {
+            if strongSelf.errorDiscoveringJetpackSite(error: err) {
                 strongSelf.displayError(error as NSError, sourceTag: .jetpackLogin)
+
+            } else if let xmlrpcValidatorError = err as? WordPressOrgXMLRPCValidatorError {
+                strongSelf.displayError(message: xmlrpcValidatorError.localizedDescription)
 
             } else if (err.domain == NSURLErrorDomain && err.code == NSURLErrorCannotFindHost) ||
                 (err.domain == NSURLErrorDomain && err.code == NSURLErrorNetworkConnectionLost) {


### PR DESCRIPTION
Fixes #9263 

This PR reorders the conditionals to restore the prompt previously shown to Jetpack users.

To test:
- You'll need a self-hosted site with Jetpack installed and connected to wpcom. 
- Break the site so it is unreachable to XML-RPC queries.  An easy way is to introduce a syntax error in the site's `xmlrpc.php` file.
- Attempt to log in to the self-hosted blog. 
- Confirm you see the following prompt:
![simulator screen shot - iphone 8 plus - 2018-05-03 at 16 25 47](https://user-images.githubusercontent.com/1435271/39604171-a6546fee-4ef0-11e8-84f3-f63259428498.png)


@etoledom or @nheagy could I trouble one of you for a review? 
