### PR TITLE
App extensions now use NSExtensionActivationRule predicates

### DIFF
--- a/WordPress/WordPressDraftActionExtension/Info-Alpha.plist
+++ b/WordPress/WordPressDraftActionExtension/Info-Alpha.plist
@@ -31,21 +31,37 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>NSExtensionActivationRule</key>
-			<dict>
-				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<integer>2</integer>
-				<key>NSExtensionActivationDictionaryVersion</key>
-				<integer>2</integer>
-				<key>NSExtensionActivationSupportsText</key>
-				<true/>
-				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
-				<integer>1</integer>
-				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
-				<integer>1</integer>
-			</dict>
-			<key>NSExtensionJavaScriptPreprocessingFile</key>
-			<string>WordPressShare</string>
-		</dict>
+            <string>
+                SUBQUERY(
+                extensionItems,
+                $extensionItem,
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.png"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg-2000"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.tiff"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.compuserve.gif"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.bmp"
+                ).@count &lt; 3
+                OR
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.text"
+                ).@count == 1
+                OR
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
+                ).@count == 1
+                ).@count >= 1
+            </string>
 		<key>NSExtensionMainStoryboard</key>
 		<string>MainInterface</string>
 		<key>NSExtensionPointIdentifier</key>

--- a/WordPress/WordPressDraftActionExtension/Info-Internal.plist
+++ b/WordPress/WordPressDraftActionExtension/Info-Internal.plist
@@ -31,18 +31,37 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>NSExtensionActivationRule</key>
-			<dict>
-				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<integer>2</integer>
-				<key>NSExtensionActivationDictionaryVersion</key>
-				<integer>2</integer>
-				<key>NSExtensionActivationSupportsText</key>
-				<true/>
-				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
-				<integer>1</integer>
-				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
-				<integer>1</integer>
-			</dict>
+            <string>
+                SUBQUERY(
+                extensionItems,
+                $extensionItem,
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.png"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg-2000"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.tiff"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.compuserve.gif"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.bmp"
+                ).@count &lt; 3
+                OR
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.text"
+                ).@count == 1
+                OR
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
+                ).@count == 1
+                ).@count >= 1
+            </string>
 			<key>NSExtensionJavaScriptPreprocessingFile</key>
 			<string>WordPressShare</string>
 		</dict>

--- a/WordPress/WordPressDraftActionExtension/Info.plist
+++ b/WordPress/WordPressDraftActionExtension/Info.plist
@@ -31,18 +31,37 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>NSExtensionActivationRule</key>
-			<dict>
-				<key>NSExtensionActivationDictionaryVersion</key>
-				<integer>2</integer>
-				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<integer>2</integer>
-				<key>NSExtensionActivationSupportsText</key>
-				<true/>
-				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
-				<integer>1</integer>
-				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
-				<integer>1</integer>
-			</dict>
+            <string>
+                SUBQUERY(
+                extensionItems,
+                $extensionItem,
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.png"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg-2000"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.tiff"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.compuserve.gif"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.bmp"
+                ).@count &lt; 3
+                OR
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.text"
+                ).@count == 1
+                OR
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
+                ).@count == 1
+                ).@count >= 1
+            </string>
 			<key>NSExtensionJavaScriptPreprocessingFile</key>
 			<string>WordPressShare</string>
 		</dict>

--- a/WordPress/WordPressShareExtension/Info-Alpha.plist
+++ b/WordPress/WordPressShareExtension/Info-Alpha.plist
@@ -33,18 +33,37 @@
 			<key>NSExtensionJavaScriptPreprocessingFile</key>
 			<string>WordPressShare</string>
 			<key>NSExtensionActivationRule</key>
-			<dict>
-				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<integer>2</integer>
-				<key>NSExtensionActivationDictionaryVersion</key>
-				<integer>2</integer>
-				<key>NSExtensionActivationSupportsText</key>
-				<true/>
-				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
-				<integer>1</integer>
-				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
-				<integer>1</integer>
-			</dict>
+            <string>
+                SUBQUERY(
+                extensionItems,
+                $extensionItem,
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.png"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg-2000"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.tiff"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.compuserve.gif"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.bmp"
+                ).@count &lt; 3
+                OR
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.text"
+                ).@count == 1
+                OR
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
+                ).@count == 1
+                ).@count >= 1
+            </string>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>
 		<string>MainInterface</string>

