### PR TITLE
Update Aztec to beta 21.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -68,8 +68,8 @@ target 'WordPress' do
     pod 'NSURL+IDN', '0.3'
     pod 'WPMediaPicker', '1.1'
     pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'd0b3c02'
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
-    pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e8c86c1c1006335a987332e7327af1a3fec3dbcd'
+    pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e8c86c1c1006335a987332e7327af1a3fec3dbcd'
     pod 'WordPressUI', '1.0.4'
 
     target 'WordPressTest' do
@@ -89,8 +89,8 @@ target 'WordPress' do
         shared_with_all_pods
         shared_with_networking_pods
 
-        pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
-        pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
+        pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e8c86c1c1006335a987332e7327af1a3fec3dbcd'
+        pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e8c86c1c1006335a987332e7327af1a3fec3dbcd'
         pod 'WordPressUI', '1.0.4'
         pod 'Gridicons', '0.15'
     end
@@ -105,8 +105,8 @@ target 'WordPress' do
         shared_with_all_pods
         shared_with_networking_pods
 
-        pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
-        pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'b989822e4fcb68f007bd661089c008333b40b8c5'
+        pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e8c86c1c1006335a987332e7327af1a3fec3dbcd'
+        pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e8c86c1c1006335a987332e7327af1a3fec3dbcd'
         pod 'WordPressUI', '1.0.4'
         pod 'Gridicons', '0.15'
     end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -164,8 +164,8 @@ DEPENDENCIES:
   - Starscream (= 3.0.4)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `b989822e4fcb68f007bd661089c008333b40b8c5`)
-  - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `b989822e4fcb68f007bd661089c008333b40b8c5`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `e8c86c1c1006335a987332e7327af1a3fec3dbcd`)
+  - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `e8c86c1c1006335a987332e7327af1a3fec3dbcd`)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `d0b3c02`)
   - WordPressKit (= 1.1)
   - WordPressShared (= 1.0.7)
@@ -213,7 +213,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPress-Aztec-iOS:
-    :commit: b989822e4fcb68f007bd661089c008333b40b8c5
+    :commit: e8c86c1c1006335a987332e7327af1a3fec3dbcd
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressAuthenticator:
     :commit: d0b3c02
@@ -224,7 +224,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPress-Aztec-iOS:
-    :commit: b989822e4fcb68f007bd661089c008333b40b8c5
+    :commit: e8c86c1c1006335a987332e7327af1a3fec3dbcd
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressAuthenticator:
     :commit: d0b3c02
@@ -266,6 +266,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: abc965466d39453ee0485bfb81804fff9be71585
+PODFILE CHECKSUM: 80c05df3d6ad2dfbc528b83559432e8a7d88d45b
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3250,16 +3250,6 @@ extension AztecPostViewController {
             }, failure: { (error) in
                 DDLogError("Unable to find information for VideoPress video with ID = \(videoPressID). Details: \(error.localizedDescription)")
             })
-        } else if let videoSrcURL = videoAttachment.url, videoSrcURL != Constants.placeholderMediaLink, videoAttachment.posterURL == nil {
-            let thumbnailGenerator = MediaVideoExporter(url: videoSrcURL)
-            thumbnailGenerator.exportPreviewImageForVideo(atURL: videoSrcURL, imageOptions: nil, onCompletion: { (exportResult) in
-                DispatchQueue.main.async {
-                    videoAttachment.posterURL = exportResult.url
-                    self.richTextView.refresh(videoAttachment)
-                }
-            }, onError: { (error) in
-                DDLogError("Unable to grab frame from video = \(videoSrcURL). Details: \(error.localizedDescription)")
-            })
         }
     }
 
@@ -3476,6 +3466,69 @@ extension AztecPostViewController {
         return icon
     }
 
