### PR TITLE
Animated gifs support on post setting featured image preview

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.h
+++ b/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.h
@@ -5,6 +5,7 @@
 
 @protocol PostFeaturedImageCellDelegate <NSObject>
 - (void)postFeatureImageCellDidFinishLoadingImage:(PostFeaturedImageCell *)cell;
+- (void)postFeatureImageCell:(PostFeaturedImageCell *)cell didFinishLoadingAnimatedImageWithData:(NSData *)animationData;
 - (void)postFeatureImageCell:(PostFeaturedImageCell *)cell didFinishLoadingImageWithError:(NSError *)error;
 @end
 

--- a/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
@@ -32,9 +32,7 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
 {
     __weak PostFeaturedImageCell *weakSelf = self;
     [self.imageLoader loadImageWithURL:url fromPost:postInformation preferedSize:size placeholder:nil success:^{
-        if (weakSelf && weakSelf.delegate) {
-            [weakSelf.delegate postFeatureImageCellDidFinishLoadingImage:weakSelf];
-        }
+        [weakSelf informDelegateSuccess];
     } error:^(NSError * _Nullable error) {
         if (weakSelf && weakSelf.delegate) {
             [weakSelf.delegate postFeatureImageCell:weakSelf didFinishLoadingImageWithError:error];
@@ -42,9 +40,28 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
     }];
 }
 
+- (void)informDelegateSuccess
+{
+    if (self.delegate == nil) {
+        return;
+    }
+
+    if (self.featuredImageView.animatedGifData) {
+        [self.delegate postFeatureImageCell:self didFinishLoadingAnimatedImageWithData:self.featuredImageView.animatedGifData];
+    } else {
+        [self.delegate postFeatureImageCellDidFinishLoadingImage:self];
+    }
+}
+
 - (UIImage *)image
 {
     return self.featuredImageView.image;
+}
+
+- (void)prepareForReuse
+{
+    [super prepareForReuse];
+    [self.featuredImageView prepForReuse];
 }
 
 #pragma mark - Helpers

--- a/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
@@ -32,7 +32,7 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
 {
     __weak PostFeaturedImageCell *weakSelf = self;
     [self.imageLoader loadImageWithURL:url fromPost:postInformation preferedSize:size placeholder:nil success:^{
-        [weakSelf informDelegateSuccess];
+        [weakSelf informDelegateImageLoaded];
     } error:^(NSError * _Nullable error) {
         if (weakSelf && weakSelf.delegate) {
             [weakSelf.delegate postFeatureImageCell:weakSelf didFinishLoadingImageWithError:error];
@@ -40,7 +40,7 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
     }];
 }
 
-- (void)informDelegateSuccess
+- (void)informDelegateImageLoaded
 {
     if (self.delegate == nil) {
         return;

--- a/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
@@ -136,17 +136,20 @@ public class CachedAnimatedImageView: UIImageView, GIFAnimatable {
 
     private func validateAndSetGifData(_ animatedImageData: Data, alternateStaticImage: UIImage? = nil, success: (() -> Void)? = nil) {
         let didVerifyDataSize = gifPlaybackStrategy.verifyDataSize(animatedImageData)
-        if didVerifyDataSize {
-            animate(data: animatedImageData, success: success)
-        } else {
-            DispatchQueue.main.async() {
-                self.animatedGifData = nil
-                if let staticImage = alternateStaticImage {
-                    self.image = staticImage
+        DispatchQueue.main.async() {
+            if let staticImage = alternateStaticImage {
+                self.image = staticImage
+            } else {
+                self.image = UIImage(data: animatedImageData)
+            }
+
+            DispatchQueue.global().async {
+                if didVerifyDataSize {
+                    self.animate(data: animatedImageData, success: success)
                 } else {
-                    self.image = UIImage(data: animatedImageData)
+                    self.animatedGifData = nil
+                    success?()
                 }
-                success?()
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.h
@@ -11,6 +11,4 @@
 
 @property (weak, nonatomic) id<FeaturedImageViewControllerDelegate> delegate;
 
-- (id)initWithPost:(AbstractPost *)post;
-
 @end

--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.h
@@ -1,8 +1,15 @@
 #import "WPImageViewController.h"
 
 @class AbstractPost;
+@class FeaturedImageViewController;
+
+@protocol FeaturedImageViewControllerDelegate <NSObject>
+- (void)FeaturedImageViewControllerOnRemoveImageButtonPressed:(FeaturedImageViewController *)controller;
+@end
 
 @interface FeaturedImageViewController : WPImageViewController
+
+@property (weak, nonatomic) id<FeaturedImageViewControllerDelegate> delegate;
 
 - (id)initWithPost:(AbstractPost *)post;
 

--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.h
@@ -1,6 +1,5 @@
 #import "WPImageViewController.h"
 
-@class AbstractPost;
 @class FeaturedImageViewController;
 
 @protocol FeaturedImageViewControllerDelegate <NSObject>

--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
@@ -12,7 +12,6 @@
 
 @property (nonatomic, strong) UIBarButtonItem *doneButton;
 @property (nonatomic, strong) UIBarButtonItem *removeButton;
-@property (nonatomic, strong) AbstractPost *post;
 
 @end
 
@@ -23,23 +22,10 @@
 
 #pragma mark - Life Cycle Methods
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
-- (id)initWithPost:(AbstractPost *)post
-{
-    self = [super initWithImage:nil andURL:[NSURL URLWithString:post.featuredImage.remoteURL]];
-    if (self) {
-        self.post = post;
-    }
-    return self;
-}
-
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+
     self.title = NSLocalizedString(@"Featured Image", @"Title for the Featured Image view");
     self.view.backgroundColor = [UIColor whiteColor];
     self.navigationItem.leftBarButtonItems = @[self.doneButton];
@@ -53,13 +39,6 @@
     // Super class will hide the status bar by default
     [self hideBars:NO animated:NO];
 
-    if (self.url) {
-        if (![self.url.absoluteString isEqualToString:self.post.featuredImage.remoteURL]) {
-            self.image = nil;
-            self.url = [NSURL URLWithString:self.post.featuredImage.remoteURL];
-        }
-    }
-
     // Called here to be sure the view is complete in case we need to present a popover from the toolbar.
     [self loadImage];
 }
@@ -68,7 +47,6 @@
 {
     [super viewWillDisappear:animated];
 
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
     self.navigationController.navigationBar.translucent = NO;
     self.navigationController.toolbar.translucent = NO;
 }
@@ -143,8 +121,6 @@
                                     if (self.delegate) {
                                         [self.delegate FeaturedImageViewControllerOnRemoveImageButtonPressed:self];
                                     }
-//                                    [self.post setFeaturedImage:nil];
-//                                    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
                                 }];
     alertController.popoverPresentationController.barButtonItem = self.removeButton;
     [self presentViewController:alertController animated:YES completion:nil];

--- a/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/FeaturedImageViewController.m
@@ -32,7 +32,6 @@
 {
     self = [super initWithImage:nil andURL:[NSURL URLWithString:post.featuredImage.remoteURL]];
     if (self) {
-        self.title = NSLocalizedString(@"Featured Image", @"Title for the Featured Image view");
         self.post = post;
     }
     return self;
@@ -41,6 +40,7 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    self.title = NSLocalizedString(@"Featured Image", @"Title for the Featured Image view");
     self.view.backgroundColor = [UIColor whiteColor];
     self.navigationItem.leftBarButtonItems = @[self.doneButton];
     self.navigationItem.rightBarButtonItems = @[self.removeButton];
@@ -140,8 +140,11 @@
     [alertController addActionWithTitle:NSLocalizedString(@"Remove", @"Remove an image/posts/etc")
                                   style:UIAlertActionStyleDestructive
                                 handler:^(UIAlertAction *alertAction) {
-                                    [self.post setFeaturedImage:nil];
-                                    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+                                    if (self.delegate) {
+                                        [self.delegate FeaturedImageViewControllerOnRemoveImageButtonPressed:self];
+                                    }
+//                                    [self.post setFeaturedImage:nil];
+//                                    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
                                 }];
     alertController.popoverPresentationController.barButtonItem = self.removeButton;
     [self presentViewController:alertController animated:YES completion:nil];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -64,7 +64,8 @@ static NSString *const TableViewFeaturedImageCellIdentifier = @"TableViewFeature
 @interface PostSettingsViewController () <UITextFieldDelegate, WPPickerViewDelegate,
 UIImagePickerControllerDelegate, UINavigationControllerDelegate,
 UIPopoverControllerDelegate, WPMediaPickerViewControllerDelegate,
-PostCategoriesViewControllerDelegate, PostFeaturedImageCellDelegate>
+PostCategoriesViewControllerDelegate, PostFeaturedImageCellDelegate,
+FeaturedImageViewControllerDelegate>
 
 @property (nonatomic, strong) AbstractPost *apost;
 @property (nonatomic, strong) UITextField *passwordTextField;
@@ -73,6 +74,8 @@ PostCategoriesViewControllerDelegate, PostFeaturedImageCellDelegate>
 @property (nonatomic, strong) NSArray *formatsList;
 @property (nonatomic, strong) WPTableImageSource *imageSource;
 @property (nonatomic, strong) UIImage *featuredImage;
+@property (nonatomic, strong) NSData *animatedFeaturedImageData;
+
 @property (nonatomic, readonly) CGSize featuredImageSize;
 @property (nonatomic, strong) PublishDatePickerView *datePicker;
 @property (assign) BOOL textFieldDidHaveFocusBeforeOrientationChange;
@@ -1201,7 +1204,15 @@ PostCategoriesViewControllerDelegate, PostFeaturedImageCellDelegate>
     if (self.apost.featuredImage) {
         // Check if the featured image is set, otherwise we don't want to do anything while it's still loading.
         if (self.featuredImage) {
-            FeaturedImageViewController *featuredImageVC = [[FeaturedImageViewController alloc] initWithPost:self.apost];
+            FeaturedImageViewController *featuredImageVC;
+            if (self.animatedFeaturedImageData) {
+                featuredImageVC = [[FeaturedImageViewController alloc] initWithGifData:self.animatedFeaturedImageData];
+            } else {
+                featuredImageVC = [[FeaturedImageViewController alloc] initWithImage:self.featuredImage];
+            }
+
+            featuredImageVC.delegate = self;
+
             UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:featuredImageVC];
             [self presentViewController:navigationController animated:YES completion:nil];
         }
@@ -1472,14 +1483,28 @@ PostCategoriesViewControllerDelegate, PostFeaturedImageCellDelegate>
 
 #pragma mark - PostFeaturedImageCellDelegate
 
+- (void)updateFeaturedImageCell:(PostFeaturedImageCell *)cell
+{
+    self.featuredImage = cell.image;
+    cell.accessibilityIdentifier = @"Current Featured Image";
+    NSInteger featuredImageSection = [self.sections indexOfObject:@(PostSettingsSectionFeaturedImage)];
+    NSIndexSet *featuredImageSectionSet = [NSIndexSet indexSetWithIndex:featuredImageSection];
+    [self.tableView reloadSections:featuredImageSectionSet withRowAnimation:UITableViewRowAnimationNone];
+}
+
+- (void)postFeatureImageCell:(PostFeaturedImageCell *)cell didFinishLoadingAnimatedImageWithData:(NSData *)animationData
+{
+    if (self.animatedFeaturedImageData == nil) {
+        self.animatedFeaturedImageData = animationData;
+        [self updateFeaturedImageCell:cell];
+    }
+}
+
 - (void)postFeatureImageCellDidFinishLoadingImage:(PostFeaturedImageCell *)cell
 {
+    self.animatedFeaturedImageData = nil;
     if (!self.featuredImage) {
-        self.featuredImage = cell.image;
-        cell.accessibilityIdentifier = @"Current Featured Image";
-        NSInteger featuredImageSection = [self.sections indexOfObject:@(PostSettingsSectionFeaturedImage)];
-        NSIndexSet *featuredImageSectionSet = [NSIndexSet indexSetWithIndex:featuredImageSection];
-        [self.tableView reloadSections:featuredImageSectionSet withRowAnimation:UITableViewRowAnimationNone];
+        [self updateFeaturedImageCell:cell];
     }
 }
 
@@ -1490,6 +1515,16 @@ PostCategoriesViewControllerDelegate, PostFeaturedImageCellDelegate>
         NSIndexPath *featureImageCellPath = [NSIndexPath indexPathForRow:0 inSection:[self.sections indexOfObject:@(PostSettingsSectionFeaturedImage)]];
         [self featuredImageFailedLoading:featureImageCellPath withError:error];
     }
+}
+
+#pragma mark - FeaturedImageViewControllerDelegate
+
+- (void)FeaturedImageViewControllerOnRemoveImageButtonPressed:(FeaturedImageViewController *)controller
+{
+    self.featuredImage = nil;
+    self.animatedFeaturedImageData = nil;
+    [self.apost setFeaturedImage:nil];
+    [self dismissViewControllerAnimated:YES completion:nil];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1483,15 +1483,6 @@ FeaturedImageViewControllerDelegate>
 
 #pragma mark - PostFeaturedImageCellDelegate
 
-- (void)updateFeaturedImageCell:(PostFeaturedImageCell *)cell
-{
-    self.featuredImage = cell.image;
-    cell.accessibilityIdentifier = @"Current Featured Image";
-    NSInteger featuredImageSection = [self.sections indexOfObject:@(PostSettingsSectionFeaturedImage)];
-    NSIndexSet *featuredImageSectionSet = [NSIndexSet indexSetWithIndex:featuredImageSection];
-    [self.tableView reloadSections:featuredImageSectionSet withRowAnimation:UITableViewRowAnimationNone];
-}
-
 - (void)postFeatureImageCell:(PostFeaturedImageCell *)cell didFinishLoadingAnimatedImageWithData:(NSData *)animationData
 {
     if (self.animatedFeaturedImageData == nil) {
@@ -1515,6 +1506,15 @@ FeaturedImageViewControllerDelegate>
         NSIndexPath *featureImageCellPath = [NSIndexPath indexPathForRow:0 inSection:[self.sections indexOfObject:@(PostSettingsSectionFeaturedImage)]];
         [self featuredImageFailedLoading:featureImageCellPath withError:error];
     }
+}
+
+- (void)updateFeaturedImageCell:(PostFeaturedImageCell *)cell
+{
+    self.featuredImage = cell.image;
+    cell.accessibilityIdentifier = @"Current Featured Image";
+    NSInteger featuredImageSection = [self.sections indexOfObject:@(PostSettingsSectionFeaturedImage)];
+    NSIndexSet *featuredImageSectionSet = [NSIndexSet indexSetWithIndex:featuredImageSection];
+    [self.tableView reloadSections:featuredImageSectionSet withRowAnimation:UITableViewRowAnimationNone];
 }
 
 #pragma mark - FeaturedImageViewControllerDelegate


### PR DESCRIPTION
Fixes #9258 

This PR adds support for animated gifs on the post setting featured image preview, using the additions on `WPImageViewController ` from #9322 .

![gif_post_setting_featured_preview](https://user-images.githubusercontent.com/9772967/39949957-924708bc-5554-11e8-9c34-58a0520eaa3e.gif)

To test:

1. Open a post with a gif as featured image
2. Press the `...` button at the top right corner.
3. Select `Post Settings`.
4. Scroll down to see the featured image.
5. Tap on the featured image.
6. You should see the animated gif in the preview.

- Test also removing the featured image from the preview.
- Adding static images and gifs.
- Test publishing/discarding changes.

@bummytime can I bother you with a review please? :)