### PR TITLE
Uploading media via the Share extension silently fails for Contributors

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -826,6 +826,8 @@
 		C58349C51806F95100B64089 /* IOS7CorrectedTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = C58349C41806F95100B64089 /* IOS7CorrectedTextView.m */; };
 		CE1CCB2D204DDD18000EE3AC /* MyProfileHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1CCB2C204DDD18000EE3AC /* MyProfileHeaderView.swift */; };
 		CE1CCB2F2050502B000EE3AC /* MyProfileHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE1CCB2E2050502B000EE3AC /* MyProfileHeaderView.xib */; };
+		CE39E17220CB117B00CABA05 /* RemoteBlog+Capabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE39E17120CB117B00CABA05 /* RemoteBlog+Capabilities.swift */; };
+		CE39E17320CB117B00CABA05 /* RemoteBlog+Capabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE39E17120CB117B00CABA05 /* RemoteBlog+Capabilities.swift */; };
 		CEBD3EAB0FF1BA3B00C1396E /* Blog.m in Sources */ = {isa = PBXBuildFile; fileRef = CEBD3EAA0FF1BA3B00C1396E /* Blog.m */; };
 		D800D86420997BA100E7C7E5 /* ReaderMenuItemCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800D86320997BA100E7C7E5 /* ReaderMenuItemCreator.swift */; };
 		D800D86620997C6E00E7C7E5 /* FollowingMenuItemCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800D86520997C6E00E7C7E5 /* FollowingMenuItemCreator.swift */; };
@@ -2365,6 +2367,7 @@
 		CDF46FFC7F78DB8FEB56E6F9 /* Pods-WordPressShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.release.xcconfig"; sourceTree = "<group>"; };
 		CE1CCB2C204DDD18000EE3AC /* MyProfileHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyProfileHeaderView.swift; sourceTree = "<group>"; };
 		CE1CCB2E2050502B000EE3AC /* MyProfileHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MyProfileHeaderView.xib; sourceTree = "<group>"; };
+		CE39E17120CB117B00CABA05 /* RemoteBlog+Capabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteBlog+Capabilities.swift"; sourceTree = "<group>"; };
 		CEBD3EA90FF1BA3B00C1396E /* Blog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Blog.h; sourceTree = "<group>"; };
 		CEBD3EAA0FF1BA3B00C1396E /* Blog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Blog.m; sourceTree = "<group>"; };
 		D61CEAC1CB25AE65B26BDC68 /* Pods-WordPressShareExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -5274,6 +5277,7 @@
 				74AC1DA0200D0CC300973CAD /* UINavigationController+Extensions.swift */,
 				741D1479200D55F6003DFD30 /* UITableView+Extensions.swift */,
 				74BC35B720499EEB00AC1525 /* RemotePostCategory+Extensions.swift */,
+				CE39E17120CB117B00CABA05 /* RemoteBlog+Capabilities.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -7817,6 +7821,7 @@
 				74021A09202E1323006CC39F /* ShareSegueHandler.swift in Sources */,
 				74021A01202E12F4006CC39F /* SharedCoreDataStack.swift in Sources */,
 				74021A14202E1393006CC39F /* ShareExtensionEditorViewController.swift in Sources */,
+				CE39E17320CB117B00CABA05 /* RemoteBlog+Capabilities.swift in Sources */,
 				74021A0F202E1370006CC39F /* ExtensionTransitioningManager.swift in Sources */,
 				74E44AD92031ED2300556205 /* WordPressDraft-Lumberjack.m in Sources */,
 				741AF3A5202F3E2A00C771A5 /* Tracks+DraftAction.swift in Sources */,
@@ -7882,6 +7887,7 @@
 				74448F542044BC7600BD4CDA /* CategoryTree.swift in Sources */,
 				74402F2A200528F200A1D4A2 /* ExtensionPresentationController.swift in Sources */,
 				B5BEA55F1C7CE6D100C8035B /* Constants.m in Sources */,
+				CE39E17220CB117B00CABA05 /* RemoteBlog+Capabilities.swift in Sources */,
 				BE6787F51FFF2886005D9F01 /* ShareModularViewController.swift in Sources */,
 				B5552D7E1CD101A600B26DF6 /* NSExtensionContext+Extensions.swift in Sources */,
 				B5552D801CD1028C00B26DF6 /* String+Extensions.swift in Sources */,

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -102,6 +102,17 @@ extension AppExtensionsService {
         })
     }
 
