### PR TITLE
Zendesk Mobile: adjust position of notification alert on navigation bar

### DIFF
--- a/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXViewControllerBase.swift
@@ -182,7 +182,7 @@ extension NUXViewControllerBase where Self: UIViewController, Self: UIViewContro
 
             notificationView = helpIndicator
             helpNotificationSize = CGSize(width: 10, height: 10)
-            let notificationCenterOffset = CGPoint(x: -5, y: 3)
+            let notificationCenterOffset = CGPoint(x: 5, y: 8)
             notificationViewCenterXConstraint = notificationView.centerXAnchor.constraint(equalTo: helpButton.trailingAnchor,
                                                                                           constant: helpButton.contentEdgeInsets.top + notificationCenterOffset.x)
             notificationViewCenterYConstraint = notificationView.centerYAnchor.constraint(equalTo: helpButton.topAnchor,


### PR DESCRIPTION
Ref #9338 

To test:

Designed position:
<img width="374" alt="design" src="https://user-images.githubusercontent.com/1816888/40195828-e396b07a-59cb-11e8-9eb1-236dcd3c2fd7.png">

Implemented position:
<img width="400" alt="implemented" src="https://user-images.githubusercontent.com/1816888/40195870-04e3009e-59cc-11e8-9b06-c6818c7a6a58.png">

@SylvesterWilmott - can you take a look please? Thanks!