### PR TITLE
Fix Xcode 10 warnings.

### DIFF
--- a/WordPress/Classes/Models/Notifications/NotificationSettings.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationSettings.swift
@@ -9,15 +9,15 @@ import Foundation
 open class NotificationSettings {
     /// Represents the Channel to which the current settings are associated.
     ///
-    open let channel: Channel
+    public let channel: Channel
 
     /// Contains an array of the available Notification Streams.
     ///
-    open let streams: [Stream]
+    public let streams: [Stream]
 
     /// Maps to the associated blog, if any.
     ///
-    open let blog: Blog?
+    public let blog: Blog?
 
 
 

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -347,7 +347,7 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     }
 }
 
-- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *))restorationHandler {
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
     // Spotlight search
     [SearchManager.shared handleWithActivity: userActivity];
     return YES;

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -347,7 +347,11 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     }
 }
 
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 120000
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable))restorationHandler {
+#else
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler {
+#endif
     // Spotlight search
     [SearchManager.shared handleWithActivity: userActivity];
     return YES;

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
@@ -19,7 +19,7 @@ extension NotificationsViewController {
                 self?.setupPrimeForPush()
             case .denied:
                 self?.setupWinback()
-            case .authorized:
+            default:
                 break
             }
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -143,7 +143,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     // MARK: - State Restoration
 
 
-    open static func viewController(withRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
+    public static func viewController(withRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
         guard let path = coder.decodeObject(forKey: restorablePostObjectURLhKey) as? String else {
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -38,7 +38,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     // Wrapper views
     @IBOutlet fileprivate weak var textHeaderStackView: UIStackView!
     @IBOutlet fileprivate weak var textFooterStackView: UIStackView!
-    fileprivate weak var textFooterTopConstraint: NSLayoutConstraint!
+    fileprivate var textFooterTopConstraint: NSLayoutConstraint!
 
     // Header realated Views
     @IBOutlet fileprivate weak var headerView: UIView!

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -8,7 +8,7 @@ import WordPressShared
 
     // MARK: - Topic Helpers
 
-    open static let discoverSiteID = NSNumber(value: 53424024)
+    public static let discoverSiteID = NSNumber(value: 53424024)
 
     /// Check if the specified topic is a default topic
     ///

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -15,7 +15,7 @@ struct ReaderPostMenuButtonTitles {
 
 
 open class ReaderPostMenu {
-    open static let BlockSiteNotification = "ReaderPostMenuBlockSiteNotification"
+    public static let BlockSiteNotification = "ReaderPostMenuBlockSiteNotification"
 
     open class func showMenuForPost(_ post: ReaderPost, topic: ReaderSiteTopic? = nil, fromView anchorView: UIView, inViewController viewController: UIViewController?) {
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostsViewController.swift
@@ -45,7 +45,7 @@ final class ReaderSavedPostsViewController: UITableViewController {
         updateAndPerformFetchRequest()
     }
 
-    open override func viewDidLayoutSubviews() {
+    public override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
         centerResultsStatusViewIfNeeded()
@@ -129,7 +129,7 @@ final class ReaderSavedPostsViewController: UITableViewController {
     }
 
 
-    @objc open func configurePostCardCell(_ cell: UITableViewCell, post: ReaderPost) {
+    @objc public func configurePostCardCell(_ cell: UITableViewCell, post: ReaderPost) {
         if postCellActions == nil {
             postCellActions = ReaderSavedPostCellActions(context: managedObjectContext(), origin: self, topic: post.topic, visibleConfirmation: false)
             postCellActions?.delegate = self

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -53,7 +53,7 @@ import Gridicons
     // MARK: - State Restoration
 
 
-    open static func viewController(withRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
+    public static func viewController(withRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
         guard let path = coder.decodeObject(forKey: restorableSearchTopicPathKey) as? String else {
             return ReaderSearchViewController.controller()
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -157,7 +157,7 @@ import WordPressFlux
     // MARK: - State Restoration
 
 
-    open static func viewController(withRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
+    public static func viewController(withRestorationIdentifierPath identifierComponents: [Any], coder: NSCoder) -> UIViewController? {
         guard let path = coder.decodeObject(forKey: restorableTopicPathKey) as? String else {
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
@@ -70,7 +70,7 @@ public enum ThemeAction {
 open class ThemeBrowserCell: UICollectionViewCell {
     // MARK: - Constants
 
-    @objc open static let reuseIdentifier = "ThemeBrowserCell"
+    @objc public static let reuseIdentifier = "ThemeBrowserCell"
 
     // MARK: - Private Aliases
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
@@ -4,7 +4,7 @@ import WordPressShared
 open class ThemeBrowserHeaderView: UICollectionReusableView {
     // MARK: - Constants
 
-    @objc open static let reuseIdentifier = "ThemeBrowserHeaderView"
+    @objc public static let reuseIdentifier = "ThemeBrowserHeaderView"
 
     // MARK: - Private Aliases
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -820,7 +820,7 @@ public protocol ThemePresenter: class {
                 alertController.presentFromRootViewController()
             },
             failure: { (error) in
-                DDLogError("Error activating theme \(theme.themeId): \(String(describing: error?.localizedDescription))")
+                DDLogError("Error activating theme \(String(describing: theme.themeId)): \(String(describing: error?.localizedDescription))")
 
                 let errorTitle = NSLocalizedString("Activation Error", comment: "Title of alert when theme activation fails")
                 let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")

--- a/WordPress/Classes/ViewRelated/Views/NavigationTitleView.swift
+++ b/WordPress/Classes/ViewRelated/Views/NavigationTitleView.swift
@@ -3,8 +3,8 @@ import UIKit
 import WordPressShared.WPFontManager
 
 open class NavigationTitleView: UIView {
-    @objc open let titleLabel       = UILabel(frame: defaultTitleFrame)
-    @objc open let subtitleLabel    = UILabel(frame: defaultSubtitleFrame)
+    @objc public let titleLabel       = UILabel(frame: defaultTitleFrame)
+    @objc public let subtitleLabel    = UILabel(frame: defaultSubtitleFrame)
 
 
     // MARK: - UIView's Methods

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -479,7 +479,7 @@ extension WPRichContentView: WPTableImageSourceDelegate {
     func tableImageSource(_ tableImageSource: WPTableImageSource!, imageFailedforIndexPath indexPath: IndexPath!, error: Error!) {
         let richMedia = mediaArray[indexPath.row]
         DDLogError("Error loading image: \(richMedia.attachment.src)")
-        DDLogError("\(error)")
+        DDLogError("\(String(describing: error))")
     }
 }
 


### PR DESCRIPTION
I've been using Xcode 10 for the past few days and I'm super pleasantly surprised how stable and fast it is.

However, WPiOS throws up few new warnings when building it in Xcode 10. 

This PR fixes it!

To test:
* Build WPiOS in Xcode 10
* Verify that there are no warnings
* Build WPiOS in Xcode 9
* Verify that it still compiles and also doesn't show any warnings.