### PR TITLE
Add animated images support in post settings.

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.h
+++ b/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.h
@@ -1,10 +1,20 @@
 #import <WordPressShared/WPTableViewCell.h>
 
+@protocol PostInformation;
+@class PostFeaturedImageCell;
+
+@protocol PostFeaturedImageCellDelegate <NSObject>
+- (void)postFeatureImageCellDidFinishLoadingImage:(PostFeaturedImageCell *)cell;
+- (void)postFeatureImageCell:(PostFeaturedImageCell *)cell didFinishLoadingImageWithError:(NSError *)error;
+@end
+
 @interface PostFeaturedImageCell : WPTableViewCell
 
 extern CGFloat const PostFeaturedImageCellMargin;
 
-- (void)setImage:(UIImage *)image;
-- (void)showLoadingSpinner:(BOOL)showSpinner;
+@property (weak, nonatomic) id<PostFeaturedImageCellDelegate> delegate;
+@property (strong, nonatomic, readonly) UIImage *image;
+
+- (void)setImageWithURL:(NSURL *)url inPost:(id<PostInformation>)postInformation withSize:(CGSize)size;
 
 @end

--- a/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
@@ -1,12 +1,13 @@
 #import "PostFeaturedImageCell.h"
 #import "UIImageView+AFNetworkingExtra.h"
+#import "WordPress-Swift.h"
 
 CGFloat const PostFeaturedImageCellMargin = 15.0f;
 
 @interface PostFeaturedImageCell ()
 
-@property (nonatomic, strong) UIImageView *featuredImageView;
-@property (nonatomic, strong) UIActivityIndicatorView *activityView;
+@property (nonatomic, strong) CachedAnimatedImageView *featuredImageView;
+@property (nonatomic, strong) ImageLoader *imageLoader;
 
 @end
 
@@ -16,19 +17,55 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
 {
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
     if (self) {
-        [self setupSubviews];
+        [self setup];
     }
     return self;
 }
 
-- (void)setupSubviews
+- (void)setup
 {
-    UIImageView *imageView = [[UIImageView alloc] init];
-    imageView.contentMode = UIViewContentModeScaleAspectFill;
-    imageView.clipsToBounds = YES;
-    imageView.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.contentView addSubview:imageView];
+    [self layoutImageView];
+    _imageLoader = [[ImageLoader alloc] initWithImageView:self.featuredImageView gifStrategy:GIFStrategyLargeGIFs];
+}
 
