### PR TITLE
Fix warning in xib

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.xib
@@ -61,7 +61,7 @@
                     <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="xGK-LG-0cx">
                         <rect key="frame" x="181" y="101" width="20" height="20"/>
                     </activityIndicatorView>
-                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="2Ri-os-5ZW">
+                    <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="2Ri-os-5ZW">
                         <rect key="frame" x="173" y="32" width="37" height="37"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="37" id="9OE-Qz-4LV"/>


### PR DESCRIPTION
Fixes a warning in Xcode.

<img width="356" alt="screen shot 2018-06-28 at 12 31 47 pm" src="https://user-images.githubusercontent.com/517257/42112742-1c28a1d6-7ba6-11e8-896f-9e798fa22428.png">

To test:
- build the project and make sure the above warning doesn't appear.

