### PR TITLE
Plugins: fix cell reuse issue

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryCollectionViewCell.swift
@@ -36,6 +36,7 @@ class PluginDirectoryCollectionViewCell: UICollectionViewCell {
 
         accessoryView?.removeFromSuperview()
         logoImageView.cancelImageDownloadTask()
+        logoImageView.image = nil
     }
 
     func configure(with directoryEntry: PluginDirectoryEntry) {

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryCollectionViewCell.swift
@@ -50,7 +50,12 @@ class PluginDirectoryCollectionViewCell: UICollectionViewCell {
     func configure(name: String, author: String, image: URL?) {
         let iconPlaceholder = Gridicon.iconOfType(.plugins, withSize: CGSize(width: 98, height: 98))
 
-        logoImageView?.downloadImage(from: image, placeholderImage: iconPlaceholder)
+        if let imageURL = image {
+            logoImageView?.downloadImage(from: image, placeholderImage: iconPlaceholder)
+        } else {
+            logoImageView.image = iconPlaceholder
+        }
+
         authorLabel?.text = author
         nameLabel?.text = name
     }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListCell.swift
@@ -27,6 +27,7 @@ class PluginListCell: UITableViewCell {
         super.prepareForReuse()
 
         iconImageView.cancelImageDownloadTask()
+        iconImageView.image = nil
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListRow.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListRow.swift
@@ -24,7 +24,12 @@ struct PluginListRow: ImmuTableRow {
 
         let iconPlaceholder = Gridicon.iconOfType(.plugins, withSize: iconSize)
         cell.iconImageView?.cancelImageDownloadTask()
-        cell.iconImageView?.downloadResizedImage(from: iconURL, placeholderImage: iconPlaceholder, pointSize: iconSize)
+
+        if let iconURL = iconURL {
+            cell.iconImageView?.downloadResizedImage(from: iconURL, placeholderImage: iconPlaceholder, pointSize: iconSize)
+        } else {
+            cell.iconImageView?.image = iconPlaceholder
+        }
 
         cell.selectionStyle = .default
         cell.pluginAccessoryView = accessoryView


### PR DESCRIPTION
Fixes #9345.

To test:
* Go to Plugin Directory (using a JP or AT site (ping me for invite if you don't have one handy))
* Tap on "See All" on the "New" section.
* Wait a second for images to load
* Scroll up and down a bit
* Verify that the cells have the same images as before you scrolled up and down

