### PR TITLE
Update feedback prompt layout for accessibility and reuse

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -34,7 +34,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
 
     /// Defines the Height of the Ratings View
     ///
-    @IBOutlet var ratingsHeightConstraint: NSLayoutConstraint!
+    @IBOutlet var ratingsSpaceConstraint: NSLayoutConstraint!
 
     /// TableView Handler: Our commander in chief!
     ///
@@ -108,12 +108,12 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         super.viewDidLoad()
 
         setupNavigationBar()
-        setupConstraints()
         setupTableView()
+        setupRatingsView()
         setupTableHeaderView()
         setupTableFooterView()
+        setupConstraints()
         setupTableHandler()
-        setupRatingsView()
         setupRefreshControl()
         setupNoResultsView()
         setupFiltersSegmentedControl()
@@ -181,6 +181,9 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
+        DispatchQueue.main.async {
+            self.setupTableHeaderView()
+        }
 
         if splitViewControllerIsHorizontallyCompact {
             tableView.deselectSelectedRowWithAnimation(true)
@@ -342,10 +345,15 @@ private extension NotificationsViewController {
     }
 
     func setupConstraints() {
-        precondition(ratingsHeightConstraint != nil)
+        precondition(ratingsSpaceConstraint != nil)
 
         // Ratings is initially hidden!
-        ratingsHeightConstraint.constant = 0
+        tableHeaderView.translatesAutoresizingMaskIntoConstraints = false
+        ratingsView.translatesAutoresizingMaskIntoConstraints = false
+
+        tableHeaderView.centerXAnchor.constraint(equalTo: tableView.centerXAnchor).isActive = true
+        tableHeaderView.topAnchor.constraint(equalTo: tableView.topAnchor).isActive = true
+        tableHeaderView.widthAnchor.constraint(equalTo: tableView.widthAnchor).isActive = true
     }
 
     func setupTableView() {
@@ -365,14 +373,14 @@ private extension NotificationsViewController {
         precondition(tableHeaderView != nil)
 
         // Fix: Update the Frame manually: Autolayout doesn't really help us, when it comes to Table Headers
-        let requiredSize        = tableHeaderView.systemLayoutSizeFitting(view.bounds.size)
-        var headerFrame         = tableHeaderView.frame
+        let requiredSize = tableHeaderView.systemLayoutSizeFitting(UILayoutFittingCompressedSize)
+        var headerFrame = tableHeaderView.frame
         headerFrame.size.height = requiredSize.height
+        tableHeaderView.frame = headerFrame
 
-        tableHeaderView.frame  = headerFrame
         tableHeaderView.layoutIfNeeded()
 
-        // Due to iOS awesomeness, unless we re-assign the tableHeaderView, iOS might never refresh the UI
+        // We reassign the tableHeaderView to force the UI to refresh. Yes, really.
         tableView.tableHeaderView = tableHeaderView
         tableView.setNeedsLayout()
     }
@@ -394,6 +402,9 @@ private extension NotificationsViewController {
 
         ratingsView.delegate = self
         ratingsView.alpha = WPAlphaZero
+
+        // this allows the selector to move to the top
+        ratingsSpaceConstraint.isActive = false
     }
 
     func setupRefreshControl() {
@@ -1197,16 +1208,14 @@ private extension NotificationsViewController {
             return
         }
 
-        guard ratingsHeightConstraint.constant != Ratings.heightFull && ratingsView.alpha != WPAlphaFull else {
+        guard ratingsView.alpha != WPAlphaFull else {
             return
         }
 
-        ratingsView.alpha = WPAlphaZero
-
+        // allows the ratings view to push the selector down
+        self.ratingsSpaceConstraint.isActive = true
         UIView.animate(withDuration: WPAnimationDurationDefault, delay: Ratings.animationDelay, options: .curveEaseIn, animations: {
             self.ratingsView.alpha = WPAlphaFull
-            self.ratingsHeightConstraint.constant = Ratings.heightFull
-
             self.setupTableHeaderView()
         }, completion: nil)
 
@@ -1214,12 +1223,11 @@ private extension NotificationsViewController {
     }
 
     func hideRatingViewWithDelay(_ delay: TimeInterval) {
+        self.ratingsSpaceConstraint.isActive = false
         UIView.animate(withDuration: WPAnimationDurationDefault,
                        delay: delay,
                        animations: {
             self.ratingsView.alpha = WPAlphaZero
-            self.ratingsHeightConstraint.constant = Ratings.heightZero
-
             self.setupTableHeaderView()
         })
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
+++ b/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="doV-5W-Rtg">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="doV-5W-Rtg">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -26,7 +26,7 @@
                     </tableView>
                     <connections>
                         <outlet property="filtersSegmentedControl" destination="W2i-rX-Pc4" id="Ewf-g4-EIc"/>
-                        <outlet property="ratingsHeightConstraint" destination="R1T-Iv-5Q8" id="380-AS-dyd"/>
+                        <outlet property="ratingsSpaceConstraint" destination="MBK-Ez-h7B" id="NJj-XL-4AG"/>
                         <outlet property="ratingsView" destination="ZnY-3K-upT" id="lUG-fd-Stc"/>
                         <outlet property="tableHeaderView" destination="Uvo-9e-l6I" id="dxx-mK-msp"/>
                         <segue destination="veA-Pg-QAw" kind="showDetail" identifier="NotificationDetailsViewController" id="qci-jy-59F"/>
@@ -40,14 +40,14 @@
                             <rect key="frame" x="0.0" y="0.0" width="600" height="100"/>
                             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="100" id="R1T-Iv-5Q8"/>
+                                <constraint firstAttribute="height" constant="100" placeholder="YES" id="R1T-Iv-5Q8"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pEF-oN-cih" userLabel="Filters View">
                             <rect key="frame" x="0.0" y="100" width="600" height="44"/>
                             <subviews>
-                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" apportionsSegmentWidthsByContent="YES" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="W2i-rX-Pc4">
-                                    <rect key="frame" x="8" y="8" width="584" height="29"/>
+                                <segmentedControl opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="left" contentVerticalAlignment="top" apportionsSegmentWidthsByContent="YES" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="W2i-rX-Pc4">
+                                    <rect key="frame" x="20" y="8" width="560" height="29"/>
                                     <segments>
                                         <segment title="All"/>
                                         <segment title="Unread"/>
@@ -77,6 +77,7 @@
                         <constraint firstItem="pEF-oN-cih" firstAttribute="top" secondItem="ZnY-3K-upT" secondAttribute="bottom" identifier="FiltersTop" id="MBK-Ez-h7B"/>
                         <constraint firstItem="ZnY-3K-upT" firstAttribute="top" secondItem="Uvo-9e-l6I" secondAttribute="top" priority="750" identifier="RatingsTop" id="SJu-PU-nzt"/>
                         <constraint firstAttribute="trailing" secondItem="ZnY-3K-upT" secondAttribute="trailing" identifier="RatingsTrailing" id="b8L-0Q-JCB"/>
+                        <constraint firstItem="pEF-oN-cih" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Uvo-9e-l6I" secondAttribute="top" id="iOI-vG-EsO"/>
                         <constraint firstItem="pEF-oN-cih" firstAttribute="centerX" secondItem="Uvo-9e-l6I" secondAttribute="centerX" identifier="FiltersCenter" id="rGu-9k-JxJ"/>
                         <constraint firstAttribute="bottom" secondItem="pEF-oN-cih" secondAttribute="bottom" identifier="FiltersBottom" id="zwD-z0-d6i"/>
                     </constraints>

--- a/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
+++ b/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
@@ -12,11 +12,12 @@ protocol AppFeedbackPromptViewDelegate: class {
 }
 
 class AppFeedbackPromptView: UIView {
-    @objc let container = UIView(frame: containerFrame)
-    @objc let label = UILabel(frame: labelFrame)
-    @objc let leftButton = UIButton(type: .custom)
-    @objc let rightButton = UIButton(type: .custom)
-    @objc var onRequestingFeedback: Bool = false
+    let label = UILabel()
+    let leftButton = RoundedButton()
+    let rightButton = RoundedButton()
+    let buttonStack = UIStackView()
+    var onRequestingFeedback = false
+    var constraintsAdded = false
 
     weak var delegate: AppFeedbackPromptViewDelegate?
 
@@ -35,13 +36,12 @@ class AppFeedbackPromptView: UIView {
     /// MARK: - Helpers
 
     fileprivate func setupSubviews() {
-        container.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin]
-        container.backgroundColor = UIColor.clear
-        addSubview(container)
-        container.center = CGPoint(x: bounds.midX, y: bounds.midY)
+        translatesAutoresizingMaskIntoConstraints = false
+        backgroundColor = UIColor.clear
 
         let textFont = WPStyleGuide.fontForTextStyle(.subheadline)
 
+        label.translatesAutoresizingMaskIntoConstraints = false
         label.textColor = UIColor(red: 50/255.0, green: 65/255.0, blue: 85/255.0, alpha: 1.0)
         label.textAlignment = .center
         label.numberOfLines = 0
@@ -49,31 +49,63 @@ class AppFeedbackPromptView: UIView {
         label.font = textFont
         label.text = NSLocalizedString("What do you think about WordPress?",
                                        comment: "This is the string we display when prompting the user to review the app")
-        container.addSubview(label)
+        addSubview(label)
 
-        leftButton.frame = CGRect(x: container.bounds.midX - 135.0, y: 50.0, width: 130.0, height: 30.0)
+        // Stack O'Buttons
+        buttonStack.translatesAutoresizingMaskIntoConstraints = false
+        buttonStack.axis = .horizontal
+        buttonStack.spacing = 10.0
+        addSubview(buttonStack)
+
+        // Yes Button
+        leftButton.translatesAutoresizingMaskIntoConstraints = false
         leftButton.backgroundColor = UIColor(red: 0.0, green: 170/255.0, blue: 220/255.0, alpha: 1.0)
-        leftButton.layer.cornerRadius = 4
-        leftButton.layer.masksToBounds = true
+        leftButton.tintColor = .white
         leftButton.setTitle(NSLocalizedString("I Like It",
                                               comment: "This is one of the buttons we display inside of the prompt to review the app"),
                             for: .normal)
         leftButton.setTitleColor(UIColor.white, for: .normal)
         leftButton.titleLabel?.font = textFont
         leftButton.addTarget(self, action: #selector(self.leftButtonTouched), for: .touchUpInside)
-        container.addSubview(leftButton)
+        buttonStack.addArrangedSubview(leftButton)
 
-        rightButton.frame = CGRect(x: container.bounds.midX + 5, y: 50.0, width: 130.0, height: 30.0)
+        // Could be Better Button
+        rightButton.translatesAutoresizingMaskIntoConstraints = false
         rightButton.backgroundColor = UIColor(red: 144/255.0, green: 174/255.0, blue: 194/255.0, alpha: 1.0)
-        rightButton.layer.cornerRadius = 4
-        rightButton.layer.masksToBounds = true
+        rightButton.tintColor = .white
         rightButton.setTitle(NSLocalizedString("Could Be Better",
                                                comment: "This is one of the buttons we display inside of the prompt to review the app"),
                              for: .normal)
         rightButton.setTitleColor(UIColor.white, for: .normal)
         rightButton.titleLabel?.font = textFont
         rightButton.addTarget(self, action: #selector(self.rightButtonTouched), for: .touchUpInside)
-        container.addSubview(rightButton)
+        buttonStack.addArrangedSubview(rightButton)
+
+        setNeedsUpdateConstraints()
+    }
+
+    override func updateConstraints() {
+        setupConstraints()
+        super.updateConstraints()
+    }
+
+    func setupConstraints() {
+        guard constraintsAdded == false else {
+            return
+        }
+        constraintsAdded = true
+
+        addConstraints([
+            label.centerXAnchor.constraint(equalTo: centerXAnchor),
+            label.topAnchor.constraint(equalTo: topAnchor, constant: LayoutConstants.verticalPadding),
+            label.bottomAnchor.constraint(equalTo: buttonStack.topAnchor, constant: -LayoutConstants.verticalPadding),
+            label.heightAnchor.constraint(greaterThanOrEqualToConstant: LayoutConstants.labelMinimumHeight),
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: LayoutConstants.horizontalPadding),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -LayoutConstants.horizontalPadding),
+            bottomAnchor.constraint(greaterThanOrEqualTo: buttonStack.bottomAnchor, constant: LayoutConstants.verticalPadding),
+            buttonStack.centerXAnchor.constraint(equalTo: centerXAnchor),
+            leftButton.widthAnchor.constraint(greaterThanOrEqualTo: rightButton.widthAnchor)
+        ])
     }
 
     @objc func leftButtonTouched() {
@@ -83,7 +115,6 @@ class AppFeedbackPromptView: UIView {
             delegate?.likedApp()
             leftButton.isHidden = true
             rightButton.isHidden = true
-            label.frame = AppFeedbackPromptView.labelBigFrame
             UIView.animate(withDuration: 0.3, animations: {() -> Void in
                 self.label.text = NSLocalizedString("Great!\n We love to hear from happy users \n😁",
                                                     comment: "This is the text we display to the user after they've indicated they like the app")
@@ -112,7 +143,10 @@ class AppFeedbackPromptView: UIView {
 
     /// MARK: - Static Constants
 
-    fileprivate static let containerFrame = CGRect(x: 0.0, y: 0.0, width: 280.0, height: 100.0)
-    fileprivate static let labelFrame = CGRect(x: 0.0, y: 0.0, width: containerFrame.width, height: 52.0)
-    fileprivate static let labelBigFrame = CGRect(x: 0.0, y: 0.0, width: containerFrame.width, height: containerFrame.height)
+    // these values based on Zeplin mockups
+    private struct LayoutConstants {
+        static let labelMinimumHeight: CGFloat = 18.0
+        static let verticalPadding: CGFloat = 15.0
+        static let horizontalPadding: CGFloat = 37.0
+    }
 }

--- a/WordPress/Classes/ViewRelated/Views/RoundedButton.swift
+++ b/WordPress/Classes/ViewRelated/Views/RoundedButton.swift
@@ -2,13 +2,13 @@ import UIKit
 
 @IBDesignable
 class RoundedButton: UIButton {
-    @IBInspectable var cornerRadius: CGFloat = 3.0 {
+    @IBInspectable var cornerRadius: CGFloat = 4.0 {
         didSet {
             updateAppearance()
         }
     }
 
-    @IBInspectable var borderWidth: CGFloat = 1.0 {
+    @IBInspectable var borderWidth: CGFloat = 0.0 {
         didSet {
             updateAppearance()
         }
@@ -20,7 +20,7 @@ class RoundedButton: UIButton {
         }
     }
 
-    @IBInspectable var verticalEdgeInset: CGFloat = 10.0 {
+    @IBInspectable var verticalEdgeInset: CGFloat = 5.0 {
         didSet {
             updateAppearance()
         }
@@ -53,12 +53,21 @@ class RoundedButton: UIButton {
         layer.borderColor = tintColor.cgColor
 
         setTitleColor(tintColor, for: UIControlState())
+        setBackgroundImage(UIImage(color: tintColor), for: .highlighted)
 
         if reversesTitleShadowWhenHighlighted {
             setTitleColor(backgroundColor, for: [.highlighted])
             setBackgroundImage(UIImage(color: tintColor), for: .highlighted)
         } else {
-            setTitleColor(tintColor.withAlphaComponent(0.3), for: .highlighted)
+            setTitleColor(tintColor.withAlphaComponent(0.5), for: .highlighted)
+            setBackgroundImage(UIImage(color: backgroundColor), for: .highlighted)
+        }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
         }
     }
 }


### PR DESCRIPTION
Refs #9185

This PR updates the code for the feedback prompt to use autolayout and to respond to system font size changes. The result is more accessible, easier reuse, and matches the recent mockups from Prime for Push. The primer in the notification tab will reuse this layout code.

![ratings request pr cropped](https://user-images.githubusercontent.com/517257/39656011-45706654-4fba-11e8-9952-c43880810a74.png)

## To test:
I recommend forcing the alert to appear on each launch by commenting out the guard statement in `NotificationsViewController.swift:showRatingViewIfApplicable()` like this:
```swift
//        guard AppRatingUtility.shared.shouldPromptForAppReview(section: Ratings.section) else {
//            return
//        }
``` 
- ensure the ratings alert appears correctly
- ensure the ratings alert still works
- ensure the layout works with all text sizes and devices, etc

## Technical Notes:
- I aggressively mangled `RoundedButton` because it isn't actually appearing anywhere, but it's very similar to this button and is prime to be reused in the future. Previous uses will still work, and now they'll have a modern design instead of the iOS 7-era one.
- Table view controllers' header views are all kinds of broken. Some of the weird layout stuff in `NotificationsViewController.swift` is to make that work. It should be commented as such 😀 