### PR TITLE
Fix a bundle issue with WPAuth

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -67,7 +67,7 @@ target 'WordPress' do
     pod 'Gridicons', '0.15'
     pod 'NSURL+IDN', '0.3'
     pod 'WPMediaPicker', '1.1'
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'd0b3c02'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'c0dd5556e2ecca15e7b662dcdd6d400729da30bc'
     pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e8c86c1c1006335a987332e7327af1a3fec3dbcd'
     pod 'WordPress-Aztec-iOS/WordPressEditor', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit =>'e8c86c1c1006335a987332e7327af1a3fec3dbcd'
     pod 'WordPressUI', '1.0.4'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -166,7 +166,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `e8c86c1c1006335a987332e7327af1a3fec3dbcd`)
   - WordPress-Aztec-iOS/WordPressEditor (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `e8c86c1c1006335a987332e7327af1a3fec3dbcd`)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `d0b3c02`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `c0dd5556e2ecca15e7b662dcdd6d400729da30bc`)
   - WordPressKit (= 1.1)
   - WordPressShared (= 1.0.7)
   - WordPressUI (= 1.0.4)
@@ -216,7 +216,7 @@ EXTERNAL SOURCES:
     :commit: e8c86c1c1006335a987332e7327af1a3fec3dbcd
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressAuthenticator:
-    :commit: d0b3c02
+    :commit: c0dd5556e2ecca15e7b662dcdd6d400729da30bc
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
@@ -227,7 +227,7 @@ CHECKOUT OPTIONS:
     :commit: e8c86c1c1006335a987332e7327af1a3fec3dbcd
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressAuthenticator:
-    :commit: d0b3c02
+    :commit: c0dd5556e2ecca15e7b662dcdd6d400729da30bc
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -266,6 +266,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 80c05df3d6ad2dfbc528b83559432e8a7d88d45b
+PODFILE CHECKSUM: 4f39a6f93769c79b8f16c74679b3961eec252576
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Fixes #9692

To test:
1. Open the login screen
2. Login and then login by site address
3. Select the need help for finding the site address button
4. Check that the fancy alert pops up and the image is there. 


