### PR TITLE
Prime for Push in Settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -121,7 +121,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
         if isDeviceStreamDisabled() {
             sections = sectionsForDisabledDeviceStream()
         } else if isDeviceStreamUnknown() {
-            sections = sectionsForUnkownDeviceStream()
+            sections = sectionsForUnknownDeviceStream()
         } else if let settings = settings, let stream = stream {
             sections = sectionsForSettings(settings, stream: stream)
         }
@@ -176,7 +176,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
         return [section]
     }
 
-    private func sectionsForUnkownDeviceStream() -> [Section] {
+    private func sectionsForUnknownDeviceStream() -> [Section] {
         defer {
             WPAnalytics.track(.pushNotificationPrimerSeen, withProperties: [Analytics.locationKey: Analytics.alertKey])
         }
@@ -240,7 +240,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
         if isDeviceStreamDisabled() {
             openApplicationSettings()
         } else if isDeviceStreamUnknown() {
-            requestNoficationAuthorization()
+            requestNotificationAuthorization()
         }
     }
 
@@ -276,7 +276,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
         UIApplication.shared.open(targetURL!)
     }
 
-    private func requestNoficationAuthorization() {
+    private func requestNotificationAuthorization() {
         defer {
             WPAnalytics.track(.pushNotificationPrimerAllowTapped, withProperties: [Analytics.locationKey: Analytics.alertKey])
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -118,7 +118,13 @@ class NotificationSettingDetailsViewController: UITableViewController {
     }
 
     @IBAction func reloadTable() {
-        sections = isDeviceStreamDisabled() ? sectionsForDisabledDeviceStream() : sectionsForSettings(settings!, stream: stream!)
+        if isDeviceStreamDisabled() {
+            sections = sectionsForDisabledDeviceStream()
+        } else if isDeviceStreamUnknown() {
+            sections = sectionsForUnkownDeviceStream()
+        } else {
+            sections = sectionsForSettings(settings!, stream: stream!)
+        }
         tableView.reloadData()
     }
 
@@ -165,6 +171,17 @@ class NotificationSettingDetailsViewController: UITableViewController {
         let footerText      = NSLocalizedString("Push Notifications have been turned off in iOS Settings App. " +
                                                 "Toggle \"Allow Notifications\" to turn them back on.",
                                                 comment: "Suggests to enable Push Notification Settings in Settings.app")
+        let section         = Section(rows: [row], footerText: footerText)
+
+        return [section]
+    }
+
+    private func sectionsForUnkownDeviceStream() -> [Section] {
+        let description     = NSLocalizedString("Allow push notifications", comment: "Shown to the user in settings when they haven't yet allowed or denied push notifications")
+        let row             = Row(kind: .Text, description: description, key: nil, value: nil)
+
+        let footerText      = NSLocalizedString("Allow WordPress to send you push notifications",
+                                                comment: "Suggests the user allow push notifications. Appears within app settings.")
         let section         = Section(rows: [row], footerText: footerText)
 
         return [section]
@@ -219,6 +236,8 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
         if isDeviceStreamDisabled() {
             openApplicationSettings()
+        } else if isDeviceStreamUnknown() {
+            // TODO: show notification request
         }
     }
 
@@ -243,6 +262,10 @@ class NotificationSettingDetailsViewController: UITableViewController {
     // MARK: - Disabled Push Notifications Handling
     private func isDeviceStreamDisabled() -> Bool {
         return stream?.kind == .Device && pushNotificationsAuthorized == .denied
+    }
+
+    private func isDeviceStreamUnknown() -> Bool {
+        return stream?.kind == .Device && pushNotificationsAuthorized == .notDetermined
     }
 
     private func openApplicationSettings() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -177,6 +177,9 @@ class NotificationSettingDetailsViewController: UITableViewController {
     }
 
     private func sectionsForUnkownDeviceStream() -> [Section] {
+        defer {
+            WPAnalytics.track(.pushNotificationPrimerSeen, withProperties: [Analytics.locationKey: Analytics.alertKey])
+        }
         let description     = NSLocalizedString("Allow push notifications", comment: "Shown to the user in settings when they haven't yet allowed or denied push notifications")
         let row             = Row(kind: .Text, description: description, key: nil, value: nil)
 
@@ -275,7 +278,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
     private func requestNoficationAuthorization() {
         defer {
-            WPAnalytics.track(.pushNotificationPrimerNoTapped, withProperties: [Analytics.locationKey: Analytics.alertKey])
+            WPAnalytics.track(.pushNotificationPrimerAllowTapped, withProperties: [Analytics.locationKey: Analytics.alertKey])
         }
         InteractiveNotificationsManager.shared.requestAuthorization { [weak self] in
             self?.refreshPushAuthorizationStatus()

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressShared
+import UserNotifications
 
 
 /// The purpose of this class is to render a collection of NotificationSettings for a given Stream,
@@ -30,7 +31,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
     /// Indicates whether push notifications have been disabled, in the device, or not.
     ///
-    private var pushNotificationsAuthorized = true {
+    private var pushNotificationsAuthorized: UNAuthorizationStatus = .notDetermined {
         didSet {
             reloadTable()
         }
@@ -241,7 +242,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
     // MARK: - Disabled Push Notifications Handling
     private func isDeviceStreamDisabled() -> Bool {
-        return stream?.kind == .Device && pushNotificationsAuthorized == false
+        return stream?.kind == .Device && pushNotificationsAuthorized == .denied
     }
 
     private func openApplicationSettings() {
@@ -251,7 +252,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
     @objc func refreshPushAuthorizationStatus() {
         PushNotificationsManager.shared.loadAuthorizationStatus { status in
-            self.pushNotificationsAuthorized = status == .authorized
+            self.pushNotificationsAuthorized = status
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -237,7 +237,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
         if isDeviceStreamDisabled() {
             openApplicationSettings()
         } else if isDeviceStreamUnknown() {
-            // TODO: show notification request
+            requestNoficationAuthorization()
         }
     }
 
@@ -271,6 +271,15 @@ class NotificationSettingDetailsViewController: UITableViewController {
     private func openApplicationSettings() {
         let targetURL = URL(string: UIApplicationOpenSettingsURLString)
         UIApplication.shared.open(targetURL!)
+    }
+
+    private func requestNoficationAuthorization() {
+        defer {
+            WPAnalytics.track(.pushNotificationPrimerNoTapped, withProperties: [Analytics.locationKey: Analytics.alertKey])
+        }
+        InteractiveNotificationsManager.shared.requestAuthorization { [weak self] in
+            self?.refreshPushAuthorizationStatus()
+        }
     }
 
     @objc func refreshPushAuthorizationStatus() {
@@ -348,5 +357,10 @@ class NotificationSettingDetailsViewController: UITableViewController {
             case Setting        = "SwitchCell"
             case Text           = "TextCell"
         }
+    }
+
+    private struct Analytics {
+        static let locationKey = "location"
+        static let alertKey = "settings"
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -122,8 +122,8 @@ class NotificationSettingDetailsViewController: UITableViewController {
             sections = sectionsForDisabledDeviceStream()
         } else if isDeviceStreamUnknown() {
             sections = sectionsForUnkownDeviceStream()
-        } else {
-            sections = sectionsForSettings(settings!, stream: stream!)
+        } else if let settings = settings, let stream = stream {
+            sections = sectionsForSettings(settings, stream: stream)
         }
         tableView.reloadData()
     }


### PR DESCRIPTION
Refs #9185

This adds a button to the push notification settings if the user ignored the prime for push alert after login.

![prime for push in settings](https://user-images.githubusercontent.com/517257/40242933-3fe42820-5a7c-11e8-8531-56aebb5b9e2b.png)

To test:
- with a fresh install login to a wpcom account
- when the push notification primer appears, tap "Not now"
- go to Me > Notification Settings > Comments on Other Sites > Push Notifications
- ensure that the new button appears
- repeat for the other two scenarios: tapping "Allow notifications" on the alert after login, and then both allowing and denying push notifications


