### PR TITLE
Display Zendesk views from correct view controller

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -320,7 +320,12 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         return { [unowned self] row in
             if FeatureFlag.zendeskMobile.enabled {
                 let controller = SupportTableViewController()
-                controller.showHelpFromViewController = self
+
+                // If iPad, show Support from Me view controller instead of navigation controller.
+                if WPDeviceIdentification.isiPad() {
+                    controller.showHelpFromViewController = self
+                }
+
                 self.showDetailViewController(controller, sender: self)
             } else {
                 let controller = SupportViewController()

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -322,7 +322,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
                 let controller = SupportTableViewController()
 
                 // If iPad, show Support from Me view controller instead of navigation controller.
-                if WPDeviceIdentification.isiPad() {
+                if !self.splitViewControllerIsHorizontallyCompact {
                     controller.showHelpFromViewController = self
                 }
 


### PR DESCRIPTION
Fixes #n/a

When the Zendesk views are displayed, `MeViewController` was _always_ used to display them, resulting in: 
`Presenting view controllers on detached view controllers is discouraged <WordPress.MeViewController: 0x7fd4a254cec0>.`


The Zendesk views should only be displayed from the `MeViewController` if the device is an iPad, so they are shown modally.

This adds an iPad check so the Zendesk views are displayed from the correct view controller.

To test:
- Run the app on an iPhone.
  - Verify the Support views show correctly (Help Center, Contact Us, My Tickets) - i.e. from the navigation controller.
- Run the app on an iPad
  - Verify the Support views show correctly (Help Center, Contact Us, My Tickets) - i.e. modally from `MeViewController`.
- Verify the log message `Presenting view controllers on detached view controllers is discouraged` no longer appears.

