### PR TITLE
Update WordPressUI version.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -70,7 +70,7 @@ target 'WordPress' do
   pod 'WPMediaPicker', '1.0'
   pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e98d89780ddd12e79144b3c66f74dae183a8c4c9'
   pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'e98d89780ddd12e79144b3c66f74dae183a8c4c9'
-  pod 'WordPressUI', '1.0.1'
+  pod 'WordPressUI', '1.0.2'
 
   target 'WordPressTest' do
     inherit! :search_paths
@@ -91,7 +91,7 @@ target 'WordPress' do
 
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e98d89780ddd12e79144b3c66f74dae183a8c4c9'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'e98d89780ddd12e79144b3c66f74dae183a8c4c9'
-    pod 'WordPressUI', '1.0.1'
+    pod 'WordPressUI', '1.0.2'
     pod 'Gridicons', '0.15'
   end
 
@@ -107,7 +107,7 @@ target 'WordPress' do
 
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e98d89780ddd12e79144b3c66f74dae183a8c4c9'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'e98d89780ddd12e79144b3c66f74dae183a8c4c9'
-    pod 'WordPressUI', '1.0.1'
+    pod 'WordPressUI', '1.0.2'
     pod 'Gridicons', '0.15'
   end
 
@@ -138,7 +138,7 @@ target 'WordPressAuthenticator' do
   ## ====================
   ##
   pod 'Gridicons', '0.15'
-  pod 'WordPressUI', '1.0.1'
+  pod 'WordPressUI', '1.0.2'
 
   ## Third party libraries
   ## =====================
@@ -172,7 +172,7 @@ target 'WordPressComStatsiOS' do
   ## Automattic libraries
   ## ====================
   ##
-  pod 'WordPressUI', '1.0.1'
+  pod 'WordPressUI', '1.0.2'
 
   target 'WordPressComStatsiOSTests' do
     inherit! :search_paths

--- a/Podfile
+++ b/Podfile
@@ -70,7 +70,7 @@ target 'WordPress' do
   pod 'WPMediaPicker', '1.0'
   pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae'
   pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'd5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae'
-  pod 'WordPressUI', '1.0.1'
+  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => 'f51c279106c0b08086b8935265c72073ac426b5d'
 
   target 'WordPressTest' do
     inherit! :search_paths
@@ -91,7 +91,7 @@ target 'WordPress' do
 
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'd5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae'
-    pod 'WordPressUI', '1.0.1'
+    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => 'f51c279106c0b08086b8935265c72073ac426b5d'
     pod 'Gridicons', '0.15'
   end
 
@@ -107,7 +107,7 @@ target 'WordPress' do
 
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'd5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae'
-    pod 'WordPressUI', '1.0.1'
+    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => 'f51c279106c0b08086b8935265c72073ac426b5d'
     pod 'Gridicons', '0.15'
   end
 
@@ -138,7 +138,7 @@ target 'WordPressAuthenticator' do
   ## ====================
   ##
   pod 'Gridicons', '0.15'
-  pod 'WordPressUI', '1.0.1'
+  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => 'f51c279106c0b08086b8935265c72073ac426b5d'
 
   ## Third party libraries
   ## =====================
@@ -172,7 +172,7 @@ target 'WordPressComStatsiOS' do
   ## Automattic libraries
   ## ====================
   ##
-  pod 'WordPressUI', '1.0.1'
+  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => 'f51c279106c0b08086b8935265c72073ac426b5d'
 
   target 'WordPressComStatsiOSTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -127,7 +127,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
     - NSObject-SafeExpectations (= 0.0.2)
-  - WordPressUI (1.0.1)
+  - WordPressUI (1.0.2)
   - WPMediaPicker (1.0)
   - wpxmlrpc (0.8.3)
   - ZendeskSDK (1.11.2.1):
@@ -169,7 +169,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `e98d89780ddd12e79144b3c66f74dae183a8c4c9`)
   - WordPressKit (= 1.0.4)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `add/reader-save-for-later-analytics`)
-  - WordPressUI (= 1.0.1)
+  - WordPressUI (= 1.0.2)
   - WPMediaPicker (= 1.0)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
@@ -267,11 +267,11 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 743dbe41492eae1d9daf3f5ba5435ab295ee668f
   WordPressKit: 4444d268171d0e1fd34f513513c16c1289a2bafa
   WordPressShared: 378a62d09417209278bf68b57720579dbcd76e0c
-  WordPressUI: 9f90f8e1e629af13e1021c6281660623d62ff953
+  WordPressUI: 70bceaff582bdd6fd8f3ed67aaa200e72fce245d
   WPMediaPicker: ceb613e43eae03268e73835d48d67f92f595aca6
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: b37f7aa0ddb0b46549635a7f6e8869ecf0d4425a
+PODFILE CHECKSUM: c5988bf1ddd6cd434230eecec496b156f1e4ff15
 
 COCOAPODS: 1.5.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -127,7 +127,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
     - NSObject-SafeExpectations (= 0.0.2)
-  - WordPressUI (1.0.1)
+  - WordPressUI (1.0.2)
   - WPMediaPicker (1.0)
   - wpxmlrpc (0.8.3)
   - ZendeskSDK (1.11.2.1):
@@ -169,7 +169,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae`)
   - WordPressKit (= 1.0.4)
   - WordPressShared (= 1.0.2)
-  - WordPressUI (= 1.0.1)
+  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `f51c279106c0b08086b8935265c72073ac426b5d`)
   - WPMediaPicker (= 1.0)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
@@ -207,7 +207,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPressKit
     - WordPressShared
-    - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
@@ -219,6 +218,9 @@ EXTERNAL SOURCES:
   WordPress-Aztec-iOS:
     :commit: d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPressUI:
+    :commit: f51c279106c0b08086b8935265c72073ac426b5d
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -227,6 +229,9 @@ CHECKOUT OPTIONS:
   WordPress-Aztec-iOS:
     :commit: d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPressUI:
+    :commit: f51c279106c0b08086b8935265c72073ac426b5d
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -262,11 +267,11 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 448c4ba1c7d748e9ed881f328963ccdc8977e0d8
   WordPressKit: 4444d268171d0e1fd34f513513c16c1289a2bafa
   WordPressShared: 378a62d09417209278bf68b57720579dbcd76e0c
-  WordPressUI: 9f90f8e1e629af13e1021c6281660623d62ff953
+  WordPressUI: 70bceaff582bdd6fd8f3ed67aaa200e72fce245d
   WPMediaPicker: ceb613e43eae03268e73835d48d67f92f595aca6
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: d22c7eddec744f231bce0eb52ccb5a23eaab8e70
+PODFILE CHECKSUM: 4ab76912a81564c0bff8adcaf6d5150d3a2f1e58
 
 COCOAPODS: 1.5.2


### PR DESCRIPTION
Fixes #9296 

At the moment the podfile referece is to a commit but if all it's ok will release a new version of the pod and update to a proper version.

To test:
 - Open the app
 - Open notifications tab
 - Scroll up and down
 - Check that all gravatars/icons are correct and assigned to the proper cell.


