### PR TITLE
[Activity Log] Implement the Flux ActivityStore.

### DIFF
--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -1,0 +1,304 @@
+import Foundation
+import WordPressKit
+import WordPressFlux
+
+// MARK: - Store helper types
+
+enum ActivityAction: Action {
+    case receiveActivities(site: JetpackSiteRef, activities: [Activity])
+    case receiveActivitiesFailed(site: JetpackSiteRef, error: Error)
+
+    case rewind(site: JetpackSiteRef, rewindID: String)
+    case rewindStarted(site: JetpackSiteRef, restoreID: String)
+    case rewindRequestFailed(site: JetpackSiteRef, error: Error)
+    case rewindFinished(site: JetpackSiteRef, restoreID: String)
+    case rewindFailed(site: JetpackSiteRef, restoreID: String)
+
+    case rewindStatusUpdated(site: JetpackSiteRef, status: RewindStatus)
+    case rewindStatusUpdateFailed(site: JetpackSiteRef, error: Error)
+    case rewindStatusUpdateTimedOut(site: JetpackSiteRef)
+}
+
+enum ActivityQuery {
+    case activities(site: JetpackSiteRef)
+    case restoreStatus(site: JetpackSiteRef)
+
+    var site: JetpackSiteRef {
+        switch self {
+        case .activities(let site):
+            return site
+        case .restoreStatus(let site):
+            return site
+        }
+    }
+}
+
+struct ActivityStoreState {
+    var activities = [JetpackSiteRef: [Activity]]()
+    var lastFetch = [JetpackSiteRef: Date]()
+    var fetchingActivities = [JetpackSiteRef: Bool]()
+
+    var rewindStatus = [JetpackSiteRef: RewindStatus]()
+    var fetchingRewindStatus = [JetpackSiteRef: Bool]()
+
+    // This needs to be `fileprivate` because `DelayStateWrapper` is private.
+    fileprivate var rewindStatusRetries = [JetpackSiteRef: DelayStateWrapper]()
+}
+
+private struct DelayStateWrapper {
+    let actionBlock: () -> Void
+
+    var delayCounter = IncrementalDelay(Constants.delaySequence)
+    var retryAttempt: Int
+    var delayedRetryAction: DispatchDelayedAction
+
+    init(actionBlock: @escaping () -> Void) {
+        self.actionBlock = actionBlock
+        self.retryAttempt = 0
+        self.delayedRetryAction = DispatchDelayedAction(delay: .seconds(delayCounter.current), action: actionBlock)
+    }
+
+    mutating func increment() {
+        delayCounter.increment()
+        delayedRetryAction.cancel()
+
+        retryAttempt += 1
+        delayedRetryAction = DispatchDelayedAction(delay: .seconds(delayCounter.current), action: actionBlock)
+    }
+}
+
+private enum Constants {
+    /// Sequence of increasing delays to apply to the fetch restore status mechanism (in seconds)
+    static let delaySequence = [1, 5]
+    static let maxRetries = 12
+}
+
+class ActivityStore: QueryStore<ActivityStoreState, ActivityQuery> {
+
+    fileprivate let refreshInterval: TimeInterval = 60 // seconds
+
+    override func queriesChanged() {
+        super.queriesChanged()
+        processQueries()
+    }
+
+    init() {
+        super.init(initialState: ActivityStoreState())
+    }
+
+    override func logError(_ error: String) {
+        DDLogError(error)
+    }
+
+    func processQueries() {
+        guard !activeQueries.isEmpty else {
+            transaction { state in
+                state.activities = [:]
+                state.rewindStatus = [:]
+                state.rewindStatusRetries = [:]
+                state.lastFetch = [:]
+                state.fetchingActivities = [:]
+                state.fetchingRewindStatus = [:]
+            }
+            return
+        }
+
+        // Fetching Activities.
+        sitesToFetch
+            .forEach { fetchActivities(site: $0) }
+
+
+        // Fetching Status
+        activeQueries.filter {
+            if case .restoreStatus = $0 { return true }
+            else { return false }
+        }
+        .compactMap { $0.site }
+        .filter { state.fetchingRewindStatus[$0] != true }
+        .unique
+        .forEach {
+            fetchRewindStatus(site: $0)
+        }
+
+    }
+    private var sitesToFetch: [JetpackSiteRef] {
+        return activeQueries
+            .filter {
+                if case .activities = $0 { return true }
+                else { return false }
+            }
+            .compactMap { $0.site }
+            .unique
+            .filter { shouldFetch(site: $0) }
+    }
+
+    func shouldFetch(site: JetpackSiteRef) -> Bool {
+        let lastFetch = state.lastFetch[site, default: .distantPast]
+        let needsRefresh = lastFetch + refreshInterval < Date()
+        let currentlyFetching = isFetching(site: site)
+        return needsRefresh && !currentlyFetching
+    }
+
+    func isFetching(site: JetpackSiteRef) -> Bool {
+        return state.fetchingActivities[site, default: false]
+    }
+
+    func isRestoring(site: JetpackSiteRef) -> Bool {
+        return false
+    }
+
+    override func onDispatch(_ action: Action) {
+        guard let activityAction = action as? ActivityAction else {
+            return
+        }
+
+        switch activityAction {
+        case .receiveActivities(let site, let activities):
+            receiveActivities(site: site, activities: activities)
+        case .receiveActivitiesFailed(let site, let error):
+            receiveActivitiesFailed(site: site, error: error)
+        case .rewind(let site, let rewindID):
+            rewind(site: site, rewindID: rewindID)
+        case .rewindStarted(let site, let restoreID):
+            rewindStarted(site: site, restoreID: restoreID)
+        case .rewindRequestFailed(let site, let error):
+            rewindFailed(site: site, error: error)
+        case .rewindStatusUpdated(let site, let status):
+            rewindStatusUpdated(site: site, status: status)
+        case .rewindStatusUpdateFailed(let site, _):
+            delayedRetryFetchRewindStatus(site: site)
+        case .rewindFinished(let site, _),
+             .rewindFailed(let site, _),
+             .rewindStatusUpdateTimedOut(let site):
+            transaction { state in
+                state.fetchingRewindStatus[site] = false
+                state.rewindStatusRetries[site] = nil
+            }
+        }
+    }
+}
+// MARK: - Selectors
+extension ActivityStore {
+    func getActivities(site: JetpackSiteRef) -> [Activity]? {
+        return state.activities[site] ?? nil
+    }
+    func getRewindStatus(site: JetpackSiteRef) -> RewindStatus? {
+        return state.rewindStatus[site] ?? nil
+    }
+}
+
+private extension ActivityStore {
+    func fetchActivities(site: JetpackSiteRef, count: Int = 1000) {
+        remote(site: site)?.getActivityForSite(
+            site.siteID,
+            count: count,
+            success: { [actionDispatcher] (activities, _ /* hasMore */) in
+                actionDispatcher.dispatch(ActivityAction.receiveActivities(site: site, activities: activities))
+        },
+            failure: { [actionDispatcher] error in
+                actionDispatcher.dispatch(ActivityAction.receiveActivitiesFailed(site: site, error: error))
+        })
+    }
+
+    func receiveActivities(site: JetpackSiteRef, activities: [Activity]) {
+        transaction { state in
+            state.activities[site] = activities
+            state.fetchingActivities[site] = false
+            state.lastFetch[site] = Date()
+        }
+    }
+
+    func receiveActivitiesFailed(site: JetpackSiteRef, error: Error) {
+        transaction { state in
+            state.fetchingActivities[site] = false
+            state.lastFetch[site] = Date()
+        }
+    }
+
+    func rewind(site: JetpackSiteRef, rewindID: String) {
+        remote(site: site)?.restoreSite(
+            site.siteID,
+            rewindID: rewindID,
+            success: { [actionDispatcher] restoreID in
+                actionDispatcher.dispatch(ActivityAction.rewindStarted(site: site, restoreID: restoreID))
+            },
+            failure: {  [actionDispatcher] error in
+                actionDispatcher.dispatch(ActivityAction.rewindRequestFailed(site: site, error: error))
+        })
+    }
+
+    func rewindStarted(site: JetpackSiteRef, restoreID: String) {
+        fetchRewindStatus(site: site)
+    }
+
+    func rewindFailed(site: JetpackSiteRef, error: Error) {
+        let message = NSLocalizedString("Unable to restore your site, please try again later or contact support.",
+                                        comment: "Text displayed when a site restore fails.")
+
+        let noticeAction = NoticeAction.post(Notice(title: message))
+
+        actionDispatcher.dispatch(noticeAction)
+    }
+
+    func fetchRewindStatus(site: JetpackSiteRef) {
+        state.fetchingRewindStatus[site] = true
+
+        remote(site: site)?.getRewindStatus(
+            site.siteID,
+            success: { [actionDispatcher] rewindStatus in
+                actionDispatcher.dispatch(ActivityAction.rewindStatusUpdated(site: site, status: rewindStatus))
+            },
+            failure: { [actionDispatcher] error in
+                actionDispatcher.dispatch(ActivityAction.rewindStatusUpdateFailed(site: site, error: error))
+        })
+    }
+
+    func delayedRetryFetchRewindStatus(site: JetpackSiteRef) {
+        // Note: this might look sorta weird, because it appears we're not at any point actually
+        // scheduling the rewind, *but*: initiating/`increment`ing the `DelayStateWrapper` has a side-effect
+        // of automagically calling the closure after an appropriate amount of time elapses.
+
+        guard var existingWrapper = state.rewindStatusRetries[site] else {
+            let newDelayWrapper = DelayStateWrapper { [weak self] in self?.fetchRewindStatus(site: site) }
+
+            state.rewindStatusRetries[site] = newDelayWrapper
+            return
+        }
+
+        guard existingWrapper.retryAttempt < Constants.maxRetries else {
+            existingWrapper.delayedRetryAction.cancel()
+            actionDispatcher.dispatch(ActivityAction.rewindStatusUpdateTimedOut(site: site))
+            return
+        }
+
+        existingWrapper.increment()
+        state.rewindStatusRetries[site] = existingWrapper
+    }
+
+    func rewindStatusUpdated(site: JetpackSiteRef, status: RewindStatus) {
+        state.rewindStatus[site] = status
+
+        guard let restoreStatus = status.restore else {
+            return
+        }
+
+        switch restoreStatus.status {
+        case .running, .queued:
+            delayedRetryFetchRewindStatus(site: site)
+        case .finished:
+            actionDispatcher.dispatch(ActivityAction.rewindFinished(site: site, restoreID: restoreStatus.id))
+        case .fail:
+            actionDispatcher.dispatch(ActivityAction.rewindFailed(site: site, restoreID: restoreStatus.id))
+        }
+    }
+
+    // MARK: - Helpers
+    func remote(site: JetpackSiteRef) -> ActivityServiceRemote? {
+        guard let token = CredentialsService().getOAuthToken(site: site) else {
+            return nil
+        }
+        let api = WordPressComRestApi(oAuthToken: token, userAgent: WPUserAgent.wordPress())
+
+        return ActivityServiceRemote(wordPressComRestApi: api)
+    }
+}

