### PR TITLE
Present "Discover" as a site stream

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -8,6 +8,7 @@ import WordPressShared
 
     // MARK: - Topic Helpers
 
+    open static let discoverSiteID = NSNumber(value: 53424024)
 
     /// Check if the specified topic is a default topic
     ///

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -328,7 +328,7 @@ import WordPressShared
     /// Present the Discover stream as a Site stream.
     ///
     private func viewControllerForDiscover() -> ReaderStreamViewController {
-        return ReaderStreamViewController.controllerWithSiteID(ReaderHelpers.discoverSiteID, isFeed: true)
+        return ReaderStreamViewController.controllerWithSiteID(ReaderHelpers.discoverSiteID, isFeed: false)
     }
 
     /// Presents the saved for later view controller

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -325,6 +325,12 @@ import WordPressShared
         return ReaderSearchViewController.controller()
     }
 
+    /// Present the Discover stream as a Site stream.
+    ///
+    private func viewControllerForDiscover() -> ReaderStreamViewController {
+        return ReaderStreamViewController.controllerWithSiteID(ReaderHelpers.discoverSiteID, isFeed: true)
+    }
+
     /// Presents the saved for later view controller
     @objc func showSavedForLater() {
         guard let indexPath = viewModel.indexPathOfSavedForLater(),
@@ -527,6 +533,11 @@ import WordPressShared
     }
 
     fileprivate func viewControllerForMenuItem(_ menuItem: ReaderMenuItem) -> UIViewController? {
+
+        if let topic = menuItem.topic, ReaderHelpers.topicIsDiscover(topic) {
+            return viewControllerForDiscover()
+        }
+
         if let topic = menuItem.topic {
             currentReaderStream = viewControllerForTopic(topic)
             return currentReaderStream


### PR DESCRIPTION
Fixes #9551 

This is a simple PR that present the Discover section of the reader as a Site stream, so the `ReaderStreamViewController` shows the header.

![discover](https://user-images.githubusercontent.com/9772967/41138924-24ce95fa-6aaa-11e8-8269-16f3fafcbf7f.png)

I knew this should be simple, but it took me a while to figure out how to do it.
I was[ inspired by Android](https://github.com/wordpress-mobile/WordPress-Android/blob/a25e974142fe0bbf4e9617e996bd49684d2da7e0/WordPress/src/main/java/org/wordpress/android/ui/reader/adapters/ReaderPostAdapter.java#L362), where they detect that it's the `Discover` and fetch the site info by ID.

To test:
- Go to the Reader menu.
- Select (to) `Discover`.
- Check that the site header is there.

cc @nozomimimi 
