### PR TITLE
Updating WordPressUI Reference

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -69,7 +69,7 @@ target 'WordPress' do
   pod 'WPMediaPicker', '1.0'
   pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'2a25da7b9b687b5e05ce128423d99f771673a6c4'
   pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '2a25da7b9b687b5e05ce128423d99f771673a6c4'
-  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '8b8732049aeefe0863519e9efbd88affd1e13a19'
+  pod 'WordPressUI', '1.0.1'
 
   target 'WordPressTest' do
     inherit! :search_paths
@@ -90,7 +90,7 @@ target 'WordPress' do
 
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'2a25da7b9b687b5e05ce128423d99f771673a6c4'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '2a25da7b9b687b5e05ce128423d99f771673a6c4'
-    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '8b8732049aeefe0863519e9efbd88affd1e13a19'
+    pod 'WordPressUI', '1.0.1'
     pod 'Gridicons', '0.15'
   end
 
@@ -106,7 +106,7 @@ target 'WordPress' do
 
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'2a25da7b9b687b5e05ce128423d99f771673a6c4'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '2a25da7b9b687b5e05ce128423d99f771673a6c4'
-    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '8b8732049aeefe0863519e9efbd88affd1e13a19'
+    pod 'WordPressUI', '1.0.1'
     pod 'Gridicons', '0.15'
   end
 
@@ -137,7 +137,7 @@ target 'WordPressAuthenticator' do
   ## ====================
   ##
   pod 'Gridicons', '0.15'
-  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '8b8732049aeefe0863519e9efbd88affd1e13a19'
+  pod 'WordPressUI', '1.0.1'
 
   ## Third party libraries
   ## =====================
@@ -171,7 +171,7 @@ target 'WordPressComStatsiOS' do
   ## Automattic libraries
   ## ====================
   ##
-  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '8b8732049aeefe0863519e9efbd88affd1e13a19'
+  pod 'WordPressUI', '1.0.1'
 
   target 'WordPressComStatsiOSTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -120,7 +120,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
     - NSObject-SafeExpectations (= 0.0.2)
-  - WordPressUI (1.0)
+  - WordPressUI (1.0.1)
   - WPMediaPicker (1.0)
   - wpxmlrpc (0.8.3)
   - ZendeskSDK (1.11.2.1):
@@ -161,7 +161,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `2a25da7b9b687b5e05ce128423d99f771673a6c4`)
   - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `2a25da7b9b687b5e05ce128423d99f771673a6c4`)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `eb742da`)
-  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `8b8732049aeefe0863519e9efbd88affd1e13a19`)
+  - WordPressUI (= 1.0.1)
   - WPMediaPicker (= 1.0)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
@@ -197,6 +197,7 @@ SPEC REPOS:
     - Starscream
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
@@ -211,9 +212,6 @@ EXTERNAL SOURCES:
   WordPressShared:
     :commit: eb742da
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
-  WordPressUI:
-    :commit: 8b8732049aeefe0863519e9efbd88affd1e13a19
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -225,9 +223,6 @@ CHECKOUT OPTIONS:
   WordPressShared:
     :commit: eb742da
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
-  WordPressUI:
-    :commit: 8b8732049aeefe0863519e9efbd88affd1e13a19
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -262,11 +257,11 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-Aztec-iOS: 448c4ba1c7d748e9ed881f328963ccdc8977e0d8
   WordPressShared: b1bed3aa4db4438fd9fe78ccd0be58c8fee19c17
-  WordPressUI: 17ea58d8b73d9f6683fe1fa71b31a7734d215e39
+  WordPressUI: 9f90f8e1e629af13e1021c6281660623d62ff953
   WPMediaPicker: ceb613e43eae03268e73835d48d67f92f595aca6
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 8ea3974981273469ae2a4e59afa5ea3ff7de62d2
+PODFILE CHECKSUM: e7887ba132dac76a1e7675cc34055c9a2e092ccf
 
 COCOAPODS: 1.5.2


### PR DESCRIPTION
### Details:
This PR updates WordPressUI to Mark 1.0.1.

CC @nheagy || @ScoutHarris 
Thanks in advance (and sorry about breaking this!!!)

Thanks for helping me out @frosty !!!

### To test:
1. Fresh install WPiOS
2. Press `Login`
3. Press `Login by entering your Site's Address`
4. Press `Need Help finding (...)`

Verify nothing blows up.
