### PR TITLE
Localized favourite to en_US

### DIFF
--- a/WordPress/Resources/AppStoreStrings.po
+++ b/WordPress/Resources/AppStoreStrings.po
@@ -71,7 +71,7 @@ msgstr ""
 
 #. translators: This is a promo message.
 msgctxt "app_store_screenshot-1"
-msgid "Enjoy your favourite sites"
+msgid "Enjoy your favorite sites"
 msgstr ""
 
 #. translators: This is a promo message.


### PR DESCRIPTION
Minor translation fix making string en_US base, will become favourite in en_GB, en_CA, en_AU, etc.