### PR TITLE
Update minimal Swift/Xcode version in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ### Download Xcode
 
-At the moment *WordPress for iOS requires Swift 3.0 and Xcode 9.0 or newer. Previous versions of Xcode can be [downloaded from Apple](https://developer.apple.com/downloads/index.action).*
+At the moment *WordPress for iOS requires Swift 4.0 and Xcode 9.3 or newer. Previous versions of Xcode can be [downloaded from Apple](https://developer.apple.com/downloads/index.action).*
 
 ### Third party tools
 


### PR DESCRIPTION
The minimum Swift/Xcode versions specified in our README were outdated and misleading. Not anymore :)

To test:
I mean... 