### PR TITLE
Issue/9433 Reader Site Search

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ def shared_with_networking_pods
     pod 'AFNetworking', '3.2.1'
     pod 'Alamofire', '4.7.2'
     pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0ba02badb90ed41beae0ca9dbf9126402f963a49'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '63be6d95ee1754e7aa75595909a1a3bb3552f780'
 end
 
 def shared_test_pods

--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ def shared_with_networking_pods
     pod 'AFNetworking', '3.2.1'
     pod 'Alamofire', '4.7.2'
     pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', '~> 1.0.6'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0ba02badb90ed41beae0ca9dbf9126402f963a49'
 end
 
 def shared_test_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -118,7 +118,7 @@ PODS:
   - WordPress-Aztec-iOS/WordPressEditor (1.0.0-beta.19)
   - WordPressKit (1.0.6):
     - AFNetworking (= 3.2.1)
-    - Alamofire (= 4.7.2)
+    - Alamofire (~> 4.7)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 0.4)
@@ -167,7 +167,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `c38d29b09cc9710ef307891f76a02c80a7002a59`)
   - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `c38d29b09cc9710ef307891f76a02c80a7002a59`)
-  - WordPressKit (~> 1.0.6)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `0ba02badb90ed41beae0ca9dbf9126402f963a49`)
   - WordPressShared (~> 1.0.5)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0`)
   - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `b5ae03494596e3da7a8f814f9cab8e96ca345bc8`)
@@ -205,7 +205,6 @@ SPEC REPOS:
     - Starscream
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPressKit
     - WordPressShared
     - wpxmlrpc
     - ZendeskSDK
@@ -217,6 +216,9 @@ EXTERNAL SOURCES:
   WordPress-Aztec-iOS:
     :commit: c38d29b09cc9710ef307891f76a02c80a7002a59
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPressKit:
+    :commit: 0ba02badb90ed41beae0ca9dbf9126402f963a49
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :commit: e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -231,6 +233,9 @@ CHECKOUT OPTIONS:
   WordPress-Aztec-iOS:
     :commit: c38d29b09cc9710ef307891f76a02c80a7002a59
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPressKit:
+    :commit: 0ba02badb90ed41beae0ca9dbf9126402f963a49
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :commit: e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -270,13 +275,13 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-Aztec-iOS: 743dbe41492eae1d9daf3f5ba5435ab295ee668f
-  WordPressKit: f62f8e68ce2300d9a8b4c2b7c743c911bbdbd343
+  WordPressKit: 4084217be7262951d157fff3df6581aa1e685b31
   WordPressShared: d7fdb0ca9302cf4bc7f3ec0fbe98d0d8eb721438
   WordPressUI: ebf73505c8957df23a1c9fe565fba553be296dc5
   WPMediaPicker: ceb613e43eae03268e73835d48d67f92f595aca6
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: fac21ae825299bf6e1eb821d27c150fae75e1193
+PODFILE CHECKSUM: aab4804b108514f5ea0d715b33e12a5a1bbf76e2
 
 COCOAPODS: 1.5.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -167,7 +167,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `c38d29b09cc9710ef307891f76a02c80a7002a59`)
   - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `c38d29b09cc9710ef307891f76a02c80a7002a59`)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `0ba02badb90ed41beae0ca9dbf9126402f963a49`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `63be6d95ee1754e7aa75595909a1a3bb3552f780`)
   - WordPressShared (~> 1.0.5)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0`)
   - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `b5ae03494596e3da7a8f814f9cab8e96ca345bc8`)
@@ -217,7 +217,7 @@ EXTERNAL SOURCES:
     :commit: c38d29b09cc9710ef307891f76a02c80a7002a59
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressKit:
-    :commit: 0ba02badb90ed41beae0ca9dbf9126402f963a49
+    :commit: 63be6d95ee1754e7aa75595909a1a3bb3552f780
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :commit: e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0
@@ -234,7 +234,7 @@ CHECKOUT OPTIONS:
     :commit: c38d29b09cc9710ef307891f76a02c80a7002a59
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressKit:
-    :commit: 0ba02badb90ed41beae0ca9dbf9126402f963a49
+    :commit: 63be6d95ee1754e7aa75595909a1a3bb3552f780
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :commit: e72725ee5aed1a2c4dffa755a78c36e3ecf6e2b0
@@ -282,6 +282,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: aab4804b108514f5ea0d715b33e12a5a1bbf76e2
+PODFILE CHECKSUM: cf19fd271d3a942d4120794896d39dd5f4afa20c
 
 COCOAPODS: 1.5.2

