### PR TITLE
Logout: Let's be friendly!

### DIFF
--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -28,6 +28,8 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
 
 - (AbstractPost *)findPostWithID:(NSNumber *)postID inBlog:(Blog *)blog;
 
+- (NSUInteger)countPostsWithoutRemote;
+
 /**
  Sync a specific post from the API
 

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -512,6 +512,14 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     return [posts firstObject];
 }
 
+- (NSUInteger)countPostsWithoutRemote
+{
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:NSStringFromClass([AbstractPost class])];
+    request.predicate = [NSPredicate predicateWithFormat:@"postID = NULL OR postID <= 0"];
+
+    return [self.managedObjectContext countForFetchRequest:request error:nil];
+}
+
 - (NSDictionary *)remoteSyncParametersDictionaryForRemote:(nonnull id <PostServiceRemote>)remote
                                               withOptions:(nonnull PostServiceSyncOptions *)options
 {

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -541,8 +541,8 @@ private extension MeViewController {
 
     enum LogoutAlert {
         static let defaultTitle =  NSLocalizedString("Log out of WordPress?", comment: "LogOut confirmation text, whenever there are no local changes")
-        static let unsavedTitleSingular = NSLocalizedString("You have changes that haven't been uploaded to your site. Logging out now will delete those changes. Log out anyway?",
-                                                            comment: "Warning displayed before logging out. The %d placeholder will contain the number of local posts")
+        static let unsavedTitleSingular = NSLocalizedString("You have changes to %d post that hasn't been uploaded to your site. Logging out now will delete those changes. Log out anyway?",
+                                                            comment: "Warning displayed before logging out. The %d placeholder will contain the number of local posts (SINGULAR!)")
         static let unsavedTitlePlural = NSLocalizedString("You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?",
                                                           comment: "Warning displayed before logging out. The %d placeholder will contain the number of local posts (PLURAL!)")
         static let cancelAction = NSLocalizedString("Cancel", comment: "")

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -427,7 +427,8 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
             return LogoutAlert.defaultTitle
         }
 
-        return String(format: LogoutAlert.unsavedTitle, count)
+        let format = count > 1 ? LogoutAlert.unsavedTitlePlural : LogoutAlert.unsavedTitleSingular
+        return String(format: format, count)
     }
 
     fileprivate func logOut() {
@@ -540,8 +541,10 @@ private extension MeViewController {
 
     enum LogoutAlert {
         static let defaultTitle =  NSLocalizedString("Log out of WordPress?", comment: "LogOut confirmation text, whenever there are no local changes")
-        static let unsavedTitle = NSLocalizedString("You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?",
-                                                    comment: "Warning displayed before logging out. The %d placeholder will contain the number of local posts")
+        static let unsavedTitleSingular = NSLocalizedString("You have changes that haven't been uploaded to your site. Logging out now will delete those changes. Log out anyway?",
+                                                            comment: "Warning displayed before logging out. The %d placeholder will contain the number of local posts")
+        static let unsavedTitlePlural = NSLocalizedString("You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?",
+                                                          comment: "Warning displayed before logging out. The %d placeholder will contain the number of local posts (PLURAL!)")
         static let cancelAction = NSLocalizedString("Cancel", comment: "")
         static let logoutAction = NSLocalizedString("Log Out", comment: "Button for confirming logging out from WordPress.com account")
     }

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -174,7 +174,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
 
         let logOut = DestructiveButtonRow(
             title: RowTitles.logOut,
-            action: confirmLogout(),
+            action: logoutRowWasPressed(),
             accessibilityIdentifier: "logOutFromWPcomButton")
 
         let wordPressComAccount = HeaderTitles.wpAccount
@@ -308,28 +308,10 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         }
     }
 
-    fileprivate func confirmLogout() -> ImmuTableAction {
+    fileprivate func logoutRowWasPressed() -> ImmuTableAction {
         return { [unowned self] row in
-            let format = NSLocalizedString("Logging out will remove all of @%@’s WordPress.com data from this device.", comment: "Label for logging out from WordPress.com account. The %@ is a placeholder for the user's screen name.")
-            let title = String(format: format, self.defaultAccount()!.username)
-            let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
-
-            let cancel = UIAlertAction(
-                title: NSLocalizedString("Cancel", comment: ""),
-                style: .cancel,
-                handler: nil)
-            let logOut = UIAlertAction(
-                title: NSLocalizedString("Log Out", comment: "Button for confirming logging out from WordPress.com account"),
-                style: .destructive,
-                handler: { [unowned self] _ in
-                self.logOut()
-            })
-
-            alert.addAction(cancel)
-            alert.addAction(logOut)
-
-            self.present(alert, animated: true, completion: nil)
             self.tableView.deselectSelectedRowWithAnimation(true)
+            self.displayLogOutAlert()
         }
     }
 
@@ -423,6 +405,31 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         service.updateUserDetails(for: account, success: { () in }, failure: { _ in })
     }
 
+
+    // MARK: - LogOut
+
+    private func displayLogOutAlert() {
+        let alert  = UIAlertController(title: logOutAlertTitle, message: nil, preferredStyle: .alert)
+        alert.addActionWithTitle(LogoutAlert.cancelAction, style: .cancel)
+        alert.addActionWithTitle(LogoutAlert.logoutAction, style: .destructive) { _ in
+            self.logOut()
+        }
+
+        present(alert, animated: true, completion: nil)
+    }
+
+    private var logOutAlertTitle: String {
+        let context = ContextManager.sharedInstance().mainContext
+        let service = PostService(managedObjectContext: context)
+        let count = service.countPostsWithoutRemote()
+
+        guard count > 0 else {
+            return LogoutAlert.defaultTitle
+        }
+
+        return String(format: LogoutAlert.unsavedTitle, count)
+    }
+
     fileprivate func logOut() {
         let context = ContextManager.sharedInstance().mainContext
         let service = AccountService(managedObjectContext: context)
@@ -431,6 +438,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         // Also clear the spotlight index
         SearchManager.shared.deleteAllSearchableItems()
     }
+
 
     // MARK: - Private Properties
 
@@ -515,8 +523,8 @@ extension MeViewController: SearchableActivityConvertable {
 
 // MARK: - Constants
 
-extension MeViewController {
-    struct RowTitles {
+private extension MeViewController {
+    enum RowTitles {
         static let appSettings = NSLocalizedString("App Settings", comment: "Link to App Settings section")
         static let myProfile = NSLocalizedString("My Profile", comment: "Link to My Profile section")
         static let accountSettings = NSLocalizedString("Account Settings", comment: "Link to Account Settings section")
@@ -526,8 +534,16 @@ extension MeViewController {
         static let logOut = NSLocalizedString("Log Out", comment: "Label for logging out from WordPress.com account")
     }
 
-    struct HeaderTitles {
+    enum HeaderTitles {
         static let wpAccount = NSLocalizedString("WordPress.com Account", comment: "WordPress.com sign-in/sign-out section header title")
+    }
+
+    enum LogoutAlert {
+        static let defaultTitle =  NSLocalizedString("Log out of WordPress?", comment: "LogOut confirmation text, whenever there are no local changes")
+        static let unsavedTitle = NSLocalizedString("You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?",
+                                                    comment: "Warning displayed before logging out. The %d placeholder will contain the number of local posts")
+        static let cancelAction = NSLocalizedString("Cancel", comment: "")
+        static let logoutAction = NSLocalizedString("Log Out", comment: "Button for confirming logging out from WordPress.com account")
     }
 }
 


### PR DESCRIPTION
### Details:
This PR implements an improved Logout Text:

- Whenever there are local changes, not persisted in the backend, the Logout Confirmation will read `You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?`
- Whenever there are no local changes, the text will just say `Log out of WordPress?`

This one goes to our friend @sendhil, who filed the issue 3 years + nearly 5 months ago. If you ever get this ping, **WE MISS YOU AROUND!!!**

Closes #3164 

@ScoutHarris may i bug you with a hopefully fun review?. Thanks in advance!!

### Scenario: No Local Changes
1. Log into WPiOS
2. Press the `+` button
3. Type anything! (Title or Body)
4. Dismiss the editor
5. Wait a few seconds, so that the post is sync'ed with our backend
6. Press `Me` > `Logout`

Verify that the text reads `Log out of WordPress?`. 

### Scenario: Local Changes
1. Log into WPiOS
2. Turn off the device's WiFi
3. Press the `+` button
4. Type anything! (Title or Body)
5. Dismiss the editor
6. Press `Me` > `Logout`

Verify that the confirmation alert reads as follows:

```
You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?
```

