### PR TITLE
Zendesk Mobile: show Zendesk notification alert when push notification received.

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -21,26 +21,29 @@ import WordPressAuthenticator
     private var userEmail: String?
     private var deviceID: String?
 
+    private static var zdAppID: String?
+    private static var zdUrl: String?
+    private static var zdClientId: String?
+
     private static var appVersion: String {
         return Bundle.main.shortVersionString() ?? Constants.unknownValue
+    }
+
+    struct PushNotificationIdentifiers {
+        static let key = "type"
+        static let type = "zendesk"
     }
 
     // MARK: - Public Methods
 
     @objc static func setup() {
-        guard let appId = ApiCredentials.zendeskAppId(),
-            let url = ApiCredentials.zendeskUrl(),
-            let clientId = ApiCredentials.zendeskClientId(),
-            appId.count > 0,
-            url.count > 0,
-            clientId.count > 0 else {
-                ZendeskUtils.toggleZendesk(enabled: false)
-                return
+        guard getZendeskCredentials() == true else {
+            return
         }
 
-        ZDKConfig.instance().initialize(withAppId: appId,
-                                        zendeskUrl: url,
-                                        clientId: clientId)
+        ZDKConfig.instance().initialize(withAppId: zdAppID,
+                                        zendeskUrl: zdUrl,
+                                        clientId: zdClientId)
 
         ZendeskUtils.toggleZendesk(enabled: true)
     }
@@ -105,11 +108,28 @@ import WordPressAuthenticator
     static func unregisterDevice(_ identifier: String) {
         ZDKConfig.instance().disablePush(identifier) { status, error in
             if let error = error {
-                print("Zendesk couldn't unregistered device: \(identifier). Error: \(error)")
+                DDLogInfo("Zendesk couldn't unregistered device: \(identifier). Error: \(error)")
             } else {
-                print("Zendesk successfully unregistered device: \(identifier)")
+                DDLogDebug("Zendesk successfully unregistered device: \(identifier)")
             }
         }
+    }
+
+    static func handlePushNotification(_ userInfo: NSDictionary) {
+
+        guard zendeskEnabled == true,
+            let payload = userInfo as? [AnyHashable: Any] else {
+                DDLogInfo("Zendesk push notification payload invalid.")
+                return
+        }
+
+        ZDKPushUtil.handlePush(payload,
+                               for: UIApplication.shared,
+                               presentationStyle: .formSheet,
+                               layoutGuide: ZDKLayoutRespectTop,
+                               withAppId: zdAppID,
+                               zendeskUrl: zdUrl,
+                               clientId: zdClientId)
     }
 
 }
@@ -117,6 +137,24 @@ import WordPressAuthenticator
 // MARK: - Private Extension
 
 private extension ZendeskUtils {
+
+    static func getZendeskCredentials() -> Bool {
+        guard let appId = ApiCredentials.zendeskAppId(),
+            let url = ApiCredentials.zendeskUrl(),
+            let clientId = ApiCredentials.zendeskClientId(),
+            appId.count > 0,
+            url.count > 0,
+            clientId.count > 0 else {
+                DDLogInfo("Unable to get Zendesk credentials.")
+                ZendeskUtils.toggleZendesk(enabled: false)
+                return false
+        }
+
+        zdAppID = appId
+        zdUrl = url
+        zdClientId = clientId
+        return true
+    }
 
     static func toggleZendesk(enabled: Bool) {
         ZendeskUtils.zendeskEnabled = enabled


### PR DESCRIPTION
Fixes #9310

**NOTES:** 
- This must be done on a real device as PNs don't work in simulators.
- To view mobile tickets in Zendesk, use the filter noted in this [comment](https://wp.me/p9xubY-6U-p2/#comment-247). 

**To test:**
The alert will only appear if: (this is dictated by ZD PN handling, not the app)
- The app is open.
- A Zendesk view is being displayed (Help Center, Contact Us, or My Tickets).

---
- Go to Support > Contact Us and submit a ticket.
- Select one of the Support options to display a Zendesk view. Leave the app open.
- Go to Zendesk, reply to your ticket.
- Verify an alert is displayed as shown below.
  - 'Open' will display the ticket that was updated.
  - 'Dismiss' will simply dismiss the alert.

ZD alert:
<img width="373" alt="zd_alert" src="https://user-images.githubusercontent.com/1816888/39789735-f4f246b0-52ee-11e8-9b1a-4f9d7f52f735.png">


---
- Do not have a Zendesk view open. Leave the app open.
- Go to Zendesk, reply to your ticket.
- Verify the alert is not shown.
---
- Go to Support > My Tickets and open your ticket.
- Go to Zendesk, reply to your ticket.
- Verify the alert is not shown, and the ticket log is updated with the new message.
---
@aerych - can I take advantage of you having a ZD account and ask for a review? Thank you!!