### PR TITLE
Issue/9342 Fix multiplied analytics trackers

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -353,13 +353,13 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
     }
 
     if ([[NSUserDefaults standardUserDefaults] objectForKey:WPAppAnalyticsDefaultsKeyUsageTracking_deprecated] == nil) {
-        [self setUserHasOptedOut:NO];
+        [self setUserHasOptedOutValue:NO];
     } else if ([[NSUserDefaults standardUserDefaults] boolForKey:WPAppAnalyticsDefaultsKeyUsageTracking_deprecated] == NO) {
         // If the user has already explicitly disabled tracking,
         // then we should mirror that to the new setting
-        [self setUserHasOptedOut:YES];
+        [self setUserHasOptedOutValue:YES];
     } else {
-        [self setUserHasOptedOut:NO];
+        [self setUserHasOptedOutValue:NO];
     }
 }
 
@@ -371,7 +371,9 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
     return [[NSUserDefaults standardUserDefaults] boolForKey:WPAppAnalyticsDefaultsUserOptedOut];
 }
 
-- (void)setUserHasOptedOut:(BOOL)optedOut
+/// This method just sets the user defaults value for UserOptedOut, and doesn't
+/// do any additional configuration of sessions or trackers.
+- (void)setUserHasOptedOutValue:(BOOL)optedOut
 {
     [[NSUserDefaults standardUserDefaults] setBool:optedOut forKey:WPAppAnalyticsDefaultsUserOptedOut];
 }
@@ -384,6 +386,8 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
             return;
         }
     }
+
+    [self setUserHasOptedOutValue:optedOut];
 
     if (optedOut) {
         [self endSession];

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -347,7 +347,7 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
 #pragma mark - Tracks Opt Out
 
 - (void)initializeOptOutTracking {
-    if ([[NSUserDefaults standardUserDefaults] objectForKey:WPAppAnalyticsDefaultsUserOptedOut] != nil) {
+    if ([WPAppAnalytics userHasOptedOutIsSet]) {
         // We've already configured the opt out setting
         return;
     }
@@ -363,6 +363,10 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
     }
 }
 
++ (BOOL)userHasOptedOutIsSet {
+    return [[NSUserDefaults standardUserDefaults] objectForKey:WPAppAnalyticsDefaultsUserOptedOut] != nil;
+}
+
 + (BOOL)userHasOptedOut {
     return [[NSUserDefaults standardUserDefaults] boolForKey:WPAppAnalyticsDefaultsUserOptedOut];
 }
@@ -370,6 +374,16 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
 - (void)setUserHasOptedOut:(BOOL)optedOut
 {
     [[NSUserDefaults standardUserDefaults] setBool:optedOut forKey:WPAppAnalyticsDefaultsUserOptedOut];
+}
+
+- (void)setUserHasOptedOut:(BOOL)optedOut
+{
+    if ([WPAppAnalytics userHasOptedOutIsSet]) {
+        BOOL currentValue = [WPAppAnalytics userHasOptedOut];
+        if (currentValue == optedOut) {
+            return;
+        }
+    }
 
     if (optedOut) {
         [self endSession];


### PR DESCRIPTION
Fixes #9342. 

This PR fixes an issue caused by the recent tracks opt out setting. The way that was implemented resulted in `WPAppAnalytics` calling `registerTrackers` and `beginSession` being called multiple times.

This this PR I've made a few tweaks to prevent that happening:

* In `setUserHasOptedOut`, we now only update the value or start / stop sessions if the value has changed from the existing value we have stored.
* In `initializeOptOutTracking`, we now only set the opt out value itself, and don't start sessions.
* On startup, the sessions should now only be started by `initializeAppTracking`.

**To test:**

* With a fresh install of the app, click "Log In" and check you only see the related analytics event show up in the console once..
* Log into the app and ensure as a logged in user you only see each analytics event show up in the console once.
* Relaunch the app and ensure you only see each analytics event show up in the console once.