### PR TITLE
Issue/9673 Universal Links: Handle new post links

### DIFF
--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -20,6 +20,11 @@ extern NSString *const WPBlogUpdatedNotification;
 - (nullable Blog *)blogByBlogId:(NSNumber *)blogID;
 
 /**
+ Returns the blog that matches with a given hostname
+ */
+- (nullable Blog *)blogByHostname:(NSString *)hostname;
+
+/**
  Returns the blog currently flagged as the one last used, or the primary blog,
  or the first blog in an alphanumerically sorted list, whichever is found first.
  */

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -33,6 +33,19 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
     return [self blogWithPredicate:predicate];
 }
 
+- (Blog *)blogByHostname:(NSString *)hostname
+{
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"url CONTAINS %@", hostname];
+    NSArray <Blog *>* blogs = [self blogsWithPredicate:predicate];
+    for (Blog *blog in blogs) {
+        if ([blog.hostname isEqualToString:hostname]) {
+            return blog;
+        }
+    }
+
+    return nil;
+}
+
 - (Blog *)lastUsedOrFirstBlog
 {
     Blog *blog = [self lastUsedOrPrimaryBlog];

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -98,6 +98,15 @@ extension WordPressAppDelegate {
 
         WordPressAuthenticator.shared.delegate = authManager
     }
+
+    @objc func handleWebActivity(_ activity: NSUserActivity) {
+        guard activity.activityType == NSUserActivityTypeBrowsingWeb,
+            let url = activity.webpageURL else {
+                return
+        }
+
+        UniversalLinkRouter.shared.handle(url: url)
+    }
 }
 
 // MARK: - UIAppearance

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -348,8 +348,12 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
 }
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *))restorationHandler {
-    // Spotlight search
-    [SearchManager.shared handleWithActivity: userActivity];
+    if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
+        [self handleWebActivity:userActivity];
+    } else {
+        // Spotlight search
+        [SearchManager.shared handleWithActivity: userActivity];
+    }
     return YES;
 }
 

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -13,7 +13,7 @@ protocol Route {
 }
 
 protocol NavigationAction {
-    func perform()
+    func perform(_ values: [String: String]?)
 }
 
 // MARK: - Route helper methods