+    func isAuthorizedToUploadMedia(in sites: [RemoteBlog], for selectedSiteID: Int) -> Bool {
+        let siteID = NSNumber(value: selectedSiteID)
+        var isAuthorizedToUploadFiles = false
+        for site in sites {
+            if site.blogID == siteID {
+                isAuthorizedToUploadFiles = site.isUserCapableOf(.uploadFiles)
+            }
+        }
+        return isAuthorizedToUploadFiles
+    }
+
     private func primarySites(with blogs: [RemoteBlog]) -> [RemoteBlog] {
         // Find the primary site (even if it's not visible)
         let primarySiteID = ShareExtensionService.retrieveShareExtensionPrimarySite()?.siteID ?? 0

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -102,14 +102,18 @@ extension AppExtensionsService {
         })
     }
 
+    /// Filters the list of sites and returns if a user is allowed to upload media for the selected site
+    ///
+    /// - Parameters:
+    /// - sites: the list of sites to filter.
+    /// - selectedSiteID: the current site the user wants to upload media to.
+    ///
     func isAuthorizedToUploadMedia(in sites: [RemoteBlog], for selectedSiteID: Int) -> Bool {
         let siteID = NSNumber(value: selectedSiteID)
-        var isAuthorizedToUploadFiles = false
-        for site in sites {
-            if site.blogID == siteID {
-                isAuthorizedToUploadFiles = site.isUserCapableOf(.uploadFiles)
-            }
+        guard let isAuthorizedToUploadFiles = sites.filter({$0.blogID == siteID}).first?.isUploadingFilesAllowed() else {
+            return false
         }
+
         return isAuthorizedToUploadFiles
     }
 

--- a/WordPress/WordPressShareExtension/RemoteBlog+Capabilities.swift
+++ b/WordPress/WordPressShareExtension/RemoteBlog+Capabilities.swift
@@ -1,0 +1,49 @@
+import Foundation
+import WordPressKit
+
+extension RemoteBlog {
+    /// Enumeration that contains all of the RemoteBlog's available capabilities.
+    ///
+    public enum Capability: String {
+        case deleteOthersPosts  = "delete_others_posts"
+        case deletePosts        = "delete_posts"
+        case editOthersPages    = "edit_others_pages"
+        case editOthersPosts    = "edit_others_posts"
+        case editPages          = "edit_pages"
+        case editPosts          = "edit_posts"
+        case editThemeOptions   = "edit_theme_options"
+        case editUsers          = "edit_users"
+        case listUsers          = "list_users"
+        case manageCategories   = "manage_categories"
+        case manageOptions      = "manage_options"
+        case promoteUsers       = "promote_users"
+        case publishPosts       = "publish_posts"
+        case uploadFiles        = "upload_files"
+        case viewStats          = "view_stats"
+    }
+
+
+    /// Returns true if a given capability is enabled. False otherwise
+    ///
+    public func isUserCapableOf(_ capability: Capability) -> Bool {
+        return capabilities?[capability.rawValue] as? Bool ?? false
+    }
+
+    /// Returns true if the current user is allowed to list a Blog's Users
+    ///
+    @objc public func isListingUsersAllowed() -> Bool {
+        return isUserCapableOf(.listUsers)
+    }
+
+    /// Returns true if the current user is allowed to publish to the Blog
+    ///
+    @objc public func isPublishingPostsAllowed() -> Bool {
+        return isUserCapableOf(.publishPosts)
+    }
+
+    /// Returns true if the current user is allowed to upload files to the Blog
+    ///
+    @objc public func isUploadingFilesAllowed() -> Bool {
+        return isUserCapableOf(.uploadFiles)
+    }
+}

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -845,16 +845,18 @@ fileprivate extension ShareModularViewController {
         }
     }
 
