### PR TITLE
Extract notifications: Move Actions to WordPressKit

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ def shared_with_networking_pods
     pod 'AFNetworking', '3.2.1'
     pod 'Alamofire', '4.7.2'
     pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/refactor-formattable-content-action-command'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0337bd2ffd480d0411b2dfc33a2891ba2cdac5de'
 end
 
 def shared_test_pods

--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ def shared_with_networking_pods
     pod 'AFNetworking', '3.2.1'
     pod 'Alamofire', '4.7.2'
     pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '2020c151ca572804e43c45baf7c27ef0ec85293a'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/refactor-formattable-content-action-command'
 end
 
 def shared_test_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -167,7 +167,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (= 1.0.0-beta.22)
   - WordPress-Editor-iOS (= 1.0.0-beta.22)
   - WordPressAuthenticator (= 1.0.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/refactor-formattable-content-action-command`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `0337bd2ffd480d0411b2dfc33a2891ba2cdac5de`)
   - WordPressShared (= 1.0.8)
   - WordPressUI (= 1.0.4)
   - WPMediaPicker (= 1.1)
@@ -215,7 +215,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPressKit:
-    :branch: feature/refactor-formattable-content-action-command
+    :commit: 0337bd2ffd480d0411b2dfc33a2891ba2cdac5de
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
@@ -223,7 +223,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPressKit:
-    :commit: 5830838a49d364062d9a99f518beac2dadeb947d
+    :commit: 0337bd2ffd480d0411b2dfc33a2891ba2cdac5de
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -263,6 +263,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: e3281a4a6abbb9ad426bd1aaddb2afd91f84bbbf
+PODFILE CHECKSUM: 031e0f773d4add4510300a816a48965c64b78fe4
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -167,7 +167,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (= 1.0.0-beta.22)
   - WordPress-Editor-iOS (= 1.0.0-beta.22)
   - WordPressAuthenticator (= 1.0.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `2020c151ca572804e43c45baf7c27ef0ec85293a`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/refactor-formattable-content-action-command`)
   - WordPressShared (= 1.0.8)
   - WordPressUI (= 1.0.4)
   - WPMediaPicker (= 1.1)
@@ -215,7 +215,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPressKit:
-    :commit: 2020c151ca572804e43c45baf7c27ef0ec85293a
+    :branch: feature/refactor-formattable-content-action-command
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
@@ -223,7 +223,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPressKit:
-    :commit: 2020c151ca572804e43c45baf7c27ef0ec85293a
+    :commit: 5830838a49d364062d9a99f518beac2dadeb947d
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -263,6 +263,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 6cc236fc87a3c36ae6dd744d8df13db3806dac6f
+PODFILE CHECKSUM: e3281a4a6abbb9ad426bd1aaddb2afd91f84bbbf
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
@@ -1,6 +1,6 @@
 import MGSwipeTableCell
 
