### PR TITLE
Avoid removing label from follow icon on the reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -499,24 +499,14 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
             likeActionButton.setTitle(likeTitle, for: .normal)
             commentActionButton.setTitle(commentTitle, for: .normal)
             saveForLaterButton.setTitle("", for: .normal)
-            followButton.setTitle("", for: .normal)
-            followButton.setTitle("", for: .selected)
-            followButton.setTitle("", for: .highlighted)
 
-            insetFollowButtonIcon(false)
         } else {
             let likeTitle = WPStyleGuide.likeCountForDisplay(likeCount)
             let commentTitle = WPStyleGuide.commentCountForDisplay(commentCount)
-            let followTitle = WPStyleGuide.followStringForDisplay(false)
-            let followingTitle = WPStyleGuide.followStringForDisplay(true)
+
 
             likeActionButton.setTitle(likeTitle, for: .normal)
             commentActionButton.setTitle(commentTitle, for: .normal)
-
-
-            followButton.setTitle(followTitle, for: .normal)
-            followButton.setTitle(followingTitle, for: .selected)
-            followButton.setTitle(followingTitle, for: .highlighted)
 
             if FeatureFlag.saveForLater.enabled {
                 WPStyleGuide.applyReaderSaveForLaterButtonTitles(saveForLaterButton)
@@ -524,9 +514,9 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
                 let shareTitle = NSLocalizedString("Share", comment: "Verb. Button title.  Tap to share a post.")
                 saveForLaterButton.setTitle(shareTitle, for: .normal)
             }
-
-            insetFollowButtonIcon(true)
         }
+
+        insetFollowButtonIcon(true)
     }
 
     /// Adds some space between the button and title.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -157,6 +157,7 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         setupCommentActionButton()
         setupLikeActionButton()
         adjustInsetsForTextDirection()
+        insetFollowButtonIcon()
     }
 
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -515,17 +516,16 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
                 saveForLaterButton.setTitle(shareTitle, for: .normal)
             }
         }
-
-        insetFollowButtonIcon(true)
     }
 
     /// Adds some space between the button and title.
     /// Setting the titleEdgeInset.left seems to be ignored in IB for whatever reason,
     /// so we'll add/remove it from the image as needed.
-    fileprivate func insetFollowButtonIcon(_ bool: Bool) {
+    fileprivate func insetFollowButtonIcon() {
         var insets = followButton.imageEdgeInsets
-        insets.right = bool ? 2.0 : 0.0
+        insets.right = 2.0
         followButton.imageEdgeInsets = insets
+        followButton.flipInsetsForRightToLeftLayoutDirection()
     }
 
     fileprivate func applyHighlightedEffect(_ highlighted: Bool, animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -241,23 +241,22 @@ extension WPStyleGuide {
     @objc public class func applyReaderFollowButtonStyle(_ button: UIButton) {
         let side = WPStyleGuide.fontSizeForTextStyle(Cards.buttonTextStyle)
         let size = CGSize(width: side, height: side)
-        let followStr = followStringForDisplay(false)
-        let followingStr = followStringForDisplay(true)
 
         let followIcon = Gridicon.iconOfType(.readerFollow, withSize: size)
         let followingIcon = Gridicon.iconOfType(.readerFollowing, withSize: size)
-        let tintedFollowIcon = followIcon.imageWithTintColor(WPStyleGuide.mediumBlue())
 
+        let tintedFollowIcon = followIcon.imageWithTintColor(WPStyleGuide.mediumBlue())
         let tintedFollowingIcon = followingIcon.imageWithTintColor(WPStyleGuide.validGreen())
+
         let highlightIcon = followingIcon.imageWithTintColor(WPStyleGuide.lightBlue())
 
         button.setImage(tintedFollowIcon, for: .normal)
         button.setImage(tintedFollowingIcon, for: .selected)
         button.setImage(highlightIcon, for: .highlighted)
 
-        button.setTitle(followStr, for: UIControlState())
-        button.setTitle(followingStr, for: .selected)
-        button.setTitle(followingStr, for: .highlighted)
+        button.setTitle(followStringForDisplay, for: UIControlState())
+        button.setTitle(followingStringForDisplay, for: .selected)
+        button.setTitle(followingStringForDisplay, for: .highlighted)
     }
 
     @objc public class func applyReaderSaveForLaterButtonStyle(_ button: UIButton) {
@@ -320,12 +319,12 @@ extension WPStyleGuide {
         }
     }
 
-    @objc public class func followStringForDisplay(_ isFollowing: Bool) -> String {
-        if isFollowing {
-            return NSLocalizedString("Following", comment: "Verb. Button title. The user is following a blog.")
-        } else {
-            return NSLocalizedString("Follow", comment: "Verb. Button title. Follow a new blog.")
-        }
+    @objc public static var followStringForDisplay: String {
+        return NSLocalizedString("Follow", comment: "Verb. Button title. Follow a new blog.")
+    }
+
+    @objc public static var followingStringForDisplay: String {
+        return NSLocalizedString("Following", comment: "Verb. Button title. The user is following a blog.")
     }
 
     @objc public class func savePostStringForDisplay(_ isSaved: Bool) -> String {


### PR DESCRIPTION
Fixes #9546 

This PR avoids the deletion of the `Follow` label from the follow button.

@nozomimimi , I noticed that the reason why it wasn't present, is because the label is removed when the card width is less than 480 points, leaving more space for the post title.

For wider screens like the iPhones on landscape or iPads, the label is always present.
This is the difference in the thinest of the screens for iOS (iPhone 5/5S):

![follow_button](https://user-images.githubusercontent.com/9772967/41133331-eee2e55e-6a8b-11e8-8ce8-d5a4841cabd7.png)

If this is OK, let's go for it!

To test:
- Go to the reader.
- Go to a stream that displays the Follow button (i.e. Discover)
- Check that the `Follow` label is present for both `Follow` and `Following` states.