### PR TITLE
Zendesk Mobile: show notification alert on navigation bar Help

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -78,7 +78,7 @@ extension WordPressAppDelegate {
         authManager = WordPressAuthenticationManager()
 
         authManager.initializeWordPressAuthenticator()
-        authManager.startRelayingHelpshiftNotifications()
+        authManager.startRelayingSupportNotifications()
 
         WordPressAuthenticator.shared.delegate = authManager
     }

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -19,6 +19,7 @@ extension NSNotification.Name {
     private override init() {}
 
     static var zendeskEnabled = false
+    static var showSupportNotificationIndicator = false
 
     private var sourceTag: WordPressSupportSourceTag?
 
@@ -146,6 +147,8 @@ extension NSNotification.Name {
     }
 
     static func pushNotificationReceived() {
+        ZendeskUtils.showSupportNotificationIndicator = true
+
         // Updating unread indicators should trigger UI updates, so send notification in main thread.
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: .ZendeskPushNotificationReceivedNotification, object: nil)

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -5,10 +5,12 @@ import WordPressAuthenticator
 
 extension NSNotification.Name {
     static let ZendeskPushNotificationReceivedNotification = NSNotification.Name(rawValue: "ZendeskPushNotificationReceivedNotification")
+    static let ZendeskPushNotificationClearedNotification = NSNotification.Name(rawValue: "ZendeskPushNotificationClearedNotification")
 }
 
 @objc extension NSNotification {
     public static let ZendeskPushNotificationReceivedNotification = NSNotification.Name.ZendeskPushNotificationReceivedNotification
+    public static let ZendeskPushNotificationClearedNotification = NSNotification.Name.ZendeskPushNotificationClearedNotification
 }
 
 @objc class ZendeskUtils: NSObject {
@@ -152,6 +154,15 @@ extension NSNotification.Name {
         // Updating unread indicators should trigger UI updates, so send notification in main thread.
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: .ZendeskPushNotificationReceivedNotification, object: nil)
+        }
+    }
+
+    static func pushNotificationRead() {
+        ZendeskUtils.showSupportNotificationIndicator = false
+
+        // Updating unread indicators should trigger UI updates, so send notification in main thread.
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .ZendeskPushNotificationClearedNotification, object: nil)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -33,7 +33,8 @@ class WordPressAuthenticationManager: NSObject {
                                                                 wpcomTermsOfServiceURL: WPAutomatticTermsOfServiceURL,
                                                                 googleLoginClientId: ApiCredentials.googleLoginClientId(),
                                                                 googleLoginServerClientId: ApiCredentials.googleLoginServerClientId(),
-                                                                userAgent: WPUserAgent.wordPress())
+                                                                userAgent: WPUserAgent.wordPress(),
+                                                                supportNotificationIndicatorFeatureFlag: FeatureFlag.zendeskMobile.enabled)
 
         WordPressAuthenticator.initialize(configuration: configuration)
     }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -17,7 +17,8 @@ class WordPressAuthenticationManager: NSObject {
     ///
     func startRelayingSupportNotifications() {
         if FeatureFlag.zendeskMobile.enabled {
-            NotificationCenter.default.addObserver(self, selector: #selector(zendeskPushNotificationReceived), name: .ZendeskPushNotificationReceivedNotification, object: nil)
+            NotificationCenter.default.addObserver(self, selector: #selector(supportPushNotificationReceived), name: .ZendeskPushNotificationReceivedNotification, object: nil)
+            NotificationCenter.default.addObserver(self, selector: #selector(supportPushNotificationCleared), name: .ZendeskPushNotificationClearedNotification, object: nil)
         } else {
             NotificationCenter.default.addObserver(self, selector: #selector(helpshiftUnreadCountWasUpdated), name: .HelpshiftUnreadCountUpdated, object: nil)
         }
@@ -82,8 +83,12 @@ extension WordPressAuthenticationManager {
         WordPressAuthenticator.shared.supportBadgeCountWasUpdated()
     }
 
-    @objc func zendeskPushNotificationReceived(_ notification: Foundation.Notification) {
-        WordPressAuthenticator.shared.zendeskPushNotificationReceived()
+    @objc func supportPushNotificationReceived(_ notification: Foundation.Notification) {
+        WordPressAuthenticator.shared.supportPushNotificationReceived()
+    }
+
+    @objc func supportPushNotificationCleared(_ notification: Foundation.Notification) {
+        WordPressAuthenticator.shared.supportPushNotificationCleared()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -194,6 +194,7 @@ private extension SupportTableViewController {
             self.showSupportNotificationIndicator = false
             self.reloadViewModel()
             self.delegate?.notificationsCleared()
+            ZendeskUtils.pushNotificationRead()
             guard let controllerToShowFrom = self.controllerToShowFrom() else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -120,8 +120,13 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
         if ([Feature enabled:FeatureFlagZendeskMobile]) {
             [[NSNotificationCenter defaultCenter] addObserver:self
-                                                     selector:@selector(zendeskPushNotificationReceived:)
+                                                     selector:@selector(refreshMeIconIndicator:)
                                                          name:NSNotification.ZendeskPushNotificationReceivedNotification
+                                                       object:nil];
+            
+            [[NSNotificationCenter defaultCenter] addObserver:self
+                                                     selector:@selector(refreshMeIconIndicator:)
+                                                         name:NSNotification.ZendeskPushNotificationClearedNotification
                                                        object:nil];
         } else {
             [[NSNotificationCenter defaultCenter] addObserver:self
@@ -732,7 +737,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
             }
             case WPTabMe: {
                 [WPAppAnalytics track:WPAnalyticsStatMeTabAccessed];
-                [self showMeBadge:NO];
+                [self showMeNotificationIcon:NO];
                 break;
             }
             default: break;
@@ -779,9 +784,9 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 #pragma mark - Zendesk Notifications
 
-- (void)zendeskPushNotificationReceived:(NSNotification *)notification
+- (void)refreshMeIconIndicator:(NSNotification *)notification
 {
-    [self showMeBadge:YES];
+    [self showMeNotificationIcon:notification.name == NSNotification.ZendeskPushNotificationReceivedNotification];
 }
 
 #pragma mark - Helpshift Notifications
@@ -829,7 +834,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     }
 }
 
-- (void)showMeBadge:(BOOL)show
+- (void)showMeNotificationIcon:(BOOL)show
 {
     UITabBarItem *meTabBarItem = self.tabBar.items[WPTabMe];
     meTabBarItem.image = self.meTabBarImageUnread;

--- a/WordPressAuthenticator/WordPressAuthenticator.xcodeproj/project.pbxproj
+++ b/WordPressAuthenticator/WordPressAuthenticator.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		050FFF3AF877DD64C5795011 /* Pods_WordPressAuthenticatorTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8735AAC66C7015A0B684D4B /* Pods_WordPressAuthenticatorTests.framework */; };
+		98AA5A5720AA1A7000A5958A /* WPHelpIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98AA5A5620AA1A7000A5958A /* WPHelpIndicatorView.swift */; };
 		B501C045208FC68700D1E58F /* LoginFieldsValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B501C03C208FC52400D1E58F /* LoginFieldsValidationTests.swift */; };
 		B501C046208FC6A700D1E58F /* WordPressAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B501C03E208FC52500D1E58F /* WordPressAuthenticatorTests.swift */; };
 		B501C048208FC79C00D1E58F /* LoginFacadeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B501C040208FC52500D1E58F /* LoginFacadeTests.m */; };
@@ -112,6 +113,7 @@
 		507363A502FE93136182BBF6 /* Pods-WordPressAuthenticator.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		5585A7E9820611F0B738272C /* Pods_WordPressAuthenticator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressAuthenticator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		75342E9B15CCDC942D18777A /* Pods-WordPressAuthenticator.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticator.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressAuthenticator/Pods-WordPressAuthenticator.debug.xcconfig"; sourceTree = "<group>"; };
+		98AA5A5620AA1A7000A5958A /* WPHelpIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPHelpIndicatorView.swift; sourceTree = "<group>"; };
 		ABBD3BD7BE3EBAF47AAB478A /* Pods-WordPressAuthenticatorTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressAuthenticatorTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressAuthenticatorTests/Pods-WordPressAuthenticatorTests.release.xcconfig"; sourceTree = "<group>"; };
 		B501C03C208FC52400D1E58F /* LoginFieldsValidationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginFieldsValidationTests.swift; sourceTree = "<group>"; };
 		B501C03E208FC52500D1E58F /* WordPressAuthenticatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressAuthenticatorTests.swift; sourceTree = "<group>"; };
@@ -334,6 +336,7 @@
 				B56090BE208A4F5400399AE4 /* NUXTableViewController.swift */,
 				B56090C3208A4F5400399AE4 /* NUXViewController.swift */,
 				B56090C2208A4F5400399AE4 /* NUXViewControllerBase.swift */,
+				98AA5A5620AA1A7000A5958A /* WPHelpIndicatorView.swift */,
 				B56090D9208A4F9C00399AE4 /* WPNUXMainButton.h */,
 				B56090DA208A4F9C00399AE4 /* WPNUXMainButton.m */,
 				B56090D5208A4F9B00399AE4 /* WPNUXPrimaryButton.h */,
@@ -746,6 +749,7 @@
 				B5609143208A563800399AE4 /* LoginSocialErrorViewController.swift in Sources */,
 				B56090F8208A533200399AE4 /* WordPressAuthenticator+Notifications.swift in Sources */,
 				B56090EA208A51D000399AE4 /* LoginFields+Validation.swift in Sources */,
+				98AA5A5720AA1A7000A5958A /* WPHelpIndicatorView.swift in Sources */,
 				B560913C208A563800399AE4 /* LoginProloguePromoViewController.swift in Sources */,
 				B560910F208A54F800399AE4 /* SafariCredentialsService.swift in Sources */,
 				B5609116208A555600399AE4 /* LoginTextField.swift in Sources */,

--- a/WordPressAuthenticator/WordPressAuthenticator/Authenticator/WordPressAuthenticator+Notifications.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/Authenticator/WordPressAuthenticator+Notifications.swift
@@ -16,4 +16,8 @@ extension NSNotification.Name {
     /// Posted whenever a Support notification is received.
     ///
     public static let wordpressSupportNotificationReceived = NSNotification.Name(rawValue: "WordPressSupportNotificationReceived")
+    
+    /// Posted whenever a Support notification has been viewed.
+    ///
+    public static let wordpressSupportNotificationCleared = NSNotification.Name(rawValue: "WordPressSupportNotificationCleared")
 }

--- a/WordPressAuthenticator/WordPressAuthenticator/Authenticator/WordPressAuthenticator+Notifications.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/Authenticator/WordPressAuthenticator+Notifications.swift
@@ -12,4 +12,8 @@ extension NSNotification.Name {
     /// Posted whenever the Support Badge needs to be updated.
     ///
     public static let wordpressSupportBadgeUpdated = NSNotification.Name(rawValue: "WordPressSupportBadgeUpdated")
+    
+    /// Posted whenever a Support notification is received.
+    ///
+    public static let wordpressSupportNotificationReceived = NSNotification.Name(rawValue: "WordPressSupportNotificationReceived")
 }

--- a/WordPressAuthenticator/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -147,6 +147,10 @@ public struct WordPressAuthenticatorConfiguration {
     ///
     let userAgent: String
 
+    /// Used to determine which view to use for new Support notifications.
+    ///
+    let supportNotificationIndicatorFeatureFlag: Bool
+    
     /// Designated Initializer
     ///
     public init (wpcomClientId: String,
@@ -155,7 +159,8 @@ public struct WordPressAuthenticatorConfiguration {
                  wpcomTermsOfServiceURL: String,
                  googleLoginClientId: String,
                  googleLoginServerClientId: String,
-                 userAgent: String) {
+                 userAgent: String,
+                 supportNotificationIndicatorFeatureFlag: Bool) {
         self.wpcomClientId = wpcomClientId
         self.wpcomSecret = wpcomSecret
         self.wpcomScheme = wpcomScheme
@@ -163,6 +168,7 @@ public struct WordPressAuthenticatorConfiguration {
         self.googleLoginClientId =  googleLoginClientId
         self.googleLoginServerClientId = googleLoginServerClientId
         self.userAgent = userAgent
+        self.supportNotificationIndicatorFeatureFlag = supportNotificationIndicatorFeatureFlag
     }
 }
 

--- a/WordPressAuthenticator/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -41,6 +41,10 @@ public protocol WordPressAuthenticatorDelegate: class {
     ///
     var supportActionEnabled: Bool { get }
 
+    /// Indicates if the Support notification indicator should be displayed.
+    ///
+    var showSupportNotificationIndicator: Bool { get }
+    
     /// Indicates if Support is available or not.
     ///
     var supportEnabled: Bool { get }
@@ -225,6 +229,10 @@ public struct WordPressAuthenticatorConfiguration {
 
     public func supportBadgeCountWasUpdated() {
         NotificationCenter.default.post(name: .wordpressSupportBadgeUpdated, object: nil)
+    }
+    
+    public func zendeskPushNotificationReceived() {
+        NotificationCenter.default.post(name: .wordpressSupportNotificationReceived, object: nil)
     }
 
     /// Indicates if the specified ViewController belongs to the Authentication Flow, or not.

--- a/WordPressAuthenticator/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -231,10 +231,14 @@ public struct WordPressAuthenticatorConfiguration {
         NotificationCenter.default.post(name: .wordpressSupportBadgeUpdated, object: nil)
     }
     
-    public func zendeskPushNotificationReceived() {
+    public func supportPushNotificationReceived() {
         NotificationCenter.default.post(name: .wordpressSupportNotificationReceived, object: nil)
     }
 
+    public func supportPushNotificationCleared() {
+        NotificationCenter.default.post(name: .wordpressSupportNotificationCleared, object: nil)
+    }
+    
     /// Indicates if the specified ViewController belongs to the Authentication Flow, or not.
     ///
     public class func isAuthenticationViewController(_ viewController: UIViewController) ->  Bool {

--- a/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXCollectionViewController.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXCollectionViewController.swift
@@ -4,6 +4,7 @@
 open class NUXCollectionViewController: UICollectionViewController, NUXViewControllerBase, UIViewControllerTransitioningDelegate {
     // MARK: NUXViewControllerBase properties
     /// these properties comply with NUXViewControllerBase and are duplicated with NUXTableViewController
+    public var helpIndicator: WPHelpIndicatorView = WPHelpIndicatorView()
     public var helpBadge: NUXHelpBadgeLabel = NUXHelpBadgeLabel()
     public var helpButton: UIButton = UIButton(type: .custom)
     public var dismissBlock: ((_ cancelled: Bool) -> Void)?

--- a/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXTableViewController.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXTableViewController.swift
@@ -4,6 +4,7 @@
 open class NUXTableViewController: UITableViewController, NUXViewControllerBase, UIViewControllerTransitioningDelegate {
     // MARK: NUXViewControllerBase properties
     /// these properties comply with NUXViewControllerBase and are duplicated with NUXTableViewController
+    public var helpIndicator: WPHelpIndicatorView = WPHelpIndicatorView()
     public var helpBadge: NUXHelpBadgeLabel = NUXHelpBadgeLabel()
     public var helpButton: UIButton = UIButton(type: .custom)
     public var dismissBlock: ((_ cancelled: Bool) -> Void)?

--- a/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXViewController.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXViewController.swift
@@ -8,6 +8,7 @@ import WordPressUI
 open class NUXViewController: UIViewController, NUXViewControllerBase, UIViewControllerTransitioningDelegate, NUXSegueHandler {
     // MARK: NUXViewControllerBase properties
     /// these properties comply with NUXViewControllerBase and are duplicated with NUXTableViewController
+    public var helpIndicator: WPHelpIndicatorView = WPHelpIndicatorView()
     public var helpBadge: NUXHelpBadgeLabel = NUXHelpBadgeLabel()
     public var helpButton: UIButton = UIButton(type: .custom)
     public var dismissBlock: ((_ cancelled: Bool) -> Void)?

--- a/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -6,6 +6,7 @@ import WordPressUI
 public protocol NUXViewControllerBase {
     var sourceTag: WordPressSupportSourceTag { get }
     var helpBadge: NUXHelpBadgeLabel { get }
+    var helpIndicator: WPHelpIndicatorView { get }
     var helpButton: UIButton { get }
     var loginFields: LoginFields { get }
     var dismissBlock: ((_ cancelled: Bool) -> Void)? { get }
@@ -106,8 +107,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
 
     func refreshSupportNotificationIndicator() {
         let showIndicator = WordPressAuthenticator.shared.delegate?.showSupportNotificationIndicator ?? false
-        helpBadge.text = nil
-        helpBadge.isHidden = !showIndicator
+        helpIndicator.isHidden = !showIndicator
     }
 
     // MARK: - Actions
@@ -163,9 +163,10 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
     ///
     public func addHelpButtonToNavController() {
         let helpButtonMarginSpacerWidth = CGFloat(-8)
-        let helpBadgeSize = CGSize(width: 12, height: 12)
         let helpButtonContainerFrame = CGRect(x: 0, y: 0, width: 44, height: 44)
         
+        var helpNotificationSize: CGSize
+        var notificationView: UIView
         
         if WordPressAuthenticator.shared.configuration.supportNotificationIndicatorFeatureFlag == true {
             // Zendesk
@@ -176,11 +177,17 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
             NotificationCenter.default.addObserver(forName: .wordpressSupportNotificationCleared, object: nil, queue: nil) { [weak self] _ in
                 self?.refreshSupportNotificationIndicator()
             }
+
+            notificationView = helpIndicator
+            helpNotificationSize = CGSize(width: 10, height: 10)
         } else {
             // Helpshift
             NotificationCenter.default.addObserver(forName: .wordpressSupportBadgeUpdated, object: nil, queue: nil) { [weak self] _ in
                 self?.refreshSupportBadge()
             }
+            
+            notificationView = helpBadge
+            helpNotificationSize = CGSize(width: 12, height: 12)
         }
 
         let customView = UIView(frame: helpButtonContainerFrame)
@@ -201,13 +208,13 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
         helpButton.topAnchor.constraint(equalTo: customView.topAnchor).isActive = true
         helpButton.bottomAnchor.constraint(equalTo: customView.bottomAnchor).isActive = true
 
-        helpBadge.translatesAutoresizingMaskIntoConstraints = false
-        helpBadge.isHidden = true
-        customView.addSubview(helpBadge)
-        helpBadge.centerXAnchor.constraint(equalTo: helpButton.trailingAnchor).isActive = true
-        helpBadge.centerYAnchor.constraint(equalTo: helpButton.topAnchor).isActive = true
-        helpBadge.widthAnchor.constraint(equalToConstant: helpBadgeSize.width).isActive = true
-        helpBadge.heightAnchor.constraint(equalToConstant: helpBadgeSize.height).isActive = true
+        notificationView.translatesAutoresizingMaskIntoConstraints = false
+        notificationView.isHidden = true
+        customView.addSubview(notificationView)
+        notificationView.centerXAnchor.constraint(equalTo: helpButton.trailingAnchor).isActive = true
+        notificationView.centerYAnchor.constraint(equalTo: helpButton.topAnchor).isActive = true
+        notificationView.widthAnchor.constraint(equalToConstant: helpNotificationSize.width).isActive = true
+        notificationView.heightAnchor.constraint(equalToConstant: helpNotificationSize.height).isActive = true
 
         let spacer = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
         spacer.width = helpButtonMarginSpacerWidth

--- a/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -165,19 +165,22 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
         let helpButtonMarginSpacerWidth = CGFloat(-8)
         let helpBadgeSize = CGSize(width: 12, height: 12)
         let helpButtonContainerFrame = CGRect(x: 0, y: 0, width: 44, height: 44)
-
-        // Zendesk
-        NotificationCenter.default.addObserver(forName: .wordpressSupportNotificationReceived, object: nil, queue: nil) { [weak self] _ in
-            self?.refreshSupportNotificationIndicator()
-        }
         
-        NotificationCenter.default.addObserver(forName: .wordpressSupportNotificationCleared, object: nil, queue: nil) { [weak self] _ in
-            self?.refreshSupportNotificationIndicator()
-        }
         
-        // Helpshift
-        NotificationCenter.default.addObserver(forName: .wordpressSupportBadgeUpdated, object: nil, queue: nil) { [weak self] _ in
-            self?.refreshSupportBadge()
+        if WordPressAuthenticator.shared.configuration.supportNotificationIndicatorFeatureFlag == true {
+            // Zendesk
+            NotificationCenter.default.addObserver(forName: .wordpressSupportNotificationReceived, object: nil, queue: nil) { [weak self] _ in
+                self?.refreshSupportNotificationIndicator()
+            }
+            
+            NotificationCenter.default.addObserver(forName: .wordpressSupportNotificationCleared, object: nil, queue: nil) { [weak self] _ in
+                self?.refreshSupportNotificationIndicator()
+            }
+        } else {
+            // Helpshift
+            NotificationCenter.default.addObserver(forName: .wordpressSupportBadgeUpdated, object: nil, queue: nil) { [weak self] _ in
+                self?.refreshSupportBadge()
+            }
         }
 
         let customView = UIView(frame: helpButtonContainerFrame)

--- a/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -171,6 +171,10 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
             self?.refreshSupportNotificationIndicator()
         }
         
+        NotificationCenter.default.addObserver(forName: .wordpressSupportNotificationCleared, object: nil, queue: nil) { [weak self] _ in
+            self?.refreshSupportNotificationIndicator()
+        }
+        
         // Helpshift
         NotificationCenter.default.addObserver(forName: .wordpressSupportBadgeUpdated, object: nil, queue: nil) { [weak self] _ in
             self?.refreshSupportBadge()

--- a/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -104,6 +104,11 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
         helpBadge.isHidden = (count == 0)
     }
 
+    func refreshSupportNotificationIndicator() {
+        let showIndicator = WordPressAuthenticator.shared.delegate?.showSupportNotificationIndicator ?? false
+        helpBadge.text = nil
+        helpBadge.isHidden = !showIndicator
+    }
 
     // MARK: - Actions
 
@@ -151,6 +156,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
 
         addHelpButtonToNavController()
         refreshSupportBadge()
+        refreshSupportNotificationIndicator()
     }
 
     /// Adds the Help Button to the nav controller
@@ -160,6 +166,12 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
         let helpBadgeSize = CGSize(width: 12, height: 12)
         let helpButtonContainerFrame = CGRect(x: 0, y: 0, width: 44, height: 44)
 
+        // Zendesk
+        NotificationCenter.default.addObserver(forName: .wordpressSupportNotificationReceived, object: nil, queue: nil) { [weak self] _ in
+            self?.refreshSupportNotificationIndicator()
+        }
+        
+        // Helpshift
         NotificationCenter.default.addObserver(forName: .wordpressSupportBadgeUpdated, object: nil, queue: nil) { [weak self] _ in
             self?.refreshSupportBadge()
         }

--- a/WordPressAuthenticator/WordPressAuthenticator/NUX/WPHelpIndicatorView.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/NUX/WPHelpIndicatorView.swift
@@ -1,0 +1,36 @@
+import UIKit
+import WordPressShared
+
+open class WPHelpIndicatorView: UIView {
+
+    struct Constants {
+        static let defaultInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        static let defaultBackgroundColor = WPStyleGuide.jazzyOrange()
+    }
+    
+    var insets: UIEdgeInsets = Constants.defaultInsets {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
+    
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
+        commonSetup()
+    }
+    
+    public required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func commonSetup() {
+        layer.masksToBounds = true
+        layer.cornerRadius = 6.0
+        backgroundColor = Constants.defaultBackgroundColor
+    }
+
+    override open func draw(_ rect: CGRect) {
+        super.draw(UIEdgeInsetsInsetRect(rect, insets))
+    }
+
+}


### PR DESCRIPTION
Fixes #9338 

This PR does two things:
1) When a ZD PN is received, it adds an orange indicator on the navigation bar Help button.
2) All the relevant VCs observe ZD `NSNotification`s for PNs received and PNs cleared. This allows all the notification indicators to be in sync, ultimately dependent on the `ZendeskUtils:showSupportNotificationIndicator` value. 

NOTE: This does not fix the issue with the Notifications tab showing an indicator when ZD PNs are received. That's still to come.

**To test:**
**1) Nav bar Help button indicator**
- Go to 'Support' and submit a ticket.
- In Zendesk, reply to your ticket (or ask me to).
- In the app, go to site creation (either WP or self-hosted).
  - Verify the indicator is shown.
- Click 'Help'
  - Verify the indicator is shown on 'My Tickets'.
- Select 'My Tickets', then close it.
  - Verify the indicator is no longer shown.
- Close to return to site creation.
  - Verify the 'Help' indicator is no longer shown.

To note, If you are in site creation when a new PN is received, the Zendesk PN alert will appear. Viewing a ticket from the ZD PN alert (no matter where it is displayed) will also clear the indicators.

**2) Indicator syncing**
Instead of listing all the possible scenarios, I'll just describe the behavior.

These indicators should all be in the same state:
- Me tab icon
- Me tab > Help & Support
- Help & Support > My Tickets
- Navigation bar Help

When a new PN is received, all these indicators should be present.
Once 'My Tickets' is selected, all these indicators should be cleared.

**Help button indicator:**
<img width="92" alt="help_indicator" src="https://user-images.githubusercontent.com/1816888/40025956-a13599cc-5790-11e8-8325-13254bdd0ac7.png">


