### PR TITLE
Ensures account_created events are not sent as an anon user.

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -223,6 +223,9 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 
     if (![self defaultWordPressComAccount]) {
         [self setDefaultWordPressComAccount:account];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [WPAnalytics refreshMetadata];
+        });
     }
 
     return account;

--- a/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/NUX/NUXLinkAuthViewController.swift
@@ -34,7 +34,6 @@ class NUXLinkAuthViewController: LoginViewController {
         if let linkSource = loginFields.meta.emailMagicLinkSource {
             switch linkSource {
             case .signup:
-                WordPressAuthenticator.track(.createdAccount, properties: ["source": "email"])
                 WordPressAuthenticator.track(.signupMagicLinkSucceeded)
             case .login:
                 WordPressAuthenticator.track(.loginMagicLinkSucceeded)

--- a/WordPressAuthenticator/WordPressAuthenticator/Signin/LoginViewController.swift
+++ b/WordPressAuthenticator/WordPressAuthenticator/Signin/LoginViewController.swift
@@ -203,6 +203,12 @@ extension LoginViewController {
                 return
             }
 
+            if self.isSignUp {
+                // Bump stat now that the account info has been synced.
+                // Note that social signups bump this stat elsewhere.
+                WordPressAuthenticator.track(.createdAccount, properties: ["source": "email"])
+            }
+
             if self.mustShowSignupEpilogue() {
                 self.showSignupEpilogue(for: credentials)
             } else if self.mustShowLoginEpilogue() {
@@ -247,6 +253,7 @@ extension LoginViewController {
             ]
         }
 
+        WPAnalytics.refreshMetadata()
         WordPressAuthenticator.track(.signedIn, properties: properties)
     }
 


### PR DESCRIPTION
Fixes #9518 

This PR makes sure that analytics meta data is refreshed during account creation via email, and bumps account_created stat after we have the proper account info and meta data is refreshed.

You can confirm the bug by setting a break point in `TracksEventService` ln 61 and inspect the values of `username` and `userID` for when the `account_created` event is dispatched.  Then create a new account.  You should see the username is empty and the userID is a UUID.   With this patch you should see the username as either a wpcom username or an email address, and the userID empty.

To test:
Set a break point as described above.
Sign up for a new account via email.
Confirm the correct values are present.

@ScoutHarris could I trouble you with this one? 
