### PR TITLE
README: Add mention of SwiftLint git hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ Trying to build the project by itself (WordPress.xcproj) after launching will re
 
 We use [SwiftLint](https://github.com/realm/SwiftLint) to enforce a common style for Swift code. The app should build and work without it, but if you plan to write code, you are encouraged to install it. No commit should have lint warnings or errors.
 
-SwiftLint is well-suited to run via [pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).
+You can set up a Git [pre-commit hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) to run SwiftLint automatically when committing by running:
+
+`rake git:install_hooks`
+
+This is the recommended way to include SwiftLint in your workflow, as it catches lint issues locally before your code makes its way to Github.
 
 Alternately, a SwiftLint scheme is exposed within the project; Xcode will show a warning if you don't have SwiftLint installed.
 


### PR DESCRIPTION
As discussed here https://github.com/wordpress-mobile/WordPress-iOS/pull/9181#issuecomment-385940664, this PR tweaks the SwiftLint section of our README to include a mention of the SwiftLint git hook.

**To test:**

* Read the text, check it's okay!