### PR TITLE
When associating posts and images uploaded via share extension, set the postID within the work item

### DIFF
--- a/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
@@ -257,9 +257,8 @@ import WordPressFlux
         let media = mediaUploadOperations(for: groupID)?.compactMap({return $0.remoteMedia})
         let syncGroup = DispatchGroup()
         media?.forEach { mediaItem in
-            mediaItem.postID = NSNumber(value: postID)
-
             syncGroup.enter()
+            mediaItem.postID = NSNumber(value: postID)
             service.update(mediaItem, success: { updatedRemoteMedia in
                 syncGroup.leave()
             }, failure: { error in


### PR DESCRIPTION
Fixes what seems to be a bug/oversight in the implementation of #9526 

My brain hurts a little bit every time I need to reason about multithreading, but it seems to me like we should perform all the work associated to a work item within the actual work item (sandwiched in between `enter` and `leave`.

The thing is, I could reproduce the issue described by @alisterscott in the original PR before making the change, I can not reproduce it again after.

The best way to reproduce the bug, for me, was to assign a few tags to the post when uploading images. That seemed to make the association fail pretty often.

To test:
1. Upload an image or two using the share extension
2. Check that the images are associated to the post created when uploading.