### PR TITLE
Updated Aztec to beta 18.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -67,7 +67,7 @@ target 'WordPress' do
   pod 'Gridicons', '0.15'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '1.0'
-  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'f8021013ee7df63e1c469ad550944c213888faaf'
+  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.18.2'
 
   target 'WordPressTest' do
     inherit! :search_paths
@@ -86,7 +86,7 @@ target 'WordPress' do
     shared_with_all_pods
     shared_with_networking_pods
 
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'f8021013ee7df63e1c469ad550944c213888faaf'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.18.2'
     pod 'Gridicons', '0.15'
   end
 
@@ -100,7 +100,7 @@ target 'WordPress' do
     shared_with_all_pods
     shared_with_networking_pods
 
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'f8021013ee7df63e1c469ad550944c213888faaf'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.18.2'
     pod 'Gridicons', '0.15'
   end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -113,7 +113,7 @@ PODS:
   - Starscream (3.0.4)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0-beta.18.1)
+  - WordPress-Aztec-iOS (1.0.0-beta.18.2)
   - WordPressShared (1.0.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
@@ -155,7 +155,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.4)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `f8021013ee7df63e1c469ad550944c213888faaf`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, tag `1.0.0-beta.18.2`)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `eb742da`)
   - WPMediaPicker (= 1.0)
   - wpxmlrpc (= 0.8.3)
@@ -166,8 +166,8 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPress-Aztec-iOS:
-    :commit: f8021013ee7df63e1c469ad550944c213888faaf
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+    :tag: 1.0.0-beta.18.2
   WordPressShared:
     :commit: eb742da
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
@@ -177,8 +177,8 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPress-Aztec-iOS:
-    :commit: f8021013ee7df63e1c469ad550944c213888faaf
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+    :tag: 1.0.0-beta.18.2
   WordPressShared:
     :commit: eb742da
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
@@ -214,12 +214,12 @@ SPEC CHECKSUMS:
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 2d8c58f68f422ce521db689fb582122220e77f8d
+  WordPress-Aztec-iOS: d3a8ddd82664e38a774866ccb754965ce0ca2aa1
   WordPressShared: b1bed3aa4db4438fd9fe78ccd0be58c8fee19c17
   WPMediaPicker: ceb613e43eae03268e73835d48d67f92f595aca6
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: ce4f4d0f73eb78e3b24c2ef49fe1bc8343eb15d9
+PODFILE CHECKSUM: 99e8103674726f10e8e7394d8ce633713f0356f5
 
 COCOAPODS: 1.4.0


### PR DESCRIPTION
This PR fixes an issue where an auto completion of text was being done using smaller or larger text than the original. For example replacing the word Love for the emoji ❤️ .

To test:

Create a new post
Type the word Cheers
Select the word
Activate the emoji keyboard (tap on the globe symbol)
see if on the autocompletion shows an emoji
tap on the autocompletion with the emoji
see if it not crashes.

cc: @loremattei 
