### PR TITLE
Setting log timestamp locale to English.

### DIFF
--- a/WordPress/Classes/Utility/Logging/CocoaLumberjack.swift
+++ b/WordPress/Classes/Utility/Logging/CocoaLumberjack.swift
@@ -20,8 +20,6 @@ import CocoaLumberjack
 //   to endorse or promote products derived from this software without specific
 //   prior written permission of Deusty, LLC.
 
-import Foundation
-
 extension DDLogFlag {
     public static func from(_ logLevel: DDLogLevel) -> DDLogFlag {
         return DDLogFlag(rawValue: logLevel.rawValue)

--- a/WordPress/Classes/Utility/Logging/CustomLogFormatter.swift
+++ b/WordPress/Classes/Utility/Logging/CustomLogFormatter.swift
@@ -12,7 +12,9 @@ class CustomLogFormatter: NSObject, DDLogFormatter {
     }()
 
     func format(message logMessage: DDLogMessage) -> String? {
-        return ("\(logTimeStampFormatter.string(from: logMessage.timestamp)) \(logMessage.message)")
+        let timestamp = logTimeStampFormatter.string(from: logMessage.timestamp)
+        let message = logMessage.message
+        return ("\(timestamp) \(message)")
     }
 
 }

--- a/WordPress/Classes/Utility/Logging/CustomLogFormatter.swift
+++ b/WordPress/Classes/Utility/Logging/CustomLogFormatter.swift
@@ -1,0 +1,18 @@
+import Foundation
+import CocoaLumberjack
+
+class CustomLogFormatter: NSObject, DDLogFormatter {
+
+    let logTimeStampFormatter: DateFormatter = {
+        let formatter           = DateFormatter()
+        formatter.locale        = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat    = "yyyy-MM-dd HH:mm:ss:SSS"
+        formatter.timeZone      = TimeZone.current
+        return formatter
+    }()
+
+    func format(message logMessage: DDLogMessage) -> String? {
+        return ("\(logTimeStampFormatter.string(from: logMessage.timestamp)) \(logMessage.message)")
+    }
+
+}

--- a/WordPress/Classes/Utility/Logging/WPLogger.m
+++ b/WordPress/Classes/Utility/Logging/WPLogger.m
@@ -3,6 +3,7 @@
 @import CocoaLumberjack;
 #import "WPCrashlyticsLogger.h"
 #import "WordPressAppDelegate.h"
+#import "WordPress-Swift.h"
 
 @interface WPLogger ()
 @property (nonatomic, strong, readwrite) DDFileLogger *fileLogger;
@@ -59,7 +60,8 @@
         DDFileLogger *fileLogger = [[DDFileLogger alloc] init];
         fileLogger.rollingFrequency = 60 * 60 * 24; // 24 hour rolling
         fileLogger.logFileManager.maximumNumberOfLogFiles = 7;
-        
+        fileLogger.logFormatter = [[CustomLogFormatter alloc] init];
+
         _fileLogger = fileLogger;
     }
     

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -597,6 +597,7 @@
 		9859DF882021099800FB848E /* SiteCreationCategoryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9859DF872021099800FB848E /* SiteCreationCategoryTableViewCell.xib */; };
 		9859DF8A20210B2100FB848E /* SiteCreationInstructionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9859DF8920210B2100FB848E /* SiteCreationInstructionTableViewCell.xib */; };
 		98656BD82037A1770079DE67 /* SignupEpilogueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98656BD72037A1770079DE67 /* SignupEpilogueViewController.swift */; };
+		986CC4D220E1B2F6004F300E /* CustomLogFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986CC4D120E1B2F6004F300E /* CustomLogFormatter.swift */; };
 		9872CB30203B8A730066A293 /* SignupEpilogueTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9872CB2F203B8A730066A293 /* SignupEpilogueTableViewController.swift */; };
 		98A25BD1203CB25F006A5807 /* SignupEpilogueCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98A25BD0203CB25F006A5807 /* SignupEpilogueCell.swift */; };
 		98A25BD3203CB278006A5807 /* SignupEpilogueCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98A25BD2203CB278006A5807 /* SignupEpilogueCell.xib */; };
