### PR TITLE
Save for Later: Prevent saved posts being deleted with their topics

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -1067,7 +1067,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     ReaderPost *post;
     NSString *globalID = remotePost.globalID;
     NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:@"ReaderPost"];
-    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"globalID = %@ AND topic = %@", globalID, topic];
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"globalID = %@ AND (topic = %@ OR topic = NULL)", globalID, topic];
     NSArray *arr = [self.managedObjectContext executeFetchRequest:fetchRequest error:&error];
 
     BOOL existing = false;

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -409,6 +409,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:@"ReaderPost"];
 
     NSPredicate *pred = [NSPredicate predicateWithFormat:@"topic = NULL AND inUse = false"];
+    pred = [self predicateIgnoringSavedForLaterPosts:pred];
     [fetchRequest setPredicate:pred];
 
     NSArray *arr = [self.managedObjectContext executeFetchRequest:fetchRequest error:&error];
@@ -872,7 +873,6 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:@"ReaderPost"];
 
     NSPredicate *pred = [NSPredicate predicateWithFormat:@"topic = %@ AND sortRank < %@", topic, rank];
-
     [fetchRequest setPredicate:pred];
 
     NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"sortRank" ascending:NO];
@@ -885,8 +885,13 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     }
 
     for (ReaderPost *post in currentPosts) {
-        DDLogInfo(@"Deleting ReaderPost: %@", post);
-        [self.managedObjectContext deleteObject:post];
+        if (post.isSavedForLater) {
+            // If the missing post is currently being used or has been saved, just remove its topic.
+            post.topic = nil;
+        } else {
+            DDLogInfo(@"Deleting ReaderPost: %@", post);
+            [self.managedObjectContext deleteObject:post];
+        }
     }
 }
 
@@ -930,8 +935,8 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
             continue;
         }
         // The post was missing from the batch and needs to be cleaned up.
-        if (post.inUse) {
-            // If the missing post is currenty being used just remove its topic.
+        if (post.inUse || post.isSavedForLater) {
+            // If the missing post is currently being used or has been saved, just remove its topic.
             post.topic = nil;
         } else {
             DDLogInfo(@"Deleting ReaderPost: %@", post);
@@ -977,7 +982,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     NSRange range = NSMakeRange(maxPosts, [posts count] - maxPosts);
     NSArray *postsToDelete = [posts subarrayWithRange:range];
     for (ReaderPost *post in postsToDelete) {
-        if (post.inUse) {
+        if (post.inUse || post.isSavedForLater) {
             post.topic = nil;
         } else {
             DDLogInfo(@"Deleting ReaderPost: %@", post.postTitle);
@@ -1014,7 +1019,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     }
 
     for (ReaderPost *post in results) {
-        if (post.inUse) {
+        if (post.inUse || post.isSavedForLater) {
             // If the missing post is currenty being used just remove its topic.
             post.topic = nil;
         } else {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
@@ -29,7 +29,7 @@ final class ReaderCellConfiguration {
         cell.setSiteName(post.blogName)
     }
 
-    func configurePostCardCell(_ cell: UITableViewCell, withPost post: ReaderPost, topic: ReaderAbstractTopic, delegate: ReaderPostCellDelegate?, loggedInActionVisibility: ReaderActionsVisibility) {
+    func configurePostCardCell(_ cell: UITableViewCell, withPost post: ReaderPost, topic: ReaderAbstractTopic? = nil, delegate: ReaderPostCellDelegate?, loggedInActionVisibility: ReaderActionsVisibility) {
         // To help avoid potential crash: https://github.com/wordpress-mobile/WordPress-iOS/issues/6757
         guard !post.isDeleted else {
             return
@@ -38,9 +38,16 @@ final class ReaderCellConfiguration {
         let postCell = cell as! ReaderPostCardCell
 
         postCell.delegate = delegate
-        postCell.hidesFollowButton = ReaderHelpers.topicIsFollowing(topic)
+
+        if let topic = topic {
+            postCell.hidesFollowButton = ReaderHelpers.topicIsFollowing(topic)
+            postCell.headerBlogButtonIsEnabled = !ReaderHelpers.isTopicSite(topic)
+        } else {
+            postCell.hidesFollowButton = true
+            postCell.headerBlogButtonIsEnabled = true
+        }
+
         postCell.loggedInActionVisibility = loggedInActionVisibility
-        postCell.headerBlogButtonIsEnabled = !ReaderHelpers.isTopicSite(topic)
         postCell.configureCell(post)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -110,17 +110,13 @@ final class ReaderSavedPostsViewController: UITableViewController {
 
 
     @objc open func configurePostCardCell(_ cell: UITableViewCell, post: ReaderPost) {
-        guard let topic = post.topic else {
-            return
-        }
-
         if postCellActions == nil {
-            postCellActions = ReaderPostCellActions(context: managedObjectContext(), origin: self, topic: topic, visibleConfirmation: false)
+            postCellActions = ReaderPostCellActions(context: managedObjectContext(), origin: self, topic: post.topic, visibleConfirmation: false)
         }
 
         cellConfiguration.configurePostCardCell(cell,
                                                 withPost: post,
-                                                topic: topic,
+                                                topic: post.topic,
                                                 delegate: postCellActions,
                                                 loggedInActionVisibility: .hidden)
     }


### PR DESCRIPTION
Fixes #9488.

Posts that have been saved for later were being deleted whenever their associated topics were deleted. A simple way to trigger this is using search:

* Search for a topic
* Save a post from the results
* Navigate out of the search section of the Reader – this deletes any search topics that were created while searching
* Go to Saved Posts
* Your saved post won't be there, because the topic has been deleted.

To fix this, I've adopted the same approach that we were using to avoid deleting 'in use' posts – if we attempt to delete a topic, we first check for any savedForLater posts that belong to that topic, and `nil` out their topic relationship.

I've also made a tweak to `createOrReplaceFromRemotePost`, so that we can find existing posts with no topic and merge them with remote posts. This fixes another issue in the search scenario mentioned above, where duplicate posts would be created if you performed the same search, as we wouldn't detect the previous topic-less post.

**To test:**

* Check the code, build and run
* Check the search scenario mentioned above and ensure your saved posts stay in the app