--- a/WordPress/Classes/Services/ReaderSiteSearchService.swift
+++ b/WordPress/Classes/Services/ReaderSiteSearchService.swift
@@ -1,0 +1,51 @@
+import Foundation
+import CocoaLumberjack
+
+typealias ReaderSiteSearchSuccessBlock = (_ feeds: [ReaderFeed], _ hasMore: Bool, _ feedCount: Int) -> Void
+typealias ReaderSiteSearchFailureBlock = (_ error: Error?) -> Void
+
+/// Allows searching for sites / feeds in the Reader.
+///
+@objc class ReaderSiteSearchService: LocalCoreDataService {
+
+    private func apiRequest() -> WordPressComRestApi {
+        let accountService = AccountService(managedObjectContext: managedObjectContext)
+        let defaultAccount = accountService.defaultWordPressComAccount()
+        if let api = defaultAccount?.wordPressComRestApi, api.hasCredentials() {
+            return api
+        }
+
+        return WordPressComRestApi(oAuthToken: nil, userAgent: WPUserAgent.wordPress())
+    }
+
+    /// Performs a search for sites / feeds matching the specified query.
+    ///
+    /// - Parameters:
+    ///     - query: The phrase to search for
+    ///     - page: Results are requested in pages. Use this to specify which
+    ///             page of results to return. 0 indexed.
+    ///     - success: Success block called on a successful search. Parameters
+    ///                are a list of ReaderFeeds, a bool for `hasMore` (are there
+    ///                more feeds to fetch), and a total feed count.
+    ///     - failure: Failure block called on a failed search.
+    ///
+    func performSearch(withQuery query: String,
+                       page: Int,
+                       success: @escaping ReaderSiteSearchSuccessBlock,
+                       failure: @escaping ReaderSiteSearchFailureBlock) {
+        let remote = ReaderSiteSearchServiceRemote(wordPressComRestApi: apiRequest())
+        remote.performSearch(query,
+                             offset: page * Constants.pageSize,
+                             count: Constants.pageSize,
+                             success: { (feeds, hasMore, feedCount) in
+            success(feeds, hasMore, feedCount)
+        }, failure: { error in
+            DDLogError("Error while performing Reader site search: \(String(describing: error))")
+            failure(error)
+        })
+    }
+
+    private enum Constants {
+        static let pageSize = 10
+    }
+}

--- a/WordPress/Classes/Services/ReaderSiteSearchService.swift
+++ b/WordPress/Classes/Services/ReaderSiteSearchService.swift
@@ -8,6 +8,9 @@ typealias ReaderSiteSearchFailureBlock = (_ error: Error?) -> Void
 ///
 @objc class ReaderSiteSearchService: LocalCoreDataService {
 
+    // The size of a single page of results when performing a search.
+    static let pageSize = 20
+
     private func apiRequest() -> WordPressComRestApi {
         let accountService = AccountService(managedObjectContext: managedObjectContext)
         let defaultAccount = accountService.defaultWordPressComAccount()
@@ -46,6 +49,6 @@ typealias ReaderSiteSearchFailureBlock = (_ error: Error?) -> Void
     }
 
     private enum Constants {
-        static let pageSize = 10
+        static let pageSize = 20
     }
 }

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -213,7 +213,6 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  */
 - (ReaderAbstractTopic *)findWithPath:(NSString *)path;
 
-
 /**
  Find a site topic by its site id
 
@@ -221,6 +220,14 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  @return A matched site topic
  */
 - (ReaderSiteTopic *)findSiteTopicWithSiteID:(NSNumber *)siteID;