--- a/WordPress/Classes/Stores/StoreContainer.swift
+++ b/WordPress/Classes/Stores/StoreContainer.swift
@@ -18,4 +18,6 @@ class StoreContainer {
     let plugin = PluginStore()
     let notice = NoticeStore()
     let timezone = TimeZoneStore()
+    let activity = ActivityStore()
+
 }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -9,7 +9,7 @@ protocol ActivityDetailPresenter: class {
 enum ActivityListViewModel {
     case loading
     case ready([Activity])
-    case error(String)
+    case error
 
     var noResultsViewModel: NoResultsViewController.Model? {
         switch self {
@@ -39,8 +39,8 @@ enum ActivityListViewModel {
             let rows = activities.map({ activity in
                 return ActivityListRow(
                     activity: activity,
-                    action: { (row) in
-                        presenter.presentDetailsFor(activity: activity)
+                    action: { [weak presenter] (row) in
+                        presenter?.presentDetailsFor(activity: activity)
                     }
                 )
             })

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -196,6 +196,7 @@
 		401A3D022027DBD80099A127 /* PluginListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 401A3D012027DBD80099A127 /* PluginListCell.xib */; };
 		4020B2BD2007AC850002C963 /* WPStyleGuide+Gridicon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4020B2BC2007AC850002C963 /* WPStyleGuide+Gridicon.swift */; };
 		4020B2BE2007AC850002C963 /* WPStyleGuide+Gridicon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4020B2BC2007AC850002C963 /* WPStyleGuide+Gridicon.swift */; };
+		402B2A7920ACD7690027C1DC /* ActivityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 402B2A7820ACD7690027C1DC /* ActivityStore.swift */; };
 		403269922027719C00608441 /* PluginDirectoryAccessoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403269912027719C00608441 /* PluginDirectoryAccessoryItem.swift */; };
 		4034FDEA2007C42400153B87 /* ExpandableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4034FDE92007C42400153B87 /* ExpandableCell.swift */; };
 		4034FDEE2007D4F700153B87 /* ExpandableCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4034FDED2007D4F700153B87 /* ExpandableCell.xib */; };
