### PR TITLE
Enable Prime for Push for everyone

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -82,9 +82,6 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:accountInContext];
 
         [[PushNotificationsManager shared] registerForRemoteNotifications];
-        if (![Feature enabled:FeatureFlagPrimeForPush]) {
-            [[InteractiveNotificationsManager shared] requestAuthorizationWithCompletion:^{}];
-        }
     };
     if ([NSThread isMainThread]) {
         // This is meant to help with testing account observers.

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -8,7 +8,6 @@ enum FeatureFlag: Int {
     case usernameChanging
     case zendeskMobile
     case saveForLater
-    case primeForPush
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -25,8 +24,6 @@ enum FeatureFlag: Int {
             return BuildConfiguration.current == .localDeveloper
         case .saveForLater:
             return false
-        case .primeForPush:
-            return BuildConfiguration.current == .localDeveloper
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -295,9 +295,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [super viewDidAppear:animated];
     [self createUserActivity];
-    if ([Feature enabled:FeatureFlagPrimeForPush]) {
-        [self showNotificationPrimerAlert];
-    }
+    [self showNotificationPrimerAlert];
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
@@ -8,7 +8,7 @@ extension NotificationsViewController {
 
     var shouldShowPrimeForPush: Bool {
         get {
-            return Feature.enabled(.primeForPush) && !UserDefaults.standard.notificationPrimerInlineWasAcknowledged
+            return !UserDefaults.standard.notificationPrimerInlineWasAcknowledged
         }
     }
 


### PR DESCRIPTION
Refs #9185

This enables prime for push features for app store and internal builds.

To test:
- ensure prime for push features still work
- ensure the old, abrupt alert for notifications doesn't appear after login

