### PR TITLE
Hide WP masterbar in post previews.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
@@ -47,6 +47,10 @@ class PostPreviewGenerator: NSObject {
 
 private extension PostPreviewGenerator {
     func attemptPreview(url: URL) {
+
+        // Attempt to append params. If that fails, fall back to the original url.
+        let url = url.appendingHideMasterbarParameters() ?? url
+
         switch authenticationRequired {
         case .nonce:
             attemptNonceAuthenticatedRequest(url: url)


### PR DESCRIPTION
Ref #6504 

Per https://github.com/wordpress-mobile/WordPress-iOS/pull/9544#issuecomment-398621187, the masterbar was still showing when viewing a Page or a Post. This hides the masterbar on Post previews.

As noted on #6504 , the admin bar will still show for self-hosted (non-JP) sites.
 
To test:
- [x] Page: Go to Site Pages > page options (...) > View. Verify the masterbar is not displayed.
- [x] Post: Go to Blog Posts > View a post. Verify the masterbar is not displayed.

