### PR TITLE
Remove extra whitespace in the comments of notifications

### DIFF
--- a/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
+++ b/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
@@ -175,7 +175,7 @@ extension NotificationBlock {
             return NSAttributedString()
         }
 
-        let tightenedText = removeCommonWhitespaceIssues(from: text)
+        let tightenedText = replaceCommonWhitespaceIssues(in: text)
         let theString = NSMutableAttributedString(string: tightenedText, attributes: attributes)
 
         if let quoteStyles = quoteStyles {
@@ -213,7 +213,8 @@ extension NotificationBlock {
     ///
     /// - Parameter baseString: string of the comment body before attributes are added
     /// - Returns: string of same length
-    private func removeCommonWhitespaceIssues(from baseString: String) -> String {
+    /// - Note: the length must be maintained or the formatting will break
+    private func replaceCommonWhitespaceIssues(in baseString: String) -> String {
         var newString: String
         // \u{200A} = hairline space (very skinny space).
         // we use these so that the ranges are still in the right position, but the extra space basically disappears
@@ -223,6 +224,11 @@ extension NotificationBlock {
         newString = newString.replacingOccurrences(of: "\t.", with: "\u{200A}.") // tabs before a space
         newString = newString.replacingOccurrences(of: "\t,", with: "\u{200A},") // tabs cefore a comman
         newString = newString.replacingOccurrences(of: "\n\t\n\t", with: "\u{200A}\u{200A}\n\t") // extra newline-with-tab before a newline-with-tab
+
+        // if the length of the string changes the range-based formatting will break
+        guard newString.count == baseString.count else {
+            return baseString
+        }
 
         return newString
     }

--- a/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
+++ b/WordPress/Classes/Extensions/Notifications/NotificationBlock+Interface.swift
@@ -175,7 +175,8 @@ extension NotificationBlock {
             return NSAttributedString()
         }
 
-        let theString = NSMutableAttributedString(string: text, attributes: attributes)
+        let tightenedText = removeCommonWhitespaceIssues(from: text)
+        let theString = NSMutableAttributedString(string: tightenedText, attributes: attributes)
 
         if let quoteStyles = quoteStyles {
             theString.applyAttributes(toQuotes: quoteStyles)
@@ -206,6 +207,24 @@ extension NotificationBlock {
         }
 
         return theString
+    }
+
+    /// Replaces some common extra whitespace with hairline spaces so that comments display better
+    ///
+    /// - Parameter baseString: string of the comment body before attributes are added
+    /// - Returns: string of same length
+    private func removeCommonWhitespaceIssues(from baseString: String) -> String {
+        var newString: String
+        // \u{200A} = hairline space (very skinny space).
+        // we use these so that the ranges are still in the right position, but the extra space basically disappears
+        newString = baseString.replacingOccurrences(of: "\t ", with: "\u{200A}\u{200A}") // tabs before a space
+        newString = newString.replacingOccurrences(of: " \t", with: " \u{200A}") // tabs after a space
+        newString = newString.replacingOccurrences(of: "\t@", with: "\u{200A}@") // tabs before @mentions
+        newString = newString.replacingOccurrences(of: "\t.", with: "\u{200A}.") // tabs before a space
+        newString = newString.replacingOccurrences(of: "\t,", with: "\u{200A},") // tabs cefore a comman
+        newString = newString.replacingOccurrences(of: "\n\t\n\t", with: "\u{200A}\u{200A}\n\t") // extra newline-with-tab before a newline-with-tab
+
+        return newString
     }
 
 


### PR DESCRIPTION
Fixes #9513, #9514

This removes several kinds of superfluous whitespace that appears in notifications for comments that include mentions or links. It adds a single pass before parsing that replaces these whitespaces with hairline spaces, which are virtually invisible but maintain the length of the source string.

To test:
- have me send you an example problem notification
- ensure that it no longer has the problem whitespace

