### PR TITLE
Add pull-to-refresh to Activity Log.

### DIFF
--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -5,6 +5,7 @@ import WordPressFlux
 // MARK: - Store helper types
 
 enum ActivityAction: Action {
+    case refreshActivities(site: JetpackSiteRef)
     case receiveActivities(site: JetpackSiteRef, activities: [Activity])
     case receiveActivitiesFailed(site: JetpackSiteRef, error: Error)
 
@@ -168,6 +169,8 @@ class ActivityStore: QueryStore<ActivityStoreState, ActivityQuery> {
             receiveActivities(site: site, activities: activities)
         case .receiveActivitiesFailed(let site, let error):
             receiveActivitiesFailed(site: site, error: error)
+        case .refreshActivities(let site):
+            refreshActivities(site: site)
         case .rewind(let site, let rewindID):
             rewind(site: site, rewindID: rewindID)
         case .rewindStarted(let site, let rewindID, let restoreID):
@@ -238,6 +241,14 @@ private extension ActivityStore {
             state.fetchingActivities[site] = false
             state.lastFetch[site] = Date()
         }
+    }
+
+    func refreshActivities(site: JetpackSiteRef) {
+        guard !isFetching(site: site) else {
+            DDLogInfo("Activity Log refresh triggered while one was in progress")
+            return
+        }
+        fetchActivities(site: site)
     }
 
     func rewind(site: JetpackSiteRef, rewindID: String) {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -44,7 +44,7 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
         }
 
         refreshControl = UIRefreshControl()
-        refreshControl?.addTarget(self, action: #selector(ActivityListViewController.userRefresh), for: .valueChanged)
+        refreshControl?.addTarget(self, action: #selector(userRefresh), for: .valueChanged)
 
         title = NSLocalizedString("Activity", comment: "Title for the activity list")
     }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -43,6 +43,9 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
             self?.refreshModel()
         }
 
+        refreshControl = UIRefreshControl()
+        refreshControl?.addTarget(self, action: #selector(ActivityListViewController.userRefresh), for: .valueChanged)
+
         title = NSLocalizedString("Activity", comment: "Title for the activity list")
     }
 
@@ -83,9 +86,29 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
         SVProgressHUD.dismiss()
     }
 
+    @objc func userRefresh() {
+        viewModel.refresh()
+    }
+
     func refreshModel() {
         handler.viewModel = viewModel.tableViewModel(presenter: self)
+        updateRefreshControl()
         updateNoResults()
+    }
+
+    private func updateRefreshControl() {
+        guard let refreshControl = refreshControl else {
+            return
+        }
+
+        switch (viewModel.refreshing, refreshControl.isRefreshing) {
+        case (true, false):
+            refreshControl.beginRefreshing()
+        case (false, true):
+            refreshControl.endRefreshing()
+        default:
+            break
+        }
     }
 
 }


### PR DESCRIPTION
Fairly simple one! Adds PTR in Activity views.

To test:
Go to Activity Log
Perform some activity that would get logged in AL via web (install a plugin, add a post, etc)
Make sure it shows up in Calypso (can take few moments)
Pull-to-refresh in the iOS app 
Verify that the new item shows in the app