--- a/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
@@ -20,7 +20,7 @@ enum MeNavigationAction: NavigationAction {
     case accountSettings
     case notificationSettings
 
-    func perform() {
+    func perform(_ values: [String: String]? = nil) {
         switch self {
         case .root:
             WPTabBarController.sharedInstance().popMeTabToRoot()

--- a/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+struct NewPostRoute: Route {
+    let path = "/post"
+    let action: NavigationAction = NewPostNavigationAction()
+}
+
+struct NewPostForSiteRoute: Route {
+    let path = "/post/:\(NewPostRoutePlaceholder.site.rawValue)"
+    let action: NavigationAction = NewPostNavigationAction()
+}
+
+struct NewPostNavigationAction: NavigationAction {
+    func perform(_ values: [String: String]? = nil) {
+        if let site = values?[NewPostRoutePlaceholder.site.rawValue] {
+            let context = ContextManager.sharedInstance().mainContext
+            let service = BlogService(managedObjectContext: context)
+            let blog = service.blog(byHostname: site)
+            WPTabBarController.sharedInstance().showPostTab(for: blog)
+        } else {
+            WPTabBarController.sharedInstance().showPostTab()
+        }
+    }
+}
+
+private enum NewPostRoutePlaceholder: String {
+    case site
+}

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -27,7 +27,7 @@ struct UniversalLinkRouter {
         let matches = matcher.routesMatching(url.path)
 
         for matchedRoute in matches {
-            matchedRoute.action.perform()
+            matchedRoute.action.perform(matchedRoute.values)
         }
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -17,7 +17,9 @@ struct UniversalLinkRouter {
     static let shared = UniversalLinkRouter(routes: [
         MeRoute(),
         MeAccountSettingsRoute(),
-        MeNotificationSettingsRoute()
+        MeNotificationSettingsRoute(),
+        NewPostRoute(),
+        NewPostForSiteRoute()
         ])
 
     /// Attempts to find a Route that matches the url's path, and perform its

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -35,6 +35,7 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)showMySitesTab;
 - (void)showReaderTab;
 - (void)showPostTab;
+- (void)showPostTabForBlog:(Blog *)blog;
 - (void)showMeTab;
 - (void)showNotificationsTab;
 - (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -479,6 +479,17 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     }
 }
 
+- (void)showPostTabForBlog:(Blog *)blog
+{
+    NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+    if ([blogService blogCountForAllAccounts] == 0) {
+        [self switchMySitesTabToAddNewSite];
+    } else {
+        [self showPostTabAnimated:YES toMedia:NO blog:blog];
+    }
+}
+
 - (void)showMeTab
 {
     [self showTabForIndex:WPTabMe];
@@ -491,15 +502,23 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia
 {
+    [self showPostTabAnimated:animated toMedia:openToMedia blog:nil];
+}
+
+- (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia blog:(Blog *)blog
+{
     if (self.presentedViewController) {
         [self dismissViewControllerAnimated:NO completion:nil];
     }
 
-    Blog *blog = [self currentlyVisibleBlog];
-    if (blog == nil) {
-        NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-        BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-        blog = [blogService lastUsedOrFirstBlog];
+    if (!blog) {
+        blog = [self currentlyVisibleBlog];
+
+        if (blog == nil) {
+            NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+            BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+            blog = [blogService lastUsedOrFirstBlog];
+        }
     }
 
     EditPostViewController* editor = [[EditPostViewController alloc] initWithBlog:blog];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		08F8CD3B1EBD2D020049D0C0 /* MediaURLExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F8CD3A1EBD2D020049D0C0 /* MediaURLExporterTests.swift */; };
 		1702BBDC1CEDEA6B00766A33 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */; };
 		1702BBE01CF3034E00766A33 /* DomainsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDF1CF3034E00766A33 /* DomainsService.swift */; };
+		1703D04C20ECD93800D292E9 /* Routes+Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1703D04B20ECD93800D292E9 /* Routes+Post.swift */; };
 		1705E55020A5DA5700EF1C9D /* ReaderSavedPostsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1705E54F20A5DA5700EF1C9D /* ReaderSavedPostsViewController.swift */; };
 		1707CE421F3121750020B7FE /* UICollectionViewCell+Tint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1707CE411F3121750020B7FE /* UICollectionViewCell+Tint.swift */; };
 		170CE7402064478600A48191 /* PostNoticeNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170CE73F2064478600A48191 /* PostNoticeNavigationCoordinator.swift */; };
@@ -1450,6 +1451,7 @@
 		131D0EE49695795ECEDAA446 /* Pods-WordPressTest.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BadgeLabel.swift; sourceTree = "<group>"; };
 		1702BBDF1CF3034E00766A33 /* DomainsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DomainsService.swift; sourceTree = "<group>"; };
+		1703D04B20ECD93800D292E9 /* Routes+Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Post.swift"; sourceTree = "<group>"; };
 		1705E54F20A5DA5700EF1C9D /* ReaderSavedPostsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSavedPostsViewController.swift; sourceTree = "<group>"; };
 		1707CE411F3121750020B7FE /* UICollectionViewCell+Tint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+Tint.swift"; sourceTree = "<group>"; };
 		170CE73F2064478600A48191 /* PostNoticeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNoticeNavigationCoordinator.swift; sourceTree = "<group>"; };
@@ -3290,6 +3292,7 @@
 			children = (
 				17B7C89F20EC1D6A0042E260 /* Route.swift */,
 				17F0E1D920EBDC0A001E9514 /* Routes+Me.swift */,
+				1703D04B20ECD93800D292E9 /* Routes+Post.swift */,
 				1714F8CF20E6DA8900226DCB /* RouteMatcher.swift */,
 				17B7C89D20EC1D0D0042E260 /* UniversalLinkRouter.swift */,
 			);
@@ -7490,6 +7493,7 @@
 				5DF7F7781B223916003A05C8 /* PostToPost30To31.m in Sources */,
 				7E52B7181FC89F2400B55EB8 /* MediaNoResultsView.swift in Sources */,
 				1746D7771D2165AE00B11D77 /* ForcePopoverPresenter.swift in Sources */,
+				1703D04C20ECD93800D292E9 /* Routes+Post.swift in Sources */,
 				E11C4B702010930B00A6619C /* Blog+Jetpack.swift in Sources */,
 				821738091FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift in Sources */,
 				5D6C4B081B603E03005E3C43 /* WPContentSyncHelper.swift in Sources */,

--- a/WordPress/WordPressTest/RouteMatcherTests.swift
+++ b/WordPress/WordPressTest/RouteMatcherTests.swift
@@ -7,7 +7,7 @@ private struct TestRoute: Route {
 }
 
 private struct TestAction: NavigationAction {
-    func perform() {}
+    func perform(_ values: [String: String]?) {}
 }
 
 class RouteMatcherTests: XCTestCase {


### PR DESCRIPTION
Implements #9673.

This PR follows on from #9694, and adds two new routes for New Posts.

* `/post`
* `/post/:domain`

**To test:**

* Same as the previous PR, add an `applinks:` entry to the Associated Domains capability for the test domain I provided.
* Open the test page I created on your device, and try both of the links in the New Posts section.
  * The first should open the editor with your primary or last used site.
  * The second has a text field where you can enter a domain (e.g. `myawesomeblog.wordpress.com`). Then tap the link. If the domain matches a site in the app, it'll open the editor for that site. Otherwise it'll default to primary or last used.