### PR TITLE
Tracking for editing Site Icon

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def shared_with_all_pods
-  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '1d657ac0ddb002712803721da8ee5752e7069637'
+  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'e2c991c69a80e8d25124426900fc8d7cf1b62307'
   pod 'CocoaLumberjack', '3.4.2'
   pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
   pod 'NSObject-SafeExpectations', '0.0.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -159,7 +159,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `2a25da7b9b687b5e05ce128423d99f771673a6c4`)
   - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `2a25da7b9b687b5e05ce128423d99f771673a6c4`)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `1d657ac0ddb002712803721da8ee5752e7069637`)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `e2c991c69a80e8d25124426900fc8d7cf1b62307`)
   - WPMediaPicker (= 0.28)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
@@ -172,7 +172,7 @@ EXTERNAL SOURCES:
     :commit: 2a25da7b9b687b5e05ce128423d99f771673a6c4
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressShared:
-    :commit: 1d657ac0ddb002712803721da8ee5752e7069637
+    :commit: e2c991c69a80e8d25124426900fc8d7cf1b62307
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
@@ -183,7 +183,7 @@ CHECKOUT OPTIONS:
     :commit: 2a25da7b9b687b5e05ce128423d99f771673a6c4
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressShared:
-    :commit: 1d657ac0ddb002712803721da8ee5752e7069637
+    :commit: e2c991c69a80e8d25124426900fc8d7cf1b62307
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
@@ -223,6 +223,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 24e87470b5f62cce7ad2b2e682fc7ab55dc51e2a
+PODFILE CHECKSUM: da3e837615c4a714482559eca654592262254222
 
 COCOAPODS: 1.4.0

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1123,6 +1123,27 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatSignupTermsButtonTapped:
             eventName = @"signup_terms_of_service_tapped";
             break;
+        case WPAnalyticsStatSiteSettingsSiteIconTapped:
+            eventName = @"my_site_icon_tapped";
+            break;
+        case WPAnalyticsStatSiteSettingsSiteIconRemoved:
+            eventName = @"my_site_icon_removed";
+            break;
+        case WPAnalyticsStatSiteSettingsSiteIconShotNew:
+            eventName = @"my_site_icon_shot_new";
+            break;
+        case WPAnalyticsStatSiteSettingsSiteIconGalleryPicked:
+            eventName = @"my_site_icon_gallery_picked";
+            break;
+        case WPAnalyticsStatSiteSettingsSiteIconCropped:
+            eventName = @"my_site_icon_cropped";
+            break;
+        case WPAnalyticsStatSiteSettingsSiteIconUploaded:
+            eventName = @"my_site_icon_uploaded";
+            break;
+        case WPAnalyticsStatSiteSettingsSiteIconUploadFailed:
+            eventName = @"my_site_icon_upload_unsuccessful";
+            break;
         case WPAnalyticsStatSiteSettingsDeleteSiteAccessed:
             eventName = @"site_settings_delete_site_accessed";
             break;
@@ -1339,6 +1360,18 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatNoStat:
         case WPAnalyticsStatPerformedCoreDataMigrationFixFor45:
         case WPAnalyticsStatMaxValue:
+        case WPAnalyticsStatNotificationsSettingsBlogNotificationsOn:
+        case WPAnalyticsStatNotificationsSettingsBlogNotificationsOff:
+        case WPAnalyticsStatNotificationsSettingsEmailNotificationsOn:
+        case WPAnalyticsStatNotificationsSettingsEmailNotificationsOff:
+        case WPAnalyticsStatNotificationsSettingsEmailDeliveryInstantly:
+        case WPAnalyticsStatNotificationsSettingsEmailDeliveryDaily:
+        case WPAnalyticsStatNotificationsSettingsEmailDeliveryWeekly:
+        case WPAnalyticsStatNotificationsSettingsCommentsNotificationsOn:
+        case WPAnalyticsStatNotificationsSettingsCommentsNotificationsOff:
+        case WPAnalyticsStatReaderListNotificationMenuOn:
+        case WPAnalyticsStatReaderListNotificationMenuOff:
+        case WPAnalyticsStatReaderListNotificationEnabled:
             return nil;
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -680,6 +680,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         // blogs that do not have capabilities since those will not support the REST API icon update
         return;
     }
+    [WPAnalytics track:WPAnalyticsStatSiteSettingsSiteIconTapped];
     [self showUpdateSiteIconAlert];
 }
 
@@ -806,6 +807,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     self.headerView.updatingIcon = YES;
     self.blog.settings.iconMediaID = @0;
     [self updateBlogSettingsAndRefreshIcon];
+    [WPAnalytics track:WPAnalyticsStatSiteSettingsSiteIconRemoved];
 }
 
 - (void)updateBlogIconWithMedia:(Media *)media

--- a/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
@@ -98,12 +98,16 @@ class SiteIconPickerPresenter: NSObject {
                         self?.onCompletion?(nil, nil)
                         return
                     }
+
+                    WPAnalytics.track(.siteSettingsSiteIconCropped)
+
                     mediaService.createMedia(with: image,
                                              objectID: blogId,
                                              progress: nil,
                                              thumbnailCallback: nil,
                                              completion: { (media, error) in
                         guard let media = media, error == nil else {
+                            WPAnalytics.track(.siteSettingsSiteIconUploadFailed)
                             self?.onCompletion?(nil, error)
                             return
                         }
@@ -111,8 +115,10 @@ class SiteIconPickerPresenter: NSObject {
                         mediaService.uploadMedia(media,
                                                  progress: &uploadProgress,
                                                  success: {
+                            WPAnalytics.track(.siteSettingsSiteIconUploaded)
                             self?.onCompletion?(media, nil)
                         }, failure: { (error) in
+                            WPAnalytics.track(.siteSettingsSiteIconUploadFailed)
                             self?.onCompletion?(nil, error)
                         })
                     })
@@ -195,6 +201,9 @@ extension SiteIconPickerPresenter: WPMediaPickerViewControllerDelegate {
         }
 
         let asset = assets.first
+
+        WPAnalytics.track(.siteSettingsSiteIconGalleryPicked)
+
         switch asset {
         case let phAsset as PHAsset:
             showLoadingMessage()


### PR DESCRIPTION
Closes #9300.

This is for tracking parity with Android version.

To test:

Go to site details, observe the console output to verify that the proper items are being printed and perform following steps:

* Tap on the site icon
* Select an image from gallery
* Crop it
* Verify that it uploaded correctly
* Repeat above while offline, verifying that the "upload failed" event is tracked
* Remove a site icon



