### PR TITLE
Add GIF badge to media picker

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -67,7 +67,7 @@ target 'WordPress' do
     pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
     pod 'Gridicons', '0.15'
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', '1.0'
+    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'b641104c9ce5c15635031fd328c980f099dafbfe'
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e98d89780ddd12e79144b3c66f74dae183a8c4c9'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'e98d89780ddd12e79144b3c66f74dae183a8c4c9'
     pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit =>'e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0'

--- a/Podfile
+++ b/Podfile
@@ -67,7 +67,7 @@ target 'WordPress' do
     pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
     pod 'Gridicons', '0.15'
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'b641104c9ce5c15635031fd328c980f099dafbfe'
+    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'b5ae03494596e3da7a8f814f9cab8e96ca345bc8'
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e98d89780ddd12e79144b3c66f74dae183a8c4c9'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'e98d89780ddd12e79144b3c66f74dae183a8c4c9'
     pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit =>'e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -170,7 +170,7 @@ DEPENDENCIES:
   - WordPressKit (~> 1.0.6)
   - WordPressShared (~> 1.0.5)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0`)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `b641104c9ce5c15635031fd328c980f099dafbfe`)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `b5ae03494596e3da7a8f814f9cab8e96ca345bc8`)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
 
@@ -221,7 +221,7 @@ EXTERNAL SOURCES:
     :commit: e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
   WPMediaPicker:
-    :commit: b641104c9ce5c15635031fd328c980f099dafbfe
+    :commit: b5ae03494596e3da7a8f814f9cab8e96ca345bc8
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
@@ -235,7 +235,7 @@ CHECKOUT OPTIONS:
     :commit: e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
   WPMediaPicker:
-    :commit: b641104c9ce5c15635031fd328c980f099dafbfe
+    :commit: b5ae03494596e3da7a8f814f9cab8e96ca345bc8
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
@@ -277,6 +277,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: a90f60bcb1422cef576f23d3d3dfc77e5ae6fbb8
+PODFILE CHECKSUM: 8d59b52a8d9b6e00568013f4fd1b7bd4aa5b4581
 
 COCOAPODS: 1.5.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -170,7 +170,7 @@ DEPENDENCIES:
   - WordPressKit (~> 1.0.6)
   - WordPressShared (~> 1.0.4)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0`)
-  - WPMediaPicker (= 1.0)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `b641104c9ce5c15635031fd328c980f099dafbfe`)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
 
@@ -207,7 +207,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPressKit
     - WordPressShared
-    - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
 
@@ -221,6 +220,9 @@ EXTERNAL SOURCES:
   WordPressUI:
     :commit: e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
+  WPMediaPicker:
+    :commit: b641104c9ce5c15635031fd328c980f099dafbfe
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -232,6 +234,9 @@ CHECKOUT OPTIONS:
   WordPressUI:
     :commit: e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
+  WPMediaPicker:
+    :commit: b641104c9ce5c15635031fd328c980f099dafbfe
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -272,6 +277,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 5264c8d38dfcfb7a3c7de222432f7361e65814cf
+PODFILE CHECKSUM: 52902e417abaffe3128ceaa3b5c828efd9a0223b
 
 COCOAPODS: 1.5.2

--- a/WordPress/Classes/Categories/Media+WPMediaAsset.m
+++ b/WordPress/Classes/Categories/Media+WPMediaAsset.m
@@ -148,4 +148,13 @@
     return [[self.objectID URIRepresentation] absoluteString];
 }
 
