### PR TITLE
Zendesk Mobile: customize UI colors

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -67,6 +67,7 @@ extension NSNotification.Name {
                                         clientId: zdClientId)
 
         toggleZendesk(enabled: true)
+        setAppearance()
 
         // User has accessed a single ticket view, typically via the Zendesk Push Notification alert.
         // In this case, we'll clear the Push Notification indicators.
@@ -402,6 +403,8 @@ private extension ZendeskUtils {
         }
     }
 
+    // MARK: - View
+
     static func configureViewController(_ controller: UIViewController) {
         // If the controller is a UIViewController, set the modal display for iPad.
         // If the controller is a UINavigationController, do nothing as the ZD views will inherit from that.
@@ -410,6 +413,26 @@ private extension ZendeskUtils {
             controller.modalTransitionStyle = .crossDissolve
         }
         presentInController = controller
+    }
+
+    static func setAppearance() {
+
+        // Create a ZDKTheme object
+        let theme = ZDKTheme.base()
+
+        // Set color properties
+        theme.primaryTextColor = WPStyleGuide.darkGrey()
+        theme.secondaryTextColor = WPStyleGuide.darkGrey()
+        theme.primaryBackgroundColor = UIColor.white
+        theme.secondaryBackgroundColor = WPStyleGuide.lightGrey()
+        theme.emptyBackgroundColor = WPStyleGuide.greyLighten30()
+        theme.metaTextColor = WPStyleGuide.greyDarken10()
+        theme.separatorColor = WPStyleGuide.greyLighten20()
+        theme.inputFieldTextColor = WPStyleGuide.darkGrey()
+        theme.inputFieldBackgroundColor = WPStyleGuide.lightGrey()
+
+        // Apply the Theme
+        theme.apply()
     }
 
     // MARK: - Get User Information


### PR DESCRIPTION
Fixes #9446 

Per [this](https://wp.me/p9xubY-cC-p2) discussion, the Zendesk UI colors have been set to:
- primaryTextColor - #2E4453 (Gray Dark)
- secondaryTextColor - #2E4453 (Gray Dark)
- primaryBackgroundColor - #FFFFFF
- secondaryBackgroundColor - #F3F6F8 (Gray Light)
- emptyBackgroundColor - #E9EFF3 (Gray Lighten 30)
- metaTextColor - #668EAA (Gray Darken 10)
- separatorColor - #C8D7E1 (Gray Lighten 20)
- inputFieldTextColor - #2E4453 (Gray Dark)
- inputFieldBackgroundColor - #F3F6F8 (Gray Light)


To test:
- Access the Help Center, Contact Us, and My Tickets.
- Verify the colors are as stated.

**Help Center:**
![help_center](https://user-images.githubusercontent.com/1816888/40449070-ad220b70-5e94-11e8-90c7-a2f24c00f1f7.png)

**New Ticket:**
![new_ticket](https://user-images.githubusercontent.com/1816888/40449124-ca611816-5e94-11e8-8f83-3de6bd116ca6.png)
![new_ticket_text](https://user-images.githubusercontent.com/1816888/40449128-d18dc7e2-5e94-11e8-8d7d-e17d2f7fe063.png)

**Ticket List:**
![ticket_list](https://user-images.githubusercontent.com/1816888/40449149-e8c83ea6-5e94-11e8-95ca-04b2901b41c7.png)

**Individual Ticket View:**
![ticket_view](https://user-images.githubusercontent.com/1816888/40449179-fe24b338-5e94-11e8-9643-868bb7b054d5.png)
![ticket_view_text](https://user-images.githubusercontent.com/1816888/40449186-01693b5e-5e95-11e8-9627-a9ffb1981ac3.png)




