### PR TITLE
Decoding XML characters before setting left and right label text in S…

### DIFF
--- a/WordPressComStatsiOS/WordPressComStatsiOS/UI/StatsTwoColumnTableViewCell.m
+++ b/WordPressComStatsiOS/WordPressComStatsiOS/UI/StatsTwoColumnTableViewCell.m
@@ -24,8 +24,8 @@
 
 - (void)doneSettingProperties
 {
-    self.leftLabel.text = self.leftText;
-    self.rightLabel.text = self.rightText;
+    self.leftLabel.text = [self.leftText stringByDecodingXMLCharacters];
+    self.rightLabel.text = [self.rightText stringByDecodingXMLCharacters];
     self.leftHandGlyph.hidden = !self.expandable && self.selectType == StatsTwoColumnTableViewCellSelectTypeDetail;
 
     if (self.selectable) {


### PR DESCRIPTION
…tatsTwoColumnTableViewCell

Fixes #9434 
This change decodes XML characters from the string before setting it as a label text.

To test:
- change your public display name to include a '&'
- go to your site's stats and find a post that was created by that user, you should see proper name (without '&amp;')


