### PR TITLE
Zendesk Mobile: show notification alert on Me tab icon

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -3,6 +3,14 @@ import ZendeskSDK
 import CoreTelephony
 import WordPressAuthenticator
 
+extension NSNotification.Name {
+    static let ZendeskPushNotificationReceivedNotification = NSNotification.Name(rawValue: "ZendeskPushNotificationReceivedNotification")
+}
+
+@objc extension NSNotification {
+    public static let ZendeskPushNotificationReceivedNotification = NSNotification.Name.ZendeskPushNotificationReceivedNotification
+}
+
 @objc class ZendeskUtils: NSObject {
 
     // MARK: - Properties
@@ -135,6 +143,13 @@ import WordPressAuthenticator
                                withAppId: zdAppID,
                                zendeskUrl: zdUrl,
                                clientId: zdClientId)
+    }
+
+    static func pushNotificationReceived() {
+        // Updating unread indicators should trigger UI updates, so send notification in main thread.
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .ZendeskPushNotificationReceivedNotification, object: nil)
+        }
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Fixes #9325

When a push notification is received from Zendesk (i.e. when an agent replies to a ticket) the Me tab icon is changed to indicate a new notification.

**NOTES:** 
- Testing needs to be done on a real device as PNs don't work in simulators.
- If you don't have access to Zendesk, please coordinate with me. I can send you messages from Zendesk.
- The indicator icon is just a stub for now. It will be replaced later with the real one.
- Currently, the app assumes all PNs belong to the Notifications tab. This is resulting in the Notifications icon indicating a new notification when a ZD PN is received, and the `applicationIconBadgeNumber` not being handled correctly. I will address these in a future PR.


**To test:**
- Go to Me > Help & Support > 'Contact Us' > submit a ticket.
  - Warning: You cannot use the email address associated with your Zendesk agent account (if you have one).

---

- Change to another tab (i.e. don't be on the Me tab).
- Minimize the app.
- Find your ticket in Zendesk, and reply to it (or ask me to do so).
- When the PN is received, either tap on it, or open the app.
  - Verify the Me tab icon has changed to a star.
  - Tap on the Me tab.
  - Verify the Me tab icon is back to the original icon.

---

- Select the Me tab.
- Minimize the app.
- Reply to your ticket in Zendesk.
- When the PN is received, either tap on it, or open the app.
  - Verify the Me tab icon is the original icon.

---

Original Me icon (tab not selected, no notifications):
<img width="57" alt="original_me" src="https://user-images.githubusercontent.com/1816888/39888394-e64838b8-5451-11e8-9837-47567e277e0c.png">

Notification Me icon (tab not selected, new notification):
Again, this is a temporary placeholder.
<img width="48" alt="notif_me" src="https://user-images.githubusercontent.com/1816888/39888423-fe852062-5451-11e8-86b3-10cad67cd05e.png">

Me icon with tab selected:
<img width="78" alt="me_selected" src="https://user-images.githubusercontent.com/1816888/39888437-077f8054-5452-11e8-98db-bf4cebb920e8.png">