+
+/**
+ Find a site topic by its feed id
+
+ @param feedID The feed id of the topic
+ @return A matched site topic
+ */
+- (ReaderSiteTopic *)findSiteTopicWithFeedID:(NSNumber *)feedID;
 
 @end
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -590,7 +590,14 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
                        success:(void (^)(NSManagedObjectID *objectID, BOOL isFollowing))success
                        failure:(void (^)(NSError *error))failure
 {
-    ReaderSiteTopic *siteTopic = [self findSiteTopicWithSiteID:siteID];
+    ReaderSiteTopic *siteTopic;
+
+    if (isFeed) {
+        siteTopic = [self findSiteTopicWithFeedID:siteID];
+    } else {
+        siteTopic = [self findSiteTopicWithSiteID:siteID];
+    }
+
     if (siteTopic) {
         if (success) {
             success(siteTopic.objectID, siteTopic.following);
@@ -1050,6 +1057,20 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 {
     NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[ReaderSiteTopic classNameWithoutNamespaces]];
     request.predicate = [NSPredicate predicateWithFormat:@"siteID = %@", siteID];
+    NSError *error;
+    NSArray *results = [self.managedObjectContext executeFetchRequest:request error:&error];
+    if (error) {
+        DDLogError(@"%@ error executing fetch request: %@", NSStringFromSelector(_cmd), error);
+        return nil;
+    }
+
+    return (ReaderSiteTopic *)[results firstObject];
+}
+
+- (ReaderSiteTopic *)findSiteTopicWithFeedID:(NSNumber *)feedID
+{
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[ReaderSiteTopic classNameWithoutNamespaces]];
+    request.predicate = [NSPredicate predicateWithFormat:@"feedID = %@", feedID];
     NSError *error;
     NSArray *results = [self.managedObjectContext executeFetchRequest:request error:&error];
     if (error) {

--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -19,11 +19,11 @@
                         <viewControllerLayoutGuide type="bottom" id="icf-FG-h6u"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="nFH-eq-cvg">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="483"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="437"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n2H-rP-0mh">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="483"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="437"/>
                                 <connections>
                                     <segue destination="ojY-lw-Nq8" kind="embed" id="HkI-vX-JZt"/>
                                 </connections>
@@ -535,7 +535,7 @@
             <objects>
                 <tableViewController id="ojY-lw-Nq8" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="8GD-qV-397">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="483"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="437"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <connections>
@@ -571,14 +571,21 @@
                                     <outlet property="delegate" destination="sKI-JH-RAG" id="fsR-5r-2Md"/>
                                 </connections>
                             </searchBar>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="KJP-Gn-VWy" customClass="FilterTabBar" customModule="WordPress" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="56" width="375" height="46"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="46" id="8Zx-Ii-BAp"/>
+                                </constraints>
+                            </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PuG-YC-OIC">
-                                <rect key="frame" x="0.0" y="56" width="375" height="547"/>
+                                <rect key="frame" x="0.0" y="102" width="375" height="501"/>
                                 <connections>
                                     <segue destination="His-O5-Cy6" kind="embed" id="xfh-l2-pdU"/>
                                 </connections>
                             </containerView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What would you like to find?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="afc-5c-5tF">
-                                <rect key="frame" x="16" y="252" width="343" height="27"/>
+                                <rect key="frame" x="16" y="275" width="343" height="27"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -587,20 +594,24 @@
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstItem="4Hq-9j-ssQ" firstAttribute="top" secondItem="PuG-YC-OIC" secondAttribute="bottom" id="00R-Fx-nqw"/>
+                            <constraint firstItem="KJP-Gn-VWy" firstAttribute="leading" secondItem="3Jv-hf-pib" secondAttribute="leading" id="3hK-Yk-mzY"/>
                             <constraint firstItem="afc-5c-5tF" firstAttribute="width" secondItem="UQY-Uf-csX" secondAttribute="width" constant="-32" id="7H0-0r-9sW"/>
-                            <constraint firstItem="PuG-YC-OIC" firstAttribute="top" secondItem="UQY-Uf-csX" secondAttribute="bottom" id="9Py-mf-1gR"/>
+                            <constraint firstItem="KJP-Gn-VWy" firstAttribute="top" secondItem="UQY-Uf-csX" secondAttribute="bottom" id="HHm-eE-R1Z"/>
                             <constraint firstItem="UQY-Uf-csX" firstAttribute="leading" secondItem="3Jv-hf-pib" secondAttribute="leading" id="OVh-zU-bdz"/>
+                            <constraint firstItem="PuG-YC-OIC" firstAttribute="top" secondItem="KJP-Gn-VWy" secondAttribute="bottom" id="SLO-Jy-5QA"/>
                             <constraint firstItem="UQY-Uf-csX" firstAttribute="top" secondItem="KDf-ab-yd0" secondAttribute="bottom" id="Vjr-r9-9fI"/>
                             <constraint firstItem="afc-5c-5tF" firstAttribute="centerY" secondItem="PuG-YC-OIC" secondAttribute="centerY" constant="-64" id="WFt-Iz-74I"/>
                             <constraint firstAttribute="trailing" secondItem="PuG-YC-OIC" secondAttribute="trailing" id="Xy7-kf-4Zi"/>
                             <constraint firstAttribute="trailing" secondItem="UQY-Uf-csX" secondAttribute="trailing" id="ack-5h-tUx"/>
                             <constraint firstItem="afc-5c-5tF" firstAttribute="centerX" secondItem="PuG-YC-OIC" secondAttribute="centerX" id="e4c-Hf-6s0"/>
+                            <constraint firstAttribute="trailing" secondItem="KJP-Gn-VWy" secondAttribute="trailing" id="oCm-Ws-bQM"/>
                             <constraint firstItem="PuG-YC-OIC" firstAttribute="leading" secondItem="3Jv-hf-pib" secondAttribute="leading" id="u5y-Zc-kp9"/>
                         </constraints>
                         <variation key="widthClass=regular" layoutMarginsFollowReadableWidth="YES"/>
                     </view>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <connections>
+                        <outlet property="filterBar" destination="KJP-Gn-VWy" id="P35-se-cGl"/>
                         <outlet property="label" destination="afc-5c-5tF" id="Ytv-PP-Zf4"/>
                         <outlet property="searchBar" destination="UQY-Uf-csX" id="df9-mO-cAe"/>
                     </connections>

--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -585,7 +585,7 @@
                                 </connections>
                             </containerView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What would you like to find?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="afc-5c-5tF">
-                                <rect key="frame" x="16" y="275" width="343" height="27"/>
+                                <rect key="frame" x="16" y="339" width="343" height="27"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -600,7 +600,7 @@
                             <constraint firstItem="UQY-Uf-csX" firstAttribute="leading" secondItem="3Jv-hf-pib" secondAttribute="leading" id="OVh-zU-bdz"/>
                             <constraint firstItem="PuG-YC-OIC" firstAttribute="top" secondItem="KJP-Gn-VWy" secondAttribute="bottom" id="SLO-Jy-5QA"/>
                             <constraint firstItem="UQY-Uf-csX" firstAttribute="top" secondItem="KDf-ab-yd0" secondAttribute="bottom" id="Vjr-r9-9fI"/>
-                            <constraint firstItem="afc-5c-5tF" firstAttribute="centerY" secondItem="PuG-YC-OIC" secondAttribute="centerY" constant="-64" id="WFt-Iz-74I"/>
+                            <constraint firstItem="afc-5c-5tF" firstAttribute="centerY" secondItem="PuG-YC-OIC" secondAttribute="centerY" id="WFt-Iz-74I"/>
                             <constraint firstAttribute="trailing" secondItem="PuG-YC-OIC" secondAttribute="trailing" id="Xy7-kf-4Zi"/>
                             <constraint firstAttribute="trailing" secondItem="UQY-Uf-csX" secondAttribute="trailing" id="ack-5h-tUx"/>
                             <constraint firstItem="afc-5c-5tF" firstAttribute="centerX" secondItem="PuG-YC-OIC" secondAttribute="centerX" id="e4c-Hf-6s0"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -10,10 +10,22 @@ import Gridicons
     @objc static let restorationClassIdentifier = "ReaderSearchViewControllerRestorationIdentifier"
     @objc static let restorableSearchTopicPathKey: String = "RestorableSearchTopicPathKey"
 
+    fileprivate enum Section: Int {
+        case posts
+        case sites
+
+        var title: String {
+            switch self {
+            case .posts: return "Posts"
+            case .sites: return "Sites"
+            }
+        }
+    }
 
     // MARK: - Properties
 
     @IBOutlet fileprivate weak var searchBar: UISearchBar!
+    @IBOutlet fileprivate weak var filterBar: FilterTabBar!
     @IBOutlet fileprivate weak var label: UILabel!
 
     fileprivate var backgroundTapRecognizer: UITapGestureRecognizer!
@@ -23,6 +35,8 @@ import Gridicons
     fileprivate var restoredSearchTopic: ReaderSearchTopic?
     fileprivate var didBumpStats = false
 
+
+    fileprivate let sections: [Section] = [ .posts, .sites ]
 
     /// A convenience method for instantiating the controller from the storyboard.
     ///
@@ -92,6 +106,7 @@ import Gridicons
 
         WPStyleGuide.configureColors(for: view, andTableView: nil)
         setupSearchBar()
+        configureFilterBar()
         configureLabel()
         configureBackgroundTapRecognizer()
         configureForRestoredTopic()
@@ -155,6 +170,14 @@ import Gridicons
         WPStyleGuide.configureSearchBar(searchBar)
     }
 
+    func configureFilterBar() {
+        filterBar.tintColor = WPStyleGuide.wordPressBlue()
+        filterBar.deselectedTabColor = WPStyleGuide.greyDarken10()
+        filterBar.dividerColor = WPStyleGuide.greyLighten20()
+        filterBar.items = sections.map({ $0.title })
+
+        filterBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
+    }
 
     @objc func configureLabel() {
         let text = NSLocalizedString("What would you like to find?", comment: "A short message that is a call to action for the Reader's Search feature.")
@@ -195,11 +218,15 @@ import Gridicons
     /// embedded stream to the topic.
     ///
     @objc func performSearch() {
-        guard let streamController = streamController else {
+        guard let phrase = searchBar.text?.trim(), !phrase.isEmpty else {
             return
         }
 
-        guard let phrase = searchBar.text?.trim(), !phrase.isEmpty else {
+        performPostsSearch(for: phrase)
+    }
+
+    private func performPostsSearch(for phrase: String) {
+        guard let streamController = streamController else {
             return
         }
 
@@ -226,6 +253,8 @@ import Gridicons
         endSearch()
     }
 
+    @objc private func selectedFilterDidChange(_ filterBar: FilterTabBar) {
+    }
 
     // MARK: - Autocomplete
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -16,8 +16,8 @@ import Gridicons
 
         var title: String {
             switch self {
-            case .posts: return "Posts"
-            case .sites: return "Sites"
+            case .posts: return NSLocalizedString("Posts", comment: "Title of a Reader tab showing Posts matching a user's search query")
+            case .sites: return NSLocalizedString("Sites", comment: "Title of a Reader tab showing Sites matching a user's search query")
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -180,7 +180,7 @@ import Gridicons
     }
 
     @objc func configureLabel() {
-        let text = NSLocalizedString("What would you like to find?", comment: "A short message that is a call to action for the Reader's Search feature.")
+        let text = NSLocalizedString("Search WordPress for a site or post.", comment: "A short message that is a call to action for the Reader's Search feature.")
         let rawAttributes = WPNUXUtility.titleAttributes(with: WPStyleGuide.greyDarken20()) as! [String: Any]
         let swiftedAttributes = NSAttributedStringKey.convertFromRaw(attributes: rawAttributes)
         label.attributedText = NSAttributedString(string: text, attributes: swiftedAttributes)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -176,6 +176,7 @@ import Gridicons
         filterBar.tintColor = WPStyleGuide.wordPressBlue()
         filterBar.deselectedTabColor = WPStyleGuide.greyDarken10()
         filterBar.dividerColor = WPStyleGuide.greyLighten20()
+        filterBar.tabSizingStyle = .equalWidths
         filterBar.items = sections.map({ $0.title })
 
         filterBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -162,7 +162,7 @@ import Gridicons
 
     @objc func setupSearchBar() {
         // Appearance must be set before the search bar is added to the view hierarchy.
-        let placeholderText = NSLocalizedString("Search WordPress.com", comment: "Placeholder text for the Reader search feature.")
+        let placeholderText = NSLocalizedString("Search WordPress", comment: "Placeholder text for the Reader search feature.")
         let attributes = WPStyleGuide.defaultSearchBarTextAttributesSwifted(WPStyleGuide.grey())
         let attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: attributes)
         UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self, ReaderSearchViewController.self]).attributedPlaceholder = attributedPlaceholder
@@ -183,9 +183,10 @@ import Gridicons
     }
 
     @objc func configureLabel() {
-        let text = NSLocalizedString("Search WordPress for a site or post.", comment: "A short message that is a call to action for the Reader's Search feature.")
+        let text = NSLocalizedString("Search WordPress\nfor a site or post", comment: "A short message that is a call to action for the Reader's Search feature.")
         let rawAttributes = WPNUXUtility.titleAttributes(with: WPStyleGuide.greyDarken20()) as! [String: Any]
         let swiftedAttributes = NSAttributedStringKey.convertFromRaw(attributes: rawAttributes)
+        label.numberOfLines = 2
         label.attributedText = NSAttributedString(string: text, attributes: swiftedAttributes)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -30,6 +30,7 @@ import Gridicons
 
     fileprivate var backgroundTapRecognizer: UITapGestureRecognizer!
     fileprivate var streamController: ReaderStreamViewController?
+    fileprivate var siteSearchController = ReaderSiteSearchViewController()
     fileprivate let searchBarSearchIconSize = CGFloat(13.0)
     fileprivate var suggestionsController: ReaderSearchSuggestionsViewController?
     fileprivate var restoredSearchTopic: ReaderSearchTopic?
@@ -110,6 +111,7 @@ import Gridicons
         configureLabel()
         configureBackgroundTapRecognizer()
         configureForRestoredTopic()
+        configureSiteSearchViewController()
     }
 
 
@@ -205,6 +207,23 @@ import Gridicons
         streamController?.readerTopic = topic
     }
 
+    private func configureSiteSearchViewController() {
+        siteSearchController.view.translatesAutoresizingMaskIntoConstraints = false
+
+        addChildViewController(siteSearchController)
+
+        view.addSubview(siteSearchController.view)
+        NSLayoutConstraint.activate([
+            view.leadingAnchor.constraint(equalTo: siteSearchController.view.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: siteSearchController.view.trailingAnchor),
+            filterBar.bottomAnchor.constraint(equalTo: siteSearchController.view.topAnchor),
+            view.bottomAnchor.constraint(equalTo: siteSearchController.view.bottomAnchor),
+            ])
+
+        siteSearchController.didMove(toParentViewController: self)
+
+        siteSearchController.view.isHidden = true
+    }
 
     // MARK: - Actions
 
@@ -223,6 +242,7 @@ import Gridicons
         }
 
         performPostsSearch(for: phrase)
+        performSitesSearch(for: phrase)
     }
 
     private func performPostsSearch(for phrase: String) {
@@ -248,12 +268,26 @@ import Gridicons
         }
     }
 
