### PR TITLE
Notifications: Present network alert only after a manual refresh

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -118,8 +118,6 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         setupFiltersSegmentedControl()
 
         reloadTableViewPreservingSelection()
-
-        observeNetworkStatus()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -816,10 +814,10 @@ extension NotificationsViewController {
             DispatchQueue.main.asyncAfter(deadline: delay) {
                 self?.refreshControl?.endRefreshing()
                 self?.clearUnreadNotifications()
-            }
 
-            if let _ = error {
-                self?.handleConnectionError()
+                if let _ = error {
+                    self?.handleConnectionError()
+                }
             }
         }
     }
@@ -1247,7 +1245,6 @@ internal extension NotificationsViewController {
 private extension NotificationsViewController {
     func syncNewNotifications() {
         guard connectionAvailable() else {
-            handleConnectionError()
             return
         }
 


### PR DESCRIPTION
Fixes #9305 

To test:
1. Load notifications.
2. Turn on Airplane mode.
3. Navigate to one notification detail.
4. Navigate back to the list. There should not be any alerts
5. Pull the notification list down to refresh. There should be an alert (only when there is no network connection)