--- a/WordPress/WordPressShareExtension/Info-Internal.plist
+++ b/WordPress/WordPressShareExtension/Info-Internal.plist
@@ -33,18 +33,37 @@
 			<key>NSExtensionJavaScriptPreprocessingFile</key>
 			<string>WordPressShare</string>
 			<key>NSExtensionActivationRule</key>
-			<dict>
-				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<integer>2</integer>
-				<key>NSExtensionActivationDictionaryVersion</key>
-				<integer>2</integer>
-				<key>NSExtensionActivationSupportsText</key>
-				<true/>
-				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
-				<integer>1</integer>
-				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
-				<integer>1</integer>
-			</dict>
+            <string>
+                SUBQUERY(
+                extensionItems,
+                $extensionItem,
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.png"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg-2000"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.tiff"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.compuserve.gif"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.bmp"
+                ).@count &lt; 3
+                OR
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.text"
+                ).@count == 1
+                OR
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
+                ).@count == 1
+                ).@count >= 1
+            </string>
 		</dict>
 		<key>NSExtensionMainStoryboard</key>
 		<string>MainInterface</string>

--- a/WordPress/WordPressShareExtension/Info.plist
+++ b/WordPress/WordPressShareExtension/Info.plist
@@ -31,18 +31,37 @@
 		<key>NSExtensionAttributes</key>
 		<dict>
 			<key>NSExtensionActivationRule</key>
-			<dict>
-				<key>NSExtensionActivationDictionaryVersion</key>
-				<integer>2</integer>
-				<key>NSExtensionActivationSupportsImageWithMaxCount</key>
-				<integer>2</integer>
-				<key>NSExtensionActivationSupportsText</key>
-				<true/>
-				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
-				<integer>1</integer>
-				<key>NSExtensionActivationSupportsWebPageWithMaxCount</key>
-				<integer>1</integer>
-			</dict>
+            <string>
+                SUBQUERY(
+                extensionItems,
+                $extensionItem,
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.png"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg-2000"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.tiff"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.compuserve.gif"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.bmp"
+                ).@count &lt; 3
+                OR
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.text"
+                ).@count == 1
+                OR
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
+                ).@count == 1
+                ).@count >= 1
+            </string>
 			<key>NSExtensionJavaScriptPreprocessingFile</key>
 			<string>WordPressShare</string>
 		</dict>


### PR DESCRIPTION
## Discussion

We have officially outgrown using the basic extension activation rules in the share/draft extensions because of the need to support more UTIs (like `public.jpeg` in the case of #5642).

So we are "upgrading" to now use the more complex (and not very documented) [predicate syntax 
](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html#//apple_ref/doc/uid/TP40014214-CH21-SW8). The 3 config `plist` files for each extension now contain 3 groupings of rules all joined by `or` clauses:

### Images (up to 2)
```
...
ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
|| ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.png"
|| ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg"
|| ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.jpeg-2000"
|| ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.tiff"
|| ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.compuserve.gif"
|| ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.bmp"
).@count &lt; 3
...
```

### Text
```
...
ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.plain-text"
|| ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.text"
).@count == 1
...
```

### URLs and web 
```
...
ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
|| ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
).@count == 1
...
```

Fixes #5642 

## Testing
So since this is a fundamental change to the activation rules, we should verify that the share and draft extension activate in the share sheet like before (as well as the actually ability to 
launch our app extension UI with the appropriate content).

### Images
* From Photos.app, try sharing 1 and/or 2 images using the share/draft extension - you should see both
* From Photos.app, try sharing 3 or more images — you should not see the extensions activate
* In Safari go to this [URL](https://s.w.org/style/images/about/WordPress-logotype-standard.png), tap the share icon at the bottom of the page and verify the extensions appear
* Try to share a gif file from Photos.app

### Web pages (from Safari)
In Safari, we are allowed to inject a JS file to extract data from a web page. Currently we are grabbing:
* The URL of the page (document.baseURI)
* A description of the page if that element is provided by the page author
* Any selected text 
* The title of the page (document.title)

### URLs
Sharing a URL should work from many apps on iOS. In this situation we simply create a link and insert it into the content body. It should be noted that even if a URL is shared from Safari, it is very possible we will not be able to extract the other information (title, description, etc). This is simply a limitation of what the extension context provides to us.

### Sharing plain text
When you select text from most apps and tap “Share…” in the context menu, this will initiate a plain text share where the only data we can pull from the shared context is the selected text. Here, we simply put that selected text into a blockquote.

/cc @loremattei 