### PR TITLE
Extensions: fixed site list ordering

### DIFF
--- a/WordPress/Classes/Services/ShareExtensionService.swift
+++ b/WordPress/Classes/Services/ShareExtensionService.swift
@@ -67,7 +67,6 @@ open class ShareExtensionService: NSObject {
         userDefaults.synchronize()
     }
 
-
     /// Sets the Maximum Media Size.
     ///
     /// - Parameter maximumMediaSize: The maximum size a media attachment might occupy.
@@ -78,6 +77,20 @@ open class ShareExtensionService: NSObject {
         }
 
         userDefaults.set(maximumMediaDimension, forKey: WPShareExtensionMaximumMediaDimensionKey)
+        userDefaults.synchronize()
+    }
+
+
+    /// Sets the recently used sites.
+    ///
+    /// - Parameter recentSites: An array of URL's representing the recently used sites.
+    ///
+    @objc class func configureShareExtensionRecentSites(_ recentSites: [String]) {
+        guard let userDefaults = UserDefaults(suiteName: WPAppGroupName) else {
+            return
+        }
+
+        userDefaults.set(recentSites, forKey: WPShareExtensionRecentSitesKey)
         userDefaults.synchronize()
     }
 
@@ -106,6 +119,7 @@ open class ShareExtensionService: NSObject {
             userDefaults.removeObject(forKey: WPShareExtensionUserDefaultsLastUsedSiteID)
             userDefaults.removeObject(forKey: WPShareExtensionUserDefaultsLastUsedSiteName)
             userDefaults.removeObject(forKey: WPShareExtensionMaximumMediaDimensionKey)
+            userDefaults.removeObject(forKey: WPShareExtensionRecentSitesKey)
             userDefaults.synchronize()
         }
     }
@@ -176,5 +190,15 @@ open class ShareExtensionService: NSObject {
         }
 
         return userDefaults.object(forKey: WPShareExtensionMaximumMediaDimensionKey) as? Int
+    }
+
+    /// Retrieves the recently used sites, if any.
+    ///
+    class func retrieveShareExtensionRecentSites() -> [String]? {
+        guard let userDefaults = UserDefaults(suiteName: WPAppGroupName) else {
+            return nil
+        }
+
+        return userDefaults.object(forKey: WPShareExtensionRecentSitesKey) as? [String]
     }
 }

--- a/WordPress/Classes/System/Constants.h
+++ b/WordPress/Classes/System/Constants.h
@@ -38,6 +38,7 @@ extern NSString *const WPShareExtensionUserDefaultsPrimarySiteID;
 extern NSString *const WPShareExtensionUserDefaultsLastUsedSiteName;
 extern NSString *const WPShareExtensionUserDefaultsLastUsedSiteID;
 extern NSString *const WPShareExtensionMaximumMediaDimensionKey;
+extern NSString *const WPShareExtensionRecentSitesKey;
 
 /// Today Widget Constants
 ///

--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -50,6 +50,7 @@ NSString *const WPShareExtensionUserDefaultsPrimarySiteID           = @"WPShareU
 NSString *const WPShareExtensionUserDefaultsLastUsedSiteName        = @"WPShareUserDefaultsLastUsedSiteName";
 NSString *const WPShareExtensionUserDefaultsLastUsedSiteID          = @"WPShareUserDefaultsLastUsedSiteID";
 NSString *const WPShareExtensionMaximumMediaDimensionKey            = @"WPShareExtensionMaximumMediaDimensionKey";
+NSString *const WPShareExtensionRecentSitesKey                      = @"WPShareExtensionRecentSitesKey";
 
 /// Today Widget Constants
 ///

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -299,6 +299,11 @@ extension WordPressAppDelegate {
                        selector: #selector(handleUIContentSizeCategoryDidChangeNotification(_:)),
                        name: NSNotification.Name.UIContentSizeCategoryDidChange,
                        object: nil)
+
+        nc.addObserver(self,
+                       selector: #selector(saveRecentSitesForExtensions),
+                       name: .WPRecentSitesChanged,
+                       object: nil)
     }
 
     @objc fileprivate func handleDefaultAccountChangedNotification(_ notification: NSNotification) {
@@ -338,8 +343,7 @@ extension WordPressAppDelegate {
         let maxImagesize = MediaSettings().maxImageSizeSetting
         ShareExtensionService.configureShareExtensionMaximumMediaDimension(maxImagesize)
 
-        let recentSites = RecentSitesService().recentSites
-        ShareExtensionService.configureShareExtensionRecentSites(recentSites)
+        saveRecentSitesForExtensions()
     }
 
     // MARK: - Today Extension
@@ -362,5 +366,10 @@ extension WordPressAppDelegate {
 
     @objc func removeShareExtensionConfiguration() {
         ShareExtensionService.removeShareExtensionConfiguration()
+    }
+
+    @objc func saveRecentSitesForExtensions() {
+        let recentSites = RecentSitesService().recentSites
+        ShareExtensionService.configureShareExtensionRecentSites(recentSites)
     }
 }

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -337,6 +337,9 @@ extension WordPressAppDelegate {
 
         let maxImagesize = MediaSettings().maxImageSizeSetting
         ShareExtensionService.configureShareExtensionMaximumMediaDimension(maxImagesize)
+
+        let recentSites = RecentSitesService().recentSites
+        ShareExtensionService.configureShareExtensionRecentSites(recentSites)
     }
 
     // MARK: - Today Extension

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -77,7 +77,7 @@ class AppExtensionsService {
 // MARK: - Sites
 
 extension AppExtensionsService {
-    /// Fetches the primary blog + visible blogs for the current account.
+    /// Fetches the primary blog + recent sites + remaining visible blogs for the current account.
     ///
     /// - Parameters:
     ///   - onSuccess: Completion handler executed after a successful fetch.


### PR DESCRIPTION
Fixes #8645 

This PR fixes the site list order in the draft/share extension based on recently used sites in WPiOS. The order of the list should be as follows:

1. Primary site (always displayed even if hidden in WPiOS)
2. Last 3 recently used sites (Can be 0-3 sites)
3. Remaining visible sites in alpha order (excluding sites from 1 and 2 ☝️ )

## Testing

While testing this, you will probably want to log into WPiOS using a few test accounts (e.g. account with many sites, a single site, a few sites, etc). Basic procedure:

1. With a fresh install of WPiOS, log into the main app.
2. Open Safari and share a page using the app extension
3. On the site list screen, verify the primary site is at the top (pre-selected) and the remaining sites are below it in alphabetical order.
4. Cancel out of the share ext
5. Go back to WPiOS and open the site info page for 1 to 3 different sites
6. Re-open Safari and share a page using the app extension
7. On the site list screen, verify:
  * the primary site is at the top (pre-selected), 
  * the 1 to 3 recently used sites from step 5 are displayed
  * the remaining sites are below the recent sites in alphabetical order

Test this out in both the draft and share extensions. You may also want to verify the proper categories appear for the selected site and that you can save/publish the post with the selected site.

@ctarda would you mind taking a peek at this? Thanks! 😄 






