### PR TITLE
WebKitViewController nav bar buttons color for accessibility bold text

### DIFF
--- a/WordPress/Classes/Utility/CookieJar.swift
+++ b/WordPress/Classes/Utility/CookieJar.swift
@@ -72,9 +72,11 @@ extension HTTPCookieStorage: CookieJarSharedImplementation {
 extension WKHTTPCookieStore: CookieJarSharedImplementation {
     func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void) {
         getAllCookies { (cookies) in
-            completion(cookies.filter({ (cookie) in
-                return cookie.matches(url: url)
-            }))
+            DispatchQueue.main.async {
+                completion(cookies.filter({ (cookie) in
+                    return cookie.matches(url: url)
+                }))
+            }
         }
     }
 

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -132,6 +132,10 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
     // Fire away!
     [self applyModalStyleIfNeeded];
     [self loadWebViewRequest];
+
+    if (UIAccessibilityIsBoldTextEnabled()) {
+        self.navigationController.navigationBar.tintColor = [WPStyleGuide greyLighten10];
+    }
 }
 
 - (void)applyModalStyleIfNeeded

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -115,9 +115,7 @@ class WebKitViewController: UIViewController {
             return
         }
         authenticator.request(url: url, cookieJar: webView.configuration.websiteDataStore.httpCookieStore) { [weak self] (request) in
-            DispatchQueue.main.async {
-                self?.load(request: request)
-            }
+            self?.load(request: request)
         }
     }
 

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -175,36 +175,37 @@ class WebKitViewController: UIViewController {
     }
 
     private func styleNavBar() {
-        let navigationBar = navigationController?.navigationBar
-        navigationBar?.barStyle = .default
-        navigationBar?.titleTextAttributes = [.foregroundColor: WPStyleGuide.darkGrey()]
-        navigationBar?.shadowImage = UIImage(color: WPStyleGuide.webViewModalNavigationBarShadow())
-        navigationBar?.setBackgroundImage(UIImage(color: WPStyleGuide.webViewModalNavigationBarBackground()), for: .default)
-
-        fixNavBarButtonsColorForBoldText()
-    }
-
-    private func fixNavBarButtonsColorForBoldText() {
-        if UIAccessibilityIsBoldTextEnabled() {
-            navigationController?.navigationBar.tintColor = WPStyleGuide.greyLighten10()
+        guard let navigationBar = navigationController?.navigationBar else {
+            return
         }
+        navigationBar.barStyle = .default
+        navigationBar.titleTextAttributes = [.foregroundColor: WPStyleGuide.darkGrey()]
+        navigationBar.shadowImage = UIImage(color: WPStyleGuide.webViewModalNavigationBarShadow())
+        navigationBar.setBackgroundImage(UIImage(color: WPStyleGuide.webViewModalNavigationBarBackground()), for: .default)
+
+        fixBarButtonsColorForBoldText(on: navigationBar)
     }
 
     private func styleNavBarButtons() {
-        navigationItem.leftBarButtonItems?.forEach(styleNavBarButton)
-        navigationItem.rightBarButtonItems?.forEach(styleNavBarButton)
-    }
-
-    private func styleNavBarButton(_ button: UIBarButtonItem) {
-        button.tintColor = WPStyleGuide.greyLighten10()
+        navigationItem.leftBarButtonItems?.forEach(styleBarButton)
+        navigationItem.rightBarButtonItems?.forEach(styleBarButton)
     }
 
     // MARK: ToolBar setup
 
     @objc func configureToolbar() {
         navigationController?.isToolbarHidden = secureInteraction
-        navigationController?.toolbar.barTintColor = UIColor.white
 
+        guard !secureInteraction else {
+            return
+        }
+
+        styleToolBar()
+        configureToolbarButtons()
+        styleToolBarButtons()
+    }
+
+    private func configureToolbarButtons() {
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
 
         let items = [
@@ -216,9 +217,31 @@ class WebKitViewController: UIViewController {
             space,
             safariButton
         ]
-
-        items.forEach(styleNavBarButton)
         setToolbarItems(items, animated: false)
+    }
+
+    private func styleToolBar() {
+        guard let toolBar = navigationController?.toolbar else {
+            return
+        }
+        toolBar.barTintColor = UIColor.white
+        fixBarButtonsColorForBoldText(on: toolBar)
+    }
+
+    private func styleToolBarButtons() {
+        navigationController?.toolbar.items?.forEach(styleBarButton)
+    }
+
+    // MARK: Helpers
+
+    private func fixBarButtonsColorForBoldText(on bar: UIView) {
+        if UIAccessibilityIsBoldTextEnabled() {
+            bar.tintColor = WPStyleGuide.greyLighten10()
+        }
+    }
+
+    private func styleBarButton(_ button: UIBarButtonItem) {
+        button.tintColor = WPStyleGuide.greyLighten10()
     }
 
     // MARK: User Actions

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -115,7 +115,9 @@ class WebKitViewController: UIViewController {
             return
         }
         authenticator.request(url: url, cookieJar: webView.configuration.websiteDataStore.httpCookieStore) { [weak self] (request) in
-            self?.load(request: request)
+            DispatchQueue.main.async {
+                self?.load(request: request)
+            }
         }
     }
 
@@ -124,9 +126,7 @@ class WebKitViewController: UIViewController {
         if addsWPComReferrer {
             request.setValue("https://wordpress.com", forHTTPHeaderField: "Referer")
         }
-        DispatchQueue.main.async { [weak self] in
-            self?.webView.load(request)
-        }
+        webView.load(request)
     }
 
     // MARK: Navigation bar setup

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -124,7 +124,9 @@ class WebKitViewController: UIViewController {
         if addsWPComReferrer {
             request.setValue("https://wordpress.com", forHTTPHeaderField: "Referer")
         }
-        webView.load(request)
+        DispatchQueue.main.async { [weak self] in
+            self?.webView.load(request)
+        }
     }
 
     // MARK: Navigation bar setup

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -8,10 +8,30 @@ class WebKitViewController: UIViewController {
     @objc let progressView = WebProgressView()
     @objc let titleView = NavigationTitleView()
 
-    @objc var backButton: UIBarButtonItem?
-    @objc var forwardButton: UIBarButtonItem?
-    @objc var shareButton: UIBarButtonItem?
-    @objc var safariButton: UIBarButtonItem?
+    @objc lazy var backButton: UIBarButtonItem = {
+        return UIBarButtonItem(image: Gridicon.iconOfType(.chevronLeft).imageFlippedForRightToLeftLayoutDirection(),
+                               style: .plain,
+                               target: self,
+                               action: #selector(goBack))
+    }()
+    @objc lazy var forwardButton: UIBarButtonItem = {
+        return UIBarButtonItem(image: Gridicon.iconOfType(.chevronRight).imageFlippedForRightToLeftLayoutDirection(),
+                               style: .plain,
+                               target: self,
+                               action: #selector(goForward))
+    }()
+    @objc lazy var shareButton: UIBarButtonItem = {
+        return UIBarButtonItem(image: Gridicon.iconOfType(.shareIOS),
+                               style: .plain,
+                               target: self,
+                               action: #selector(share))
+    }()
+    @objc lazy var safariButton: UIBarButtonItem = {
+        return UIBarButtonItem(image: Gridicon.iconOfType(.globe),
+                               style: .plain,
+                               target: self,
+                               action: #selector(openInSafari))
+    }()
     @objc var customOptionsButton: UIBarButtonItem?
 
     @objc let url: URL
@@ -107,23 +127,11 @@ class WebKitViewController: UIViewController {
         webView.load(request)
     }
 
+    // MARK: Navigation bar setup
+
     @objc func configureNavigation() {
-        let closeButton = UIBarButtonItem(image: Gridicon.iconOfType(.cross), style: .plain, target: self, action: #selector(WebKitViewController.close))
-        closeButton.accessibilityLabel = NSLocalizedString("Dismiss", comment: "Dismiss a view. Verb")
-
-        titleView.titleLabel.text = NSLocalizedString("Loading...", comment: "Loading. Verb")
-        if let title = customTitle {
-            self.title = title
-        } else {
-            navigationItem.titleView = titleView
-        }
-
-        let refreshButton = UIBarButtonItem(image: Gridicon.iconOfType(.refresh), style: .plain, target: self, action: #selector(WebKitViewController.refresh))
-        if let customOptionsButton = customOptionsButton {
-            navigationItem.rightBarButtonItems = [refreshButton, customOptionsButton]
-        } else if !secureInteraction {
-            navigationItem.rightBarButtonItem = refreshButton
-        }
+        setupNavBarTitleView()
+        setupRefreshButton()
 
         // Modal styling
         // Proceed only if this Modal, and it's the only view in the stack.
@@ -132,63 +140,86 @@ class WebKitViewController: UIViewController {
             return
         }
 
+        setupCloseButton()
+        styleNavBar()
+        styleNavBarButtons()
+    }
+
+    private func setupRefreshButton() {
+        let refreshButton = UIBarButtonItem(image: Gridicon.iconOfType(.refresh), style: .plain, target: self, action: #selector(WebKitViewController.refresh))
+        if let customOptionsButton = customOptionsButton {
+            navigationItem.rightBarButtonItems = [refreshButton, customOptionsButton]
+        } else if !secureInteraction {
+            navigationItem.rightBarButtonItem = refreshButton
+        }
+    }
+
+    private func setupCloseButton() {
+        let closeButton = UIBarButtonItem(image: Gridicon.iconOfType(.cross), style: .plain, target: self, action: #selector(WebKitViewController.close))
+        closeButton.accessibilityLabel = NSLocalizedString("Dismiss", comment: "Dismiss a view. Verb")
         navigationItem.leftBarButtonItem = closeButton
+    }
 
-        let navigationBar = navigationController?.navigationBar
-        navigationBar?.shadowImage = UIImage(color: WPStyleGuide.webViewModalNavigationBarShadow())
-        navigationBar?.barStyle = .default
-        navigationBar?.setBackgroundImage(UIImage(color: WPStyleGuide.webViewModalNavigationBarBackground()), for: .default)
-        navigationBar?.titleTextAttributes = [.foregroundColor: WPStyleGuide.darkGrey()]
-
+    private func setupNavBarTitleView() {
+        titleView.titleLabel.text = NSLocalizedString("Loading...", comment: "Loading. Verb")
         titleView.titleLabel.textColor = WPStyleGuide.darkGrey()
         titleView.subtitleLabel.textColor = WPStyleGuide.grey()
-        closeButton.tintColor = WPStyleGuide.greyLighten10()
-        refreshButton.tintColor = WPStyleGuide.greyLighten10()
-        customOptionsButton?.tintColor = WPStyleGuide.greyLighten10()
+
+        if let title = customTitle {
+            self.title = title
+        } else {
+            navigationItem.titleView = titleView
+        }
     }
+
+    private func styleNavBar() {
+        let navigationBar = navigationController?.navigationBar
+        navigationBar?.barStyle = .default
+        navigationBar?.titleTextAttributes = [.foregroundColor: WPStyleGuide.darkGrey()]
+        navigationBar?.shadowImage = UIImage(color: WPStyleGuide.webViewModalNavigationBarShadow())
+        navigationBar?.setBackgroundImage(UIImage(color: WPStyleGuide.webViewModalNavigationBarBackground()), for: .default)
+
+        fixNavBarButtonsColorForBoldText()
+    }
+
+    private func fixNavBarButtonsColorForBoldText() {
+        if UIAccessibilityIsBoldTextEnabled() {
+            navigationController?.navigationBar.tintColor = WPStyleGuide.greyLighten10()
+        }
+    }
+
+    private func styleNavBarButtons() {
+        navigationItem.leftBarButtonItems?.forEach(styleNavBarButton)
+        navigationItem.rightBarButtonItems?.forEach(styleNavBarButton)
+    }
+
+    private func styleNavBarButton(_ button: UIBarButtonItem) {
+        button.tintColor = WPStyleGuide.greyLighten10()
+    }
+
+    // MARK: ToolBar setup
 
     @objc func configureToolbar() {
         navigationController?.isToolbarHidden = secureInteraction
         navigationController?.toolbar.barTintColor = UIColor.white
 
-        backButton = UIBarButtonItem(image: Gridicon.iconOfType(.chevronLeft).imageFlippedForRightToLeftLayoutDirection(),
-                                     style: .plain,
-                                     target: self,
-                                     action: #selector(WebKitViewController.goBack))
-
-        forwardButton = UIBarButtonItem(image: Gridicon.iconOfType(.chevronRight).imageFlippedForRightToLeftLayoutDirection(),
-                                        style: .plain,
-                                        target: self,
-                                        action: #selector(WebKitViewController.goForward))
-
-        shareButton = UIBarButtonItem(image: Gridicon.iconOfType(.shareIOS),
-                                      style: .plain,
-                                      target: self,
-                                      action: #selector(WebKitViewController.share))
-
-        safariButton = UIBarButtonItem(image: Gridicon.iconOfType(.globe),
-                                       style: .plain,
-                                       target: self,
-                                       action: #selector(WebKitViewController.openInSafari))
-
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
 
         let items = [
-            backButton!,
+            backButton,
             space,
-            forwardButton!,
+            forwardButton,
             space,
-            shareButton!,
+            shareButton,
             space,
-            safariButton!
+            safariButton
         ]
 
-        items.forEach({ (button) in
-            button.tintColor = WPStyleGuide.greyLighten10()
-        })
-
+        items.forEach(styleNavBarButton)
         setToolbarItems(items, animated: false)
     }
+
+    // MARK: User Actions
 
     @objc func close() {
         dismiss(animated: true, completion: nil)
@@ -247,8 +278,8 @@ class WebKitViewController: UIViewController {
             progressView.progress = Float(webView.estimatedProgress)
             progressView.isHidden = webView.estimatedProgress == 1
         case #keyPath(WKWebView.isLoading):
-            backButton?.isEnabled = webView.canGoBack
-            forwardButton?.isEnabled = webView.canGoForward
+            backButton.isEnabled = webView.canGoBack
+            forwardButton.isEnabled = webView.canGoForward
         default:
             assertionFailure("Observed change to web view that we are not handling")
         }


### PR DESCRIPTION
Fixes #9396 

This PR fixes the UIBarButtonItem tint color on the `WebKitViewController` when `UIAccessibilityBoldText` is enabled.

![img_2979](https://user-images.githubusercontent.com/9772967/41050926-543eb5f8-697a-11e8-9666-f9dc87595867.png)

**Notes**:
- The issue is a iOS 11 bug where the `UIBarButtonItem.appearance().tintColor` conflict with the tint color of the item instance. This was fixed by re-setting the bar tint color to override the appearance setting.
- Tool bar button items also had this problem, but the color was changing to a darker one.
- There was a thread error in this class. This also was addressed.
- I took the opportunity for a small refactor to organize the code and remove a couple of (harmless) optionals and `!`s.

@koke could you please take a look? :)

To test:
 - Go to the system Settings app > General > Accessibility > Bold Text and turn it on. 
![screen shot 2018-05-17 at 5 00 15 pm](https://user-images.githubusercontent.com/17755234/40203623-cadd53c2-59f3-11e8-8139-c86c42dd9d76.png)
- Reopen the WordPress app, go to the Reader, click on any result and then click on a link to open the page in the app's internal browser. 
- Alternatively, go to My Sites > "Pick any site" > External > and tap on "View Site" to open the site in the app's internal browser.
- Check that the navigation bar buttons and the toolbar buttons are styled as expected.