### PR TITLE
Activity Log: UI updates

### DIFF
--- a/WordPress/Classes/Extensions/Array.swift
+++ b/WordPress/Classes/Extensions/Array.swift
@@ -43,7 +43,9 @@ extension Array {
     /// of the original array by Value.
     ///
     public func sortedGroup<Value: Equatable>(keyPath: KeyPath<Element, Value>) -> [(Value, [Element])] {
-        return sortedGroup { element in return element[keyPath: keyPath] }
+        return sortedGroup {
+            element in return element[keyPath: keyPath]
+        }
     }
 
     /// Returns an array of [(Value, [Element])] resulting of grouping the sorted elements

--- a/WordPress/Classes/Extensions/Array.swift
+++ b/WordPress/Classes/Extensions/Array.swift
@@ -43,11 +43,18 @@ extension Array {
     /// of the original array by Value.
     ///
     public func sortedGroup<Value: Equatable>(keyPath: KeyPath<Element, Value>) -> [(Value, [Element])] {
+        return sortedGroup { element in return element[keyPath: keyPath] }
+    }
+
+    /// Returns an array of [(Value, [Element])] resulting of grouping the sorted elements
+    /// of the original array by the Value returned from the `transforming` closure.
+    ///
+    public func sortedGroup<Value: Equatable>(transforming: ((Element) -> Value)) -> [(Value, [Element])] {
         var currentValue: Value?
         var currentGroup = [Element]()
         var result = [(Value, [Element])]()
         forEach { (element) in
-            let value = element[keyPath: keyPath]
+            let value = transforming(element)
             if currentValue != value {
                 if let currentValue = currentValue {
                     result.append((currentValue, currentGroup))
@@ -62,4 +69,6 @@ extension Array {
         }
         return result
     }
+
+
 }

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -468,9 +468,14 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
             return [self supportsPushNotifications];
         case BlogFeatureThemeBrowsing:
             return [self supportsRestApi] && [self isAdmin];
-        case BlogFeatureActivity:
+        case BlogFeatureActivity: {
             // For now Activity is suported for admin users
-            return [self supportsRestApi] && [self isAdmin];
+            BOOL supportsAL = [self supportsRestApi] && [self isAdmin];
+            BOOL isJetpack = ![self isHostedAtWPcom];
+            BOOL isPaidWPCom = [self isHostedAtWPcom] && [self hasPaidPlan];
+
+            return supportsAL && (isJetpack || isPaidWPCom);
+        }
         case BlogFeatureCustomThemes:
             return [self supportsRestApi] && [self isAdmin] && ![self isHostedAtWPcom];
         case BlogFeaturePremiumThemes:

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -112,8 +112,7 @@ class ActivityStore: QueryStore<ActivityStoreState, ActivityQuery> {
         activeQueries.filter {
             if case .restoreStatus = $0 {
                 return true
-            }
-            else {
+            } else {
                 return false
             }
         }
@@ -130,8 +129,7 @@ class ActivityStore: QueryStore<ActivityStoreState, ActivityQuery> {
             .filter {
                 if case .activities = $0 {
                     return true
-                }
-                else {
+                } else {
                     return false
                 }
             }

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -368,27 +368,7 @@ private extension ActivityStore {
     }
 
     private func mediumString(from date: Date, adjustingTimezoneTo site: JetpackSiteRef) -> String {
-        guard let timezone = timeZone(for: site) else {
-            return date.mediumStringWithTime()
-        }
-
-        let formatter = DateFormatter()
-        formatter.doesRelativeDateFormatting = true
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-        formatter.timeZone = timezone
-
+        let formatter = ActivityDateFormatting.mediumDateFormatterWithTime(for: site)
         return formatter.string(from: date)
-    }
-
-    private func timeZone(for site: JetpackSiteRef) -> TimeZone? {
-        let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-
-        guard let blog = blogService.blog(byBlogId: site.siteID as NSNumber) else {
-            return TimeZone(secondsFromGMT: 0)
-        }
-
-        return blogService.timeZone(for: blog)
     }
 }

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -251,7 +251,7 @@ private extension ActivityStore {
         if let activity = getActivity(site: site, rewindID: rewindID) {
             let formattedString = mediumString(from: activity.published, adjustingTimezoneTo: site)
 
-            let message = String(format: NSLocalizedString("Rewinding to %@", comment: "Notice showing the date the site is being rewinded to"), formattedString)
+            let message = String(format: NSLocalizedString("Rewinding to %@", comment: "Notice showing the date the site is being rewinded to. '%@' is a placeholder that will expand to a date."), formattedString)
             notice = Notice(title: title, message: message)
         } else {
             notice = Notice(title: title)
@@ -273,7 +273,7 @@ private extension ActivityStore {
         if let activity = getActivity(site: site, rewindID: restoreID) {
             let formattedString = mediumString(from: activity.published, adjustingTimezoneTo: site)
 
-            let message = String(format: NSLocalizedString("Rewound to %@", comment: "Notice showing the date the site is being rewinded to"), formattedString)
+            let message = String(format: NSLocalizedString("Rewound to %@", comment: "Notice showing the date the site is being rewinded to. '%@' is a placeholder that will expand to a date."), formattedString)
             notice = Notice(title: title, message: message)
         } else {
             notice = Notice(title: title)

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -334,7 +334,7 @@ private extension ActivityStore {
             // let's keep retrying as long as it's registered — we want users to see the updates.
             // The retry logic should only kick-in when the site is off-screen, so we can pop-up a Notice
             // letting users know what's happening with their site.
-            DispatchDelayedAction(delay: .seconds(Constants.delaySequence.last!)) { [weak self] in
+            _ = DispatchDelayedAction(delay: .seconds(Constants.delaySequence.last!)) { [weak self] in
                 self?.fetchRewindStatus(site: site)
             }
             return

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDateFormatting.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDateFormatting.swift
@@ -1,0 +1,36 @@
+// Activity Log has some specific needs when it comes to formatting Dates, that pop up in few places.
+// (at the minimum the Activity Log list, detail view, and the `ActivityStore`.
+// This encapsulates those needs in one place.
+struct ActivityDateFormatting {
+    static func mediumDateFormatterWithTime(for site: JetpackSiteRef,
+                                            managedObjectContext: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.doesRelativeDateFormatting = true
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        formatter.timeZone = timeZone(for: site)
+
+        return formatter
+    }
+
+    static func longDateFormatterWithoutTime(for site: JetpackSiteRef,
+                                             managedObjectContext: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .long
+        formatter.timeStyle = .none
+        formatter.timeZone = timeZone(for: site)
+
+        return formatter
+    }
+
+    static func timeZone(for site: JetpackSiteRef, managedObjectContext: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) -> TimeZone {
+        let blogService = BlogService(managedObjectContext: managedObjectContext)
+
+        guard let blog = blogService.blog(byBlogId: site.siteID as NSNumber) else {
+            DDLogInfo("[ActivityDateFormatting] Couldn't find a blog with specified siteID. Falling back to UTC.")
+            return TimeZone(secondsFromGMT: 0)!
+        }
+
+        return blogService.timeZone(for: blog)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -5,6 +5,8 @@ import WordPressUI
 class ActivityDetailViewController: UIViewController {
 
     var activity: Activity?
+    var dateFormatter: DateFormatter?
+
     weak var rewindPresenter: ActivityRewindPresenter?
 
     @IBOutlet private var imageView: CircularImageView!
@@ -80,7 +82,7 @@ class ActivityDetailViewController: UIViewController {
         nameLabel.text = activity.actor?.displayName
         roleLabel.text = activity.actor?.role.localizedCapitalized
 
-        dateLabel.text = activity.publishedDateUTCWithoutTime
+        dateLabel.text = dateFormatter?.string(from: activity.published) ?? activity.publishedDateUTCWithoutTime
 
         textLabel.text = activity.text
         summaryLabel.text = activity.summary
@@ -91,7 +93,7 @@ class ActivityDetailViewController: UIViewController {
         let timeFormatter = DateFormatter()
         timeFormatter.dateStyle = .none
         timeFormatter.timeStyle = .short
-        timeFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        timeFormatter.timeZone = dateFormatter?.timeZone ?? TimeZone(secondsFromGMT: 0)
 
         timeLabel.text = timeFormatter.string(from: activity.published)
     }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -5,7 +5,7 @@ import WordPressUI
 class ActivityDetailViewController: UIViewController {
 
     var activity: Activity?
-    var dateFormatter: DateFormatter?
+    var site: JetpackSiteRef?
 
     weak var rewindPresenter: ActivityRewindPresenter?
 
@@ -74,7 +74,7 @@ class ActivityDetailViewController: UIViewController {
     }
 
     private func setupText() {
-        guard let activity = activity else {
+        guard let activity = activity, let site = site else {
             return
         }
 
@@ -82,18 +82,19 @@ class ActivityDetailViewController: UIViewController {
         nameLabel.text = activity.actor?.displayName
         roleLabel.text = activity.actor?.role.localizedCapitalized
 
-        dateLabel.text = dateFormatter?.string(from: activity.published) ?? activity.publishedDateUTCWithoutTime
-
         textLabel.text = activity.text
         summaryLabel.text = activity.summary
 
         rewindButton.setTitle(NSLocalizedString("Rewind", comment: "Title for button allowing user to rewind their Jetpack site"),
                                                 for: .normal)
 
+        let dateFormatter = ActivityDateFormatting.longDateFormatterWithoutTime(for: site)
+        dateLabel.text = dateFormatter.string(from: activity.published)
+
         let timeFormatter = DateFormatter()
         timeFormatter.dateStyle = .none
         timeFormatter.timeStyle = .short
-        timeFormatter.timeZone = dateFormatter?.timeZone ?? TimeZone(secondsFromGMT: 0)
+        timeFormatter.timeZone = dateFormatter.timeZone
 
         timeLabel.text = timeFormatter.string(from: activity.published)
     }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -183,6 +183,7 @@ extension ActivityListViewController: ActivityDetailPresenter {
         }
 
         detailVC.activity = activity
+        detailVC.dateFormatter = viewModel.longDateFormatterWithoutTime
         detailVC.rewindPresenter = self
 
         self.navigationController?.pushViewController(detailVC, animated: true)

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -216,9 +216,10 @@ private extension ActivityListViewController {
     }
 
     func updateNoResults() {
-        hideNoResults()
         if let noResultsViewModel = viewModel.noResultsViewModel() {
             showNoResults(noResultsViewModel)
+        } else {
+            hideNoResults()
         }
     }
 
@@ -234,7 +235,10 @@ private extension ActivityListViewController {
 
         noResultsViewController.bindViewModel(viewModel)
 
-        tableView.addSubview(withFadeAnimation: noResultsViewController.view)
+        if noResultsViewController.view.superview != tableView {
+            tableView.addSubview(withFadeAnimation: noResultsViewController.view)
+        }
+
         addChildViewController(noResultsViewController)
         noResultsViewController.didMove(toParentViewController: self)
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -182,8 +182,8 @@ extension ActivityListViewController: ActivityDetailPresenter {
             return
         }
 
+        detailVC.site = site
         detailVC.activity = activity
-        detailVC.dateFormatter = viewModel.longDateFormatterWithoutTime
         detailVC.rewindPresenter = self
 
         self.navigationController?.pushViewController(detailVC, animated: true)

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -1,3 +1,5 @@
+import WordPressFlux
+
 protocol ActivityRewindPresenter: class {
     func presentRewindFor(activity: Activity)
 }
@@ -6,55 +8,144 @@ protocol ActivityDetailPresenter: class {
     func presentDetailsFor(activity: Activity)
 }
 
-enum ActivityListViewModel {
-    case loading
-    case ready([Activity])
-    case error
+class ActivityListViewModel: Observable {
 
-    var noResultsViewModel: NoResultsViewController.Model? {
-        switch self {
-        case .loading:
-            return NoResultsViewController.Model(title: NSLocalizedString("Loading Activities...", comment: "Text displayed while loading the activity feed for a site"))
-        case .ready:
+    let site: JetpackSiteRef
+    let store: ActivityStore
+
+    let changeDispatcher = Dispatcher<Void>()
+
+    private let activitiesReceipt: Receipt
+    private let rewindStatusReceipt: Receipt
+    private let storeReceipt: Receipt
+
+    var errorViewModel: NoResultsViewController.Model?
+
+    init(site: JetpackSiteRef, store: ActivityStore = StoreContainer.shared.activity) {
+        self.site = site
+        self.store = store
+
+        activitiesReceipt = store.query(.activities(site: site))
+        rewindStatusReceipt = store.query(.restoreStatus(site: site))
+
+        storeReceipt = store.onChange { [weak changeDispatcher] in
+            changeDispatcher?.dispatch()
+        }
+    }
+
+    func noResultsViewModel() -> NoResultsViewController.Model? {
+        guard store.getActivities(site: site) == nil else {
             return nil
-        case .error:
-            let appDelegate = WordPressAppDelegate.sharedInstance()
-            if (appDelegate?.connectionAvailable)! {
-                return NoResultsViewController.Model(title: NSLocalizedString("Oops", comment: ""),
-                                                     subtitle: NSLocalizedString("There was an error loading activities", comment: "Text displayed when there is a failure loading the activity feed"),
-                                                     buttonText: NSLocalizedString("Contact support", comment: "Button label for contacting support"))
-            } else {
-                return NoResultsViewController.Model(title: NSLocalizedString("No connection", comment: ""),
-                                                     subtitle: NSLocalizedString("An active internet connection is required to view activities", comment: ""))
+        }
 
-            }
+        if store.isFetching(site: site) {
+            return NoResultsViewController.Model(title: NSLocalizedString("Loading Activities...", comment: "Text displayed while loading the activity feed for a site"))
+        }
+
+        let appDelegate = WordPressAppDelegate.sharedInstance()
+        if (appDelegate?.connectionAvailable)! {
+            return NoResultsViewController.Model(title: NSLocalizedString("Oops", comment: ""),
+                                                 subtitle: NSLocalizedString("There was an error loading activities", comment: "Text displayed when there is a failure loading the activity feed"),
+                                                 buttonText: NSLocalizedString("Contact support", comment: "Button label for contacting support"))
+        } else {
+            return NoResultsViewController.Model(title: NSLocalizedString("No connection", comment: ""),
+                                                 subtitle: NSLocalizedString("An active internet connection is required to view activities", comment: ""))
+
         }
     }
 
     func tableViewModel(presenter: ActivityDetailPresenter) -> ImmuTable {
-        switch self {
-        case .loading, .error:
+        guard let activities = store.getActivities(site: site) else {
             return .Empty
-        case .ready(let activities):
-            let rows = activities.map({ activity in
-                return ActivityListRow(
-                    activity: activity,
-                    action: { [weak presenter] (row) in
-                        presenter?.presentDetailsFor(activity: activity)
-                    }
-                )
-            })
+        }
 
-            let publishedDateUTCKeyPath = \ActivityListRow.activity.publishedDateUTCWithoutTime
-            let groupedRows = rows.sortedGroup(keyPath: publishedDateUTCKeyPath)
+        let activitiesRows = activities.map({ activity in
+            return ActivityListRow(
+                activity: activity,
+                action: { [weak presenter] (row) in
+                    presenter?.presentDetailsFor(activity: activity)
+                }
+            )
+        })
 
-            let tableSections = groupedRows.map { (date, rows) in
+        let groupedRows = activitiesRows.sortedGroup {
+            return longDateFormatterWithoutTime.string(from: $0.activity.published)
+        }
+
+        let activitiesSections = groupedRows
+            .map { (date, rows) in
                 return ImmuTableSection(headerText: date,
                                         optionalRows: rows,
                                         footerText: nil)
             }
 
-            return ImmuTable(optionalSections: tableSections)
+        return ImmuTable(optionalSections: [restoreStatusSection()] + activitiesSections)
+        // So far the only "extra" section is the restore one. In the future, this will include
+        // showing plugin updates/CTA's and other things like this.
+    }
+
+    private func restoreStatusSection() -> ImmuTableSection? {
+        guard let restore = store.getRewindStatus(site: site)?.restore, restore.status == .running || restore.status == .queued else {
+            return nil
         }
+
+        let title = NSLocalizedString("Currently restoring your site", comment: "Title of the cell displaying status of a rewind in progress")
+        let summary: String
+        let progress = max(Float(restore.progress) / 100, 0.05)
+        // We don't want to show a completely empty progress bar — it'd seem something is broken. 5% looks acceptable
+        // for the starting state.
+
+        if let rewindPoint = store.getActivity(site: site, rewindID: restore.id) {
+            let dateString = mediumDateFormatterWithTime.string(from: rewindPoint.published)
+            let messageFormat = NSLocalizedString("Rewinding to %@",
+                comment: "Text showing the point in time the site is being currently restored to")
+
+            summary = String(format: messageFormat, dateString)
+        } else {
+            summary = ""
+        }
+
+        let rewindRow = RewindStatusRow(
+            title: title,
+            summary: summary,
+            progress: progress
+        )
+
+        return ImmuTableSection(headerText: NSLocalizedString("Rewind", comment: "Title of section showing rewind status"),
+                                rows: [rewindRow],
+                                footerText: nil)
+    }
+
+
+    // MARK: - Date/Time handling
+
+    lazy var longDateFormatterWithoutTime: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .long
+        formatter.timeStyle = .none
+        formatter.timeZone = timeZone(for: site)
+
+        return formatter
+    }()
+
+    lazy var mediumDateFormatterWithTime: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.doesRelativeDateFormatting = true
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        formatter.timeZone = timeZone(for: site)
+
+        return formatter
+    }()
+
+    private func timeZone(for site: JetpackSiteRef) -> TimeZone {
+        let context = ContextManager.sharedInstance().mainContext
+        let blogService = BlogService(managedObjectContext: context)
+
+        guard let blog = blogService.blog(byBlogId: site.siteID as NSNumber) else {
+            return TimeZone(secondsFromGMT: 0)!
+        }
+
+        return blogService.timeZone(for: blog)
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -120,32 +120,10 @@ class ActivityListViewModel: Observable {
     // MARK: - Date/Time handling
 
     lazy var longDateFormatterWithoutTime: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .long
-        formatter.timeStyle = .none
-        formatter.timeZone = timeZone(for: site)
-
-        return formatter
+        return ActivityDateFormatting.longDateFormatterWithoutTime(for: site)
     }()
 
     lazy var mediumDateFormatterWithTime: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.doesRelativeDateFormatting = true
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-        formatter.timeZone = timeZone(for: site)
-
-        return formatter
+        return ActivityDateFormatting.mediumDateFormatterWithTime(for: site)
     }()
-
-    private func timeZone(for site: JetpackSiteRef) -> TimeZone {
-        let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-
-        guard let blog = blogService.blog(byBlogId: site.siteID as NSNumber) else {
-            return TimeZone(secondsFromGMT: 0)!
-        }
-
-        return blogService.timeZone(for: blog)
-    }
 }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -44,11 +44,11 @@ class ActivityListViewModel: Observable {
 
         let appDelegate = WordPressAppDelegate.sharedInstance()
         if (appDelegate?.connectionAvailable)! {
-            return NoResultsViewController.Model(title: NSLocalizedString("Oops", comment: ""),
+            return NoResultsViewController.Model(title: NSLocalizedString("Oops", comment: "Title for the view when there's an error loading Activity Log"),
                                                  subtitle: NSLocalizedString("There was an error loading activities", comment: "Text displayed when there is a failure loading the activity feed"),
                                                  buttonText: NSLocalizedString("Contact support", comment: "Button label for contacting support"))
         } else {
-            return NoResultsViewController.Model(title: NSLocalizedString("No connection", comment: ""),
+            return NoResultsViewController.Model(title: NSLocalizedString("No connection", comment: "Title for the error view when there's no connection"),
                                                  subtitle: NSLocalizedString("An active internet connection is required to view activities", comment: ""))
 
         }
@@ -98,7 +98,7 @@ class ActivityListViewModel: Observable {
         if let rewindPoint = store.getActivity(site: site, rewindID: restore.id) {
             let dateString = mediumDateFormatterWithTime.string(from: rewindPoint.published)
             let messageFormat = NSLocalizedString("Rewinding to %@",
-                comment: "Text showing the point in time the site is being currently restored to")
+                comment: "Text showing the point in time the site is being currently restored to. %@' is a placeholder that will expand to a date.")
 
             summary = String(format: messageFormat, dateString)
         } else {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -56,8 +56,8 @@ open class RewindStatusTableViewCell: ActivityTableViewCell {
 
     @IBOutlet private var progressView: UIProgressView!
 
-    private(set) var title: String = ""
-    private(set) var summary: String = ""
+    private(set) var title = ""
+    private(set) var summary = ""
     private(set) var progress: Float = 0.0
 
     open func configureCell(title: String,

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -51,3 +51,30 @@ open class ActivityTableViewCell: WPTableViewCell {
     @IBOutlet fileprivate var rewindIconContainer: UIView!
     @IBOutlet fileprivate var rewindIcon: UIImageView!
 }
+
+open class RewindStatusTableViewCell: ActivityTableViewCell {
+
+    @IBOutlet private var progressView: UIProgressView!
+
+    private(set) var title: String = ""
+    private(set) var summary: String = ""
+    private(set) var progress: Float = 0.0
+
+    open func configureCell(title: String,
+                            summary: String,
+                            progress: Float) {
+        self.title = title
+        self.summary = summary
+        self.progress = progress
+
+        contentLabel.text = title
+        summaryLabel.text = summary
+
+        iconBackgroundImageView.backgroundColor = WPStyleGuide.wordPressBlue()
+        iconImageView.image = Gridicon.iconOfType(.noticeOutline).imageWithTintColor(.white)
+        iconImageView.isHidden = false
+        rewindIconContainer.isHidden = true
+
+        progressView.setProgress(progress, animated: true)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/RewindStatusRow.swift
+++ b/WordPress/Classes/ViewRelated/Activity/RewindStatusRow.swift
@@ -1,0 +1,24 @@
+
+struct RewindStatusRow: ImmuTableRow {
+
+    typealias CellType = RewindStatusTableViewCell
+
+    static let cell: ImmuTableCell = {
+        let nib = UINib(nibName: "RewindStatusTableViewCell", bundle: Bundle(for: CellType.self))
+        return ImmuTableCell.nib(nib, CellType.self)
+    }()
+
+    let action: ImmuTableAction? = nil
+
+    let title: String
+    let summary: String
+    let progress: Float
+
+    func configureCell(_ cell: UITableViewCell) {
+        let cell = cell as! CellType
+
+        cell.configureCell(title: title, summary: summary, progress: progress)
+        cell.selectionStyle = .none
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Activity/RewindStatusTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Activity/RewindStatusTableViewCell.xib
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14269.14" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14252.5"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="71" id="ArX-Tt-Izx" customClass="RewindStatusTableViewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="323" height="67"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="ArX-Tt-Izx" id="CDt-z4-jmn">
+                <rect key="frame" x="0.0" y="0.0" width="323" height="66.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6Gz-B7-Enk" userLabel="icon" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                        <rect key="frame" x="16" y="12.5" width="38" height="38"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="38" id="P8N-bo-sEE"/>
+                            <constraint firstAttribute="width" constant="38" id="uQ5-UY-w3c"/>
+                        </constraints>
+                    </imageView>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0Of-tF-rRE">
+                        <rect key="frame" x="23" y="19.5" width="24" height="24"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="24" id="CV5-Fd-8zY"/>
+                            <constraint firstAttribute="height" constant="24" id="R4E-ax-Lq1"/>
+                        </constraints>
+                    </imageView>
+                    <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="NER-gg-Sq1">
+                        <rect key="frame" x="64" y="11" width="243" height="40.5"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="Tbk-Tr-FTw">
+                                <rect key="frame" x="0.0" y="0.0" width="221" height="40.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="218" translatesAutoresizingMaskIntoConstraints="NO" id="Dp7-4M-cWe">
+                                        <rect key="frame" x="0.0" y="0.0" width="221" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="218" translatesAutoresizingMaskIntoConstraints="NO" id="fTj-Ko-X8N">
+                                        <rect key="frame" x="0.0" y="22.5" width="221" height="18"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                        <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
+                            </stackView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="myK-Kw-z4d">
+                                <rect key="frame" x="225" y="0.0" width="18" height="40.5"/>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="alw-xI-pFZ">
+                                        <rect key="frame" x="0.0" y="11.5" width="18" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="18" id="7jv-wm-9my"/>
+                                            <constraint firstAttribute="width" constant="18" id="8bv-AL-pdH"/>
+                                        </constraints>
+                                    </imageView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="alw-xI-pFZ" firstAttribute="centerY" secondItem="myK-Kw-z4d" secondAttribute="centerY" id="BNe-fa-7XP"/>
+                                    <constraint firstItem="alw-xI-pFZ" firstAttribute="centerX" secondItem="myK-Kw-z4d" secondAttribute="centerX" id="QrL-4S-sN5"/>
+                                    <constraint firstAttribute="width" priority="999" constant="18" id="gNd-0v-PQ6"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="myK-Kw-z4d" firstAttribute="top" secondItem="NER-gg-Sq1" secondAttribute="top" id="243-rf-LEe"/>
+                            <constraint firstAttribute="trailing" secondItem="myK-Kw-z4d" secondAttribute="trailing" id="NFP-MO-8jz"/>
+                        </constraints>
+                    </stackView>
+                    <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" insetsLayoutMarginsFromSafeArea="NO" progressViewStyle="bar" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="nty-aK-z8B">
+                        <rect key="frame" x="0.0" y="62.5" width="323" height="5"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="4" id="wWm-ff-q3v"/>
+                        </constraints>
+                        <color key="progressTintColor" red="0.0" green="0.66666666669999997" blue="0.86274509799999999" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="trackTintColor" red="0.78431372549019607" green="0.84313725490196079" blue="0.88235294117647056" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                    </progressView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="6Gz-B7-Enk" firstAttribute="centerY" secondItem="NER-gg-Sq1" secondAttribute="centerY" id="4oW-Eb-5zi"/>
+                    <constraint firstItem="NER-gg-Sq1" firstAttribute="leading" secondItem="CDt-z4-jmn" secondAttribute="leading" constant="64" id="5Hc-UA-maH"/>
+                    <constraint firstItem="NER-gg-Sq1" firstAttribute="top" secondItem="CDt-z4-jmn" secondAttribute="top" constant="11" id="E2c-yV-6OW"/>
+                    <constraint firstAttribute="bottom" secondItem="nty-aK-z8B" secondAttribute="bottom" id="Jdc-J4-1Rx"/>
+                    <constraint firstItem="6Gz-B7-Enk" firstAttribute="leading" secondItem="CDt-z4-jmn" secondAttribute="leading" constant="16" id="Poc-zK-UBM"/>
+                    <constraint firstItem="0Of-tF-rRE" firstAttribute="centerY" secondItem="6Gz-B7-Enk" secondAttribute="centerY" id="Wp6-NE-L5B"/>
+                    <constraint firstItem="0Of-tF-rRE" firstAttribute="centerX" secondItem="6Gz-B7-Enk" secondAttribute="centerX" id="fpL-u9-gbf"/>
+                    <constraint firstAttribute="trailing" secondItem="nty-aK-z8B" secondAttribute="trailing" id="fyP-e6-zOe"/>
+                    <constraint firstAttribute="bottom" secondItem="NER-gg-Sq1" secondAttribute="bottom" constant="15" id="mFg-1P-7LS"/>
+                    <constraint firstItem="nty-aK-z8B" firstAttribute="leading" secondItem="CDt-z4-jmn" secondAttribute="leading" id="rlq-8u-X7R"/>
+                    <constraint firstAttribute="trailing" secondItem="NER-gg-Sq1" secondAttribute="trailing" constant="16" id="uUW-8I-hYp"/>
+                </constraints>
+            </tableViewCellContentView>
+            <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+            <connections>
+                <outlet property="contentLabel" destination="Dp7-4M-cWe" id="0li-gE-dou"/>
+                <outlet property="iconBackgroundImageView" destination="6Gz-B7-Enk" id="KLx-eM-FR4"/>
+                <outlet property="iconImageView" destination="0Of-tF-rRE" id="B7M-m6-Cq9"/>
+                <outlet property="progressView" destination="nty-aK-z8B" id="pGi-1E-50A"/>
+                <outlet property="rewindIcon" destination="alw-xI-pFZ" id="So2-ib-HaQ"/>
+                <outlet property="rewindIconContainer" destination="myK-Kw-z4d" id="a0I-Pa-puu"/>
+                <outlet property="summaryLabel" destination="fTj-Ko-X8N" id="7dl-UR-Ydi"/>
+            </connections>
+            <point key="canvasLocation" x="35.5" y="52.5"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
@@ -22,7 +22,7 @@ enum PlanListViewModel {
                                                      subtitle: NSLocalizedString("There was an error loading plans", comment: ""),
                                                      buttonText: NSLocalizedString("Contact support", comment: ""))
             } else {
-                return NoResultsViewController.Model(title: NSLocalizedString("No connection", comment: ""),
+                return NoResultsViewController.Model(title: NSLocalizedString("No connection", comment: "Title for the error view when there's no connection"),
                                                      subtitle: NSLocalizedString("An active internet connection is required to view plans", comment: ""))
             }
         }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewModel.swift
@@ -21,7 +21,6 @@ class PluginDirectoryViewModel: Observable {
     private let popularReceipt: Receipt
     private let newReceipt: Receipt
 
-    private var storeReceipt: Receipt?
     private var actionReceipt: Receipt?
 
     private let throttle = Scheduler(seconds: 1)

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewModel.swift
@@ -211,7 +211,7 @@ class PluginListViewModel: Observable {
                 )
             } else {
                 return WPNoResultsView.Model(
-                    title: NSLocalizedString("No connection", comment: ""),
+                    title: NSLocalizedString("No connection", comment: "Title for the error view when there's no connection"),
                     message: NSLocalizedString("An active internet connection is required to view plugins", comment: "")
                 )
             }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -200,9 +200,11 @@
 		403269922027719C00608441 /* PluginDirectoryAccessoryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403269912027719C00608441 /* PluginDirectoryAccessoryItem.swift */; };
 		4034FDEA2007C42400153B87 /* ExpandableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4034FDE92007C42400153B87 /* ExpandableCell.swift */; };
 		4034FDEE2007D4F700153B87 /* ExpandableCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4034FDED2007D4F700153B87 /* ExpandableCell.xib */; };
+		403F57BC20E5CA6A004E889A /* RewindStatusRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403F57BB20E5CA6A004E889A /* RewindStatusRow.swift */; };
 		4058F41A1FF40EE1000D5559 /* PluginDetailViewHeaderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4058F4191FF40EE1000D5559 /* PluginDetailViewHeaderCell.xib */; };
 		405B53FB1F83C369002E19BF /* FancyAlerts+VerificationPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405B53FA1F83C369002E19BF /* FancyAlerts+VerificationPrompt.swift */; };
 		40640046200ED30300106789 /* TextWithAccessoryButtonCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 40640045200ED30300106789 /* TextWithAccessoryButtonCell.xib */; };
+		4070D75C20E5F55A007CEBDA /* RewindStatusTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4070D75B20E5F55A007CEBDA /* RewindStatusTableViewCell.xib */; };
 		40A2777F20191AA500D078D5 /* PluginDirectoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A2777E20191AA500D078D5 /* PluginDirectoryCollectionViewCell.swift */; };
 		40A2778120191B5E00D078D5 /* PluginDirectoryCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 40A2778020191B5E00D078D5 /* PluginDirectoryCollectionViewCell.xib */; };
 		40ADB15520686870009A9161 /* PluginStore+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40ADB15420686870009A9161 /* PluginStore+Persistence.swift */; };
@@ -1547,9 +1549,11 @@
 		403269912027719C00608441 /* PluginDirectoryAccessoryItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryAccessoryItem.swift; sourceTree = "<group>"; };
 		4034FDE92007C42400153B87 /* ExpandableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandableCell.swift; sourceTree = "<group>"; };
 		4034FDED2007D4F700153B87 /* ExpandableCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ExpandableCell.xib; sourceTree = "<group>"; };
+		403F57BB20E5CA6A004E889A /* RewindStatusRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewindStatusRow.swift; sourceTree = "<group>"; };
 		4058F4191FF40EE1000D5559 /* PluginDetailViewHeaderCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginDetailViewHeaderCell.xib; sourceTree = "<group>"; };
 		405B53FA1F83C369002E19BF /* FancyAlerts+VerificationPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FancyAlerts+VerificationPrompt.swift"; sourceTree = "<group>"; };
 		40640045200ED30300106789 /* TextWithAccessoryButtonCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextWithAccessoryButtonCell.xib; sourceTree = "<group>"; };
+		4070D75B20E5F55A007CEBDA /* RewindStatusTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RewindStatusTableViewCell.xib; sourceTree = "<group>"; };
 		40A2777E20191AA500D078D5 /* PluginDirectoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		40A2778020191B5E00D078D5 /* PluginDirectoryCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginDirectoryCollectionViewCell.xib; sourceTree = "<group>"; };
 		40ADB15420686870009A9161 /* PluginStore+Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PluginStore+Persistence.swift"; sourceTree = "<group>"; };
@@ -4067,6 +4071,7 @@
 			isa = PBXGroup;
 			children = (
 				82FC612B1FA8B7FC00A1757E /* ActivityListRow.swift */,
+				403F57BB20E5CA6A004E889A /* RewindStatusRow.swift */,
 				82A062DD2017BCBA0084CE7C /* ActivityListSectionHeaderView.swift */,
 				82A062DB2017BC220084CE7C /* ActivityListSectionHeaderView.xib */,
 				82FC611D1FA8ADAC00A1757E /* ActivityListViewController.swift */,
@@ -4078,6 +4083,7 @@
 				82B67B351FC726CD006FB593 /* Memoize.swift */,
 				82FC611F1FA8ADAC00A1757E /* WPStyleGuide+Activity.swift */,
 				4019B27020885AB900A0C7EB /* Activity.storyboard */,
+				4070D75B20E5F55A007CEBDA /* RewindStatusTableViewCell.xib */,
 			);
 			path = Activity;
 			sourceTree = "<group>";
@@ -6492,6 +6498,7 @@
 				B5C66B781ACF073900F68370 /* NoteBlockImageTableViewCell.xib in Resources */,
 				B59F34A1207678480069992D /* SignupEpilogue.storyboard in Resources */,
 				B5683DB81B6C03810043447C /* NoteTableHeaderView.xib in Resources */,
+				4070D75C20E5F55A007CEBDA /* RewindStatusTableViewCell.xib in Resources */,
 				5D13FA571AF99C2100F06492 /* PageListSectionHeaderView.xib in Resources */,
 				B54E1DF21A0A7BAA00807537 /* ReplyTextView.xib in Resources */,
 				08D499671CDD20450004809A /* Menus.storyboard in Resources */,
@@ -7545,6 +7552,7 @@
 				7470840F1E269669002CA726 /* JetpackLoginViewController.swift in Sources */,
 				E60C2ED71DE5075100488630 /* ReaderCommentCell.swift in Sources */,
 				5DBCD9D518F35D7500B32229 /* ReaderTopicService.m in Sources */,
+				403F57BC20E5CA6A004E889A /* RewindStatusRow.swift in Sources */,
 				E6DE44671B90D251000FA7EF /* ReaderHelpers.swift in Sources */,
 				5D42A3DF175E7452005CFF05 /* AbstractPost.m in Sources */,
 				FACB36F11C5C2BF800C6DF4E /* ThemeWebNavigationDelegate.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -205,6 +205,7 @@
 		405B53FB1F83C369002E19BF /* FancyAlerts+VerificationPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405B53FA1F83C369002E19BF /* FancyAlerts+VerificationPrompt.swift */; };
 		40640046200ED30300106789 /* TextWithAccessoryButtonCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 40640045200ED30300106789 /* TextWithAccessoryButtonCell.xib */; };
 		4070D75C20E5F55A007CEBDA /* RewindStatusTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4070D75B20E5F55A007CEBDA /* RewindStatusTableViewCell.xib */; };
+		4070D75E20E6B4E4007CEBDA /* ActivityDateFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4070D75D20E6B4E4007CEBDA /* ActivityDateFormatting.swift */; };
 		40A2777F20191AA500D078D5 /* PluginDirectoryCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A2777E20191AA500D078D5 /* PluginDirectoryCollectionViewCell.swift */; };
 		40A2778120191B5E00D078D5 /* PluginDirectoryCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 40A2778020191B5E00D078D5 /* PluginDirectoryCollectionViewCell.xib */; };
 		40ADB15520686870009A9161 /* PluginStore+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40ADB15420686870009A9161 /* PluginStore+Persistence.swift */; };
@@ -1554,6 +1555,7 @@
 		405B53FA1F83C369002E19BF /* FancyAlerts+VerificationPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FancyAlerts+VerificationPrompt.swift"; sourceTree = "<group>"; };
 		40640045200ED30300106789 /* TextWithAccessoryButtonCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextWithAccessoryButtonCell.xib; sourceTree = "<group>"; };
 		4070D75B20E5F55A007CEBDA /* RewindStatusTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RewindStatusTableViewCell.xib; sourceTree = "<group>"; };
+		4070D75D20E6B4E4007CEBDA /* ActivityDateFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityDateFormatting.swift; sourceTree = "<group>"; };
 		40A2777E20191AA500D078D5 /* PluginDirectoryCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryCollectionViewCell.swift; sourceTree = "<group>"; };
 		40A2778020191B5E00D078D5 /* PluginDirectoryCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginDirectoryCollectionViewCell.xib; sourceTree = "<group>"; };
 		40ADB15420686870009A9161 /* PluginStore+Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PluginStore+Persistence.swift"; sourceTree = "<group>"; };
@@ -4082,6 +4084,7 @@
 				825327571FBF7CD600B8B7D2 /* ActivityUtils.swift */,
 				82B67B351FC726CD006FB593 /* Memoize.swift */,
 				82FC611F1FA8ADAC00A1757E /* WPStyleGuide+Activity.swift */,
+				4070D75D20E6B4E4007CEBDA /* ActivityDateFormatting.swift */,
 				4019B27020885AB900A0C7EB /* Activity.storyboard */,
 				4070D75B20E5F55A007CEBDA /* RewindStatusTableViewCell.xib */,
 			);
@@ -7039,6 +7042,7 @@
 				E6D170371EF9D8D10046D433 /* SiteInfo.swift in Sources */,
 				822D60B11F4C747E0016C46D /* JetpackSecuritySettingsViewController.swift in Sources */,
 				E16A76F31FC4766900A661E3 /* CredentialsService.swift in Sources */,
+				4070D75E20E6B4E4007CEBDA /* ActivityDateFormatting.swift in Sources */,
 				E2AA87A518523E5300886693 /* UIView+Subviews.m in Sources */,
 				5D51ADAF19A832AF00539C0B /* WordPress-20-21.xcmappingmodel in Sources */,
 				43FB3F471EC10F1E00FC8A62 /* LoginEpilogueTableViewController.swift in Sources */,


### PR DESCRIPTION
This:
* updates how the AL displays status of a restore currently in progress 
* gets rid of HUD in AL in favor of Notices
* makes sure that we display date/time in site's timezone, not UTC

To test:

* TZ stuff:
    *  Make sure that your website is set to a different timezone than UTC
    * Go to AL
    * Go to any event details
    * Verify that the date/time displayed is correct (you can use Calypso to compare if you're not keen on doing TZ math in your head :P)
* Restore status stuff
    * Go to AL
    * Start a restore
    * Verify the notices posted at the bottom of the screen make sense
    * Verify that there's a new section at the top of the AL during the restore process
    * Verify that the new section displays progress at least somewhat in sync with Calypso (we poll the network much less often than Web does to save our user's data, but it should be ~roughly the same).

Fun fact: during debugging this I found out that I have a site that has a restore hanging since *drumroll* April, 4th. Given it reports as 78% percent complete, it should be done somewhere around July 23rd :P

