### PR TITLE
Zendesk Mobile: allow users to change their Support email

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -309,7 +309,6 @@ private extension ZendeskUtils {
         ZendeskUtils.getUserInformationAndShowPrompt(withName: true) { success in
             completion(success)
         }
-
     }
 
     static func getUserInformationAndShowPrompt(withName: Bool, completion: @escaping (Bool) -> Void) {

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -160,12 +160,9 @@ extension NSNotification.Name {
     ///
     func showSupportEmailPrompt(from controller: UIViewController, completion: @escaping (Bool) -> Void) {
         ZendeskUtils.configureViewController(controller)
-        ZendeskUtils.promptUserForInformation(withName: false) { success in
-            guard success else {
-                completion(false)
-                return
-            }
-            completion(true)
+
+        ZendeskUtils.getUserInformationAndShowPrompt(withName: false) { success in
+            completion(success)
         }
     }
 
@@ -309,8 +306,15 @@ private extension ZendeskUtils {
             }
         }
 
+        ZendeskUtils.getUserInformationAndShowPrompt(withName: true) { success in
+            completion(success)
+        }
+
+    }
+
+    static func getUserInformationAndShowPrompt(withName: Bool, completion: @escaping (Bool) -> Void) {
         ZendeskUtils.getUserInformationIfAvailable {
-            ZendeskUtils.promptUserForInformation(withName: true) { success in
+            ZendeskUtils.promptUserForInformation(withName: withName) { success in
                 guard success else {
                     DDLogInfo("No user information to create Zendesk identity with.")
                     completion(false)

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -158,12 +158,14 @@ extension NSNotification.Name {
 
     /// Displays an alert allowing the user to change their Support email address.
     ///
-    func showSupportEmailPrompt(from controller: UIViewController) {
+    func showSupportEmailPrompt(from controller: UIViewController, completion: @escaping (Bool) -> Void) {
         ZendeskUtils.configureViewController(controller)
         ZendeskUtils.promptUserForInformation(withName: false) { success in
             guard success else {
+                completion(false)
                 return
             }
+            completion(true)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -296,7 +296,7 @@ private extension SupportTableViewController {
         static let activityLogs = NSLocalizedString("Activity Logs", comment: "Option in Support view to see activity logs.")
         static let informationFooter = NSLocalizedString("The Extra Debug feature includes additional information in activity logs, and can help us troubleshoot issues with the app.", comment: "Support screen footer text explaining the Extra Debug feature.")
         static let contactEmail = NSLocalizedString("Contact Email", comment: "Support email label.")
-        static let emailNotSet = NSLocalizedString("not set", comment: "Display value for Support email field if there is no user email address.")
+        static let emailNotSet = NSLocalizedString("Not Set", comment: "Display value for Support email field if there is no user email address.")
     }
 
     // MARK: - User Defaults Keys

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -43,6 +43,11 @@ class SupportTableViewController: UITableViewController {
         setupTable()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        reloadViewModel()
+    }
+
     @objc func showFromTabBar() {
         let navigationController = UINavigationController.init(rootViewController: self)
 
@@ -207,7 +212,12 @@ private extension SupportTableViewController {
                 return
             }
 
-            ZendeskUtils.sharedInstance.showSupportEmailPrompt(from: controllerToShowFrom)
+            ZendeskUtils.sharedInstance.showSupportEmailPrompt(from: controllerToShowFrom) { success in
+                guard success else {
+                    return
+                }
+                self.reloadViewModel()
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #9492

When a user first contacts Support they are prompted for an email address and name. That information is used for all future Support requests.

This adds an option on the 'Help & Support' page to allow the user to change the email address used for contacting Support.

NOTE: When you change the Support email address, you will no longer have access to tickets created with the prior email address.

To test:

---

- Start with a fresh install (to clear any previous UD information).
- Log in.
- Go to Help & Support.
  - Verify 'Contact Email' is 'not set'.
- Select 'Contact Email'.
  - Verify your account email is pre-populated.
- Select 'OK' (you can change the email address if you like).
  - Verify 'Contact Email' now shows your email address.
- Select 'Contact Us' or 'My Tickets'.
  - Verify you are not prompted for your information.
  - Verify the log message `Using existing Zendesk identity: <your_email>, <your_name>` has the correct email.

---

- Start with a fresh install (to clear previous UD information).
- Log in.
- Go to Help & Support.
  - Verify 'Contact Email' is 'not set'.
- Select 'Contact Us' or 'My Tickets.'
- 'OK' to confirm your email and name. Then 'Cancel' to return.
  - Verify 'Contact Email' now shows your email address.

---

**Screenshots**

No Email:
![no_email](https://user-images.githubusercontent.com/1816888/40792528-64f716d2-64b7-11e8-8eab-1fec84162ade.png)

Prompt:
![prompt](https://user-images.githubusercontent.com/1816888/40792556-77ccbadc-64b7-11e8-8836-f82045181fed.png)

With Email:
![with_email](https://user-images.githubusercontent.com/1816888/40752032-ef6445de-642a-11e8-8adc-769053456fab.png)


