### PR TITLE
Update media picker to 1.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -66,7 +66,7 @@ target 'WordPress' do
     pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
     pod 'Gridicons', '0.15'
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'b5ae03494596e3da7a8f814f9cab8e96ca345bc8'
+    pod 'WPMediaPicker', '1.1'
     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'd0b3c02'
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -130,7 +130,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.0.4)
-  - WPMediaPicker (1.0)
+  - WPMediaPicker (1.1)
   - wpxmlrpc (0.8.3)
   - ZendeskSDK (1.11.2.1):
     - ZendeskSDK/Providers (= 1.11.2.1)
@@ -170,7 +170,7 @@ DEPENDENCIES:
   - WordPressKit (= 1.1)
   - WordPressShared (= 1.0.7)
   - WordPressUI (= 1.0.4)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `b5ae03494596e3da7a8f814f9cab8e96ca345bc8`)
+  - WPMediaPicker (= 1.1)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
 
@@ -204,6 +204,7 @@ SPEC REPOS:
     - WordPressKit
     - WordPressShared
     - WordPressUI
+    - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
 
@@ -217,9 +218,6 @@ EXTERNAL SOURCES:
   WordPressAuthenticator:
     :commit: d0b3c02
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-  WPMediaPicker:
-    :commit: b5ae03494596e3da7a8f814f9cab8e96ca345bc8
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -231,9 +229,6 @@ CHECKOUT OPTIONS:
   WordPressAuthenticator:
     :commit: d0b3c02
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
-  WPMediaPicker:
-    :commit: b5ae03494596e3da7a8f814f9cab8e96ca345bc8
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -267,10 +262,10 @@ SPEC CHECKSUMS:
   WordPressKit: a24baaa783c3a221f2d9a51c19318cbb27333373
   WordPressShared: db964b81e02ff9be1ea2ff65ca9a4d57c49e82ba
   WordPressUI: f2348649b63b5a9392a72b1d2f46dd1d72e80ad9
-  WPMediaPicker: ceb613e43eae03268e73835d48d67f92f595aca6
+  WPMediaPicker: 5cc9386a4720f906d8fb79c7c4090d216b9f2348
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: a20f71813959d61819686b9c08f0a2c5d7e4e8a9
+PODFILE CHECKSUM: abc965466d39453ee0485bfb81804fff9be71585
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -99,7 +99,9 @@
     ///
     private func loadGif(with url: URL, from source: ImageSourceInformation, preferredSize size: CGSize) {
         let request: URLRequest
-        if source.isPrivateOnWPCom {
+        if url.isFileURL {
+            request = URLRequest(url: url)
+        } else if source.isPrivateOnWPCom {
             request = PrivateSiteURLProtocol.requestForPrivateSite(from: url)
         } else {
             // Photon helper set the size to load the retina version. We don't want that for gifs


### PR DESCRIPTION
This PR updates the WPMediaPicker to version 1.1

To test:
 - Open the following sections on the app and see if everything is working ok
 - Media Library
 - New Post and try to add media to it
 - Gravatar picker
 - Site icon picker


