### PR TITLE
Add the word `draft` in the appropriate local push notification titles…

### DIFF
--- a/WordPress/WordPressShareExtension/ExtensionNotificationManager.swift
+++ b/WordPress/WordPressShareExtension/ExtensionNotificationManager.swift
@@ -12,9 +12,9 @@ class ExtensionNotificationManager {
     ///   - blogID: ID string representing a blog/site
     ///   - mediaItemCount: Number of media items included with the post. Default is 0.
     ///
-    static func scheduleSuccessNotification(postUploadOpID: String, postID: String, blogID: String, mediaItemCount: Int = 0, notificationDate: Date = Date()) {
+    static func scheduleSuccessNotification(postUploadOpID: String, postID: String, blogID: String, mediaItemCount: Int = 0, notificationDate: Date = Date(), postStatus: String) {
         let userInfo = makeUserInfoDict(postUploadOpID: postUploadOpID, postID: postID, blogID: blogID)
-        let title = ShareNoticeText.successTitle(mediaItemCount: mediaItemCount)
+        let title = ShareNoticeText.successTitle(mediaItemCount: mediaItemCount, postStatus: postStatus)
         let body = notificationDate.mediumString()
         scheduleLocalNotification(title: title, body: body, category: ShareNoticeConstants.categorySuccessIdentifier, userInfo: userInfo)
     }
@@ -27,9 +27,9 @@ class ExtensionNotificationManager {
     ///   - blogID: ID string representing a blog/site
     ///   - mediaItemCount: Number of media items included with the post. Default is 0.
     ///
-    static func scheduleFailureNotification(postUploadOpID: String, postID: String, blogID: String, mediaItemCount: Int = 0, notificationDate: Date = Date()) {
+    static func scheduleFailureNotification(postUploadOpID: String, postID: String, blogID: String, mediaItemCount: Int = 0, notificationDate: Date = Date(), postStatus: String) {
         let userInfo = makeUserInfoDict(postUploadOpID: postUploadOpID, postID: postID, blogID: blogID)
-        let title = ShareNoticeText.successTitle(mediaItemCount: mediaItemCount)
+        let title = ShareNoticeText.successTitle(mediaItemCount: mediaItemCount, postStatus: postStatus)
         let body = notificationDate.mediumString()
         scheduleLocalNotification(title: title, body: body, category: ShareNoticeConstants.categoryFailureIdentifier, userInfo: userInfo)
     }

--- a/WordPress/WordPressShareExtension/ShareNoticeConstants.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeConstants.swift
@@ -17,22 +17,36 @@ enum ShareNoticeUserInfoKey {
 struct ShareNoticeText {
     static let actionEditPost       = NSLocalizedString("Edit Post", comment: "Button title. Opens the editor to edit an existing post.")
 
+    static let successDraftTitleDefault = NSLocalizedString("1 draft post uploaded", comment: "Local notification displayed to the user when a single draft post has been successfully uploaded.")
     static let successTitleDefault  = NSLocalizedString("1 post uploaded", comment: "Alert displayed to the user when a single post has been successfully uploaded.")
+    static let successDraftTitleSingular = NSLocalizedString("Uploaded 1 draft post, 1 file", comment: "Local notification displayed to the user when a single draft post and 1 file has been uploaded successfully.")
     static let successTitleSingular = NSLocalizedString("Uploaded 1 post, 1 file", comment: "System notification displayed to the user when a single post and 1 file has uploaded successfully.")
+    static let successDraftTitlePlural = NSLocalizedString("Uploaded 1 draft post, %ld files", comment: "Local notification displayed to the user when a single draft post and multiple files have uploaded successfully.")
     static let successTitlePlural   = NSLocalizedString("Uploaded 1 post, %ld files", comment: "System notification displayed to the user when a single post and multiple files have uploaded successfully.")
 
+    static let failureDraftTitleDefault = NSLocalizedString("Unable to upload 1 draft post", comment: "Alert displayed to the user when a single post has failed to upload.")
     static let failureTitleDefault  = NSLocalizedString("Unable to upload 1 post", comment: "Alert displayed to the user when a single post has failed to upload.")
+    static let failureDraftTitleSingular = NSLocalizedString("Unable to upload 1 draft post, 1 file", comment: "Alert displayed to the user when a single post and 1 file has failed to upload.")
     static let failureTitleSingular = NSLocalizedString("Unable to upload 1 post, 1 file", comment: "Alert displayed to the user when a single post and 1 file has failed to upload.")
+    static let failureDraftTitlePlural = NSLocalizedString("Unable to upload 1 draft post, %ld files", comment: "Alert displayed to the user when a single post and multiple files have failed to upload.")
     static let failureTitlePlural   = NSLocalizedString("Unable to upload 1 post, %ld files", comment: "Alert displayed to the user when a single post and multiple files have failed to upload.")
 
     /// Helper method to provide the formatted version of a success title based on the media item count.
     ///
-    static func successTitle(mediaItemCount: Int = 0) -> String {
-        if mediaItemCount == 0 {
-            return successTitleDefault
-        } else {
-            return pluralize(mediaItemCount, singular: successTitleSingular, plural: successTitlePlural)
+    static func successTitle(mediaItemCount: Int = 0, postStatus: String) -> String {
+        if mediaItemCount == 0 && postStatus == Constants.draftStatus {
+            return successDraftTitleDefault
         }
+
+        if mediaItemCount == 0 && postStatus != Constants.draftStatus {
+            return successTitleDefault
+        }
+
+        if mediaItemCount > 0 && postStatus == Constants.draftStatus {
+            return pluralize(mediaItemCount, singular: successDraftTitleSingular, plural: successDraftTitlePlural)
+        }
+
+        return pluralize(mediaItemCount, singular: successTitleSingular, plural: successTitlePlural)
     }
 
     /// Helper method to provide the formatted version of a failure title based on the media item count.
@@ -54,5 +68,9 @@ struct ShareNoticeText {
         } else {
             return String(format: plural, count)
         }
+    }
+
+    struct Constants {
+        static let draftStatus = "draft"
     }
 }

--- a/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeViewModel.swift
@@ -2,6 +2,7 @@ struct ShareNoticeViewModel {
     private let postInContext: Post?
     private let uploadStatus: UploadOperation.UploadStatus
     private let uploadedMediaCount: Int
+    private let postStatus: Post.Status?
 
     init?(post: Post?, uploadStatus: UploadOperation.UploadStatus, uploadedMediaCount: Int = 0) {
         guard uploadStatus != .pending, uploadStatus != .inProgress else {
@@ -11,6 +12,7 @@ struct ShareNoticeViewModel {
         self.postInContext = post
         self.uploadStatus = uploadStatus
         self.uploadedMediaCount = uploadedMediaCount
+        self.postStatus = post?.status
     }
 
     var notice: Notice? {
@@ -78,11 +80,11 @@ struct ShareNoticeViewModel {
     }
 
     private var successfulTitle: String {
-        if uploadedMediaCount == 0 {
+        if uploadedMediaCount == 0 && postStatus != .draft {
             return ShareNoticeText.successTitleDefault
         }
 
-        return ShareNoticeText.successTitle(mediaItemCount: uploadedMediaCount)
+        return ShareNoticeText.successTitle(mediaItemCount: uploadedMediaCount, postStatus: (postStatus?.rawValue)!)
     }
 
     private var failedTitle: String {


### PR DESCRIPTION
...for a successful or failed uploaded draft post.

Fixes #8672 

## To test
1. Verify the `Save as Draft` option in Share activity is available to you by navigating to Safari and tapping the Share button. A black and white WordPress logo with `Save as Draft` text should appear on the bottom row of the Share activity. If it isn't available, follow the `How to turn on Save as Draft` instructions below the test instructions.
2. Choose any article or non-media item to save as a draft by using the Share button and selecting Save as Draft. For example, this can be a website in Safari or an article in Pocket.
3. Wait for a few seconds while WordPress uploads the post. A success or failure local push notification will be presented to let you know if the draft post uploaded. Ensure the text says "1 draft post uploaded" (if successful upload) or "Unable to upload 1 draft post" (if fail)
4. Test the media item draft post:
- visit the Photos app
- select a single photo
- hit the Share button 
- choose Save as Draft
- (add any details / make any edits you like) and Save
- wait a few seconds for the upload to happen. Ensure the text says "Uploaded 1 draft post, 1 file" upon success or "Unable to upload 1 draft post, 1 file" if it failed.

**How to turn on "Save as Draft"**
1. Trigger the share extension by attempting to share a piece of content. (For example, Safari > Share button).
2. Choose the "More" button
3. Find the "Save as Draft" activity, turn it on, and hit "Done".
4. The WordPress "Save as Draft" option should appear in the bottom row.

Requesting a @bummytime review please :)
