### PR TITLE
No Results View: refactor creating a controller instance

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -206,16 +206,6 @@ extension ActivityListViewController {
 
 private extension ActivityListViewController {
 
-    func setupNoResultsViewController() {
-        let noResultsStoryboard = UIStoryboard(name: "NoResults", bundle: nil)
-        guard let noResultsViewController = noResultsStoryboard.instantiateViewController(withIdentifier: "NoResults") as? NoResultsViewController else {
-            return
-        }
-
-        noResultsViewController.delegate = self
-        self.noResultsViewController = noResultsViewController
-    }
-
     func updateNoResults() {
         if let noResultsViewModel = viewModel.noResultsViewModel() {
             showNoResults(noResultsViewModel)
@@ -227,7 +217,8 @@ private extension ActivityListViewController {
     func showNoResults(_ viewModel: NoResultsViewController.Model) {
 
         if noResultsViewController == nil {
-            setupNoResultsViewController()
+            noResultsViewController = NoResultsViewController.controller()
+            noResultsViewController?.delegate = self
         }
 
         guard let noResultsViewController = noResultsViewController else {

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -516,15 +516,9 @@ static NSInteger HideSearchMinSites = 3;
 - (void)instantiateNoResultsViewControllerIfNeeded
 {
     if (!self.noResultsViewController) {
-        [self instantiateNoResultsViewController];
+        self.noResultsViewController = [NoResultsViewController controller];
+        self.noResultsViewController.delegate = self;
     }
-}
-
-- (void)instantiateNoResultsViewController
-{
-    UIStoryboard *noResultsSB = [UIStoryboard storyboardWithName:@"NoResults" bundle:nil];
-    self.noResultsViewController = [noResultsSB instantiateViewControllerWithIdentifier:@"NoResults"];
-    self.noResultsViewController.delegate = self;
 }
 
 #pragma mark - Notifications

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -50,6 +50,40 @@ import WordPressAuthenticator
         configureView()
     }
 
+    /// Public method to get controller instance and set view values.
+    ///
+    /// - Parameters:
+    ///   - title:          Main descriptive text. Required.
+    ///   - buttonTitle:    Title of action button. Optional.
+    ///   - subtitle:       Secondary descriptive text. Optional.
+    ///   - image:          Name of image file to use. Optional.
+    ///   - accessoryView:  View to show instead of the image. Optional.
+    ///
+    class func controllerWith(title: String,
+                              buttonTitle: String? = nil,
+                              subtitle: String? = nil,
+                              image: String? = nil,
+                              accessoryView: UIView? = nil) -> NoResultsViewController {
+
+        let controller = NoResultsViewController.controller()
+        controller.titleText = title
+        controller.subtitleText = subtitle
+        controller.buttonText = buttonTitle
+        controller.imageName = image
+        controller.accessorySubview = accessoryView
+        return controller
+    }
+
+    /// Public method to get controller instance.
+    /// As this only creates the controller, the configure method should be called
+    /// to set the view values before presenting the No Results View.
+    ///
+    class func controller() -> NoResultsViewController {
+        let storyBoard = UIStoryboard(name: "NoResults", bundle: nil)
+        let controller = storyBoard.instantiateViewController(withIdentifier: "NoResults") as! NoResultsViewController
+        return controller
+    }
+
     /// Public method to provide values for text elements.
     ///
     /// - Parameters:

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -78,7 +78,7 @@ import WordPressAuthenticator
     /// As this only creates the controller, the configure method should be called
     /// to set the view values before presenting the No Results View.
     ///
-    class func controller() -> NoResultsViewController {
+    @objc class func controller() -> NoResultsViewController {
         let storyBoard = UIStoryboard(name: "NoResults", bundle: nil)
         let controller = storyBoard.instantiateViewController(withIdentifier: "NoResults") as! NoResultsViewController
         return controller

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -59,11 +59,11 @@ import WordPressAuthenticator
     ///   - image:          Name of image file to use. Optional.
     ///   - accessoryView:  View to show instead of the image. Optional.
     ///
-    class func controllerWith(title: String,
-                              buttonTitle: String? = nil,
-                              subtitle: String? = nil,
-                              image: String? = nil,
-                              accessoryView: UIView? = nil) -> NoResultsViewController {
+    @objc class func controllerWith(title: String,
+                                    buttonTitle: String? = nil,
+                                    subtitle: String? = nil,
+                                    image: String? = nil,
+                                    accessoryView: UIView? = nil) -> NoResultsViewController {
 
         let controller = NoResultsViewController.controller()
         controller.titleText = title

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -114,12 +114,22 @@ import WordPressAuthenticator
         navigationItem.leftBarButtonItem = dismissButton
     }
 
-    /// Use the values provided in the actual elements.
+    /// Public method to get the view height when adding the No Results View to a table cell.
     ///
-    private func configureView() {
+    func heightForTableCell() -> CGFloat {
+        return noResultsView.frame.height
+    }
+
+}
+
+private extension NoResultsViewController {
+
+    // MARK: - View
+
+    func configureView() {
 
         guard let titleText = titleText else {
-                return
+            return
         }
 
         titleLabel.text = titleText
@@ -157,17 +167,6 @@ import WordPressAuthenticator
         view.layoutIfNeeded()
     }
 
-    // MARK: - Helpers
-
-    private func accessibilityIdentifier(for string: String) -> String {
-        let buttonIdFormat = NSLocalizedString("%@ Button", comment: "Accessibility identifier for buttons.")
-        return String(format: buttonIdFormat, string)
-    }
-
-    func heightForTableCell() -> CGFloat {
-        return noResultsView.frame.height
-    }
-
     // MARK: - Button Handling
 
     @IBAction func actionButtonPressed(_ sender: Any) {
@@ -176,6 +175,13 @@ import WordPressAuthenticator
 
     @objc func dismissButtonPressed() {
         delegate?.dismissButtonPressed?()
+    }
+
+    // MARK: - Helpers
+
+    func accessibilityIdentifier(for string: String) -> String {
+        let buttonIdFormat = NSLocalizedString("%@ Button", comment: "Accessibility identifier for buttons.")
+        return String(format: buttonIdFormat, string)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationDomainsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationDomainsTableViewController.swift
@@ -292,13 +292,10 @@ private extension SiteCreationDomainsTableViewController {
     }
 
     func instantiateNoResultsViewController() {
-        let noResultsSB = UIStoryboard(name: "NoResults", bundle: nil)
-        noResultsViewController = noResultsSB.instantiateViewController(withIdentifier: "NoResults") as? NoResultsViewController
-
         let title = NSLocalizedString("We couldn't find any available address with the words you entered - let's try again.", comment: "Primary message shown when there are no domains that match the user entered text.")
         let subtitle = NSLocalizedString("Enter different words above and we'll look for an address that matches it.", comment: "Secondary message shown when there are no domains that match the user entered text.")
 
-        noResultsViewController?.configure(title: title, buttonTitle: nil, subtitle: subtitle)
+        noResultsViewController = NoResultsViewController.controllerWith(title: title, buttonTitle: nil, subtitle: subtitle)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -323,7 +323,8 @@ private extension PlanDetailViewController {
         removeNoResultsFromView()
 
         if noResultsViewController == nil {
-            instantiateNoResultsViewController()
+            noResultsViewController = NoResultsViewController.controller()
+            noResultsViewController?.delegate = self
         }
 
         guard let noResultsViewController = noResultsViewController,
@@ -337,12 +338,6 @@ private extension PlanDetailViewController {
         cell.contentView.addSubview(noResultsViewController.view)
         addChildViewController(noResultsViewController)
         noResultsViewController.didMove(toParentViewController: self)
-    }
-
-    func instantiateNoResultsViewController() {
-        let noResultsSB = UIStoryboard(name: "NoResults", bundle: nil)
-        noResultsViewController = noResultsSB.instantiateViewController(withIdentifier: "NoResults") as? NoResultsViewController
-        noResultsViewController?.delegate = self
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -87,16 +87,6 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
 
     // MARK: - NoResults Handling
 
-    private func setupNoResultsViewController() {
-        let noResultsStoryboard = UIStoryboard(name: "NoResults", bundle: nil)
-        guard let noResultsViewController = noResultsStoryboard.instantiateViewController(withIdentifier: "NoResults") as? NoResultsViewController else {
-            return
-        }
-
-        noResultsViewController.delegate = self
-        self.noResultsViewController = noResultsViewController
-    }
-
     private func updateNoResults() {
         hideNoResults()
         if let noResultsViewModel = viewModel.noResultsViewModel {
@@ -107,7 +97,8 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
     private func showNoResults(_ viewModel: NoResultsViewController.Model) {
 
         if noResultsViewController == nil {
-            setupNoResultsViewController()
+            noResultsViewController = NoResultsViewController.controller()
+            noResultsViewController?.delegate = self
         }
 
         guard let noResultsViewController = noResultsViewController else {

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -61,7 +61,6 @@
     
     [super viewDidLoad];
     [self setupWebView];
-    [self setupNoResultsViewController];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -101,12 +100,6 @@
         self.webView.delegate = self;
     }
     [self.view addSubview:self.webView];
-}
-
-- (void)setupNoResultsViewController {
-    UIStoryboard *noResultsSB = [UIStoryboard storyboardWithName:@"NoResults" bundle:nil];
-    self.noResultsViewController = [noResultsSB instantiateViewControllerWithIdentifier:@"NoResults"];
-    self.noResultsViewController.delegate = self;
 }
 
 #pragma mark - Loading
@@ -227,7 +220,7 @@
 }
 
 - (void)previewFailed:(PostPreviewGenerator *)generator message:(NSString *)message {
-    [self showNoResultsWithTite:message];
+    [self showNoResultsWithTitle:message];
     [self reloadWhenConnectionRestored];
 }
 
@@ -239,12 +232,14 @@
     [self refreshWebView];
 }
 
-- (void)showNoResultsWithTite:(NSString *)title {
-    [self.noResultsViewController configureWithTitle:title
-                                         buttonTitle:NSLocalizedString(@"Retry", @"Button to retry a preview that failed to load")
-                                            subtitle:nil
-                                               image:nil
-                                       accessoryView:nil];
+- (void)showNoResultsWithTitle:(NSString *)title {
+    self.noResultsViewController = [NoResultsViewController controllerWithTitle:title
+                                                                    buttonTitle:NSLocalizedString(@"Retry", @"Button to retry a preview that failed to load")
+                                                                       subtitle:nil
+                                                                          image:nil
+                                                                  accessoryView:nil];
+    self.noResultsViewController.delegate = self;
+
     [self.view layoutIfNeeded];
     [self addChildViewController:self.noResultsViewController];
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -889,13 +889,15 @@ private extension ThemeBrowserViewController {
         }
 
         if noResultsViewController == nil {
-            let title = searchController.isActive ? NoResultsTitles.noThemes : NoResultsTitles.fetchingThemes
-            noResultsViewController = NoResultsViewController.controllerWith(title: title)
+            noResultsViewController = NoResultsViewController.controller()
         }
 
         guard let noResultsViewController = noResultsViewController else {
             return
         }
+
+        let title = searchController.isActive ? NoResultsTitles.noThemes : NoResultsTitles.fetchingThemes
+        noResultsViewController.configure(title: title)
 
         addChildViewController(noResultsViewController)
         collectionView.addSubview(noResultsViewController.view)

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -882,15 +882,6 @@ private extension ThemeBrowserViewController {
         }
     }
 
-    func setupNoResultsViewController() {
-        let noResultsStoryboard = UIStoryboard(name: "NoResults", bundle: nil)
-        guard let noResultsViewController = noResultsStoryboard.instantiateViewController(withIdentifier: "NoResults") as? NoResultsViewController else {
-            return
-        }
-
-        self.noResultsViewController = noResultsViewController
-    }
-
     func showNoResults() {
 
         guard !noResultsShown else {
@@ -898,15 +889,13 @@ private extension ThemeBrowserViewController {
         }
 
         if noResultsViewController == nil {
-            setupNoResultsViewController()
+            let title = searchController.isActive ? NoResultsTitles.noThemes : NoResultsTitles.fetchingThemes
+            noResultsViewController = NoResultsViewController.controllerWith(title: title)
         }
 
         guard let noResultsViewController = noResultsViewController else {
             return
         }
-
-        let title = searchController.isActive ? NoResultsTitles.noThemes : NoResultsTitles.fetchingThemes
-        noResultsViewController.configure(title: title)
 
         addChildViewController(noResultsViewController)
         collectionView.addSubview(noResultsViewController.view)


### PR DESCRIPTION
Ref #9504 

This adds `NoResultsViewController:controller` and `NoResultsViewController:controllerWith` class methods to get a controller instance. View controllers that show the `NoResultsViewController` now call one of these methods to get an instance.

To test:

---

Activity List:

- Disable internet connection.
- Go to site details > Activity.
- Verify the No Results View appears.

---

Blog List:

- Hide all sites.
- Verify the No Results View appears.

---

Site Creation > Domain suggestions:

- Start the Site Creation process.
  - NOTE: The '+' nav bar button is not working (an existing problem on `develop` that is being addressed). You can use an account that has no sites, and use the 'Add new site' button.
- On the domain selection page (step 4), enter a domain that returns no suggestions (basically, a really long string of random characters).
- Verify the No Results View appears.

---

Plan List:

- Disable internet connection.
- Go to site details > Plans.
- Verify the No Results View appears.

---

Plan Details:

- Go to site details > Plans.
- Disable internet connection.
- Verify the No Results View appears.

---

**NOTE**:
This is sort of a partial cleanup of the NRV process. In a future PR, I'll be looking at showing/hiding the NRV (i.e. the code in several almost identical `showNoResults` & `hideNoResults` methods). 