### PR TITLE
Importing FormatableContent objects from WordPressKit

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ def shared_with_networking_pods
     pod 'AFNetworking', '3.2.1'
     pod 'Alamofire', '4.7.2'
     pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0337bd2ffd480d0411b2dfc33a2891ba2cdac5de'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '508e6bf6940c03c933f00c169881965c3271c597'
 end
 
 def shared_test_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -167,7 +167,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (= 1.0.0-beta.23)
   - WordPress-Editor-iOS (= 1.0.0-beta.23)
   - WordPressAuthenticator (= 1.0.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `0337bd2ffd480d0411b2dfc33a2891ba2cdac5de`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `508e6bf6940c03c933f00c169881965c3271c597`)
   - WordPressShared (= 1.0.8)
   - WordPressUI (= 1.0.4)
   - WPMediaPicker (= 1.1)
@@ -215,7 +215,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPressKit:
-    :commit: 0337bd2ffd480d0411b2dfc33a2891ba2cdac5de
+    :commit: 508e6bf6940c03c933f00c169881965c3271c597
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 CHECKOUT OPTIONS:
@@ -223,7 +223,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPressKit:
-    :commit: 0337bd2ffd480d0411b2dfc33a2891ba2cdac5de
+    :commit: 508e6bf6940c03c933f00c169881965c3271c597
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -263,6 +263,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 04bff3164ec9accf41e1d88604d476b6e54cc9a2
+PODFILE CHECKSUM: 97641989c26338acbc1ae222f579db33445cb5a1
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/FormattableContent/DefaultFormattableContentAction.swift
+++ b/WordPress/Classes/Utility/FormattableContent/DefaultFormattableContentAction.swift
@@ -1,5 +1,5 @@
 public class DefaultFormattableContentAction: FormattableContentAction {
-    public var enabled: Bool 
+    public var enabled: Bool
 
     public var on: Bool {
         didSet {

--- a/WordPress/Classes/Utility/FormattableContent/DefaultFormattableContentAction.swift
+++ b/WordPress/Classes/Utility/FormattableContent/DefaultFormattableContentAction.swift
@@ -1,0 +1,34 @@
+public class DefaultFormattableContentAction: FormattableContentAction {
+    public var enabled: Bool 
+
+    public var on: Bool {
+        didSet {
+            command?.on = on
+        }
+    }
+
+    public private(set) var command: FormattableContentActionCommand?
+
+    public var identifier: Identifier {
+        return type(of: self).actionIdentifier()
+    }
+
+    public init(on: Bool, command: FormattableContentActionCommand) {
+        self.on = on
+        self.enabled = true
+        self.command = command
+    }
+
+    public func execute(context: ActionContext) {
+        command?.execute(context: context)
+    }
+}
+
+public final class ApproveCommentAction: DefaultFormattableContentAction { }
+public final class FollowAction: DefaultFormattableContentAction { }
+public final class LikeCommentAction: DefaultFormattableContentAction { }
+public final class ReplyToCommentAction: DefaultFormattableContentAction { }
+public final class MarkAsSpamAction: DefaultFormattableContentAction { }
+public final class TrashCommentAction: DefaultFormattableContentAction { }
+public final class LikePostAction: DefaultFormattableContentAction { }
+public final class EditCommentAction: DefaultFormattableContentAction { }

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContent.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContent.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public protocol FormattableContent {
+    var text: String? { get }
+    var ranges: [FormattableContentRange] { get }
+    var parent: FormattableContentParent? { get }
+    var actions: [FormattableContentAction]? { get }
+    var meta: [String: AnyObject]? { get }
+    var kind: FormattableContentKind { get }
+
+    init(dictionary: [String: AnyObject], actions commandActions: [FormattableContentAction], parent note: FormattableContentParent)
+
+    func action(id: Identifier) -> FormattableContentAction?
+    func isActionEnabled(id: Identifier) -> Bool
+    func isActionOn(id: Identifier) -> Bool
+}
+
+public struct FormattableContentKind: Equatable, Hashable {
+    let rawValue: String
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+public extension FormattableContent {
+    public func isActionEnabled(id: Identifier) -> Bool {
+        return action(id: id)?.enabled ?? false
+    }
+
+    public func isActionOn(id: Identifier) -> Bool {
+        return action(id: id)?.on ?? false
+    }
+
+    public func action(id: Identifier) -> FormattableContentAction? {
+        return actions?.filter {
+            $0.identifier == id
+        }.first
+    }
+}

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentAction.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentAction.swift
@@ -1,0 +1,89 @@
+
+/// Protocol to help transition from NotificationBlock to FormattableObject
+public protocol ActionableObject: AnyObject {
+    var notificationID: String? { get }
+    var metaSiteID: NSNumber? { get }
+    var metaCommentID: NSNumber? { get }
+    var isCommentApproved: Bool { get }
+    var text: String? { get }
+    var textOverride: String? { get set }
+    func action(id: Identifier) -> FormattableContentAction?
+}
+
+public protocol FormattableContentActionParser {
+    func parse(_ dictionary: [String: AnyObject]?) -> [FormattableContentAction]
+}
+
+/// Used by both NotificationsViewController and NotificationDetailsViewController.
+///
+public enum NotificationDeletionKind {
+    case spamming
+    case deletion
+
+    public var legendText: String {
+        switch self {
+        case .deletion:
+            return NSLocalizedString("Comment has been deleted", comment: "Displayed when a Comment is deleted")
+        case .spamming:
+            return NSLocalizedString("Comment has been marked as Spam", comment: "Displayed when a Comment is spammed")
+        }
+    }
+}
+
+public struct NotificationDeletionRequest {
+    public let kind: NotificationDeletionKind
+    public let action: (_ completion: @escaping ((Bool) -> Void)) -> Void
+    public init(kind: NotificationDeletionKind, action: @escaping (_ completion: @escaping ((Bool) -> Void)) -> Void) {
+        self.kind = kind
+        self.action = action
+    }
+}
+
+public struct Identifier: Equatable, Hashable {
+    private let rawValue: String
+
+    public init(value: String) {
+        rawValue = value
+    }
+}
+
+extension Identifier: CustomStringConvertible {
+    public var description: String {
+        return rawValue
+    }
+}
+
+
+public typealias ActionContextRequest = (NotificationDeletionRequest?, Bool) -> Void
+public struct ActionContext {
+    public let block: ActionableObject
+    public let content: String
+    public let completion: ActionContextRequest?
+
+    public init(block: ActionableObject, content: String = "", completion: ActionContextRequest? = nil) {
+        self.block = block
+        self.content = content
+        self.completion = completion
+    }
+}
+
+public protocol FormattableContentAction: CustomStringConvertible {
+    var identifier: Identifier { get }
+    var enabled: Bool { get }
+    var on: Bool { get }
+    var command: FormattableContentActionCommand? { get }
+
+    func execute(context: ActionContext)
+}
+
+extension FormattableContentAction {
+    public var description: String {
+        return identifier.description + "enabled \(enabled)"
+    }
+}
+
+extension FormattableContentAction {
+    public static func actionIdentifier() -> Identifier {
+        return Identifier(value: String(describing: self))
+    }
+}

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentActionCommand.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentActionCommand.swift
@@ -1,0 +1,19 @@
+public protocol FormattableContentActionCommand: CustomStringConvertible {
+    var identifier: Identifier { get }
+    var icon: UIButton? { get }
+    var on: Bool { get set }
+
+    func execute(context: ActionContext)
+}
+
+extension FormattableContentActionCommand {
+    public static func commandIdentifier() -> Identifier {
+        return Identifier(value: String(describing: self))
+    }
+}
+
+extension FormattableContentActionCommand {
+    public var description: String {
+        return identifier.description
+    }
+}

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentFactory.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentFactory.swift
@@ -1,0 +1,20 @@
+
+public protocol FormattableContentFactory {
+    static func content(from blocks: [[String: AnyObject]],  actionsParser parser: FormattableContentActionParser , parent: FormattableContentParent) -> [FormattableContent]
+}
+
+struct ActivityFormattableContentFactory: FormattableContentFactory {
+    public static func content(from blocks: [[String: AnyObject]],
+                               actionsParser parser: FormattableContentActionParser ,
+                               parent: FormattableContentParent) -> [FormattableContent] {
+
+        return blocks.compactMap {
+            let actions = parser.parse($0[Constants.ActionsKey] as? [String: AnyObject])
+            return FormattableTextContent(dictionary: $0, actions: actions, parent: parent)
+        }
+    }
+}
+
+private enum Constants {
+    static let ActionsKey = "actions"
+}

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentFactory.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentFactory.swift
@@ -1,11 +1,11 @@
 
 public protocol FormattableContentFactory {
-    static func content(from blocks: [[String: AnyObject]],  actionsParser parser: FormattableContentActionParser , parent: FormattableContentParent) -> [FormattableContent]
+    static func content(from blocks: [[String: AnyObject]], actionsParser parser: FormattableContentActionParser, parent: FormattableContentParent) -> [FormattableContent]
 }
 
 struct ActivityFormattableContentFactory: FormattableContentFactory {
     public static func content(from blocks: [[String: AnyObject]],
-                               actionsParser parser: FormattableContentActionParser ,
+                               actionsParser parser: FormattableContentActionParser,
                                parent: FormattableContentParent) -> [FormattableContent] {
 
         return blocks.compactMap {

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentFormatter.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentFormatter.swift
@@ -1,0 +1,111 @@
+
+import Foundation
+
+public class FormattableContentFormatter {
+
+    /// Helper used by the +Interface Extension.
+    ///
+    fileprivate var dynamicAttributesCache = [String: AnyObject]()
+
+    public init() {
+    }
+
+    public func render(content: FormattableContent, with styles: FormattableContentStyles) -> NSAttributedString {
+        let attributedText = memoize {
+            let snippet = self.text(from: content, with: styles)
+
+            return snippet.trimNewlines()
+        }
+
+        return attributedText(styles.key)
+    }
+
+    public func resetCache() {
+        dynamicAttributesCache.removeAll()
+    }
+
+    /// This method is meant to aid cache-implementation into all of the AttriutedString getters introduced
+    /// in this extension.
+    ///
+    /// - Parameter fn: A Closure that, on execution, returns an attributed string.
+    ///
+    /// - Returns: A new Closure that on execution will either hit the cache, or execute the closure `fn`
+    ///            and store its return value in the cache.
+    ///
+    fileprivate func memoize(_ fn: @escaping () -> NSAttributedString) -> (String) -> NSAttributedString {
+        return { cacheKey in
+
+            if let cachedSubject = self.cacheValueForKey(cacheKey) as? NSAttributedString {
+                return cachedSubject
+            }
+
+            let newValue = fn()
+            self.setCacheValue(newValue, forKey: cacheKey)
+            return newValue
+        }
+    }
+
+    // Dynamic Attribute Cache: Used internally by the Interface Extension, as an optimization.
+    ///
+    func cacheValueForKey(_ key: String) -> AnyObject? {
+        return dynamicAttributesCache[key]
+    }
+
+    /// Stores a specified value within the Dynamic Attributes Cache.
+    ///
+    func setCacheValue(_ value: AnyObject?, forKey key: String) {
+        guard let value = value else {
+            dynamicAttributesCache.removeValue(forKey: key)
+            return
+        }
+
+        dynamicAttributesCache[key] = value
+    }
+
+    private func text(from content: FormattableContent, with styles: FormattableContentStyles) -> NSAttributedString {
+
+        guard let text = content.text else {
+            return NSAttributedString()
+        }
+
+        let tightenedText = replaceCommonWhitespaceIssues(in: text)
+        let theString = NSMutableAttributedString(string: tightenedText, attributes: styles.attributes)
+
+        if let quoteStyles = styles.quoteStyles {
+            theString.applyAttributes(toQuotes: quoteStyles)
+        }
+
+        // Apply the Ranges
+        var lengthShift = 0
+
+        for range in content.ranges {
+            lengthShift += range.apply(styles, to: theString, withShift: lengthShift)
+        }
+
+        return theString
+    }
+
+    /// Replaces some common extra whitespace with hairline spaces so that comments display better
+    ///
+    /// - Parameter baseString: string of the comment body before attributes are added
+    /// - Returns: string of same length
+    /// - Note: the length must be maintained or the formatting will break
+    private func replaceCommonWhitespaceIssues(in baseString: String) -> String {
+        var newString: String
+        // \u{200A} = hairline space (very skinny space).
+        // we use these so that the ranges are still in the right position, but the extra space basically disappears
+        newString = baseString.replacingOccurrences(of: "\t ", with: "\u{200A}\u{200A}") // tabs before a space
+        newString = newString.replacingOccurrences(of: " \t", with: " \u{200A}") // tabs after a space
+        newString = newString.replacingOccurrences(of: "\t@", with: "\u{200A}@") // tabs before @mentions
+        newString = newString.replacingOccurrences(of: "\t.", with: "\u{200A}.") // tabs before a space
+        newString = newString.replacingOccurrences(of: "\t,", with: "\u{200A},") // tabs cefore a comman
+        newString = newString.replacingOccurrences(of: "\n\t\n\t", with: "\u{200A}\u{200A}\n\t") // extra newline-with-tab before a newline-with-tab
+
+        // if the length of the string changes the range-based formatting will break
+        guard newString.count == baseString.count else {
+            return baseString
+        }
+
+        return newString
+    }
+}

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentGroup.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentGroup.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+// MARK: - FormattableContentGroup: Adapter to match 1 View <> 1 BlockGroup
+//
+open class FormattableContentGroup {
+
+    public struct Kind: Equatable {
+        private var rawValue: String
+        public init(_ rawValue: String) {
+            self.rawValue = rawValue
+        }
+    }
+
+    /// Grouped Blocks
+    ///
+    public let blocks: [FormattableContent]
+
+    public let kind: Kind
+
+    /// Designated Initializer
+    ///
+    public init(blocks: [FormattableContent], kind: Kind) {
+        self.blocks = blocks
+        self.kind = kind
+    }
+}
+
+// MARK: - Helpers Methods
+//
+extension FormattableContentGroup {
+
+    public func blockOfKind<ContentType: FormattableContent>(_ kind: FormattableContentKind) -> ContentType? {
+        return FormattableContentGroup.blockOfKind(kind, from: blocks)
+    }
+
+    /// Returns the First Block of a specified kind.
+    ///
+    public class func blockOfKind<ContentType: FormattableContent>(_ kind: FormattableContentKind, from blocks: [FormattableContent]) -> ContentType? {
+        for block in blocks where block.kind == kind {
+            return block as? ContentType
+        }
+        return nil
+    }
+}

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentParent.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentParent.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public enum ParentKind: String {
+    case Comment        = "comment"
+    case CommentLike    = "comment_like"
+    case Follow         = "follow"
+    case Like           = "like"
+    case Matcher        = "automattcher"
+    case NewPost        = "new_post"
+    case Post           = "post"
+    case User           = "user"
+    case Unknown        = "unknown"
+
+    var toTypeValue: String {
+        return rawValue
+    }
+}
+
+public protocol FormattableContentParent: AnyObject {
+    var metaCommentID: NSNumber? { get }
+    var uniqueID: String? { get }
+    var kind: ParentKind { get }
+    var metaReplyID: NSNumber? { get }
+    var isPingback: Bool { get }
+    func didChangeOverrides()
+    func isEqual(to other: FormattableContentParent) -> Bool
+}

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
@@ -1,0 +1,128 @@
+import Foundation
+
+public protocol FormattableContentRange {
+    typealias Shift = Int
+    var range: NSRange { get }
+    func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) -> Shift
+}
+
+// MARK: - DefaultFormattableContentRange Entity
+//
+public class NotificationContentRange: FormattableContentRange {
+    public let kind: Kind
+    public let range: NSRange
+
+    public let userID: NSNumber?
+    public let siteID: NSNumber?
+    public let postID: NSNumber?
+    public let url: URL?
+
+    public init(kind: Kind, properties: Properties) {
+        self.kind = kind
+        range = properties.range
+        url = properties.url
+        siteID = properties.siteID
+        userID = properties.userID
+        postID = properties.postID
+    }
+
+    public func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) -> Shift {
+        let shiftedRange = rangeShifted(by: shift)
+
+        apply(styles, to: string, at: shiftedRange)
+        applyURLStyles(to: string, shiftedRange: shiftedRange, applying: styles)
+
+        return 0
+    }
+
+    fileprivate func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, at shiftedRange: NSRange) {
+        if let rangeStyle = styles.rangeStylesMap?[kind] {
+            string.addAttributes(rangeStyle, range: shiftedRange)
+        }
+    }
+
+    fileprivate func applyURLStyles(to string: NSMutableAttributedString, shiftedRange: NSRange, applying styles: FormattableContentStyles) {
+        if let url = url, let linksColor = styles.linksColor {
+            string.addAttribute(.link, value: url, range: shiftedRange)
+            string.addAttribute(.foregroundColor, value: linksColor, range: shiftedRange)
+        }
+    }
+
+    fileprivate func rangeShifted(by shift: Int) -> NSRange {
+        return NSMakeRange(range.location + shift, range.length)
+    }
+}
+
+public extension NotificationContentRange {
+    public struct Kind: Equatable, Hashable {
+        let rawType: String
+
+        public init(_ rawType: String) {
+            self.rawType = rawType
+        }
+    }
+}
+
+public class FormattableCommentRange: NotificationContentRange {
+    public let commentID: NSNumber?
+
+    public init(commentID: NSNumber?, properties: Properties) {
+        self.commentID = commentID
+        super.init(kind: .comment, properties: properties)
+    }
+}
+
+public class FormattableNoticonRange: NotificationContentRange {
+    public let value: String
+
+    private var noticon: String {
+        return value + " "
+    }
+
+    public init(value: String, properties: Properties) {
+        self.value = value
+        super.init(kind: .noticon, properties: properties)
+    }
+
+    public override func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) -> Shift {
+
+        let shiftedRange = rangeShifted(by: shift)
+        string.replaceCharacters(in: shiftedRange, with: noticon)
+
+        let superShift = super.apply(styles, to: string, withShift: shift)
+
+        return noticon.count + superShift
+    }
+
+    override func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, at shiftedRange: NSRange) {
+        let longerRange = NSMakeRange(shiftedRange.location, shiftedRange.length + noticon.count)
+        super.apply(styles, to: string, at: longerRange)
+    }
+}
+
+extension NotificationContentRange {
+    public struct Properties {
+        let range: NSRange
+        public var url: URL?
+        public var siteID: NSNumber?
+        public var userID: NSNumber?
+        public var postID: NSNumber?
+
+        public init(range: NSRange) {
+            self.range = range
+        }
+    }
+}
+
+public extension NotificationContentRange.Kind {
+    public static let user       = NotificationContentRange.Kind("user")
+    public static let post       = NotificationContentRange.Kind("post")
+    public static let comment    = NotificationContentRange.Kind("comment")
+    public static let stats      = NotificationContentRange.Kind("stat")
+    public static let follow     = NotificationContentRange.Kind("follow")
+    public static let blockquote = NotificationContentRange.Kind("blockquote")
+    public static let noticon    = NotificationContentRange.Kind("noticon")
+    public static let site       = NotificationContentRange.Kind("site")
+    public static let match      = NotificationContentRange.Kind("match")
+    public static let link       = NotificationContentRange.Kind("link")
+}

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentStyles.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentStyles.swift
@@ -1,0 +1,8 @@
+
+public protocol FormattableContentStyles {
+    var attributes: [NSAttributedStringKey: Any] { get }
+    var quoteStyles: [NSAttributedStringKey: Any]? { get }
+    var rangeStylesMap: [NotificationContentRange.Kind: [NSAttributedStringKey: Any]]? { get }
+    var linksColor: UIColor? { get }
+    var key: String { get }
+}

--- a/WordPress/Classes/Utility/FormattableContent/FormattableMediaContent.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableMediaContent.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+
+
+// MARK: - FormattableMediaContent Entity
+//
+public class FormattableMediaItem {
+    /// Kind of the current Media.
+    ///
+    public let kind: Kind
+
+    /// Text Range Associated!
+    ///
+    public let range: NSRange
+
+    /// Resource URL, if any.
+    ///
+    public private(set) var mediaURL: URL?
+
+    /// Resource Size, if any.
+    ///
+    public private(set) var size: CGSize?
+
+
+    /// Designated Initializer.
+    ///
+    init?(dictionary: [String: AnyObject]) {
+        guard let type = dictionary[MediaKeys.RawType] as? String, let indices = dictionary[MediaKeys.Indices] as? [Int],
+            let start = indices.first, let end = indices.last else {
+                return nil
+        }
+
+        kind = Kind(rawValue: type) ?? .Image
+        range = NSMakeRange(start, end - start)
+
+        if let url = dictionary[MediaKeys.URL] as? String {
+            mediaURL = URL(string: url)
+        }
+
+        if let width = dictionary[MediaKeys.Width] as? NSNumber, let height = dictionary[MediaKeys.Height] as? NSNumber {
+            size = CGSize(width: width.intValue, height: height.intValue)
+        }
+    }
+}
+
+
+// MARK: - NotificationRange Parsers
+//
+extension FormattableMediaItem {
+    /// Parses FormattableMediaContent instances, given an array of raw media.
+    ///
+    public class func mediaFromArray(_ media: [[String: AnyObject]]?) -> [FormattableMediaItem] {
+        let parsed = media?.compactMap {
+            return FormattableMediaItem(dictionary: $0)
+        }
+
+        return parsed ?? []
+    }
+}
+
+
+// MARK: - FormattableMediaContent Types
+//
+public extension FormattableMediaItem {
+    /// Known kinds of Media Entities
+    ///
+    public enum Kind: String {
+        case Image              = "image"
+        case Badge              = "badge"
+    }
+
+    /// Parsing Keys
+    ///
+    fileprivate enum MediaKeys {
+        static let RawType      = "type"
+        static let URL          = "url"
+        static let Indices      = "indices"
+        static let Width        = "width"
+        static let Height       = "height"
+    }
+}

--- a/WordPress/Classes/Utility/FormattableContent/FormattableTextContent.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableTextContent.swift
@@ -17,11 +17,11 @@ open class FormattableTextContent: FormattableContent {
     public let ranges: [FormattableContentRange]
     public var parent: FormattableContentParent?
     public var actions: [FormattableContentAction]?
-    public var meta: [String : AnyObject]?
+    public var meta: [String: AnyObject]?
 
     private let internalText: String?
 
-    public required init(dictionary: [String : AnyObject], actions commandActions: [FormattableContentAction], parent note: FormattableContentParent) {
+    public required init(dictionary: [String: AnyObject], actions commandActions: [FormattableContentAction], parent note: FormattableContentParent) {
         let rawRanges   = dictionary[Constants.BlockKeys.Ranges] as? [[String: AnyObject]]
 
         actions = commandActions

--- a/WordPress/Classes/Utility/FormattableContent/FormattableTextContent.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableTextContent.swift
@@ -1,0 +1,61 @@
+
+import Foundation
+
+public extension FormattableContentKind {
+    public static let text = FormattableContentKind("text")
+}
+
+open class FormattableTextContent: FormattableContent {
+    open var kind: FormattableContentKind {
+        return .text
+    }
+
+    open var text: String? {
+        return internalText
+    }
+
+    public let ranges: [FormattableContentRange]
+    public var parent: FormattableContentParent?
+    public var actions: [FormattableContentAction]?
+    public var meta: [String : AnyObject]?
+
+    private let internalText: String?
+
+    public required init(dictionary: [String : AnyObject], actions commandActions: [FormattableContentAction], parent note: FormattableContentParent) {
+        let rawRanges   = dictionary[Constants.BlockKeys.Ranges] as? [[String: AnyObject]]
+
+        actions = commandActions
+        ranges = FormattableTextContent.rangesFrom(rawRanges)
+        parent = note
+        internalText = dictionary[Constants.BlockKeys.Text] as? String
+        meta = dictionary[Constants.BlockKeys.Meta] as? [String: AnyObject]
+    }
+
+    public init(text: String, ranges: [NotificationContentRange]) {
+        self.internalText = text
+        self.ranges = ranges
+    }
+
+    private static func rangesFrom(_ rawRanges: [[String: AnyObject]]?) -> [NotificationContentRange] {
+        let parsed = rawRanges?.compactMap(NotificationContentRangeFactory.contentRange)
+        return parsed ?? []
+    }
+}
+
+public extension FormattableMediaItem {
+    fileprivate enum MediaKeys {
+        static let RawType      = "type"
+        static let URL          = "url"
+        static let Indices      = "indices"
+        static let Width        = "width"
+        static let Height       = "height"
+    }
+}
+
+private enum Constants {
+    fileprivate enum BlockKeys {
+        static let Meta         = "meta"
+        static let Ranges       = "ranges"
+        static let Text         = "text"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListRow.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListRow.swift
@@ -7,12 +7,21 @@ struct ActivityListRow: ImmuTableRow {
         return ImmuTableCell.nib(nib, CellType.self)
     }()
 
-    let activity: Activity
+    var activity: Activity {
+        return formattableActivity.activity
+    }
     let action: ImmuTableAction?
+    
+    private let formattableActivity: FormattableActivity
+
+    init(formattableActivity: FormattableActivity, action: ImmuTableAction?) {
+        self.formattableActivity = formattableActivity
+        self.action = action
+    }
 
     func configureCell(_ cell: UITableViewCell) {
         let cell = cell as! CellType
-        cell.configureCell(activity)
+        cell.configureCell(formattableActivity)
         cell.selectionStyle = .none
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListRow.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListRow.swift
@@ -11,7 +11,7 @@ struct ActivityListRow: ImmuTableRow {
         return formattableActivity.activity
     }
     let action: ImmuTableAction?
-    
+
     private let formattableActivity: FormattableActivity
 
     init(formattableActivity: FormattableActivity, action: ImmuTableAction?) {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -58,12 +58,12 @@ class ActivityListViewModel: Observable {
         guard let activities = store.getActivities(site: site) else {
             return .Empty
         }
-
-        let activitiesRows = activities.map({ activity in
+        let formattableActivities = activities.map(FormattableActivity.init)
+        let activitiesRows = formattableActivities.map({ formattableActivity in
             return ActivityListRow(
-                activity: activity,
+                formattableActivity: formattableActivity,
                 action: { [weak presenter] (row) in
-                    presenter?.presentDetailsFor(activity: activity)
+                    presenter?.presentDetailsFor(activity: formattableActivity.activity)
                 }
             )
         })

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -17,11 +17,15 @@ open class ActivityTableViewCell: WPTableViewCell {
 
     // MARK: - Public Methods
 
-    open func configureCell(_ activity: Activity) {
-        self.activity = activity
+    func configureCell(_ formattableActivity: FormattableActivity) {
+        activity = formattableActivity.activity
+        guard let activity = activity else {
+            return
+        }
+
         summaryLabel.text = activity.summary
         if FeatureFlag.extractNotifications.enabled {
-            contentLabel.attributedText = activity.formattedContent(using: SubjectContentStyles())
+            contentLabel.attributedText = formattableActivity.formattedContent(using: SubjectContentStyles())
         } else {
             contentLabel.text = activity.text
         }

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityActionsParser.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityActionsParser.swift
@@ -1,6 +1,6 @@
 
 class ActivityActionsParser: FormattableContentActionParser {
-    func parse(_ dictionary: [String : AnyObject]?) -> [FormattableContentAction] {
+    func parse(_ dictionary: [String: AnyObject]?) -> [FormattableContentAction] {
         return []
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityActionsParser.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityActionsParser.swift
@@ -1,0 +1,6 @@
+
+class ActivityActionsParser: FormattableContentActionParser {
+    func parse(_ dictionary: [String : AnyObject]?) -> [FormattableContentAction] {
+        return []
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentGroup.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentGroup.swift
@@ -1,0 +1,11 @@
+
+class ActivityContentGroup: FormattableContentGroup {
+    class func create(with subject: [[String: AnyObject]], parent: FormattableContentParent) -> FormattableContentGroup {
+        let blocks = ActivityFormattableContentFactory.content(from: subject, actionsParser: ActivityActionsParser(), parent: parent)
+        return FormattableContentGroup(blocks: blocks, kind: .activity)
+    }
+}
+
+extension FormattableContentGroup.Kind {
+    static let activity = FormattableContentGroup.Kind("activity")
+}

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/FormattableActivity.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/FormattableActivity.swift
@@ -1,0 +1,63 @@
+
+class FormattableActivity {
+    let activity: Activity
+    private let formatter = FormattableContentFormatter()
+    private var cachedContentGroup: FormattableContentGroup? = nil
+
+    private var contentGroup: FormattableContentGroup? {
+        guard let content = activity.content as? [String: AnyObject], content.isEmpty == false else {
+            return nil
+        }
+        return ActivityContentGroup.create(with: [content], parent: self)
+    }
+
+    init(with activity: Activity) {
+        self.activity = activity
+    }
+
+    public func formattedContent(using styles: FormattableContentStyles) -> NSAttributedString {
+        guard let textBlock: FormattableTextContent = contentGroup?.blockOfKind(.text) else {
+            return NSAttributedString()
+        }
+        return formatter.render(content: textBlock, with: styles)
+    }
+}
+
+extension FormattableActivity: FormattableContentParent {
+    public func isEqual(to other: FormattableContentParent) -> Bool {
+        guard let otherActivity = other as? FormattableActivity else {
+            return false
+        }
+        return self.activity == otherActivity.activity
+    }
+
+    public var metaCommentID: NSNumber? {
+        return 0
+    }
+
+    public var uniqueID: String? {
+        return activity.activityID
+    }
+
+    public var kind: ParentKind {
+        return .Unknown
+    }
+
+    public var metaReplyID: NSNumber? {
+        return 0
+    }
+
+    public var isPingback: Bool {
+        return false
+    }
+
+    public func didChangeOverrides() {
+
+    }
+}
+
+extension Activity: Equatable {
+    public static func == (lhs: Activity, rhs: Activity) -> Bool {
+        return lhs.activityID == rhs.activityID
+    }
+}

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationContentRangeFactory.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationContentRangeFactory.swift
@@ -1,0 +1,96 @@
+
+struct NotificationContentRangeFactory {
+    static func contentRange(from dictionary: [String: AnyObject]) -> NotificationContentRange? {
+        guard let range = rangeFrom(dictionary) else {
+            return nil
+        }
+        let properties = propertiesFrom(dictionary, with: range)
+
+        if let kind = kindString(from: dictionary) {
+            return contentRange(ofKind: kind, with: properties, from: dictionary)
+        }
+
+        return contentRangeWithoutKindSpecified(with: properties, from: dictionary)
+    }
+
+    private static func rangeFrom(_ dictionary: [String: AnyObject]) -> NSRange? {
+        guard let indices = dictionary[RangeKeys.indices] as? [Int],
+            let start = indices.first,
+            let end = indices.last else {
+                return nil
+        }
+        return NSMakeRange(start, end - start)
+    }
+
+    private static func propertiesFrom(_ dictionary: [String: AnyObject], with range: NSRange) -> NotificationContentRange.Properties {
+        var properties = NotificationContentRange.Properties(range: range)
+
+        properties.siteID = dictionary[RangeKeys.siteId] as? NSNumber
+        properties.postID = dictionary[RangeKeys.postId] as? NSNumber
+
+        if let url = dictionary[RangeKeys.url] as? String {
+            properties.url = URL(string: url)
+        }
+        return properties
+    }
+
+    private static func kindString(from dictionary: [String: AnyObject]) -> String? {
+        return dictionary[RangeKeys.rawType] as? String
+    }
+
+    private static func contentRange(ofKind type: String, with properties: NotificationContentRange.Properties, from dictionary: [String: AnyObject]) -> NotificationContentRange? {
+        var properties = properties
+        let kind = NotificationContentRange.Kind(type)
+
+        switch kind {
+        case .comment:
+            let commentID = dictionary[RangeKeys.id] as? NSNumber
+            return FormattableCommentRange(commentID: commentID, properties: properties)
+        case .noticon:
+            guard let value = dictionary[RangeKeys.value] as? String else {
+                fallthrough
+            }
+            return FormattableNoticonRange(value: value, properties: properties)
+        case .post:
+            properties.postID = dictionary[RangeKeys.id] as? NSNumber
+            return NotificationContentRange(kind: kind, properties: properties)
+        case .site:
+            properties.siteID = dictionary[RangeKeys.id] as? NSNumber
+            return NotificationContentRange(kind: kind, properties: properties)
+        case .user:
+            properties.userID = dictionary[RangeKeys.id] as? NSNumber
+            return NotificationContentRange(kind: kind, properties: properties)
+        default:
+            return NotificationContentRange(kind: kind, properties: properties)
+        }
+    }
+
+    private static func contentRangeWithoutKindSpecified(with properties: NotificationContentRange.Properties, from dictionary: [String: AnyObject]) -> NotificationContentRange? {
+        if containsSiteID(dictionary) {
+            return NotificationContentRange(kind: .site, properties: properties)
+        }
+        if containsValidURL(dictionary) {
+            return NotificationContentRange(kind: .link, properties: properties)
+        }
+        return nil
+    }
+
+    private static func containsSiteID(_ dictionary: [String: AnyObject]) -> Bool {
+        return (dictionary[RangeKeys.siteId] as? NSNumber) != nil
+    }
+
+    private static func containsValidURL(_ dictionary: [String: AnyObject]) -> Bool {
+        let urlString = dictionary[RangeKeys.url] as? String ?? ""
+        return URL(string: urlString) != nil
+    }
+
+    enum RangeKeys {
+        static let rawType = "type"
+        static let url = "url"
+        static let indices = "indices"
+        static let id = "id"
+        static let value = "value"
+        static let siteId = "site_id"
+        static let postId = "post_id"
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -487,6 +487,22 @@
 		7E3E7A6420E44ED60075D159 /* SubjectContentGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A6320E44ED60075D159 /* SubjectContentGroup.swift */; };
 		7E3E7A6620E44F200075D159 /* HeaderContentGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A6520E44F200075D159 /* HeaderContentGroup.swift */; };
 		7E3E7A6820E44F440075D159 /* Notification+FormattableContentParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A6720E44F440075D159 /* Notification+FormattableContentParent.swift */; };
+		7E4123B920F4097B00DF8486 /* FormattableContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123AC20F4097900DF8486 /* FormattableContentFactory.swift */; };
+		7E4123BA20F4097B00DF8486 /* FormattableContentGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123AD20F4097900DF8486 /* FormattableContentGroup.swift */; };
+		7E4123BB20F4097B00DF8486 /* FormattableContentParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123AE20F4097A00DF8486 /* FormattableContentParent.swift */; };
+		7E4123BC20F4097B00DF8486 /* DefaultFormattableContentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123AF20F4097A00DF8486 /* DefaultFormattableContentAction.swift */; };
+		7E4123BD20F4097B00DF8486 /* FormattableMediaContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123B020F4097A00DF8486 /* FormattableMediaContent.swift */; };
+		7E4123BE20F4097B00DF8486 /* NotificationContentRangeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123B120F4097A00DF8486 /* NotificationContentRangeFactory.swift */; };
+		7E4123BF20F4097B00DF8486 /* FormattableContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123B220F4097A00DF8486 /* FormattableContent.swift */; };
+		7E4123C020F4097B00DF8486 /* FormattableTextContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123B320F4097A00DF8486 /* FormattableTextContent.swift */; };
+		7E4123C120F4097B00DF8486 /* FormattableContentRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123B420F4097A00DF8486 /* FormattableContentRange.swift */; };
+		7E4123C220F4097B00DF8486 /* FormattableContentFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123B520F4097B00DF8486 /* FormattableContentFormatter.swift */; };
+		7E4123C320F4097B00DF8486 /* FormattableContentStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123B620F4097B00DF8486 /* FormattableContentStyles.swift */; };
+		7E4123C420F4097B00DF8486 /* FormattableContentActionCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123B720F4097B00DF8486 /* FormattableContentActionCommand.swift */; };
+		7E4123C520F4097B00DF8486 /* FormattableContentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123B820F4097B00DF8486 /* FormattableContentAction.swift */; };
+		7E4123C820F417EF00DF8486 /* FormattableActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123C720F417EF00DF8486 /* FormattableActivity.swift */; };
+		7E4123CA20F4184200DF8486 /* ActivityContentGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123C920F4184200DF8486 /* ActivityContentGroup.swift */; };
+		7E4123CC20F418A500DF8486 /* ActivityActionsParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123CB20F418A500DF8486 /* ActivityActionsParser.swift */; };
 		7E52B7181FC89F2400B55EB8 /* MediaNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */; };
 		7E729C28209A087300F76599 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C27209A087200F76599 /* ImageLoader.swift */; };
 		7E729C2A209A241100F76599 /* AbstractPost+PostInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */; };
