### PR TITLE
Update Gemfile.lock after running rake dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,10 +114,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.5.2)
-  danger
-  rake
-  xcpretty-travis-formatter
+  cocoapods (~> 1.5.2)!
+  danger!
+  rake!
+  xcpretty-travis-formatter!
 
 BUNDLED WITH
    1.16.1


### PR DESCRIPTION
Afer the changes in #9535, I'm getting a different Gemfile.lock every time I run `rake dependencies`. I'm pushing this and hoping it still works for everyone else. If another environment tries to revert it, we'll investigate further.