### PR TITLE
Blog list: add pull-to-refresh.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -347,12 +347,13 @@ static NSInteger HideSearchMinSites = 3;
 - (void)syncBlogs
 {
     NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
+
+    __weak __typeof(self) weakSelf = self;
     [context performBlock:^{
         AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
         BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
         WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
 
-        __weak __typeof(self) weakSelf = self;
         if (defaultAccount) {
             [blogService syncBlogsForAccount:defaultAccount success:^{
                 [weakSelf.tableView.refreshControl endRefreshing];


### PR DESCRIPTION
Fixes #3898.

Adds pull-to-refresh to list of blogs:

![simulator screen shot - iphone 8 plus - 2018-05-15 at 03 30 11](https://user-images.githubusercontent.com/1594081/40031517-515b87b2-57f0-11e8-8594-cdfd7b4ba5d5.png)

To test:
1. Go to the list of blogs in the app
2. Go to [WP.com on the web](https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs&show=visible) and perform some action that'd be visible in this list, like hiding a blog/making it visible.
3. Pull-to-refresh in the app
4. Verify that the change from the web is reflected in the app


