### PR TITLE
Issue/9667 Universal Links: Stats

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+enum StatsRoute {
+    case root
+    case site
+}
+
+extension StatsRoute: Route {
+    var action: NavigationAction {
+        return self
+    }
+
+    var path: String {
+        switch self {
+        case .root:
+            return "/stats"
+        case .site:
+            return "/stats/:domain"
+        }
+    }
+}
+
+extension StatsRoute: NavigationAction {
+    func perform(_ values: [String: String]?) {
+        guard let coordinator = WPTabBarController.sharedInstance().mySitesCoordinator else {
+            return
+        }
+
+        switch self {
+        case .root:
+            if let blog = defaultBlog() {
+                coordinator.showStats(for: blog)
+            }
+        case .site:
+            if let blog = blog(from: values) {
+                coordinator.showStats(for: blog)
+            }
+        default:
+            break
+        }
+    }
+
+    private func defaultBlog() -> Blog? {
+        let context = ContextManager.sharedInstance().mainContext
+        let service = BlogService(managedObjectContext: context)
+
+        return service.lastUsedOrFirstBlog()
+    }
+
+    private func blog(from values: [String: String]?) -> Blog? {
+        guard let domain = values?["domain"] else {
+            return nil
+        }
+
+        let context = ContextManager.sharedInstance().mainContext
+        let service = BlogService(managedObjectContext: context)
+
+        return service.blog(byHostname: domain)
+    }
+}

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -1,8 +1,14 @@
 import Foundation
+import WordPressComStatsiOS
 
 enum StatsRoute {
     case root
     case site
+    case daySite
+    case weekSite
+    case monthSite
+    case yearSite
+    case insights
     case activityLog
 }
 
@@ -17,6 +23,16 @@ extension StatsRoute: Route {
             return "/stats"
         case .site:
             return "/stats/:domain"
+        case .daySite:
+            return "/stats/day/:domain"
+        case .weekSite:
+            return "/stats/week/:domain"
+        case .monthSite:
+            return "/stats/month/:domain"
+        case .yearSite:
+            return "/stats/year/:domain"
+        case .insights:
+            return "/stats/insights/:domain"
         case .activityLog:
             return "/stats/activity/:domain"
         }
@@ -37,6 +53,31 @@ extension StatsRoute: NavigationAction {
         case .site:
             if let blog = blog(from: values) {
                 coordinator.showStats(for: blog)
+            }
+        case .daySite:
+            if let blog = blog(from: values) {
+                coordinator.showStats(for: blog,
+                                      timePeriod: StatsPeriodType.days)
+            }
+        case .weekSite:
+            if let blog = blog(from: values) {
+                coordinator.showStats(for: blog,
+                                      timePeriod: StatsPeriodType.weeks)
+            }
+        case .monthSite:
+            if let blog = blog(from: values) {
+                coordinator.showStats(for: blog,
+                                      timePeriod: StatsPeriodType.months)
+            }
+        case .yearSite:
+            if let blog = blog(from: values) {
+                coordinator.showStats(for: blog,
+                                      timePeriod: StatsPeriodType.years)
+            }
+        case .insights:
+            if let blog = blog(from: values) {
+                coordinator.showStats(for: blog,
+                                      timePeriod: StatsPeriodType.insights)
             }
         case .activityLog:
             if let blog = blog(from: values) {

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -3,6 +3,7 @@ import Foundation
 enum StatsRoute {
     case root
     case site
+    case activityLog
 }
 
 extension StatsRoute: Route {
@@ -16,6 +17,8 @@ extension StatsRoute: Route {
             return "/stats"
         case .site:
             return "/stats/:domain"
+        case .activityLog:
+            return "/stats/activity/:domain"
         }
     }
 }
@@ -35,8 +38,10 @@ extension StatsRoute: NavigationAction {
             if let blog = blog(from: values) {
                 coordinator.showStats(for: blog)
             }
-        default:
-            break
+        case .activityLog:
+            if let blog = blog(from: values) {
+                coordinator.showActivityLog(for: blog)
+            }
         }
     }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -9,6 +9,8 @@ enum StatsRoute {
     case monthSite
     case yearSite
     case insights
+    case dayCategory
+    case annualStats
     case activityLog
 }
 
@@ -33,6 +35,10 @@ extension StatsRoute: Route {
             return "/stats/year/:domain"
         case .insights:
             return "/stats/insights/:domain"
+        case .dayCategory:
+            return "/stats/day/:category/:domain"
+        case .annualStats:
+            return "/stats/annualstats/:domain"
         case .activityLog:
             return "/stats/activity/:domain"
         }
