### PR TITLE
Merge 10.0 into 10.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -68,8 +68,8 @@ target 'WordPress' do
   pod 'Gridicons', '0.15'
   pod 'NSURL+IDN', '0.3'
   pod 'WPMediaPicker', '1.0'
-  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'2a25da7b9b687b5e05ce128423d99f771673a6c4'
-  pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '2a25da7b9b687b5e05ce128423d99f771673a6c4'
+  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.19'
+  pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.19'
   pod 'WordPressUI', '1.0.1'
 
   target 'WordPressTest' do
@@ -89,8 +89,8 @@ target 'WordPress' do
     shared_with_all_pods
     shared_with_networking_pods
 
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'2a25da7b9b687b5e05ce128423d99f771673a6c4'
-    pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '2a25da7b9b687b5e05ce128423d99f771673a6c4'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.19'
+    pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.19'
     pod 'WordPressUI', '1.0.1'
     pod 'Gridicons', '0.15'
   end
@@ -105,8 +105,8 @@ target 'WordPress' do
     shared_with_all_pods
     shared_with_networking_pods
 
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'2a25da7b9b687b5e05ce128423d99f771673a6c4'
-    pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '2a25da7b9b687b5e05ce128423d99f771673a6c4'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.19'
+    pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.19'
     pod 'WordPressUI', '1.0.1'
     pod 'Gridicons', '0.15'
   end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -113,9 +113,9 @@ PODS:
   - Starscream (3.0.4)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0-beta.18.1):
-    - WordPress-Aztec-iOS/WordPressEditor (= 1.0.0-beta.18.1)
-  - WordPress-Aztec-iOS/WordPressEditor (1.0.0-beta.18.1)
+  - WordPress-Aztec-iOS (1.0.0-beta.19):
+    - WordPress-Aztec-iOS/WordPressEditor (= 1.0.0-beta.19)
+  - WordPress-Aztec-iOS/WordPressEditor (1.0.0-beta.19)
   - WordPressKit (1.0.3):
     - AFNetworking (= 3.2.1)
     - Alamofire (= 4.7.2)
@@ -165,8 +165,8 @@ DEPENDENCIES:
   - Starscream (= 3.0.4)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `2a25da7b9b687b5e05ce128423d99f771673a6c4`)
-  - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `2a25da7b9b687b5e05ce128423d99f771673a6c4`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, tag `1.0.0-beta.19`)
+  - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, tag `1.0.0-beta.19`)
   - WordPressKit (= 1.0.3)
   - WordPressShared (= 1.0.1)
   - WordPressUI (= 1.0.1)
@@ -217,16 +217,16 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPress-Aztec-iOS:
-    :commit: 2a25da7b9b687b5e05ce128423d99f771673a6c4
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+    :tag: 1.0.0-beta.19
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPress-Aztec-iOS:
-    :commit: 2a25da7b9b687b5e05ce128423d99f771673a6c4
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+    :tag: 1.0.0-beta.19
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -259,7 +259,7 @@ SPEC CHECKSUMS:
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 448c4ba1c7d748e9ed881f328963ccdc8977e0d8
+  WordPress-Aztec-iOS: 743dbe41492eae1d9daf3f5ba5435ab295ee668f
   WordPressKit: 58a8663d557c4c8def59b6492f9ef7736a69b60d
   WordPressShared: 13a743d923796382419e03521e47491e9322087e
   WordPressUI: 9f90f8e1e629af13e1021c6281660623d62ff953
@@ -267,6 +267,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 093103ebe66b3749e8a7325380ca79e77c98d283
+PODFILE CHECKSUM: 5b25d733014591f7fc8a4c23617b1cc0612c13c7
 
 COCOAPODS: 1.5.2

--- a/WordPressAuthenticator/WordPressAuthenticator/Signin/LoginEmailViewController.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/Signin/LoginEmailViewController.swift
@@ -567,7 +567,8 @@ extension LoginEmailViewController: LoginSocialErrorViewControllerDelegate {
     func retryAsSignup() {
         cleanupAfterSocialErrors()
 
-        let storyboard = UIStoryboard(name: "Signup", bundle: nil)
+
+        let storyboard = UIStoryboard(name: "Signup", bundle: Bundle(for: LoginEmailViewController.self))
         if let controller = storyboard.instantiateViewController(withIdentifier: "emailEntry") as? SignupEmailViewController {
             controller.loginFields = loginFields
             navigationController?.pushViewController(controller, animated: true)


### PR DESCRIPTION
This PR merges the fixes in 10.0.2 into the release/10.1.

Due to the fact that Aztec editor in 10.1 is newer that the one in 10.0, the branches were not directly mergeable.

What's in this PR:
- merged release/10.0 into release/10.1 -> took Nate's fix, kept 10.1 version of Aztec
- updated Aztec version to Beta-19 (which should be the Aztec in 10.1 + emoji fix).

Please, check it with a lot of care :-) 
cc/ @diegoreymendez @elibud @SergioEstevao 