@@ -2071,6 +2072,7 @@
 		9859DF872021099800FB848E /* SiteCreationCategoryTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SiteCreationCategoryTableViewCell.xib; sourceTree = "<group>"; };
 		9859DF8920210B2100FB848E /* SiteCreationInstructionTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SiteCreationInstructionTableViewCell.xib; sourceTree = "<group>"; };
 		98656BD72037A1770079DE67 /* SignupEpilogueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupEpilogueViewController.swift; sourceTree = "<group>"; };
+		986CC4D120E1B2F6004F300E /* CustomLogFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomLogFormatter.swift; sourceTree = "<group>"; };
 		9872CB2F203B8A730066A293 /* SignupEpilogueTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupEpilogueTableViewController.swift; sourceTree = "<group>"; };
 		98A25BD0203CB25F006A5807 /* SignupEpilogueCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignupEpilogueCell.swift; sourceTree = "<group>"; };
 		98A25BD2203CB278006A5807 /* SignupEpilogueCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SignupEpilogueCell.xib; sourceTree = "<group>"; };
@@ -3594,6 +3596,7 @@
 				938CF3DB1EF1BE6800AF838E /* CocoaLumberjack.swift */,
 				59DD94321AC479ED0032DD6B /* WPLogger.h */,
 				59DD94331AC479ED0032DD6B /* WPLogger.m */,
+				986CC4D120E1B2F6004F300E /* CustomLogFormatter.swift */,
 			);
 			path = Logging;
 			sourceTree = "<group>";
@@ -7044,6 +7047,7 @@
 				E62AFB6C1DC8E593007484FC /* WPRichTextFormatter.swift in Sources */,
 				74CEF0781F9AA10100B729CA /* ShareExtensionSessionManager.swift in Sources */,
 				74FA4BE51FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */,
+				986CC4D220E1B2F6004F300E /* CustomLogFormatter.swift in Sources */,
 				433432521E9ED18900915988 /* LoginEpilogueViewController.swift in Sources */,
 				E1DD4CCB1CAE41B800C3863E /* PagedViewController.swift in Sources */,
 				B549BA681CF7447E0086C608 /* InvitePersonViewController.swift in Sources */,


### PR DESCRIPTION
Ref #9625 

When the logs are sent to Zendesk, the timestamps were translated to the device language.

<img width="279" alt="translated" src="https://user-images.githubusercontent.com/1816888/41881614-966c0f12-78a1-11e8-9892-effc7b52eabb.png">

In app, the logs would look like:
```
٢٠١٨/٠٦/٢٢ ١٦:٤١:٠٠:٠٧٠  Crash count: 0
٢٠١٨/٠٦/٢٢ ١٦:٤١:٠٠:٠٧٠  Debug mode:  Debug
٢٠١٨/٠٦/٢٢ ١٦:٤١:٠٠:٠٧٠  Extra debug: NO
```

This change sets the log timestamp locale to English so the HEs can read them.

**To test:**

**NOTE**: It is not necessary to actually create a Zendesk ticket. In `ZendeskUtils:getLogFile`, you can log out `logText` to see what is being sent to Zendesk.

- Start with a fresh install (it's easier to see the new logs that way).
- Change your device language to something vastly different than English (for example, Spanish didn't make a difference. Try something like Arabic).
- Go to Me > Help & Support > Contact Us.
- Verify the timestamps in `logText` are in English, in the format `yyyy-MM-dd HH:mm:ss:SSS`.

```
2018-06-25 18:11:17:176 Crash count: 0
2018-06-25 18:11:17:176 Debug mode:  Debug
2018-06-25 18:11:17:176 Extra debug: NO
```