@@ -78,6 +84,16 @@ extension StatsRoute: NavigationAction {
             if let blog = blog(from: values) {
                 coordinator.showStats(for: blog,
                                       timePeriod: StatsPeriodType.insights)
+            }
+        case .dayCategory:
+            if let blog = blog(from: values) {
+                coordinator.showStats(for: blog,
+                                      timePeriod: StatsPeriodType.days)
+            }
+        case .annualStats:
+            if let blog = blog(from: values) {
+                coordinator.showStats(for: blog,
+                                      timePeriod: StatsPeriodType.years)
             }
         case .activityLog:
             if let blog = blog(from: values) {

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -30,7 +30,9 @@ struct UniversalLinkRouter {
         ReaderRoute.list,
         ReaderRoute.tag,
         ReaderRoute.feedsPost,
-        ReaderRoute.blogsPost
+        ReaderRoute.blogsPost,
+        StatsRoute.root,
+        StatsRoute.site
         ])
 
     /// Attempts to find a Route that matches the url's path, and perform its

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -32,7 +32,8 @@ struct UniversalLinkRouter {
         ReaderRoute.feedsPost,
         ReaderRoute.blogsPost,
         StatsRoute.root,
-        StatsRoute.site
+        StatsRoute.site,
+        StatsRoute.activityLog
         ])
 
     /// Attempts to find a Route that matches the url's path, and perform its

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -14,13 +14,28 @@ struct UniversalLinkRouter {
     // app delegate, and because it's primarily written in objective-c we can't
     // add a struct property there.
     //
-    static let shared = UniversalLinkRouter(routes: [
+    static let shared = UniversalLinkRouter(routes: MeRoutes +
+        NewPostRoutes +
+        NotificationsRoutes +
+        ReaderRoutes +
+        StatsRoutes)
+
+    private static let MeRoutes: [Route] = [
         MeRoute(),
         MeAccountSettingsRoute(),
-        MeNotificationSettingsRoute(),
+        MeNotificationSettingsRoute()
+    ]
+
+    private static let NewPostRoutes: [Route] = [
         NewPostRoute(),
-        NewPostForSiteRoute(),
-        NotificationsRoute(),
+        NewPostForSiteRoute()
+    ]
+
+    private static let NotificationsRoutes: [Route] = [
+        NotificationsRoute()
+    ]
+
+    private static let ReaderRoutes: [Route] = [
         ReaderRoute.root,
         ReaderRoute.discover,
         ReaderRoute.search,
@@ -30,11 +45,19 @@ struct UniversalLinkRouter {
         ReaderRoute.list,
         ReaderRoute.tag,
         ReaderRoute.feedsPost,
-        ReaderRoute.blogsPost,
+        ReaderRoute.blogsPost
+    ]
+
+    private static let StatsRoutes: [Route] = [
         StatsRoute.root,
         StatsRoute.site,
+        StatsRoute.daySite,
+        StatsRoute.weekSite,
+        StatsRoute.monthSite,
+        StatsRoute.yearSite,
+        StatsRoute.insights,
         StatsRoute.activityLog
-        ])
+    ]
 
     /// Attempts to find a Route that matches the url's path, and perform its
     /// associated action.

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -56,6 +56,8 @@ struct UniversalLinkRouter {
         StatsRoute.monthSite,
         StatsRoute.yearSite,
         StatsRoute.insights,
+        StatsRoute.dayCategory,
+        StatsRoute.annualStats,
         StatsRoute.activityLog
     ]
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
@@ -8,7 +8,8 @@ typedef NS_ENUM(NSUInteger, BlogDetailsSubsection) {
     BlogDetailsSubsectionCustomize,
     BlogDetailsSubsectionThemes,
     BlogDetailsSubsectionMedia,
-    BlogDetailsSubsectionPages
+    BlogDetailsSubsectionPages,
+    BlogDetailsSubsectionActivity
 };
 
 @interface BlogDetailsViewController : UITableViewController <UIViewControllerRestoration> {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -349,6 +349,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                   scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
             [self showPageList];
             break;
+        case BlogDetailsSubsectionActivity:
+            if ([self.blog supports:BlogFeatureActivity]) {
+                self.restorableSelectedIndexPath = indexPath;
+                [self.tableView selectRowAtIndexPath:indexPath
+                                            animated:NO
+                                      scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
+                [self showActivity];
+            }
+            break;
     }
 }
 
@@ -357,6 +366,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     switch (section) {
         case BlogDetailsSubsectionStats:
             return [NSIndexPath indexPathForRow:0 inSection:0];
+        case BlogDetailsSubsectionActivity:
+            return [NSIndexPath indexPathForRow:1 inSection:0];
         case BlogDetailsSubsectionPosts:
             return [NSIndexPath indexPathForRow:0 inSection:1];
         case BlogDetailsSubsectionThemes:

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressComStatsiOS
 
 @objc
 class MySitesCoordinator: NSObject {
@@ -34,6 +35,22 @@ class MySitesCoordinator: NSObject {
         }
     }
 
+    func showStats(for blog: Blog, timePeriod: StatsPeriodType) {
+        showBlogDetails(for: blog)
+
+        if let blogDetailsViewController = mySitesNavigationController.topViewController as? BlogDetailsViewController {
+            // Setting this user default is a bit of a hack, but it's by far the easiest way to
+            // get the stats view controller displaying the correct period. I spent some time
+            // trying to do it differently, but the existing stats view controller setup is
+            // quite complex and contains many nested child view controllers. As we're planning
+            // to revamp that section in the not too distant future, I opted for this simpler
+            // configuration for now. 2018-07-11 @frosty
+            UserDefaults.standard.set(timePeriod.rawValue, forKey: MySitesCoordinator.statsPeriodTypeDefaultsKey)
+
+            blogDetailsViewController.showDetailView(for: .stats)
+        }
+    }
+
     func showActivityLog(for blog: Blog) {
         showBlogDetails(for: blog)
 
@@ -41,4 +58,6 @@ class MySitesCoordinator: NSObject {
             blogDetailsViewController.showDetailView(for: .activity)
         }
     }
+
+    private static let statsPeriodTypeDefaultsKey = "LastSelectedStatsPeriodType"
 }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -1,0 +1,36 @@
+import UIKit
+
+@objc
+class MySitesCoordinator: NSObject {
+    let mySitesNavigationController: UINavigationController
+    let blogListViewController: BlogListViewController
+
+    @objc
+    init(mySitesNavigationController: UINavigationController,
+         blogListViewController: BlogListViewController) {
+        self.mySitesNavigationController = mySitesNavigationController
+        self.blogListViewController = blogListViewController
+
+        super.init()
+    }
+
+    private func prepareToNavigate() {
+        WPTabBarController.sharedInstance().showMySitesTab()
+
+        mySitesNavigationController.viewControllers = [blogListViewController]
+    }
+
+    func showBlogDetails(for blog: Blog) {
+        prepareToNavigate()
+
+        blogListViewController.setSelectedBlog(blog, animated: false)
+    }
+
+    func showStats(for blog: Blog) {
+        showBlogDetails(for: blog)
+
+        if let blogDetailsViewController = mySitesNavigationController.topViewController as? BlogDetailsViewController {
+            blogDetailsViewController.showDetailView(for: .stats)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -33,4 +33,12 @@ class MySitesCoordinator: NSObject {
             blogDetailsViewController.showDetailView(for: .stats)
         }
     }
+
+    func showActivityLog(for blog: Blog) {
+        showBlogDetails(for: blog)
+
+        if let blogDetailsViewController = mySitesNavigationController.topViewController as? BlogDetailsViewController {
+            blogDetailsViewController.showDetailView(for: .activity)
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -15,6 +15,7 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 @class Blog;
 @class BlogListViewController;
 @class MeViewController;
+@class MySitesCoordinator;
 @class NotificationsViewController;
 @class ReaderCoordinator;
 @class ReaderMenuViewController;
@@ -28,6 +29,7 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 @property (nonatomic, strong, readonly) NotificationsViewController *notificationsViewController;
 @property (nonatomic, strong, readonly) MeViewController *meViewController;
 
+@property (nonatomic, strong, readonly) MySitesCoordinator *mySitesCoordinator;
 @property (nonatomic, strong, readonly) ReaderCoordinator *readerCoordinator;
 
 + (instancetype)sharedInstance;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -452,6 +452,12 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 #pragma mark - Navigation Coordinators
 
+- (MySitesCoordinator *)mySitesCoordinator
+{
+    return [[MySitesCoordinator alloc] initWithMySitesNavigationController:self.blogListNavigationController
+                                                    blogListViewController:self.blogListViewController];
+}
+
 - (ReaderCoordinator *)readerCoordinator
 {
     return [[ReaderCoordinator alloc] initWithReaderNavigationController:self.readerNavigationController

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -126,6 +126,8 @@
 		1707CE421F3121750020B7FE /* UICollectionViewCell+Tint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1707CE411F3121750020B7FE /* UICollectionViewCell+Tint.swift */; };
 		170CE7402064478600A48191 /* PostNoticeNavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170CE73F2064478600A48191 /* PostNoticeNavigationCoordinator.swift */; };
 		1714F8D020E6DA8900226DCB /* RouteMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1714F8CF20E6DA8900226DCB /* RouteMatcher.swift */; };
+		1715179220F4B2EB002C4A38 /* Routes+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1715179120F4B2EB002C4A38 /* Routes+Stats.swift */; };
+		1715179420F4B5CD002C4A38 /* MySitesCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1715179320F4B5CD002C4A38 /* MySitesCoordinator.swift */; };
 		171909E4206CFFCD0054DF0B /* FancyAlertViewController+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171909E3206CFFCD0054DF0B /* FancyAlertViewController+Async.swift */; };
 		171963401D378D5100898E8B /* SearchWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1719633F1D378D5100898E8B /* SearchWrapperView.swift */; };
 		1724DDC81C60F1200099D273 /* PlanDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1724DDC71C60F1200099D273 /* PlanDetailViewController.swift */; };
