### PR TITLE
Update delete site alert

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -200,7 +200,7 @@ open class DeleteSiteViewController: UITableViewController {
         let styledMessage: NSMutableAttributedString = NSMutableAttributedString(string: message)
         styledMessage.append(styledUrl)
 
-        // Create alert        
+        // Create alert
         let confirmTitle = NSLocalizedString("Confirm Delete Site", comment: "Title of Delete Site confirmation alert")
         let alertController = UIAlertController(title: confirmTitle, message: nil, preferredStyle: .alert)
         alertController.setValue(styledMessage, forKey: "attributedMessage")
@@ -208,7 +208,7 @@ open class DeleteSiteViewController: UITableViewController {
         let cancelTitle = NSLocalizedString("Cancel", comment: "Alert dismissal title")
         alertController.addCancelActionWithTitle(cancelTitle, handler: nil)
 
-        let deleteTitle = NSLocalizedString("Delete this site", comment: "Delete Site confirmation action title")
+        let deleteTitle = NSLocalizedString("Permanently Delete Site", comment: "Delete Site confirmation action title")
         let deleteAction = UIAlertAction(title: deleteTitle, style: .destructive, handler: { action in
             self.deleteSiteConfirmed()
         })

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -195,7 +195,7 @@ open class DeleteSiteViewController: UITableViewController {
         urlParagraphStyle.lineBreakMode = .byCharWrapping
         styledUrl.addAttribute(.paragraphStyle, value: urlParagraphStyle, range: NSMakeRange(0, styledUrl.string.count - 1))
 
-        let message = NSLocalizedString("\nPlease type your site address to confirm deletion. Your site will then be permanently deleted.\n\n",
+        let message = NSLocalizedString("\nTo confirm, please re-enter your site's address before deleting.\n\n",
                                              comment: "Message of Delete Site confirmation alert; substitution is site's host.")
         let styledMessage: NSMutableAttributedString = NSMutableAttributedString(string: message)
         styledMessage.append(styledUrl)

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -188,10 +188,22 @@ open class DeleteSiteViewController: UITableViewController {
     /// - Returns: UIAlertController
     ///
     fileprivate func confirmDeleteController() -> UIAlertController {
+
+        // Create atributed strings for URL and message body so we can wrap the URL byCharWrapping.
+        let styledUrl: NSMutableAttributedString = NSMutableAttributedString(string: blog.displayURL! as String)
+        let urlParagraphStyle = NSMutableParagraphStyle()
+        urlParagraphStyle.lineBreakMode = .byCharWrapping
+        styledUrl.addAttribute(.paragraphStyle, value: urlParagraphStyle, range: NSMakeRange(0, styledUrl.string.count - 1))
+
+        let message = NSLocalizedString("\nPlease type your site address to confirm deletion. Your site will then be permanently deleted.\n\n",
+                                             comment: "Message of Delete Site confirmation alert; substitution is site's host.")
+        let styledMessage: NSMutableAttributedString = NSMutableAttributedString(string: message)
+        styledMessage.append(styledUrl)
+
+        // Create alert        
         let confirmTitle = NSLocalizedString("Confirm Delete Site", comment: "Title of Delete Site confirmation alert")
-        let messageFormat = NSLocalizedString("Please type in \n\n%@\n\n in the field below to confirm. Your site will then be gone forever.", comment: "Message of Delete Site confirmation alert; substitution is site's host")
-        let message = String(format: messageFormat, blog.displayURL!)
-        let alertController = UIAlertController(title: confirmTitle, message: message, preferredStyle: .alert)
+        let alertController = UIAlertController(title: confirmTitle, message: nil, preferredStyle: .alert)
+        alertController.setValue(styledMessage, forKey: "attributedMessage")
 
         let cancelTitle = NSLocalizedString("Cancel", comment: "Alert dismissal title")
         alertController.addCancelActionWithTitle(cancelTitle, handler: nil)


### PR DESCRIPTION
Fixes #9217 

To test:
- Create a WordPress.com site with a very long site address (or increase the device text size).
- Go to site details > Settings > Delete Site > Delete Site.
  - Verify there is no hyphen in the URL.
  - Verify the message is `To confirm, please re-enter your site's address before deleting.`.
  - Verify the delete button text is `Permanently Delete Site`.

![delete_alert](https://user-images.githubusercontent.com/1816888/40992971-7f8c7206-68b5-11e8-956c-7704768840de.png)
