### PR TITLE
Universal Links: Add app banner routes

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Routes to handle WordPress.com app banner "Open in app" links.
+/// Banner routes always begin https://apps.wordpress.com/get and can contain
+/// an optional fragment to route to a specific part of the app. The fragment
+/// will be treated like any other route The fragment
+/// can contain additional components to route more specifically:
+///
+///   * /get#post
+///   * /get#post/discover.wordpress.com
+///
+struct AppBannerRoute: Route {
+    let path = "/get"
+
+    var action: NavigationAction {
+        return self
+    }
+}
+
+extension AppBannerRoute: NavigationAction {
+    func perform(_ values: [String: String]?) {
+        guard let fragment = values?[MatchedRouteURLComponentKey.fragment.rawValue] else {
+            return
+        }
+
+        // Convert the fragment into a URL and ask the link router to handle
+        // it like a normal route.
+        var components = URLComponents()
+        components.path = "/" + fragment
+
+        if let url = components.url {
+            UniversalLinkRouter.shared.handle(url: url)
+        }
+    }
+}

--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Routes to handle WordPress.com app banner "Open in app" links.
 /// Banner routes always begin https://apps.wordpress.com/get and can contain
 /// an optional fragment to route to a specific part of the app. The fragment
-/// will be treated like any other route The fragment
+/// will be treated like any other route. The fragment
 /// can contain additional components to route more specifically:
 ///
 ///   * /get#post

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -14,11 +14,13 @@ struct UniversalLinkRouter {
     // app delegate, and because it's primarily written in objective-c we can't
     // add a struct property there.
     //
-    static let shared = UniversalLinkRouter(routes: MeRoutes +
+    static let shared = UniversalLinkRouter(routes:
+        MeRoutes +
         NewPostRoutes +
         NotificationsRoutes +
         ReaderRoutes +
-        StatsRoutes)
+        StatsRoutes +
+        AppBannerRoutes)
 
     private static let MeRoutes: [Route] = [
         MeRoute(),
@@ -61,11 +63,15 @@ struct UniversalLinkRouter {
         StatsRoute.activityLog
     ]
 
+    private static let AppBannerRoutes: [Route] = [
+        AppBannerRoute()
+    ]
+
     /// Attempts to find a Route that matches the url's path, and perform its
     /// associated action.
     ///
     func handle(url: URL) {
-        let matches = matcher.routesMatching(url.path)
+        let matches = matcher.routesMatching(url)
 
         for matchedRoute in matches {
             matchedRoute.action.perform(matchedRoute.values)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		17B7C8A020EC1D6A0042E260 /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B7C89F20EC1D6A0042E260 /* Route.swift */; };
 		17B7C8C120EE2A870042E260 /* Routes+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B7C8C020EE2A870042E260 /* Routes+Notifications.swift */; };
 		17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */; };
+		17BD4A0820F76A4700975AC3 /* Routes+Banners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */; };
 		17BEE0041FC867C20074C124 /* WordPressAppDelegate+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BEE0031FC867C20074C124 /* WordPressAppDelegate+Swift.swift */; };
 		17CE77ED20C6C2F3001DEA5A /* ReaderSiteSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */; };
 		17CE77EF20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */; };
@@ -1506,6 +1507,7 @@
 		17B7C89F20EC1D6A0042E260 /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
 		17B7C8C020EE2A870042E260 /* Routes+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Notifications.swift"; sourceTree = "<group>"; };
 		17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaLibraryViewController.swift; sourceTree = "<group>"; };
+		17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Banners.swift"; sourceTree = "<group>"; };
 		17BEE0031FC867C20074C124 /* WordPressAppDelegate+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAppDelegate+Swift.swift"; sourceTree = "<group>"; };
 		17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchService.swift; sourceTree = "<group>"; };
 		17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchViewController.swift; sourceTree = "<group>"; };
@@ -3306,6 +3308,7 @@
 				1703D04B20ECD93800D292E9 /* Routes+Post.swift */,
 				17A4A36820EE51870071C2CA /* Routes+Reader.swift */,
 				1715179120F4B2EB002C4A38 /* Routes+Stats.swift */,
+				17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */,
 				1714F8CF20E6DA8900226DCB /* RouteMatcher.swift */,
 				17B7C89D20EC1D0D0042E260 /* UniversalLinkRouter.swift */,
 			);
@@ -7102,6 +7105,7 @@
 				93C486511810445D00A24725 /* ActivityLogViewController.m in Sources */,
 				086C4D101E81F9240011D960 /* Media+Blog.swift in Sources */,
 				08216FCB1CDBF96000304BA7 /* MenuItemEditingHeaderView.m in Sources */,
+				17BD4A0820F76A4700975AC3 /* Routes+Banners.swift in Sources */,
 				1702BBDC1CEDEA6B00766A33 /* BadgeLabel.swift in Sources */,
 				4388FEFE20A4E0B900783948 /* NotificationsViewController+AppRatings.swift in Sources */,
 				93C1148518EDF6E100DAC95C /* BlogService.m in Sources */,