+    private func performSitesSearch(for phrase: String) {
+        siteSearchController.searchTerm = phrase
+    }
+
 
     @objc func handleBackgroundTap(_ gesture: UITapGestureRecognizer) {
         endSearch()
     }
 
     @objc private func selectedFilterDidChange(_ filterBar: FilterTabBar) {
+        let section = sections[filterBar.selectedIndex]
+
+        switch section {
+        case .posts:
+            streamController?.view.isHidden = false
+            siteSearchController.view.isHidden = true
+        case .sites:
+            streamController?.view.isHidden = true
+            siteSearchController.view.isHidden = false
+        }
     }
 
     // MARK: - Autocomplete

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
@@ -93,12 +93,23 @@ class ReaderSiteSearchViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let feed = feeds[indexPath.row]
-        guard let feedID = Int(feed.feedID) else {
+
+        guard let streamViewController = readerStreamViewController(for: feed) else {
             return
         }
 
-        let streamViewController = ReaderStreamViewController.controllerWithSiteID(feedID as NSNumber,
-                                                                                   isFeed: true)
-        showDetailViewController(streamViewController, sender: self)
+        navigationController?.pushViewController(streamViewController, animated: true)
+    }
+
+    private func readerStreamViewController(for feed: ReaderFeed) -> ReaderStreamViewController? {
+        if let feedID = feed.feedID, let feedIDValue = Int(feedID) {
+            return ReaderStreamViewController.controllerWithSiteID(feedIDValue as NSNumber,
+                                                                   isFeed: true)
+        } else if let blogID = feed.blogID, let blogIDValue = Int(blogID) {
+            return ReaderStreamViewController.controllerWithSiteID(blogIDValue as NSNumber,
+                                                                   isFeed: false)
+        }
+
+        return nil
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
@@ -1,0 +1,104 @@
+import UIKit
+
+/// Displays search results from a reader site search.
+///
+class ReaderSiteSearchViewController: UITableViewController {
+
+    // MARK: - Properties
+
+    lazy var tableHandler: WPTableViewHandler = {
+        let tableHandler = WPTableViewHandler(tableView: self.tableView)
+        return tableHandler
+    }()
+
+    var feeds: [ReaderFeed] = []
+
+    var searchTerm: String? = nil {
+        didSet {
+            performSearch(for: searchTerm)
+        }
+    }
+
+    // MARK: - View lifecycle
+
+    init() {
+        super.init(style: .plain)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        WPStyleGuide.configureColors(for: self.view, andTableView: tableView)
+
+        tableView.register(WPBlogTableViewCell.self, forCellReuseIdentifier: WPBlogTableViewCell.reuseIdentifier())
+        tableView.tableFooterView = UIView()
+    }
+
+    // MARK: - Actions
+
+    private func performSearch(for term: String?) {
+        guard let term = term,
+            !term.isEmpty else {
+                return
+        }
+
+        let context = ContextManager.sharedInstance().mainContext
+        let service = ReaderSiteSearchService(managedObjectContext: context)
+        service.performSearch(withQuery: term,
+                              page: 0,
+                              success: { [weak self] (feeds, _, _) in
+            self?.feeds = feeds
+            self?.tableView.reloadData()
+            }, failure: { _ in
+        })
+    }
+
+    // MARK: - UITableViewDataSource
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return feeds.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: WPBlogTableViewCell.reuseIdentifier(), for: indexPath)
+
+        let feed = feeds[indexPath.row]
+        configureCell(cell, forFeed: feed)
+
+        return cell
+    }
+
+    private func configureCell(_ cell: UITableViewCell, forFeed feed: ReaderFeed) {
+        WPStyleGuide.configureTableViewBlogCell(cell)
+
+        cell.textLabel?.text = feed.title
+        cell.detailTextLabel?.text = feed.url.absoluteString
+        cell.accessoryType = .disclosureIndicator
+
+        if let blavatarURL = feed.blavatarURL {
+            cell.imageView?.downloadSiteIcon(at: blavatarURL.absoluteString,
+                                             placeholderImage: UIImage.siteIconPlaceholderImage)
+        } else {
+            cell.imageView?.image = UIImage.siteIconPlaceholderImage
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let feed = feeds[indexPath.row]
+        guard let feedID = Int(feed.feedID) else {
+            return
+        }
+
+        let streamViewController = ReaderStreamViewController.controllerWithSiteID(feedID as NSNumber,
+                                                                                   isFeed: true)
+        showDetailViewController(streamViewController, sender: self)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
@@ -11,13 +11,25 @@ class ReaderSiteSearchViewController: UITableViewController {
         return tableHandler
     }()
 
-    var feeds: [ReaderFeed] = []
+    var feeds: [ReaderFeed] = [] {
+        didSet {
+            reloadData()
+        }
+    }
 
     var searchTerm: String? = nil {
         didSet {
+            feeds = []
+
             performSearch(for: searchTerm)
         }
     }
+
+    let statusView: WPNoResultsView = {
+        let view = WPNoResultsView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
 
     // MARK: - View lifecycle
 
@@ -36,6 +48,8 @@ class ReaderSiteSearchViewController: UITableViewController {
 
         tableView.register(WPBlogTableViewCell.self, forCellReuseIdentifier: WPBlogTableViewCell.reuseIdentifier())
         tableView.tableFooterView = UIView()
+
+        view.backgroundColor = .clear
     }
 
     // MARK: - Actions
@@ -46,15 +60,70 @@ class ReaderSiteSearchViewController: UITableViewController {
                 return
         }
 
+        showLoadingView()
+
         let context = ContextManager.sharedInstance().mainContext
         let service = ReaderSiteSearchService(managedObjectContext: context)
         service.performSearch(withQuery: term,
                               page: 0,
                               success: { [weak self] (feeds, _, _) in
             self?.feeds = feeds
-            self?.tableView.reloadData()
-            }, failure: { _ in
+            self?.reloadData()
+            }, failure: { [weak self] _ in
+                self?.showLoadingFailedView()
         })
+    }
+
+    private func reloadData() {
+        tableView.reloadData()
+
+        if feeds.count == 0 {
+            showNoResultsView()
+        } else {
+            hideStatusView()
+        }
+    }
+
+    // MARK: - Status View
+
+    private func showNoResultsView() {
+        statusView.titleText = NSLocalizedString("No sites found", comment: "A message title")
+
+        let localizedMessageText = NSLocalizedString("No sites found matching %@ in your language.", comment: "Message shown when the reader finds no sites for the specified search phrase. The %@ is a placeholder for the search phrase.")
+        statusView.messageText = NSString(format: localizedMessageText as NSString, searchTerm ?? "") as String
+
+        statusView.accessoryView = nil
+        statusView.buttonTitle = nil
+
+        showStatusView()
+    }
+
+    private func showLoadingView() {
+        statusView.titleText = NSLocalizedString("Fetching sites...", comment: "A brief prompt when the user is searching for sites in the Reader.")
+        statusView.messageText = ""
+        statusView.buttonTitle = nil
+
+        let boxView = WPAnimatedBox()
+        statusView.accessoryView = boxView
+        showStatusView()
+        boxView.animate(afterDelay: 0.3)
+    }
+
+    private func showLoadingFailedView() {
+        statusView.titleText = NSLocalizedString("Problem loading sites", comment: "Error message title informing the user that a search for sites in the Reader could not be loaded.")
+        statusView.messageText = NSLocalizedString("Sorry. Your search results could not be loaded.", comment: "A short error message leting the user know the requested search could not be performed.")
+        showStatusView()
+    }
+
+    private func showStatusView() {
+        if !statusView.isDescendant(of: tableView) {
+            tableView.addSubview(withFadeAnimation: statusView)
+            tableView.pinSubviewAtCenter(statusView)
+        }
+    }
+
+    private func hideStatusView() {
+        statusView.removeFromSuperview()
     }
 
     // MARK: - UITableViewDataSource
@@ -80,7 +149,8 @@ class ReaderSiteSearchViewController: UITableViewController {
         WPStyleGuide.configureTableViewBlogCell(cell)
 
         cell.textLabel?.text = feed.title
-        cell.detailTextLabel?.text = feed.url.absoluteString
+        cell.detailTextLabel?.text =  feed.urlForDisplay
+
         cell.accessoryType = .disclosureIndicator
 
         if let blavatarURL = feed.blavatarURL {
@@ -111,5 +181,21 @@ class ReaderSiteSearchViewController: UITableViewController {
         }
 
         return nil
+    }
+}
+
+extension ReaderFeed {
+    var urlForDisplay: String {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+            let host = components.host else {
+            return url.absoluteString
+        }
+
+        let path = components.path
+        if path.isEmpty && path != "/" {
+            return host + path
+        } else {
+            return host
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -318,8 +318,11 @@ class FilterTabBar: UIControl {
         selectionIndicatorLeadingConstraint?.isActive = false
         selectionIndicatorTrailingConstraint?.isActive = false
 
-        selectionIndicatorLeadingConstraint = selectionIndicator.leadingAnchor.constraint(equalTo: tab.leadingAnchor, constant: tab.contentEdgeInsets.left)
-        selectionIndicatorTrailingConstraint = selectionIndicator.trailingAnchor.constraint(equalTo: tab.trailingAnchor, constant: -tab.contentEdgeInsets.right)
+        let leadingConstant = (tabSizingStyle == .equalWidths) ? 0.0 : tab.contentEdgeInsets.left
+        let trailingConstant = (tabSizingStyle == .equalWidths) ? 0.0 : -tab.contentEdgeInsets.right
+
+        selectionIndicatorLeadingConstraint = selectionIndicator.leadingAnchor.constraint(equalTo: tab.leadingAnchor, constant: leadingConstant)
+        selectionIndicatorTrailingConstraint = selectionIndicator.trailingAnchor.constraint(equalTo: tab.trailingAnchor, constant: trailingConstant)
 
         selectionIndicatorLeadingConstraint?.isActive = true
         selectionIndicatorTrailingConstraint?.isActive = true

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */; };
 		17BEE0041FC867C20074C124 /* WordPressAppDelegate+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BEE0031FC867C20074C124 /* WordPressAppDelegate+Swift.swift */; };
 		17CE77ED20C6C2F3001DEA5A /* ReaderSiteSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */; };
+		17CE77EF20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */; };
 		17D2FDC21C6A468A00944265 /* PlanComparisonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */; };
 		17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */; };
 		17D975AF1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */; };
