### PR TITLE
Issue/9463 Improve Save for Later accessibility

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def shared_with_all_pods
-  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'add/reader-save-for-later-analytics'
+  pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'no-results-accessibility'
   pod 'CocoaLumberjack', '3.4.2'
   pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
   pod 'NSObject-SafeExpectations', '0.0.2'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -168,7 +168,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae`)
   - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae`)
   - WordPressKit (= 1.0.4)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `add/reader-save-for-later-analytics`)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `no-results-accessibility`)
   - WordPressUI (= 1.0.1)
   - WPMediaPicker (= 1.0)
   - wpxmlrpc (= 0.8.3)
@@ -219,7 +219,7 @@ EXTERNAL SOURCES:
     :commit: d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressShared:
-    :branch: add/reader-save-for-later-analytics
+    :branch: no-results-accessibility
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
@@ -230,7 +230,7 @@ CHECKOUT OPTIONS:
     :commit: d5d9fbcf21cbd16bca9876b37f1f44c8ff8bc3ae
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressShared:
-    :commit: 89f05883295000fb9b0a5a3ad02f16c328354e52
+    :commit: b8d340d3b740f6ea548b9e948a8d20849715be7e
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
@@ -272,6 +272,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 3198075362d49b279412e47ffbbade443063b2f8
+PODFILE CHECKSUM: a4798b8e865bf117da50292c25be53ff1ba1c53f
 
 COCOAPODS: 1.5.2

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -986,6 +986,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
         ReaderSaveForLaterAction().execute(with: readerPost, context: context, origin: .postDetail) { [weak self] in
             self?.saveForLaterButton.isSelected = readerPost.isSavedForLater
+            self?.prepareActionButtonsForVoiceOver()
         }
     }
 
@@ -1232,6 +1233,7 @@ extension ReaderDetailViewController: Accessible {
         prepareMenuForVoiceOver()
         prepareHeaderForVoiceOver()
         prepareContentForVoiceOver()
+        prepareActionButtonsForVoiceOver()
     }
 
     private func prepareMenuForVoiceOver() {
@@ -1283,5 +1285,11 @@ extension ReaderDetailViewController: Accessible {
 
         titleLabel.accessibilityLabel = title
         titleLabel.accessibilityTraits = UIAccessibilityTraitStaticText
+    }
+
+    private func prepareActionButtonsForVoiceOver() {
+        let isSavedForLater = post?.isSavedForLater ?? false
+        saveForLaterButton.accessibilityLabel = isSavedForLater ? NSLocalizedString("Saved Post", comment: "Accessibility label for the 'Save Post' button when a post has been saved.") : NSLocalizedString("Save post", comment: "Accessibility label for the 'Save Post' button.")
+        saveForLaterButton.accessibilityHint = isSavedForLater ? NSLocalizedString("Remove this post from my saved posts.", comment: "Accessibility hint for the 'Save Post' button when a post is already saved.") : NSLocalizedString("Saves this post for later.", comment: "Accessibility hint for the 'Save Post' button.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -498,7 +498,7 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
 
             let likeTitle = WPStyleGuide.likeCountForDisplay(likeCount)
             let commentTitle = WPStyleGuide.commentCountForDisplay(commentCount)
-            let saveForLaterTitle = FeatureFlag.saveForLater.enabled ? NSLocalizedString("Save for Later", comment: "Verb. Button title.  Tap to save a post for later.") : NSLocalizedString("Share", comment: "Verb. Button title.  Tap to share a post.")
+            let saveForLaterTitle = FeatureFlag.saveForLater.enabled ? NSLocalizedString("Save", comment: "Verb. Button title.  Tap to save a post for later.") : NSLocalizedString("Share", comment: "Verb. Button title.  Tap to share a post.")
             let followTitle = WPStyleGuide.followStringForDisplay(false)
             let followingTitle = WPStyleGuide.followStringForDisplay(true)
 
@@ -628,7 +628,11 @@ extension ReaderPostCardCell: Accessible {
     func prepareForVoiceOver() {
         prepareCardForVoiceOver()
         prepareHeaderButtonForVoiceOver()
-        prepareShareForVoiceOver()
+        if FeatureFlag.saveForLater.enabled {
+            prepareSaveForLaterForVoiceOver()
+        } else {
+            prepareShareForVoiceOver()
+        }
         prepareCommentsForVoiceOver()
         prepareLikeForVoiceOver()
         prepareMenuForVoiceOver()
@@ -685,10 +689,16 @@ extension ReaderPostCardCell: Accessible {
         return String(format: format, title)
     }
 
+    private func prepareSaveForLaterForVoiceOver() {
+        let isSavedForLater = contentProvider?.isSavedForLater() ?? false
+        saveForLaterButton.accessibilityLabel = isSavedForLater ? NSLocalizedString("Saved Post", comment: "Accessibility label for the 'Save Post' button when a post has been saved.") : NSLocalizedString("Save post", comment: "Accessibility label for the 'Save Post' button.")
+        saveForLaterButton.accessibilityHint = isSavedForLater ? NSLocalizedString("Remove this post from my saved posts.", comment: "Accessibility hint for the 'Save Post' button when a post is already saved.") : NSLocalizedString("Saves this post for later.", comment: "Accessibility hint for the 'Save Post' button.")
+        saveForLaterButton.accessibilityTraits = UIAccessibilityTraitButton
+    }
+
     private func prepareShareForVoiceOver() {
-        let saveForLaterFlag = FeatureFlag.saveForLater.enabled
-        saveForLaterButton.accessibilityLabel = saveForLaterFlag ? NSLocalizedString("Save for Later", comment: "Spoken accessibility label") :  NSLocalizedString("Share", comment: "Spoken accessibility label")
-        saveForLaterButton.accessibilityHint = saveForLaterFlag ? NSLocalizedString("Saves this post for later", comment: "Spoken accessibility save for later buttons") : NSLocalizedString("Shares this post", comment: "Spoken accessibility hint for Share buttons")
+        saveForLaterButton.accessibilityLabel = NSLocalizedString("Share", comment: "Spoken accessibility label")
+        saveForLaterButton.accessibilityHint = NSLocalizedString("Shares this post", comment: "Spoken accessibility hint for Share buttons")
         saveForLaterButton.accessibilityTraits = UIAccessibilityTraitButton
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -185,6 +185,8 @@ extension ReaderSavedPostsViewController: WPTableViewHandlerDelegate {
         let icon = Gridicon.iconOfType(.bookmarkOutline, withSize: CGSize(width: 18, height: 18))
         messageText.replace("[bookmark-outline]", with: icon)
         noResultsView.attributedMessageText = messageText
+
+        noResultsView.accessibilityLabel = NSLocalizedString("No posts saved – yet! Tap the Save Post button to save a post to your list.", comment: "Alternative accessibility text displayed to Voiceover users on the Reader Saved Posts screen.")
     }
 
     @objc func hideNoResultsView() {


### PR DESCRIPTION
Fixes #9463.

This PR makes a few small tweaks to VoiceOver accessibility for Saved Post controls:

* The Save Post button in both the reader card and reader details now reflects the current saved state and also provides a hint of what the button will do.
* The no results view in ReaderSavedPostsViewController now contains an accessibility label which improves Voiceover readability (as the standard message label includes an icon, which can't be read).

**To test:**

* Check the code
* Using VoiceOver, highlight the Save Post button both when a post is saved and not saved, and check the VoiceOver text / hint reflects the current state.
* Visit Saved Posts when you have no saved posts, and check the no results view is read correctly.
