### PR TITLE
AztecPostViewController: Preventing UIViewControllerHierarchyInconsistency

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/AztecMediaPickingCoordinator.swift
@@ -3,12 +3,9 @@ import WPMediaPicker
 
 /// Prepares the alert controller that will be presented when tapping the "more" button in Aztec's Format Bar
 final class AztecMediaPickingCoordinator {
-    private weak var delegate: MediaPickingOptionsDelegate?
-
     private let stockPhotos = StockPhotosPicker()
 
-    init(delegate: MediaPickingOptionsDelegate & StockPhotosPickerDelegate) {
-        self.delegate = delegate
+    init(delegate: StockPhotosPickerDelegate) {
         stockPhotos.delegate = delegate
     }
 
@@ -45,9 +42,7 @@ final class AztecMediaPickingCoordinator {
     }
 
     private func cancelAction() -> UIAlertAction {
-        return UIAlertAction(title: .cancelMoreOptions, style: .cancel, handler: { [weak self] action in
-            self?.delegate?.didCancel()
-        })
+        return UIAlertAction(title: .cancelMoreOptions, style: .cancel, handler: nil)
     }
 
     private func showStockPhotos(origin: UIViewController, blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/MediaPickingOptionsDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/MediaPickingOptionsDelegate.swift
@@ -1,4 +1,0 @@
-/// Notifies its implementation of lifecycle events in AztecMoreCoordinator
-protocol MediaPickingOptionsDelegate: class {
-    func didCancel()
-}

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecNavigationController.swift
@@ -1,0 +1,37 @@
+import Foundation
+import UIKit
+
+
+// MARK: - AztecNavigationControllerDelegate Protocol
+//
+protocol AztecNavigationControllerDelegate: UINavigationControllerDelegate {
+
+    /// This method is called whenever an instance of `UIAlertController` (was presented modally) and gets dismissed.
+    ///
+    func navigationController(_ navigationController: UINavigationController, didDismiss alertController: UIAlertController)
+}
+
+
+// MARK: - AztecNavigationController
+//
+class AztecNavigationController: UINavigationController {
+
+    /// Returns the `AztecNavigationControllerDelegate`, if any.
+    ///
+    private var aztecDelegate: AztecNavigationControllerDelegate? {
+        return delegate as? AztecNavigationControllerDelegate
+    }
+
+
+    // MARK: - Overriden Methods
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        guard let alertController = presentedViewController as? UIAlertController else {
+            super.dismiss(animated: flag, completion: completion)
+            return
+        }
+
+        super.dismiss(animated: flag, completion: completion)
+        aztecDelegate?.navigationController(self, didDismiss: alertController)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3818,12 +3818,6 @@ extension AztecPostViewController: UIDocumentPickerDelegate {
     }
 }
 
-extension AztecPostViewController: MediaPickingOptionsDelegate {
-    func didCancel() {
-        restoreFirstResponder()
-    }
-}
-
 extension AztecPostViewController: StockPhotosPickerDelegate {
     func stockPhotosPicker(_ picker: StockPhotosPicker, didFinishPicking assets: [StockPhotosMedia]) {
         assets.forEach {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1071,7 +1071,7 @@ extension AztecPostViewController {
 }
 
 
-// MARK: -  AztecNavigationControllerDelegate Conformance
+// MARK: - AztecNavigationControllerDelegate Conformance
 
 extension AztecPostViewController: AztecNavigationControllerDelegate {
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1417,18 +1417,27 @@ private extension AztecPostViewController {
             self.toggleEditingMode()
         }
 
-        alert.addDefaultActionWithTitle(MoreSheetAlert.previewTitle) { [unowned self]  _ in
+        alert.addDefaultActionWithTitle(MoreSheetAlert.previewTitle) { [unowned self] _ in
             self.displayPreview()
         }
 
-        alert.addDefaultActionWithTitle(MoreSheetAlert.postSettingsTitle) { [unowned self]  _ in
+        alert.addDefaultActionWithTitle(MoreSheetAlert.postSettingsTitle) { [unowned self] _ in
             self.displayPostSettings()
         }
 
-        alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle)
+        alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle) { [weak self] _ in
+            // Preventing `UIViewControllerHierarchyInconsistency`
+            // Ref.: https://github.com/wordpress-mobile/WordPress-iOS/issues/8995
+            //
+            self?.restoreFirstResponder()
+        }
 
         alert.popoverPresentationController?.barButtonItem = moreBarButtonItem
 
+        // Preventing `UIViewControllerHierarchyInconsistency`
+        // Ref.: https://github.com/wordpress-mobile/WordPress-iOS/issues/8995
+        //
+        rememberFirstResponder()
         present(alert, animated: true, completion: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2286,8 +2286,6 @@ extension AztecPostViewController {
     }
 
     private func showMore(from: FormatBarItem) {
-        rememberFirstResponder()
-
         let moreCoordinatorContext = MediaPickingContext(origin: self, view: view, blog: post.blog)
         moreCoordinator.present(context: moreCoordinatorContext)
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1425,20 +1425,11 @@ private extension AztecPostViewController {
             self.displayPostSettings()
         }
 
-        alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle) { [weak self] _ in
-            // Preventing `UIViewControllerHierarchyInconsistency`
-            // Ref.: https://github.com/wordpress-mobile/WordPress-iOS/issues/8995
-            //
-            self?.restoreFirstResponder()
-        }
+        alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle)
 
         alert.popoverPresentationController?.barButtonItem = moreBarButtonItem
 
-        // Preventing `UIViewControllerHierarchyInconsistency`
-        // Ref.: https://github.com/wordpress-mobile/WordPress-iOS/issues/8995
-        //
-        rememberFirstResponder()
-        present(alert, animated: true, completion: nil)
+        present(alert, animated: true)
     }
 
     func displaySwitchSiteAlert() {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -571,6 +571,9 @@ class AztecPostViewController: UIViewController, PostEditor {
             return
         }
 
+        /// Wire AztecNavigationControllerDelegate
+        ///
+        navigationController.delegate = self
         configureMediaProgressView(in: navigationController.navigationBar)
     }
 
@@ -990,6 +993,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 }
 
+
 // MARK: - Format Bar Updating
 
 extension AztecPostViewController {
@@ -1047,6 +1051,15 @@ extension AztecPostViewController {
     /// an ActionSheet onscreen.
     ///
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        // Preventing `UIViewControllerHierarchyInconsistency`
+        // Ref.: https://github.com/wordpress-mobile/WordPress-iOS/issues/8995
+        //
+        if viewControllerToPresent is UIAlertController {
+            rememberFirstResponder()
+        }
+
+        /// Ref.: https://github.com/wordpress-mobile/WordPress-iOS/pull/6666
+        ///
         super.present(viewControllerToPresent, animated: flag) {
             if let alert = viewControllerToPresent as? UIAlertController, alert.preferredStyle == .actionSheet {
                 alert.popoverPresentationController?.passthroughViews = nil
@@ -1054,6 +1067,19 @@ extension AztecPostViewController {
 
             completion?()
         }
+    }
+}
+
+
+// MARK: -  AztecNavigationControllerDelegate Conformance
+
+extension AztecPostViewController: AztecNavigationControllerDelegate {
+
+    func navigationController(_ navigationController: UINavigationController, didDismiss alertController: UIAlertController) {
+        // Preventing `UIViewControllerHierarchyInconsistency`
+        // Ref.: https://github.com/wordpress-mobile/WordPress-iOS/issues/8995
+        //
+        restoreFirstResponder()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -3,14 +3,11 @@ import WPMediaPicker
 
 /// Prepares the alert controller that will be presented when tapping the "+" button in Media Library
 final class MediaLibraryMediaPickingCoordinator {
-    private weak var delegate: MediaPickingOptionsDelegate?
-
     private let stockPhotos = StockPhotosPicker()
     private let cameraCapture = CameraCaptureCoordinator()
     private let mediaLibrary = MediaLibraryPicker()
 
-    init(delegate: MediaPickingOptionsDelegate & StockPhotosPickerDelegate & WPMediaPickerViewControllerDelegate) {
-        self.delegate = delegate
+    init(delegate: StockPhotosPickerDelegate & WPMediaPickerViewControllerDelegate) {
         stockPhotos.delegate = delegate
         mediaLibrary.delegate = delegate
     }
@@ -74,9 +71,7 @@ final class MediaLibraryMediaPickingCoordinator {
     }
 
     private func cancelAction() -> UIAlertAction {
-        return UIAlertAction(title: .cancelMoreOptions, style: .cancel, handler: { [weak self] action in
-            self?.delegate?.didCancel()
-        })
+        return UIAlertAction(title: .cancelMoreOptions, style: .cancel, handler: nil)
     }
 
     private func showCameraCapture(origin: UIViewController, blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -635,12 +635,6 @@ fileprivate extension Blog {
     }
 }
 
-extension MediaLibraryViewController: MediaPickingOptionsDelegate {
-    func didCancel() {
-
-    }
-}
-
 extension MediaLibraryViewController: StockPhotosPickerDelegate {
     func stockPhotosPicker(_ picker: StockPhotosPicker, didFinishPicking assets: [StockPhotosMedia]) {
         guard assets.count > 0 else {

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -140,7 +140,7 @@ class EditPostViewController: UIViewController {
         editor.restorationClass = nil
         editor.restorationIdentifier = nil
 
-        let navController = UINavigationController(rootViewController: editor)
+        let navController = AztecNavigationController(rootViewController: editor)
         navController.modalPresentationStyle = .fullScreen
 
         let generator = UIImpactFeedbackGenerator(style: .medium)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -778,6 +778,7 @@
 		B5F995A01B59708C00AB0B3E /* NotificationSettingsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = B5F9959F1B59708C00AB0B3E /* NotificationSettingsViewController.xib */; };
 		B5FA22831C99F6180016CA7C /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
 		B5FA868C1D10A4C400AB5F7E /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA868A1D10A41600AB5F7E /* UIImage+Extensions.swift */; };
+		B5FDF9F320D842D2006D14E3 /* AztecNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FDF9F220D842D2006D14E3 /* AztecNavigationController.swift */; };
 		B5FF3BE71CAD881100C1D597 /* ImageCropOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FF3BE61CAD881100C1D597 /* ImageCropOverlayView.swift */; };
 		BE1071FC1BC75E7400906AFF /* WPStyleGuide+Blog.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1071FB1BC75E7400906AFF /* WPStyleGuide+Blog.swift */; };
 		BE1071FF1BC75FFA00906AFF /* WPStyleGuide+BlogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE1071FE1BC75FFA00906AFF /* WPStyleGuide+BlogTests.swift */; };
@@ -2282,6 +2283,7 @@
 		B5FA22821C99F6180016CA7C /* Tracks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Tracks.swift; path = WordPressShareExtension/Tracks.swift; sourceTree = SOURCE_ROOT; };
 		B5FA868A1D10A41600AB5F7E /* UIImage+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIImage+Extensions.swift"; path = "WordPressShareExtension/UIImage+Extensions.swift"; sourceTree = SOURCE_ROOT; };
 		B5FD4520199D0C9A00286FBB /* WordPress-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "WordPress-Bridging-Header.h"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
+		B5FDF9F220D842D2006D14E3 /* AztecNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecNavigationController.swift; sourceTree = "<group>"; };
 		B5FF3BE61CAD881100C1D597 /* ImageCropOverlayView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCropOverlayView.swift; sourceTree = "<group>"; };
 		B60BB199C4D84FFF05C0F97E /* Pods-WordPressDraftActionExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressDraftActionExtension.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressDraftActionExtension/Pods-WordPressDraftActionExtension.release.xcconfig"; sourceTree = "<group>"; };
 		B7556D1D8CFA5CEAEAC481B9 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -4664,6 +4666,7 @@
 			isa = PBXGroup;
 			children = (
 				B50C0C5C1EF42A4A00372C65 /* AztecAttachmentViewController.swift */,
+				B5FDF9F220D842D2006D14E3 /* AztecNavigationController.swift */,
 				B50C0C5D1EF42A4A00372C65 /* AztecPostViewController.swift */,
 				B538F3881EF46EC8001003D5 /* UnknownEditorViewController.swift */,
 			);
@@ -6980,6 +6983,7 @@
 				59DCA5211CC68AF3000F245F /* PageListViewController.swift in Sources */,
 				B5ECA6CA1DBAA0020062D7E0 /* CoreDataHelper.swift in Sources */,
 				FFC6ADDA1B56F366002F3C84 /* LocalCoreDataService.m in Sources */,
+				B5FDF9F320D842D2006D14E3 /* AztecNavigationController.swift in Sources */,
 				B587798619B799EB00E57C5A /* Notification+Interface.swift in Sources */,
 				175A650C20B6F7280023E71B /* ReaderSaveForLater+Analytics.swift in Sources */,
 				984B4EF320742FCC00F87888 /* ZendeskUtils.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -885,7 +885,6 @@
 		D8A3A5B3206A49BF00992576 /* StockPhotosMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5B2206A49BF00992576 /* StockPhotosMedia.swift */; };
 		D8A3A5B5206A4C7800992576 /* StockPhotosPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5B4206A4C7800992576 /* StockPhotosPicker.swift */; };
 		D8A3A5B7206A563900992576 /* StockPhotosPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A3A5B6206A563900992576 /* StockPhotosPlaceholder.swift */; };
-		D8B43E70206B439F00DDAFAA /* MediaPickingOptionsDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B43E6F206B439F00DDAFAA /* MediaPickingOptionsDelegate.swift */; };
 		D8B6BEB7203E11F2007C8A19 /* Bundle+LoadFromNib.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B6BEB6203E11F2007C8A19 /* Bundle+LoadFromNib.swift */; };
 		D8B9B58F204F4EA1003C6042 /* NetworkAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */; };
 		D8B9B591204F658A003C6042 /* CommentsViewController+NetworkAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B9B590204F658A003C6042 /* CommentsViewController+NetworkAware.swift */; };
@@ -2406,7 +2405,6 @@
 		D8A3A5B2206A49BF00992576 /* StockPhotosMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosMedia.swift; sourceTree = "<group>"; };
 		D8A3A5B4206A4C7800992576 /* StockPhotosPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosPicker.swift; sourceTree = "<group>"; };
 		D8A3A5B6206A563900992576 /* StockPhotosPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosPlaceholder.swift; sourceTree = "<group>"; };
-		D8B43E6F206B439F00DDAFAA /* MediaPickingOptionsDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingOptionsDelegate.swift; sourceTree = "<group>"; };
 		D8B6BEB6203E11F2007C8A19 /* Bundle+LoadFromNib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+LoadFromNib.swift"; sourceTree = "<group>"; };
 		D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAware.swift; sourceTree = "<group>"; };
 		D8B9B590204F658A003C6042 /* CommentsViewController+NetworkAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentsViewController+NetworkAware.swift"; sourceTree = "<group>"; };
@@ -5551,7 +5549,6 @@
 				D8A3A5B2206A49BF00992576 /* StockPhotosMedia.swift */,
 				D8A3A5B4206A4C7800992576 /* StockPhotosPicker.swift */,
 				D8A3A5B6206A563900992576 /* StockPhotosPlaceholder.swift */,
-				D8B43E6F206B439F00DDAFAA /* MediaPickingOptionsDelegate.swift */,
 				D80BC79D20746B4100614A59 /* MediaPickingContext.swift */,
 				D83CA3A420842CAF0060E310 /* Pageable.swift */,
 				D83CA3A620842CD90060E310 /* ResultsPage.swift */,
@@ -7224,7 +7221,6 @@
 				F126FE0020A33BDB0010EB6E /* VideoUploadProcessor.swift in Sources */,
 				E14B74111C7B16FD00C26E21 /* WPNoResultsView+Model.swift in Sources */,
 				E166FA1B1BB0656B00374B5B /* PeopleCellViewModel.swift in Sources */,
-				D8B43E70206B439F00DDAFAA /* MediaPickingOptionsDelegate.swift in Sources */,
 				83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */,
 				B56994451B7A7EF200FF26FA /* WPStyleGuide+Comments.swift in Sources */,
 				74AF4D741FE417D200E3EBFE /* MediaUploadOperation.swift in Sources */,


### PR DESCRIPTION
### Details:
This PR fixes an ugly  crash in the Posts Editor

Fixes #8995
@etoledom sir, would you be game for a super fun review?

Thanks in advance!

### Scenario: More Options
1. Launch Aztec
2. Press the `+` button
3. Press the `...` button (navbar top right)
4. Press `Keep Editing`
5. Press the `...` navbar button, again
6. Verify the app doesn't crash!

### Scenario: Image Options
1. Open Aztec editor.
2. Add an image to the editor.
3. Press the + button on the input accessory view to show the media picker at the bottom.
4. Tap on the image added to the editor to show the image options.
5. Tap on Dismiss.
6. Repeat 4 and 5. Verify the app doesn't crash

### Scenario: (Even) More Media Options!
1. Open Aztec editor.
2. Tap on the body to activate the accessory input bar.
3. Press + button to open the media picker.
4. Press the ... button on the input accessory bar to show the options of Free Photo Library and Other Apps.
5. Choose Dismiss.

Verify the app doesn't break.

### Scenario: State Restoration
1. Launch Aztec
2. Send the app to Background (CMD + Shift + H in the simulator)
3. Click the **Stop** button
4. Click **Run**
5. Verify Aztec is onscreen (yay! state restoration worked!)
6. Go thru the **two scenarios above** and verify they work fine.
