### PR TITLE
Don’t show ‘Need help’ button on 'Unable to Sync' alert if internet not accessible.

### DIFF
--- a/WordPress/Classes/Utility/WPError.h
+++ b/WordPress/Classes/Utility/WPError.h
@@ -40,7 +40,7 @@ extern NSString * const WPErrorSupportSourceKey;
  Show a general alert with a custom title and message.
  
  @discussion The buttons provided are localized: "OK" and "Need help?"
-             "Need help?" opens the SupportViewController
+             "Need help?" opens Support
              "OK" simply dismisses the alert.
  
  @param title for the alert
@@ -52,7 +52,7 @@ extern NSString * const WPErrorSupportSourceKey;
  Show a general alert with a custom title and message.
  
  @discussion The buttons provided are localized: "OK" and optionally "Need help?"
-             "Need help?" opens the SupportViewController
+             "Need help?" opens Support
              "OK" simply dismisses the alert.
  
  @param title for the alert
@@ -66,7 +66,7 @@ extern NSString * const WPErrorSupportSourceKey;
  Supply a block to execute custom logic when the OK button is pressed
  
  @discussion The buttons provided are localized: "OK" and optionally "Need help?"
-             "Need help?" opens the SupportViewController
+             "Need help?" opens Support
              "OK" simply dismisses the alert.
  
  @param title for the alert

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -7,8 +7,6 @@
 #import <wpxmlrpc/WPXMLRPC.h>
 #import "WordPress-Swift.h"
 
-
-
 NSInteger const SupportButtonIndex = 0;
 NSString * const WordPressAppErrorDomain = @"org.wordpress.iphone";
 NSString * const WPErrorSupportSourceKey = @"helpshift-support-source";
@@ -170,7 +168,9 @@ NSString * const WPErrorSupportSourceKey = @"helpshift-support-source";
                                                              [WPError internalInstance].alertShowing = NO;
                                                          }];
         [alertController addAction:action];
-        if (showSupport) {
+        
+        // Add the 'Need help' button only if internet is accessible (i.e. if the user can actually get help).
+        if (showSupport && ReachabilityUtils.isInternetReachable) {
             NSString *supportText = NSLocalizedString(@"Need Help?", @"'Need help?' button label, links off to the WP for iOS FAQ.");
             UIAlertAction *action = [UIAlertAction actionWithTitle:supportText
                                                              style:UIAlertActionStyleCancel


### PR DESCRIPTION
Fixes #9347 

On the 'Unable to Sync' alert, don't show the 'Need Help' button if the internet is unreachable.

To test:
- Disable internet connection.
- Start app.
- On the 'Unable to Sync' alert, verify the 'Need Help' button does not appear.

![sync_alert](https://user-images.githubusercontent.com/1816888/40944955-ea7ca84e-6813-11e8-9486-be14704cfc58.png)

