### PR TITLE
Fixed a retain cycle in WPAnimatedBox

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPAnimatedBox.m
+++ b/WordPress/Classes/ViewRelated/Views/WPAnimatedBox.m
@@ -1,16 +1,14 @@
 #import "WPAnimatedBox.h"
 
 @interface WPAnimatedBox () {
-
     UIImageView *_container;
     UIImageView *_containerBack;
-    UIImageView *_page1;
-    UIImageView *_page2;
-    UIImageView *_page3;
 }
 
 @property (nonatomic, assign, readwrite) BOOL isAnimating;
-
+@property (nonatomic, retain) UIImageView *page1;
+@property (nonatomic, retain) UIImageView *page2;
+@property (nonatomic, retain) UIImageView *page3;
 @end
 
 @implementation WPAnimatedBox
@@ -35,6 +33,11 @@ static CGFloat const WPAnimatedBoxYPosPage3 = WPAnimatedBoxAnimationTolerance + 
     }
     
     return self;
+}
+
+- (void)dealloc
+{
+    _isAnimating = NO;
 }
 
 - (void)setupView
@@ -96,19 +99,23 @@ static CGFloat const WPAnimatedBoxYPosPage3 = WPAnimatedBoxAnimationTolerance + 
 {
     self.isAnimating = YES;
 
+    __weak __typeof(self) weakSelf = self;
+
     [UIView animateWithDuration:1.4 delay:0.1 usingSpringWithDamping:0.5 initialSpringVelocity:0.1 options:UIViewAnimationOptionCurveEaseOut animations:^{
-        self->_page1.transform = CGAffineTransformIdentity;
+        weakSelf.page1.transform = CGAffineTransformIdentity;
     } completion:nil];
     [UIView animateWithDuration:1 delay:0.0 usingSpringWithDamping:0.65 initialSpringVelocity:0.01 options:UIViewAnimationOptionCurveEaseOut animations:^{
-        self->_page2.transform = CGAffineTransformIdentity;
+        weakSelf.page2.transform = CGAffineTransformIdentity;
     } completion:nil];
     [UIView animateWithDuration:1.2 delay:0.2 usingSpringWithDamping:0.5 initialSpringVelocity:0.1 options:UIViewAnimationOptionCurveEaseOut animations:^{
-        self->_page3.transform = CGAffineTransformIdentity;
+        weakSelf.page3.transform = CGAffineTransformIdentity;
     } completion:^void(BOOL finished) {
         [UIView animateWithDuration:0.8 delay:2.0 usingSpringWithDamping:0.8 initialSpringVelocity:0.0 options:UIViewAnimationOptionCurveEaseOut animations:^{
-            [self moveAnimationToFirstFrame];
+            [weakSelf moveAnimationToFirstFrame];
         } completion:^(BOOL finished) {
-            [self playAnimation];
+            if (weakSelf.isAnimating) {
+                [weakSelf playAnimation];
+            }
         }];
     }];
 }


### PR DESCRIPTION
I just realised that we had a retain cycle in WPAnimatedBox – not sure if it might've been caused by the changes in #9710, because the completion block references self, and the animation repeats indefinitely.

**To test:**

* Build and run the app
* Tap into Blog Posts and back out, and then navigate into another screen like Comments
* Repeat this multiple times
* Use the memory graph in Xcode to check for instances of WPAnimatedBox. On develop, you should see multiple instances hanging around, but not on this branch:

<img width="191" alt="screen shot 2018-07-10 at 13 42 34" src="https://user-images.githubusercontent.com/4780/42514296-f75eb2e2-8450-11e8-967c-130746bbb5cd.png">
