### PR TITLE
Roles: change button text on alert

### DIFF
--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -343,10 +343,10 @@ private extension InvitePersonViewController {
 
         let message = messageMap[error] ?? messageMap[.unknownError]!
         let title = NSLocalizedString("Sorry!", comment: "Invite Validation Alert")
-        let accept = NSLocalizedString("Accept", comment: "Invite Accept Button")
+        let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
 
-        alert.addDefaultActionWithTitle(accept)
+        alert.addDefaultActionWithTitle(okTitle)
         present(alert, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
Fixes #5858 

To test:
- Follow steps on #5858 
- Verify action button title is 'OK'.

![alert_text](https://user-images.githubusercontent.com/1816888/41627663-6b588db8-73de-11e8-945e-f2d7afd9e029.png)