+    func fetchPosterImageFor(videoAttachment: VideoAttachment, onSuccess: @escaping (UIImage) -> (), onFailure: @escaping () -> ()) {
+        guard let videoSrcURL = videoAttachment.url, videoSrcURL != Constants.placeholderMediaLink, videoAttachment.posterURL == nil else {
+            onFailure()
+            return
+        }
+        let thumbnailGenerator = MediaVideoExporter(url: videoSrcURL)
+        thumbnailGenerator.exportPreviewImageForVideo(atURL: videoSrcURL, imageOptions: nil, onCompletion: { (exportResult) in
+            guard let image = UIImage(contentsOfFile: exportResult.url.path) else {
+                onFailure()
+                return
+            }
+            DispatchQueue.main.async {
+                onSuccess(image)
+            }
+        }, onError: { (error) in
+            DDLogError("Unable to grab frame from video = \(videoSrcURL). Details: \(error.localizedDescription)")
+            onFailure()
+        })
+    }
+
+    func downloadImage(from url: URL, success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
+        var requestURL = url
+        let imageMaxDimension = max(UIScreen.main.bounds.size.width, UIScreen.main.bounds.size.height)
+        //use height zero to maintain the aspect ratio when fetching
+        var size = CGSize(width: imageMaxDimension, height: 0)
+        let request: URLRequest
+        if url.isFileURL {
+            request = URLRequest(url: url)
+        } else if self.post.blog.isPrivate() {
+            // private wpcom image needs special handling.
+            // the size that WPImageHelper expects is pixel size
+            size.width = size.width * UIScreen.main.scale
+            requestURL = WPImageURLHelper.imageURLWithSize(size, forImageURL: requestURL)
+            request = PrivateSiteURLProtocol.requestForPrivateSite(from: requestURL)
+        } else if !self.post.blog.isHostedAtWPcom && self.post.blog.isBasicAuthCredentialStored() {
+            size.width = size.width * UIScreen.main.scale
+            requestURL = WPImageURLHelper.imageURLWithSize(size, forImageURL: requestURL)
+            request = URLRequest(url: requestURL)
+        } else {
+            // the size that PhotonImageURLHelper expects is points size
+            requestURL = PhotonImageURLHelper.photonURL(with: size, forImageURL: requestURL)
+            request = URLRequest(url: requestURL)
+        }
+
+        let receipt = ImageDownloader.shared.downloadImage(for: request) { [weak self] (image, error) in
+            guard let _ = self else {
+                return
+            }
+
+            DispatchQueue.main.async {
+                guard let image = image else {
+                    DDLogError("Unable to download image for attachment with url = \(url). Details: \(String(describing: error?.localizedDescription))")
+                    failure()
+                    return
+                }
+
+                success(image)
+            }
+        }
+
+        activeMediaRequests.append(receipt)
+    }
+
     @objc func applicationWillResignActive(_ notification: Foundation.Notification) {
 
         // [2018-03-05] Need to close the options VC on backgrounding to prevent view hierarchy inconsistency crasher.
@@ -3568,48 +3621,20 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
     }
 
     func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
