### PR TITLE
Gif export progress fix

### DIFF
--- a/WordPress/Classes/Utility/Media/MediaAssetExporter.swift
+++ b/WordPress/Classes/Utility/Media/MediaAssetExporter.swift
@@ -225,14 +225,12 @@ class MediaAssetExporter: MediaExporter {
         options.isNetworkAccessAllowed = true
         let progress = Progress.discreteProgress(totalUnitCount: MediaExportProgressUnits.done)
         progress.isCancellable = false
-        options.progressHandler = { (progressValue) in
-            progress.completedUnitCount = Int64(progressValue * Double(MediaExportProgressUnits.done))
-        }
         let manager = PHAssetResourceManager.default()
         manager.writeData(for: resource,
                           toFile: url,
                           options: options,
                           completionHandler: { (error) in
+                            progress.completedUnitCount = progress.totalUnitCount
                             if let error = error {
                                 onError(self.exporterErrorWith(error: error))
                                 return


### PR DESCRIPTION
Fixes #9329 

This PR fixes an issue where the media upload progress never finishes when exporting a gif file.

It took me a while to figure out to what was the problem until I noticed a difference in the `mediaGlobalProgress` object when exporting static images and gifs.

This is how the `mediaGlobalProgress` object looks like in every progress update:

**Static images**
```
<NSProgress: 0x1c4133240> : Parent: 0x0 / Fraction completed: 1.0000 / Completed: 0 of 1  
  <NSProgress: 0x1c4128ca0> : Parent: 0x1c4133240 / Fraction completed: 1.0000 / Completed: 25 of 100  
    <NSProgress: 0x1c0127800> : Parent: 0x1c4128ca0 / Fraction completed: 1.0000 / Completed: 2592808 of 2592809  

<NSProgress: 0x1c4133240> : Parent: 0x0 / Fraction completed: 1.0000 / Completed: 1 of 1  
```

**Gifs** (It always got stuck at 75%)
```
<NSProgress: 0x1c03280c0> : Parent: 0x0 / Fraction completed: 0.7500 / Completed: 0 of 1  
  <NSProgress: 0x1c0328160> : Parent: 0x1c03280c0 / Fraction completed: 0.7500 / Completed: 0 of 100  
    <NSProgress: 0x1c0327440> : Parent: 0x1c0328160 / Fraction completed: 1.0000 / Completed: 679445 of 679446  
    <NSProgress: 0x1c0328200> : Parent: 0x1c0328160 / Fraction completed: 0.0000 / Completed: 0 of 1  
      <NSProgress: 0x1c03274e0> : Parent: 0x1c0328200 / Fraction completed: 0.0000 / Completed: 0 of 1  
        <NSProgress: 0x1c013d880> : Parent: 0x1c03274e0 / Fraction completed: 0.0000 / Completed: 0 of 100  


<NSProgress: 0x1c03280c0> : Parent: 0x0 / Fraction completed: 0.7500 / Completed: 0 of 1  
  <NSProgress: 0x1c0328160> : Parent: 0x1c03280c0 / Fraction completed: 0.7500 / Completed: 75 of 100  
    <NSProgress: 0x1c0328200> : Parent: 0x1c0328160 / Fraction completed: 0.0000 / Completed: 0 of 1  
      <NSProgress: 0x1c03274e0> : Parent: 0x1c0328200 / Fraction completed: 0.0000 / Completed: 0 of 1  
        <NSProgress: 0x1c013d880> : Parent: 0x1c03274e0 / Fraction completed: 0.0000 / Completed: 0 of 100  
```

Finally I noticed that the progress handler was never called in the exprortGif method (`MediaAssetExporter.swift:210`), so I manually completed the progress inside the completion handler and that seems to do the trick.

[There's a video](https://cldup.com/foZn3cmYNf.mp4)

I'm not sure if this is the best solution. @SergioEstevao could you please take a look at this?

To test:
- Start writing/editing a post.
- Add a new media item.
- Select an animated gif image from your device.
- Check that the upload finishes successfully.

cc @bummytime 
