### PR TITLE
Update WordPressUI to 1.0.4

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -70,7 +70,7 @@ target 'WordPress' do
     pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'b5ae03494596e3da7a8f814f9cab8e96ca345bc8'
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'c38d29b09cc9710ef307891f76a02c80a7002a59'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'c38d29b09cc9710ef307891f76a02c80a7002a59'
-    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit =>'e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0'
+    pod 'WordPressUI', '1.0.4'
 
     target 'WordPressTest' do
         inherit! :search_paths
@@ -91,7 +91,7 @@ target 'WordPress' do
 
         pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'c38d29b09cc9710ef307891f76a02c80a7002a59'
         pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'c38d29b09cc9710ef307891f76a02c80a7002a59'
-        pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit =>'e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0'
+        pod 'WordPressUI', '1.0.4'
         pod 'Gridicons', '0.15'
     end
 
@@ -107,7 +107,7 @@ target 'WordPress' do
 
         pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'c38d29b09cc9710ef307891f76a02c80a7002a59'
         pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'c38d29b09cc9710ef307891f76a02c80a7002a59'
-        pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit =>'e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0'
+        pod 'WordPressUI', '1.0.4'
         pod 'Gridicons', '0.15'
     end
 
@@ -138,7 +138,7 @@ target 'WordPressAuthenticator' do
     ## ====================
     ##
     pod 'Gridicons', '0.15'
-    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit =>'e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0'
+    pod 'WordPressUI', '1.0.4'
 
     ## Third party libraries
     ## =====================
@@ -172,7 +172,7 @@ target 'WordPressComStatsiOS' do
     ## Automattic libraries
     ## ====================
     ##
-    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit =>'e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0'
+    pod 'WordPressUI', '1.0.4'
 
     target 'WordPressComStatsiOSTests' do
         inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -127,7 +127,7 @@ PODS:
   - WordPressShared (1.0.5):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
-  - WordPressUI (1.0.3)
+  - WordPressUI (1.0.4)
   - WPMediaPicker (1.0)
   - wpxmlrpc (0.8.3)
   - ZendeskSDK (1.11.2.1):
@@ -169,7 +169,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `c38d29b09cc9710ef307891f76a02c80a7002a59`)
   - WordPressKit (~> 1.0.6)
   - WordPressShared (~> 1.0.5)
-  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0`)
+  - WordPressUI (= 1.0.4)
   - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `b5ae03494596e3da7a8f814f9cab8e96ca345bc8`)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
@@ -207,6 +207,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPressKit
     - WordPressShared
+    - WordPressUI
     - wpxmlrpc
     - ZendeskSDK
 
@@ -217,9 +218,6 @@ EXTERNAL SOURCES:
   WordPress-Aztec-iOS:
     :commit: c38d29b09cc9710ef307891f76a02c80a7002a59
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WordPressUI:
-    :commit: e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
   WPMediaPicker:
     :commit: b5ae03494596e3da7a8f814f9cab8e96ca345bc8
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
@@ -231,9 +229,6 @@ CHECKOUT OPTIONS:
   WordPress-Aztec-iOS:
     :commit: c38d29b09cc9710ef307891f76a02c80a7002a59
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WordPressUI:
-    :commit: e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
   WPMediaPicker:
     :commit: b5ae03494596e3da7a8f814f9cab8e96ca345bc8
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
@@ -272,11 +267,11 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 743dbe41492eae1d9daf3f5ba5435ab295ee668f
   WordPressKit: f62f8e68ce2300d9a8b4c2b7c743c911bbdbd343
   WordPressShared: d7fdb0ca9302cf4bc7f3ec0fbe98d0d8eb721438
-  WordPressUI: ebf73505c8957df23a1c9fe565fba553be296dc5
+  WordPressUI: f2348649b63b5a9392a72b1d2f46dd1d72e80ad9
   WPMediaPicker: ceb613e43eae03268e73835d48d67f92f595aca6
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: fac21ae825299bf6e1eb821d27c150fae75e1193
+PODFILE CHECKSUM: d7d743758e28d15a14d5c492266e0436cc2dd59f
 
 COCOAPODS: 1.5.2


### PR DESCRIPTION
Simple PR to update the WordPressUI pod to the last version `1.0.4`.

To test:
- `pod install --repo-update`
- Check that the project builds and run correctly.

cc: @loremattei 