### PR TITLE
Update WordPressUI-iOS in Podfile to use Fancy Alert constraint fix

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -70,7 +70,7 @@ target 'WordPress' do
   pod 'WPMediaPicker', '1.0'
   pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.19'
   pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.19'
-  pod 'WordPressUI', '1.0.1'
+  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => 'fix/fancy-alert-constraint'
 
   target 'WordPressTest' do
     inherit! :search_paths
@@ -91,7 +91,7 @@ target 'WordPress' do
 
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.19'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.19'
-    pod 'WordPressUI', '1.0.1'
+    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => 'fix/fancy-alert-constraint'
     pod 'Gridicons', '0.15'
   end
 
@@ -107,7 +107,7 @@ target 'WordPress' do
 
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.19'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag =>'1.0.0-beta.19'
-    pod 'WordPressUI', '1.0.1'
+    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => 'fix/fancy-alert-constraint'
     pod 'Gridicons', '0.15'
   end
 
@@ -138,7 +138,7 @@ target 'WordPressAuthenticator' do
   ## ====================
   ##
   pod 'Gridicons', '0.15'
-  pod 'WordPressUI', '1.0.1'
+  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => 'fix/fancy-alert-constraint'
 
   ## Third party libraries
   ## =====================
@@ -172,7 +172,7 @@ target 'WordPressComStatsiOS' do
   ## Automattic libraries
   ## ====================
   ##
-  pod 'WordPressUI', '1.0.1'
+  pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => 'fix/fancy-alert-constraint'
 
   target 'WordPressComStatsiOSTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -127,7 +127,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
     - NSObject-SafeExpectations (= 0.0.2)
-  - WordPressUI (1.0.1)
+  - WordPressUI (1.0.2)
   - WPMediaPicker (1.0)
   - wpxmlrpc (0.8.3)
   - ZendeskSDK (1.11.2.1):
@@ -169,7 +169,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, tag `1.0.0-beta.19`)
   - WordPressKit (= 1.0.3)
   - WordPressShared (= 1.0.1)
-  - WordPressUI (= 1.0.1)
+  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, branch `fix/fancy-alert-constraint`)
   - WPMediaPicker (= 1.0)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
@@ -207,7 +207,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPressKit
     - WordPressShared
-    - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
@@ -219,6 +218,9 @@ EXTERNAL SOURCES:
   WordPress-Aztec-iOS:
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
     :tag: 1.0.0-beta.19
+  WordPressUI:
+    :branch: fix/fancy-alert-constraint
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -227,6 +229,9 @@ CHECKOUT OPTIONS:
   WordPress-Aztec-iOS:
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
     :tag: 1.0.0-beta.19
+  WordPressUI:
+    :commit: 3d6c31b21439336e7e04c4442a6dfbd6e1dd1e10
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -262,11 +267,11 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 743dbe41492eae1d9daf3f5ba5435ab295ee668f
   WordPressKit: 58a8663d557c4c8def59b6492f9ef7736a69b60d
   WordPressShared: 13a743d923796382419e03521e47491e9322087e
-  WordPressUI: 9f90f8e1e629af13e1021c6281660623d62ff953
+  WordPressUI: 70bceaff582bdd6fd8f3ed67aaa200e72fce245d
   WPMediaPicker: ceb613e43eae03268e73835d48d67f92f595aca6
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 5b25d733014591f7fc8a4c23617b1cc0612c13c7
+PODFILE CHECKSUM: 82c73b09402a5cb16ca2fe98337487643125bd36
 
 COCOAPODS: 1.5.2


### PR DESCRIPTION
Fixes #9443. This PR is essentially the same as #9471, which targetted `release/10.0`, but instead targets `release/10.1`. The primary difference is that in 10.0, WordPressUI was part of the main WPiOS project.

In 10.1, WordPressUI is now in its own pod so there's a separate PR apply the same update there: https://github.com/wordpress-mobile/WordPressUI-iOS/pull/5. In this PR, we're simply updating the Podfile to point to that new version.

This PR currently points to a branch, but I'll update it to point to a release number once the WordPressUI PR is merged.

---

Original fix description:

When FancyAlertView was converted from a UIViewController, the outlet for `titleAccessoryButtonTrailingConstraint` was made weak when it was [previously strong](https://github.com/wordpress-mobile/WordPress-iOS/commit/e243a7ae092cce26a39dd2a5b1be6d5c9a971ea0#diff-b61bca2cc9ab4f4c7b28db5b4d9f022bL112). This meant that when we deactivate the constraint it was getting deallocated. If we then try to apply a new configuration to the fancy alert, we get a crash when we try to configure the now deallocated constraint.

**To test:**

* Run `pod install`
* Update `needsEmailVerification` in `WPAccount` to `return true`
* Log in and open the editor, and add some text
* Tap Publish, then tap Resend on the alert that appears
* Without this patch, the app will crash. With the app, the fancy alert should transition to show new information and there should be no crash.

cc @elibud @loremattei 