### PR TITLE
Issue/9668 Universal Links: Handle Notifications link

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
@@ -23,6 +23,7 @@ enum MeNavigationAction: NavigationAction {
     func perform(_ values: [String: String]? = nil) {
         switch self {
         case .root:
+            WPTabBarController.sharedInstance().showMeTab()
             WPTabBarController.sharedInstance().popMeTabToRoot()
         case .accountSettings:
             WPTabBarController.sharedInstance().switchMeTabToAccountSettings()

--- a/WordPress/Classes/Utility/Universal Links/Routes+Notifications.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Notifications.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct NotificationsRoute: Route {
+    let path = "/notifications"
+    let action: NavigationAction = NotificationsNavigationAction()
+}
+
+struct NotificationsNavigationAction: NavigationAction {
+    func perform(_ values: [String: String]?) {
+        WPTabBarController.sharedInstance().showNotificationsTab()
+        WPTabBarController.sharedInstance().popNotificationsTabToRoot()
+    }
+}

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -19,7 +19,8 @@ struct UniversalLinkRouter {
         MeAccountSettingsRoute(),
         MeNotificationSettingsRoute(),
         NewPostRoute(),
-        NewPostForSiteRoute()
+        NewPostForSiteRoute(),
+        NotificationsRoute()
         ])
 
     /// Attempts to find a Route that matches the url's path, and perform its

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -54,7 +54,9 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)switchMeTabToAppSettings;
 - (void)switchMeTabToNotificationSettings;
 - (void)switchMeTabToSupport;
+
 - (void)popMeTabToRoot;
+- (void)popNotificationsTabToRoot;
 
 - (void)switchReaderTabToSavedPosts;
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -550,6 +550,12 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     }
 }
 
+
+- (void)popNotificationsTabToRoot
+{
+    [self.notificationsNavigationController popToRootViewControllerAnimated:NO];
+}
+
 - (void)switchTabToPostsListForPost:(AbstractPost *)post
 {
     UIViewController *topVC = [self.blogListSplitViewController topDetailViewController];

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -550,6 +550,10 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     }
 }
 
+- (void)popMeTabToRoot
+{
+    [self.meNavigationController popToRootViewControllerAnimated:NO];
+}
 
 - (void)popNotificationsTabToRoot
 {
@@ -709,12 +713,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.meViewController navigateToHelpAndSupport];
     });
-}
-
-- (void)popMeTabToRoot
-{
-    [self showMeTab];
-    [self.meNavigationController popToRootViewControllerAnimated:NO];
 }
 
 - (void)switchReaderTabToSavedPosts

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		17AF92251C46634000A99CFB /* BlogSiteVisibilityHelperTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */; };
 		17B7C89E20EC1D0D0042E260 /* UniversalLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B7C89D20EC1D0D0042E260 /* UniversalLinkRouter.swift */; };
 		17B7C8A020EC1D6A0042E260 /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B7C89F20EC1D6A0042E260 /* Route.swift */; };
+		17B7C8C120EE2A870042E260 /* Routes+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B7C8C020EE2A870042E260 /* Routes+Notifications.swift */; };
 		17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */; };
 		17BEE0041FC867C20074C124 /* WordPressAppDelegate+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BEE0031FC867C20074C124 /* WordPressAppDelegate+Swift.swift */; };
 		17CE77ED20C6C2F3001DEA5A /* ReaderSiteSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */; };
@@ -1495,6 +1496,7 @@
 		17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogSiteVisibilityHelperTest.m; sourceTree = "<group>"; };
 		17B7C89D20EC1D0D0042E260 /* UniversalLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalLinkRouter.swift; sourceTree = "<group>"; };
 		17B7C89F20EC1D6A0042E260 /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
+		17B7C8C020EE2A870042E260 /* Routes+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Notifications.swift"; sourceTree = "<group>"; };
 		17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaLibraryViewController.swift; sourceTree = "<group>"; };
 		17BEE0031FC867C20074C124 /* WordPressAppDelegate+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAppDelegate+Swift.swift"; sourceTree = "<group>"; };
 		17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchService.swift; sourceTree = "<group>"; };
@@ -3292,6 +3294,7 @@
 			children = (
 				17B7C89F20EC1D6A0042E260 /* Route.swift */,
 				17F0E1D920EBDC0A001E9514 /* Routes+Me.swift */,
+				17B7C8C020EE2A870042E260 /* Routes+Notifications.swift */,
 				1703D04B20ECD93800D292E9 /* Routes+Post.swift */,
 				1714F8CF20E6DA8900226DCB /* RouteMatcher.swift */,
 				17B7C89D20EC1D0D0042E260 /* UniversalLinkRouter.swift */,
@@ -7679,6 +7682,7 @@
 				087EBFA81F02313E001F7ACE /* MediaThumbnailService.swift in Sources */,
 				08F8CD2A1EBD22EF0049D0C0 /* MediaExporter.swift in Sources */,
 				E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */,
+				17B7C8C120EE2A870042E260 /* Routes+Notifications.swift in Sources */,
 				E6431DE71C4E892900FD8D90 /* SharingViewController.m in Sources */,
 				FF286C761DE70A4500383A62 /* NSURL+Exporters.swift in Sources */,
 				E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */,


### PR DESCRIPTION
Implements #9668.

This PR follows on from #9702, and adds a universal links route for Notifications:

* `/notifications`

**To test:**

* Same as the previous PR, add an applinks: entry to the Associated Domains capability for the test domain I provided.
* In Safari on your device, open the test page I created and try the Notifications link. Check that the notifications section of the app launches.

Thanks so much for taking a look at these PRs, @etoledom!