### PR TITLE
Make WPAnimatedBox animation loop

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPAnimatedBox.m
+++ b/WordPress/Classes/ViewRelated/Views/WPAnimatedBox.m
@@ -105,7 +105,7 @@ static CGFloat const WPAnimatedBoxYPosPage3 = WPAnimatedBoxAnimationTolerance + 
     [UIView animateWithDuration:1.2 delay:0.2 usingSpringWithDamping:0.5 initialSpringVelocity:0.1 options:UIViewAnimationOptionCurveEaseOut animations:^{
         self->_page3.transform = CGAffineTransformIdentity;
     } completion:^void(BOOL finished) {
-        [UIView animateWithDuration:0.8 delay:0.0 usingSpringWithDamping:0.8 initialSpringVelocity:0.0 options:UIViewAnimationOptionCurveEaseOut animations:^{
+        [UIView animateWithDuration:0.8 delay:2.0 usingSpringWithDamping:0.8 initialSpringVelocity:0.0 options:UIViewAnimationOptionCurveEaseOut animations:^{
             [self moveAnimationToFirstFrame];
         } completion:^(BOOL finished) {
             [self playAnimation];

--- a/WordPress/Classes/ViewRelated/Views/WPAnimatedBox.m
+++ b/WordPress/Classes/ViewRelated/Views/WPAnimatedBox.m
@@ -101,12 +101,16 @@ static CGFloat const WPAnimatedBoxYPosPage3 = WPAnimatedBoxAnimationTolerance + 
     } completion:nil];
     [UIView animateWithDuration:1 delay:0.0 usingSpringWithDamping:0.65 initialSpringVelocity:0.01 options:UIViewAnimationOptionCurveEaseOut animations:^{
         self->_page2.transform = CGAffineTransformIdentity;
-    } completion: ^void(BOOL finished) {
-        self.isAnimating = NO;
-    }];
+    } completion:nil];
     [UIView animateWithDuration:1.2 delay:0.2 usingSpringWithDamping:0.5 initialSpringVelocity:0.1 options:UIViewAnimationOptionCurveEaseOut animations:^{
         self->_page3.transform = CGAffineTransformIdentity;
-    } completion:nil];
+    } completion:^void(BOOL finished) {
+        [UIView animateWithDuration:0.8 delay:0.0 usingSpringWithDamping:0.8 initialSpringVelocity:0.0 options:UIViewAnimationOptionCurveEaseOut animations:^{
+            [self moveAnimationToFirstFrame];
+        } completion:^(BOOL finished) {
+            [self playAnimation];
+        }];
+    }];
 }
 
 - (void)animate


### PR DESCRIPTION
Fixes #9304

With this PR the loading animation for posts will loop for long loading times.

![loading animation](https://user-images.githubusercontent.com/517257/42351443-355c916e-8072-11e8-9e4f-d1c9c8a8c605.gif)

To test:
- break your internet or otherwise make post loading fail
- go to notifications and tap on a post notification
- watch the loading animation until you've had your fill