@@ -1921,6 +1937,22 @@
 		7E3E7A6320E44ED60075D159 /* SubjectContentGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubjectContentGroup.swift; sourceTree = "<group>"; };
 		7E3E7A6520E44F200075D159 /* HeaderContentGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderContentGroup.swift; sourceTree = "<group>"; };
 		7E3E7A6720E44F440075D159 /* Notification+FormattableContentParent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+FormattableContentParent.swift"; sourceTree = "<group>"; };
+		7E4123AC20F4097900DF8486 /* FormattableContentFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattableContentFactory.swift; sourceTree = "<group>"; };
+		7E4123AD20F4097900DF8486 /* FormattableContentGroup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattableContentGroup.swift; sourceTree = "<group>"; };
+		7E4123AE20F4097A00DF8486 /* FormattableContentParent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattableContentParent.swift; sourceTree = "<group>"; };
+		7E4123AF20F4097A00DF8486 /* DefaultFormattableContentAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultFormattableContentAction.swift; sourceTree = "<group>"; };
+		7E4123B020F4097A00DF8486 /* FormattableMediaContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattableMediaContent.swift; sourceTree = "<group>"; };
+		7E4123B120F4097A00DF8486 /* NotificationContentRangeFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationContentRangeFactory.swift; sourceTree = "<group>"; };
+		7E4123B220F4097A00DF8486 /* FormattableContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattableContent.swift; sourceTree = "<group>"; };
+		7E4123B320F4097A00DF8486 /* FormattableTextContent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattableTextContent.swift; sourceTree = "<group>"; };
+		7E4123B420F4097A00DF8486 /* FormattableContentRange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattableContentRange.swift; sourceTree = "<group>"; };
+		7E4123B520F4097B00DF8486 /* FormattableContentFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattableContentFormatter.swift; sourceTree = "<group>"; };
+		7E4123B620F4097B00DF8486 /* FormattableContentStyles.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattableContentStyles.swift; sourceTree = "<group>"; };
+		7E4123B720F4097B00DF8486 /* FormattableContentActionCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattableContentActionCommand.swift; sourceTree = "<group>"; };
+		7E4123B820F4097B00DF8486 /* FormattableContentAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FormattableContentAction.swift; sourceTree = "<group>"; };
+		7E4123C720F417EF00DF8486 /* FormattableActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableActivity.swift; sourceTree = "<group>"; };
+		7E4123C920F4184200DF8486 /* ActivityContentGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityContentGroup.swift; sourceTree = "<group>"; };
+		7E4123CB20F418A500DF8486 /* ActivityActionsParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityActionsParser.swift; sourceTree = "<group>"; };
 		7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaNoResultsView.swift; sourceTree = "<group>"; };
 		7E729C27209A087200F76599 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+PostInformation.swift"; sourceTree = "<group>"; };
@@ -4141,6 +4173,7 @@
 			children = (
 				7E3E7A5E20E44E110075D159 /* Styles */,
 				7EFF207F20EAC59D009C4699 /* Groups */,