+- (NSString *)UTTypeIdentifier
+{
+    NSString *extension = [self fileExtension];
+    if (!extension.length) {
+        return nil;
+    }
+    return (__bridge_transfer NSString *)UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, (__bridge CFStringRef)extension, NULL);
+}
+
 @end

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2114,7 +2114,8 @@ extension AztecPostViewController {
         options.filter = [.all]
         options.allowCaptureOfMedia = false
         options.showSearchBar = true
-
+        options.badgedUTTypes = [String(kUTTypeGIF)]
+        
         let picker = WPNavigationMediaPickerViewController()
 
         switch dataSourceType {
@@ -2156,6 +2157,7 @@ extension AztecPostViewController {
         options.allowMultipleSelection = true
         options.allowCaptureOfMedia = false
         options.scrollVertically = true
+        options.badgedUTTypes = [String(kUTTypeGIF)]
 
         let picker = WPInputMediaPickerViewController(options: options)
         mediaPickerInputViewController = picker

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2115,7 +2115,7 @@ extension AztecPostViewController {
         options.allowCaptureOfMedia = false
         options.showSearchBar = true
         options.badgedUTTypes = [String(kUTTypeGIF)]
-        
+
         let picker = WPNavigationMediaPickerViewController()
 
         switch dataSourceType {

--- a/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
@@ -2,7 +2,7 @@ import Foundation
 import SVProgressHUD
 import WPMediaPicker
 import WordPressShared
-
+import MobileCoreServices
 
 /// Encapsulates the interactions required to capture a new site icon image, crop it and resize it.
 ///
@@ -35,6 +35,7 @@ class SiteIconPickerPresenter: NSObject {
         options.filter = [.image]
         options.allowMultipleSelection = false
         options.showSearchBar = true
+        options.badgedUTTypes = [String(kUTTypeGIF)]
 
         let pickerViewController = WPNavigationMediaPickerViewController(options: options)
 

--- a/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
@@ -2,6 +2,7 @@ import Foundation
 import WPMediaPicker
 import WordPressShared
 import Photos
+import MobileCoreServices
 
 // Encapsulates all of the interactions required to capture a new Gravatar image, and resize it.
 //
@@ -102,6 +103,7 @@ class GravatarPickerViewController: UIViewController, WPMediaPickerViewControlle
         options.filter = [.image]
         options.preferFrontCamera = true
         options.allowMultipleSelection = false
+        options.badgedUTTypes = [String(kUTTypeGIF)]
 
         let pickerViewController = WPNavigationMediaPickerViewController(options: options)
         pickerViewController.delegate = self

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPicker.swift
@@ -1,4 +1,5 @@
 import WPMediaPicker
+import MobileCoreServices
 
 /// Encapsulates launching and customization of a media picker to import media from the Photos Library
 final class MediaLibraryPicker: NSObject {
@@ -13,7 +14,7 @@ final class MediaLibraryPicker: NSObject {
         options.showMostRecentFirst = true
         options.filter = [.all]
         options.allowCaptureOfMedia = false
-
+        options.badgedUTTypes = [String(kUTTypeGIF)]
 
         let picker = WPNavigationMediaPickerViewController(options: options)
         picker.dataSource = dataSource

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -5,7 +5,6 @@ import WordPressShared
 import WPMediaPicker
 import MobileCoreServices
 
-
 /// Displays the user's media library in a grid
 ///
 class MediaLibraryViewController: WPMediaPickerViewController {
@@ -71,6 +70,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         options.allowCaptureOfMedia = false
         options.showSearchBar = true
         options.showActionBar = false
+        options.badgedUTTypes = [String(kUTTypeGIF)]
 
         return options
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1259,6 +1259,7 @@ FeaturedImageViewControllerDelegate>
     options.allowMultipleSelection = NO;
     options.filter = WPMediaTypeImage;
     options.showSearchBar = YES;
+    options.badgedUTTypes = [NSSet setWithObject: (__bridge NSString *)kUTTypeGIF];
     WPNavigationMediaPickerViewController *picker = [[WPNavigationMediaPickerViewController alloc] initWithOptions:options];
     self.mediaDataSource = [[WPAndDeviceMediaLibraryDataSource alloc] initWithPost:self.apost
                                                              initialDataSourceType:MediaPickerDataSourceTypeMediaLibrary];


### PR DESCRIPTION
Fixes #9353 

This PR implements the [changes in the MediaPicker project](https://github.com/wordpress-mobile/MediaPicker-iOS/pull/295) to show a small GIF badge at the top right of the media picker cell.

![img_2862](https://user-images.githubusercontent.com/9772967/40742310-1a3a1590-641c-11e8-89bc-6ec9c19b27fc.png)

To test:
Check that the gif badge shows on:

- [x]  Media Library.
- [x] Media Library -> Add -> Chose from My Device.
- [x] Aztec -> Add (Keyboard area picker).
- [x] Aztec -> Add -> Device media (from the `image` icon).
- [x] Aztec -> Add -> WordPress Library (`W` logo icon).
- [x] Site Icon Picker.
- [x] Profile Photo picker.