### PR TITLE
Updates Aztec to 1.0.0-beta.23.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -68,8 +68,8 @@ target 'WordPress' do
     pod 'NSURL+IDN', '0.3'
     pod 'WPMediaPicker', '1.1'
     pod 'WordPressAuthenticator', '1.0.0'
-    pod 'WordPress-Aztec-iOS', '1.0.0-beta.22'
-	pod 'WordPress-Editor-iOS', '1.0.0-beta.22'
+    pod 'WordPress-Aztec-iOS', '1.0.0-beta.23'
+	pod 'WordPress-Editor-iOS', '1.0.0-beta.23'
     pod 'WordPressUI', '1.0.4'
 
     target 'WordPressTest' do
@@ -89,8 +89,8 @@ target 'WordPress' do
         shared_with_all_pods
         shared_with_networking_pods
 
-        pod 'WordPress-Aztec-iOS', '1.0.0-beta.22'
-        pod 'WordPress-Editor-iOS', '1.0.0-beta.22'
+        pod 'WordPress-Aztec-iOS', '1.0.0-beta.23'
+        pod 'WordPress-Editor-iOS', '1.0.0-beta.23'
         pod 'WordPressUI', '1.0.4'
         pod 'Gridicons', '0.16'
     end
@@ -105,8 +105,8 @@ target 'WordPress' do
         shared_with_all_pods
         shared_with_networking_pods
 
-        pod 'WordPress-Aztec-iOS', '1.0.0-beta.22'
-        pod 'WordPress-Editor-iOS', '1.0.0-beta.22'
+        pod 'WordPress-Aztec-iOS', '1.0.0-beta.23'
+        pod 'WordPress-Editor-iOS', '1.0.0-beta.23'
         pod 'WordPressUI', '1.0.4'
         pod 'Gridicons', '0.16'
     end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -102,9 +102,9 @@ PODS:
   - Starscream (3.0.4)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0-beta.22)
-  - WordPress-Editor-iOS (1.0.0-beta.22):
-    - WordPress-Aztec-iOS (= 1.0.0-beta.22)
+  - WordPress-Aztec-iOS (1.0.0-beta.23)
+  - WordPress-Editor-iOS (1.0.0-beta.23):
+    - WordPress-Aztec-iOS (= 1.0.0-beta.23)
   - WordPressAuthenticator (1.0.0):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.2)
@@ -164,8 +164,8 @@ DEPENDENCIES:
   - Starscream (= 3.0.4)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (= 1.0.0-beta.22)
-  - WordPress-Editor-iOS (= 1.0.0-beta.22)
+  - WordPress-Aztec-iOS (= 1.0.0-beta.23)
+  - WordPress-Editor-iOS (= 1.0.0-beta.23)
   - WordPressAuthenticator (= 1.0.0)
   - WordPressKit (= 1.1)
   - WordPressShared (= 1.0.8)
@@ -248,8 +248,8 @@ SPEC CHECKSUMS:
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 0802c44a63e9e265697b8e9ee864e86fa8ed040d
-  WordPress-Editor-iOS: 02a8866e98e235a7740ea0403a6b37bb19d8a3df
+  WordPress-Aztec-iOS: f2cc5402915e6f62db9681a0872e308ba8c9850c
+  WordPress-Editor-iOS: 4f46c2fa98f3017e9e39ad30ba9f03dbd6612ce4
   WordPressAuthenticator: 4c802aa18781858253daf984f873e3efe0dac7ef
   WordPressKit: a24baaa783c3a221f2d9a51c19318cbb27333373
   WordPressShared: 063e1e8b1a7aaf635abf17f091a2d235a068abdc
@@ -258,6 +258,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 370cf0baf10111958c189d0c1da67042ad9379ef
+PODFILE CHECKSUM: 333f36413a5fb5cc56eb731a6b9d67fae8d78264
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
### Description:

Fixes an issue that was causing paragraphs to merge when they shouldn't have.

This does the same as https://github.com/wordpress-mobile/WordPress-iOS/pull/9715 but for WPiOS 10.4, integrating a proper 1.0.0-beta.23 Aztec release.

Fixes #9706 for WPiOS 10.4.

### Details:

![paragraphsmerged](https://user-images.githubusercontent.com/1836005/42388552-48958aa6-811c-11e8-8261-658a0a615564.gif)

### Testing:

- Create a new post.
- Type several paragraphs of text as shown in the GIF above.
- Switch to HTML mode and back and make sure that paragraphs are not incorrectly merged together.