@@ -1495,6 +1496,7 @@
 		17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaLibraryViewController.swift; sourceTree = "<group>"; };
 		17BEE0031FC867C20074C124 /* WordPressAppDelegate+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAppDelegate+Swift.swift"; sourceTree = "<group>"; };
 		17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchService.swift; sourceTree = "<group>"; };
+		17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchViewController.swift; sourceTree = "<group>"; };
 		17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanComparisonViewController.swift; sourceTree = "<group>"; };
 		17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProgressCoordinatorNoticeViewModel.swift; sourceTree = "<group>"; };
 		17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Aztec.swift"; sourceTree = "<group>"; };
@@ -3662,6 +3664,7 @@
 				5D1D04741B7A50B100CDE646 /* ReaderStreamViewController.swift */,
 				1705E54F20A5DA5700EF1C9D /* ReaderSavedPostsViewController.swift */,
 				E69551F51B8B6AE200CB8E4F /* ReaderStreamViewController+Helper.swift */,
+				17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */,
 				E69EF9D21BFA539F00ED0554 /* ReaderDetailViewController.swift */,
 				E64ECA4C1CE62041000188A0 /* ReaderSearchViewController.swift */,
 				E6DAABDC1CF632EC0069D933 /* ReaderSearchSuggestionsViewController.swift */,
