### PR TITLE
New Privacy Settings section

### DIFF
--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -13,6 +13,7 @@ extern NSString *const WPMobileReaderDetailURL;
 extern NSString *const WPAutomatticMainURL;
 extern NSString *const WPAutomatticTermsOfServiceURL;
 extern NSString *const WPAutomatticPrivacyURL;
+extern NSString *const WPAutomatticCookiesURL;
 extern NSString *const WPAutomatticAppsBlogURL;
 extern NSString *const WPGithubMainURL;
 extern NSString *const WPTwitterWordPressHandle;

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -13,6 +13,7 @@ NSString *const WPMobileReaderDetailURL                             = @"https://
 NSString *const WPAutomatticMainURL                                 = @"https://automattic.com/";
 NSString *const WPAutomatticTermsOfServiceURL                       = @"https://wordpress.com/tos/";
 NSString *const WPAutomatticPrivacyURL                              = @"https://automattic.com/privacy/";
+NSString *const WPAutomatticCookiesURL                              = @"https://automattic.com/cookies/";
 NSString *const WPAutomatticAppsBlogURL                             = @"https://apps.wordpress.com/blog/";
 NSString *const WPGithubMainURL                                     = @"https://github.com/wordpress-mobile/WordPress-iOS/";
 NSString *const WPTwitterWordPressHandle                            = @"@WordPressiOS";

