### PR TITLE
Gifs: Avoid gifs flashing when reloading

### DIFF
--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -31,7 +31,9 @@
     /// Call this in a table/collection cell's `prepareForReuse()`.
     ///
     @objc func prepareForReuse() {
-        imageView.image = nil
+        if !imageView.isGif {
+            imageView.image = nil
+        }
         imageView.prepForReuse()
     }
 


### PR DESCRIPTION
Fixes #9278 

This PR is a proposal to solve the issue that makes Gifs to flash when the cell reload.
The strategy simply set the `.image` property to `nil` when the image is not a gif.
And, when the image **is** a gif, this uses the given placeholder to reset the animated gif, just if the gif to load is different to the one that is displaying.

![gif_no_flash](https://user-images.githubusercontent.com/9772967/39703364-3cbce340-51de-11e8-9be6-e65a78b37b82.gif)

@bummytime This probably will have conflicts with your branch. I stole the `var originalURLRequest: URLRequest?` from there. :)

To test:

Follow the steps given in the issue #9278 