### PR TITLE
Notifications: Pingbacks Read Source footer

### DIFF
--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -157,6 +157,18 @@ class Notification: NSManagedObject {
 // MARK: - Notification Computed Properties
 //
 extension Notification {
+
+    /// Verifies if the current notification is a Pingback.
+    /// Same as below: SORRY about the Duck Typing Snippet.
+    ///
+    var isPingback: Bool {
+        guard let subjectRanges = subjectBlock?.ranges, subjectRanges.count == 2 else {
+            return false
+        }
+
+        return subjectRanges.first?.kind == .Site && subjectRanges.last?.kind == .Post
+    }
+
     /// Verifies if the current notification is actually a Badge one.
     /// Note: Sorry about the following snippet. I'm (and will always be) against Duck Typing.
     ///

--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -159,7 +159,6 @@ class Notification: NSManagedObject {
 extension Notification {
 
     /// Verifies if the current notification is a Pingback.
-    /// Same as below: SORRY about the Duck Typing Snippet.
     ///
     var isPingback: Bool {
         guard let subjectRanges = subjectBlock?.ranges, subjectRanges.count == 2 else {

--- a/WordPress/Classes/Models/Notifications/NotificationBlock.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationBlock.swift
@@ -68,6 +68,18 @@ class NotificationBlock: Equatable {
         type    = dictionary[BlockKeys.RawType] as? String
         text    = dictionary[BlockKeys.Text] as? String
     }
+
+    /// Forgive Me:
+    /// AVOID USING This Initializer at all costs. Consider getting the backend patched before creating these entities, locally.
+    ///
+    init(text: String?, ranges: [NotificationRange] = [], media: [NotificationMedia] = []) {
+        self.text = text
+        self.ranges = ranges
+        self.media =  media
+        self.actions = nil
+        self.meta = nil
+        self.type = nil
+    }
 }
 
 

--- a/WordPress/Classes/Models/Notifications/NotificationBlock.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationBlock.swift
@@ -69,8 +69,15 @@ class NotificationBlock: Equatable {
         text    = dictionary[BlockKeys.Text] as? String
     }
 
-    /// Forgive Me:
-    /// AVOID USING This Initializer at all costs. Consider getting the backend patched before creating these entities, locally.
+    /// AVOID USING This Initializer at all costs.
+    ///
+    /// The Notifications stack was designed to render the Model entities, retrieved via the Backend's API, for several reasons.
+    /// Most important one is: iOS, Android, WordPress.com and the WordPress Desktop App need to look consistent, all over.
+    ///
+    /// If you're tampering with the Backend Response, just to get a new UI component onscreen, means that you'll break consistency.
+    /// Please consider patching the backend first, so that the actual response contains (whatever) you need it to contain!.
+    ///
+    /// Alternatively, depending on what you need to get done, you may also consider modifying the way the current blocks look like.
     ///
     init(text: String?, ranges: [NotificationRange] = [], media: [NotificationMedia] = []) {
         self.text = text

--- a/WordPress/Classes/Models/Notifications/NotificationBlockGroup.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationBlockGroup.swift
@@ -159,7 +159,7 @@ private extension NotificationBlockGroup {
     /// Returns a BlockGroup containing a single Text Block, which links to the specified URL.
     ///
     class func pingbackReadMoreGroup(for url: URL) -> NotificationBlockGroup {
-        let text = NSLocalizedString("Read the source post", comment: "")
+        let text = NSLocalizedString("Read the source post", comment: "Displayed at the footer of a Pingback Notification.")
         let textRange = NSRange(location: 0, length: text.count)
         let zeroRange = NSRange(location: 0, length: 0)
 

--- a/WordPress/Classes/Models/Notifications/NotificationBlockGroup.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationBlockGroup.swift
@@ -169,7 +169,7 @@ private extension NotificationBlockGroup {
         ]
 
         let block = NotificationBlock(text: text, ranges: ranges)
-        return NotificationBlockGroup(blocks: [block], kind: .text)
+        return NotificationBlockGroup(blocks: [block], kind: .footer)
     }
 }
 

--- a/WordPress/Classes/Models/Notifications/NotificationBlockGroup.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationBlockGroup.swift
@@ -127,6 +127,13 @@ private extension NotificationBlockGroup {
             groups.append(NotificationBlockGroup(blocks: [block], kind: kind))
         }
 
+        // Hoping the reviewer can forgive me. Pingback Notifications require a locally generated block.
+        //
+        if parent.isPingback, let homeURL = user.metaLinksHome {
+            let blockGroup = pingbackReadMoreGroup(for: homeURL)
+            groups.append(blockGroup)
+        }
+
         // Actions Group: A copy of the Comment Block (Actions)
         groups.append(NotificationBlockGroup(blocks: actionGroupBlocks, kind: .actions))
 
@@ -141,6 +148,28 @@ private extension NotificationBlockGroup {
         }
 
         return nil
+    }
+}
+
+
+// MARK: - Private Parsing Helpers
+//
+private extension NotificationBlockGroup {
+
+    /// Returns a BlockGroup containing a single Text Block, which links to the specified URL.
+    ///
+    class func pingbackReadMoreGroup(for url: URL) -> NotificationBlockGroup {
+        let text = NSLocalizedString("Read the source post", comment: "")
+        let textRange = NSRange(location: 0, length: text.count)
+        let zeroRange = NSRange(location: 0, length: 0)
+
+        let ranges = [
+            NotificationRange(kind: .Noticon, range: zeroRange, value: "\u{f107}"),
+            NotificationRange(kind: .Link, range: textRange, url: url)
+        ]
+
+        let block = NotificationBlock(text: text, ranges: ranges)
+        return NotificationBlockGroup(blocks: [block], kind: .text)
     }
 }
 

--- a/WordPress/Classes/Models/Notifications/NotificationBlockGroup.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationBlockGroup.swift
@@ -164,7 +164,7 @@ private extension NotificationBlockGroup {
         let zeroRange = NSRange(location: 0, length: 0)
 
         let ranges = [
-            NotificationRange(kind: .Noticon, range: zeroRange, value: "\u{f107}"),
+            NotificationRange(kind: .Noticon, range: zeroRange, value: "\u{f442}"),
             NotificationRange(kind: .Link, range: textRange, url: url)
         ]
 

--- a/WordPress/Classes/Models/Notifications/NotificationBlockGroup.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationBlockGroup.swift
@@ -127,7 +127,7 @@ private extension NotificationBlockGroup {
             groups.append(NotificationBlockGroup(blocks: [block], kind: kind))
         }
 
-        // Hoping the reviewer can forgive me. Pingback Notifications require a locally generated block.
+        // Whenever Possible *REMOVE* this workaround. Pingback Notifications require a locally generated block.
         //
         if parent.isPingback, let homeURL = user.metaLinksHome {
             let blockGroup = pingbackReadMoreGroup(for: homeURL)

--- a/WordPress/Classes/Models/Notifications/NotificationRange.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationRange.swift
@@ -84,6 +84,21 @@ class NotificationRange {
     }
 
 
+    /// Forgive Me:
+    /// AVOID USING This Initializer at all costs. Consider getting the backend patched before creating these entities, locally.
+    ///
+    init(kind: Kind, range: NSRange, url: URL? = nil, commentID: NSNumber? = nil, postID: NSNumber? = nil, siteID: NSNumber? = nil, userID: NSNumber? = nil, value: String? = nil) {
+        self.kind = kind
+        self.range = range
+        self.url = url
+        self.commentID = commentID
+        self.postID = postID
+        self.siteID = siteID
+        self.userID = userID
+        self.value = value
+    }
+
+
     /// Returns the NotificationRange Kind, for a given raw Notification Range.
     ///
     /// - Details:

--- a/WordPress/Classes/Models/Notifications/NotificationRange.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationRange.swift
@@ -84,8 +84,15 @@ class NotificationRange {
     }
 
 
-    /// Forgive Me:
-    /// AVOID USING This Initializer at all costs. Consider getting the backend patched before creating these entities, locally.
+    /// AVOID USING This Initializer at all costs.
+    ///
+    /// The Notifications stack was designed to render the Model entities, retrieved via the Backend's API, for several reasons.
+    /// Most important one is: iOS, Android, WordPress.com and the WordPress Desktop App need to look consistent, all over.
+    ///
+    /// If you're tampering with the Backend Response, just to get a new UI component onscreen, means that you'll break consistency.
+    /// Please consider patching the backend first, so that the actual response contains (whatever) you need it to contain!.
+    ///
+    /// Alternatively, depending on what you need to get done, you may also consider modifying the way the current blocks look like.
     ///
     init(kind: Kind, range: NSRange, url: URL? = nil, commentID: NSNumber? = nil, postID: NSNumber? = nil, siteID: NSNumber? = nil, userID: NSNumber? = nil, value: String? = nil) {
         self.kind = kind


### PR DESCRIPTION
### Details:
This PR introduces locally generated NotificationBlocks. We should probably hold merging this until we hear back from the Android team (this workaround may not be possible there).

Closes #9479

@frosty would you be game for a (sad, sad, oh very sad) review? (THANKS!!!)

cc @planarvoidoid @elibud 

### IMPORTANT NOTE:
The actual UX looks slightly different from the one suggested in the mockups. However: this looks 100% exactly the same as the `You replied to this comment` footer, already present in Comment Notifications. @folletto do you think this is acceptable?

Pasting below screenshots for both, this PR and the `You've replied to(...)` UI, already present!.

(Sorry about bugging you sir, introducing a right hand side icon involves a bit of a much bigger change!!).

### To test:
1. Receive a Pingback Notification
2. Open it's details
3. Verify the new footer is there
4. Press over the new footer
5. Verify the related post shows up onscreen.


--

### Sample:

![simulator screen shot - iphone se - 2018-06-06 at 14 59 08](https://user-images.githubusercontent.com/1195260/41056517-cdc668ec-699a-11e8-87fa-63a1dcb912da.png)

### **You've replied to...** footer

![simulator screen shot - iphone se - 2018-06-06 at 14 59 41](https://user-images.githubusercontent.com/1195260/41056545-e43f0c28-699a-11e8-95cc-51fe40c403f7.png)
