### PR TITLE
BlogList: Fixes a data source issue when switching account

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -560,6 +560,7 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)wordPressComAccountChanged:(NSNotification *)notification
 {
+    [self.tableView reloadData];
     [self setEditing:NO];
     [self updateSearchVisibility];
 }


### PR DESCRIPTION
When logging out and back in, we were seeing an issue where the system would try and reload a cell in the blog list, even though the data no longer contained any items. This created a crash because we tried to fetch data for an index path that didn't exist.

This was triggered by the call to `layoutIfNeeded` when adding the no results view in `BlogListViewController`. In this PR, we've added a call to refresh the table's data before that happens.

Original stack trace:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = Fatal error: Index out of range
 ...
  * frame #8: 0x000000010cd51031 WordPress`BlogListDataSource.blog(indexPath=2 indices, self=0x0000600000322f80) at BlogListDataSource.swift:147
    frame #9: 0x000000010cd54611 WordPress`BlogListDataSource.tableView(tableView=0x00007facf609c000, indexPath=2 indices, self=0x0000600000322f80) at BlogListDataSource.swift:315
    frame #10: 0x000000010cd5638c WordPress`@objc BlogListDataSource.tableView(_:cellForRowAt:) at BlogListDataSource.swift:0
    frame #11: 0x00000001103995c7 UIKit`-[UITableView _createPreparedCellForGlobalRow:withIndexPath:willDisplay:] + 783
    frame #12: 0x0000000110399b44 UIKit`-[UITableView _createPreparedCellForGlobalRow:willDisplay:] + 74
    frame #13: 0x0000000110360f0a UIKit`-[UITableView _updateVisibleCellsNow:isRecursive:] + 3168
    frame #14: 0x0000000110381840 UIKit`-[UITableView layoutSubviews] + 176
    frame #15: 0x000000011030b808 UIKit`-[UIView(CALayerDelegate) layoutSublayersOfLayer:] + 1515
    frame #16: 0x000000011401f61a QuartzCore`-[CALayer layoutSublayers] + 177
    frame #17: 0x000000011402382b QuartzCore`CA::Layer::layout_if_needed(CA::Transaction*) + 395
    frame #18: 0x00000001102f568d UIKit`-[UIView(Hierarchy) layoutBelowIfNeeded] + 662
    frame #19: 0x000000010ca6697d WordPress`-[BlogListViewController addNoResultsToView](self=0x00007facf1d15ac0, _cmd="addNoResultsToView") at BlogListViewController.m:274
    frame #20: 0x000000010ca66d0f WordPress`-[BlogListViewController showNoResultsViewForSiteCount:](self=0x00007facf1d15ac0, _cmd="showNoResultsViewForSiteCount:", siteCount=0) at BlogListViewController.m:293
    frame #21: 0x000000010ca667b7 WordPress`-[BlogListViewController updateViewsForCurrentSiteCount](self=0x00007facf1d15ac0, _cmd="updateViewsForCurrentSiteCount") at BlogListViewController.m:254
    frame #22: 0x000000010ca6cbff WordPress`-[BlogListViewController setEditing:animated:](self=0x00007facf1d15ac0, _cmd="setEditing:animated:", editing=NO, animated=NO) at BlogListViewController.m:815
    frame #23: 0x000000010ca69a6c WordPress`-[BlogListViewController wordPressComAccountChanged:](self=0x00007facf1d15ac0, _cmd="wordPressComAccountChanged:", notification=@"WPAccountDefaultWordPressComAccountChangedNotification") at BlogListViewController.m:563
    frame #24: 0x000000011894ab8c CoreFoundation`__CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 12
    frame #25: 0x000000011894aa65 CoreFoundation`_CFXRegistrationPost + 453
    frame #26: 0x000000011894a7a1 CoreFoundation`___CFXNotificationPost_block_invoke + 225
    frame #27: 0x000000011890c422 CoreFoundation`-[_CFXNotificationRegistrar find:object:observer:enumerator:] + 1826
    frame #28: 0x000000011890b5a1 CoreFoundation`_CFXNotificationPost + 609
    frame #29: 0x0000000114f73e57 Foundation`-[NSNotificationCenter postNotificationName:object:userInfo:] + 66
    frame #30: 0x000000010ca31c10 WordPress`__48-[AccountService setDefaultWordPressComAccount:]_block_invoke(.block_descriptor=0x0000600000253860) at AccountService.m:82
    frame #31: 0x000000010ca31a92 WordPress`-[AccountService setDefaultWordPressComAccount:](self=0x000060c00000acb0, _cmd="setDefaultWordPressComAccount:", account=0x000060c00028cb70) at AccountService.m:93
```

*To test:*

* Log into the app. It seems more likely that the crash happens if you have a lot of sites in your account (I think perhaps if they take up more than 1 screen's height in the blog list).
* In "My Sites", tap "Switch Site" to go back to the blog list.
* Tap Me and then Log out.
* Log back in again.
* In `release/10.0` the app should crash on login. In this branch, it shouldn't.