### PR TITLE
AppRatingsUtility: Change how often we prompt users for reviews.

### DIFF
--- a/WordPress/Classes/Utility/Ratings/AppRatingsUtility.swift
+++ b/WordPress/Classes/Utility/Ratings/AppRatingsUtility.swift
@@ -19,7 +19,8 @@ class AppRatingUtility: NSObject {
     @objc var appReviewUrl: URL = Constants.defaultAppReviewURL
 
     /// Sets the number of days that have to pass between AppReview prompts
-    /// Since Apple only allows 3 prompts per year, we are settings this number to 122
+    /// Apple only allows 3 prompts per year. We're trying to be a bit more conservative and are doing
+    /// up to 2 times a year (183 = round(365/2)).
     @objc var numberOfDaysToWaitBetweenPrompts: Int = 183
 
     private let defaults: UserDefaults

--- a/WordPress/Classes/Utility/Ratings/AppRatingsUtility.swift
+++ b/WordPress/Classes/Utility/Ratings/AppRatingsUtility.swift
@@ -20,7 +20,7 @@ class AppRatingUtility: NSObject {
 
     /// Sets the number of days that have to pass between AppReview prompts
     /// Since Apple only allows 3 prompts per year, we are settings this number to 122
-    @objc var numberOfDaysToWaitBetweenPrompts: Int = 122
+    @objc var numberOfDaysToWaitBetweenPrompts: Int = 183
 
     private let defaults: UserDefaults
     private var sections = [String: Section]()

--- a/WordPress/WordPressTest/AppRatingUtilityTests.swift
+++ b/WordPress/WordPressTest/AppRatingUtilityTests.swift
@@ -273,7 +273,8 @@ class AppRatingUtilityTests: XCTestCase {
     }
 
     func testAppReviewPromptedAfterEnoughTime() {
-        let fourMonthsAgo = Calendar.current.date(byAdding: .day, value: -123, to: Date())
+        let magicValue = -(Int(ceil(365 / 2)) + 1)
+        let fourMonthsAgo = Calendar.current.date(byAdding: .day, value: magicValue, to: Date())
         self.utility._overrideLastPromptToRateDate(fourMonthsAgo!)
         self.utility.systemWideSignificantEventCountRequiredForPrompt = 1
         self.utility.incrementSignificantEvent()


### PR DESCRIPTION
We want to experiment if frequency of how often we bug people for reviews on the App Store has influence over the ratings themselves. (p2: p5uIfZ-8p6-p2). 

Let's start with changing it to twice/y from up to 3 times/year. 

