### PR TITLE
Check for NoResultsViewController before using it.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -267,9 +267,7 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)addNoResultsToView
 {
-    if (!self.noResultsViewController) {
-        [self instantiateNoResultsViewController];
-    }
+    [self instantiateNoResultsViewControllerIfNeeded];
 
     [self.view layoutIfNeeded];
     [self addChildViewController:self.noResultsViewController];
@@ -288,16 +286,19 @@ static NSInteger HideSearchMinSites = 3;
         [self bypassBlogListViewController];
     }
 
+    [self instantiateNoResultsViewControllerIfNeeded];
+    
     // If we have no sites, show the No Results VC.
     if (siteCount == 0) {
-        [self addNoResultsToView];
-
         [self.noResultsViewController configureWithTitle:NSLocalizedString(@"Create a new site for your business, magazine, or personal blog; or connect an existing WordPress installation.", "Text shown when the account has no sites.") buttonTitle:NSLocalizedString(@"Add new site","Title of button to add a new site.") subtitle:nil image:nil];
+        [self addNoResultsToView];
     }
 }
 
 - (void)showNoResultsViewForAllSitesHidden
 {
+    [self instantiateNoResultsViewControllerIfNeeded];
+    
     NSUInteger count = self.dataSource.allBlogsCount;
     
     NSString *singularTitle = NSLocalizedString(@"You have 1 hidden WordPress site.", @"Message informing the user that all of their sites are currently hidden (singular)");
@@ -307,9 +308,7 @@ static NSInteger HideSearchMinSites = 3;
     NSString *multipleSubtitle = NSLocalizedString(@"To manage them here, set them to visible.", @"Prompt asking user to make sites visible in order to use them in the app (plural)");
     
     NSString *buttonTitle = NSLocalizedString(@"Change Visibility", @"Button title to edit visibility of sites.");
-
-    [self addNoResultsToView];
-
+    
     if (count == 1) {
         [self.noResultsViewController configureWithTitle:singularTitle
                                              buttonTitle:buttonTitle
@@ -321,6 +320,9 @@ static NSInteger HideSearchMinSites = 3;
                                                 subtitle:multipleSubtitle
                                                    image:nil];
     }
+
+    [self addNoResultsToView];
+    
 }
 
 - (void)updateSplitViewAppearanceForSiteCount:(NSUInteger)siteCount
@@ -503,6 +505,13 @@ static NSInteger HideSearchMinSites = 3;
     self.searchBar.delegate = self;
 
     [WPStyleGuide configureSearchBar:self.searchBar];
+}
+
+- (void)instantiateNoResultsViewControllerIfNeeded
+{
+    if (!self.noResultsViewController) {
+        [self instantiateNoResultsViewController];
+    }
 }
 
 - (void)instantiateNoResultsViewController


### PR DESCRIPTION
Fixes #9536 

This adds missing checks to verify the `NoResultsViewController` has been instantiated before using it.

Suggestion: it's easier to see this issue if you log into a WP account, then add a self-hosted site. That way, when you remove the self-hosted site, the login screen doesn't appear immediately. And this issue became blatantly obvious.

**To test:**

**Account with no sites:**
- Add a self hosted site.
- Go to My Sites > swipe left > Remove site.
- Verify the No Results View displays correctly.

![no_sites](https://user-images.githubusercontent.com/1816888/41127665-e63157ce-6a68-11e8-8f99-f24932411c90.png)

---

**With all sites hidden:**
- Add a self hosted site.
- Go to My Sites > swipe left > Remove site.
- Verify the No Results View displays correctly.

![hidden_sites](https://user-images.githubusercontent.com/1816888/41127595-aadcd9aa-6a68-11e8-96d4-d56e8d2d5fce.png)