-final class ApproveComment: DefaultNotificationAction {
+final class ApproveComment: DefaultNotificationActionCommand {
     private enum TitleStrings {
         static let approve = NSLocalizedString("Approve", comment: "Approves a Comment")
         static let unapprove = NSLocalizedString("Unapprove", comment: "Unapproves a Comment")

--- a/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
@@ -1,6 +1,6 @@
 import MGSwipeTableCell
 
-final class EditComment: DefaultNotificationAction {
+final class EditComment: DefaultNotificationActionCommand {
     let editIcon: UIButton = {
         let title = NSLocalizedString("Edit", comment: "Edits a Comment")
         return MGSwipeButton(title: title, backgroundColor: WPStyleGuide.wordPressBlue())

--- a/WordPress/Classes/Models/Notifications/Actions/Follow.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/Follow.swift
@@ -1,6 +1,6 @@
 import MGSwipeTableCell
 
-final class Follow: DefaultNotificationAction {
+final class Follow: DefaultNotificationActionCommand {
     let followIcon: UIButton = {
         let title = NSLocalizedString("Follow", comment: "Prompt to follow a blog.")
         return MGSwipeButton(title: title, backgroundColor: WPStyleGuide.wordPressBlue())

--- a/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
@@ -1,6 +1,6 @@
 import MGSwipeTableCell
 
-final class LikeComment: DefaultNotificationAction {
+final class LikeComment: DefaultNotificationActionCommand {
     private enum TitleStrings {
         static let like = NSLocalizedString("Like", comment: "Likes a Comment")
         static let unlike = NSLocalizedString("Liked", comment: "A comment is marked as liked")

--- a/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
@@ -1,6 +1,6 @@
 import MGSwipeTableCell
 
-final class LikePost: DefaultNotificationAction {
+final class LikePost: DefaultNotificationActionCommand {
     let likeIcon: UIButton = {
         let title = NSLocalizedString("Like", comment: "Like a post.")
         return MGSwipeButton(title: title, backgroundColor: WPStyleGuide.wordPressBlue())

--- a/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
@@ -1,6 +1,6 @@
 import MGSwipeTableCell
 
-final class MarkAsSpam: DefaultNotificationAction {
+final class MarkAsSpam: DefaultNotificationActionCommand {
     let spamIcon: UIButton = {
         let title = NSLocalizedString("Spam", comment: "Mark s comment as spam.")
         return MGSwipeButton(title: title, backgroundColor: WPStyleGuide.wordPressBlue())

--- a/WordPress/Classes/Models/Notifications/Actions/NotificationAction.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/NotificationAction.swift
@@ -1,12 +1,6 @@
-import MGSwipeTableCell
-
-class DefaultNotificationAction: FormattableContentAction {
-    var enabled: Bool
-
-    var on: Bool
-
+class DefaultNotificationAction: FormattableContentActionCommand {
     var identifier: Identifier {
-        return type(of: self).actionIdentifier()
+        return type(of: self).commandIdentifier()
     }
 
     private(set) lazy var mainContext: NSManagedObjectContext? = {
@@ -19,11 +13,6 @@ class DefaultNotificationAction: FormattableContentAction {
 
     var icon: UIButton? {
         return nil
-    }
-
-    init(on: Bool) {
-        self.on = on
-        self.enabled = true
     }
 
     func execute(context: ActionContext) { }

--- a/WordPress/Classes/Models/Notifications/Actions/NotificationAction.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/NotificationAction.swift
@@ -1,4 +1,4 @@
-class DefaultNotificationAction: FormattableContentActionCommand {
+class DefaultNotificationActionCommand: FormattableContentActionCommand {
     var identifier: Identifier {
         return type(of: self).commandIdentifier()
     }

--- a/WordPress/Classes/Models/Notifications/Actions/NotificationAction.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/NotificationAction.swift
@@ -1,4 +1,6 @@
 class DefaultNotificationActionCommand: FormattableContentActionCommand {
+    var on: Bool
+
     var identifier: Identifier {
         return type(of: self).commandIdentifier()
     }
@@ -13,6 +15,10 @@ class DefaultNotificationActionCommand: FormattableContentActionCommand {
 
     var icon: UIButton? {
         return nil
+    }
+
+    public init(on: Bool) {
+        self.on = on
     }
 
     func execute(context: ActionContext) { }

--- a/WordPress/Classes/Models/Notifications/Actions/NotificationActionParser.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/NotificationActionParser.swift
@@ -1,3 +1,5 @@
+import WordPressKit
+
 struct NotificationActionParser: FormattableContentActionParser {
     private enum Action: String {
         case approve = "approve-comment"
@@ -49,39 +51,47 @@ struct NotificationActionParser: FormattableContentActionParser {
     }
 
     private func approveAction(on: Bool) -> FormattableContentAction {
-        return ApproveComment(on: on)
+        //return ApproveComment(on: on)
+        return ApproveCommentAction(on: on)
     }
 
     private func followAction(on: Bool) -> FormattableContentAction {
-        return Follow(on: on)
+        return FollowAction(on: on)
+        //return Follow(on: on)
     }
 
     private func likeCommentAction(on: Bool) -> FormattableContentAction {
-        return LikeComment(on: on)
+        return LikeCommentAction(on: on)
+        //return LikeComment(on: on)
     }
 
     private func likePostAction(on: Bool) -> FormattableContentAction {
-        return LikePost(on: on)
+        return LikePostAction(on: on)
+        //return LikePost(on: on)
     }
 
     private func replyAction(on: Bool) -> FormattableContentAction {
-        return ReplyToComment(on: on)
+        return ReplyToCommentAction(on: on)
+        //return ReplyToComment(on: on)
     }
 
     private func spamAction(on: Bool) -> FormattableContentAction {
-        return MarkAsSpam(on: on)
+        return MarkAsSpamAction(on: on)
+        //return MarkAsSpam(on: on)
     }
 
     private func editCommentAction(on: Bool) -> FormattableContentAction {
-        return EditComment(on: on)
+        return EditCommentAction(on: on)
+        //return EditComment(on: on)
     }
 
     private func trashAction(on: Bool) -> FormattableContentAction {
-        return TrashComment(on: on)
+        return TrashCommentAction(on: on)
+        //return TrashComment(on: on)
     }
 
     private func notFoundAction(on: Bool) -> FormattableContentAction {
-        print("======= printing not found action ")
-        return DefaultNotificationAction(on: on)
+        //return DefaultNotificationAction(on: on)
+        return DefaultFormattableContentAction(on: on)
     }
 }

--- a/WordPress/Classes/Models/Notifications/Actions/NotificationActionParser.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/NotificationActionParser.swift
@@ -51,47 +51,38 @@ struct NotificationActionParser: FormattableContentActionParser {
     }
 
     private func approveAction(on: Bool) -> FormattableContentAction {
-        //return ApproveComment(on: on)
         return ApproveCommentAction(on: on)
     }
 
     private func followAction(on: Bool) -> FormattableContentAction {
         return FollowAction(on: on)
-        //return Follow(on: on)
     }
 
     private func likeCommentAction(on: Bool) -> FormattableContentAction {
         return LikeCommentAction(on: on)
-        //return LikeComment(on: on)
     }
 
     private func likePostAction(on: Bool) -> FormattableContentAction {
         return LikePostAction(on: on)
-        //return LikePost(on: on)
     }
 
     private func replyAction(on: Bool) -> FormattableContentAction {
         return ReplyToCommentAction(on: on)
-        //return ReplyToComment(on: on)
     }
 
     private func spamAction(on: Bool) -> FormattableContentAction {
         return MarkAsSpamAction(on: on)
-        //return MarkAsSpam(on: on)
     }
 
     private func editCommentAction(on: Bool) -> FormattableContentAction {
         return EditCommentAction(on: on)
-        //return EditComment(on: on)
     }
 
     private func trashAction(on: Bool) -> FormattableContentAction {
         return TrashCommentAction(on: on)
-        //return TrashComment(on: on)
     }
 
     private func notFoundAction(on: Bool) -> FormattableContentAction {
-        //return DefaultNotificationAction(on: on)
         return DefaultFormattableContentAction(on: on)
     }
 }

--- a/WordPress/Classes/Models/Notifications/Actions/NotificationActionParser.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/NotificationActionParser.swift
@@ -51,62 +51,55 @@ struct NotificationActionParser: FormattableContentActionParser {
     }
 
     private func approveAction(on: Bool) -> FormattableContentAction {
-        let action = ApproveCommentAction(on: on)
-        action.command = ApproveComment(on: on)
+        let command = ApproveComment(on: on)
 
-        return action
+        return ApproveCommentAction(on: on, command: command)
     }
 
     private func followAction(on: Bool) -> FormattableContentAction {
-        let action = FollowAction(on: on)
-        action.command = Follow(on: on)
+        let command = Follow(on: on)
 
-        return action
+        return FollowAction(on: on, command: command)
     }
 
     private func likeCommentAction(on: Bool) -> FormattableContentAction {
-        let action = LikeCommentAction(on: on)
-        action.command = LikeComment(on: on)
+        let command = LikeComment(on: on)
 
-        return action
+        return LikeCommentAction(on: on, command: command)
     }
 
     private func likePostAction(on: Bool) -> FormattableContentAction {
-        let action = LikePostAction(on: on)
-        action.command = LikePost(on: on)
+        let command = LikePost(on: on)
 
-        return action
+        return LikePostAction(on: on, command: command)
     }
 
     private func replyAction(on: Bool) -> FormattableContentAction {
-        let action = ReplyToCommentAction(on: on)
-        action.command = ReplyToComment(on: on)
+        let command = ReplyToComment(on: on)
 
-        return action
+        return ReplyToCommentAction(on: on, command: command)
     }
 
     private func spamAction(on: Bool) -> FormattableContentAction {
-        let action = MarkAsSpamAction(on: on)
-        action.command = MarkAsSpam(on: on)
+        let command = MarkAsSpam(on: on)
 
-        return action
+        return MarkAsSpamAction(on: on, command: command)
     }
 
     private func editCommentAction(on: Bool) -> FormattableContentAction {
-        let action = EditCommentAction(on: on)
-        action.command = EditComment(on: on)
+        let command = EditComment(on: on)
 
-        return action
+        return EditCommentAction(on: on, command: command)
     }
 
     private func trashAction(on: Bool) -> FormattableContentAction {
-        let action = TrashCommentAction(on: on)
-        action.command = TrashComment(on: on)
+        let command = TrashComment(on: on)
 
-        return action
+        return TrashCommentAction(on: on, command: command)
     }
 
     private func notFoundAction(on: Bool) -> FormattableContentAction {
-        return DefaultFormattableContentAction(on: on)
+        let command = DefaultNotificationActionCommand(on: on)
+        return DefaultFormattableContentAction(on: on, command: command)
     }
 }

--- a/WordPress/Classes/Models/Notifications/Actions/NotificationActionParser.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/NotificationActionParser.swift
@@ -51,35 +51,59 @@ struct NotificationActionParser: FormattableContentActionParser {
     }
 
     private func approveAction(on: Bool) -> FormattableContentAction {
-        return ApproveCommentAction(on: on)
+        let action = ApproveCommentAction(on: on)
+        action.command = ApproveComment(on: on)
+
+        return action
     }
 
     private func followAction(on: Bool) -> FormattableContentAction {
-        return FollowAction(on: on)
+        let action = FollowAction(on: on)
+        action.command = Follow(on: on)
+
+        return action
     }
 
     private func likeCommentAction(on: Bool) -> FormattableContentAction {
-        return LikeCommentAction(on: on)
+        let action = LikeCommentAction(on: on)
+        action.command = LikeComment(on: on)
+
+        return action
     }
 
     private func likePostAction(on: Bool) -> FormattableContentAction {
-        return LikePostAction(on: on)
+        let action = LikePostAction(on: on)
+        action.command = LikePost(on: on)
+
+        return action
     }
 
     private func replyAction(on: Bool) -> FormattableContentAction {
-        return ReplyToCommentAction(on: on)
+        let action = ReplyToCommentAction(on: on)
+        action.command = ReplyToComment(on: on)
+
+        return action
     }
 
     private func spamAction(on: Bool) -> FormattableContentAction {
-        return MarkAsSpamAction(on: on)
+        let action = MarkAsSpamAction(on: on)
+        action.command = MarkAsSpam(on: on)
+
+        return action
     }
 
     private func editCommentAction(on: Bool) -> FormattableContentAction {
-        return EditCommentAction(on: on)
+        let action = EditCommentAction(on: on)
+        action.command = EditComment(on: on)
+
+        return action
     }
 
     private func trashAction(on: Bool) -> FormattableContentAction {
-        return TrashCommentAction(on: on)
+        let action = TrashCommentAction(on: on)
+        action.command = TrashComment(on: on)
+
+        return action
     }
 
     private func notFoundAction(on: Bool) -> FormattableContentAction {

--- a/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
@@ -1,6 +1,6 @@
 import MGSwipeTableCell
 
-final class ReplyToComment: DefaultNotificationAction {
+final class ReplyToComment: DefaultNotificationActionCommand {
     let replyIcon: UIButton = {
         let title = NSLocalizedString("Reply", comment: "Reply to a comment.")
         return MGSwipeButton(title: title, backgroundColor: WPStyleGuide.wordPressBlue())

--- a/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
@@ -1,6 +1,6 @@
 import MGSwipeTableCell
 
-final class TrashComment: DefaultNotificationAction {
+final class TrashComment: DefaultNotificationActionCommand {
     let trashIcon: UIButton = {
         let title = NSLocalizedString("Trash", comment: "Trashes a comment")
         return MGSwipeButton(title: title, backgroundColor: WPStyleGuide.errorRed())

--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -221,7 +221,7 @@ extension Notification {
         }
 
         //return block.isActionEnabled(.Approve) && !block.isActionOn(.Approve)
-        let commandId = ApproveComment.actionIdentifier()
+        let commandId = ApproveCommentAction.actionIdentifier()
         return block.isActionEnabled(id: commandId) && !block.isActionOn(id: commandId)
     }
 

--- a/WordPress/Classes/Models/Notifications/NotificationBlock.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationBlock.swift
@@ -129,7 +129,7 @@ extension NotificationBlock {
     ///
     var isCommentApproved: Bool {
         //return isActionOn(.Approve) || !isActionEnabled(.Approve)
-        let identifier = ApproveComment.actionIdentifier()
+        let identifier = ApproveCommentAction.actionIdentifier()
         return isActionOn(id: identifier) || !isActionEnabled(id: identifier)
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -953,7 +953,7 @@ private extension NotificationDetailsViewController {
         cell.isApproveEnabled   = commentBlock.isActionEnabled(id: ApproveCommentAction.actionIdentifier())
         cell.isTrashEnabled     = commentBlock.isActionEnabled(id: TrashCommentAction.actionIdentifier())
         cell.isSpamEnabled      = commentBlock.isActionEnabled(id: MarkAsSpamAction.actionIdentifier())
-        cell.isEditEnabled      = commentBlock.isActionOn(id: ApproveCommentActio0n.actionIdentifier())
+        cell.isEditEnabled      = commentBlock.isActionOn(id: ApproveCommentAction.actionIdentifier())
         cell.isLikeOn           = commentBlock.isActionOn(id: LikeCommentAction.actionIdentifier())
         cell.isApproveOn        = commentBlock.isActionOn(id: ApproveCommentAction.actionIdentifier())
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -472,7 +472,7 @@ extension NotificationDetailsViewController {
         }
 
         //return block.isActionOn(.Reply)
-        return block.action(id: ReplyToComment.actionIdentifier())?.on ?? false
+        return block.action(id: ReplyToCommentAction.actionIdentifier())?.on ?? false
     }
 
     func storeNotificationReplyIfNeeded() {
@@ -630,10 +630,8 @@ private extension NotificationDetailsViewController {
         cell.accessoryType = hasHomeURL ? .disclosureIndicator : .none
         cell.name = userBlock.text
         cell.blogTitle = hasHomeTitle ? userBlock.metaTitlesHome : userBlock.metaLinksHome?.host
-        //cell.isFollowEnabled = userBlock.isActionEnabled(.Follow)
-        cell.isFollowEnabled = userBlock.isActionEnabled(id: Follow.actionIdentifier())
-        //cell.isFollowOn = userBlock.isActionOn(.Follow)
-        cell.isFollowOn = userBlock.isActionOn(id: Follow.actionIdentifier())
+        cell.isFollowEnabled = userBlock.isActionEnabled(id: FollowAction.actionIdentifier())
+        cell.isFollowOn = userBlock.isActionOn(id: FollowAction.actionIdentifier())
 
         cell.onFollowClick = { [weak self] in
             self?.followSiteWithBlock(userBlock)
@@ -714,14 +712,14 @@ private extension NotificationDetailsViewController {
         // Setup: Properties
         // Note: Approve Action is actually a synonym for 'Edit' (Based on Calypso's basecode)
         //
-        cell.isReplyEnabled     = UIDevice.isPad() && commentBlock.isActionOn(id: ReplyToComment.actionIdentifier())
-        cell.isLikeEnabled      = commentBlock.isActionEnabled(id: LikeComment.actionIdentifier())
-        cell.isApproveEnabled   = commentBlock.isActionEnabled(id: ApproveComment.actionIdentifier())
-        cell.isTrashEnabled     = commentBlock.isActionEnabled(id: TrashComment.actionIdentifier())
-        cell.isSpamEnabled      = commentBlock.isActionEnabled(id: MarkAsSpam.actionIdentifier())
-        cell.isEditEnabled      = commentBlock.isActionOn(id: ApproveComment.actionIdentifier())
-        cell.isLikeOn           = commentBlock.isActionOn(id: LikeComment.actionIdentifier())
-        cell.isApproveOn        = commentBlock.isActionOn(id: ApproveComment.actionIdentifier())
+        cell.isReplyEnabled     = UIDevice.isPad() && commentBlock.isActionOn(id: ReplyToCommentAction.actionIdentifier())
+        cell.isLikeEnabled      = commentBlock.isActionEnabled(id: LikeCommentAction.actionIdentifier())
+        cell.isApproveEnabled   = commentBlock.isActionEnabled(id: ApproveCommentAction.actionIdentifier())
+        cell.isTrashEnabled     = commentBlock.isActionEnabled(id: TrashCommentAction.actionIdentifier())
+        cell.isSpamEnabled      = commentBlock.isActionEnabled(id: MarkAsSpamAction.actionIdentifier())
+        cell.isEditEnabled      = commentBlock.isActionOn(id: ApproveCommentAction.actionIdentifier())
+        cell.isLikeOn           = commentBlock.isActionOn(id: LikeCommentAction.actionIdentifier())
+        cell.isApproveOn        = commentBlock.isActionOn(id: ApproveCommentAction.actionIdentifier())
 
         // Setup: Callbacks
         cell.onReplyClick = { [weak self] _ in
@@ -867,8 +865,8 @@ private extension NotificationDetailsViewController {
         cell.accessoryType = hasHomeURL ? .disclosureIndicator : .none
         cell.name = userBlock.text
         cell.blogTitle = hasHomeTitle ? userBlock.metaTitlesHome : userBlock.metaLinksHome?.host
-        cell.isFollowEnabled = userBlock.isActionEnabled(id: Follow.actionIdentifier())
-        cell.isFollowOn = userBlock.isActionOn(id: Follow.actionIdentifier())
+        cell.isFollowEnabled = userBlock.isActionEnabled(id: FollowAction.actionIdentifier())
+        cell.isFollowOn = userBlock.isActionOn(id: FollowAction.actionIdentifier())
 
          cell.onFollowClick = { [weak self] in
             self?.followSiteWithBlock(userBlock)
@@ -950,14 +948,14 @@ private extension NotificationDetailsViewController {
         // Setup: Properties
         // Note: Approve Action is actually a synonym for 'Edit' (Based on Calypso's basecode)
         //
-        cell.isReplyEnabled     = UIDevice.isPad() && commentBlock.isActionOn(id: ReplyToComment.actionIdentifier())
-        cell.isLikeEnabled      = commentBlock.isActionEnabled(id: LikeComment.actionIdentifier())
-        cell.isApproveEnabled   = commentBlock.isActionEnabled(id: ApproveComment.actionIdentifier())
-        cell.isTrashEnabled     = commentBlock.isActionEnabled(id: TrashComment.actionIdentifier())
-        cell.isSpamEnabled      = commentBlock.isActionEnabled(id: MarkAsSpam.actionIdentifier())
-        cell.isEditEnabled      = commentBlock.isActionOn(id: ApproveComment.actionIdentifier())
-        cell.isLikeOn           = commentBlock.isActionOn(id: LikeComment.actionIdentifier())
-        cell.isApproveOn        = commentBlock.isActionOn(id: ApproveComment.actionIdentifier())
+        cell.isReplyEnabled     = UIDevice.isPad() && commentBlock.isActionOn(id: ReplyToCommentAction.actionIdentifier())
+        cell.isLikeEnabled      = commentBlock.isActionEnabled(id: LikeCommentAction.actionIdentifier())
+        cell.isApproveEnabled   = commentBlock.isActionEnabled(id: ApproveCommentAction.actionIdentifier())
+        cell.isTrashEnabled     = commentBlock.isActionEnabled(id: TrashCommentAction.actionIdentifier())
+        cell.isSpamEnabled      = commentBlock.isActionEnabled(id: MarkAsSpamAction.actionIdentifier())
+        cell.isEditEnabled      = commentBlock.isActionOn(id: ApproveCommentActio0n.actionIdentifier())
+        cell.isLikeOn           = commentBlock.isActionOn(id: LikeCommentAction.actionIdentifier())
+        cell.isApproveOn        = commentBlock.isActionOn(id: ApproveCommentAction.actionIdentifier())
 
         // Setup: Callbacks
         cell.onReplyClick = { [weak self] _ in
@@ -1329,7 +1327,7 @@ private extension NotificationDetailsViewController {
     }
 
     func likeCommentWithBlock(_ block: ActionableObject) {
-        guard let likeAction = block.action(id: LikeComment.actionIdentifier()) else {
+        guard let likeAction = block.action(id: LikeCommentAction.actionIdentifier()) else {
             return
         }
         let actionContext = ActionContext(block: block)
@@ -1338,7 +1336,7 @@ private extension NotificationDetailsViewController {
     }
 
     func unlikeCommentWithBlock(_ block: ActionableObject) {
-        guard let likeAction = block.action(id: LikeComment.actionIdentifier()) else {
+        guard let likeAction = block.action(id: LikeCommentAction.actionIdentifier()) else {
             return
         }
         let actionContext = ActionContext(block: block)
@@ -1347,7 +1345,7 @@ private extension NotificationDetailsViewController {
     }
 
     func approveCommentWithBlock(_ block: ActionableObject) {
-        guard let approveAction = block.action(id: ApproveComment.actionIdentifier()) else {
+        guard let approveAction = block.action(id: ApproveCommentAction.actionIdentifier()) else {
             return
         }
 
@@ -1357,7 +1355,7 @@ private extension NotificationDetailsViewController {
     }
 
     func unapproveCommentWithBlock(_ block: ActionableObject) {
-        guard let approveAction = block.action(id: ApproveComment.actionIdentifier()) else {
+        guard let approveAction = block.action(id: ApproveCommentAction.actionIdentifier()) else {
             return
         }
 
@@ -1369,7 +1367,7 @@ private extension NotificationDetailsViewController {
     func spamCommentWithBlock(_ block: ActionableObject) {
         precondition(onDeletionRequestCallback != nil)
 
-        guard let spamAction = block.action(id: MarkAsSpam.actionIdentifier()) else {
+        guard let spamAction = block.action(id: MarkAsSpamAction.actionIdentifier()) else {
             return
         }
 
@@ -1390,7 +1388,7 @@ private extension NotificationDetailsViewController {
     func trashCommentWithBlock(_ block: ActionableObject) {
         precondition(onDeletionRequestCallback != nil)
 
-        guard let trashAction = block.action(id: TrashComment.actionIdentifier()) else {
+        guard let trashAction = block.action(id: TrashCommentAction.actionIdentifier()) else {
             return
         }
 
@@ -1409,7 +1407,7 @@ private extension NotificationDetailsViewController {
     }
 
     func replyCommentWithBlock(_ block: ActionableObject, content: String) {
-        guard let replyAction = block.action(id: ReplyToComment.actionIdentifier()) else {
+        guard let replyAction = block.action(id: ReplyToCommentAction.actionIdentifier()) else {
             return
         }
 
@@ -1431,7 +1429,7 @@ private extension NotificationDetailsViewController {
     }
 
     func updateCommentWithBlock(_ block: ActionableObject, content: String) {
-        guard let editCommentAction = block.action(id: EditComment.actionIdentifier()) else {
+        guard let editCommentAction = block.action(id: EditCommentAction.actionIdentifier()) else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1026,7 +1026,7 @@ private extension NotificationsViewController {
         }
 
         // Comments: Trash
-        if let trashCommand = block.action(id: TrashComment.actionIdentifier()), let button = trashCommand.icon as? MGSwipeButton {
+        if let trashAction = block.action(id: TrashCommentAction.actionIdentifier()), let button = trashAction.command?.icon as? MGSwipeButton {
             button.callback = { [weak self] _ in
                 let actionContext = ActionContext(block: block, completion: { [weak self] (request, success) in
                     guard let request = request else {
@@ -1034,7 +1034,7 @@ private extension NotificationsViewController {
                     }
                     self?.showUndeleteForNoteWithID(note.objectID, request: request)
                 })
-                trashCommand.execute(context: actionContext)
+                trashAction.execute(context: actionContext)
                 return true
             }
             rightButtons.append(button)
@@ -1044,11 +1044,11 @@ private extension NotificationsViewController {
             return rightButtons
         }
 
-        let approveCommand = block.action(id: ApproveCommentAction.actionIdentifier())
-        let button = approveCommand?.icon as? MGSwipeButton
+        let approveAction = block.action(id: ApproveCommentAction.actionIdentifier())
+        let button = approveAction?.command?.icon as? MGSwipeButton
         button?.callback = { _ in
             let actionContext = ActionContext(block: block)
-            approveCommand?.execute(context: actionContext)
+            approveAction?.execute(context: actionContext)
             return true
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1040,11 +1040,11 @@ private extension NotificationsViewController {
             rightButtons.append(button)
         }
 
-        guard let approveEnabled = block.action(id: ApproveComment.actionIdentifier())?.enabled, approveEnabled == true else {
+        guard let approveEnabled = block.action(id: ApproveCommentAction.actionIdentifier())?.enabled, approveEnabled == true else {
             return rightButtons
         }
 
-        let approveCommand = block.action(id: ApproveComment.actionIdentifier())
+        let approveCommand = block.action(id: ApproveCommentAction.actionIdentifier())
         let button = approveCommand?.icon as? MGSwipeButton
         button?.callback = { _ in
             let actionContext = ActionContext(block: block)

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/FormattableCommentContent.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/FormattableCommentContent.swift
@@ -6,7 +6,7 @@ class FormattableCommentContent: NotificationTextContent {
     }
 
     var isCommentApproved: Bool {
-        let identifier = ApproveComment.actionIdentifier()
+        let identifier = ApproveCommentAction.actionIdentifier()
         return isActionOn(id: identifier) || !isActionEnabled(id: identifier)
     }
 


### PR DESCRIPTION
This is the best way I can think of to move the Notification Actions down to `WordPressKit` while making the UI / BL concerns remain as concerns for clients of `WordPressKit`.

The `pod` file is pointing to a branch in `WordPressKit` and not to a specific commit hash. If / when this PR gets ready to merge, I would update that to make it point to a specific commit / tag

To test:
- Run `pod install`
- Notification Actions should still work

