### PR TITLE
Gif support media library item view

### DIFF
--- a/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
@@ -1,10 +1,10 @@
 
-extension AbstractPost: PostInformation {
+extension AbstractPost: ImageSourceInformation {
     var isPrivateOnWPCom: Bool {
         return isPrivate() && blog.isHostedAtWPcom
     }
 
-    var isBlogSelfHostedWithCredentials: Bool {
+    var isSelfHostedWithCredentials: Bool {
         return !blog.isHostedAtWPcom && blog.isBasicAuthCredentialStored()
     }
 }

--- a/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
@@ -5,6 +5,6 @@ extension AbstractPost: ImageSourceInformation {
     }
 
     var isSelfHostedWithCredentials: Bool {
-        return !blog.isHostedAtWPcom && blog.isBasicAuthCredentialStored()
+        return blog.isSelfHostedWithCredentials
     }
 }

--- a/WordPress/Classes/Extensions/Blog+ImageSourceInformation.swift
+++ b/WordPress/Classes/Extensions/Blog+ImageSourceInformation.swift
@@ -1,0 +1,10 @@
+
+extension Blog: ImageSourceInformation {
+    var isPrivateOnWPCom: Bool {
+        return isHostedAtWPcom && isPrivate()
+    }
+
+    var isSelfHostedWithCredentials: Bool {
+        return !isHostedAtWPcom && isBasicAuthCredentialStored()
+    }
+}

--- a/WordPress/Classes/Models/ReaderCardContent+PostInformation.swift
+++ b/WordPress/Classes/Models/ReaderCardContent+PostInformation.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class ReaderCardContent: PostInformation {
+class ReaderCardContent: ImageSourceInformation {
     private let originalProvider: ReaderPostContentProvider
 
     init(provider: ReaderPostContentProvider) {
@@ -11,7 +11,7 @@ class ReaderCardContent: PostInformation {
         return originalProvider.isPrivate() && originalProvider.isWPCom()
     }
 
-    var isBlogSelfHostedWithCredentials: Bool {
+    var isSelfHostedWithCredentials: Bool {
         return !originalProvider.isWPCom() && !originalProvider.isJetpack()
     }
 }

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -1,7 +1,7 @@
 
 /// Protocol used to abstract the information needed to load post related images.
 ///
-@objc protocol PostInformation {
+@objc protocol ImageSourceInformation {
 
     /// The post is private and hosted on WPcom.
     /// Redundant name due to naming conflict.
@@ -10,16 +10,16 @@
 
     /// The blog is self-hosted and there is already a basic auth credential stored.
     ///
-    var isBlogSelfHostedWithCredentials: Bool { get }
+    var isSelfHostedWithCredentials: Bool { get }
 }
 
 
-extension Blog: PostInformation {
+extension Blog: ImageSourceInformation {
     var isPrivateOnWPCom: Bool {
         return self.isHostedAtWPcom && self.isPrivate()
     }
 
-    var isBlogSelfHostedWithCredentials: Bool {
+    var isSelfHostedWithCredentials: Bool {
         return !self.isHostedAtWPcom && self.isBasicAuthCredentialStored()
     }
 }
@@ -54,7 +54,7 @@ extension Blog: PostInformation {
     ///   - post: The post where the image is loaded from.
     ///   - size: The prefered size of the image to load.
     ///
-    func loadImage(with url: URL, from post: PostInformation, preferedSize size: CGSize = .zero) {
+    func loadImage(with url: URL, from post: ImageSourceInformation, preferedSize size: CGSize = .zero) {
         if url.isGif {
             loadGif(with: url, from: post)
         } else {
@@ -73,7 +73,7 @@ extension Blog: PostInformation {
     ///   - placeholder: A placeholder to show while the image is loading.
     ///   - success: A closure to be called if the image was loaded successfully.
     ///   - error: A closure to be called if there was an error loading the image.
-    func loadImage(with url: URL, from post: PostInformation, preferedSize size: CGSize = .zero, placeholder: UIImage?, success: (() -> Void)?, error: ((Error?) -> Void)?) {
+    func loadImage(with url: URL, from post: ImageSourceInformation, preferedSize size: CGSize = .zero, placeholder: UIImage?, success: (() -> Void)?, error: ((Error?) -> Void)?) {
         self.placeholder = placeholder
         successHandler = success
         errorHandler = error
@@ -85,7 +85,7 @@ extension Blog: PostInformation {
 
     /// Load an animated image from the given URL.
     ///
-    private func loadGif(with url: URL, from post: PostInformation) {
+    private func loadGif(with url: URL, from post: ImageSourceInformation) {
         let request: URLRequest
         if post.isPrivateOnWPCom {
             request = PrivateSiteURLProtocol.requestForPrivateSite(from: url)
@@ -97,12 +97,12 @@ extension Blog: PostInformation {
 
     /// Load a static image from the given URL.
     ///
-    private func loadStillImage(with url: URL, from post: PostInformation, preferedSize size: CGSize) {
+    private func loadStillImage(with url: URL, from post: ImageSourceInformation, preferedSize size: CGSize) {
         if url.isFileURL {
             downloadImage(from: url)
         } else if post.isPrivateOnWPCom {
             loadPrivateImage(with: url, from: post, preferedSize: size)
-        } else if post.isBlogSelfHostedWithCredentials {
+        } else if post.isSelfHostedWithCredentials {
             downloadImage(from: url)
         } else {
             loadProtonUrl(with: url, preferedSize: size)
@@ -111,7 +111,7 @@ extension Blog: PostInformation {
 
     /// Loads the image from a private post hosted in WPCom.
     ///
-    private func loadPrivateImage(with url: URL, from post: PostInformation, preferedSize size: CGSize) {
+    private func loadPrivateImage(with url: URL, from post: ImageSourceInformation, preferedSize size: CGSize) {
         let scale = UIScreen.main.scale
         let scaledSize = CGSize(width: size.width * scale, height: size.height * scale)
         let scaledURL = WPImageURLHelper.imageURLWithSize(scaledSize, forImageURL: url)

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -13,6 +13,17 @@
     var isBlogSelfHostedWithCredentials: Bool { get }
 }
 
+
+extension Blog: PostInformation {
+    var isPrivateOnWPCom: Bool {
+        return self.isHostedAtWPcom && self.isPrivate()
+    }
+
+    var isBlogSelfHostedWithCredentials: Bool {
+        return !self.isHostedAtWPcom && self.isBasicAuthCredentialStored()
+    }
+}
+
 /// Class used together with `CachedAnimatedImageView` to facilitate the loading of both
 /// still images and animated gifs.
 ///

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -29,14 +29,15 @@
         super.init()
     }
 
+    /// Removes the gif animation and prevents it from animate again.
     /// Call this in a table/collection cell's `prepareForReuse()`.
     ///
     @objc func prepareForReuse() {
         imageView.prepForReuse()
     }
 
-
-    /// Load an image from the specific Media object. If it's a gif, it will animate it.
+    @objc(loadImageFromMedia:preferredSize:placeholder:success:error:)
+    /// Load an image from the given Media object. If it's a gif, it will animate it.
     /// For any other type of media, this will load the corresponding static image.
     ///
     /// - Parameters:
@@ -45,6 +46,7 @@
     ///   - size: The prefered size of the image to load.
     ///   - success: A closure to be called if the image was loaded successfully.
     ///   - error: A closure to be called if there was an error loading the image.
+    ///
     func loadImage(media: Media, preferredSize size: CGSize = .zero, placeholder: UIImage?, success: (() -> Void)?, error: ((Error?) -> Void)?) {
 
         self.placeholder = placeholder
@@ -78,7 +80,7 @@
             loadGif(with: url, from: post)
         } else {
             imageView.clean()
-            loadStillImage(with: url, from: post, preferedSize: size)
+            loadStaticImage(with: url, from: post, preferedSize: size)
         }
     }
 
@@ -117,7 +119,7 @@
 
     /// Load a static image from the given URL.
     ///
-    private func loadStillImage(with url: URL, from post: ImageSourceInformation, preferedSize size: CGSize) {
+    private func loadStaticImage(with url: URL, from post: ImageSourceInformation, preferedSize size: CGSize) {
         if url.isFileURL {
             downloadImage(from: url)
         } else if post.isPrivateOnWPCom {
@@ -221,8 +223,6 @@
             self.errorHandler?(error)
         }
     }
-
-
 
     private func url(from media: Media) -> URL? {
         if let localUrl = media.absoluteLocalURL {

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -154,6 +154,7 @@
 
     private func loadImage(from media: Media, preferredSize size: CGSize) {
         imageView.image = placeholder
+        imageView.startLoadingAnimation()
         media.image(with: size) {  [weak self] (image, error) in
             if let image = image {
                 self?.imageView.image = image

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -13,17 +13,6 @@
     var isSelfHostedWithCredentials: Bool { get }
 }
 
-
-extension Blog: ImageSourceInformation {
-    var isPrivateOnWPCom: Bool {
-        return self.isHostedAtWPcom && self.isPrivate()
-    }
-
-    var isSelfHostedWithCredentials: Bool {
-        return !self.isHostedAtWPcom && self.isBasicAuthCredentialStored()
-    }
-}
-
 /// Class used together with `CachedAnimatedImageView` to facilitate the loading of both
 /// still images and animated gifs.
 ///

--- a/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
@@ -212,27 +212,13 @@ struct MediaImageRow: ImmuTableRow {
         return nil
     }
 
-    private var imageURL: URL? {
-        if let url = media.absoluteLocalURL {
-            return url
-        } else if let urlString = media.remoteURL, let url = URL(string: urlString)  {
-            return url
-        }
-        return nil
-    }
-
     private func loadImageFor(_ cell: MediaItemImageTableViewCell) {
-        guard let url = imageURL else {
-            return
-        }
-        cell.imageLoader.loadImage(with: url, from: media.blog, placeholder: placeholderImage, success: nil) { (error) in
-            if let error = error {
-                self.show(error)
-            }
+        cell.imageLoader.loadImage(media: media, placeholder: placeholderImage, success: nil) { (error) in
+            self.show(error)
         }
     }
 
-    private func show(_ error: Error) {
+    private func show(_ error: Error?) {
         let alertController = UIAlertController(title: nil, message: NSLocalizedString("There was a problem loading the media item.",
                                                                                        comment: "Error message displayed when the Media Library is unable to load a full sized preview of an item."), preferredStyle: .alert)
         alertController.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: "Verb. User action to dismiss error alert when failing to load media item."))

--- a/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
@@ -5,8 +5,6 @@ import WordPressShared
 class MediaItemImageTableViewCell: WPTableViewCell {
 
     @objc let customImageView = CachedAnimatedImageView()
-    @objc let activityIndicator = UIActivityIndicatorView(activityIndicatorStyle: .white)
-    @objc let activityMaskView = UIView()
     @objc let videoIconView = PlayIconView()
 
     @objc lazy var imageLoader: ImageLoader = {
@@ -39,7 +37,6 @@ class MediaItemImageTableViewCell: WPTableViewCell {
 
     @objc func commonInit() {
         setupImageView()
-        setupLoadingViews()
         setupVideoIconView()
     }
 
@@ -56,27 +53,6 @@ class MediaItemImageTableViewCell: WPTableViewCell {
             ])
 
         customImageView.setContentHuggingPriority(.defaultLow, for: .horizontal)
-    }
-
-    private func setupLoadingViews() {
-        contentView.addSubview(activityMaskView)
-        activityMaskView.translatesAutoresizingMaskIntoConstraints = false
-        activityMaskView.backgroundColor = .black
-        activityMaskView.alpha = 0.5
-
-        contentView.addSubview(activityIndicator)
-        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
-        activityIndicator.hidesWhenStopped = true
-
-        NSLayoutConstraint.activate([
-            activityIndicator.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
-            activityIndicator.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
-
-            activityMaskView.leadingAnchor.constraint(equalTo: customImageView.leadingAnchor),
-            activityMaskView.trailingAnchor.constraint(equalTo: customImageView.trailingAnchor),
-            activityMaskView.topAnchor.constraint(equalTo: customImageView.topAnchor),
-            activityMaskView.bottomAnchor.constraint(equalTo: customImageView.bottomAnchor)
-            ])
     }
 
     private func setupVideoIconView() {
@@ -122,7 +98,6 @@ class MediaItemImageTableViewCell: WPTableViewCell {
     }
 
     private func resetBackgroundColors() {
-        customImageView.backgroundColor = .black
         contentView.backgroundColor = .white
     }
 
@@ -132,18 +107,9 @@ class MediaItemImageTableViewCell: WPTableViewCell {
         videoIconView.center = contentView.center
     }
 
-    // MARK: - Loading
-
-    @objc var isLoading: Bool = false {
-        didSet {
-            if isLoading {
-                activityMaskView.alpha = 0.5
-                activityIndicator.startAnimating()
-            } else {
-                activityMaskView.alpha = 0
-                activityIndicator.stopAnimating()
-            }
-        }
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageLoader.prepareForReuse()
     }
 }
 
@@ -212,12 +178,6 @@ struct MediaImageRow: ImmuTableRow {
         }
     }
 
-    func willDisplay(_ cell: UITableViewCell) {
-        if let cell = cell as? MediaItemImageTableViewCell {
-            cell.customImageView.backgroundColor = .black
-        }
-    }
-
     private func setAspectRatioFor(_ cell: MediaItemImageTableViewCell) {
         guard let width = media.width, let height = media.height, width.floatValue > 0 else {
             return
@@ -262,14 +222,11 @@ struct MediaImageRow: ImmuTableRow {
     }
 
     private func loadImageFor(_ cell: MediaItemImageTableViewCell) {
-        if !cell.isLoading && cell.customImageView.image == nil {
-//            addPlaceholderImageFor(cell)
+        if cell.customImageView.image == nil {
             guard let url = imageURL else {
                 return
             }
-            cell.imageLoader.loadImage(with: url, from: media.blog, placeholder: placeholderImage, success: {
-
-            }) { (error) in
+            cell.imageLoader.loadImage(with: url, from: media.blog, placeholder: placeholderImage, success: nil) { (error) in
                 if let error = error {
                     self.show(error)
                 }
@@ -282,13 +239,6 @@ struct MediaImageRow: ImmuTableRow {
                                                                                        comment: "Error message displayed when the Media Library is unable to load a full sized preview of an item."), preferredStyle: .alert)
         alertController.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: "Verb. User action to dismiss error alert when failing to load media item."))
         alertController.presentFromRootViewController()
-    }
-
-    private func animateImageChange(image: UIImage, for cell: MediaItemImageTableViewCell) {
-        UIView.transition(with: cell.customImageView, duration: 0.2, options: .transitionCrossDissolve, animations: {
-            cell.isLoading = false
-            cell.customImageView.image = image
-        }, completion: nil)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
@@ -222,14 +222,12 @@ struct MediaImageRow: ImmuTableRow {
     }
 
     private func loadImageFor(_ cell: MediaItemImageTableViewCell) {
-        if cell.customImageView.image == nil {
-            guard let url = imageURL else {
-                return
-            }
-            cell.imageLoader.loadImage(with: url, from: media.blog, placeholder: placeholderImage, success: nil) { (error) in
-                if let error = error {
-                    self.show(error)
-                }
+        guard let url = imageURL else {
+            return
+        }
+        cell.imageLoader.loadImage(with: url, from: media.blog, placeholder: placeholderImage, success: nil) { (error) in
+            if let error = error {
+                self.show(error)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.h
+++ b/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.h
@@ -1,6 +1,6 @@
 #import <WordPressShared/WPTableViewCell.h>
 
-@protocol PostInformation;
+@protocol ImageSourceInformation;
 @class PostFeaturedImageCell;
 
 @protocol PostFeaturedImageCellDelegate <NSObject>
@@ -15,6 +15,6 @@ extern CGFloat const PostFeaturedImageCellMargin;
 @property (weak, nonatomic) id<PostFeaturedImageCellDelegate> delegate;
 @property (strong, nonatomic, readonly) UIImage *image;
 
-- (void)setImageWithURL:(NSURL *)url inPost:(id<PostInformation>)postInformation withSize:(CGSize)size;
+- (void)setImageWithURL:(NSURL *)url inPost:(id<ImageSourceInformation>)postInformation withSize:(CGSize)size;
 
 @end

--- a/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.m
@@ -28,7 +28,7 @@ CGFloat const PostFeaturedImageCellMargin = 15.0f;
     _imageLoader = [[ImageLoader alloc] initWithImageView:self.featuredImageView gifStrategy:GIFStrategyLargeGIFs];
 }
 
-- (void)setImageWithURL:(NSURL *)url inPost:(id<PostInformation>)postInformation withSize:(CGSize)size
+- (void)setImageWithURL:(NSURL *)url inPost:(id<ImageSourceInformation>)postInformation withSize:(CGSize)size
 {
     __weak PostFeaturedImageCell *weakSelf = self;
     [self.imageLoader loadImageWithURL:url fromPost:postInformation preferedSize:size placeholder:nil success:^{

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -416,12 +416,6 @@ extension MediaItemViewController {
         return tableView.rowHeight
     }
 
-    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        if let row = viewModel.rowAtIndexPath(indexPath) as? MediaImageRow {
-            row.willDisplay(cell)
-        }
-    }
-
     override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
         WPStyleGuide.configureTableViewSectionHeader(view)
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -473,6 +473,7 @@
 		7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */; };
 		7EAD7CD0206D761200BEDCFD /* MediaExternalExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */; };
 		7EBB4126206C388100012D98 /* StockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBB4125206C388100012D98 /* StockPhotosService.swift */; };
+		7ED3695520A9F091007B0D56 /* Blog+ImageSourceInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED3695420A9F091007B0D56 /* Blog+ImageSourceInformation.swift */; };
 		820ADD701F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */; };
 		820ADD721F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */; };
 		821738091FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821738081FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift */; };
@@ -1863,6 +1864,7 @@
 		7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonHeaderCell.swift; sourceTree = "<group>"; };
 		7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExternalExporter.swift; sourceTree = "<group>"; };
 		7EBB4125206C388100012D98 /* StockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosService.swift; sourceTree = "<group>"; };
+		7ED3695420A9F091007B0D56 /* Blog+ImageSourceInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+ImageSourceInformation.swift"; sourceTree = "<group>"; };
 		820ADD6C1F3A0DA0002D7F93 /* WordPress 64.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 64.xcdatamodel"; sourceTree = "<group>"; };
 		820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ThemeBrowserSectionHeaderView.xib; sourceTree = "<group>"; };
 		820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSectionHeaderView.swift; sourceTree = "<group>"; };
@@ -4961,6 +4963,7 @@
 				B54C02231F38F50100574572 /* String+RegEx.swift */,
 				FFD12D5D1FE1998D00F20A00 /* Progress+Helpers.swift */,
 				7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */,
+				7ED3695420A9F091007B0D56 /* Blog+ImageSourceInformation.swift */,
 				9F3EFCA2208E308900268758 /* UIViewController+Notice.swift */,
 			);
 			path = Extensions;
@@ -7064,6 +7067,7 @@
 				B587798619B799EB00E57C5A /* Notification+Interface.swift in Sources */,
 				984B4EF320742FCC00F87888 /* ZendeskUtils.swift in Sources */,
 				0828D7FA1E6E09AE00C7C7D4 /* WPAppAnalytics+Media.swift in Sources */,
+				7ED3695520A9F091007B0D56 /* Blog+ImageSourceInformation.swift in Sources */,
 				591AA5011CEF9BF20074934F /* Post.swift in Sources */,
 				C545E0A21811B9880020844C /* ContextManager.m in Sources */,
 				E161B7EC1F839345000FDF0B /* CookieJar.swift in Sources */,


### PR DESCRIPTION
Fixes #9354 

This PR adds support for animated gif images in the `MediaItemViewController`.

![gifs_media_item_view](https://user-images.githubusercontent.com/9772967/40058485-41615c86-581f-11e8-8b82-3e8a1488b7d8.gif)

*Notes:*
- To correctly load the thumbnail of any kind of media, it was necessary to add a new method on `ImageLoader` that accept a `Media` object as source. Hopefully this will be useful in other areas of the app too.
- The name of the protocol `PostInformation` changed to `ImageSourceInformation`, since this images are loaded outside of any post, and it was necessary for `Blog` to conform to it too.
- The loading indicator background color was black and now it is white. This will be addressed by #9357 when we unify all image loading indicator styles.

To test:
- Load different media types in your media library (gifs, images, videos, pdfs, music, etc...)
- Open the detail of all of them and check that the thumb image shows correctly.