### PR TITLE
Extensions: Exclude WPiOS extensions from login share sheet

### DIFF
--- a/WordPress/WordPressDraftActionExtension/Info-Alpha.plist
+++ b/WordPress/WordPressDraftActionExtension/Info-Alpha.plist
@@ -35,7 +35,7 @@
                 SUBQUERY(
                 extensionItems,
                 $extensionItem,
-                SUBQUERY(
+                (SUBQUERY(
                 $extensionItem.attachments,
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
@@ -59,7 +59,14 @@
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
-                ).@count == 1
+                ).@count == 1)
+                AND
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.appextension.find-login-action"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.appextension.save-login-action"
+                ).@count == 0
                 ).@count >= 1
             </string>
 		<key>NSExtensionMainStoryboard</key>

--- a/WordPress/WordPressDraftActionExtension/Info-Internal.plist
+++ b/WordPress/WordPressDraftActionExtension/Info-Internal.plist
@@ -35,7 +35,7 @@
                 SUBQUERY(
                 extensionItems,
                 $extensionItem,
-                SUBQUERY(
+                (SUBQUERY(
                 $extensionItem.attachments,
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
@@ -59,7 +59,14 @@
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
-                ).@count == 1
+                ).@count == 1)
+                AND
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.appextension.find-login-action"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.appextension.save-login-action"
+                ).@count == 0
                 ).@count >= 1
             </string>
 			<key>NSExtensionJavaScriptPreprocessingFile</key>

--- a/WordPress/WordPressDraftActionExtension/Info.plist
+++ b/WordPress/WordPressDraftActionExtension/Info.plist
@@ -35,7 +35,7 @@
                 SUBQUERY(
                 extensionItems,
                 $extensionItem,
-                SUBQUERY(
+                (SUBQUERY(
                 $extensionItem.attachments,
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
@@ -59,7 +59,14 @@
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
-                ).@count == 1
+                ).@count == 1)
+                AND
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.appextension.find-login-action"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.appextension.save-login-action"
+                ).@count == 0
                 ).@count >= 1
             </string>
 			<key>NSExtensionJavaScriptPreprocessingFile</key>

--- a/WordPress/WordPressShareExtension/Info-Alpha.plist
+++ b/WordPress/WordPressShareExtension/Info-Alpha.plist
@@ -37,7 +37,7 @@
                 SUBQUERY(
                 extensionItems,
                 $extensionItem,
-                SUBQUERY(
+                (SUBQUERY(
                 $extensionItem.attachments,
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
@@ -61,7 +61,14 @@
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
-                ).@count == 1
+                ).@count == 1)
+                AND
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.appextension.find-login-action"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.appextension.save-login-action"
+                ).@count == 0
                 ).@count >= 1
             </string>
 		</dict>

--- a/WordPress/WordPressShareExtension/Info-Internal.plist
+++ b/WordPress/WordPressShareExtension/Info-Internal.plist
@@ -37,7 +37,7 @@
                 SUBQUERY(
                 extensionItems,
                 $extensionItem,
-                SUBQUERY(
+                (SUBQUERY(
                 $extensionItem.attachments,
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
@@ -61,7 +61,14 @@
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
-                ).@count == 1
+                ).@count == 1)
+                AND
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.appextension.find-login-action"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.appextension.save-login-action"
+                ).@count == 0
                 ).@count >= 1
             </string>
 		</dict>

--- a/WordPress/WordPressShareExtension/Info.plist
+++ b/WordPress/WordPressShareExtension/Info.plist
@@ -35,7 +35,7 @@
                 SUBQUERY(
                 extensionItems,
                 $extensionItem,
-                SUBQUERY(
+                (SUBQUERY(
                 $extensionItem.attachments,
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.image"
@@ -59,7 +59,14 @@
                 $attachment,
                 ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.url"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.file-url"
-                ).@count == 1
+                ).@count == 1)
+                AND
+                SUBQUERY(
+                $extensionItem.attachments,
+                $attachment,
+                ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.appextension.find-login-action"
+                || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "org.appextension.save-login-action"
+                ).@count == 0
                 ).@count >= 1
             </string>
 			<key>NSExtensionJavaScriptPreprocessingFile</key>


### PR DESCRIPTION
![3](https://user-images.githubusercontent.com/154014/41671638-59798396-747d-11e8-8f05-5f8bd6d725cf.jpg)

With the updates to the extension activation rules in activation in #9543, we inadvertently added the WPiOS extensions to the login share sheet. The PR fixes that by adding an exclusionary `SUBQUERY` which filters out the 1Password UTIs.

Fixes #9574 

## Testing

### Path 1:
0. Make sure you are logged out of the app
1.  Attempt to login using 1Password
2. Verify the WPiOS extensions do not appear in the login share sheet

### Other things:
Verify the WPiOS app extensions still appear in the share sheet when sharing other things.

@mindgraffiti would you mind taking a look at this? 😄 

