### PR TITLE
Refactor formattable content range (implementation)

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ def shared_with_networking_pods
     pod 'AFNetworking', '3.2.1'
     pod 'Alamofire', '4.7.2'
     pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '98db02bc90f1e8c34c763c1b25ae9da964dad3ba'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '2020c151ca572804e43c45baf7c27ef0ec85293a'
 end
 
 def shared_test_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -167,7 +167,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (= 1.0.0-beta.22)
   - WordPress-Editor-iOS (= 1.0.0-beta.22)
   - WordPressAuthenticator (= 1.0.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `98db02bc90f1e8c34c763c1b25ae9da964dad3ba`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `2020c151ca572804e43c45baf7c27ef0ec85293a`)
   - WordPressShared (= 1.0.8)
   - WordPressUI (= 1.0.4)
   - WPMediaPicker (= 1.1)
@@ -215,7 +215,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPressKit:
-    :commit: 98db02bc90f1e8c34c763c1b25ae9da964dad3ba
+    :commit: 2020c151ca572804e43c45baf7c27ef0ec85293a
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
@@ -223,7 +223,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPressKit:
-    :commit: 98db02bc90f1e8c34c763c1b25ae9da964dad3ba
+    :commit: 2020c151ca572804e43c45baf7c27ef0ec85293a
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -263,6 +263,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 727b675a0d598aae8a8da09665374ddcf8be6ad3
+PODFILE CHECKSUM: 6cc236fc87a3c36ae6dd744d8df13db3806dac6f
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/FormattableCommentContent.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/FormattableCommentContent.swift
@@ -17,16 +17,6 @@ class FormattableCommentContent: NotificationTextContent {
     private var metaIds: [String: AnyObject]? {
         return meta?[Constants.MetaKeys.Ids] as? [String: AnyObject]
     }
-
-    func formattableContentRangeWithCommentId(_ commentID: NSNumber) -> FormattableContentRange? {
-        for range in ranges {
-            if let rangeCommentID = range.commentID, rangeCommentID.isEqual(commentID) {
-                return range
-            }
-        }
-
-        return nil
-    }
 }
 
 extension FormattableCommentContent: Equatable {

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Groups/BodyContentGroup.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Groups/BodyContentGroup.swift
@@ -35,7 +35,7 @@ class BodyContentGroup: FormattableContentGroup {
 
         let middleGroupBlocks = contentFrom(blocks, differentThan: comment, and: user)
 
-        let actionGroupBlocks   = [comment]
+        let actionGroupBlocks = [comment]
 
         // Comment Group: Comment + User Blocks
         groups.append(FormattableContentGroup(blocks: commentGroupBlocks, kind: .comment))
@@ -46,7 +46,7 @@ class BodyContentGroup: FormattableContentGroup {
             // If the block contains a range that matches with the metaReplyID field, we'll need to render this
             // with a custom style. Translates into the `You replied to this comment` footer.
             //
-            if let commentContent = block as? FormattableCommentContent,
+            if let commentContent = block as? NotificationTextContent,
                 let parentReplyID = parent.metaReplyID,
                 commentContent.formattableContentRangeWithCommentId(parentReplyID) != nil {
 
@@ -85,9 +85,12 @@ class BodyContentGroup: FormattableContentGroup {
         let textRange = NSRange(location: 0, length: text.count)
         let zeroRange = NSRange(location: 0, length: 0)
 
+        var properties = NotificationContentRange.Properties(range: textRange)
+        properties.url = url
+
         let ranges = [
-            FormattableContentRange(kind: .Noticon, range: zeroRange, value: "\u{f442}"),
-            FormattableContentRange(kind: .Link, range: textRange, url: url)
+            FormattableNoticonRange(value: "\u{f442}", properties: NotificationContentRange.Properties(range: zeroRange)),
+            NotificationContentRange(kind: .link, properties: properties)
         ]
 
         let block = FormattableTextContent(text: text, ranges: ranges)

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
@@ -68,6 +68,16 @@ class NotificationTextContent: FormattableTextContent, FormattableMediaContent {
         media = FormattableMediaItem.mediaFromArray(rawMedia)
         super.init(dictionary: dictionary, actions: commandActions, parent: note)
     }
+
+    func formattableContentRangeWithCommentId(_ commentID: NSNumber) -> NotificationContentRange? {
+        for range in ranges.compactMap({ $0 as? FormattableCommentRange }) {
+            if let commentID = range.commentID, commentID.isEqual(commentID) {
+                return range
+            }
+        }
+
+        return nil
+    }
 }
 
 private enum Constants {

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/BadgeContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/BadgeContentStyles.swift
@@ -15,12 +15,12 @@ class BadgeContentStyles: FormattableContentStyles {
         return WPStyleGuide.Notifications.badgeBoldStyle
     }
 
-    var rangeStylesMap: [FormattableContentRange.Kind: [NSAttributedStringKey: Any]]? {
+    var rangeStylesMap: [NotificationContentRange.Kind: [NSAttributedStringKey: Any]]? {
         return [
-            .User: WPStyleGuide.Notifications.badgeBoldStyle,
-            .Post: WPStyleGuide.Notifications.badgeItalicsStyle,
-            .Comment: WPStyleGuide.Notifications.badgeItalicsStyle,
-            .Blockquote: WPStyleGuide.Notifications.badgeQuotedStyle
+            .user: WPStyleGuide.Notifications.badgeBoldStyle,
+            .post: WPStyleGuide.Notifications.badgeItalicsStyle,
+            .comment: WPStyleGuide.Notifications.badgeItalicsStyle,
+            .blockquote: WPStyleGuide.Notifications.badgeQuotedStyle
         ]
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/FooterContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/FooterContentStyles.swift
@@ -6,9 +6,9 @@ class FooterContentStyles: FormattableContentStyles {
 
     var quoteStyles: [NSAttributedStringKey: Any]? = nil
 
-    var rangeStylesMap: [FormattableContentRange.Kind: [NSAttributedStringKey: Any]]? {
+    var rangeStylesMap: [NotificationContentRange.Kind: [NSAttributedStringKey: Any]]? {
         return [
-            .Noticon: WPStyleGuide.Notifications.blockNoticonStyle
+            .noticon: WPStyleGuide.Notifications.blockNoticonStyle
         ]
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/HeaderContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/HeaderContentStyles.swift
@@ -6,11 +6,11 @@ class HeaderContentStyles: FormattableContentStyles {
 
     var quoteStyles: [NSAttributedStringKey: Any]? = nil
 
-    var rangeStylesMap: [FormattableContentRange.Kind: [NSAttributedStringKey: Any]]? {
+    var rangeStylesMap: [NotificationContentRange.Kind: [NSAttributedStringKey: Any]]? {
         return [
-            .User: WPStyleGuide.Notifications.headerTitleBoldStyle,
-            .Post: WPStyleGuide.Notifications.headerTitleContextStyle,
-            .Comment: WPStyleGuide.Notifications.headerTitleContextStyle
+            .user: WPStyleGuide.Notifications.headerTitleBoldStyle,
+            .post: WPStyleGuide.Notifications.headerTitleContextStyle,
+            .comment: WPStyleGuide.Notifications.headerTitleContextStyle
         ]
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/RichTextContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/RichTextContentStyles.swift
@@ -19,11 +19,11 @@ class RichTextContentStyles: FormattableContentStyles {
         return WPStyleGuide.Notifications.contentBlockBoldStyle
     }
 
-    var rangeStylesMap: [FormattableContentRange.Kind: [NSAttributedStringKey: Any]]? {
+    var rangeStylesMap: [NotificationContentRange.Kind: [NSAttributedStringKey: Any]]? {
         return [
-            .Blockquote: WPStyleGuide.Notifications.contentBlockQuotedStyle,
-            .Noticon: WPStyleGuide.Notifications.blockNoticonStyle,
-            .Match: WPStyleGuide.Notifications.contentBlockMatchStyle
+            .blockquote: WPStyleGuide.Notifications.contentBlockQuotedStyle,
+            .noticon: WPStyleGuide.Notifications.blockNoticonStyle,
+            .match: WPStyleGuide.Notifications.contentBlockMatchStyle
         ]
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/SnipetsContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/SnipetsContentStyles.swift
@@ -6,7 +6,7 @@ class SnipetsContentStyles: FormattableContentStyles {
 
     var quoteStyles: [NSAttributedStringKey: Any]? = nil
 
-    var rangeStylesMap: [FormattableContentRange.Kind: [NSAttributedStringKey: Any]]? = nil
+    var rangeStylesMap: [NotificationContentRange.Kind: [NSAttributedStringKey: Any]]? = nil
 
     var linksColor: UIColor? = nil
 

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/SubjectContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/SubjectContentStyles.swift
@@ -8,13 +8,13 @@ class SubjectContentStyles: FormattableContentStyles {
         return WPStyleGuide.Notifications.subjectItalicsStyle
     }
 
-    var rangeStylesMap: [FormattableContentRange.Kind: [NSAttributedStringKey: Any]]? {
+    var rangeStylesMap: [NotificationContentRange.Kind: [NSAttributedStringKey: Any]]? {
         return [
-            .User: WPStyleGuide.Notifications.subjectBoldStyle,
-            .Post: WPStyleGuide.Notifications.subjectItalicsStyle,
-            .Comment: WPStyleGuide.Notifications.subjectItalicsStyle,
-            .Blockquote: WPStyleGuide.Notifications.subjectQuotedStyle,
-            .Noticon: WPStyleGuide.Notifications.subjectNoticonStyle
+            .user: WPStyleGuide.Notifications.subjectBoldStyle,
+            .post: WPStyleGuide.Notifications.subjectItalicsStyle,
+            .comment: WPStyleGuide.Notifications.subjectItalicsStyle,
+            .blockquote: WPStyleGuide.Notifications.subjectQuotedStyle,
+            .noticon: WPStyleGuide.Notifications.subjectNoticonStyle
         ]
     }
 


### PR DESCRIPTION
Fixes #9709 

This PR implement the changes in WordPressKit, where FormattableContentRange was refactored.

To test:
- `pod install`
- Build and run.
- Check that all kind of notifications display as they should.


