### PR TITLE
Track whether a post includes Gutenberg blocks

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -28,4 +28,8 @@ extension AbstractPost {
             }
         }
     }
+
+    @objc func containsGutenbergBlocks() -> Bool {
+        return content?.contains("<!-- wp:") ?? false
+    }
 }

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -20,6 +20,7 @@ NSString * const WPAppAnalyticsKeyFeedItemID = @"feed_item_id";
 NSString * const WPAppAnalyticsKeyIsJetpack = @"is_jetpack";
 NSString * const WPAppAnalyticsKeySessionCount = @"session_count";
 NSString * const WPAppAnalyticsKeyEditorSource = @"editor_source";
+NSString * const WPAppAnalyticsKeyHasGutenbergBlocks = @"has_gutenberg_blocks";
 static NSString * const WPAppAnalyticsKeyLastVisibleScreen = @"last_visible_screen";
 static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
 
@@ -264,6 +265,7 @@ static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
     if (postOrPage.postID.integerValue > 0) {
         mutableProperties[WPAppAnalyticsKeyPostID] = postOrPage.postID;
     }
+    mutableProperties[WPAppAnalyticsKeyHasGutenbergBlocks] = @([postOrPage containsGutenbergBlocks]);
 
     [WPAppAnalytics track:stat withProperties:mutableProperties withBlog:postOrPage.blog];
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -351,7 +351,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             presentAlertForPageBeingUploaded()
             return
         }
-        WPAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics())
+        WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: apost)
         showEditor(post: apost)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -457,7 +457,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         }
         editor.modalPresentationStyle = .fullScreen
         present(editor, animated: false, completion: nil)
-        WPAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics())
+        WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: apost)
     }
 
     func presentAlertForPostBeingUploaded() {


### PR DESCRIPTION
This adds a `has_gutenberg_blocks` property to many events related to editing a post, including but not limited to `post_list_button_pressed`, `editor_draft_saved`, `editor_post_scheduled`, `editor_post_published`, `editor_post_updated`, `editor_quick_post_published`, and `editor_quick_draft_saved`.

Fixes #9580 

To test:

Watch Xcode's console for tracks events, you should see the `has_gutenberg_blocks` property with the right value when:
- Opening a post in the editor
- Closing the editor dismissing changes
- Updating a draft
- Publishing a draft