### PR TITLE
Updates Gemfile to use cocoapods v1.5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gem 'rake'
-gem 'cocoapods', '~> 1.4.0'
+gem 'cocoapods', '~> 1.5.2'
 gem 'xcpretty-travis-formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.6)
+    CFPropertyList (3.0.0)
     activesupport (4.2.10)
       i18n (~> 0.7)
       minitest (~> 5.1)
@@ -9,12 +9,12 @@ GEM
       tzinfo (~> 1.1)
     atomos (0.1.2)
     claide (1.0.2)
-    cocoapods (1.4.0)
+    cocoapods (1.5.2)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.4.0)
+      cocoapods-core (= 1.5.2)
       cocoapods-deintegrate (>= 1.0.2, < 2.0)
-      cocoapods-downloader (>= 1.1.3, < 2.0)
+      cocoapods-downloader (>= 1.2.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-stats (>= 1.0.0, < 2.0)
@@ -24,16 +24,16 @@ GEM
       escape (~> 0.0.4)
       fourflusher (~> 2.0.1)
       gh_inspector (~> 1.0)
-      molinillo (~> 0.6.4)
+      molinillo (~> 0.6.5)
       nap (~> 1.0)
       ruby-macho (~> 1.1)
-      xcodeproj (>= 1.5.4, < 2.0)
-    cocoapods-core (1.4.0)
+      xcodeproj (>= 1.5.7, < 2.0)
+    cocoapods-core (1.5.2)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
     cocoapods-deintegrate (1.0.2)
-    cocoapods-downloader (1.1.3)
+    cocoapods-downloader (1.2.0)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
@@ -51,8 +51,8 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     minitest (5.11.3)
-    molinillo (0.6.4)
-    nanaimo (0.2.3)
+    molinillo (0.6.5)
+    nanaimo (0.2.5)
     nap (1.1.0)
     netrc (0.11.0)
     rake (12.0.0)
@@ -61,12 +61,12 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    xcodeproj (1.5.6)
-      CFPropertyList (~> 2.3.3)
+    xcodeproj (1.5.9)
+      CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.2)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
-      nanaimo (~> 0.2.3)
+      nanaimo (~> 0.2.5)
     xcpretty (0.2.4)
       rouge (~> 1.8)
     xcpretty-travis-formatter (0.0.4)
@@ -76,7 +76,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.4.0)
+  cocoapods (~> 1.5.2)
   rake
   xcpretty-travis-formatter
 


### PR DESCRIPTION
We updated `develop` to use Cocoapods to 1.5.2 in #9369. This PR updates the `Gemfile` and `Gemfile.lock` to also use 1.5.2 so `rake` and `bundler` are on the same page.

## Testing

**Note: You probably want to try the following on a fresh git clone of the WPiOS repo!**

**Clear the decks:**

(If you are using a fresh git clone of the WPiOS repo you can ignore this part)
1. In terminal, `cd` into the WordPress-iOS repo dir
2. Either run `rake clobber` **OR** manually do the following:
* Delete (or temporarily `mv`) the `vendor` dir
* Delete (or temporarily `mv`) the `.bundle` file
* Delete (or temporarily `mv`) the `Pods` dir

**Install stuff and test:**
1. Run `bundle install`
2. Run `rake dependencies`
3. Run `pod install`
4. Run `rake xcode` and then build and run WPiOS.
5. Make sure all the unit tests execute successfully.
6. Make sure BB is happy with this as well. :-)

Let me know if you have any questions!

