### PR TITLE
Implement FormattableContent on Activity Log Detail

### DIFF
--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentFactory.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentFactory.swift
@@ -1,6 +1,8 @@
 
 public protocol FormattableContentFactory {
-    static func content(from blocks: [[String: AnyObject]], actionsParser parser: FormattableContentActionParser, parent: FormattableContentParent) -> [FormattableContent]
+    static func content(from blocks: [[String: AnyObject]],
+                        actionsParser parser: FormattableContentActionParser,
+                        parent: FormattableContentParent) -> [FormattableContent]
 }
 
 struct ActivityFormattableContentFactory: FormattableContentFactory {

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
@@ -6,9 +6,23 @@ public protocol FormattableContentRange {
     func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) -> Shift
 }
 
+protocol LinkContentRange {
+    var url: URL? { get }
+    func applyURLStyles(to string: NSMutableAttributedString, shiftedRange: NSRange, applying styles: FormattableContentStyles)
+}
+
+extension LinkContentRange where Self: FormattableContentRange {
+    func applyURLStyles(to string: NSMutableAttributedString, shiftedRange: NSRange, applying styles: FormattableContentStyles) {
+        if let url = url, let linksColor = styles.linksColor {
+            string.addAttribute(.link, value: url, range: shiftedRange)
+            string.addAttribute(.foregroundColor, value: linksColor, range: shiftedRange)
+        }
+    }
+}
+
 // MARK: - DefaultFormattableContentRange Entity
 //