+- (void)setImageWithURL:(NSURL *)url inPost:(id<PostInformation>)postInformation withSize:(CGSize)size
+{
+    __weak PostFeaturedImageCell *weakSelf = self;
+    [self.imageLoader loadImageWithURL:url fromPost:postInformation preferedSize:size placeholder:nil success:^{
+        if (weakSelf && weakSelf.delegate) {
+            [weakSelf.delegate postFeatureImageCellDidFinishLoadingImage:weakSelf];
+        }
+    } error:^(NSError * _Nullable error) {
+        if (weakSelf && weakSelf.delegate) {
+            [weakSelf.delegate postFeatureImageCell:weakSelf didFinishLoadingImageWithError:error];
+        }
+    }];
+}
+
+- (UIImage *)image
+{
+    return self.featuredImageView.image;
+}
+
+#pragma mark - Helpers
+
+- (CachedAnimatedImageView *)featuredImageView
+{
+    if (!_featuredImageView) {
+        _featuredImageView = [[CachedAnimatedImageView alloc] init];
+        _featuredImageView.contentMode = UIViewContentModeScaleAspectFill;
+        _featuredImageView.clipsToBounds = YES;
+        _featuredImageView.translatesAutoresizingMaskIntoConstraints = NO;
+    }
+
+    return _featuredImageView;
+}
+
+- (void)layoutImageView
+{
+    UIView *imageView = self.featuredImageView;
+
+    [self.contentView addSubview:imageView];
     UILayoutGuide *readableGuide = self.contentView.readableContentGuide;
     [NSLayoutConstraint activateConstraints:@[
                                               [imageView.leadingAnchor constraintEqualToAnchor:readableGuide.leadingAnchor],
@@ -36,36 +73,6 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
                                               [imageView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:PostFeaturedImageCellMargin],
                                               [imageView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor constant:-PostFeaturedImageCellMargin]
                                               ]];
-    _featuredImageView = imageView;
-
-    CGRect contentFrame = self.contentView.frame;
-    UIActivityIndicatorView *activityView = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleGray];
-    CGRect activityFrame = activityView.frame;
-    CGFloat x = (contentFrame.size.width - activityFrame.size.width) / 2.0f;
-    CGFloat y = (contentFrame.size.height - activityFrame.size.height) / 2.0f;
-    activityFrame = CGRectMake(x, y, activityFrame.size.width, activityFrame.size.height);
-    activityView.frame = activityFrame;
-    activityView.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin | UIViewAutoresizingFlexibleTopMargin | UIViewAutoresizingFlexibleBottomMargin;
-    activityView.hidesWhenStopped = YES;
-    [self.contentView addSubview:activityView];
-    _activityView = activityView;
-}
-
-- (void)setImage:(UIImage *)image
-{
-    [self.featuredImageView setImage:image];
-    [self showLoadingSpinner:NO];
-}
-
-- (void)showLoadingSpinner:(BOOL)showSpinner
-{
-    if (showSpinner) {
-        [self.activityView startAnimating];
-    } else {
-        [self.activityView stopAnimating];
-    }
-    self.featuredImageView.hidden = showSpinner;
-    self.textLabel.text = @"";
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -51,7 +51,7 @@ typedef NS_ENUM(NSInteger, PostSettingsRow) {
 };
 
 static CGFloat CellHeight = 44.0f;
-static CGFloat LoadingCellHeight = 50.0f;
+static CGFloat LoadingIndicatorHeight = 20.0f;
 
 static NSInteger RowIndexForDatePicker = 0;
 static NSInteger RowIndexForPassword = 3;
@@ -59,6 +59,7 @@ static CGFloat LocationCellHeightToWidthAspectRatio = 0.5f;
 
 static NSString *const TableViewActivityCellIdentifier = @"TableViewActivityCellIdentifier";
 static NSString *const TableViewProgressCellIdentifier = @"TableViewProgressCellIdentifier";
+static NSString *const TableViewFeaturedImageCellIdentifier = @"TableViewFeaturedImageCellIdentifier";
 
 @interface PostSettingsViewController () <UITextFieldDelegate, WPPickerViewDelegate,
 UIImagePickerControllerDelegate, UINavigationControllerDelegate,
@@ -140,8 +141,9 @@ PostCategoriesViewControllerDelegate, PostFeaturedImageCellDelegate>
     [self setupPublicizeConnections];
 
     [self.tableView registerNib:[UINib nibWithNibName:@"WPTableViewActivityCell" bundle:nil] forCellReuseIdentifier:TableViewActivityCellIdentifier];
-
     [self.tableView registerClass:[WPProgressTableViewCell class] forCellReuseIdentifier:TableViewProgressCellIdentifier];
+    [self.tableView registerClass:[PostFeaturedImageCell class] forCellReuseIdentifier:TableViewFeaturedImageCellIdentifier];
+
 
     self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, 0.0, 44.0)]; // add some vertical padding
 
@@ -503,11 +505,11 @@ PostCategoriesViewControllerDelegate, PostFeaturedImageCellDelegate>
 
     if (sectionId == PostSettingsSectionFeaturedImage) {
         if ([self isUploadingMedia]) {
-            return CellHeight + (2.0 * PostFeaturedImageCellMargin);
+            return CellHeight + (2.f * PostFeaturedImageCellMargin);
         } else if (self.featuredImage) {
-            return self.featuredImageSize.height;
+            return self.featuredImageSize.height + 2.f * PostFeaturedImageCellMargin;
         } else {
-            return LoadingCellHeight;
+            return LoadingIndicatorHeight + 2.f * PostFeaturedImageCellMargin;
         }
     }
 
