### PR TITLE
Crasher fix for adding a tag in reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -50,9 +50,9 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
     self = [super initWithStyle:UITableViewStyleGrouped];
     if (self) {
         [self commonInitWithPlaceholder:placeholder hint:hint];
-        
-        _originalString = text;
-        _originalAttributedString = [[NSAttributedString alloc] initWithString:text];
+
+        _originalString = (text && !text.isEmpty) ? text : @"";
+        _originalAttributedString = [[NSAttributedString alloc] initWithString:_originalString];
         _textField.text = text;
     }
     return self;


### PR DESCRIPTION
Fixes #9302 

Crash was occurring when `SettingsTextViewController`'s  `initWithText:placeholder:hint:` was called from `ReaderMenuViewController.showAddTag()` with a nil text param. This PR adds a simple check in `initWithText:placeholder:hint:` that will replace any nil text params with an empty text string.

### Testing:
1. Open the reader main menu
2. press "Add tag"
3. Verify it doesn't crash
4. Add a tag string and save
5. From the main menu, press "Add tag" again
6. Verify it doesn't crash 😄 

@etoledom Since you were able to repro this crasher, would you mind taking a very quick look at this?

/cc @loremattei 
