### PR TITLE
Reader Detail: Update Save for Later button title / style

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -23,7 +23,7 @@ enum FeatureFlag: Int {
         case .zendeskMobile:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .saveForLater:
-            return false
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -395,7 +395,7 @@
                                             <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="hcl-0D-0Ha"/>
                                         </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="4" maxY="0.0"/>
+                                        <inset key="titleEdgeInsets" minX="4" minY="0.0" maxX="-4" maxY="0.0"/>
                                         <state key="normal" title="0" image="icon-reader-comment">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -410,6 +410,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         WPStyleGuide.applyReaderCardTagButtonStyle(tagButton)
         WPStyleGuide.applyReaderCardActionButtonStyle(commentButton)
         WPStyleGuide.applyReaderCardActionButtonStyle(likeButton)
+        WPStyleGuide.applyReaderCardActionButtonStyle(saveForLaterButton)
     }
 
 
@@ -802,13 +803,33 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
         let size = Gridicon.defaultSize
         let icon = Gridicon.iconOfType(.bookmarkOutline, withSize: size)
-        let highlightedIcon = Gridicon.iconOfType(.bookmark, withSize: size)
+        let selectedIcon = Gridicon.iconOfType(.bookmark, withSize: size)
 
-        let tintedIcon = icon.imageWithTintColor(WPStyleGuide.greyLighten10())
-        let tintedHighlightedIcon = highlightedIcon.imageWithTintColor(WPStyleGuide.mediumBlue())
+        let normalColor = WPStyleGuide.greyLighten10()
+        let selectedColor = WPStyleGuide.mediumBlue()
+        let highlightedColor = WPStyleGuide.lightBlue()
+
+        let tintedIcon = icon.imageWithTintColor(normalColor)
+        let tintedSelectedIcon = selectedIcon.imageWithTintColor(selectedColor)
+        let tintedHighlightedIcon = icon.imageWithTintColor(highlightedColor)
+        let tintedSelectedHighlightedIcon = selectedIcon.imageWithTintColor(highlightedColor)
 
         saveForLaterButton.setImage(tintedIcon, for: .normal)
-        saveForLaterButton.setImage(tintedHighlightedIcon, for: .selected)
+        saveForLaterButton.setImage(tintedSelectedIcon, for: .selected)
+        saveForLaterButton.setImage(tintedHighlightedIcon, for: .highlighted)
+        saveForLaterButton.setImage(tintedSelectedHighlightedIcon, for: [.highlighted, .selected])
+
+        let saveTitle = NSLocalizedString("Save", comment: "Title of action button to save a Reader post to read later.")
+        let savedTitle = NSLocalizedString("Saved", comment: "Title of action button for a Reader post that has been saved to read later.")
+
+        saveForLaterButton.setTitle(saveTitle, for: .normal)
+        saveForLaterButton.setTitle(savedTitle, for: .selected)
+        saveForLaterButton.setTitle(savedTitle, for: [.highlighted, .selected])
+
+        saveForLaterButton.setTitleColor(normalColor, for: .normal)
+        saveForLaterButton.setTitleColor(selectedColor, for: .selected)
+        saveForLaterButton.setTitleColor(highlightedColor, for: .highlighted)
+        saveForLaterButton.setTitleColor(highlightedColor, for: [.highlighted, .selected])
 
         saveForLaterButton.isHidden = false
         saveForLaterButton.isSelected = post?.isSavedForLater ?? false

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -814,10 +814,6 @@ extension ReaderPostCardCell {
         return headerBlogButton
     }
 
-    func getShareButtonForTesting() -> UIButton {
-        return saveForLaterButton
-    }
-
     func getCommentsButtonForTesting() -> UIButton {
         return commentActionButton
     }

--- a/WordPress/WordPressTest/ReaderPostCardCellTests.swift
+++ b/WordPress/WordPressTest/ReaderPostCardCellTests.swift
@@ -146,7 +146,6 @@ final class ReaderPostCardCellTests: XCTestCase {
 
     private struct TestConstants {
         static let headerLabel = "Post by An author, from A blog name, "
-        static let shareLabel = "Share"
         static let moreLabel = "More"
         static let commentLabel = "2 comments"
         static let visitLabel = "Visit"
@@ -168,10 +167,6 @@ final class ReaderPostCardCellTests: XCTestCase {
     func testHeaderLabelMatchesExpectation() {
         let expectedHeaderLabel = TestConstants.headerLabel + mock!.dateForDisplay().mediumString()
         XCTAssertEqual(cell?.getHeaderButtonForTesting().accessibilityLabel, expectedHeaderLabel, "Incorrect accessibility label: Header Button ")
-    }
-
-    func testShareButtonLabelMatchesExpectation() {
-        XCTAssertEqual(cell?.getShareButtonForTesting().accessibilityLabel, TestConstants.shareLabel, "Incorrect accessibility label: Share button")
     }
 
     func testCommentsButtonLabelMatchesExpectation() {


### PR DESCRIPTION
Fixes #9425. This PR updates the Save for Later button in the Reader detail view:

* Adds a title, which is different depending on whether the post is already saved or not
* Updates the icon and tint colors for the various selection states

![save-button-states](https://user-images.githubusercontent.com/4780/40356624-8764cadc-5db1-11e8-9472-3a29810578dd.png)

**To test:**

* Build and run
* Navigate to the detail view for a post in the Reader
* Check that the appearance for the Save button in the bottom right match the illustration above