@@ -7623,6 +7626,7 @@
 				D80BC7A4207487F200614A59 /* MediaLibraryPicker.swift in Sources */,
 				E663D1901C65383E0017F109 /* SharingAccountViewController.swift in Sources */,
 				93DEB88219E5BF7100F9546D /* TodayExtensionService.m in Sources */,
+				17CE77EF20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift in Sources */,
 				98D60B9E1FFEE3D800145190 /* SiteCreationThemeSelectionCell.swift in Sources */,
 				5D42A3E2175E7452005CFF05 /* ReaderPost.m in Sources */,
 				D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		17AF92251C46634000A99CFB /* BlogSiteVisibilityHelperTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */; };
 		17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */; };
 		17BEE0041FC867C20074C124 /* WordPressAppDelegate+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BEE0031FC867C20074C124 /* WordPressAppDelegate+Swift.swift */; };
+		17CE77ED20C6C2F3001DEA5A /* ReaderSiteSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */; };
 		17D2FDC21C6A468A00944265 /* PlanComparisonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */; };
 		17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */; };
 		17D975AF1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */; };
@@ -1493,6 +1494,7 @@
 		17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogSiteVisibilityHelperTest.m; sourceTree = "<group>"; };
 		17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaLibraryViewController.swift; sourceTree = "<group>"; };
 		17BEE0031FC867C20074C124 /* WordPressAppDelegate+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAppDelegate+Swift.swift"; sourceTree = "<group>"; };
+		17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchService.swift; sourceTree = "<group>"; };
 		17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanComparisonViewController.swift; sourceTree = "<group>"; };
 		17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProgressCoordinatorNoticeViewModel.swift; sourceTree = "<group>"; };
 		17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Aztec.swift"; sourceTree = "<group>"; };
@@ -4512,6 +4514,7 @@
 				5DBCD9D418F35D7500B32229 /* ReaderTopicService.m */,
 				9F3EFCA0208E305D00268758 /* ReaderTopicService+Subscriptions.swift */,
 				E62079E01CF7A61200F5CD46 /* ReaderSearchSuggestionService.swift */,
