### PR TITLE
HotFix: Check for existing featuredImage url befo…

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.h
+++ b/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.h
@@ -13,9 +13,9 @@
 
 extern CGFloat const PostFeaturedImageCellMargin;
 
-@property (weak, nonatomic) id<PostFeaturedImageCellDelegate> delegate;
-@property (strong, nonatomic, readonly) UIImage *image;
+@property (weak, nonatomic, nullable) id<PostFeaturedImageCellDelegate> delegate;
+@property (strong, nonatomic, readonly, nullable) UIImage *image;
 
-- (void)setImageWithURL:(NSURL *)url inPost:(id<ImageSourceInformation>)postInformation withSize:(CGSize)size;
+- (void)setImageWithURL:(nonnull NSURL *)url inPost:(nonnull id<ImageSourceInformation>)postInformation withSize:(CGSize)size;
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -724,47 +724,73 @@ FeaturedImageViewControllerDelegate>
 
 - (UITableViewCell *)configureFeaturedImageCellForIndexPath:(NSIndexPath *)indexPath
 {
-    UITableViewCell *cell;
-
     if (!self.apost.featuredImage && !self.isUploadingMedia) {
-        WPTableViewActivityCell *activityCell = [self getWPTableViewActivityCell];
-        activityCell.textLabel.text = NSLocalizedString(@"Set Featured Image", @"");
-        activityCell.tag = PostSettingsRowFeaturedImageAdd;
-
-        cell = activityCell;
+        return [self cellForSetFeaturedImage];
 
     } else if (self.isUploadingMedia || self.apost.featuredImage.remoteStatus == MediaRemoteStatusPushing) {
         if (!self.isUploadingMedia) {
             self.isUploadingMedia = YES;
-            [self setupObservingOfMedia: self.apost.featuredImage];
+            [self setupObservingOfMedia:self.apost.featuredImage];
         }
         self.featuredImage = nil;
-        self.progressCell = [self.tableView dequeueReusableCellWithIdentifier:TableViewProgressCellIdentifier forIndexPath:indexPath];
-        [WPStyleGuide configureTableViewCell:self.progressCell];        
-        [self.progressCell setProgress:self.featuredImageProgress];
-        self.progressCell.tag = PostSettingsRowFeaturedLoading;
-        cell = self.progressCell;
+        return [self cellForFeaturedImageUploadProgressAtIndexPath:indexPath];
+
     } else if (self.apost.featuredImage && self.apost.featuredImage.remoteStatus == MediaRemoteStatusFailed) {
-        WPTableViewActivityCell *activityCell = [self getWPTableViewActivityCell];
-        activityCell.textLabel.text = NSLocalizedString(@"Upload failed. Tap for options.", @"Description to show on post setting for a featured image that failed to upload.");
-        activityCell.tag = PostSettingsRowFeaturedImageRemove;
-        cell = activityCell;
+        return [self cellForFeaturedImageError];
+
     } else {
-        PostFeaturedImageCell *featuredImageCell = [self.tableView dequeueReusableCellWithIdentifier:TableViewFeaturedImageCellIdentifier forIndexPath:indexPath];
-        featuredImageCell.delegate = self;
-        [WPStyleGuide configureTableViewCell:featuredImageCell];
-
-        NSURL *featuredURL = [NSURL URLWithString:self.apost.featuredImage.remoteURL];
+        NSURL *featuredURL = [self urlForFeaturedImage];
         if (!featuredURL) {
-            featuredURL = self.apost.featuredImageURLForDisplay;
+            return [self cellForFeaturedImageError];
         }
-        [featuredImageCell setImageWithURL:featuredURL inPost:self.apost withSize:self.featuredImageSize];
 
-        cell = featuredImageCell;
-        cell.tag = PostSettingsRowFeaturedImage;
+        return [self cellForFeaturedImageWithURL:featuredURL atIndexPath:indexPath];
     }
+}
 