@@ -1459,6 +1461,8 @@
 		1707CE411F3121750020B7FE /* UICollectionViewCell+Tint.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UICollectionViewCell+Tint.swift"; sourceTree = "<group>"; };
 		170CE73F2064478600A48191 /* PostNoticeNavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNoticeNavigationCoordinator.swift; sourceTree = "<group>"; };
 		1714F8CF20E6DA8900226DCB /* RouteMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteMatcher.swift; sourceTree = "<group>"; };
+		1715179120F4B2EB002C4A38 /* Routes+Stats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Stats.swift"; sourceTree = "<group>"; };
+		1715179320F4B5CD002C4A38 /* MySitesCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySitesCoordinator.swift; sourceTree = "<group>"; };
 		171909E3206CFFCD0054DF0B /* FancyAlertViewController+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FancyAlertViewController+Async.swift"; sourceTree = "<group>"; };
 		1719633F1D378D5100898E8B /* SearchWrapperView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SearchWrapperView.swift; sourceTree = "<group>"; };
 		1724DDC71C60F1200099D273 /* PlanDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanDetailViewController.swift; sourceTree = "<group>"; };
@@ -3301,6 +3305,7 @@
 				17B7C8C020EE2A870042E260 /* Routes+Notifications.swift */,
 				1703D04B20ECD93800D292E9 /* Routes+Post.swift */,
 				17A4A36820EE51870071C2CA /* Routes+Reader.swift */,