--- a/WordPress/WordPressTest/RouteMatcherTests.swift
+++ b/WordPress/WordPressTest/RouteMatcherTests.swift
@@ -19,7 +19,7 @@ class RouteMatcherTests: XCTestCase {
         routes = [ TestRoute(path: "/me") ]
         matcher = RouteMatcher(routes: routes)
 
-        let matches = matcher.routesMatching("/hello")
+        let matches = matcher.routesMatching(URL(string: "/hello")!)
         XCTAssert(matches.count == 0)
     }
 
@@ -27,7 +27,7 @@ class RouteMatcherTests: XCTestCase {
         routes = [ TestRoute(path: "/me"), TestRoute(path: "/me/account") ]
         matcher = RouteMatcher(routes: routes)
 
-        let matches = matcher.routesMatching("/me") as [Route]
+        let matches = matcher.routesMatching(URL(string: "/me")!) as [Route]
         XCTAssert(matches.first!.isEqual(to: routes.first!))
         XCTAssert(matches.count == 1)
     }
@@ -36,7 +36,7 @@ class RouteMatcherTests: XCTestCase {
         routes = [ TestRoute(path: "/me"), TestRoute(path: "/me/account") ]
         matcher = RouteMatcher(routes: routes)
 
-        let matches = matcher.routesMatching("/me/account") as [Route]
+        let matches = matcher.routesMatching(URL(string: "/me/account")!) as [Route]
         XCTAssert(matches.first!.isEqual(to: routes.last!))
         XCTAssert(matches.count == 1)
     }
@@ -45,7 +45,7 @@ class RouteMatcherTests: XCTestCase {
         routes = [ TestRoute(path: "/me"), TestRoute(path: "/me") ]
         matcher = RouteMatcher(routes: routes)
 
-        let matches = matcher.routesMatching("/me") as [Route]
+        let matches = matcher.routesMatching(URL(string: "/me")!) as [Route]
         XCTAssert(matches.elementsEqual(routes, by: { $0.isEqual(to: $1) }))
     }
 
@@ -53,7 +53,7 @@ class RouteMatcherTests: XCTestCase {
         routes = [ TestRoute(path: "/me/:placeholder") ]
         matcher = RouteMatcher(routes: routes)
 
-        let matches = matcher.routesMatching("/me/hello") as [Route]
+        let matches = matcher.routesMatching(URL(string: "/me/hello")!) as [Route]
         XCTAssert(matches.first!.isEqual(to: routes.first!))
         XCTAssert(matches.count == 1)
     }
@@ -64,7 +64,7 @@ class RouteMatcherTests: XCTestCase {
         routes = [ TestRoute(path: "/me/:account") ]
         matcher = RouteMatcher(routes: routes)
 
-        let matches = matcher.routesMatching("/me/bobsmith")
+        let matches = matcher.routesMatching(URL(string: "/me/bobsmith")!)
         let values = matches.first!.values
         XCTAssert(values.count == 1)
         XCTAssertEqual(values["account"], "bobsmith")
@@ -74,7 +74,7 @@ class RouteMatcherTests: XCTestCase {
         routes = [ TestRoute(path: "/me") ]
         matcher = RouteMatcher(routes: routes)
 
-        let matches = matcher.routesMatching("/me")
+        let matches = matcher.routesMatching(URL(string: "/me")!)
         XCTAssert(matches.first!.values.count == 0)
     }
 
@@ -82,7 +82,7 @@ class RouteMatcherTests: XCTestCase {
         routes = [ TestRoute(path: "/me/:account/share/:type") ]
         matcher = RouteMatcher(routes: routes)
 
-        let matches = matcher.routesMatching("/me/bobsmith")
+        let matches = matcher.routesMatching(URL(string: "/me/bobsmith")!)
         XCTAssert(matches.count == 0)
     }
 
@@ -90,7 +90,7 @@ class RouteMatcherTests: XCTestCase {
         routes = [ TestRoute(path: "/me/:account/share/:type") ]
         matcher = RouteMatcher(routes: routes)
 
-        let matches = matcher.routesMatching("/me/bobsmith/share/group")
+        let matches = matcher.routesMatching(URL(string: "/me/bobsmith/share/group")!)
         let values = matches.first!.values
         XCTAssert(values.count == 2)
         XCTAssertEqual(values["account"], "bobsmith")
@@ -103,7 +103,7 @@ class RouteMatcherTests: XCTestCase {
                    TestRoute(path: "/me/:account/share/:test") ]
         matcher = RouteMatcher(routes: routes)
 
-        let matches = matcher.routesMatching("/me/bobsmith/share/group")
+        let matches = matcher.routesMatching(URL(string: "/me/bobsmith/share/group")!)
         XCTAssert(matches.count == 2)
 
         let values1 = matches.first!.values


### PR DESCRIPTION
Implements #9752. This is the last main universal links PR, and adds support for the URLs we'll use to handle links from app banners.

The app banners will all link to `apps.wordpress.com/get`, and use a URL fragment to link to a specific part of the app. In this PR, I'm stripping out the URL fragment, and passing it to the URL router to handle it as we would any other route. This allows us to point the banners to anywhere that we currently support with universal links.

**To test:**

Testing is a little simplified now, as we've [updated](https://github.com/wordpress-mobile/WordPress-iOS/issues/9753) the `apple-app-site-association` file on WordPress.com. 

* Add an `applinks:wordpress.com` entry to the main target's capabilities.
* Visit the usual test page in Safari on your device, try each of the links in the Apps section – they should direct you to the appropriate place in the app.