### PR TITLE
Editor: pressing tab while the caret is in the title moves the caret to the content.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -929,6 +929,12 @@ class AztecPostViewController: UIViewController, PostEditor {
     // MARK: - Keyboard Handling
 
     override var keyCommands: [UIKeyCommand] {
+        if titleTextField.isFirstResponder {
+            return [
+                UIKeyCommand(input: "\t", modifierFlags: [], action: #selector(tabOnTitle))
+            ]
+        }
+
         if richTextView.isFirstResponder {
             return [
                 UIKeyCommand(input: "B", modifierFlags: .command, action: #selector(toggleBold), discoverabilityTitle: NSLocalizedString("Bold", comment: "Discoverability title for bold formatting keyboard shortcut.")),
@@ -2005,6 +2011,20 @@ extension AztecPostViewController {
         richTextView.inputAssistantItem.trailingBarButtonGroups = originalTrailingBarButtonGroup
         richTextView.autocorrectionType = .yes
         richTextView.reloadInputViews()
+    }
+
+    @objc func tabOnTitle() {
+        let activeTextView: UITextView = {
+            switch mode {
+            case .html:
+                return htmlTextView
+            case .richText:
+                return richTextView
+            }
+        }()
+
+        activeTextView.becomeFirstResponder()
+        activeTextView.selectedTextRange = activeTextView.textRange(from: activeTextView.endOfDocument, to: activeTextView.endOfDocument)
     }
 
     @IBAction @objc func presentMediaPickerWasPressed() {


### PR DESCRIPTION
While editing a post, the caret should be moved when the title has first-responder status and the user press tabs.

Fixes #9273.

The issue description matches the testing steps.