+				1715179120F4B2EB002C4A38 /* Routes+Stats.swift */,
 				1714F8CF20E6DA8900226DCB /* RouteMatcher.swift */,
 				17B7C89D20EC1D0D0042E260 /* UniversalLinkRouter.swift */,
 			);
@@ -3311,6 +3316,7 @@
 			isa = PBXGroup;
 			children = (
 				17A4A36B20EE55320071C2CA /* ReaderCoordinator.swift */,
+				1715179320F4B5CD002C4A38 /* MySitesCoordinator.swift */,
 			);
 			path = Coordinators;
 			sourceTree = "<group>";
@@ -7180,6 +7186,7 @@
 				08216FD01CDBF96000304BA7 /* MenuItemSourceFooterView.m in Sources */,
 				17F0AE301F091563007D5A6B /* ConfettiView.swift in Sources */,
 				5DED0E181B432E0400431FCD /* SourcePostAttribution.m in Sources */,
+				1715179420F4B5CD002C4A38 /* MySitesCoordinator.swift in Sources */,
 				08D978561CD2AF7D0054F19A /* MenuItem+ViewDesign.m in Sources */,
 				B52C4C7F199D74AE009FD823 /* NoteTableViewCell.swift in Sources */,
 				315FC2C51A2CB29300E7CDA2 /* MeHeaderView.m in Sources */,
@@ -7190,6 +7197,7 @@
 				5DFA7EC71AF814E40072023B /* PageListTableViewCell.m in Sources */,
 				5D62BAD718AA88210044E5F7 /* PageSettingsViewController.m in Sources */,
 				17D2FDC21C6A468A00944265 /* PlanComparisonViewController.swift in Sources */,
+				1715179220F4B2EB002C4A38 /* Routes+Stats.swift in Sources */,
 				74729CAA2057100200D1394D /* SearchIdentifierGenerator.swift in Sources */,
 				B57273601B66CCEF000D1C4F /* AlertInternalView.swift in Sources */,
 				433432541E9EE0B100915988 /* EpilogueSegue.swift in Sources */,


### PR DESCRIPTION
Implements #9667. This PR follows on from #9728, and adds a universal links route for Stats:

* `/stats` -> Shows stats for last used or primary blog
* `/stats/:domain` -> Shows stats for specified blog
* `/stats/day/:domain` -> Day view for blog
* `/stats/week/:domain` -> Week view for blog
* `/stats/month/:domain` -> Month view for blog
* `/stats/year/:domain` -> Year view for blog
* `/stats/insights/:domain` -> Insights view for blog
* `/stats/day/:category/:domain` -> Day view for blog (we ignore the category, as it's all on one page anyway)
* `/stats/annualstats/:domain` -> Year view for blog
* `/stats/activity/:domain` -> Activity log

**To test:**

* Same as the previous PRs, add an applinks: entry to the Associated Domains capability for the test domain I provided.
* In Safari on your device, open the test page I created and try each of the Stats links. Check that the various items in the Stats section of the app launch as expected. Please let me know if you have any questions!

Thanks!
