### PR TITLE
Sets up hockeyapp daily notifications

### DIFF
--- a/WordPress/Classes/Utility/HockeyManager.m
+++ b/WordPress/Classes/Utility/HockeyManager.m
@@ -17,6 +17,7 @@
                                                            delegate:self];
     [[BITHockeyManager sharedHockeyManager].authenticator setIdentificationType:BITAuthenticatorIdentificationTypeDevice];
     [[BITHockeyManager sharedHockeyManager] setDisableCrashManager: YES]; //disable crash reporting
+    [[BITHockeyManager sharedHockeyManager].updateManager setUpdateSetting : BITUpdateCheckDaily]; // Sets up daily notifications on notmandatory updates
     [[BITHockeyManager sharedHockeyManager] startManager];
     [[BITHockeyManager sharedHockeyManager].authenticator authenticateInstallation];
 }

--- a/WordPress/Classes/Utility/HockeyManager.m
+++ b/WordPress/Classes/Utility/HockeyManager.m
@@ -17,7 +17,7 @@
                                                            delegate:self];
     [[BITHockeyManager sharedHockeyManager].authenticator setIdentificationType:BITAuthenticatorIdentificationTypeDevice];
     [[BITHockeyManager sharedHockeyManager] setDisableCrashManager: YES]; //disable crash reporting
-    [[BITHockeyManager sharedHockeyManager].updateManager setUpdateSetting : BITUpdateCheckDaily]; // Sets up daily notifications on notmandatory updates
+    [[BITHockeyManager sharedHockeyManager].updateManager setUpdateSetting: BITUpdateCheckDaily]; // Sets up daily notifications on notmandatory updates
     [[BITHockeyManager sharedHockeyManager] startManager];
     [[BITHockeyManager sharedHockeyManager].authenticator authenticateInstallation];
 }


### PR DESCRIPTION
This is related to #9538 and configures the HockeyApp SDK to daily check for updates and to show an update notification to the user when a new build is available.
If the update is not set as mandatory on the server side, the user can choose to update or to ignore the notification. Ignored updates will be re-notified the next day.

**To test**:
The relevant part of the HockeyApp SDK is documented [here](https://hockeyapp.net/help/sdk/ios/5.1.2/Classes/BITUpdateManager.html#/c:objc(cs)BITUpdateManager(im)checkForUpdate). 

Some hacking is required to actually test:
1. _Hack_: change the App internal version to something older than the latest build on HockeyApp (in the _Version.internal.xcconfig_ file);
2. _Hack_: disable the Mandatory Update flag on the server side;
3. Run the app and check the notification is shown;
4. Ignore the notification and check that you can navigate the app, exit and relaunch it without getting the dialog again.
5. Wait a day, or set the date of your device accordingly, and check the the notification is displayed again.

