### PR TITLE
Fix IDN domain login

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -128,21 +128,22 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
 // Used as a key to store passwords, if you change the algorithm, logins will break
 - (NSString *)displayURL
 {
-    NSString *url = [NSURL IDNDecodedHostname:self.url];
-    NSAssert(url != nil, @"Decoded url shouldn't be nil");
-    if (url == nil) {
-        DDLogInfo(@"displayURL: decoded url is nil: %@", self.url);
-        return self.url;
-    }
     NSError *error = nil;
     NSRegularExpression *protocol = [NSRegularExpression regularExpressionWithPattern:@"http(s?)://" options:NSRegularExpressionCaseInsensitive error:&error];
-    NSString *result = [NSString stringWithFormat:@"%@", [protocol stringByReplacingMatchesInString:url options:0 range:NSMakeRange(0, [url length]) withTemplate:@""]];
+    NSString *result = [NSString stringWithFormat:@"%@", [protocol stringByReplacingMatchesInString:self.url options:0 range:NSMakeRange(0, [self.url length]) withTemplate:@""]];
 
     if ([result hasSuffix:@"/"]) {
         result = [result substringToIndex:[result length] - 1];
     }
 
-    return result;
+    NSString *decodedResult = [NSURL IDNDecodedHostname:result];
+    NSAssert(decodedResult != nil, @"Decoded url shouldn't be nil");
+    if (decodedResult == nil) {
+        DDLogInfo(@"displayURL: decoded url is nil: %@", self.url);
+        return result;
+    }
+
+    return decodedResult;
 }
 
 - (NSString *)hostURL

--- a/WordPressAuthenticator/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/Authenticator/WordPressAuthenticator.swift
@@ -459,7 +459,7 @@ public struct WordPressAuthenticatorConfiguration {
         try? path.removeSuffix(pattern: "/wp-admin/?")
         path.removeSuffix("/")
 
-        return NSURL.idnDecodedURL(path)
+        return path
     }
 
 

--- a/WordPressAuthenticator/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/Signin/LoginSelfHostedViewController.swift
@@ -171,7 +171,7 @@ class LoginSelfHostedViewController: LoginViewController, NUXKeyboardResponder {
     func configureBlogDetailHeaderView(siteInfo: WordPressComSiteInfo) {
         let siteAddress = sanitizedSiteAddress(siteAddress: siteInfo.url)
         siteHeaderView.title = siteInfo.name
-        siteHeaderView.subtitle = siteAddress
+        siteHeaderView.subtitle = NSURL.idnDecodedURL(siteAddress)
         siteHeaderView.subtitleIsHidden = false
 
         siteHeaderView.blavatarBorderIsHidden = false

--- a/WordPressAuthenticator/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
+++ b/WordPressAuthenticator/WordPressAuthenticatorTests/Authenticator/WordPressAuthenticatorTests.swift
@@ -34,9 +34,9 @@ class WordPressAuthenticatorTests: XCTestCase {
         baseURL = "http://例.例"
         let punycode = "http://xn--fsq.xn--fsq"
         url = WordPressAuthenticator.baseSiteURL(string: baseURL)
-        XCTAssert(url == baseURL)
+        XCTAssert(url == punycode)
         url = WordPressAuthenticator.baseSiteURL(string: punycode)
-        XCTAssert(url == baseURL)
+        XCTAssert(url == punycode)
     }
 
     func testEmailAddressTokenHandling() {


### PR DESCRIPTION
Fixes #9251

This PR will allow users with IDN (international/non-ascii) domains to login to the app once again.

![idn-domain-screen](https://user-images.githubusercontent.com/517257/40811582-0290d748-64ef-11e8-8009-5f6d78620405.png)

To test:
- login to a site with an IDN domain or subdomain
- ensure it works

