### PR TITLE
FancyAlertView: Make constraint strong to match previous view controller

### DIFF
--- a/WordPressUI/WordPressUI/FancyAlert/FancyAlertView.swift
+++ b/WordPressUI/WordPressUI/FancyAlert/FancyAlertView.swift
@@ -17,7 +17,7 @@ open class FancyAlertView: UIView {
     /// Title
     ///
     @IBOutlet weak var titleLabel: UILabel!
-    @IBOutlet weak var titleAccessoryButtonTrailingConstraint: NSLayoutConstraint!
+    @IBOutlet var titleAccessoryButtonTrailingConstraint: NSLayoutConstraint!
 
     /// Body
     ///


### PR DESCRIPTION
Fixes #9443.

When FancyAlertView was converted from a UIViewController, the outlet for `titleAccessoryButtonTrailingConstraint` was made weak when it was [previously strong](https://github.com/wordpress-mobile/WordPress-iOS/commit/e243a7ae092cce26a39dd2a5b1be6d5c9a971ea0#diff-b61bca2cc9ab4f4c7b28db5b4d9f022bL112). This meant that when we deactivate the constraint it was getting deallocated. If we then try to apply a new configuration to the fancy alert, we get a crash when we try to configure the now deallocated constraint.

**To test:**

* Update `needsEmailVerification` in `WPAccount` to `return true`
* Log in and open the editor, and add some text
* Tap Publish, then tap Resend on the alert that appears
* Without this patch, the app will crash. With the app, the fancy alert should transition to show new information and there should be no crash.

cc @elibud @loremattei 