@@ -745,13 +747,9 @@ PostCategoriesViewControllerDelegate, PostFeaturedImageCellDelegate>
         activityCell.tag = PostSettingsRowFeaturedImageRemove;
         cell = activityCell;
     } else {
-        static NSString *FeaturedImageCellIdentifier = @"FeaturedImageCellIdentifier";
-        PostFeaturedImageCell *featuredImageCell = [self.tableView dequeueReusableCellWithIdentifier:FeaturedImageCellIdentifier];
-        if (!cell) {
-            featuredImageCell = [[PostFeaturedImageCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:FeaturedImageCellIdentifier];
-            featuredImageCell.delegate = self;
-            [WPStyleGuide configureTableViewCell:featuredImageCell];
-        }
+        PostFeaturedImageCell *featuredImageCell = [self.tableView dequeueReusableCellWithIdentifier:TableViewFeaturedImageCellIdentifier forIndexPath:indexPath];
+        featuredImageCell.delegate = self;
+        [WPStyleGuide configureTableViewCell:featuredImageCell];
 
         NSURL *featuredURL = [NSURL URLWithString:self.apost.featuredImage.remoteURL];
         if (!featuredURL) {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1476,6 +1476,7 @@ PostCategoriesViewControllerDelegate, PostFeaturedImageCellDelegate>
 {
     if (!self.featuredImage) {
         self.featuredImage = cell.image;
+        cell.accessibilityIdentifier = @"Current Featured Image";
         NSInteger featuredImageSection = [self.sections indexOfObject:@(PostSettingsSectionFeaturedImage)];
         NSIndexSet *featuredImageSectionSet = [NSIndexSet indexSetWithIndex:featuredImageSection];
         [self.tableView reloadSections:featuredImageSectionSet withRowAnimation:UITableViewRowAnimationNone];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -51,6 +51,8 @@ typedef NS_ENUM(NSInteger, PostSettingsRow) {
 };
 
 static CGFloat CellHeight = 44.0f;
+static CGFloat LoadingCellHeight = 50.0f;
+
 static NSInteger RowIndexForDatePicker = 0;
 static NSInteger RowIndexForPassword = 3;
 static CGFloat LocationCellHeightToWidthAspectRatio = 0.5f;
@@ -60,7 +62,8 @@ static NSString *const TableViewProgressCellIdentifier = @"TableViewProgressCell
 
 @interface PostSettingsViewController () <UITextFieldDelegate, WPPickerViewDelegate,
 UIImagePickerControllerDelegate, UINavigationControllerDelegate,
-UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategoriesViewControllerDelegate>
+UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate,
+PostCategoriesViewControllerDelegate, PostFeaturedImageCellDelegate>
 
 @property (nonatomic, strong) AbstractPost *apost;
 @property (nonatomic, strong) UITextField *passwordTextField;
@@ -69,6 +72,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
 @property (nonatomic, strong) NSArray *formatsList;
 @property (nonatomic, strong) WPTableImageSource *imageSource;
 @property (nonatomic, strong) UIImage *featuredImage;
+@property (nonatomic, readonly) CGSize featuredImageSize;
 @property (nonatomic, strong) PublishDatePickerView *datePicker;
 @property (assign) BOOL textFieldDidHaveFocusBeforeOrientationChange;
 
@@ -498,15 +502,12 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     }
 
     if (sectionId == PostSettingsSectionFeaturedImage) {
-        if (self.featuredImage) {
-            CGFloat cellMargins = (2 * PostFeaturedImageCellMargin);
-            CGFloat imageWidth = self.featuredImage.size.width;
-            CGFloat imageHeight = self.featuredImage.size.height;
-            width = width - cellMargins;
-            CGFloat height = ceilf((width / imageWidth) * imageHeight);
-            return height + cellMargins;
-        } else if ([self isUploadingMedia]) {
+        if ([self isUploadingMedia]) {
             return CellHeight + (2.0 * PostFeaturedImageCellMargin);
+        } else if (self.featuredImage) {
+            return self.featuredImageSize.height;
+        } else {
+            return LoadingCellHeight;
         }
     }
 
@@ -732,7 +733,7 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
             self.isUploadingMedia = YES;
             [self setupObservingOfMedia: self.apost.featuredImage];
         }
-
+        self.featuredImage = nil;
         self.progressCell = [self.tableView dequeueReusableCellWithIdentifier:TableViewProgressCellIdentifier forIndexPath:indexPath];
         [WPStyleGuide configureTableViewCell:self.progressCell];        
         [self.progressCell setProgress:self.featuredImageProgress];
@@ -748,18 +749,15 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
         PostFeaturedImageCell *featuredImageCell = [self.tableView dequeueReusableCellWithIdentifier:FeaturedImageCellIdentifier];
         if (!cell) {
             featuredImageCell = [[PostFeaturedImageCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:FeaturedImageCellIdentifier];
+            featuredImageCell.delegate = self;
             [WPStyleGuide configureTableViewCell:featuredImageCell];
         }
 
-        if (self.featuredImage) {
-            [featuredImageCell setImage:self.featuredImage];
-            featuredImageCell.accessibilityIdentifier = @"Current Featured Image";
-        } else {
-            [featuredImageCell showLoadingSpinner:YES];
-            if (!self.isUploadingMedia){
-                [self loadFeaturedImage:indexPath];
-            }
+        NSURL *featuredURL = [NSURL URLWithString:self.apost.featuredImage.remoteURL];
+        if (!featuredURL) {
+            featuredURL = self.apost.featuredImageURLForDisplay;
         }
+        [featuredImageCell setImageWithURL:featuredURL inPost:self.apost withSize:self.featuredImageSize];
 
         cell = featuredImageCell;
         cell.tag = PostSettingsRowFeaturedImage;
@@ -1282,31 +1280,18 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     [self.navigationController pushViewController:tagsPicker animated:YES];
 }
 
-- (void)loadFeaturedImage:(NSIndexPath *)indexPath
+- (CGSize)featuredImageSize
 {
-    Media *media = self.apost.featuredImage;
-    if (!media) {
-        return;
-    }
     CGFloat width = CGRectGetWidth(self.view.frame);
     width = width - (PostFeaturedImageCellMargin * 2); // left and right cell margins
     CGFloat height = ceilf(width * 0.66);
-    CGSize imageSize = CGSizeMake(width, height);
-    [MediaThumbnailCoordinator.shared thumbnailFor:media with:imageSize onCompletion:^(UIImage * image, NSError * error) {
-        if (error) {
-            [self featuredImageFailedLoading:indexPath withError:error];
-            return;
-        }
-        self.featuredImage = image;
-        [self.tableView reloadData];
-    }];
+    return CGSizeMake(width, height);
 }
 
-- (void) featuredImageFailedLoading:(NSIndexPath *)indexPath withError:(NSError *)error
+- (void)featuredImageFailedLoading:(NSIndexPath *)indexPath withError:(NSError *)error
 {
     DDLogError(@"Error loading featured image: %@", error);
-    PostFeaturedImageCell *cell = (PostFeaturedImageCell *)[self.tableView cellForRowAtIndexPath:indexPath];
-    [cell showLoadingSpinner:NO];
+    UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:indexPath];
     cell.textLabel.text = NSLocalizedString(@"Featured Image did not load", @"");
 }
 
@@ -1485,6 +1470,27 @@ UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate, PostCategories
     // Save changes.
     self.post.categories = [categories mutableCopy];
     [self.post save];
+}
+
+#pragma mark - PostFeaturedImageCellDelegate
+
+- (void)postFeatureImageCellDidFinishLoadingImage:(PostFeaturedImageCell *)cell
+{
+    if (!self.featuredImage) {
+        self.featuredImage = cell.image;
+        NSInteger featuredImageSection = [self.sections indexOfObject:@(PostSettingsSectionFeaturedImage)];
+        NSIndexSet *featuredImageSectionSet = [NSIndexSet indexSetWithIndex:featuredImageSection];
+        [self.tableView reloadSections:featuredImageSectionSet withRowAnimation:UITableViewRowAnimationNone];
+    }
+}
+
+- (void)postFeatureImageCell:(PostFeaturedImageCell *)cell didFinishLoadingImageWithError:(NSError *)error
+{
+    self.featuredImage = nil;
+    if (error) {
+        NSIndexPath *featureImageCellPath = [NSIndexPath indexPathForRow:0 inSection:[self.sections indexOfObject:@(PostSettingsSectionFeaturedImage)]];
+        [self featuredImageFailedLoading:featureImageCellPath withError:error];
+    }
 }
 
 @end


### PR DESCRIPTION
Fixes #9257 

This PR adds gifs animation support in the Post Settings screen.

![post_settings_gif](https://user-images.githubusercontent.com/9772967/39830081-c0394ede-5396-11e8-9d45-c08a08f85846.gif)

To test:
- Go to the posts list and select a random post (or start editing a new one)
- Press `...` button at the top right.
- Select `Post Settings`.
- Set / change the featured image to an animated gif.
- Check that uploading images works properly.
- Test saving the changes/publishing/saving as draft/Discarding changes.

