### PR TITLE
Fix/9623 crash post settings view controller release

### DIFF
--- a/WordPress/Classes/Models/Page.swift
+++ b/WordPress/Classes/Models/Page.swift
@@ -29,4 +29,11 @@ class Page: AbstractPost {
             preconditionFailure("Invalid key path for a section identifier")
         }
     }
+
+    override func featuredImageURLForDisplay() -> URL? {
+        guard let path = pathForDisplayImage else {
+            return nil
+        }
+        return URL(string: path)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageSettingsViewController.m
@@ -8,20 +8,6 @@
 
 @implementation PageSettingsViewController
 
-- (void)addPostPropertiesObserver
-{
-    [self.apost addObserver:self
-                forKeyPath:NSStringFromSelector(@selector(featuredImage))
-                   options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionOld
-                   context:nil];
-
-}
-
-- (void)removePostPropertiesObserver
-{
-    [self.apost removeObserver:self forKeyPath:NSStringFromSelector(@selector(featuredImage))];
-}
-
 - (void)configureSections
 {
     self.sections = @[@(PostSettingsSectionMeta),@(PostSettingsSectionFeaturedImage)];


### PR DESCRIPTION
Fixes #9623 

This PR fixes a couple of issues in the `PostSettingsViewController` regarding the `featured image,`when it was used to display Page settings.

The discussion of how this was fixed can be found in the [issue thread](https://github.com/wordpress-mobile/WordPress-iOS/issues/9623#issuecomment-399259310)

**Note:**
I made a new branch to target `release/10.3`

To test:

1. Go to Site Pages.
2. Select a page to edit.
3. Go to the Page (Post) Settings.
4. Add a featured image.
5. Check that it works as expected.

To trigger the first (original) issue regarding `featuredImageURLForDisplay`, the page needs to have a featured image, where the associated `Media` object is on `.stub` state. I'm not sure how to trigger this organically.
Alternatively, for testing purposes, we can replace the `urlForFeaturedImage` implementation to:
`return self.apost.featuredImageURLForDisplay;` directly (`PostSettingsViewController.m:788`) and then:
1. Open the Site Pages list.
2. Open a published page with a featured image.
3. Check that the featured image load correctly from `featuredImageURLForDisplay`.

*Note:*
Since the `featuredImageURLForDisplay` is synchronized when the post/page is sync with the server, this won't work when adding a featured image locally. For those cases, the `Media` object should not be on `.stub` state (as far as I understand) and be able to load the image from the local URL.