### PR TITLE
WPAppAnalytics: ensure events don't get wiped on app background.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def shared_with_all_pods
-  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '864f31b2cf816512ac89a132287c0e47632c04a5'
+  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'eb742da'
   pod 'CocoaLumberjack', '3.4.1'
   pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
   pod 'NSObject-SafeExpectations', '0.0.2'

--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def shared_with_all_pods
-  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '1d657ac0ddb002712803721da8ee5752e7069637'
+  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '864f31b2cf816512ac89a132287c0e47632c04a5'
   pod 'CocoaLumberjack', '3.4.1'
   pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
   pod 'NSObject-SafeExpectations', '0.0.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -156,7 +156,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `f8021013ee7df63e1c469ad550944c213888faaf`)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `864f31b2cf816512ac89a132287c0e47632c04a5`)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `eb742da`)
   - WPMediaPicker (= 1.0)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
@@ -169,7 +169,7 @@ EXTERNAL SOURCES:
     :commit: f8021013ee7df63e1c469ad550944c213888faaf
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressShared:
-    :commit: 864f31b2cf816512ac89a132287c0e47632c04a5
+    :commit: eb742da
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
@@ -180,7 +180,7 @@ CHECKOUT OPTIONS:
     :commit: f8021013ee7df63e1c469ad550944c213888faaf
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressShared:
-    :commit: 864f31b2cf816512ac89a132287c0e47632c04a5
+    :commit: eb742da
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
@@ -220,6 +220,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 27285bff942c870e8ae822084519d13d9c5344d3
+PODFILE CHECKSUM: ce4f4d0f73eb78e3b24c2ef49fe1bc8343eb15d9
 
 COCOAPODS: 1.4.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -156,7 +156,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `f8021013ee7df63e1c469ad550944c213888faaf`)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `1d657ac0ddb002712803721da8ee5752e7069637`)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `864f31b2cf816512ac89a132287c0e47632c04a5`)
   - WPMediaPicker (= 1.0)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
@@ -169,7 +169,7 @@ EXTERNAL SOURCES:
     :commit: f8021013ee7df63e1c469ad550944c213888faaf
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressShared:
-    :commit: 1d657ac0ddb002712803721da8ee5752e7069637
+    :commit: 864f31b2cf816512ac89a132287c0e47632c04a5
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
@@ -180,7 +180,7 @@ CHECKOUT OPTIONS:
     :commit: f8021013ee7df63e1c469ad550944c213888faaf
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressShared:
-    :commit: 1d657ac0ddb002712803721da8ee5752e7069637
+    :commit: 864f31b2cf816512ac89a132287c0e47632c04a5
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
@@ -220,6 +220,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: adaf0c391dcfb9a18118cf47fc4c9125a713cd25
+PODFILE CHECKSUM: 27285bff942c870e8ae822084519d13d9c5344d3
 
 COCOAPODS: 1.4.0

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1338,6 +1338,25 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatDefaultAccountChanged:
         case WPAnalyticsStatNoStat:
         case WPAnalyticsStatPerformedCoreDataMigrationFixFor45:
+        case WPAnalyticsStatNotificationsSettingsBlogNotificationsOn:
+        case WPAnalyticsStatNotificationsSettingsBlogNotificationsOff:
+        case WPAnalyticsStatNotificationsSettingsEmailNotificationsOn:
+        case WPAnalyticsStatNotificationsSettingsEmailNotificationsOff:
+        case WPAnalyticsStatNotificationsSettingsEmailDeliveryInstantly:
+        case WPAnalyticsStatNotificationsSettingsEmailDeliveryDaily:
+        case WPAnalyticsStatNotificationsSettingsEmailDeliveryWeekly:
+        case WPAnalyticsStatNotificationsSettingsCommentsNotificationsOn:
+        case WPAnalyticsStatNotificationsSettingsCommentsNotificationsOff:
+        case WPAnalyticsStatReaderListNotificationMenuOn:
+        case WPAnalyticsStatReaderListNotificationMenuOff:
+        case WPAnalyticsStatReaderListNotificationEnabled:
+        case WPAnalyticsStatSiteSettingsSiteIconTapped:
+        case WPAnalyticsStatSiteSettingsSiteIconRemoved:
+        case WPAnalyticsStatSiteSettingsSiteIconShotNew:
+        case WPAnalyticsStatSiteSettingsSiteIconGalleryPicked:
+        case WPAnalyticsStatSiteSettingsSiteIconCropped:
+        case WPAnalyticsStatSiteSettingsSiteIconUploaded:
+        case WPAnalyticsStatSiteSettingsSiteIconUploadFailed:
         case WPAnalyticsStatMaxValue:
             return nil;
     }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -88,7 +88,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     [self refreshMetadata];
 }
 
-- (void)endSession
+- (void)clearQueuedEvents
 {
     [self.tracksService clearQueuedEvents];
 }

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -99,6 +99,7 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
 
 - (void)clearTrackers
 {
+    [WPAnalytics clearQueuedEvents];
     [WPAnalytics clearTrackers];
 }
 


### PR DESCRIPTION
Fixes #9343.

Note: this relies on https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/131. The hash in `Podfile` now points to the commit in a branch. I'll update _this_ PR with hash pointing to develop once the PR in -iOS-Shared gets merged.


To test:

There are two stages to this. First one is making sure we're not accidentally wiping events on backgrounding:

1. Locate the Tracks database file. My preferred way is stopping the app in debugger, doing `po NSHomeDirectory()` and then `cd`-ing to that path. Tracks database will then be in `Documents/Tracks.sqlite`)
2. Open the database file (either by doing `sqlite3 Documents/Tracks.sqlite` or using your preferred SQLite GUI)
3. Make sure that the app is offline and you haven't opted out of tracking.
4. Perform some activity in the app that generates Tracking events (switching between tabs works)
5. Verify that there are events in the database (`SELECT * FROM ZTRACKSEVENT;`)
6. Background the app.
7. Make sure that the events are still there (`SELECT * FROM ZTRACKSEVENT;` again).

The other is to make sure we're clearing out the events we want to:
1. Repeat steps 1-5 above.
2. Go to Me->App Settings.
3. Turn off tracking events in "Send Statistics" toggle.
5. Verify that there are *no* events in the database. (`SELECT * FROM ZTRACKSEVENT;` should return an empty result set)