### PR TITLE
Reader Save for Later: Adds analytics

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def shared_with_all_pods
-  pod 'WordPressShared', '1.0.2'
+  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'add/reader-save-for-later-analytics'
   pod 'CocoaLumberjack', '3.4.2'
   pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
   pod 'NSObject-SafeExpectations', '0.0.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -168,7 +168,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae`)
   - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae`)
   - WordPressKit (= 1.0.4)
-  - WordPressShared (= 1.0.2)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `add/reader-save-for-later-analytics`)
   - WordPressUI (= 1.0.1)
   - WPMediaPicker (= 1.0)
   - wpxmlrpc (= 0.8.3)
@@ -206,7 +206,6 @@ SPEC REPOS:
     - SVProgressHUD
     - UIDeviceIdentifier
     - WordPressKit
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -219,6 +218,9 @@ EXTERNAL SOURCES:
   WordPress-Aztec-iOS:
     :commit: d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPressShared:
+    :branch: add/reader-save-for-later-analytics
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -227,6 +229,9 @@ CHECKOUT OPTIONS:
   WordPress-Aztec-iOS:
     :commit: d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPressShared:
+    :commit: 89f05883295000fb9b0a5a3ad02f16c328354e52
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -267,6 +272,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: d22c7eddec744f231bce0eb52ccb5a23eaab8e70
+PODFILE CHECKSUM: 3198075362d49b279412e47ffbbade443063b2f8
 
 COCOAPODS: 1.5.2

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -997,6 +997,18 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatReaderListNotificationEnabled:
             eventName = @"followed_blog_notifications_reader_enabled";
             break;
+        case WPAnalyticsStatReaderPostSaved:
+            eventName = @"reader_post_saved";
+            break;
+        case WPAnalyticsStatReaderPostUnsaved:
+            eventName = @"reader_post_unsaved";
+            break;
+        case WPAnalyticsStatReaderSavedPostOpened:
+            eventName = @"reader_saved_post_opened";
+            break;
+        case WPAnalyticsStatReaderSavedListViewed:
+            eventName = @"reader_saved_list_viewed";
+            break;
         case WPAnalyticsStatReaderSearchLoaded:
             eventName = @"reader_search_loaded";
             break;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -984,7 +984,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             return
         }
 
-        ReaderSaveForLaterAction().execute(with: readerPost, context: context) { [weak self] in
+        ReaderSaveForLaterAction().execute(with: readerPost, context: context, origin: .postDetail) { [weak self] in
             self?.saveForLaterButton.isSelected = readerPost.isSavedForLater
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -320,18 +320,21 @@ import WordPressShared
 
     /// Presents the saved for later view controller
     @objc func showSavedForLater() {
-        guard let indexPath = viewModel.indexPathOfSavedForLater() else {
-            return
+        guard let indexPath = viewModel.indexPathOfSavedForLater(),
+            let menuItem = viewModel.menuItemAtIndexPath(indexPath),
+            let viewController = viewControllerForMenuItem(menuItem) else {
+                return
         }
 
         tableView.selectRow(at: indexPath, animated: false, scrollPosition: .middle)
-        self.tableView(self.tableView, didSelectRowAt: indexPath)
+        restorableSelectedIndexPath = indexPath
+
+        showDetailViewController(viewController, sender: self)
     }
 
     fileprivate func viewControllerForSavedPosts() -> ReaderSavedPostsViewController {
         return ReaderSavedPostsViewController()
     }
-
 
     /// Presents a new view controller for subscribing to a new tag.
     ///
@@ -503,6 +506,10 @@ import WordPressShared
             tableView.deselectSelectedRowWithAnimation(true)
             showAddTag()
             return
+        }
+
+        if menuItem.type == .savedPosts {
+            trackSavedPostsNavigation()
         }
 
         restorableSelectedIndexPath = indexPath

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -97,7 +97,14 @@ final class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
     }
 
     fileprivate func toggleSavedForLater(for post: ReaderPost) {
-        ReaderSaveForLaterAction(visibleConfirmation: visibleConfirmation).execute(with: post, context: context)
+        let actionOrigin: ReaderSaveForLaterOrigin
+        if origin is ReaderSavedPostsViewController {
+            actionOrigin = .savedStream
+        } else {
+            actionOrigin = .otherStream
+        }
+
+        ReaderSaveForLaterAction(visibleConfirmation: visibleConfirmation).execute(with: post, context: context, origin: actionOrigin)
     }
 
     fileprivate func visitSiteForPost(_ post: ReaderPost) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -18,6 +18,19 @@ enum ReaderSaveForLaterOrigin {
             return ""
         }
     }
+
+    fileprivate var viewAllPostsValue: String {
+        switch self {
+        case .savedStream:
+            return "post_list_saved_post_notice"
+        case .otherStream:
+            return "post_list_saved_post_notice"
+        case .postDetail:
+            return "post_details_saved_post_notice"
+        case .readerMenu:
+            return "reader_filter"
+        }
+    }
 }
 
 
@@ -34,5 +47,17 @@ extension ReaderSaveForLaterAction {
         } else {
             WPAppAnalytics.track(.readerPostUnsaved, withProperties: properties)
         }
+    }
+
+    func trackViewAllSavedPostsAction(origin: ReaderSaveForLaterOrigin) {
+        let properties = [ readerSaveForLaterSourceKey: origin.viewAllPostsValue ]
+
+        WPAppAnalytics.track(.readerSavedListViewed, withProperties: properties)
+    }
+}
+
+extension ReaderMenuViewController {
+    func trackSavedPostsNavigation() {
+        WPAppAnalytics.track(.readerSavedListViewed, withProperties: [ readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.readerMenu.viewAllPostsValue ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum ReaderSaveForLaterOrigin {
+    case savedStream
+    case otherStream
+    case postDetail
+    case readerMenu
+
+    fileprivate var saveActionValue: String {
+        switch self {
+        case .savedStream:
+            return "saved_post_list"
+        case .otherStream:
+            return "other_post_list"
+        case .postDetail:
+            return "post_details"
+        case .readerMenu:
+            return ""
+        }
+    }
+}
+
+
+private let readerSaveForLaterSourceKey = "source"
+
+extension ReaderSaveForLaterAction {
+    func trackSaveAction(for post: ReaderPost, origin: ReaderSaveForLaterOrigin) {
+        let willSave = (post.isSavedForLater == false)
+
+        let properties = [ readerSaveForLaterSourceKey: origin.saveActionValue ]
+
+        if willSave {
+            WPAppAnalytics.track(.readerPostSaved, withProperties: properties)
+        } else {
+            WPAppAnalytics.track(.readerPostUnsaved, withProperties: properties)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -19,6 +19,19 @@ enum ReaderSaveForLaterOrigin {
         }
     }
 
+    fileprivate var openPostValue: String {
+        switch self {
+        case .savedStream:
+            return "saved_post_list"
+        case .otherStream:
+            return "other_post_list"
+        case .postDetail:
+            return ""
+        case .readerMenu:
+            return ""
+        }
+    }
+
     fileprivate var viewAllPostsValue: String {
         switch self {
         case .savedStream:
@@ -59,5 +72,17 @@ extension ReaderSaveForLaterAction {
 extension ReaderMenuViewController {
     func trackSavedPostsNavigation() {
         WPAppAnalytics.track(.readerSavedListViewed, withProperties: [ readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.readerMenu.viewAllPostsValue ])
+    }
+}
+
+extension ReaderSavedPostsViewController {
+    func trackSavedPostNavigation() {
+        WPAppAnalytics.track(.readerSavedPostOpened, withProperties: [ readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.savedStream.openPostValue ])
+    }
+}
+
+extension ReaderStreamViewController {
+    func trackSavedPostNavigation() {
+        WPAppAnalytics.track(.readerSavedPostOpened, withProperties: [ readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.otherStream.openPostValue ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
@@ -70,6 +70,7 @@ final class ReaderSaveForLaterAction {
                             feedbackType: .success,
                             actionTitle: Strings.undo,
                             actionHandler: {
+                                self.trackSaveAction(for: post, origin: origin)
                                 self.toggleSavedForLater(post, context: context, origin: origin, completion: completion)
         })
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
@@ -17,11 +17,12 @@ final class ReaderSaveForLaterAction {
         self.visibleConfirmation = visibleConfirmation
     }
 
-    func execute(with post: ReaderPost, context: NSManagedObjectContext, completion: (() -> Void)? = nil) {
-        toggleSavedForLater(post, context: context, completion: completion)
+    func execute(with post: ReaderPost, context: NSManagedObjectContext, origin: ReaderSaveForLaterOrigin, completion: (() -> Void)? = nil) {
+        trackSaveAction(for: post, origin: origin)
+        toggleSavedForLater(post, context: context, origin: origin, completion: completion)
     }
 
-    private func toggleSavedForLater(_ post: ReaderPost, context: NSManagedObjectContext, completion: (() -> Void)?) {
+    private func toggleSavedForLater(_ post: ReaderPost, context: NSManagedObjectContext, origin: ReaderSaveForLaterOrigin, completion: (() -> Void)?) {
         let readerPostService = ReaderPostService(managedObjectContext: context)
 
         readerPostService.toggleSavedForLater(for: post, success: {
@@ -33,7 +34,7 @@ final class ReaderSaveForLaterAction {
         })
     }
 
-    private func presentSuccessNotice(for post: ReaderPost, context: NSManagedObjectContext, completion: (() -> Void)?) {
+    private func presentSuccessNotice(for post: ReaderPost, context: NSManagedObjectContext, origin: ReaderSaveForLaterOrigin, completion: (() -> Void)?) {
         guard visibleConfirmation else {
             return
         }
@@ -43,6 +44,7 @@ final class ReaderSaveForLaterAction {
         } else {
             presentPostRemovedNotice(for: post,
                                      context: context,
+                                     origin: origin,
                                      completion: completion)
         }
     }
@@ -58,7 +60,7 @@ final class ReaderSaveForLaterAction {
         present(notice)
     }
 
-    private func presentPostRemovedNotice(for post: ReaderPost, context: NSManagedObjectContext, completion: (() -> Void)?) {
+    private func presentPostRemovedNotice(for post: ReaderPost, context: NSManagedObjectContext, origin: ReaderSaveForLaterOrigin, completion: (() -> Void)?) {
         guard visibleConfirmation else {
             return
         }
@@ -67,7 +69,7 @@ final class ReaderSaveForLaterAction {
                             feedbackType: .success,
                             actionTitle: Strings.undo,
                             actionHandler: {
-                                self.toggleSavedForLater(post, context: context, completion: completion)
+                                self.toggleSavedForLater(post, context: context, origin: origin, completion: completion)
         })
 
         present(notice)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterAction.swift
@@ -26,7 +26,7 @@ final class ReaderSaveForLaterAction {
         let readerPostService = ReaderPostService(managedObjectContext: context)
 
         readerPostService.toggleSavedForLater(for: post, success: {
-            self.presentSuccessNotice(for: post, context: context, completion: completion)
+            self.presentSuccessNotice(for: post, context: context, origin: origin, completion: completion)
             completion?()
             }, failure: { error in
                 self.presentErrorNotice(error, activating: !post.isSavedForLater)
@@ -40,7 +40,7 @@ final class ReaderSaveForLaterAction {
         }
 
         if post.isSavedForLater {
-            presentPostSavedNotice()
+            presentPostSavedNotice(origin: origin)
         } else {
             presentPostRemovedNotice(for: post,
                                      context: context,
@@ -49,11 +49,12 @@ final class ReaderSaveForLaterAction {
         }
     }
 
-    private func presentPostSavedNotice() {
+    private func presentPostSavedNotice(origin: ReaderSaveForLaterOrigin) {
         let notice = Notice(title: Strings.postSaved,
                             feedbackType: .success,
                             actionTitle: Strings.viewAll,
                             actionHandler: {
+                                self.trackViewAllSavedPostsAction(origin: origin)
                                 self.showAll()
         })
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -297,11 +297,6 @@ extension ReaderSavedPostsViewController: WPTableViewHandlerDelegate {
             return
         }
 
-        //        if recentlyBlockedSitePostObjectIDs.contains(apost.objectID) {
-        //            unblockSiteForPost(apost)
-        //            return
-        //        }
-
         if let topic = post.topic, ReaderHelpers.isTopicSearchTopic(topic) {
             WPAppAnalytics.track(.readerSearchResultTapped)
 
@@ -326,6 +321,8 @@ extension ReaderSavedPostsViewController: WPTableViewHandlerDelegate {
             controller = ReaderDetailViewController.controllerWithPost(post)
 
         }
+
+        trackSavedPostNavigation()
 
         navigationController?.pushFullscreenViewController(controller, animated: true)
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1469,6 +1469,10 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
 
         }
 
+        if post.isSavedForLater {
+            trackSavedPostNavigation()
+        }
+
         navigationController?.pushFullscreenViewController(controller, animated: true)
 
         tableView.deselectRow(at: indexPath, animated: false)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		1759F1701FE017BF0003EC81 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1759F16F1FE017BF0003EC81 /* Queue.swift */; };
 		1759F1721FE017F20003EC81 /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1759F1711FE017F20003EC81 /* QueueTests.swift */; };
 		1759F1801FE1460C0003EC81 /* NoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1759F17F1FE1460C0003EC81 /* NoticeView.swift */; };
+		175A650C20B6F7280023E71B /* ReaderSaveForLater+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 175A650B20B6F7280023E71B /* ReaderSaveForLater+Analytics.swift */; };
 		176579F71C63A40F0000978E /* PurchaseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176579F61C63A40F0000978E /* PurchaseButton.swift */; };
 		1767494E1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */; };
 		176DEEE91D4615FE00331F30 /* WPSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */; };
@@ -1467,6 +1468,7 @@
 		1759F16F1FE017BF0003EC81 /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
 		1759F1711FE017F20003EC81 /* QueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTests.swift; sourceTree = "<group>"; };
 		1759F17F1FE1460C0003EC81 /* NoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeView.swift; sourceTree = "<group>"; };
+		175A650B20B6F7280023E71B /* ReaderSaveForLater+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderSaveForLater+Analytics.swift"; sourceTree = "<group>"; };
 		176579F61C63A40F0000978E /* PurchaseButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PurchaseButton.swift; sourceTree = "<group>"; };
 		1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSearchHeaderView.swift; sourceTree = "<group>"; };
 		176DEEE81D4615FE00331F30 /* WPSplitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPSplitViewController.swift; sourceTree = "<group>"; };
@@ -5555,6 +5557,7 @@
 				D8212CC420AA83F9008E8AE8 /* ReaderCommentAction.swift */,
 				D8212CC620AA85C1008E8AE8 /* ReaderHeaderAction.swift */,
 				D8212CC820AA87E5008E8AE8 /* ReaderMenuAction.swift */,
+				175A650B20B6F7280023E71B /* ReaderSaveForLater+Analytics.swift */,
 			);
 			name = ReaderPostActions;
 			sourceTree = "<group>";
@@ -7039,6 +7042,7 @@
 				B5ECA6CA1DBAA0020062D7E0 /* CoreDataHelper.swift in Sources */,
 				FFC6ADDA1B56F366002F3C84 /* LocalCoreDataService.m in Sources */,
 				B587798619B799EB00E57C5A /* Notification+Interface.swift in Sources */,
+				175A650C20B6F7280023E71B /* ReaderSaveForLater+Analytics.swift in Sources */,
 				984B4EF320742FCC00F87888 /* ZendeskUtils.swift in Sources */,
 				0828D7FA1E6E09AE00C7C7D4 /* WPAppAnalytics+Media.swift in Sources */,
 				7ED3695520A9F091007B0D56 /* Blog+ImageSourceInformation.swift in Sources */,


### PR DESCRIPTION
Fixes #9349. 

This PR adds analytics tracking for the Reader Save for Later feature. It's intended to match as closely as possible the Android [events](https://github.com/wordpress-mobile/WordPress-Android/issues/7716) and [tracking](https://github.com/wordpress-mobile/WordPress-Android/pull/7776)

**Notes:** 

* This currently points to a branch of `WordPress-Shared-iOS` with the new events: `add/reader-save-for-later-analytics`. I'll make a new release of the pod before merging this.

There were one or two cases from the Android PR that we can't / don't track here:

*   `READER_POST_SAVED_FROM_SAVED_POST_LIST` – This will be possible once we add a way to undo unsaving a post on the Saved Posts list.
* `READER_SAVED_LIST_VIEWED_FROM_POST_DETAILS_NOTICE` we currently don't trigger the notice that contains a 'view all' action from the post details screen.

**To test:**

* Perform each of the events in the Reader, and check the corresponding action is logged in the console with a 🔵:

- [x] In a list that _isn't_ "Saved Posts" (e.g. Followed Sites) tap the bookmark icon on a post to save it.
  - **Event:** `reader_post_saved` **Properties:** `source: other_post_list`
- [x] In the same post, tap the icon again to unsave the post.
  - **Event:** `reader_post_unsaved` **Properties:** `source: other_post_list`
- [x] Save the post again and tap into the details.
  - **Event:** `reader_saved_post_opened` **Properties:** `source: other_post_list`
- [x] On the details screen, tap the Save button to unsave the post.
  - **Event:** `reader_post_unsaved ` **Properties:** `source: post_details`
- [x] Tap the Save button again to save the post again.
  - **Event:** `reader_post_saved ` **Properties:** `source: post_details`
- [x] Tap back to the list, and tap the Save button of the post again to unsave it once more. In the Notice that appears at the bottom of the screen, tap Undo.
  - **Event:** `reader_post_saved` **Properties:** `source: other_post_list`
- [x] Tap the save icon one more time to save the post again. In the Notice that appears at the bottom of the screen, tap "View All"
  - **Event:** `reader_saved_list_viewed` **Properties:** `source: post_list_saved_post_notice`
- [x] You should now be on the saved posts list, with a post there. Tap into the post.
  - **Event:** `reader_saved_post_opened` **Properties:** `source: saved_post_list`
- [x] Tap Back to go back to the saved posts list. Tap the Save icon on the post to unsave it.
  - **Event:** `reader_post_unsaved ` **Properties:** `source: saved_post_list`
- [x] Tap Back again to go to the Reader menu. Tap "Saved Posts".
  - **Event:** `reader_saved_list_viewed` **Properties:** `source: reader_filter`

I think that covers everything!

cc @khaykov – Care to check over this too?