-public class NotificationContentRange: FormattableContentRange {
+public class NotificationContentRange: FormattableContentRange, LinkContentRange {
     public let kind: Kind
     public let range: NSRange
 
@@ -38,13 +52,6 @@ public class NotificationContentRange: FormattableContentRange {
     fileprivate func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, at shiftedRange: NSRange) {
         if let rangeStyle = styles.rangeStylesMap?[kind] {
             string.addAttributes(rangeStyle, range: shiftedRange)
-        }
-    }
-
-    fileprivate func applyURLStyles(to string: NSMutableAttributedString, shiftedRange: NSRange, applying styles: FormattableContentStyles) {
-        if let url = url, let linksColor = styles.linksColor {
-            string.addAttribute(.link, value: url, range: shiftedRange)
-            string.addAttribute(.foregroundColor, value: linksColor, range: shiftedRange)
         }
     }
 
@@ -125,4 +132,5 @@ public extension NotificationContentRange.Kind {
     public static let site       = NotificationContentRange.Kind("site")
     public static let match      = NotificationContentRange.Kind("match")
     public static let link       = NotificationContentRange.Kind("link")
+    public static let italic     = NotificationContentRange.Kind("i")
 }

--- a/WordPress/Classes/ViewRelated/Activity/Activity.storyboard
+++ b/WordPress/Classes/ViewRelated/Activity/Activity.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14295.6" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14270.1"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,10 +19,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2EY-TD-6V1" userLabel="container view">
-                                <rect key="frame" x="0.0" y="20" width="375" height="149.5"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="357.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="mSI-6P-kcW">
-                                        <rect key="frame" x="16" y="16" width="343" height="117.5"/>
+                                        <rect key="frame" x="16" y="16" width="343" height="325.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="DDN-1Y-KHk" userLabel="header">
                                                 <rect key="frame" x="0.0" y="0.0" width="343" height="38.5"/>
@@ -72,16 +72,23 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="jlr-kR-xzq" userLabel="content">
-                                                <rect key="frame" x="0.0" y="68.5" width="343" height="49"/>
+                                                <rect key="frame" x="0.0" y="68.5" width="343" height="257"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZGb-bM-Y2p">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZGb-bM-Y2p" customClass="RichTextVIew">
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
+                                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3sW-BH-Aq9">
+                                                        <rect key="frame" x="0.0" y="28.5" width="343" height="200"/>
+                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                    </textView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ASx-wD-w08">
-                                                        <rect key="frame" x="0.0" y="28.5" width="343" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="236.5" width="343" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <color key="textColor" red="0.40000000000000002" green="0.55686274509803924" blue="0.66666666666666663" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
@@ -89,7 +96,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Ouv-sN-axZ" userLabel="rewind">
-                                                <rect key="frame" x="0.0" y="117.5" width="343" height="44.5"/>
+                                                <rect key="frame" x="0.0" y="325.5" width="343" height="44.5"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yPg-ua-Eim">
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="0.5"/>
@@ -147,6 +154,7 @@
                         <outlet property="roleLabel" destination="hWd-Yt-cp5" id="UVe-9x-2E2"/>
                         <outlet property="summaryLabel" destination="ASx-wD-w08" id="THa-Vd-ylW"/>
                         <outlet property="textLabel" destination="ZGb-bM-Y2p" id="qUF-RI-rlQ"/>
+                        <outlet property="textView" destination="3sW-BH-Aq9" id="6w7-jX-TJa"/>
                         <outlet property="timeLabel" destination="Cqx-0J-WUT" id="vaU-Gy-hCg"/>
                     </connections>
                 </viewController>

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -4,7 +4,11 @@ import WordPressUI
 
 class ActivityDetailViewController: UIViewController {
 
-    var activity: Activity?
+    var formattableActivity: FormattableActivity? {
+        didSet {
+            activity = formattableActivity?.activity
+        }
+    }
     var site: JetpackSiteRef?
 
     weak var rewindPresenter: ActivityRewindPresenter?
@@ -17,6 +21,8 @@ class ActivityDetailViewController: UIViewController {
     @IBOutlet private var timeLabel: UILabel!
     @IBOutlet private var dateLabel: UILabel!
 
+    
+    @IBOutlet weak var textView: UITextView!
     @IBOutlet private var textLabel: UILabel!
     @IBOutlet private var summaryLabel: UILabel!
 
@@ -27,6 +33,8 @@ class ActivityDetailViewController: UIViewController {
     @IBOutlet private var bottomConstaint: NSLayoutConstraint!
 
     @IBOutlet private var rewindButton: UIButton!
+
+    private var activity: Activity?
 
     override func viewDidLoad() {
         setupFonts()
@@ -44,13 +52,24 @@ class ActivityDetailViewController: UIViewController {
         nameLabel.font = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize,
                                            weight: .semibold)
 
-        textLabel.font = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize,
-                                           weight: .semibold)
+        if FeatureFlag.extractNotifications.enabled == false {
+            textLabel.font = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize,
+                                               weight: .semibold)
+        }
     }
 
     private func setupViews() {
         guard let activity = activity else {
             return
+        }
+
+        let showFormattedText = FeatureFlag.extractNotifications.enabled
+        textLabel.isHidden = showFormattedText
+        textView.isHidden = !showFormattedText
+
+        if showFormattedText {
+            textView.textContainerInset = .zero
+            textView.textContainer.lineFragmentPadding = 0
         }
 
         if activity.isRewindable {
@@ -83,7 +102,11 @@ class ActivityDetailViewController: UIViewController {
         nameLabel.text = activity.actor?.displayName
         roleLabel.text = activity.actor?.role.localizedCapitalized
 
-        textLabel.text = activity.text
+        if FeatureFlag.extractNotifications.enabled {
+            textView.attributedText = formattableActivity?.formattedContent(using: ActivityContentStyles())
+        } else {
+            textLabel.text = activity.text
+        }
         summaryLabel.text = activity.summary
 
         rewindButton.setTitle(NSLocalizedString("Rewind", comment: "Title for button allowing user to rewind their Jetpack site"),

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -177,14 +177,14 @@ extension ActivityListViewController: ActivityRewindPresenter {
 }
 extension ActivityListViewController: ActivityDetailPresenter {
 
-    func presentDetailsFor(activity: Activity) {
+    func presentDetailsFor(activity: FormattableActivity) {
         let activityStoryboard = UIStoryboard(name: "Activity", bundle: nil)
         guard let detailVC = activityStoryboard.instantiateViewController(withIdentifier: "ActivityDetailViewController") as? ActivityDetailViewController else {
             return
         }
 
         detailVC.site = site
-        detailVC.activity = activity
+        detailVC.formattableActivity = activity
         detailVC.rewindPresenter = self
 
         self.navigationController?.pushViewController(detailVC, animated: true)

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -5,7 +5,7 @@ protocol ActivityRewindPresenter: class {
 }
 
 protocol ActivityDetailPresenter: class {
-    func presentDetailsFor(activity: Activity)
+    func presentDetailsFor(activity: FormattableActivity)
 }
 
 class ActivityListViewModel: Observable {
@@ -63,7 +63,7 @@ class ActivityListViewModel: Observable {
             return ActivityListRow(
                 formattableActivity: formattableActivity,
                 action: { [weak presenter] (row) in
-                    presenter?.presentDetailsFor(activity: formattableActivity.activity)
+                    presenter?.presentDetailsFor(activity: formattableActivity)
                 }
             )
         })

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -24,11 +24,7 @@ open class ActivityTableViewCell: WPTableViewCell {
         }
 
         summaryLabel.text = activity.summary
-        if FeatureFlag.extractNotifications.enabled {
-            contentLabel.attributedText = formattableActivity.formattedContent(using: SubjectContentStyles())
-        } else {
-            contentLabel.text = activity.text
-        }
+        contentLabel.text = activity.text
 
         iconBackgroundImageView.backgroundColor = Style.getColorByActivityStatus(activity)
         if let iconImage = Style.getIconForActivity(activity) {

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentStyles.swift
@@ -10,23 +10,10 @@ class ActivityContentStyles: FormattableContentStyles {
         return [
             .post: WPStyleGuide.ActivityStyleGuide.contentItalicStyle,
             .comment: WPStyleGuide.ActivityStyleGuide.contentItalicStyle,
+            .italic: WPStyleGuide.ActivityStyleGuide.contentItalicStyle
         ]
     }
 
     var linksColor: UIColor? = WPStyleGuide.ActivityStyleGuide.linkColor
-    var key: String = "SubjectContentStyles"
-}
-
-class ItalicContentRange: FormattableContentRange {
-    var url: URL?
-    let range: NSRange
-
-    public init(range: NSRange, url: URL?) {
-        self.range = range
-        self.url = url
-    }
-
-    func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) -> FormattableContentRange.Shift {
-        return 0
-    }
+    var key: String = "ActivityContentStyles"
 }

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentStyles.swift
@@ -1,0 +1,32 @@
+
+class ActivityContentStyles: FormattableContentStyles {
+    var attributes: [NSAttributedStringKey: Any] {
+        return WPStyleGuide.ActivityStyleGuide.contentRegularStyle
+    }
+
+    var quoteStyles: [NSAttributedStringKey: Any]? = nil
+
+    var rangeStylesMap: [NotificationContentRange.Kind: [NSAttributedStringKey: Any]]? {
+        return [
+            .post: WPStyleGuide.ActivityStyleGuide.contentItalicStyle,
+            .comment: WPStyleGuide.ActivityStyleGuide.contentItalicStyle,
+        ]
+    }
+
+    var linksColor: UIColor? = WPStyleGuide.ActivityStyleGuide.linkColor
+    var key: String = "SubjectContentStyles"
+}
+
+class ItalicContentRange: FormattableContentRange {
+    var url: URL?
+    let range: NSRange
+
+    public init(range: NSRange, url: URL?) {
+        self.range = range
+        self.url = url
+    }
+
+    func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) -> FormattableContentRange.Shift {
+        return 0
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentStyles.swift
@@ -4,8 +4,6 @@ class ActivityContentStyles: FormattableContentStyles {
         return WPStyleGuide.ActivityStyleGuide.contentRegularStyle
     }
 
-    var quoteStyles: [NSAttributedStringKey: Any]? = nil
-
     var rangeStylesMap: [NotificationContentRange.Kind: [NSAttributedStringKey: Any]]? {
         return [
             .post: WPStyleGuide.ActivityStyleGuide.contentItalicStyle,
@@ -14,6 +12,7 @@ class ActivityContentStyles: FormattableContentStyles {
         ]
     }
 
-    var linksColor: UIColor? = WPStyleGuide.ActivityStyleGuide.linkColor
-    var key: String = "ActivityContentStyles"
+    let linksColor: UIColor? = WPStyleGuide.ActivityStyleGuide.linkColor
+    let quoteStyles: [NSAttributedStringKey: Any]? = nil
+    let key: String = "ActivityContentStyles"
 }

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentStyles.swift
@@ -7,7 +7,7 @@ class ActivityContentStyles: FormattableContentStyles {
     var rangeStylesMap: [NotificationContentRange.Kind: [NSAttributedStringKey: Any]]? {
         return [
             .post: WPStyleGuide.ActivityStyleGuide.contentItalicStyle,
-            .comment: WPStyleGuide.ActivityStyleGuide.contentItalicStyle,
+            .comment: WPStyleGuide.ActivityStyleGuide.contentRegularStyle,
             .italic: WPStyleGuide.ActivityStyleGuide.contentItalicStyle
         ]
     }

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/FormattableActivity.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/FormattableActivity.swift
@@ -1,6 +1,7 @@
 
 class FormattableActivity {
     let activity: Activity
+    
     private let formatter = FormattableContentFormatter()
     private var cachedContentGroup: FormattableContentGroup? = nil
 

--- a/WordPress/Classes/ViewRelated/Activity/WPStyleGuide+Activity.swift
+++ b/WordPress/Classes/ViewRelated/Activity/WPStyleGuide+Activity.swift
@@ -9,6 +9,20 @@ extension WPStyleGuide {
     public struct ActivityStyleGuide {
 
         // MARK: - Public Properties
+        
+        public static let linkColor = WPStyleGuide.baseLighterBlue()
+
+        public static var contentRegularStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: contentParagraph,
+                     .font: contentRegularFont,
+                     .foregroundColor: contentTextColor ]
+        }
+
+        public static var contentItalicStyle: [NSAttributedStringKey: Any] {
+            return  [.paragraphStyle: contentParagraph,
+                     .font: contentItalicFont,
+                     .foregroundColor: contentTextColor ]
+        }
 
         public static func gravatarPlaceholderImage() -> UIImage {
             return gravatar
@@ -69,6 +83,37 @@ extension WPStyleGuide {
         }
 
         // MARK: - Private Properties
+
+        private static let contentTextColor = WPStyleGuide.littleEddieGrey()
+
+        private static var minimumLineHeight: CGFloat {
+            return contentFontSize * 1.3
+        }
+
+        private static let contentParagraph = NSMutableParagraphStyle(
+            minLineHeight: minimumLineHeight, lineBreakMode: .byWordWrapping, alignment: .natural
+        )
+
+        private static var contentFontSize: CGFloat {
+            return  UIFont.preferredFont(forTextStyle: .body).pointSize
+        }
+
+        private static var contentRegularFont: UIFont {
+            if #available(iOS 11.0, *) {
+                return WPStyleGuide.fontForTextStyle(.body)
+
+            } else {
+                return WPFontManager.systemRegularFont(ofSize: contentFontSize)
+            }
+        }
+
+        private static var contentItalicFont: UIFont {
+            if #available(iOS 11.0, *) {
+                return  WPStyleGuide.fontForTextStyle(.body, symbolicTraits: .traitItalic)
+            } else {
+                return WPFontManager.systemItalicFont(ofSize: contentFontSize)
+            }
+        }
 
         fileprivate static let gravatar = UIImage(named: "gravatar")!
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -476,6 +476,7 @@
 		7E14635720B3BEAB00B95F41 /* WPStyleGuide+Loader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E14635620B3BEAB00B95F41 /* WPStyleGuide+Loader.swift */; };
 		7E21C761202BBC8E00837CF5 /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E21C760202BBC8D00837CF5 /* iAd.framework */; };
 		7E21C765202BBF4400837CF5 /* SearchAdsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E21C764202BBF4400837CF5 /* SearchAdsAttribution.swift */; };
+		7E3AB3DB20F52654001F33B6 /* ActivityContentStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3AB3DA20F52654001F33B6 /* ActivityContentStyles.swift */; };
 		7E3E7A5320E44B260075D159 /* SubjectContentStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A5220E44B260075D159 /* SubjectContentStyles.swift */; };
 		7E3E7A5520E44B4B0075D159 /* SnipetsContentStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A5420E44B4B0075D159 /* SnipetsContentStyles.swift */; };
 		7E3E7A5720E44D130075D159 /* HeaderContentStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A5620E44D130075D159 /* HeaderContentStyles.swift */; };
@@ -1926,6 +1927,7 @@
 		7E14635620B3BEAB00B95F41 /* WPStyleGuide+Loader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Loader.swift"; sourceTree = "<group>"; };
 		7E21C760202BBC8D00837CF5 /* iAd.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = iAd.framework; path = System/Library/Frameworks/iAd.framework; sourceTree = SDKROOT; };
 		7E21C764202BBF4400837CF5 /* SearchAdsAttribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SearchAdsAttribution.swift; path = iAds/SearchAdsAttribution.swift; sourceTree = "<group>"; };
+		7E3AB3DA20F52654001F33B6 /* ActivityContentStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityContentStyles.swift; sourceTree = "<group>"; };
 		7E3E7A5220E44B260075D159 /* SubjectContentStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubjectContentStyles.swift; sourceTree = "<group>"; };
 		7E3E7A5420E44B4B0075D159 /* SnipetsContentStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnipetsContentStyles.swift; sourceTree = "<group>"; };
 		7E3E7A5620E44D130075D159 /* HeaderContentStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderContentStyles.swift; sourceTree = "<group>"; };
@@ -4221,6 +4223,7 @@
 				7E4123C720F417EF00DF8486 /* FormattableActivity.swift */,
 				7E4123C920F4184200DF8486 /* ActivityContentGroup.swift */,
 				7E4123CB20F418A500DF8486 /* ActivityActionsParser.swift */,
+				7E3AB3DA20F52654001F33B6 /* ActivityContentStyles.swift */,
 			);
 			path = FormattableContent;
 			sourceTree = "<group>";
@@ -7881,6 +7884,7 @@
 				08F8CD2A1EBD22EF0049D0C0 /* MediaExporter.swift in Sources */,
 				E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */,
 				17B7C8C120EE2A870042E260 /* Routes+Notifications.swift in Sources */,
+				7E3AB3DB20F52654001F33B6 /* ActivityContentStyles.swift in Sources */,
 				E6431DE71C4E892900FD8D90 /* SharingViewController.m in Sources */,
 				7E4123C820F417EF00DF8486 /* FormattableActivity.swift in Sources */,
 				FF286C761DE70A4500383A62 /* NSURL+Exporters.swift in Sources */,


### PR DESCRIPTION
Fixes #9740 

This PR implements `FormattableContent` to format the content string on `Activity Log Detail`.

![activitylog](https://user-images.githubusercontent.com/9772967/42548197-f4ac00ca-8493-11e8-80d2-4dc5b8a4a38f.png)


**Note:**
- Links will open on Safari.
- Not all links will open.
- There are kinds of Ranges yet to be implemented (`plugin`, `theme`).

All these points will be addressed on separated PRs.
And also if the design need to change, let's do it on a separated PR

To test:
- Open Activity Log.
- Check that the following kind of ranges are formatted correctly:
  - Italic (Found on events like: `Default post category changes from <i>some</i> to <i>another</I>`
  - Link (On the pingback example, the first link is a `link` type. It has a url without specifying type)
  - Post (The names of posts formatted as a `italic` link)
  - Comment (`Commented by someone on somewhere...`, the first `Commented` is `comment` type. Formatted as a link)