### PR TITLE
Reader: Clear saved posts on account change

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -124,7 +124,12 @@ extern NSString * const ReaderPostServiceToggleSiteFollowingState;
 - (void)deletePostsWithNoTopic;
 
 /**
- Globally sets the `inUse` flag to fall for all posts.
+ Sets the `isSavedForLater` flag to false for all posts.
+ */
+- (void)clearSavedPostFlags;
+
+/**
+ Globally sets the `inUse` flag to false for all posts.
  */
 - (void)clearInUseFlags;
 

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -426,6 +426,24 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
 }
 
+- (void)clearSavedPostFlags
+{
+    NSError *error;
+    NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:@"ReaderPost"];
+    request.predicate = [NSPredicate predicateWithFormat:@"isSavedForLater = true"];
+    NSArray *results = [self.managedObjectContext executeFetchRequest:request error:&error];
+    if (error) {
+        DDLogError(@"%@, unsaving saved posts: %@", NSStringFromSelector(_cmd), error);
+        return;
+    }
+
+    for (ReaderPost *post in results) {
+        post.isSavedForLater = NO;
+    }
+
+    [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
+}
+
 - (void)clearInUseFlags
 {
     NSError *error;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -209,6 +209,12 @@ import WordPressShared
         }
     }
 
+    /// Clears all saved posts, so they can be deleted by cleanup methods.
+    ///
+    func clearSavedPosts() {
+        let context = ContextManager.sharedInstance().mainContext
+        ReaderPostService(managedObjectContext: context).clearSavedPostFlags()
+    }
 
     // MARK: - Instance Methods
 
@@ -231,6 +237,7 @@ import WordPressShared
 
         // Clean up obsolete content.
         unflagInUseContent()
+        clearSavedPosts()
         cleanupStaleContent(removeAllTopics: true)
 
         // Clean up stale search history


### PR DESCRIPTION
Ideally we’d like to save a user’s saved Reader posts if they log out of the app and then back in with the same account - but we’ll need to work out the right way to detect whether the account has changed. 

At the moment, we never wipe the list of saved posts, no matter who logs in. Until we have a proper solution, we should clear the list of saved posts on log out to prevent users potentially seeing which posts a different user had saved. This PR implements that functionality.

**To test:**

* Log in and save some posts
* Log out and log back in
* Ensure the list of saved posts is empty. Prior to this PR, you’d still see your saved posts.

