### PR TITLE
Refresh data on Notification Detail.

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -186,6 +186,7 @@ class NotificationDetailsViewController: UIViewController {
     }
 
     fileprivate func refreshInterface() {
+        formatter.resetCache()
         tableView.reloadData()
         attachReplyViewIfNeeded()
         attachSuggestionsViewIfNeeded()


### PR DESCRIPTION
Fixes #9768

This PR adds a `formatter .resetCache` call on `NotificationDetailsViewController` when the interface needs to be refreshed.
This makes all the attributed strings to be rebuild with the new data.

**To test:**

Navigation:
- Open a notification that is shown on the `NotificationDetailsViewController`.
- Navigate with the top right arrows to the previous or next notification.
- Check that the screen shows the correct information.

Edition:
- Open a comment notification.
- Edit and save.
- Check that the screen shows the change made.

