### PR TITLE
Fix crash on iPads for wpcom accounts without any blogs

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.h
@@ -8,7 +8,7 @@
 
 - (void)setSelectedBlog:(Blog *)selectedBlog animated:(BOOL)animated;
 
-- (void)presentInterfaceForAddingNewSite;
+- (void)presentInterfaceForAddingNewSiteFrom:(UIView *)sourceView;
 - (void)bypassBlogListViewController;
 - (BOOL)shouldBypassBlogListViewControllerWhenSelectedFromTabBar;
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -431,10 +431,10 @@ static NSInteger HideSearchMinSites = 3;
 
 #pragma mark - Public methods
 
-- (void)presentInterfaceForAddingNewSite
+- (void)presentInterfaceForAddingNewSiteFrom:(UIView *)sourceView
 {
     [self.navigationController popToRootViewControllerAnimated:YES];
-    [self addSite];
+    [self showAddSiteAlertFromView:sourceView];
 }
 
 - (BOOL)shouldBypassBlogListViewControllerWhenSelectedFromTabBar
@@ -868,7 +868,7 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)addSite
 {
-    [self showAddSiteAlertFromButton:self.noResultsViewController.actionButton];
+    [self showAddSiteAlertFromView:self.noResultsViewController.actionButton];
 }
 
 - (UIAlertController *)makeAddSiteAlertController
@@ -876,6 +876,7 @@ static NSInteger HideSearchMinSites = 3;
     UIAlertController *addSiteAlertController = [UIAlertController alertControllerWithTitle:nil
                                                                                     message:nil
                                                                              preferredStyle:UIAlertControllerStyleActionSheet];
+//    addSiteAlertController.popoverPresentationController.sourceView = self.noResultsViewController.actionButton;
     if ([self defaultWordPressComAccount]) {
         UIAlertAction *addNewWordPressAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Create WordPress.com site", @"Create WordPress.com site button")
                                                                         style:UIAlertActionStyleDefault
@@ -981,18 +982,18 @@ static NSInteger HideSearchMinSites = 3;
 #pragma mark - NoResultsViewControllerDelegate
 
 - (void)actionButtonPressed {
-    [self addSite];
+    [self showAddSiteAlertFromView:self.noResultsViewController.actionButton];
 }
 
 #pragma mark - View Delegate Helper
 
-- (void)showAddSiteAlertFromButton:(UIButton *)sourceButton
+- (void)showAddSiteAlertFromView:(UIView *)sourceView
 {
     if (self.dataSource.allBlogsCount == 0) {
         UIAlertController *addSiteAlertController = [self makeAddSiteAlertController];
-        addSiteAlertController.popoverPresentationController.sourceView = sourceButton;
-        addSiteAlertController.popoverPresentationController.sourceRect = sourceButton.bounds;
-        addSiteAlertController.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
+        addSiteAlertController.popoverPresentationController.sourceView = sourceView;
+        addSiteAlertController.popoverPresentationController.sourceRect = sourceView.bounds;
+        addSiteAlertController.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp | UIPopoverArrowDirectionDown;
         
         [self presentViewController:addSiteAlertController animated:YES completion:nil];
         self.addSiteAlertController = addSiteAlertController;

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -993,7 +993,7 @@ static NSInteger HideSearchMinSites = 3;
         UIAlertController *addSiteAlertController = [self makeAddSiteAlertController];
         addSiteAlertController.popoverPresentationController.sourceView = sourceView;
         addSiteAlertController.popoverPresentationController.sourceRect = sourceView.bounds;
-        addSiteAlertController.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp | UIPopoverArrowDirectionDown;
+        addSiteAlertController.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionUp;
         
         [self presentViewController:addSiteAlertController animated:YES completion:nil];
         self.addSiteAlertController = addSiteAlertController;

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -868,11 +868,7 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)addSite
 {
-    UIAlertController *addSiteAlertController = [self makeAddSiteAlertController];
-    addSiteAlertController.popoverPresentationController.barButtonItem = self.addSiteButton;
-
-    [self presentViewController:addSiteAlertController animated:YES completion:nil];
-    self.addSiteAlertController = addSiteAlertController;
+    [self showAddSiteAlertFromButton:self.noResultsViewController.actionButton];
 }
 
 - (UIAlertController *)makeAddSiteAlertController
@@ -985,7 +981,7 @@ static NSInteger HideSearchMinSites = 3;
 #pragma mark - NoResultsViewControllerDelegate
 
 - (void)actionButtonPressed {
-    [self showAddSiteAlertFromButton:self.noResultsViewController.actionButton];
+    [self addSite];
 }
 
 #pragma mark - View Delegate Helper

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -876,7 +876,7 @@ static NSInteger HideSearchMinSites = 3;
     UIAlertController *addSiteAlertController = [UIAlertController alertControllerWithTitle:nil
                                                                                     message:nil
                                                                              preferredStyle:UIAlertControllerStyleActionSheet];
-//    addSiteAlertController.popoverPresentationController.sourceView = self.noResultsViewController.actionButton;
+
     if ([self defaultWordPressComAccount]) {
         UIAlertAction *addNewWordPressAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Create WordPress.com site", @"Create WordPress.com site button")
                                                                         style:UIAlertActionStyleDefault

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -574,7 +574,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (void)switchMySitesTabToAddNewSite
 {
     [self showTabForIndex:WPTabMySites];
-    [self.blogListViewController presentInterfaceForAddingNewSite];
+    [self.blogListViewController presentInterfaceForAddingNewSiteFrom:self.tabBar];
 }
 
 - (void)switchMySitesTabToStatsViewForBlog:(Blog *)blog


### PR DESCRIPTION
Refs #8807

Our new WordPress.com signup process allows users to use the app without having any blogs. Sadly when on iPad these users can crash the app just by tapping the Write button in the tab bar. This PR fixes that, by presenting the options to create or add a blog, just as on iPhone.

To test:
- on iPad, login with a wpcom user that has no blogs
- tap the Write button
- ensure the app does not crash

