### PR TITLE
Fix issue where images could get cropped on the reader detail

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -283,7 +283,7 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
     ///
     fileprivate func sizeForAttachment(_ attachment: WPTextAttachment) -> CGSize {
         let width: CGFloat = attachment.width > 0 ? attachment.width : textContainer.size.width
-        let height: CGFloat = attachment.height > 0 ? attachment.height : Constants.defaultAttachmentHeight
+        let height: CGFloat = attachment.height > 0 ? attachment.height : textContainer.size.height
         return CGSize(width: width, height: height)
     }
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -283,7 +283,7 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
     ///
     fileprivate func sizeForAttachment(_ attachment: WPTextAttachment) -> CGSize {
         let width: CGFloat = attachment.width > 0 ? attachment.width : textContainer.size.width
-        let height: CGFloat = attachment.height > 0 ? attachment.height : textContainer.size.height
+        let height: CGFloat = attachment.height > 0 ? attachment.height : maxDisplaySize.height
         return CGSize(width: width, height: height)
     }
 


### PR DESCRIPTION
Fixes #9532 

- The new implementation for Gif support was relaying on the html attributes for `height` and `width` to show the final image size.
- For some reason that I couldn't find, some images doesn't have those attributes in their html code, so that information was not available.
- When this happened, the fallback height size was 50pts, and the image got cropped to that size by Photon.

To solve this, there where two changes:
- If the `height` and `width` html attributes are not found, we will search for the `data-orig-size` attribute that seems to be present more often, and get the size from there.
- If the previous still fails, the new fallback value is the screen height, so the image doesn't get cropped by Photon. When the image is available, the `intrinsicContentSize` will give the final and correct image size.

![reader_image](https://user-images.githubusercontent.com/9772967/41078832-a886316c-69e4-11e8-96e0-64edf8d92440.png)

**Note**:
- Since this issue is in the release branch, I'm targeting that branch to solve it before it goes to the store.

To test:

I couldn't get to reproduce uploading an image without the size attributes, but I know that it happens with the first image of this post:
[https://etoledom.wordpress.com/2018/06/03/centro-de-lima/](https://etoledom.wordpress.com/2018/06/03/centro-de-lima/)

- Open that post in the reader.
- Check that the images display correctly