--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -247,13 +247,22 @@ struct SwitchRow: ImmuTableRow {
 
     let title: String
     let value: Bool
+    let icon: UIImage?
     let action: ImmuTableAction? = nil
     let onChange: (Bool) -> Void
+
+    init(title: String, value: Bool, icon: UIImage? = nil, onChange: @escaping (Bool) -> Void) {
+        self.title = title
+        self.value = value
+        self.icon = icon
+        self.onChange = onChange
+    }
 
     func configureCell(_ cell: UITableViewCell) {
         let cell = cell as! SwitchTableViewCell
 
         cell.textLabel?.text = title
+        cell.imageView?.image = icon
         cell.selectionStyle = .none
         cell.on = value
         cell.onChange = onChange

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -87,12 +87,6 @@ class AppSettingsViewController: UITableViewController {
             detail: MediaSettings().maxVideoSizeSetting.description,
             action: pushVideoResolutionSettings())
 
-        let mediaRemoveLocation = SwitchRow(
-            title: NSLocalizedString("Remove Location From Media", comment: "Option to enable the removal of location information/gps from photos and videos"),
-            value: Bool(MediaSettings().removeLocationSetting),
-            onChange: mediaRemoveLocationChanged()
-        )
-
         let mediaCacheRow = TextRow(title: NSLocalizedString("Media Cache Size", comment: "Label for size of media cache in the app."),
                                     value: mediaCacheRowDescription)
 
@@ -114,12 +108,16 @@ class AppSettingsViewController: UITableViewController {
         )
         editorRows.append(nativeEditor)
 
-        let usageTrackingHeader = NSLocalizedString("Usage Statistics", comment: "App usage data settings section header")
-        let usageTrackingRow = SwitchRow(
-            title: NSLocalizedString("Send Statistics", comment: "Label for switch to turn on/off sending app usage data"),
-            value: !WPAppAnalytics.userHasOptedOut(),
-            onChange: usageTrackingChanged())
-        let usageTrackingFooter = NSLocalizedString("Automatically send usage statistics to help us improve WordPress for iOS", comment: "App usage data settings section footer describing what the setting does.")
+        let privacyHeader = NSLocalizedString("Privacy", comment: "Privacy settings section header")
+        let mediaRemoveLocation = SwitchRow(
+            title: NSLocalizedString("Remove Location From Media", comment: "Option to enable the removal of location information/gps from photos and videos"),
+            value: Bool(MediaSettings().removeLocationSetting),
+            onChange: mediaRemoveLocationChanged()
+        )
+        let privacySettings = NavigationItemRow(
+            title: NSLocalizedString("Privacy Settings", comment: "Link to privacy settings page"),
+            action: openPrivacySettings()
+        )
 
         let otherHeader = NSLocalizedString("Other", comment: "Link to About section (contains info about the app)")
         let spotlightClearCacheRow = DestructiveButtonRow(
@@ -143,15 +141,16 @@ class AppSettingsViewController: UITableViewController {
                 rows: [
                     imageSizingRow,
                     videoSizingRow,
-                    mediaRemoveLocation,
                     mediaCacheRow,
                     mediaClearCacheRow
                 ],
                 footerText: nil),
             ImmuTableSection(
-                headerText: usageTrackingHeader,
-                rows: [usageTrackingRow],
-                footerText: usageTrackingFooter
+                headerText: privacyHeader,
+                rows: [
+                    mediaRemoveLocation,
+                    privacySettings
+                ]
             ),
             ImmuTableSection(
                 headerText: otherHeader,
@@ -283,19 +282,16 @@ class AppSettingsViewController: UITableViewController {
         }
     }
 
-    @objc func usageTrackingChanged() -> (Bool) -> Void {
-        return { enabled in
-            let appAnalytics = WordPressAppDelegate.sharedInstance().analytics
-            appAnalytics?.setUserHasOptedOut(!enabled)
-
-            let accountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-            AccountSettingsHelper(accountService: accountService).updateTracksOptOutSetting(!enabled)
-        }
-    }
-
     func pushAbout() -> ImmuTableAction {
         return { [weak self] row in
             let controller = AboutViewController()
+            self?.navigationController?.pushViewController(controller, animated: true)
+        }
+    }
+
+    func openPrivacySettings() -> ImmuTableAction {
+        return { [weak self] _ in
+            let controller = PrivacySettingsViewController()
             self?.navigationController?.pushViewController(controller, animated: true)
         }
     }

--- a/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
@@ -6,7 +6,7 @@ class PrivacySettingsViewController: UITableViewController {
 
     override init(style: UITableViewStyle) {
         super.init(style: style)
-        navigationItem.title = NSLocalizedString("App Settings", comment: "App Settings Title")
+        navigationItem.title = NSLocalizedString("Privacy Settings", comment: "Privacy Settings Title")
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
@@ -138,8 +138,20 @@ class PrivacySettingsViewController: UITableViewController {
 
 }
 
+private class InfoCell: WPTableViewCellDefault {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard var imageFrame = imageView?.frame,
+            let textFrame = textLabel?.frame else {
+                return
+        }
+        imageFrame.origin.y = textFrame.origin.y + layoutMargins.top
+        imageView?.frame = imageFrame
+    }
+}
+
 private struct InfoRow: ImmuTableRow {
-    static let cell = ImmuTableCell.class(WPTableViewCellDefault.self)
+    static let cell = ImmuTableCell.class(InfoCell.self)
 
     let title: String
     let icon: UIImage

--- a/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
@@ -175,6 +175,7 @@ private struct PaddedLinkRow: ImmuTableRow {
 
     func configureCell(_ cell: UITableViewCell) {
         cell.textLabel?.text = title
+        cell.imageView?.image = UIImage(color: .clear, havingSize: Gridicon.defaultSize)
 
         WPStyleGuide.configureTableViewActionCell(cell)
     }

--- a/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
@@ -145,7 +145,12 @@ private class InfoCell: WPTableViewCellDefault {
             let textFrame = textLabel?.frame else {
                 return
         }
-        imageFrame.origin.y = textFrame.origin.y + layoutMargins.top
+        // The layout margins of the text label are 2px lower than we'd like
+        // for our image to look centered vertically against the text.
+        // Ultimately we probably need a custom cell with auto layout
+        // constraints, but for now we'll just manually adjust the position.
+        let offset: CGFloat = 2.0
+        imageFrame.origin.y = textFrame.origin.y + layoutMargins.top - offset
         imageView?.frame = imageFrame
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
@@ -1,0 +1,169 @@
+import Gridicons
+import UIKit
+
+class PrivacySettingsViewController: UITableViewController {
+    fileprivate var handler: ImmuTableViewHandler!
+
+    override init(style: UITableViewStyle) {
+        super.init(style: style)
+        navigationItem.title = NSLocalizedString("App Settings", comment: "App Settings Title")
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    required convenience init() {
+        self.init(style: .grouped)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        ImmuTable.registerRows([
+            InfoRow.self,
+            SwitchRow.self,
+            PaddedLinkRow.self
+            ], tableView: self.tableView)
+
+        handler = ImmuTableViewHandler(takeOver: self)
+        reloadViewModel()
+
+        WPStyleGuide.configureColors(for: view, andTableView: tableView)
+        WPStyleGuide.configureAutomaticHeightRows(for: tableView)
+
+        addAccountSettingsChangedObserver()
+    }
+
+    private func addAccountSettingsChangedObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(accountSettingsDidChange(_:)), name: NSNotification.Name.AccountSettingsChanged, object: nil)
+    }
+
+    @objc
+    private func accountSettingsDidChange(_ notification: Notification) {
+        reloadViewModel()
+    }
+
+    // MARK: - Model mapping
+
+    fileprivate func reloadViewModel() {
+        handler.viewModel = tableViewModel()
+    }
+
+    func tableViewModel() -> ImmuTable {
+        let collectInformation = SwitchRow(
+            title: NSLocalizedString("Collect information", comment: "Label for switch to turn on/off sending app usage data"),
+            value: !WPAppAnalytics.userHasOptedOut(),
+            icon: Gridicon.iconOfType(.stats),
+            onChange: usageTrackingChanged()
+        )
+
+        let shareInfoText = InfoRow(
+            title: NSLocalizedString("Share information with our analytics tool about your use of services while logged in to your WordPress.com account.", comment: "Informational text for Collect Information setting"),
+            icon: Gridicon.iconOfType(.info)
+        )
+
+        let shareInfoLink = PaddedLinkRow(
+            title: NSLocalizedString("Learn more", comment: "Link to cookie policy"),
+            action: openCookiePolicy()
+        )
+
+        let privacyText = InfoRow(
+            title: NSLocalizedString("This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy.", comment: "Informational text for the privacy policy link"),
+            icon: Gridicon.iconOfType(.userCircle)
+        )
+
+        let privacyLink = PaddedLinkRow(
+            title: NSLocalizedString("Read privacy policy", comment: "Link to privacy policy"),
+            action: openPrivacyPolicy()
+        )
+
+        let otherTracking = InfoRow(
+            title: NSLocalizedString("We use other tracking tools, including some from third parties. Read about these and how to control them.", comment: "Informational text about link to other tracking tools"),
+            icon: Gridicon.iconOfType(.briefcase)
+        )
+
+        let otherTrackingLink = PaddedLinkRow(
+            title: NSLocalizedString("Learn more", comment: "Link to cookie policy"),
+            action: openCookiePolicy()
+        )
+
+        return ImmuTable(sections: [
+            ImmuTableSection(rows: [
+                collectInformation,
+                shareInfoText,
+                shareInfoLink
+                ]),
+            ImmuTableSection(rows: [
+                privacyText,
+                privacyLink
+                ]),
+            ImmuTableSection(rows: [
+                otherTracking,
+                otherTrackingLink
+                ])
+            ])
+    }
+
+    func usageTrackingChanged() -> (Bool) -> Void {
+        return { enabled in
+            let appAnalytics = WordPressAppDelegate.sharedInstance().analytics
+            appAnalytics?.setUserHasOptedOut(!enabled)
+
+            let accountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+            AccountSettingsHelper(accountService: accountService).updateTracksOptOutSetting(!enabled)
+        }
+    }
+
+    func openCookiePolicy() -> ImmuTableAction {
+        return { [weak self] _ in
+            self?.displayWebView(WPAutomatticCookiesURL)
+        }
+    }
+
+    func openPrivacyPolicy() -> ImmuTableAction {
+        return { [weak self] _ in
+            self?.displayWebView(WPAutomatticPrivacyURL)
+        }
+    }
+
+    func displayWebView(_ urlString: String) {
+        guard let url = URL(string: urlString) else {
+            return
+        }
+        let webViewController = WebViewControllerFactory.controller(url: url)
+        let navigation = UINavigationController(rootViewController: webViewController)
+        present(navigation, animated: true, completion: nil)
+    }
+
+}
+
+private struct InfoRow: ImmuTableRow {
+    static let cell = ImmuTableCell.class(WPTableViewCellDefault.self)
+
+    let title: String
+    let icon: UIImage
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+        cell.textLabel?.text = title
+        cell.textLabel?.numberOfLines = 10
+        cell.imageView?.image = icon
+        cell.selectionStyle = .none
+
+        WPStyleGuide.configureTableViewCell(cell)
+    }
+}
+
+private struct PaddedLinkRow: ImmuTableRow {
+    static let cell = ImmuTableCell.class(WPTableViewCellDefault.self)
+
+    let title: String
+    let action: ImmuTableAction?
+
+    func configureCell(_ cell: UITableViewCell) {
+        cell.textLabel?.text = title
+
+        WPStyleGuide.configureTableViewActionCell(cell)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1009,6 +1009,7 @@
 		E1AB5A091E0BF31E00574B4E /* ArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB5A081E0BF31E00574B4E /* ArrayTests.swift */; };
 		E1AB5A3A1E0C464700574B4E /* DelayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB5A391E0C464700574B4E /* DelayTests.swift */; };
 		E1AC282D18282423004D394C /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		E1ADE0EB20A9EF6200D6AADC /* PrivacySettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ADE0EA20A9EF6200D6AADC /* PrivacySettingsViewController.swift */; };
 		E1AFA8C31E8E34230004A323 /* WordPressShare.js in Resources */ = {isa = PBXBuildFile; fileRef = E1AFA8C21E8E34230004A323 /* WordPressShare.js */; };
 		E1B23B081BFB3B370006559B /* MyProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B23B071BFB3B370006559B /* MyProfileViewController.swift */; };
 		E1B62A7B13AA61A100A6FCA4 /* WPWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E1B62A7A13AA61A100A6FCA4 /* WPWebViewController.m */; };
@@ -2577,6 +2578,7 @@
 		E1AB5A081E0BF31E00574B4E /* ArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayTests.swift; sourceTree = "<group>"; };
 		E1AB5A391E0C464700574B4E /* DelayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DelayTests.swift; sourceTree = "<group>"; };
 		E1AC8CB91E54B891006FD056 /* ar */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ar; path = ar.lproj/Localizable.strings; sourceTree = "<group>"; };
+		E1ADE0EA20A9EF6200D6AADC /* PrivacySettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsViewController.swift; sourceTree = "<group>"; };
 		E1AFA8C21E8E34230004A323 /* WordPressShare.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; name = WordPressShare.js; path = WordPressShareExtension/WordPressShare.js; sourceTree = SOURCE_ROOT; };
 		E1B23B071BFB3B370006559B /* MyProfileViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyProfileViewController.swift; sourceTree = "<group>"; };
 		E1B2FF581C637AE200F6BDEA /* PlanListViewControllerTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanListViewControllerTest.swift; sourceTree = "<group>"; };
@@ -3516,6 +3518,7 @@
 				93069F54176237A4000C966D /* ActivityLogViewController.h */,
 				93069F55176237A4000C966D /* ActivityLogViewController.m */,
 				FFA162301CB7031A00E2E110 /* AppSettingsViewController.swift */,
+				E1ADE0EA20A9EF6200D6AADC /* PrivacySettingsViewController.swift */,
 				B53B02B21CAC3AAC003190A0 /* GravatarPickerViewController.swift */,
 				315FC2C31A2CB29300E7CDA2 /* MeHeaderView.h */,
 				315FC2C41A2CB29300E7CDA2 /* MeHeaderView.m */,
@@ -7701,6 +7704,7 @@
 				82FC612A1FA8B6F000A1757E /* ActivityListViewModel.swift in Sources */,
 				5D119DA3176FBE040073D83A /* UIImageView+AFNetworkingExtra.m in Sources */,
 				E17780801C97FA9500FA7E14 /* StoreKit+Debug.swift in Sources */,
+				E1ADE0EB20A9EF6200D6AADC /* PrivacySettingsViewController.swift in Sources */,
 				E6431DE61C4E892900FD8D90 /* SharingDetailViewController.m in Sources */,
 				B50EED791C0E5B2400D278CA /* SettingsPickerViewController.swift in Sources */,
 				E1F5A1BC1771C90A00E0495F /* WPTableImageSource.m in Sources */,


### PR DESCRIPTION
Replaces the analytics opt-out with a dedicated privacy page with more
information and links to the privacy and cookies policies.

@frosty besides a review, I need a bit of help with the UI. According to @folletto's design, the icons should be top-aligned, and the read more links should be left-aligned with the other texts. I'm not sure how to do either, and you might have some ideas 🙏 

![simulator screen shot - iphone x - 2018-05-14 at 19 10 16](https://user-images.githubusercontent.com/8739/40012688-b4ae1b58-57ab-11e8-9b2e-d01da3c4cb8e.png)


Fixes #9359 

To test:

- Go to App Settings > Privacy Settings
- Verify that it matches the design in #9359 
- Make sure the toggle works

