### PR TITLE
Issue/9530 featured image bug

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -566,19 +566,22 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 {
     id<MediaServiceRemote> remote = [self remoteForBlog:blog];
     NSManagedObjectID *blogObjectID = [blog objectID];
-    [remote getMediaLibraryWithSuccess:^(NSArray *media) {
-                               [self.managedObjectContext performBlock:^{
-                                   Blog *blogInContext = (Blog *)[self.managedObjectContext objectWithID:blogObjectID];
-                                   [self mergeMedia:media forBlog:blogInContext completionHandler:success];
-                               }];
-                           }
-                           failure:^(NSError *error) {
-                               if (failure) {
+    [self.managedObjectContext performBlock:^{
+        Blog *blogInContext = (Blog *)[self.managedObjectContext objectWithID:blogObjectID];
+        NSSet *originalLocalMedia = blog.media;
+        [remote getMediaLibraryWithSuccess:^(NSArray *media) {
                                    [self.managedObjectContext performBlock:^{
-                                       failure(error);
+                                       [self mergeMedia:media forBlog:blogInContext baseMedia:originalLocalMedia completionHandler:success];
                                    }];
                                }
-                           }];
+                               failure:^(NSError *error) {
+                                   if (failure) {
+                                       [self.managedObjectContext performBlock:^{
+                                           failure(error);
+                                       }];
+                                   }
+                               }];
+    }];
 }
 
 - (NSInteger)getMediaLibraryCountForBlog:(Blog *)blog
@@ -736,6 +739,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 
 - (void)mergeMedia:(NSArray *)media
            forBlog:(Blog *)blog
+         baseMedia:(NSSet *)originalBlogMedia
  completionHandler:(void (^)(void))completion
 {
     NSParameterAssert(blog);
@@ -751,7 +755,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
             [mediaToKeep addObject:local];
         }
     }
-    NSMutableSet *mediaToDelete = [NSMutableSet setWithSet:blog.media];
+    NSMutableSet *mediaToDelete = [NSMutableSet setWithSet:originalBlogMedia];
     [mediaToDelete minusSet:mediaToKeep];
     for (Media *deleteMedia in mediaToDelete) {
         // only delete media that is server based

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -568,7 +568,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
     NSManagedObjectID *blogObjectID = [blog objectID];
     [self.managedObjectContext performBlock:^{
         Blog *blogInContext = (Blog *)[self.managedObjectContext objectWithID:blogObjectID];
-        NSSet *originalLocalMedia = blog.media;
+        NSSet *originalLocalMedia = blogInContext.media;
         [remote getMediaLibraryWithSuccess:^(NSArray *media) {
                                    [self.managedObjectContext performBlock:^{
                                        [self mergeMedia:media forBlog:blogInContext baseMedia:originalLocalMedia completionHandler:success];

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -786,7 +786,12 @@ FeaturedImageViewControllerDelegate>
 }
 
 - (nullable NSURL *)urlForFeaturedImage {
-    NSURL *featuredURL = [NSURL URLWithString:self.apost.featuredImage.remoteURL];
+    NSURL *featuredURL = self.apost.featuredImage.absoluteLocalURL;
+
+    if (!featuredURL || ![featuredURL checkResourceIsReachableAndReturnError:nil]) {
+        featuredURL = [NSURL URLWithString:self.apost.featuredImage.remoteURL];
+    }
+
     if (!featuredURL) {
         featuredURL = self.apost.featuredImageURLForDisplay;
     }


### PR DESCRIPTION
Fixes #9530 

As the original bug report there where scenarios where an feature image was being set by the user and then removed automatically by the app. It took me a while to track it down but here what I found

- The user set the feature image a new post using a some photo existing on his device
- The image is set has featured image locally and the upload is started 
- When the upload was finished the image was show
- Running concurrently a sync for the blog media was being run ( normally being triggered by opening the media picker to select the media to use)
- That sync started before the new feature image was upload so the server didn't have it on it's answer
- Because the syncs for media are paginated on a big media library while the pages are being fetched the media upload could be finished and a new media object was created locally and sync with the server
- When all the pages of media are sync we start a merge process between the media that we have locally and the media that was fetched from the server.
- Because the initial page fetch didnt include the new feature image media object that media object was deleted
- The featured image that was set on the post receives a core data refresh saying media delete and then deletes the relationship
- Featured image is gone....

To test:
 - On a blog with a lot of media
 - Start a new post
 - Select post options
 - Set a feature media object
 - Wait for upload to finish
 - Make sure that after a while you don't set the media object disappear automatically
 - Go out of post settings and back and see if it's still set
 - Save the post
 - See if feature image is set correctly.


