### PR TITLE
Save for later: Add 'remove from saved posts' animation

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -935,7 +935,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
             continue;
         }
         // The post was missing from the batch and needs to be cleaned up.
-        if (post.inUse || post.isSavedForLater) {
+        if ([self topicShouldBeClearedFor:post]) {
             // If the missing post is currently being used or has been saved, just remove its topic.
             post.topic = nil;
         } else {
@@ -982,7 +982,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     NSRange range = NSMakeRange(maxPosts, [posts count] - maxPosts);
     NSArray *postsToDelete = [posts subarrayWithRange:range];
     for (ReaderPost *post in postsToDelete) {
-        if (post.inUse || post.isSavedForLater) {
+        if ([self topicShouldBeClearedFor:post]) {
             post.topic = nil;
         } else {
             DDLogInfo(@"Deleting ReaderPost: %@", post.postTitle);
@@ -1019,7 +1019,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     }
 
     for (ReaderPost *post in results) {
-        if (post.inUse || post.isSavedForLater) {
+        if ([self topicShouldBeClearedFor:post]) {
             // If the missing post is currenty being used just remove its topic.
             post.topic = nil;
         } else {
@@ -1027,6 +1027,11 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
             [self.managedObjectContext deleteObject:post];
         }
     }
+}
+
+- (BOOL)topicShouldBeClearedFor:(ReaderPost *)post
+{
+    return (post.inUse || post.isSavedForLater);
 }
 
 

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.h
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.h
@@ -70,6 +70,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)applyRestorePageButtonStyle:(UIButton *)button;
 
+#pragma mark - Reader Posts
+
++ (void)applyRestoreSavedPostLabelStyle:(UILabel *)label;
+
++ (void)applyRestoreSavedPostTitleLabelStyle:(UILabel *)label;
+
++ (void)applyRestoreSavedPostButtonStyle:(UIButton *)button;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -215,11 +215,39 @@
 
 + (void)applyRestorePageLabelStyle:(UILabel *)label
 {
-    [self configureLabelForRegularFontStyle:label];
+    label.font = [WPStyleGuide regularFont];
     label.textColor = [self grey];
 }
 
 + (void)applyRestorePageButtonStyle:(UIButton *)button
+{
+    [WPStyleGuide configureLabel:button.titleLabel
+                       textStyle:UIFontTextStyleCallout
+                      fontWeight:UIFontWeightSemibold];
+    [button setTitleColor:[WPStyleGuide wordPressBlue] forState:UIControlStateNormal];
+    [button setTitleColor:[WPStyleGuide darkBlue] forState:UIControlStateHighlighted];
+}
+
++ (void)applyRestoreSavedPostLabelStyle:(UILabel *)label
+{
+    [WPStyleGuide configureLabel:label textStyle:UIFontTextStyleCallout];
+    label.textColor = [self greyDarken10];
+}
+
++ (void)applyRestoreSavedPostTitleLabelStyle:(UILabel *)label
+{
+    [WPStyleGuide configureLabel:label
+                       textStyle:UIFontTextStyleCallout
+                      fontWeight:UIFontWeightSemibold];
+
+    UIFontDescriptor *descriptor = [label.font fontDescriptor];
+    UIFontDescriptorSymbolicTraits traits = [descriptor symbolicTraits];
+    descriptor = [descriptor fontDescriptorWithSymbolicTraits:traits | UIFontDescriptorTraitItalic];
+    label.font = [UIFont fontWithDescriptor:descriptor size:label.font.pointSize];
+    label.textColor = [self greyDarken10];
+}
+
++ (void)applyRestoreSavedPostButtonStyle:(UIButton *)button
 {
     [WPStyleGuide configureLabel:button.titleLabel
                        textStyle:UIFontTextStyleCallout

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -1,5 +1,5 @@
 /// Action commands in Reader cells
-final class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
+class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
     private let context: NSManagedObjectContext
     private weak var origin: UIViewController?
     private let topic: ReaderAbstractTopic?

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -96,7 +96,7 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         }
     }
 
-    fileprivate func toggleSavedForLater(for post: ReaderPost) {
+    func toggleSavedForLater(for post: ReaderPost) {
         let actionOrigin: ReaderSaveForLaterOrigin
         if origin is ReaderSavedPostsViewController {
             actionOrigin = .savedStream

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterRemovedPosts.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterRemovedPosts.swift
@@ -1,3 +1,23 @@
 final class ReaderSaveForLaterRemovedPosts {
+    private var removedPosts: [ReaderPost]
 
+    init() {
+        removedPosts = []
+    }
+
+    func add(_ post: ReaderPost) {
+        removedPosts.append(post)
+    }
+
+    func remove(_ post: ReaderPost) {
+        guard let index = removedPosts.index(of: post) else {
+            return
+        }
+
+        removedPosts.remove(at: index)
+    }
+
+    func contains(_ post: ReaderPost) -> Bool {
+        return removedPosts.contains(post)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterRemovedPosts.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterRemovedPosts.swift
@@ -1,0 +1,3 @@
+final class ReaderSaveForLaterRemovedPosts {
+
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterRemovedPosts.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLaterRemovedPosts.swift
@@ -20,4 +20,8 @@ final class ReaderSaveForLaterRemovedPosts {
     func contains(_ post: ReaderPost) -> Bool {
         return removedPosts.contains(post)
     }
+
+    func all() -> [ReaderPost] {
+        return removedPosts
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
@@ -17,7 +17,7 @@ final class ReaderSavedPostCellActions: ReaderPostCellActions {
         delegate?.willRemove(cell)
     }
 
-    func contains(_ post: ReaderPost) -> Bool {
+    func postIsRemoved(_ post: ReaderPost) -> Bool {
         return removedPosts.contains(post)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
@@ -1,0 +1,20 @@
+final class ReaderSavedPostCellActions: ReaderPostCellActions {
+    /// Posts that have been removed but not yet discarded
+    private var removedPosts = ReaderSaveForLaterRemovedPosts()
+
+    override func readerCell(_ cell: ReaderPostCardCell, saveActionForProvider provider: ReaderPostContentProvider) {
+        if let post = provider as? ReaderPost {
+            removedPosts.add(post)
+        }
+
+        super.readerCell(cell, saveActionForProvider: provider)
+    }
+
+    func contains(_ post: ReaderPost) -> Bool {
+        return removedPosts.contains(post)
+    }
+
+    func remove(_ post: ReaderPost) {
+        removedPosts.remove(post)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
@@ -21,7 +21,7 @@ final class ReaderSavedPostCellActions: ReaderPostCellActions {
         return removedPosts.contains(post)
     }
 
-    func remove(_ post: ReaderPost) {
+    func restoreUnsavedPost(_ post: ReaderPost) {
         removedPosts.remove(post)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
@@ -23,4 +23,12 @@ final class ReaderSavedPostCellActions: ReaderPostCellActions {
     func remove(_ post: ReaderPost) {
         removedPosts.remove(post)
     }
+
+    func clear() {
+        let allRemovedPosts = removedPosts.all()
+        for post in allRemovedPosts {
+            toggleSavedForLater(for: post)
+        }
+        removedPosts = ReaderSaveForLaterRemovedPosts()
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
@@ -2,6 +2,8 @@ protocol ReaderSavedPostCellActionsDelegate: class {
     func willRemove(_ cell: ReaderPostCardCell)
 }
 
+
+/// Specialises ReaderPostCellActions to provide specific overrides for the ReaderSavedPostsViewController
 final class ReaderSavedPostCellActions: ReaderPostCellActions {
     /// Posts that have been removed but not yet discarded
     private var removedPosts = ReaderSaveForLaterRemovedPosts()
@@ -13,7 +15,6 @@ final class ReaderSavedPostCellActions: ReaderPostCellActions {
             removedPosts.add(post)
         }
         delegate?.willRemove(cell)
-        //super.readerCell(cell, saveActionForProvider: provider)
     }
 
     func contains(_ post: ReaderPost) -> Bool {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
@@ -25,7 +25,7 @@ final class ReaderSavedPostCellActions: ReaderPostCellActions {
         removedPosts.remove(post)
     }
 
-    func clear() {
+    func clearRemovedPosts() {
         let allRemovedPosts = removedPosts.all()
         for post in allRemovedPosts {
             toggleSavedForLater(for: post)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostCellActions.swift
@@ -1,13 +1,19 @@
+protocol ReaderSavedPostCellActionsDelegate: class {
+    func willRemove(_ cell: ReaderPostCardCell)
+}
+
 final class ReaderSavedPostCellActions: ReaderPostCellActions {
     /// Posts that have been removed but not yet discarded
     private var removedPosts = ReaderSaveForLaterRemovedPosts()
+
+    weak var delegate: ReaderSavedPostCellActionsDelegate?
 
     override func readerCell(_ cell: ReaderPostCardCell, saveActionForProvider provider: ReaderPostContentProvider) {
         if let post = provider as? ReaderPost {
             removedPosts.add(post)
         }
-
-        super.readerCell(cell, saveActionForProvider: provider)
+        delegate?.willRemove(cell)
+        //super.readerCell(cell, saveActionForProvider: provider)
     }
 
     func contains(_ post: ReaderPost) -> Bool {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
@@ -34,11 +34,8 @@ final class ReaderSavedPostUndoCell: UITableViewCell {
     private func applyStyles() {
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = 1.0
-//        backgroundColor = WPStyleGuide.greyLighten30()
-//        contentView.backgroundColor = WPStyleGuide.greyLighten30()
-//        borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-//        borderedView.layer.borderWidth = 1.0
 
-        WPStyleGuide.applyReaderCardTitleLabelStyle(title)
+        WPStyleGuide.applyRestorePostLabelStyle(removed)
+        WPStyleGuide.applyRestorePostLabelStyle(title)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+final class ReaderSavedPostUndoCell: UITableViewCell {
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
@@ -8,13 +8,15 @@ protocol ReaderPostUndoCellDelegate: NSObjectProtocol {
 final class ReaderSavedPostUndoCell: UITableViewCell {
     @IBOutlet weak var removed: UILabel!
     @IBOutlet weak var title: UILabel!
+    @IBOutlet weak var borderedView: UIView!
+    @IBOutlet weak var undoButton: UIButton!
 
     weak var delegate: ReaderPostUndoCellDelegate?
     weak var contentProvider: ReaderPostContentProvider?
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
+        applyStyles()
     }
 
     @IBAction func undo(_ sender: Any) {
@@ -27,5 +29,16 @@ final class ReaderSavedPostUndoCell: UITableViewCell {
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
         setHighlighted(selected, animated: animated)
+    }
+
+    private func applyStyles() {
+        borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
+        borderedView.layer.borderWidth = 1.0
+//        backgroundColor = WPStyleGuide.greyLighten30()
+//        contentView.backgroundColor = WPStyleGuide.greyLighten30()
+//        borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
+//        borderedView.layer.borderWidth = 1.0
+
+        WPStyleGuide.applyReaderCardTitleLabelStyle(title)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 protocol ReaderPostUndoCellDelegate: NSObjectProtocol {
-    func readerCell(_ cell: ReaderSavedPostUndoCell, undoActionForProvider provider: ReaderPostContentProvider)
+    func readerCellWillUndo(_ cell: ReaderSavedPostUndoCell)
 }
 
 final class ReaderSavedPostUndoCell: UITableViewCell {
@@ -12,7 +12,6 @@ final class ReaderSavedPostUndoCell: UITableViewCell {
     @IBOutlet weak var undoButton: UIButton!
 
     weak var delegate: ReaderPostUndoCellDelegate?
-    weak var contentProvider: ReaderPostContentProvider?
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -20,10 +19,7 @@ final class ReaderSavedPostUndoCell: UITableViewCell {
     }
 
     @IBAction func undo(_ sender: Any) {
-        guard let provider = contentProvider else {
-            return
-        }
-        delegate?.readerCell(self, undoActionForProvider: provider)
+        delegate?.readerCellWillUndo(self)
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
@@ -1,14 +1,19 @@
 import UIKit
 
 final class ReaderSavedPostUndoCell: UITableViewCell {
+    @IBOutlet weak var removed: UILabel!
+    @IBOutlet weak var title: UILabel!
+
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
     }
 
+    @IBAction func undo(_ sender: Any) {
+    }
+
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
+        setHighlighted(selected, animated: animated)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
@@ -13,8 +13,15 @@ final class ReaderSavedPostUndoCell: UITableViewCell {
 
     weak var delegate: ReaderPostUndoCellDelegate?
 
+    private enum Strings {
+        static let removed = NSLocalizedString("Removed", comment: "Label indicating a post has been removed from Saved For Later")
+        static let undo = NSLocalizedString("Undo", comment: "Undo action")
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
+        setupRemovedLabel()
+        setupUndoButton()
         applyStyles()
     }
 
@@ -25,6 +32,14 @@ final class ReaderSavedPostUndoCell: UITableViewCell {
     override func setSelected(_ selected: Bool, animated: Bool) {
         super.setSelected(selected, animated: animated)
         setHighlighted(selected, animated: animated)
+    }
+
+    private func setupRemovedLabel() {
+        removed.text = Strings.removed
+    }
+
+    private func setupUndoButton() {
+        undoButton.setTitle(Strings.undo, for: .normal)
     }
 
     private func applyStyles() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import Gridicons
 
 protocol ReaderPostUndoCellDelegate: NSObjectProtocol {
     func readerCellWillUndo(_ cell: ReaderSavedPostUndoCell)
@@ -40,6 +41,11 @@ final class ReaderSavedPostUndoCell: UITableViewCell {
 
     private func setupUndoButton() {
         undoButton.setTitle(Strings.undo, for: .normal)
+        let size = CGSize(width: 20, height: 20)
+        let icon = Gridicon.iconOfType(.undo, withSize: size)
+        let tintedIcon = icon.imageWithTintColor(WPStyleGuide.lightBlue())
+
+        undoButton.setImage(tintedIcon, for: .normal)
     }
 
     private func applyStyles() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
@@ -1,8 +1,16 @@
+import Foundation
 import UIKit
+
+protocol ReaderPostUndoCellDelegate: NSObjectProtocol {
+    func readerCell(_ cell: ReaderSavedPostUndoCell, undoActionForProvider provider: ReaderPostContentProvider)
+}
 
 final class ReaderSavedPostUndoCell: UITableViewCell {
     @IBOutlet weak var removed: UILabel!
     @IBOutlet weak var title: UILabel!
+
+    weak var delegate: ReaderPostUndoCellDelegate?
+    weak var contentProvider: ReaderPostContentProvider?
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -10,6 +18,10 @@ final class ReaderSavedPostUndoCell: UITableViewCell {
     }
 
     @IBAction func undo(_ sender: Any) {
+        guard let provider = contentProvider else {
+            return
+        }
+        delegate?.readerCell(self, undoActionForProvider: provider)
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
@@ -41,9 +41,8 @@ final class ReaderSavedPostUndoCell: UITableViewCell {
 
     private func setupUndoButton() {
         undoButton.setTitle(Strings.undo, for: .normal)
-        let size = CGSize(width: 20, height: 20)
-        let icon = Gridicon.iconOfType(.undo, withSize: size)
-        let tintedIcon = icon.imageWithTintColor(WPStyleGuide.lightBlue())
+        let icon = Gridicon.iconOfType(.undo)
+        let tintedIcon = icon.imageWithTintColor(WPStyleGuide.wordPressBlue())
 
         undoButton.setImage(tintedIcon, for: .normal)
     }
@@ -52,7 +51,8 @@ final class ReaderSavedPostUndoCell: UITableViewCell {
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = 1.0
 
-        WPStyleGuide.applyRestorePostLabelStyle(removed)
-        WPStyleGuide.applyRestorePostLabelStyle(title)
+        WPStyleGuide.applyRestoreSavedPostLabelStyle(removed)
+        WPStyleGuide.applyRestoreSavedPostTitleLabelStyle(title)
+        WPStyleGuide.applyRestoreSavedPostButtonStyle(undoButton)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
@@ -6,16 +6,17 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="ReaderSavedPostUndoCell" customModule="WordPress" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="ReaderSavedPostUndoCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" layoutMarginsFollowReadableWidth="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
@@ -23,27 +24,27 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
-                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-wL-AiS">
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-wL-AiS">
                         <rect key="frame" x="16" y="6" width="288" height="30"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="edF-mf-PsH">
-                                <rect key="frame" x="0.0" y="0.0" width="242" height="30"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="edF-mf-PsH">
+                                <rect key="frame" x="0.0" y="0.0" width="226" height="30"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="Removed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qPM-It-aeV">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Removed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qPM-It-aeV">
                                         <rect key="frame" x="0.0" y="0.0" width="71.5" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lnR-4i-vdi">
-                                        <rect key="frame" x="79.5" y="0.0" width="162.5" height="30"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lnR-4i-vdi">
+                                        <rect key="frame" x="77.5" y="0.0" width="148.5" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jmj-W8-Yz3">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jmj-W8-Yz3">
                                 <rect key="frame" x="242" y="0.0" width="46" height="30"/>
                                 <state key="normal" title="Button"/>
                                 <connections>
@@ -54,10 +55,10 @@
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="0qS-wL-AiS" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="FCo-M3-vdJ"/>
+                    <constraint firstItem="0qS-wL-AiS" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="FCo-M3-vdJ"/>
                     <constraint firstAttribute="trailing" secondItem="TBy-h6-gyK" secondAttribute="trailing" id="HV5-h3-5B3"/>
                     <constraint firstAttribute="bottom" secondItem="TBy-h6-gyK" secondAttribute="bottom" constant="-0.5" id="UDU-ic-hD6"/>
-                    <constraint firstAttribute="trailing" secondItem="0qS-wL-AiS" secondAttribute="trailing" constant="16" id="dU4-cX-eF9"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="0qS-wL-AiS" secondAttribute="trailing" id="dU4-cX-eF9"/>
                     <constraint firstItem="TBy-h6-gyK" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="eGO-Jj-XbX"/>
                     <constraint firstItem="TBy-h6-gyK" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="pGx-RV-Mba"/>
                     <constraint firstItem="0qS-wL-AiS" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="rhX-kB-f68"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
@@ -26,17 +26,17 @@
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-wL-AiS">
                         <rect key="frame" x="16" y="6" width="304" height="30"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="edF-mf-PsH">
-                                <rect key="frame" x="0.0" y="0.0" width="230" height="30"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="edF-mf-PsH">
+                                <rect key="frame" x="0.0" y="0.0" width="216.5" height="30"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Removed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qPM-It-aeV">
-                                        <rect key="frame" x="0.0" y="0.0" width="115" height="30"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Removed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qPM-It-aeV">
+                                        <rect key="frame" x="0.0" y="0.0" width="136.5" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lnR-4i-vdi">
-                                        <rect key="frame" x="115" y="0.0" width="115" height="30"/>
+                                        <rect key="frame" x="136.5" y="0.0" width="80" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -44,7 +44,7 @@
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jmj-W8-Yz3">
-                                <rect key="frame" x="230" y="0.0" width="74" height="30"/>
+                                <rect key="frame" x="216.5" y="0.0" width="87.5" height="30"/>
                                 <state key="normal" title="Button"/>
                                 <connections>
                                     <action selector="undo:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="ZyQ-ga-eiX"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="ReaderSavedPostUndoCell" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
@@ -26,17 +26,17 @@
                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-wL-AiS">
                         <rect key="frame" x="16" y="6" width="288" height="30"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="edF-mf-PsH">
+                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="edF-mf-PsH">
                                 <rect key="frame" x="0.0" y="0.0" width="242" height="30"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Removed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qPM-It-aeV">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="Removed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qPM-It-aeV">
                                         <rect key="frame" x="0.0" y="0.0" width="71.5" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lnR-4i-vdi">
-                                        <rect key="frame" x="71.5" y="0.0" width="170.5" height="30"/>
+                                        <rect key="frame" x="79.5" y="0.0" width="162.5" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
@@ -23,28 +23,28 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
-                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-wL-AiS">
+                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-wL-AiS">
                         <rect key="frame" x="16" y="6" width="304" height="30"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="edF-mf-PsH">
-                                <rect key="frame" x="0.0" y="0.0" width="216.5" height="30"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="edF-mf-PsH">
+                                <rect key="frame" x="0.0" y="0.0" width="258" height="30"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Removed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qPM-It-aeV">
-                                        <rect key="frame" x="0.0" y="0.0" width="136.5" height="30"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Removed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qPM-It-aeV">
+                                        <rect key="frame" x="0.0" y="0.0" width="71.5" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lnR-4i-vdi">
-                                        <rect key="frame" x="136.5" y="0.0" width="80" height="30"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lnR-4i-vdi">
+                                        <rect key="frame" x="71.5" y="0.0" width="186.5" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jmj-W8-Yz3">
-                                <rect key="frame" x="216.5" y="0.0" width="87.5" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jmj-W8-Yz3">
+                                <rect key="frame" x="258" y="0.0" width="46" height="30"/>
                                 <state key="normal" title="Button"/>
                                 <connections>
                                     <action selector="undo:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="ZyQ-ga-eiX"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
@@ -24,10 +24,10 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-wL-AiS">
-                        <rect key="frame" x="16" y="6" width="304" height="30"/>
+                        <rect key="frame" x="16" y="6" width="288" height="30"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="edF-mf-PsH">
-                                <rect key="frame" x="0.0" y="0.0" width="258" height="30"/>
+                                <rect key="frame" x="0.0" y="0.0" width="242" height="30"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Removed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qPM-It-aeV">
                                         <rect key="frame" x="0.0" y="0.0" width="71.5" height="30"/>
@@ -36,7 +36,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lnR-4i-vdi">
-                                        <rect key="frame" x="71.5" y="0.0" width="186.5" height="30"/>
+                                        <rect key="frame" x="71.5" y="0.0" width="170.5" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -44,7 +44,7 @@
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="250" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jmj-W8-Yz3">
-                                <rect key="frame" x="258" y="0.0" width="46" height="30"/>
+                                <rect key="frame" x="242" y="0.0" width="46" height="30"/>
                                 <state key="normal" title="Button"/>
                                 <connections>
                                     <action selector="undo:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="ZyQ-ga-eiX"/>
@@ -57,7 +57,7 @@
                     <constraint firstItem="0qS-wL-AiS" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="FCo-M3-vdJ"/>
                     <constraint firstAttribute="trailing" secondItem="TBy-h6-gyK" secondAttribute="trailing" id="HV5-h3-5B3"/>
                     <constraint firstAttribute="bottom" secondItem="TBy-h6-gyK" secondAttribute="bottom" constant="-0.5" id="UDU-ic-hD6"/>
-                    <constraint firstAttribute="trailing" secondItem="0qS-wL-AiS" secondAttribute="trailing" id="dU4-cX-eF9"/>
+                    <constraint firstAttribute="trailing" secondItem="0qS-wL-AiS" secondAttribute="trailing" constant="16" id="dU4-cX-eF9"/>
                     <constraint firstItem="TBy-h6-gyK" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="eGO-Jj-XbX"/>
                     <constraint firstItem="TBy-h6-gyK" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="pGx-RV-Mba"/>
                     <constraint firstItem="0qS-wL-AiS" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="rhX-kB-f68"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
@@ -19,6 +19,10 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TBy-h6-gyK" userLabel="Bordered View">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </view>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-wL-AiS">
                         <rect key="frame" x="16" y="6" width="304" height="30"/>
                         <subviews>
@@ -51,14 +55,20 @@
                 </subviews>
                 <constraints>
                     <constraint firstItem="0qS-wL-AiS" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="FCo-M3-vdJ"/>
+                    <constraint firstAttribute="trailing" secondItem="TBy-h6-gyK" secondAttribute="trailing" id="HV5-h3-5B3"/>
+                    <constraint firstAttribute="bottom" secondItem="TBy-h6-gyK" secondAttribute="bottom" constant="-0.5" id="UDU-ic-hD6"/>
                     <constraint firstAttribute="trailing" secondItem="0qS-wL-AiS" secondAttribute="trailing" id="dU4-cX-eF9"/>
+                    <constraint firstItem="TBy-h6-gyK" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="eGO-Jj-XbX"/>
+                    <constraint firstItem="TBy-h6-gyK" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="pGx-RV-Mba"/>
                     <constraint firstItem="0qS-wL-AiS" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="rhX-kB-f68"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="borderedView" destination="TBy-h6-gyK" id="yrB-iu-Zba"/>
                 <outlet property="removed" destination="qPM-It-aeV" id="UIu-47-UqL"/>
                 <outlet property="title" destination="lnR-4i-vdi" id="Eol-Q8-exV"/>
+                <outlet property="undoButton" destination="Jmj-W8-Yz3" id="rWp-Qa-Nyt"/>
             </connections>
         </tableViewCell>
     </objects>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
@@ -1,21 +1,65 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="ReaderSavedPostUndoCell" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="ReaderSavedPostUndoCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-wL-AiS">
+                        <rect key="frame" x="16" y="6" width="304" height="30"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="edF-mf-PsH">
+                                <rect key="frame" x="0.0" y="0.0" width="230" height="30"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Removed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qPM-It-aeV">
+                                        <rect key="frame" x="0.0" y="0.0" width="115" height="30"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lnR-4i-vdi">
+                                        <rect key="frame" x="115" y="0.0" width="115" height="30"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jmj-W8-Yz3">
+                                <rect key="frame" x="230" y="0.0" width="74" height="30"/>
+                                <state key="normal" title="Button"/>
+                                <connections>
+                                    <action selector="undo:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="ZyQ-ga-eiX"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="0qS-wL-AiS" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="FCo-M3-vdJ"/>
+                    <constraint firstAttribute="trailing" secondItem="0qS-wL-AiS" secondAttribute="trailing" id="dU4-cX-eF9"/>
+                    <constraint firstItem="0qS-wL-AiS" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="rhX-kB-f68"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="removed" destination="qPM-It-aeV" id="UIu-47-UqL"/>
+                <outlet property="title" destination="lnR-4i-vdi" id="Eol-Q8-exV"/>
+            </connections>
         </tableViewCell>
     </objects>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -13,7 +13,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="ReaderSavedPostUndoCell" customModule="WordPress" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="44" id="KGk-i7-Jjw" customClass="ReaderSavedPostUndoCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" layoutMarginsFollowReadableWidth="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
@@ -23,6 +23,9 @@
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TBy-h6-gyK" userLabel="Bordered View">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="44" id="OeB-Do-X3c"/>
+                        </constraints>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-wL-AiS">
                         <rect key="frame" x="16" y="6" width="288" height="30"/>
@@ -57,7 +60,7 @@
                 <constraints>
                     <constraint firstItem="0qS-wL-AiS" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="FCo-M3-vdJ"/>
                     <constraint firstAttribute="trailing" secondItem="TBy-h6-gyK" secondAttribute="trailing" id="HV5-h3-5B3"/>
-                    <constraint firstAttribute="bottom" secondItem="TBy-h6-gyK" secondAttribute="bottom" constant="-0.5" id="UDU-ic-hD6"/>
+                    <constraint firstAttribute="bottom" secondItem="TBy-h6-gyK" secondAttribute="bottom" id="UDU-ic-hD6"/>
                     <constraint firstAttribute="trailingMargin" secondItem="0qS-wL-AiS" secondAttribute="trailing" id="dU4-cX-eF9"/>
                     <constraint firstItem="TBy-h6-gyK" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="eGO-Jj-XbX"/>
                     <constraint firstItem="TBy-h6-gyK" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="pGx-RV-Mba"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
@@ -35,7 +35,7 @@
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lnR-4i-vdi">
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lnR-4i-vdi">
                                         <rect key="frame" x="79.5" y="0.0" width="162.5" height="30"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -254,12 +254,17 @@ extension ReaderSavedPostsViewController: WPTableViewHandlerDelegate {
 
         if postCellActions?.contains(post) == true {
             let cell = undoCell(tableView)
+            configureUndoCell(cell, with: post)
             return cell
         }
 
         let cell = tableConfiguration.postCardCell(tableView)
         configurePostCardCell(cell, post: post)
         return cell
+    }
+
+    private func configureUndoCell(_ cell: ReaderSavedPostUndoCell, with post: ReaderPost) {
+        cell.title.text = post.titleForDisplay()
     }
 
     override public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -59,7 +59,7 @@ final class ReaderSavedPostsViewController: UITableViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        postCellActions?.clear()
+        postCellActions?.clearRemovedPosts()
     }
 
     func centerResultsStatusViewIfNeeded() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -265,6 +265,8 @@ extension ReaderSavedPostsViewController: WPTableViewHandlerDelegate {
 
     private func configureUndoCell(_ cell: ReaderSavedPostUndoCell, with post: ReaderPost) {
         cell.title.text = post.titleForDisplay()
+        cell.contentProvider = post
+        cell.delegate = self
     }
 
     override public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -359,6 +361,19 @@ extension ReaderSavedPostsViewController: ReaderSavedPostCellActionsDelegate {
             tableView.reloadRows(at: [cellIndex], with: .fade)
         }
     }
+}
 
+extension ReaderSavedPostsViewController: ReaderPostUndoCellDelegate {
+    func readerCell(_ cell: ReaderSavedPostUndoCell, undoActionForProvider provider: ReaderPostContentProvider) {
+        if let cellIndex = tableView.indexPath(for: cell) {
+            guard let posts = content.content as? [ReaderPost] else {
+                DDLogError("[ReaderStreamViewController tableView:didSelectRowAtIndexPath:] fetchedObjects was nil.")
+                return
+            }
 
+            let post = posts[cellIndex.row]
+            postCellActions?.remove(post)
+            tableView.reloadRows(at: [cellIndex], with: .fade)
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -258,19 +258,16 @@ extension ReaderSavedPostsViewController: WPTableViewHandlerDelegate {
         }
         let post = posts[indexPath.row]
 
-        //        if recentlyBlockedSitePostObjectIDs.contains(post.objectID) {
-        //            let cell = tableView.dequeueReusableCell(withIdentifier: readerBlockedCellReuseIdentifier) as! ReaderBlockedSiteCell
-//        cellConfiguration.configureBlockedCell(cell,
-//                                               withContent: content,
-//                                               atIndexPath: indexPath)
-        //            return cell
-        //        }
-
         if post.isCross() {
             let cell = tableConfiguration.crossPostCell(tableView)
             cellConfiguration.configureCrossPostCell(cell,
                                                      withContent: content,
                                                      atIndexPath: indexPath)
+            return cell
+        }
+
+        if removedPosts?.contains(post) == true {
+            let cell = undoCell(tableView)
             return cell
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -26,9 +26,7 @@ final class ReaderSavedPostsViewController: UITableViewController {
     /// Configuration of cells
     private let cellConfiguration = ReaderCellConfiguration()
     /// Actions
-    private var postCellActions: ReaderPostCellActions?
-    /// Posts that have been removed but not yet discarded
-    private var removedPosts: ReaderSaveForLaterRemovedPosts?
+    private var postCellActions: ReaderSavedPostCellActions?
 
     fileprivate lazy var displayContext: NSManagedObjectContext = ContextManager.sharedInstance().newMainContextChildContext()
 
@@ -57,12 +55,6 @@ final class ReaderSavedPostsViewController: UITableViewController {
         super.viewDidAppear(animated)
 
         refreshNoResultsView()
-        setupRemovedPosts()
-    }
-
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        clearRemovedPosts()
     }
 
     func centerResultsStatusViewIfNeeded() {
@@ -89,14 +81,6 @@ final class ReaderSavedPostsViewController: UITableViewController {
 
     fileprivate func setupContentHandler() {
         content.initializeContent(tableView: tableView, delegate: self)
-    }
-
-    private func setupRemovedPosts() {
-        removedPosts = ReaderSaveForLaterRemovedPosts()
-    }
-
-    private func clearRemovedPosts() {
-        removedPosts = nil
     }
 
     /// The fetch request can need a different predicate depending on how the content
@@ -143,7 +127,7 @@ final class ReaderSavedPostsViewController: UITableViewController {
 
     @objc open func configurePostCardCell(_ cell: UITableViewCell, post: ReaderPost) {
         if postCellActions == nil {
-            postCellActions = ReaderPostCellActions(context: managedObjectContext(), origin: self, topic: post.topic, visibleConfirmation: false)
+            postCellActions = ReaderSavedPostCellActions(context: managedObjectContext(), origin: self, topic: post.topic, visibleConfirmation: false)
         }
 
         cellConfiguration.configurePostCardCell(cell,
@@ -266,7 +250,7 @@ extension ReaderSavedPostsViewController: WPTableViewHandlerDelegate {
             return cell
         }
 
-        if removedPosts?.contains(post) == true {
+        if postCellActions?.contains(post) == true {
             let cell = undoCell(tableView)
             return cell
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -11,6 +11,7 @@ final class ReaderSavedPostsViewController: UITableViewController {
     private enum UndoCell {
         static let nibName = "ReaderSavedPostUndoCell"
         static let reuseIdentifier = "ReaderUndoCellReuseIdentifier"
+        static let height: CGFloat = 44
     }
 
     fileprivate var noResultsView: WPNoResultsView!

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -256,7 +256,7 @@ extension ReaderSavedPostsViewController: WPTableViewHandlerDelegate {
         }
 
 
-        if postCellActions?.contains(post) == true {
+        if postCellActions?.postIsRemoved(post) == true {
             let cell = undoCell(tableView)
             configureUndoCell(cell, with: post)
             return cell

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -7,6 +7,12 @@ final class ReaderSavedPostsViewController: UITableViewController {
     private enum Strings {
         static let title = NSLocalizedString("Saved Posts", comment: "Title for list of posts saved for later")
     }
+
+    private enum UndoCell {
+        static let nibName = "ReaderSavedPostUndoCell"
+        static let reuseIdentifier = "ReaderUndoCellReuseIdentifier"
+    }
+
     fileprivate var noResultsView: WPNoResultsView!
     fileprivate var footerView: PostListFooterView!
     fileprivate let heightForFooterView = CGFloat(34.0)
@@ -60,6 +66,13 @@ final class ReaderSavedPostsViewController: UITableViewController {
 
     fileprivate func setupTableView() {
         tableConfiguration.setup(tableView)
+
+        setUpUndoCell(tableView)
+    }
+
+    private func setUpUndoCell(_ tableView: UITableView) {
+        let nib = UINib(nibName: UndoCell.nibName, bundle: nil)
+        tableView.register(nib, forCellReuseIdentifier: UndoCell.reuseIdentifier)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -27,6 +27,8 @@ final class ReaderSavedPostsViewController: UITableViewController {
     private let cellConfiguration = ReaderCellConfiguration()
     /// Actions
     private var postCellActions: ReaderPostCellActions?
+    /// Posts that have been removed but not yet discarded
+    private var removedPosts: ReaderSaveForLaterRemovedPosts?
 
     fileprivate lazy var displayContext: NSManagedObjectContext = ContextManager.sharedInstance().newMainContextChildContext()
 
@@ -55,6 +57,12 @@ final class ReaderSavedPostsViewController: UITableViewController {
         super.viewDidAppear(animated)
 
         refreshNoResultsView()
+        setupRemovedPosts()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        clearRemovedPosts()
     }
 
     func centerResultsStatusViewIfNeeded() {
@@ -67,10 +75,10 @@ final class ReaderSavedPostsViewController: UITableViewController {
 
     fileprivate func setupTableView() {
         tableConfiguration.setup(tableView)
-        setUpUndoCell(tableView)
+        setupUndoCell(tableView)
     }
 
-    private func setUpUndoCell(_ tableView: UITableView) {
+    private func setupUndoCell(_ tableView: UITableView) {
         let nib = UINib(nibName: UndoCell.nibName, bundle: nil)
         tableView.register(nib, forCellReuseIdentifier: UndoCell.reuseIdentifier)
     }
@@ -81,6 +89,14 @@ final class ReaderSavedPostsViewController: UITableViewController {
 
     fileprivate func setupContentHandler() {
         content.initializeContent(tableView: tableView, delegate: self)
+    }
+
+    private func setupRemovedPosts() {
+        removedPosts = ReaderSaveForLaterRemovedPosts()
+    }
+
+    private func clearRemovedPosts() {
+        removedPosts = nil
     }
 
     /// The fetch request can need a different predicate depending on how the content

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -57,8 +57,8 @@ final class ReaderSavedPostsViewController: UITableViewController {
         refreshNoResultsView()
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillAppear(animated)
+    deinit {
+        print("===== deinit =====")
         postCellActions?.clearRemovedPosts()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -265,7 +265,6 @@ extension ReaderSavedPostsViewController: WPTableViewHandlerDelegate {
 
     private func configureUndoCell(_ cell: ReaderSavedPostUndoCell, with post: ReaderPost) {
         cell.title.text = post.titleForDisplay()
-        cell.contentProvider = post
         cell.delegate = self
     }
 
@@ -364,7 +363,7 @@ extension ReaderSavedPostsViewController: ReaderSavedPostCellActionsDelegate {
 }
 
 extension ReaderSavedPostsViewController: ReaderPostUndoCellDelegate {
-    func readerCell(_ cell: ReaderSavedPostUndoCell, undoActionForProvider provider: ReaderPostContentProvider) {
+    func readerCellWillUndo(_ cell: ReaderSavedPostUndoCell) {
         if let cellIndex = tableView.indexPath(for: cell),
             let post: ReaderPost = content.object(at: cellIndex) {
                 postCellActions?.remove(post)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -128,6 +128,7 @@ final class ReaderSavedPostsViewController: UITableViewController {
     @objc open func configurePostCardCell(_ cell: UITableViewCell, post: ReaderPost) {
         if postCellActions == nil {
             postCellActions = ReaderSavedPostCellActions(context: managedObjectContext(), origin: self, topic: post.topic, visibleConfirmation: false)
+            postCellActions?.delegate = self
         }
 
         cellConfiguration.configurePostCardCell(cell,
@@ -250,6 +251,7 @@ extension ReaderSavedPostsViewController: WPTableViewHandlerDelegate {
             return cell
         }
 
+
         if postCellActions?.contains(post) == true {
             let cell = undoCell(tableView)
             return cell
@@ -344,4 +346,14 @@ extension ReaderSavedPostsViewController: WPTableViewHandlerDelegate {
     public func configureCell(_ cell: UITableViewCell, at indexPath: IndexPath) {
         // Do nothing
     }
+}
+
+extension ReaderSavedPostsViewController: ReaderSavedPostCellActionsDelegate {
+    func willRemove(_ cell: ReaderPostCardCell) {
+        if let cellIndex = tableView.indexPath(for: cell) {
+            tableView.reloadRows(at: [cellIndex], with: .fade)
+        }
+    }
+
+
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -370,7 +370,7 @@ extension ReaderSavedPostsViewController: ReaderPostUndoCellDelegate {
     func readerCellWillUndo(_ cell: ReaderSavedPostUndoCell) {
         if let cellIndex = tableView.indexPath(for: cell),
             let post: ReaderPost = content.object(at: cellIndex) {
-                postCellActions?.remove(post)
+                postCellActions?.restoreUnsavedPost(post)
                 tableView.reloadRows(at: [cellIndex], with: .fade)
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -67,7 +67,6 @@ final class ReaderSavedPostsViewController: UITableViewController {
 
     fileprivate func setupTableView() {
         tableConfiguration.setup(tableView)
-
         setUpUndoCell(tableView)
     }
 
@@ -76,6 +75,9 @@ final class ReaderSavedPostsViewController: UITableViewController {
         tableView.register(nib, forCellReuseIdentifier: UndoCell.reuseIdentifier)
     }
 
+    func undoCell(_ tableView: UITableView) -> ReaderSavedPostUndoCell {
+        return tableView.dequeueReusableCell(withIdentifier: UndoCell.reuseIdentifier) as! ReaderSavedPostUndoCell
+    }
 
     fileprivate func setupContentHandler() {
         content.initializeContent(tableView: tableView, delegate: self)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -365,15 +365,10 @@ extension ReaderSavedPostsViewController: ReaderSavedPostCellActionsDelegate {
 
 extension ReaderSavedPostsViewController: ReaderPostUndoCellDelegate {
     func readerCell(_ cell: ReaderSavedPostUndoCell, undoActionForProvider provider: ReaderPostContentProvider) {
-        if let cellIndex = tableView.indexPath(for: cell) {
-            guard let posts = content.content as? [ReaderPost] else {
-                DDLogError("[ReaderStreamViewController tableView:didSelectRowAtIndexPath:] fetchedObjects was nil.")
-                return
-            }
-
-            let post = posts[cellIndex.row]
-            postCellActions?.remove(post)
-            tableView.reloadRows(at: [cellIndex], with: .fade)
+        if let cellIndex = tableView.indexPath(for: cell),
+            let post: ReaderPost = content.object(at: cellIndex) {
+                postCellActions?.remove(post)
+                tableView.reloadRows(at: [cellIndex], with: .fade)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -58,7 +58,6 @@ final class ReaderSavedPostsViewController: UITableViewController {
     }
 
     deinit {
-        print("===== deinit =====")
         postCellActions?.clearRemovedPosts()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -57,6 +57,11 @@ final class ReaderSavedPostsViewController: UITableViewController {
         refreshNoResultsView()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        postCellActions?.clear()
+    }
+
     func centerResultsStatusViewIfNeeded() {
         if noResultsView.isDescendant(of: tableView) {
             noResultsView.centerInSuperview()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -869,6 +869,8 @@
 		D83CA3AB20842E5F0060E310 /* StockPhotosResultsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83CA3AA20842E5F0060E310 /* StockPhotosResultsPage.swift */; };
 		D83CA3B02084CAAF0060E310 /* StockPhotosDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83CA3AF2084CAAF0060E310 /* StockPhotosDataLoader.swift */; };
 		D87A329620ABD60700F4726F /* ReaderTableContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87A329520ABD60700F4726F /* ReaderTableContent.swift */; };
+		D88106F720C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88106F520C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift */; };
+		D88106F820C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */; };
 		D88A6492208D7A0A008AE9BC /* MockStockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88A6491208D7A0A008AE9BC /* MockStockPhotosService.swift */; };
 		D88A6494208D7AD0008AE9BC /* DefaultStockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88A6493208D7AD0008AE9BC /* DefaultStockPhotosService.swift */; };
 		D88A6496208D7B0B008AE9BC /* NullStockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88A6495208D7B0B008AE9BC /* NullStockPhotosService.swift */; };
@@ -2405,6 +2407,8 @@
 		D83CA3AA20842E5F0060E310 /* StockPhotosResultsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosResultsPage.swift; sourceTree = "<group>"; };
 		D83CA3AF2084CAAF0060E310 /* StockPhotosDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosDataLoader.swift; sourceTree = "<group>"; };
 		D87A329520ABD60700F4726F /* ReaderTableContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTableContent.swift; sourceTree = "<group>"; };
+		D88106F520C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSavedPostUndoCell.swift; sourceTree = "<group>"; };
+		D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderSavedPostUndoCell.xib; sourceTree = "<group>"; };
 		D88A6491208D7A0A008AE9BC /* MockStockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStockPhotosService.swift; sourceTree = "<group>"; };
 		D88A6493208D7AD0008AE9BC /* DefaultStockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStockPhotosService.swift; sourceTree = "<group>"; };
 		D88A6495208D7B0B008AE9BC /* NullStockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullStockPhotosService.swift; sourceTree = "<group>"; };
@@ -3729,6 +3733,8 @@
 				E6A3384D1BB0A50900371587 /* ReaderGapMarkerCell.xib */,
 				E6D3E8481BEBD871002692E8 /* ReaderCrossPostCell.swift */,
 				E6D3E84A1BEBD888002692E8 /* ReaderCrossPostCell.xib */,
+				D88106F520C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift */,
+				D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */,
 			);
 			name = Cards;
 			sourceTree = "<group>";
@@ -6523,6 +6529,7 @@
 				40640046200ED30300106789 /* TextWithAccessoryButtonCell.xib in Resources */,
 				FF00889D204DFF77007CCE66 /* MediaQuotaCell.xib in Resources */,
 				931DF4D618D09A2F00540BDD /* InfoPlist.strings in Resources */,
+				D88106F820C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib in Resources */,
 				5D5A6E941B613CA400DAF819 /* ReaderPostCardCell.xib in Resources */,
 				1731BCD11DD9EFF1009FE3AE /* HelpshiftCustomConfig.plist in Resources */,
 				4019B27120885AB900A0C7EB /* Activity.storyboard in Resources */,
@@ -7609,6 +7616,7 @@
 				5D42A3E2175E7452005CFF05 /* ReaderPost.m in Sources */,
 				D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */,
 				982A4C3520227D6700B5518E /* NoResultsViewController.swift in Sources */,
+				D88106F720C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift in Sources */,
 				74EA3B88202A0462004F802D /* ShareNoticeConstants.swift in Sources */,
 				FF1933FF1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m in Sources */,
 				B54075D41D3D7D5B0095C318 /* IntrinsicTableView.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -871,6 +871,7 @@
 		D87A329620ABD60700F4726F /* ReaderTableContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87A329520ABD60700F4726F /* ReaderTableContent.swift */; };
 		D88106F720C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88106F520C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift */; };
 		D88106F820C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */; };
+		D88106FA20C0CFEE001D2F00 /* ReaderSaveForLaterRemovedPosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88106F920C0CFEE001D2F00 /* ReaderSaveForLaterRemovedPosts.swift */; };
 		D88A6492208D7A0A008AE9BC /* MockStockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88A6491208D7A0A008AE9BC /* MockStockPhotosService.swift */; };
 		D88A6494208D7AD0008AE9BC /* DefaultStockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88A6493208D7AD0008AE9BC /* DefaultStockPhotosService.swift */; };
 		D88A6496208D7B0B008AE9BC /* NullStockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88A6495208D7B0B008AE9BC /* NullStockPhotosService.swift */; };
@@ -2409,6 +2410,7 @@
 		D87A329520ABD60700F4726F /* ReaderTableContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTableContent.swift; sourceTree = "<group>"; };
 		D88106F520C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSavedPostUndoCell.swift; sourceTree = "<group>"; };
 		D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderSavedPostUndoCell.xib; sourceTree = "<group>"; };
+		D88106F920C0CFEE001D2F00 /* ReaderSaveForLaterRemovedPosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSaveForLaterRemovedPosts.swift; sourceTree = "<group>"; };
 		D88A6491208D7A0A008AE9BC /* MockStockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStockPhotosService.swift; sourceTree = "<group>"; };
 		D88A6493208D7AD0008AE9BC /* DefaultStockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStockPhotosService.swift; sourceTree = "<group>"; };
 		D88A6495208D7B0B008AE9BC /* NullStockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullStockPhotosService.swift; sourceTree = "<group>"; };
@@ -3670,6 +3672,7 @@
 				D87A329520ABD60700F4726F /* ReaderTableContent.swift */,
 				D817798F20ABF26800330998 /* ReaderCellConfiguration.swift */,
 				D817799320ABFDB300330998 /* ReaderPostCellActions.swift */,
+				D88106F920C0CFEE001D2F00 /* ReaderSaveForLaterRemovedPosts.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -7197,6 +7200,7 @@
 				433432541E9EE0B100915988 /* EpilogueSegue.swift in Sources */,
 				D800D86E2099857000E7C7E5 /* SearchMenuItemCreator.swift in Sources */,
 				9827B3B1201FF30700530AF5 /* SiteCreationFields.swift in Sources */,
+				D88106FA20C0CFEE001D2F00 /* ReaderSaveForLaterRemovedPosts.swift in Sources */,
 				1751E5931CE23801000CA08D /* NSAttributedString+StyledHTML.swift in Sources */,
 				D8071631203DA23700B32FD9 /* Accessible.swift in Sources */,
 				98077B5A2075561800109F95 /* SupportTableViewController.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -872,6 +872,7 @@
 		D88106F720C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88106F520C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift */; };
 		D88106F820C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */; };
 		D88106FA20C0CFEE001D2F00 /* ReaderSaveForLaterRemovedPosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88106F920C0CFEE001D2F00 /* ReaderSaveForLaterRemovedPosts.swift */; };
+		D88106FC20C0D4A4001D2F00 /* ReaderSavedPostCellActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88106FB20C0D4A4001D2F00 /* ReaderSavedPostCellActions.swift */; };
 		D88A6492208D7A0A008AE9BC /* MockStockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88A6491208D7A0A008AE9BC /* MockStockPhotosService.swift */; };
 		D88A6494208D7AD0008AE9BC /* DefaultStockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88A6493208D7AD0008AE9BC /* DefaultStockPhotosService.swift */; };
 		D88A6496208D7B0B008AE9BC /* NullStockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88A6495208D7B0B008AE9BC /* NullStockPhotosService.swift */; };
@@ -2411,6 +2412,7 @@
 		D88106F520C0C9A8001D2F00 /* ReaderSavedPostUndoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSavedPostUndoCell.swift; sourceTree = "<group>"; };
 		D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderSavedPostUndoCell.xib; sourceTree = "<group>"; };
 		D88106F920C0CFEE001D2F00 /* ReaderSaveForLaterRemovedPosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSaveForLaterRemovedPosts.swift; sourceTree = "<group>"; };
+		D88106FB20C0D4A4001D2F00 /* ReaderSavedPostCellActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSavedPostCellActions.swift; sourceTree = "<group>"; };
 		D88A6491208D7A0A008AE9BC /* MockStockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStockPhotosService.swift; sourceTree = "<group>"; };
 		D88A6493208D7AD0008AE9BC /* DefaultStockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStockPhotosService.swift; sourceTree = "<group>"; };
 		D88A6495208D7B0B008AE9BC /* NullStockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullStockPhotosService.swift; sourceTree = "<group>"; };
@@ -3673,6 +3675,7 @@
 				D817798F20ABF26800330998 /* ReaderCellConfiguration.swift */,
 				D817799320ABFDB300330998 /* ReaderPostCellActions.swift */,
 				D88106F920C0CFEE001D2F00 /* ReaderSaveForLaterRemovedPosts.swift */,
+				D88106FB20C0D4A4001D2F00 /* ReaderSavedPostCellActions.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -7544,6 +7547,7 @@
 				7E729C28209A087300F76599 /* ImageLoader.swift in Sources */,
 				5D146EBB189857ED0068FDC6 /* FeaturedImageViewController.m in Sources */,
 				D817799020ABF26800330998 /* ReaderCellConfiguration.swift in Sources */,
+				D88106FC20C0D4A4001D2F00 /* ReaderSavedPostCellActions.swift in Sources */,
 				31EC15081A5B6675009FC8B3 /* WPStyleGuide+Suggestions.m in Sources */,
 				9F74696B209EFD0C0074D52B /* CheckmarkTableViewCell.swift in Sources */,
 				FF5371631FDFF64F00619A3F /* MediaService.swift in Sources */,


### PR DESCRIPTION
Implements #9474 

An early PR to validate the general direction.
![animation_recording mov](https://user-images.githubusercontent.com/2722505/40821390-7cf1a2ca-651b-11e8-9105-606973787146.gif)

Implement removal animation and undo by not actually removing the flag marking `ReaderPost`s a saved for later, but by tracking the post that have been selected for removal, and presenting a cell containing their "collapsed state" (title, and undo button) in their place.

Caveats: 
- The design of the collapsed cell is not final. I run out of time and I wanted to validate the rest of the implementation as soon as possible.

To test:
1. Mark a few posts as saved for later
2. Navigate to Saved Posts
3. Tap the "Save for Later" button (bookmark icon) in a few posts. The posts should collapse.
4. Tap Undo. The post should be visible again
5. Navigate away from Saved Posts. Posts that were "removed" should not be visible anymore when navigating back to Saved Posts.