-    func showAlert() {
-        let title = NSLocalizedString("Sharing Error", comment: "Share extension error dialog title.")
-        let message = NSLocalizedString("Whoops, something went wrong while sharing. You can try again, maybe it was a glitch.", comment: "Share extension error dialog text.")
+    func showAlert(title: String = NSLocalizedString("Sharing Error", comment: "Share extension error dialog title."),
+                   message: String = NSLocalizedString("Whoops, something went wrong while sharing. You can try again, maybe it was a glitch.", comment: "Share extension error dialog text."),
+                   retry: Bool = true) {
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
 
-        let acceptButtonText = NSLocalizedString("Try again", comment: "Share extension error dialog retry button label.")
-        let acceptAction = UIAlertAction(title: acceptButtonText, style: .default) { (action) in
-            self.savePostToRemoteSite()
+        if retry {
+            let acceptButtonText = NSLocalizedString("Try again", comment: "Share extension error dialog retry button label.")
+            let acceptAction = UIAlertAction(title: acceptButtonText, style: .default) { (action) in
+                self.savePostToRemoteSite()
+            }
+            alertController.addAction(acceptAction)
         }
-        alertController.addAction(acceptAction)
 
         let dismissButtonText = NSLocalizedString("Nevermind", comment: "Share extension error dialog cancel button label.")
         let dismissAction = UIAlertAction(title: dismissButtonText, style: .cancel) { (action) in

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -844,17 +844,14 @@ fileprivate extension ShareModularViewController {
         }, onFailure: {
             let error = self.createErrorWithDescription("Failed to save and upload post with no media.")
             self.tracks.trackExtensionError(error)
-            self.showAlert()
+            self.showRetryAlert()
         })
     }
 
     func showUnauthorizedAlert() {
         let error = self.createErrorWithDescription("This role is unable to upload media.")
         self.tracks.trackExtensionError(error)
-        let title = NSLocalizedString("Sharing Error", comment: "Share extension error dialog title.")
-        let message = NSLocalizedString("Your account does not have permission to upload media to this site. The Site Administrator can change these permissions.", comment: "Share extension error dialog text.")
-        let dismiss = NSLocalizedString("Return to post", comment: "Share extension error dialog cancel button text")
-        self.showAlert(title: title, message: message, dismiss: dismiss, retry: false)
+        self.showPermissionsAlert()
     }
 
     func uploadPostAndMedia(service: AppExtensionsService, siteID: Int, localImageURLs: [URL]) {
@@ -871,29 +868,42 @@ fileprivate extension ShareModularViewController {
         }, onFailure: {
             let error = self.createErrorWithDescription("Failed to save and upload post with media.")
             self.tracks.trackExtensionError(error)
-            self.showAlert()
+            self.showRetryAlert()
         })
     }
 
-    func showAlert(title: String = NSLocalizedString("Sharing Error", comment: "Share extension error dialog title."),
-                   message: String = NSLocalizedString("Whoops, something went wrong while sharing. You can try again, maybe it was a glitch.", comment: "Share extension error dialog text."),
-                   dismiss: String = NSLocalizedString("Dismiss", comment: "Share extension error dialog cancel button label."),
-                   retry: Bool = true) {
+    func showRetryAlert() {
+        let title: String = NSLocalizedString("Sharing Error", comment: "Share extension error dialog title.")
+        let message: String = NSLocalizedString("Whoops, something went wrong while sharing. You can try again, maybe it was a glitch.", comment: "Share extension error dialog text.")
+        let dismiss: String = NSLocalizedString("Dismiss", comment: "Share extension error dialog cancel button label.")
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
 
-        if retry {
-            let acceptButtonText = NSLocalizedString("Try again", comment: "Share extension error dialog retry button label.")
-            let acceptAction = UIAlertAction(title: acceptButtonText, style: .default) { (action) in
-                self.savePostToRemoteSite()
-            }
-            alertController.addAction(acceptAction)
+        let acceptButtonText = NSLocalizedString("Try again", comment: "Share extension error dialog retry button label.")
+        let acceptAction = UIAlertAction(title: acceptButtonText, style: .default) { (action) in
+            self.savePostToRemoteSite()
         }
+        alertController.addAction(acceptAction)
 
         let dismissButtonText = dismiss
         let dismissAction = UIAlertAction(title: dismissButtonText, style: .cancel) { (action) in
             self.showCancellingView()
             self.cleanUpSharedContainerAndCache()
             self.dismiss()
+        }
+        alertController.addAction(dismissAction)
+
+        present(alertController, animated: true, completion: nil)
+    }
+
+    func showPermissionsAlert() {
+        let title = NSLocalizedString("Sharing Error", comment: "Share extension error dialog title.")
+        let message = NSLocalizedString("Your account does not have permission to upload media to this site. The Site Administrator can change these permissions.", comment: "Share extension error dialog text.")
+        let dismiss = NSLocalizedString("Return to post", comment: "Share extension error dialog cancel button text")
+
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+
+        let dismissAction = UIAlertAction(title: dismiss, style: .cancel) { [weak self] (action) in
+            self?.clearAllNoResultsViews()
         }
         alertController.addAction(dismissAction)
 

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -795,6 +795,12 @@ fileprivate extension ShareModularViewController {
             return
         }
 
+        guard let siteList = sites else {
+            let error = createErrorWithDescription("Could not save post to remote site: remote sites list missing.")
+            self.tracks.trackExtensionError(error)
+            return
+        }
+
         isPublishingPost = true
         sitesTableView.refreshControl = nil
         clearSiteDataAndRefreshSitesTable()
@@ -808,8 +814,33 @@ fileprivate extension ShareModularViewController {
 
         // Then proceed uploading the actual post
         let networkService = AppExtensionsService()
+        let isAuthorizedToUploadFiles = networkService.isAuthorizedToUploadMedia(in: siteList, for: siteID)
         let localImageURLs = [URL](shareData.sharedImageDict.keys)
-        if !localImageURLs.isEmpty {
+
+        if localImageURLs.isEmpty {
+            // No media. just a simple post
+            networkService.saveAndUploadPost(title: shareData.title,
+                                             body: shareData.contentBody,
+                                             tags: shareData.tags,
+                                             categories: shareData.selectedCategoriesIDString,
+                                             status: shareData.postStatus.rawValue,
+                                             siteID: siteID,
+                                             onComplete: {
+                                                self.tracks.trackExtensionPosted(self.shareData.postStatus.rawValue)
+                                                self.dismiss()
+            }, onFailure: {
+                let error = self.createErrorWithDescription("Failed to save and upload post with no media.")
+                self.tracks.trackExtensionError(error)
+                self.showAlert()
+            })
+        } else if isAuthorizedToUploadFiles == false {
+            // Error: this role is unable to upload media.
+            let error = self.createErrorWithDescription("This role is unable to upload media.")
+            self.tracks.trackExtensionError(error)
+            let title = NSLocalizedString("Sharing Error", comment: "Share extension error dialog title.")
+            let message = NSLocalizedString("This role is unable to upload media. Please contact your Site Administrator.", comment: "Share extension error dialog text.")
+            self.showAlert(title: title, message: message, retry: false)
+        } else {
             // We have media, so let's upload it with the post
             networkService.uploadPostWithMedia(title: shareData.title,
                                                body: shareData.contentBody,
@@ -823,22 +854,6 @@ fileprivate extension ShareModularViewController {
                                                 self.dismiss()
             }, onFailure: {
                 let error = self.createErrorWithDescription("Failed to save and upload post with media.")
-                self.tracks.trackExtensionError(error)
-                self.showAlert()
-            })
-        } else {
-            // No media. just a simple post
-            networkService.saveAndUploadPost(title: shareData.title,
-                                             body: shareData.contentBody,
-                                             tags: shareData.tags,
-                                             categories: shareData.selectedCategoriesIDString,
-                                             status: shareData.postStatus.rawValue,
-                                             siteID: siteID,
-                                             onComplete: {
-                                                self.tracks.trackExtensionPosted(self.shareData.postStatus.rawValue)
-                                                self.dismiss()
-            }, onFailure: {
-                let error = self.createErrorWithDescription("Failed to save and upload post with no media.")
                 self.tracks.trackExtensionError(error)
                 self.showAlert()
             })


### PR DESCRIPTION
#Fixes #8621. Is dependent upon [WordPressKit-iOS PR #13](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/13)

cc: @ctarda in case you're interested :)

# Description
When a user (whose role is set to `Contributor` on a site) shares media via either share extension (main share activity extension or `Save as Draft`), the background upload silently fails and the post sans media is uploaded anyway. Instead, when a `Contributor` attempts to share some media by using the extension, there should be an alert that appears to tell the user they can't take that action.

## Testing Setup
1. Ensure you have the WordPress Share activity and the `Save as Draft` options turned on. If you're not sure if you have it, check out **How to turn on `Save as Draft`** at the bottom.
2. On your test website that you'll be sharing to, ensure that your user is set to the `Contributor` role

### Testing publishing a post 
1. Go to the Photos app and select some photo(s)
2. Press the Share icon button
3. Choose WordPress (the full-color app icon with the word "WordPress" below it)
4. Tap **Next**
5. In the **Publish post on:** section, choose your test site 
6. Tap **Publish**

**Expected Result**
An alert appears with the title **Sharing Error**. Message: This role is unable to upload media. Please contact your Site Administrator. Button title: Nevermind (dismisses alert and the modal view)
![img_1883](https://user-images.githubusercontent.com/1062444/41125861-50fcad22-6a6b-11e8-934c-f2c40faf7ef3.PNG)

### Testing `Save as Draft` 
1. Go to the Photos app and select some photo(s)
2. Press the Share icon button
3. Choose `Save as Draft` (the black and white app icon with the words "Save as Draft" below it)
4. Tap **Save**

The same alert listed in the first test should appear.

#### How to turn on "Save as Draft"
1. Trigger the share extension by attempting to share a piece of content. (For example, Safari > Share button).
2. Choose the "More" button
3. Find the "Save as Draft" activity, turn it on, and hit "Done".
4. The WordPress "Save as Draft" option should appear in the bottom row.

