### PR TITLE
Update 'clear media cache' labelling

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -329,7 +329,7 @@ private extension AppSettingsViewController {
                 mediaCacheRow,
                 mediaClearCacheRow
             ],
-            footerText: NSLocalizedString("Free up storage space on this device by clearing your temporary media files. This will not affect media on your site.",
+            footerText: NSLocalizedString("Free up storage space on this device by deleting temporary media files. This will not affect the media on your site.",
                                           comment: "Explanatory text for clearing device media cache.")
         )
     }

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -77,17 +77,6 @@ class AppSettingsViewController: UITableViewController {
 
     func tableViewModel() -> ImmuTable {
 
-        let editorSettings = EditorSettings()
-        let _ = NSLocalizedString("Editor", comment: "Title label for the editor settings section in the app settings")
-        var editorRows = [ImmuTableRow]()
-
-        let nativeEditor = CheckmarkRow(
-            title: NSLocalizedString("Visual", comment: "Option to enable the Aztec editor."),
-            checked: editorSettings.isEnabled(.aztec),
-            action: enableEditor(.aztec)
-        )
-        editorRows.append(nativeEditor)
-
         return ImmuTable(sections: [
             mediaTableSection(),
             privacyTableSection(),
@@ -308,6 +297,7 @@ fileprivate struct ImageSizingRow: ImmuTableRow {
 // MARK: - Table Sections Private Extension
 
 private extension AppSettingsViewController {
+
     func mediaTableSection() -> ImmuTableSection {
         let mediaHeader = NSLocalizedString("Media", comment: "Title label for the media settings section in the app settings")
 
@@ -394,4 +384,5 @@ private extension AppSettingsViewController {
             ],
             footerText: nil)
     }
+
 }

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -76,26 +76,6 @@ class AppSettingsViewController: UITableViewController {
     }
 
     func tableViewModel() -> ImmuTable {
-        let mediaHeader = NSLocalizedString("Media", comment: "Title label for the media settings section in the app settings")
-        let imageSizingRow = ImageSizingRow(
-            title: NSLocalizedString("Max Image Upload Size", comment: "Title for the image size settings option."),
-            value: Int(MediaSettings().maxImageSizeSetting),
-            onChange: imageSizeChanged())
-
-        let videoSizingRow = NavigationItemRow(
-            title: NSLocalizedString("Max Video Upload Size", comment: "Title for the video size settings option."),
-            detail: MediaSettings().maxVideoSizeSetting.description,
-            action: pushVideoResolutionSettings())
-
-        let mediaCacheRow = TextRow(title: NSLocalizedString("Media Cache Size", comment: "Label for size of media cache in the app."),
-                                    value: mediaCacheRowDescription)
-
-        let mediaClearCacheRow = DestructiveButtonRow(
-            title: NSLocalizedString("Clear Device Media Cache", comment: "Label for button that clears all media cache."),
-            action: { [weak self] row in
-                self?.clearMediaCache()
-            },
-            accessibilityIdentifier: "mediaClearCacheButton")
 
         let editorSettings = EditorSettings()
         let _ = NSLocalizedString("Editor", comment: "Title label for the editor settings section in the app settings")
@@ -108,59 +88,10 @@ class AppSettingsViewController: UITableViewController {
         )
         editorRows.append(nativeEditor)
 
-        let privacyHeader = NSLocalizedString("Privacy", comment: "Privacy settings section header")
-        let mediaRemoveLocation = SwitchRow(
-            title: NSLocalizedString("Remove Location From Media", comment: "Option to enable the removal of location information/gps from photos and videos"),
-            value: Bool(MediaSettings().removeLocationSetting),
-            onChange: mediaRemoveLocationChanged()
-        )
-        let privacySettings = NavigationItemRow(
-            title: NSLocalizedString("Privacy Settings", comment: "Link to privacy settings page"),
-            action: openPrivacySettings()
-        )
-
-        let otherHeader = NSLocalizedString("Other", comment: "Link to About section (contains info about the app)")
-        let spotlightClearCacheRow = DestructiveButtonRow(
-            title: NSLocalizedString("Clear Spotlight Index", comment: "Label for button that clears the spotlight index on device."),
-            action: clearSpotlightCache(),
-            accessibilityIdentifier: "spotlightClearCacheButton")
-
-        let settingsRow = NavigationItemRow(
-            title: NSLocalizedString("Open Device Settings", comment: "Opens iOS's Device Settings for WordPress App"),
-            action: openApplicationSettings()
-        )
-
-        let aboutRow = NavigationItemRow(
-            title: NSLocalizedString("About WordPress for iOS", comment: "Link to About screen for WordPress for iOS"),
-            action: pushAbout()
-        )
-
         return ImmuTable(sections: [
-            ImmuTableSection(
-                headerText: mediaHeader,
-                rows: [
-                    imageSizingRow,
-                    videoSizingRow,
-                    mediaCacheRow,
-                    mediaClearCacheRow
-                ],
-                footerText: NSLocalizedString("Free up storage space on this device by clearing your temporary media files. This will not affect media on your site.", comment: "Explanatory text for clearing device media cache.")
-            ),
-            ImmuTableSection(
-                headerText: privacyHeader,
-                rows: [
-                    mediaRemoveLocation,
-                    privacySettings
-                ]
-            ),
-            ImmuTableSection(
-                headerText: otherHeader,
-                rows: [
-                    spotlightClearCacheRow,
-                    settingsRow,
-                    aboutRow
-                ],
-                footerText: nil)
+            mediaTableSection(),
+            privacyTableSection(),
+            otherTableSection()
             ])
     }
 
@@ -371,5 +302,96 @@ fileprivate struct ImageSizingRow: ImmuTableRow {
         cell.selectionStyle = .none
 
         (cell.minValue, cell.maxValue) = MediaSettings().allowedImageSizeRange
+    }
+}
+
+// MARK: - Table Sections Private Extension
+
+private extension AppSettingsViewController {
+    func mediaTableSection() -> ImmuTableSection {
+        let mediaHeader = NSLocalizedString("Media", comment: "Title label for the media settings section in the app settings")
+
+        let imageSizingRow = ImageSizingRow(
+            title: NSLocalizedString("Max Image Upload Size", comment: "Title for the image size settings option."),
+            value: Int(MediaSettings().maxImageSizeSetting),
+            onChange: imageSizeChanged())
+
+        let videoSizingRow = NavigationItemRow(
+            title: NSLocalizedString("Max Video Upload Size", comment: "Title for the video size settings option."),
+            detail: MediaSettings().maxVideoSizeSetting.description,
+            action: pushVideoResolutionSettings())
+
+        let mediaCacheRow = TextRow(title: NSLocalizedString("Media Cache Size", comment: "Label for size of media cache in the app."),
+                                    value: mediaCacheRowDescription)
+
+        let mediaClearCacheRow = DestructiveButtonRow(
+            title: NSLocalizedString("Clear Device Media Cache", comment: "Label for button that clears all media cache."),
+            action: { [weak self] row in
+                self?.clearMediaCache()
+            },
+            accessibilityIdentifier: "mediaClearCacheButton")
+
+        return ImmuTableSection(
+            headerText: mediaHeader,
+            rows: [
+                imageSizingRow,
+                videoSizingRow,
+                mediaCacheRow,
+                mediaClearCacheRow
+            ],
+            footerText: NSLocalizedString("Free up storage space on this device by clearing your temporary media files. This will not affect media on your site.",
+                                          comment: "Explanatory text for clearing device media cache.")
+        )
+    }
+
+    func privacyTableSection() -> ImmuTableSection {
+        let privacyHeader = NSLocalizedString("Privacy", comment: "Privacy settings section header")
+
+        let mediaRemoveLocation = SwitchRow(
+            title: NSLocalizedString("Remove Location From Media", comment: "Option to enable the removal of location information/gps from photos and videos"),
+            value: Bool(MediaSettings().removeLocationSetting),
+            onChange: mediaRemoveLocationChanged()
+        )
+
+        let privacySettings = NavigationItemRow(
+            title: NSLocalizedString("Privacy Settings", comment: "Link to privacy settings page"),
+            action: openPrivacySettings()
+        )
+
+        return ImmuTableSection(
+            headerText: privacyHeader,
+            rows: [
+                mediaRemoveLocation,
+                privacySettings
+            ]
+        )
+    }
+
+    func otherTableSection() -> ImmuTableSection {
+        let otherHeader = NSLocalizedString("Other", comment: "Link to About section (contains info about the app)")
+
+        let spotlightClearCacheRow = DestructiveButtonRow(
+            title: NSLocalizedString("Clear Spotlight Index", comment: "Label for button that clears the spotlight index on device."),
+            action: clearSpotlightCache(),
+            accessibilityIdentifier: "spotlightClearCacheButton")
+
+        let settingsRow = NavigationItemRow(
+            title: NSLocalizedString("Open Device Settings", comment: "Opens iOS's Device Settings for WordPress App"),
+            action: openApplicationSettings()
+        )
+
+        let aboutRow = NavigationItemRow(
+            title: NSLocalizedString("About WordPress for iOS", comment: "Link to About screen for WordPress for iOS"),
+            action: pushAbout()
+        )
+
+        return ImmuTableSection(
+            headerText: otherHeader,
+            rows: [
+                spotlightClearCacheRow,
+                settingsRow,
+                aboutRow
+            ],
+            footerText: nil)
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -91,7 +91,7 @@ class AppSettingsViewController: UITableViewController {
                                     value: mediaCacheRowDescription)
 
         let mediaClearCacheRow = DestructiveButtonRow(
-            title: NSLocalizedString("Clear Media Cache", comment: "Label for button that clears all media cache."),
+            title: NSLocalizedString("Clear Device Media Cache", comment: "Label for button that clears all media cache."),
             action: { [weak self] row in
                 self?.clearMediaCache()
             },
@@ -144,7 +144,8 @@ class AppSettingsViewController: UITableViewController {
                     mediaCacheRow,
                     mediaClearCacheRow
                 ],
-                footerText: nil),
+                footerText: NSLocalizedString("Free up storage space on this device by clearing your temporary media files. This will not affect media on your site.", comment: "Explanatory text for clearing device media cache.")
+            ),
             ImmuTableSection(
                 headerText: privacyHeader,
                 rows: [


### PR DESCRIPTION
Fixes #9485 

From the discussion on #9485 , the following labels have been updated:
- The clear cache button label is now `Clear Device Media Cache`.
- The `Media` section now has a footer: `Free up storage space on this device by deleting temporary media files. This will not affect the media on your site.`

To test:
Go to Me > App Settings.
Verify the changes in the Media section:
![clear_cache](https://user-images.githubusercontent.com/1816888/41613323-7f435a0a-73b2-11e8-8d0b-6ba2668065a2.png)







