### PR TITLE
Setting isHidden to false when configuring SaveForLater button.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -469,6 +469,7 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
 
 
     fileprivate func configureSaveForLaterButton() {
+        saveForLaterButton.isHidden = false
         let postIsSavedForLater = contentProvider?.isSavedForLater() ?? false
         saveForLaterButton.isSelected = postIsSavedForLater
     }


### PR DESCRIPTION
Fixes #9454 

This change sets SaveForLater button as visible when it is configured for reuse.

To test:
- Open Reader tab, tap on Discover cell
Case 1:
- Scroll through posts having SaveForLater button and scroll back. The button should still be visible
Case 2:
- Tap on SaveForLater button in any post. The button should still remain visible.


