### PR TITLE
Integrates the latest from Aztec.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -68,8 +68,8 @@ target 'WordPress' do
     pod 'NSURL+IDN', '0.3'
     pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'b5ae03494596e3da7a8f814f9cab8e96ca345bc8'
     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'd0b3c02'
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'c04b12273f5aec2cc3300fd212836781efc8b356'
-    pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'c04b12273f5aec2cc3300fd212836781efc8b356'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
+    pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
     pod 'WordPressUI', '1.0.4'
 
     target 'WordPressTest' do
@@ -89,8 +89,8 @@ target 'WordPress' do
         shared_with_all_pods
         shared_with_networking_pods
 
-        pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'c04b12273f5aec2cc3300fd212836781efc8b356'
-        pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'c04b12273f5aec2cc3300fd212836781efc8b356'
+        pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
+        pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
         pod 'WordPressUI', '1.0.4'
         pod 'Gridicons', '0.15'
     end
@@ -105,8 +105,8 @@ target 'WordPress' do
         shared_with_all_pods
         shared_with_networking_pods
 
-        pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'c04b12273f5aec2cc3300fd212836781efc8b356'
-        pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'c04b12273f5aec2cc3300fd212836781efc8b356'
+        pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
+        pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
         pod 'WordPressUI', '1.0.4'
         pod 'Gridicons', '0.15'
     end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -164,8 +164,8 @@ DEPENDENCIES:
   - Starscream (= 3.0.4)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `c04b12273f5aec2cc3300fd212836781efc8b356`)
-  - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `c04b12273f5aec2cc3300fd212836781efc8b356`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `b989822e4fcb68f007bd661089c008333b40b8c5`)
+  - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `b989822e4fcb68f007bd661089c008333b40b8c5`)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `d0b3c02`)
   - WordPressKit (= 1.1)
   - WordPressShared (= 1.0.7)
@@ -212,7 +212,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPress-Aztec-iOS:
-    :commit: c04b12273f5aec2cc3300fd212836781efc8b356
+    :commit: b989822e4fcb68f007bd661089c008333b40b8c5
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressAuthenticator:
     :commit: d0b3c02
@@ -226,7 +226,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPress-Aztec-iOS:
-    :commit: c04b12273f5aec2cc3300fd212836781efc8b356
+    :commit: b989822e4fcb68f007bd661089c008333b40b8c5
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressAuthenticator:
     :commit: d0b3c02
@@ -271,6 +271,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: db0b20e6f70062b1bb85da5515b95d0f1ebae3b2
+PODFILE CHECKSUM: a20f71813959d61819686b9c08f0a2c5d7e4e8a9
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -16,13 +16,13 @@ class AztecAttachmentViewController: UITableViewController {
         }
     }
 
-    var alignment = ImageAttachment.Alignment.none
+    var alignment: ImageAttachment.Alignment? = nil
     var linkURL: URL?
     var size = ImageAttachment.Size.none
     @objc var alt: String?
     var caption: NSAttributedString?
 
-    var onUpdate: ((_ alignment: ImageAttachment.Alignment, _ size: ImageAttachment.Size, _ linkURL: URL?, _ altText: String?, _ caption: NSAttributedString?) -> Void)?
+    var onUpdate: ((_ alignment: ImageAttachment.Alignment?, _ size: ImageAttachment.Size, _ linkURL: URL?, _ altText: String?, _ caption: NSAttributedString?) -> Void)?
     @objc var onCancel: (() -> Void)?
 
     fileprivate var handler: ImmuTableViewHandler!
@@ -74,7 +74,7 @@ class AztecAttachmentViewController: UITableViewController {
 
         let alignmentRow = EditableTextRow(
             title: NSLocalizedString("Alignment", comment: "Image alignment option title."),
-            value: alignment.localizedString,
+            value: alignment?.localizedString ?? ImageAttachment.Alignment.none.localizedString,
             action: displayAlignmentSelector)
 
         let linkToRow = EditableTextRow(
@@ -167,11 +167,11 @@ class AztecAttachmentViewController: UITableViewController {
         let currentValue = alignment
 
         let dict: [String: Any] = [
-            SettingsSelectionDefaultValueKey: alignment,
+            SettingsSelectionDefaultValueKey: alignment ?? ImageAttachment.Alignment.none,
             SettingsSelectionTitleKey: NSLocalizedString("Alignment", comment: "Title of the screen for choosing an image's alignment."),
             SettingsSelectionTitlesKey: titles,
             SettingsSelectionValuesKey: values,
-            SettingsSelectionCurrentValueKey: currentValue
+            SettingsSelectionCurrentValueKey: currentValue ?? ImageAttachment.Alignment.none
         ]
 
         guard let vc = SettingsSelectionViewController(dictionary: dict) else {

--- a/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
+++ b/WordPress/WordPressTest/Posts/PostAttachmentTests.swift
@@ -60,7 +60,8 @@ class PostAttachmentTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
 
         let html = richTextView.getHTML()
-        XCTAssert(html == "<p>\(prefixString)<img src=\"\(imageName)\" class=\"alignnone\" alt=\"\(altValue)\"></p>")
+        let expected = "<p>\(prefixString)<img src=\"\(imageName)\" alt=\"\(altValue)\"></p>"
+        XCTAssertEqual(html, expected)
     }
 
     func testIfAltValueWasLeftEmptyForImageAttachment() {
@@ -94,7 +95,8 @@ class PostAttachmentTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
 
         let html = richTextView.getHTML()
-        XCTAssert(html == "<p>\(prefixString)<img src=\"\(imageName)\" class=\"alignnone\"></p>")
+        let expected = "<p>\(prefixString)<img src=\"\(imageName)\"></p>"
+        XCTAssertEqual(html, expected)
     }
 
     func testIfLinkURLValueWasAddedToImageAttachment() {
@@ -126,6 +128,8 @@ class PostAttachmentTests: XCTestCase {
         waitForExpectations(timeout: 1, handler: nil)
 
         let html = richTextView.getHTML()
-        XCTAssertEqual(html, "<p>Image with link: <a href=\"https://wordpress.com/\"><img src=\"\(imageName)\" class=\"alignnone\"></a></p>")
+        let expected = "<p>Image with link: <a href=\"https://wordpress.com/\"><img src=\"\(imageName)\"></a></p>"
+
+        XCTAssertEqual(html, expected)
     }
 }


### PR DESCRIPTION
Integrates some additional Aztec / Gutenberg compatibility fixes.

Since these were tested already, we should be good to go.  These are the issues included in this PR.

- https://github.com/wordpress-mobile/AztecEditor-iOS/issues/886
- https://github.com/wordpress-mobile/AztecEditor-iOS/issues/578

Also: `<pre>` multi-line elements are now merged properly.

Fyi @loremattei 