### PR TITLE
Update cocoapods to 1.5.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org' do
   gem 'rake'
-  gem 'cocoapods', '~> 1.5.2'
+  gem 'cocoapods', '1.5.3'
   gem 'xcpretty-travis-formatter'
   gem 'danger'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,10 +15,10 @@ GEM
       cork
       nap
       open4 (~> 1.3)
-    cocoapods (1.5.2)
+    cocoapods (1.5.3)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.5.2)
+      cocoapods-core (= 1.5.3)
       cocoapods-deintegrate (>= 1.0.2, < 2.0)
       cocoapods-downloader (>= 1.2.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -34,12 +34,12 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.1)
       xcodeproj (>= 1.5.7, < 2.0)
-    cocoapods-core (1.5.2)
+    cocoapods-core (1.5.3)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
     cocoapods-deintegrate (1.0.2)
-    cocoapods-downloader (1.2.0)
+    cocoapods-downloader (1.2.1)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
@@ -89,7 +89,7 @@ GEM
     public_suffix (3.0.2)
     rake (12.0.0)
     rouge (1.11.1)
-    ruby-macho (1.1.0)
+    ruby-macho (1.2.0)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
@@ -114,7 +114,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.5.2)!
+  cocoapods (= 1.5.3)!
   danger!
   rake!
   xcpretty-travis-formatter!


### PR DESCRIPTION
In #9592 the cocoapods version got bumped to 1.5.3 in the Podfile.lock file, but the dependency wasn't updated in the Gemfile. As a result, when you ran `rake dependencies` it would change the Podfile.lock back to 1.5.2, leaving you with a dirty checkout.

To test, make sure running `rake dependencies` doesn't change the `Podfile.lock` file.