### PR TITLE
[ActivityLog] Remove the Activity feature flag.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -4,7 +4,6 @@
 enum FeatureFlag: Int {
     case exampleFeature
     case jetpackDisconnect
-    case activity
     case saveForLater
     case gifSupportInReaderDetail
     case extractNotifications
@@ -16,8 +15,6 @@ enum FeatureFlag: Int {
             return true
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
-        case .activity:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .saveForLater:
             return true
         case .gifSupportInReaderDetail:

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -444,7 +444,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                      [weakSelf showStats];
                                                  }]];
 
-    if ([Feature enabled:FeatureFlagActivity] && [self.blog supports:BlogFeatureActivity]) {
+    if ([self.blog supports:BlogFeatureActivity]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Activity", @"Noun. Links to a blog's Activity screen.")
                                                         image:[Gridicon iconOfType:GridiconTypeHistory]
                                                      callback:^{


### PR DESCRIPTION
This removes the feature flag for Activity Log, shipping it to everyone (as long as their blog is compatible).

![](https://media.giphy.com/media/dcubXtnbck0RG/giphy.gif)
(imagine that says "Activity Log", instead of "Bees")

You get Activity Log, you get Activity Log, and YOU!!! get Activity Log!

To test:
Look at the code :)
But if you wanted to test for realsies, I'm actually not sure. Build the app in release configuration and verify that Activity Log is there?