### PR TITLE
Add a feature flag for extract notifications

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -7,6 +7,7 @@ enum FeatureFlag: Int {
     case activity
     case saveForLater
     case gifSupportInReaderDetail
+    case extractNotifications
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -21,6 +22,8 @@ enum FeatureFlag: Int {
             return true
         case .gifSupportInReaderDetail:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
+        case .extractNotifications:
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 }


### PR DESCRIPTION
I am not sure we'd need this, but I guess it won't hurt to have a feature flag in case we need it.

To test: 
1. The project should build
2. The tests should pass.

There are no user-facing or functional changes
