### PR TITLE
Updates version management script to display both version strings

### DIFF
--- a/Scripts/manage-version.sh
+++ b/Scripts/manage-version.sh
@@ -213,9 +213,6 @@ function doBranching() {
 
         # Push to origin
         git push -u origin $releaseBranch >> $logFile 2>&1 || stopOnError
-
-        # Set branch protection
-        ./github-helper.rb set_prot $newMainVer
     fi 
 }
 
@@ -464,6 +461,7 @@ elif [ $cmd == $CMD_BUMP_INTERNAL ]; then
     bumpInternal 
 elif [ $cmd == $CMD_GET_VERSION ]; then
     echo $currentVer 
+    echo $currentIntVer
 else
     showUsage
 fi


### PR DESCRIPTION
This PR updates the `manage-version.sh` script with two changes that are preparatory to the next PRs which will add higher level tooling:
- both the internal and the external version are output when `get-version` is invoked, in order to allow the other tooling to be aware of them both.
- the call to `github-helper.rb` is removed and moved to the Ruby caller in order to have better and easier error management.

## To test
1. enter `Script` folder;
2. call `./manage-version.sh get-version`;
3. check that both internal and itc versions are printed out.