-    return cell;
+- (UITableViewCell *)cellForSetFeaturedImage
+{
+    WPTableViewActivityCell *activityCell = [self getWPTableViewActivityCell];
+    activityCell.textLabel.text = NSLocalizedString(@"Set Featured Image", @"");
+    activityCell.tag = PostSettingsRowFeaturedImageAdd;
+
+    return activityCell;
+}
+
+- (UITableViewCell *)cellForFeaturedImageError
+{
+    WPTableViewActivityCell *activityCell = [self getWPTableViewActivityCell];
+    activityCell.textLabel.text = NSLocalizedString(@"Upload failed. Tap for options.", @"Description to show on post setting for a featured image that failed to upload.");
+    activityCell.tag = PostSettingsRowFeaturedImageRemove;
+    return activityCell;
+}
+
+- (UITableViewCell *)cellForFeaturedImageUploadProgressAtIndexPath:(NSIndexPath *)indexPath
+{
+    self.progressCell = [self.tableView dequeueReusableCellWithIdentifier:TableViewProgressCellIdentifier forIndexPath:indexPath];
+    [WPStyleGuide configureTableViewCell:self.progressCell];
+    [self.progressCell setProgress:self.featuredImageProgress];
+    self.progressCell.tag = PostSettingsRowFeaturedLoading;
+    return self.progressCell;
+}
+
+- (UITableViewCell *)cellForFeaturedImageWithURL:(nonnull NSURL *)featuredURL atIndexPath:(NSIndexPath *)indexPath
+{
+    PostFeaturedImageCell *featuredImageCell = [self.tableView dequeueReusableCellWithIdentifier:TableViewFeaturedImageCellIdentifier forIndexPath:indexPath];
+    featuredImageCell.delegate = self;
+    [WPStyleGuide configureTableViewCell:featuredImageCell];
+
+    [featuredImageCell setImageWithURL:featuredURL inPost:self.apost withSize:self.featuredImageSize];
+    featuredImageCell.tag = PostSettingsRowFeaturedImage;
+    return featuredImageCell;
+}
+
+- (nullable NSURL *)urlForFeaturedImage {
+    NSURL *featuredURL = [NSURL URLWithString:self.apost.featuredImage.remoteURL];
+    if (!featuredURL) {
+        featuredURL = self.apost.featuredImageURLForDisplay;
+    }
+    return featuredURL;
 }
 
 - (UITableViewCell *)configureShareCellForIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -741,7 +741,7 @@ FeaturedImageViewControllerDelegate>
     } else {
         NSURL *featuredURL = [self urlForFeaturedImage];
         if (!featuredURL) {
-            return [self cellForFeaturedImageError];
+            return [self cellForSetFeaturedImage];
         }
 
         return [self cellForFeaturedImageWithURL:featuredURL atIndexPath:indexPath];
@@ -1241,6 +1241,9 @@ FeaturedImageViewControllerDelegate>
 
             UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:featuredImageVC];
             [self presentViewController:navigationController animated:YES completion:nil];
+        } else if ([self urlForFeaturedImage] == nil) {
+            //If we don't have a featured image url, the image won't be loaded.
+            [self showMediaPicker];
         }
     } else {
         if (!self.isUploadingMedia) {


### PR DESCRIPTION
Fixes Crashlytics issue # 28979

This issue happens when the Obj-C runtime send a nil objet to a Swift non-null method parameter, making bridge to crash.

In this particular instance, `PostContentProvider.featuredImageURLForDisplay` could be nil, but it was not marked as `nullable`.
This possible nil Url was sent to `PostFeaturedImageCell.setImageWithURL:inPost:postInformation withSize:`, where the NSURL parameter wasn't marked as `nullable` either.

And finally, this possible nil Url was sent to Swift via `ImageLoader.loadImage(url:post:size:placeholder:success:error:` where the URL parameter is **not** optional, making it crash when URL was nil.

**To solve this**: 
- The featured url getter was encapsulated to easily mark it as `nullable` (`- (nullable NSURL *)urlForFeaturedImage`).
- `nullability` attributes where added to the `PostFeaturedImageCell` interface.
- Check for featuredURL nullability before sending it to load the image.

**Note**:
Ideally we would add nullability attributes to `PostContentProvider`, or remove `PostContentProvider` completely as @aerych suggested (since `BasePost` and `AbstractPost` already implements nullability). But I decided to take the faster way to fix these crashes.

**Note 2**
I'm not sure why a post with `featuredMedia` might not have a `featuredImageURLForDisplay`. There might be a deeper issue or another way to get the missing url that is not being taking into account.


**To test**:

I couldn't get a way to reproduce the issue organically. Passing a literal `nil` as a featuredURL would create the exact same crash reported.

- Go to Post List.
- Open a post.
- Go to `Post Settings`
- Check that featured images display correctly (add one if there are none)
- 🚨Hack 🚨: Return nil on `urlForFeaturedImage` (`PostSettingsViewController:793`)
- Check that the app doesn't crash.

cc: @loremattei 