### PR TITLE
Fixing Warning

### DIFF
--- a/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
@@ -258,6 +258,8 @@ import WordPressFlux
         let syncGroup = DispatchGroup()
         media?.forEach { mediaItem in
             mediaItem.postID = NSNumber(value: postID)
+
+            syncGroup.enter()
             service.update(mediaItem, success: { updatedRemoteMedia in
                 syncGroup.leave()
             }, failure: { error in

--- a/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
@@ -258,7 +258,7 @@ import WordPressFlux
         let syncGroup = DispatchGroup()
         media?.forEach { mediaItem in
             mediaItem.postID = NSNumber(value: postID)
-            service.update(mediaItem, success: { [weak self] updatedRemoteMedia in
+            service.update(mediaItem, success: { updatedRemoteMedia in
                 syncGroup.leave()
             }, failure: { error in
                 var errorString = "Error creating post in share extension"


### PR DESCRIPTION
### Details:
This PR fixes a warning introduced in PR #9526, along with a missing DispatchGroup call:

@ctarda `dispatchGroup.enter()` must be called, always, before the `leave()` instruction. Otherwise, it's analog to closing a door that was never open.

[More here](https://developer.apple.com/documentation/dispatch/dispatchgroup/1452872-leave).

### To test:
1. Verify the warning is gone
2. Repeat the testing steps detailed in #9526, and verify everything is okay

---

@ctarda please, before merging new code, make **extra sure** no new warnings show up neither in the top or left hand side. Thanks in advance!

![warning](https://user-images.githubusercontent.com/1195260/41187454-05ae70a6-6b80-11e8-8e5f-e4cc896058c2.jpg)


