### PR TITLE
Adds basic Core Data model checks when changing things in a release branch

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -7,3 +7,10 @@ warn("PR has more than 500 lines of code changing. Consider splitting into small
 # PRs should have a milestone attached
 has_milestone = github.pr_json["milestone"] != nil
 warn("PR is not assigned to a milestone.", sticky: false) unless has_milestone
+
+### Core Data Model Safety Checks
+
+target_release_branch = github.branch_for_base.start_with? "release"
+has_modified_model = git.modified_files.include? "WordPress/Classes/WordPress.xcdatamodeld/*/contents"
+
+warn("Core Data: Do not edit an existing model in a release branch unless it hasn't been released to testers yet. Instead create a new model version and merge back to develop soon.") if has_modified_model


### PR DESCRIPTION
Closes #9383 

This PR adds a warning to PRs that modify an existing Core Data model instead of creating a new version when inside of a release branch.

I created two test branches and a test PR to run Danger against for this PR. 

To test:
1. Check out this branch.
2. Run `rake dependencies` to ensure Danger is installed.
3. Run `bundle exec danger pr https://github.com/wordpress-mobile/WordPress-iOS/pull/9556`. You should only see a warning about a missing milestone.
4. In Xcode, modify any model version (76, the latest, is good).
5. Run step 3 again. You should see a warning about editing a model in a release branch.
6. Revert your model changes. Added a new model version based off of 76.
7. Run step 3 again. You shouldn't see any warning about the model being modified in a release branch.

Note to self: After this PR is merged, whack #9556 and the branches `release/develop-for-testing` and `release/testing-danger-core-data`.



