### PR TITLE
Update Gridicons to 0.16

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -64,7 +64,7 @@ target 'WordPress' do
     ## ====================
     ##
     pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
-    pod 'Gridicons', :git => 'https://github.com/Automattic/Gridicons-iOS.git', :commit => '20e95239625168db0560b938691c3aee0e6568b1'
+    pod 'Gridicons', '0.16'
     pod 'NSURL+IDN', '0.3'
     pod 'WPMediaPicker', '1.1'
     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'd0b3c02'
@@ -92,7 +92,7 @@ target 'WordPress' do
         pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
         pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
         pod 'WordPressUI', '1.0.4'
-        pod 'Gridicons', :git => 'https://github.com/Automattic/Gridicons-iOS.git', :commit => '20e95239625168db0560b938691c3aee0e6568b1'
+        pod 'Gridicons', '0.16'
     end
 
 
@@ -108,7 +108,7 @@ target 'WordPress' do
         pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
         pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
         pod 'WordPressUI', '1.0.4'
-        pod 'Gridicons', :git => 'https://github.com/Automattic/Gridicons-iOS.git', :commit => '20e95239625168db0560b938691c3aee0e6568b1'
+        pod 'Gridicons', '0.16'
     end
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -45,7 +45,7 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.1.4)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.1.4)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.1.4)"
-  - Gridicons (0.15)
+  - Gridicons (0.16)
   - HockeySDK (5.1.2):
     - HockeySDK/DefaultLib (= 5.1.2)
   - HockeySDK/DefaultLib (5.1.2)
@@ -149,7 +149,7 @@ DEPENDENCIES:
   - Crashlytics (= 3.10.1)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - Gifu (= 3.1.0)
-  - Gridicons (from `https://github.com/Automattic/Gridicons-iOS.git`, commit `20e95239625168db0560b938691c3aee0e6568b1`)
+  - Gridicons (= 0.16)
   - HockeySDK (= 5.1.2)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -187,6 +187,7 @@ SPEC REPOS:
     - Gifu
     - GoogleSignInRepacked
     - GoogleToolboxForMac
+    - Gridicons
     - HockeySDK
     - lottie-ios
     - MGSwipeTableCell
@@ -211,9 +212,6 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  Gridicons:
-    :commit: 20e95239625168db0560b938691c3aee0e6568b1
-    :git: https://github.com/Automattic/Gridicons-iOS.git
   WordPress-Aztec-iOS:
     :commit: b989822e4fcb68f007bd661089c008333b40b8c5
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
@@ -225,9 +223,6 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  Gridicons:
-    :commit: 20e95239625168db0560b938691c3aee0e6568b1
-    :git: https://github.com/Automattic/Gridicons-iOS.git
   WordPress-Aztec-iOS:
     :commit: b989822e4fcb68f007bd661089c008333b40b8c5
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
@@ -248,7 +243,7 @@ SPEC CHECKSUMS:
   Gifu: fd1e9e3a15ac5d90bae0a510e4ed9f94b485ab03
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
-  Gridicons: 0e5e76ad9fc6f7cbc3da137a9751ef516c5aef73
+  Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
   HockeySDK: 38b7e2726af1ea86ae97ce4b5de33ab0817e3500
   lottie-ios: d699fdee68d7b63e721d949388b015fef1aaa4ac
   MGSwipeTableCell: fb20e983988bde2b8d0df29c2d9e1d8ffd10b74a
@@ -271,6 +266,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: f042911581fd261a16b4adbfd61ffd5584d84fdf
+PODFILE CHECKSUM: 07ff7bdbdc5813b0978f1f2b374ad975c8c4f170
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
This PR updates the Gridicons pod to the new version 0.16

To test:
- run `pod install` (`--repo-update` might be necessary)
- Check that the project builds and run properly.
