### PR TITLE
WordPressAppDelegate: Nukes duplicate auth initialization

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -85,9 +85,6 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     // Basic networking setup
     [self configureReachability];
 
-    // Setup the Authenticator!
-    [self configureWordPressAuthenticator];
-
     // Set the main window up
     [self.window makeKeyAndVisible];
 


### PR DESCRIPTION
### Details:
Fixing a bad 9.9 merge!. This PR removes a duplicated WordPressAuthenticator initialization.

### To test:
1. Clean
2. Fresh install > Launch

Verify nothing breaks violently!

@ScoutHarris may i bug you with a quick check?
Thanks!!



