### PR TITLE
Send Free Space to Zendesk in English.

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -549,12 +549,25 @@ private extension ZendeskUtils {
     static func getDeviceFreeSpace() -> String {
 
         guard let resourceValues = try? URL(fileURLWithPath: "/").resourceValues(forKeys: [.volumeAvailableCapacityKey]),
-            let capacity = resourceValues.volumeAvailableCapacity else {
+            let capacityBytes = resourceValues.volumeAvailableCapacity else {
                 return Constants.unknownValue
         }
 
         // format string using human readable units. ex: 1.5 GB
-        return ByteCountFormatter.string(fromByteCount: Int64(capacity), countStyle: .binary)
+        // Since ByteCountFormatter.string translates the string and has no locale setting,
+        // do the byte conversion manually so the Free Space is in English.
+        let sizeAbbreviations = ["bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+        var sizeAbbreviationsIndex = 0
+        var capacity = Double(capacityBytes)
+
+        while capacity > 1024 {
+            capacity /= 1024
+            sizeAbbreviationsIndex += 1
+        }
+
+        let formattedCapacity = String(format: "%4.2f", capacity)
+        let sizeAbbreviation = sizeAbbreviations[sizeAbbreviationsIndex]
+        return "\(formattedCapacity) \(sizeAbbreviation)"
     }
 
     static func getLogFile() -> String {


### PR DESCRIPTION
Ref #9625 

When the Free Space is sent to Zendesk, it was translated to the device language.

<img width="278" alt="translated" src="https://user-images.githubusercontent.com/1816888/41932036-166cf4b0-793d-11e8-8229-b43cec195df7.png">

This change sends the Free Space in English.

**To test:**

**NOTE**: It is not necessary to actually create a Zendesk ticket. In `ZendeskUtils:getDeviceFreeSpace`, you can log out the `return` value to see what is being sent to Zendesk.
`print("Free Space: \(formattedCapacity) \(sizeAbbreviation)")`

- Change your device language to something vastly different than English (for example, Spanish didn't make a difference. Try something like Arabic).
- Go to Me > Help & Support > Contact Us.
- Verify the logged Free Space is in English, and is the correct value and format. Ex:
`Free Space: 1.68 TB`


