### PR TITLE
Save for later: Support for logged actions in ReaderSavedPostsViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -95,7 +95,8 @@ final class ReaderSavedPostsViewController: UITableViewController {
             return
         }
 
-        // TODO: Allow logged in features
+        let isLoggedIn = AccountHelper.isDotcomAvailable()
+
         if postCellActions == nil {
             postCellActions = ReaderPostCellActions(context: managedObjectContext(), origin: self, topic: topic, visibleConfirmation: false)
         }
@@ -103,7 +104,7 @@ final class ReaderSavedPostsViewController: UITableViewController {
                                                 withPost: post,
                                                 topic: topic,
                                                 delegate: postCellActions,
-                                                loggedIn: false)
+                                                loggedIn: isLoggedIn)
     }
 }
 


### PR DESCRIPTION
Implements #9413 

I don't really know if this is what I am supposed to do, but this seems to be what `ReaderStreamViewController` is doing, and, also, by this commit, it is possible to like / comment on posts that are in the Saved for Later list.

Before and after:
![loggedin](https://user-images.githubusercontent.com/2722505/40291150-ec6178d0-5c77-11e8-848c-41aa47adde04.jpg)


To test:
0. Activate feature flag
1. Navigate to Saved Post
2. Verify that the Saved Posts list is behaving as it should