+				17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */,
 				E102B78F1E714F24007928E8 /* RecentSitesService.swift */,
 				930F09161C7D110E00995926 /* ShareExtensionService.swift */,
 				E616E4B21C480896002C024E /* SharingService.swift */,
@@ -7659,6 +7662,7 @@
 				D80BC7A22074739400614A59 /* MediaLibraryStrings.swift in Sources */,
 				5DB3BA0518D0E7B600F3F3E9 /* WPPickerView.m in Sources */,
 				B5E94D151FE04815000E7C20 /* UIImageView+SiteIcon.swift in Sources */,
+				17CE77ED20C6C2F3001DEA5A /* ReaderSiteSearchService.swift in Sources */,
 				5D42A405175E76A7005CFF05 /* WPImageViewController.m in Sources */,
 				E61084C01B9B47BA008050C5 /* ReaderListTopic.swift in Sources */,
 				E6374DC11C444D8B00F24720 /* PublicizeService.swift in Sources */,


### PR DESCRIPTION
Fixes #9433. This PR extends Reader search to allow searching of sites as well as posts. Results should roughly match the results in the Reader in Calypso (which has a Sites section on the right side of the search results).

![reader-site-search-1](https://user-images.githubusercontent.com/4780/41180960-f5d14f40-6b67-11e8-881e-38a216370c24.gif)

The majority of the changes are a new service, `ReaderSiteSearchService` and a new view controller, `ReaderSiteSearchServiceViewController`. There are also changes to `ReaderSearchViewController` to accommodate the new search.

**To test:**

* Build and run.
* Navigate to Reader > Search
* Try some searches!
* Check that switching between Posts and Sites works correctly.
* Check that infinite scrolling works correctly in the posts list. Try a search that returns a lot of results (like `WordPress`), and also one that only returns a few pages – I found that `splatoon team` should only return 3 pages, so you should see infinite scrolling stop after 3 pages.
* Check searching when you have no connectivity.
* Try a search that has no results.
* Try a search that only has one results – for example: `tiredoldhack`.