### PR TITLE
Zendesk Mobile: Support email prompt - update text.

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -893,7 +893,7 @@ private extension ZendeskUtils {
 
     struct LocalizedText {
         static let alertMessageWithName = NSLocalizedString("To continue please enter your email address and name.", comment: "Instructions for alert asking for email and name.")
-        static let alertMessage = NSLocalizedString("To continue please enter your email address.", comment: "Instructions for alert asking for email.")
+        static let alertMessage = NSLocalizedString("Please enter your email address.", comment: "Instructions for alert asking for email.")
         static let alertSubmit = NSLocalizedString("OK", comment: "Submit button on prompt for user information.")
         static let alertCancel = NSLocalizedString("Cancel", comment: "Cancel prompt for user information.")
         static let emailPlaceholder = NSLocalizedString("Email", comment: "Email address text field placeholder")


### PR DESCRIPTION
Ref #9492 

This updates the message on the Support email prompt to match Android (https://github.com/wordpress-mobile/WordPress-Android/pull/7829#issuecomment-394301233).


To test:
- Go to Me > Help & Support.
- Select Contact Email.
- Verify the message text is "Please enter your email address.".

![email_prompt](https://user-images.githubusercontent.com/1816888/40931995-3b7e2fda-67ea-11e8-9021-7db3251b69bb.png)