+				7E4123B120F4097A00DF8486 /* NotificationContentRangeFactory.swift */,
 				7E3E7A6720E44F440075D159 /* Notification+FormattableContentParent.swift */,
 				7EFF208520EAD918009C4699 /* FormattableUserContent.swift */,
 				7EFF208920EADCB6009C4699 /* NotificationTextContent.swift */,
@@ -4161,6 +4194,35 @@
 				7E3E7A5C20E44DB00075D159 /* BadgeContentStyles.swift */,
 			);
 			path = Styles;
+			sourceTree = "<group>";
+		};
+		7E4123AB20F4096200DF8486 /* FormattableContent */ = {
+			isa = PBXGroup;
+			children = (
+				7E4123AF20F4097A00DF8486 /* DefaultFormattableContentAction.swift */,
+				7E4123B220F4097A00DF8486 /* FormattableContent.swift */,
+				7E4123B820F4097B00DF8486 /* FormattableContentAction.swift */,
+				7E4123B720F4097B00DF8486 /* FormattableContentActionCommand.swift */,
+				7E4123AC20F4097900DF8486 /* FormattableContentFactory.swift */,
+				7E4123B520F4097B00DF8486 /* FormattableContentFormatter.swift */,
+				7E4123AD20F4097900DF8486 /* FormattableContentGroup.swift */,
+				7E4123AE20F4097A00DF8486 /* FormattableContentParent.swift */,
+				7E4123B420F4097A00DF8486 /* FormattableContentRange.swift */,
+				7E4123B620F4097B00DF8486 /* FormattableContentStyles.swift */,
+				7E4123B020F4097A00DF8486 /* FormattableMediaContent.swift */,
+				7E4123B320F4097A00DF8486 /* FormattableTextContent.swift */,
+			);
+			path = FormattableContent;
+			sourceTree = "<group>";
+		};
+		7E4123C620F4178E00DF8486 /* FormattableContent */ = {
+			isa = PBXGroup;
+			children = (
+				7E4123C720F417EF00DF8486 /* FormattableActivity.swift */,
+				7E4123C920F4184200DF8486 /* ActivityContentGroup.swift */,
+				7E4123CB20F418A500DF8486 /* ActivityActionsParser.swift */,
+			);
+			path = FormattableContent;
 			sourceTree = "<group>";
 		};
 		7EFF207F20EAC59D009C4699 /* Groups */ = {
@@ -4185,6 +4247,7 @@
 		82FC61181FA8ADAC00A1757E /* Activity */ = {
 			isa = PBXGroup;
 			children = (
+				7E4123C620F4178E00DF8486 /* FormattableContent */,
 				82FC612B1FA8B7FC00A1757E /* ActivityListRow.swift */,
 				403F57BB20E5CA6A004E889A /* RewindStatusRow.swift */,
 				82A062DD2017BCBA0084CE7C /* ActivityListSectionHeaderView.swift */,
@@ -4337,6 +4400,7 @@
 		8584FDB4192437160019C02E /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				7E4123AB20F4096200DF8486 /* FormattableContent */,
 				1797373920EBDA1100377B4E /* Universal Links */,
 				984B4EF120742FB900F87888 /* Zendesk */,
 				7E21C763202BBE9F00837CF5 /* iAds */,
@@ -7144,6 +7208,7 @@
 				5D577D33189127BE00B964C3 /* PostGeolocationViewController.m in Sources */,
 				FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */,
 				1D3623260D0F684500981E51 /* WordPressAppDelegate.m in Sources */,
+				7E4123CC20F418A500DF8486 /* ActivityActionsParser.swift in Sources */,
 				98A437B0200693C0004A8A57 /* SiteCreationDomainsViewController.swift in Sources */,
 				17F0E1DA20EBDC0A001E9514 /* Routes+Me.swift in Sources */,
 				D83CA3AB20842E5F0060E310 /* StockPhotosResultsPage.swift in Sources */,
@@ -7157,6 +7222,7 @@
 				5DB3BA0818D11D8D00F3F3E9 /* PublishDatePickerView.m in Sources */,
 				5D2B30B91B7411C700DA15F3 /* ReaderCardDiscoverAttributionView.swift in Sources */,
 				E1E89C6C1FD80E74006E7A33 /* Plugin.swift in Sources */,
+				7E4123BD20F4097B00DF8486 /* FormattableMediaContent.swift in Sources */,
 				E1C265C91BECFCDD00DC4C6B /* WPCrashlyticsLogger.m in Sources */,
 				D87A329620ABD60700F4726F /* ReaderTableContent.swift in Sources */,
 				319D6E7B19E447500013871C /* Suggestion.m in Sources */,
@@ -7166,6 +7232,7 @@
 				E16A76F11FC4758300A661E3 /* JetpackSiteRef.swift in Sources */,
 				B5B56D3219AFB68800B4E29B /* WPStyleGuide+Reply.swift in Sources */,
 				30EABE0918A5903400B73A9C /* WPBlogTableViewCell.m in Sources */,
+				7E4123BE20F4097B00DF8486 /* NotificationContentRangeFactory.swift in Sources */,
 				5D13FA551AF99C0300F06492 /* PageListSectionHeaderView.m in Sources */,
 				E6D170371EF9D8D10046D433 /* SiteInfo.swift in Sources */,
 				822D60B11F4C747E0016C46D /* JetpackSecuritySettingsViewController.swift in Sources */,
@@ -7225,6 +7292,7 @@
 				A0E293F10E21027E00C6919C /* WPAddPostCategoryViewController.m in Sources */,
 				E6BDEA731CE4824300682885 /* ReaderSearchTopic.swift in Sources */,
 				5D5A6E931B613CA400DAF819 /* ReaderPostCardCell.swift in Sources */,
+				7E4123C020F4097B00DF8486 /* FormattableTextContent.swift in Sources */,
 				E10520581F2B1CC900A948F6 /* WordPress-61-62.xcmappingmodel in Sources */,
 				B5772AC41C9C7A070031F97E /* GravatarService.swift in Sources */,
 				1705E55020A5DA5700EF1C9D /* ReaderSavedPostsViewController.swift in Sources */,
@@ -7240,6 +7308,7 @@
 				FF28B3F11AEB251200E11AAE /* InfoPListTranslator.m in Sources */,
 				086E1FE01BBB35D2002D86CA /* MenusViewController.m in Sources */,
 				9F3EFCA3208E308A00268758 /* UIViewController+Notice.swift in Sources */,
+				7E4123BB20F4097B00DF8486 /* FormattableContentParent.swift in Sources */,
 				59E1D46F1CEF77B500126697 /* Page+CoreDataProperties.swift in Sources */,
 				FF00889B204DF3ED007CCE66 /* Blog+Quota.swift in Sources */,
 				C533CF350E6D3ADA000C3DE8 /* CommentsViewController.m in Sources */,
@@ -7290,6 +7359,7 @@
 				B5E167F419C08D18009535AA /* NSCalendar+Helpers.swift in Sources */,
 				FF00889F204E01AE007CCE66 /* MediaQuotaCell.swift in Sources */,
 				E6805D311DCD399600168E4F /* WPRichTextImage.swift in Sources */,
+				7E4123C120F4097B00DF8486 /* FormattableContentRange.swift in Sources */,
 				08D978581CD2AF7D0054F19A /* MenuItemSourceHeaderView.m in Sources */,
 				BE1071FC1BC75E7400906AFF /* WPStyleGuide+Blog.swift in Sources */,
 				B56695B01D411EEB007E342F /* KeyboardDismissHelper.swift in Sources */,
@@ -7315,9 +7385,11 @@
 				98B24D5F2017E5490082BA78 /* SiteCreationEpilogueViewController.swift in Sources */,
 				FFDA7E501B8DF6E500B83C56 /* BlogSiteVisibilityHelper.m in Sources */,
 				E66E2A691FE432BC00788F22 /* TitleBadgeDisclosureCell.swift in Sources */,
+				7E4123BF20F4097B00DF8486 /* FormattableContent.swift in Sources */,
 				FF70A3221FD5840500BC270D /* PHAsset+Metadata.swift in Sources */,
 				5DA5BF4418E32DCF005F11F9 /* Theme.m in Sources */,
 				D8A3A5B1206A49A100992576 /* StockPhotosMediaGroup.swift in Sources */,
+				7E4123BC20F4097B00DF8486 /* DefaultFormattableContentAction.swift in Sources */,
 				ADF544C2195A0F620092213D /* CustomHighlightButton.m in Sources */,
 				17B7C89E20EC1D0D0042E260 /* UniversalLinkRouter.swift in Sources */,
 				40A2777F20191AA500D078D5 /* PluginDirectoryCollectionViewCell.swift in Sources */,
@@ -7469,6 +7541,7 @@
 				5D1D04761B7A50B100CDE646 /* ReaderStreamViewController.swift in Sources */,
 				B57B92BD1B73B08100DFF00B /* SeparatorsView.swift in Sources */,
 				E69BA1981BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m in Sources */,
+				7E4123C320F4097B00DF8486 /* FormattableContentStyles.swift in Sources */,
 				080C44A91CE14A9F00B3A02F /* MenuDetailsViewController.m in Sources */,
 				08216FCF1CDBF96000304BA7 /* MenuItemSourceCell.m in Sources */,
 				462F4E0A18369F0B0028D2F8 /* BlogDetailsViewController.m in Sources */,
@@ -7503,10 +7576,12 @@
 				7E3E7A5D20E44DB00075D159 /* BadgeContentStyles.swift in Sources */,
 				5D4E30D11AA4B41A000D9904 /* WPStyleGuide+Posts.m in Sources */,
 				5D17530F1A97D2CA0031A082 /* PostCardTableViewCell.m in Sources */,
+				7E4123CA20F4184200DF8486 /* ActivityContentGroup.swift in Sources */,
 				08F8CD2F1EBD29440049D0C0 /* MediaImageExporter.swift in Sources */,
 				E13F23C314FE84600081D9CC /* NSMutableDictionary+Helpers.m in Sources */,
 				D816C1F020E0893A00C4D82F /* LikeComment.swift in Sources */,
 				59E1D46E1CEF77B500126697 /* Page.swift in Sources */,
+				7E4123C220F4097B00DF8486 /* FormattableContentFormatter.swift in Sources */,
 				98F24AE820190506001A80F9 /* SiteCreationSitePreviewViewController.swift in Sources */,
 				7E21C765202BBF4400837CF5 /* SearchAdsAttribution.swift in Sources */,
 				5DF8D26119E82B1000A2CD95 /* ReaderCommentsViewController.m in Sources */,
@@ -7531,6 +7606,7 @@
 				5D97C2F315CAF8D8009B44DD /* UINavigationController+KeyboardFix.m in Sources */,
 				D8B9B591204F658A003C6042 /* CommentsViewController+NetworkAware.swift in Sources */,
 				4034FDEA2007C42400153B87 /* ExpandableCell.swift in Sources */,
+				7E4123B920F4097B00DF8486 /* FormattableContentFactory.swift in Sources */,
 				40E469932017F4070030DB5F /* PluginDirectoryViewController.swift in Sources */,
 				E1D28E931F2F6EB500A5DAFD /* RoleService.swift in Sources */,
 				B5C9401A1DB900DC0079D4FF /* AccountHelper.swift in Sources */,
@@ -7567,6 +7643,7 @@
 				E240859C183D82AE002EB0EF /* WPAnimatedBox.m in Sources */,
 				17BEE0041FC867C20074C124 /* WordPressAppDelegate+Swift.swift in Sources */,
 				08472A201C727E020040769D /* PostServiceOptions.m in Sources */,
+				7E4123BA20F4097B00DF8486 /* FormattableContentGroup.swift in Sources */,
 				08216FD21CDBF96000304BA7 /* MenuItemSourceViewController.m in Sources */,
 				74558369201A1FD3007809BB /* WPReusableTableViewCells.swift in Sources */,
 				E6DAABDD1CF632EC0069D933 /* ReaderSearchSuggestionsViewController.swift in Sources */,
@@ -7765,6 +7842,7 @@
 				E6374DC11C444D8B00F24720 /* PublicizeService.swift in Sources */,
 				931D26FE19EDA10D00114F17 /* ALIterativeMigrator.m in Sources */,
 				5DA3EE161925090A00294E0B /* MediaService.m in Sources */,
+				7E4123C520F4097B00DF8486 /* FormattableContentAction.swift in Sources */,
 				E65219FB1B8D10DA000B1217 /* ReaderBlockedSiteCell.swift in Sources */,
 				9859DF86202107C600FB848E /* SiteCreationCategoryTableViewCells.swift in Sources */,
 				7435CE7320A4B9170075A1B9 /* AnimatedImageCache.swift in Sources */,
@@ -7804,6 +7882,7 @@
 				E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */,
 				17B7C8C120EE2A870042E260 /* Routes+Notifications.swift in Sources */,
 				E6431DE71C4E892900FD8D90 /* SharingViewController.m in Sources */,
+				7E4123C820F417EF00DF8486 /* FormattableActivity.swift in Sources */,
 				FF286C761DE70A4500383A62 /* NSURL+Exporters.swift in Sources */,
 				E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */,
 				D8212CC320AA7F57008E8AE8 /* ReaderBlockSiteAction.swift in Sources */,
@@ -7834,6 +7913,7 @@
 				E1F5A1BC1771C90A00E0495F /* WPTableImageSource.m in Sources */,
 				5948AD0E1AB734F2006E8882 /* WPAppAnalytics.m in Sources */,
 				B53AD9BF1BE9584B009AB87E /* SettingsSelectionViewController.m in Sources */,
+				7E4123C420F4097B00DF8486 /* FormattableContentActionCommand.swift in Sources */,
 				17A28DCB2052FB5D00EA6D9E /* AuthorFilterViewController.swift in Sources */,
 				08D345521CD7F50900358E8C /* MenusSelectionItemView.m in Sources */,
 				4020B2BD2007AC850002C963 /* WPStyleGuide+Gridicon.swift in Sources */,


### PR DESCRIPTION
Fixes #9731 

This PR moves all `FormattableContent` code the main WP app.
As expected, Notifications didn't notice the change and it continues to work as before.

For Activity log, it was necessary a small change. There's a new wrapper class `FormattableActivity` that parse the activity `content` property as a `FormattableContentGroup`.

To test:
- Build and run.
- Check that all notifications continue to display as they should.
- Check that Activity Log formats its content as it should (the proper formatting will be applied later on)
