### PR TITLE
Notifications: Extending Comment's "Source" Clickable Area

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -353,7 +353,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
         [weakSelf openWebViewWithURL:url];
     };
 
-    cell.onDetailsClick = ^(UIButton *sender){
+    cell.onUserClick = ^{
         NSURL *url = [NSURL URLWithString:self.comment.author_url];
         if (url) {
             [weakSelf openWebViewWithURL:url];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -660,7 +660,7 @@ private extension NotificationDetailsViewController {
         cell.isApproved             = commentBlock.isCommentApproved
 
         // Setup: Callbacks
-        cell.onDetailsClick = { [weak self] sender in
+        cell.onUserClick = { [weak self] in
             guard let homeURL = userBlock.metaLinksHome else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
@@ -9,9 +9,16 @@ class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource
     // MARK: - IBOutlets
     @IBOutlet private weak var textView: RichTextView!
 
-    // MARK: - Public Properties
+    /// onUrlClick: Called whenever a URL is pressed within the textView's Area.
+    ///
     @objc var onUrlClick: ((URL) -> Void)?
+
+    /// onAttachmentClick: Called whenever a NSTextAttachment receives a press event
+    ///
     @objc var onAttachmentClick: ((NSTextAttachment) -> Void)?
+
+    /// Attributed Text!
+    ///
     @objc var attributedText: NSAttributedString? {
         set {
             textView.attributedText = newValue
@@ -22,12 +29,16 @@ class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource
         }
     }
 
+    /// Indicates if this is a Badge Block
+    ///
     override var isBadge: Bool {
         didSet {
             backgroundColor = WPStyleGuide.Notifications.blockBackgroundColorForRichText(isBadge)
         }
     }
 
+    /// TextView's NSLink Color
+    ///
     @objc var linkColor: UIColor? {
         didSet {
             if let unwrappedLinkColor = linkColor {
@@ -36,6 +47,8 @@ class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource
         }
     }
 
+    /// TextView's Data Detectors
+    ///
     @objc var dataDetectors: UIDataDetectorTypes {
         set {
             textView.dataDetectorTypes = newValue
@@ -45,6 +58,8 @@ class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource
         }
     }
 
+    /// Wraps Up TextView.selectable Property
+    ///
     @objc var isTextViewSelectable: Bool {
         set {
             textView.selectable = newValue
@@ -54,6 +69,8 @@ class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource
         }
     }
 
+    /// Wraps Up TextView.isUserInteractionEnabled Property
+    ///
     @objc var isTextViewClickable: Bool {
         set {
             textView.isUserInteractionEnabled = newValue
@@ -63,14 +80,15 @@ class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource
         }
     }
 
+
     // MARK: - View Methods
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
         backgroundColor = WPStyleGuide.Notifications.blockBackgroundColor
         selectionStyle = .none
 
-        assert(textView != nil)
         textView.contentInset = .zero
         textView.textContainerInset = .zero
         textView.backgroundColor = .clear
@@ -85,6 +103,7 @@ class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource
 
 
     // MARK: - RichTextView Data Source
+
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         onUrlClick?(URL)
         return false


### PR DESCRIPTION
### Details:
This PR is actually VERY tiny, but since i was in the neighborhood, i seriously needed to modernize few things:

- Documented several properties
- **NoteBlockCommentTableViewCell** changes:
  - *titleLabel* is now clickable
  - *refreshDetails* got an improved logic

Ref. #9480

### To test:
1. Log into WordPress.com
2. Open the Notifications tab
3. Open any Comment-Y notification
4. Verify that the Clickable Area (outlined in the image below) opens the source URL

@nheagy You game for a superquick review?
cc @elibud "Pingback Mark I"

Thanks in advance!


![clickable](https://user-images.githubusercontent.com/1195260/41042335-c5f38514-6977-11e8-9492-5cd625c5ba04.jpg)