@@ -1542,6 +1543,7 @@
 		4019B27020885AB900A0C7EB /* Activity.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Activity.storyboard; sourceTree = "<group>"; };
 		401A3D012027DBD80099A127 /* PluginListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListCell.xib; sourceTree = "<group>"; };
 		4020B2BC2007AC850002C963 /* WPStyleGuide+Gridicon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Gridicon.swift"; sourceTree = "<group>"; };
+		402B2A7820ACD7690027C1DC /* ActivityStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStore.swift; sourceTree = "<group>"; };
 		403269912027719C00608441 /* PluginDirectoryAccessoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryAccessoryItem.swift; sourceTree = "<group>"; };
 		4034FDE92007C42400153B87 /* ExpandableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandableCell.swift; sourceTree = "<group>"; };
 		4034FDED2007D4F700153B87 /* ExpandableCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ExpandableCell.xib; sourceTree = "<group>"; };
@@ -5890,6 +5892,7 @@
 				17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */,
 				E1CB6DA2200F376400945457 /* TimeZoneStore.swift */,
 				40ADB15420686870009A9161 /* PluginStore+Persistence.swift */,
+				402B2A7820ACD7690027C1DC /* ActivityStore.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -7253,6 +7256,7 @@
 				1702BBE01CF3034E00766A33 /* DomainsService.swift in Sources */,
 				D817799420ABFDB300330998 /* ReaderPostCellActions.swift in Sources */,
 				FF7E510A1FBDE0C500AD2918 /* MediaAttachment+WordPress.swift in Sources */,
+				402B2A7920ACD7690027C1DC /* ActivityStore.swift in Sources */,
 				E62AFB6A1DC8E593007484FC /* NSAttributedString+WPRichText.swift in Sources */,
 				B54866CA1A0D7042004AC79D /* NSAttributedString+Helpers.swift in Sources */,
 				E105205B1F2B1CF400A948F6 /* BlogToBlogMigration_61_62.swift in Sources */,


### PR DESCRIPTION
Wowee, was that long in the making. I did end up rewriting most of it few times in the meantime because `~turns out~` I made few bad assumptions along the way, but hey. Who doesn't?!

This is part 1 of... at least three, I think. I wanted to break my changes into smaller chunks, so it's easier to review in separation — so this is just the Flux part of it. The new UI part for showing restore status and improved View Model is the next part :)

To test:
1. Go to Activity Log
2. Make sure things still display properly!
3. Try rewinding a site that's semi-disposable, verify that works
4. Throw your hands up in the air like you don't care

Note: there might be some UI weirdness happening around displaying the HUD with status: this shouldn't be considered a blocker, next PR is changing how we deal with that entirely — should be up very soon.