-        var requestURL = url
-        if let videoAttachment = attachment as? VideoAttachment, let posterURL = videoAttachment.posterURL {
-            requestURL = posterURL
-        }
-        let imageMaxDimension = max(UIScreen.main.bounds.size.width, UIScreen.main.bounds.size.height)
-        //use height zero to maintain the aspect ratio when fetching
-        var size = CGSize(width: imageMaxDimension, height: 0)
-        let request: URLRequest
-        if url.isFileURL {
-            request = URLRequest(url: url)
-        } else if self.post.blog.isPrivate() {
-            // private wpcom image needs special handling.
-            // the size that WPImageHelper expects is pixel size
-            size.width = size.width * UIScreen.main.scale
-            requestURL = WPImageURLHelper.imageURLWithSize(size, forImageURL: requestURL)
-            request = PrivateSiteURLProtocol.requestForPrivateSite(from: requestURL)
-        } else if !self.post.blog.isHostedAtWPcom && self.post.blog.isBasicAuthCredentialStored() {
-            size.width = size.width * UIScreen.main.scale
-            requestURL = WPImageURLHelper.imageURLWithSize(size, forImageURL: requestURL)
-            request = URLRequest(url: requestURL)
-        } else {
-            // the size that PhotonImageURLHelper expects is points size
-            requestURL = PhotonImageURLHelper.photonURL(with: size, forImageURL: requestURL)
-            request = URLRequest(url: requestURL)
-        }
-
-        let receipt = ImageDownloader.shared.downloadImage(for: request) { [weak self] (image, error) in
-            guard let _ = self else {
+        switch attachment {
+        case let videoAttachment as VideoAttachment:
+            guard let posterURL = videoAttachment.posterURL else {
+                // Let's get a frame from the video directly
+                fetchPosterImageFor(videoAttachment: videoAttachment, onSuccess: success, onFailure: failure)
                 return
             }
-
-            DispatchQueue.main.async {
-                guard let image = image else {
-                    failure()
-                    return
-                }
-
-                success(image)
-            }
+            downloadImage(from: posterURL, success: success, onFailure: failure)
+        case is ImageAttachment:
+            downloadImage(from: url, success: success, onFailure: failure)
+        default:
+            failure()
         }
 
-        activeMediaRequests.append(receipt)
     }
 
     func textView(_ textView: TextView, urlFor imageAttachment: ImageAttachment) -> URL? {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -766,7 +766,8 @@ class AztecPostViewController: UIViewController, PostEditor {
         let providers: [TextViewAttachmentImageProvider] = [
             SpecialTagAttachmentRenderer(),
             CommentAttachmentRenderer(font: Fonts.regular),
-            HTMLAttachmentRenderer(font: Fonts.regular)
+            HTMLAttachmentRenderer(font: Fonts.regular),
+            GutenpackAttachmentRenderer()
         ]
 
         for provider in providers {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3093,7 +3093,7 @@ extension AztecPostViewController {
                     replacePlaceholder(attachment: imageAttachment, with: documentURLString)
                 }
             } else if let videoAttachment = attachment as? VideoAttachment, let videoURLString = media.remoteURL {
-                videoAttachment.srcURL = URL(string: videoURLString)
+                videoAttachment.updateURL(URL(string: videoURLString))
                 var posterChange = false
                 if let videoPosterURLString = media.remoteThumbnailURL {
                     videoAttachment.posterURL = URL(string: videoPosterURLString)
@@ -3236,13 +3236,13 @@ extension AztecPostViewController {
             videoAttachment.image = Gridicon.iconOfType(.video, withSize: Constants.mediaPlaceholderImageSize)
             self.richTextView.refresh(videoAttachment)
         }
-        if let videoSrcURL = videoAttachment.srcURL,
+        if let videoSrcURL = videoAttachment.url,
            videoSrcURL.scheme == VideoShortcodeProcessor.videoPressScheme,
            let videoPressID = videoSrcURL.host {
             // It's videoPress video so let's fetch the information for the video
             let mediaService = MediaService(managedObjectContext: ContextManager.sharedInstance().mainContext)
             mediaService.getMediaURL(fromVideoPressID: videoPressID, in: self.post.blog, success: { (videoURLString, posterURLString) in
-                videoAttachment.srcURL = URL(string: videoURLString)
+                videoAttachment.updateURL(URL(string: videoURLString))
                 if let validPosterURLString = posterURLString, let posterURL = URL(string: validPosterURLString) {
                     videoAttachment.posterURL = posterURL
                 }
@@ -3250,7 +3250,7 @@ extension AztecPostViewController {
             }, failure: { (error) in
                 DDLogError("Unable to find information for VideoPress video with ID = \(videoPressID). Details: \(error.localizedDescription)")
             })
-        } else if let videoSrcURL = videoAttachment.srcURL, videoSrcURL != Constants.placeholderMediaLink, videoAttachment.posterURL == nil {
+        } else if let videoSrcURL = videoAttachment.url, videoSrcURL != Constants.placeholderMediaLink, videoAttachment.posterURL == nil {
             let thumbnailGenerator = MediaVideoExporter(url: videoSrcURL)
             thumbnailGenerator.exportPreviewImageForVideo(atURL: videoSrcURL, imageOptions: nil, onCompletion: { (exportResult) in
                 DispatchQueue.main.async {
@@ -3410,7 +3410,7 @@ extension AztecPostViewController {
     }
 
     func displayPlayerFor(videoAttachment: VideoAttachment, atPosition position: CGPoint) {
-        guard let videoURL = videoAttachment.srcURL else {
+        guard let videoURL = videoAttachment.url else {
             return
         }
         guard let videoPressID = videoAttachment.videoPressID else {
@@ -3427,7 +3427,7 @@ extension AztecPostViewController {
                 self.displayUnableToPlayVideoAlert()
                 return
             }
-            videoAttachment.srcURL = videoURL
+            videoAttachment.updateURL(videoURL)
             if let validPosterURLString = posterURLString, let posterURL = URL(string: validPosterURLString) {
                 videoAttachment.posterURL = posterURL
             }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3569,6 +3569,9 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
 
     func textView(_ textView: TextView, attachment: NSTextAttachment, imageAt url: URL, onSuccess success: @escaping (UIImage) -> Void, onFailure failure: @escaping () -> Void) {
         var requestURL = url
+        if let videoAttachment = attachment as? VideoAttachment, let posterURL = videoAttachment.posterURL {
+            requestURL = posterURL
+        }
         let imageMaxDimension = max(UIScreen.main.bounds.size.width, UIScreen.main.bounds.size.height)
         //use height zero to maintain the aspect ratio when fetching
         var size = CGSize(width: imageMaxDimension, height: 0)


### PR DESCRIPTION
Updates the app to Aztec version 21

This version brings the following fixes:

- Better support for video elements without a poster image defined ( Gutenberg video blocks)
- Improved merging of blocks, solves some issues around pre/blockquote/caption/figure

To test:
 - Test the editor with handling of blockquotes, pre and figure
 - Test the editor with insertion of videos in Calypso mode (.com and .org) and Gutenberg mode.


