### PR TITLE
Update gifu pod to 3.1.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,7 @@ target 'WordPress' do
     pod 'SVProgressHUD', '2.2.5'
     pod 'Crashlytics', '3.10.1'
     pod 'BuddyBuildSDK', '1.0.17', :configurations => ['Release-Alpha']
-    pod 'Gifu', '3.0.0'
+    pod 'Gifu', '3.1.0'
     pod 'MGSwipeTableCell', '1.6.7'
     pod 'lottie-ios', '2.5.0'
     pod 'Starscream', '3.0.4'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
   - FormatterKit/Resources (1.8.2)
   - FormatterKit/TimeIntervalFormatter (1.8.2):
     - FormatterKit/Resources
-  - Gifu (3.0.0)
+  - Gifu (3.1.0)
   - GoogleSignInRepacked (4.1.2):
     - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
     - "GoogleToolboxForMac/NSString+URLArguments (~> 2.1)"
@@ -148,7 +148,7 @@ DEPENDENCIES:
   - CocoaLumberjack (= 3.4.2)
   - Crashlytics (= 3.10.1)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
-  - Gifu (= 3.0.0)
+  - Gifu (= 3.1.0)
   - Gridicons (= 0.15)
   - HockeySDK (= 5.1.2)
   - lottie-ios (= 2.5.0)
@@ -245,7 +245,7 @@ SPEC CHECKSUMS:
   Crashlytics: aee1a064cbbf99b32efa3f056a5f458d846bc8ff
   Fabric: bda89e242bce1b7b8ab264248cf3407774ce0095
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
-  Gifu: 6543ca2056a3d697097c09fe543ef49348ccc892
+  Gifu: fd1e9e3a15ac5d90bae0a510e4ed9f94b485ab03
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
   Gridicons: 0e5e76ad9fc6f7cbc3da137a9751ef516c5aef73
@@ -271,6 +271,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: b76ff32ab10d07d4f47f5bcb1a289a9fccc97249
+PODFILE CHECKSUM: 87b682e6d637c0bade68f9138a415ea63f903da4
 
 COCOAPODS: 1.5.2


### PR DESCRIPTION
Updates the gifu pod to 3.1.0.

To test: build, ensure animated GIFs still work


