### PR TITLE
Refresh notification cell after approving / unapproving a comment

### DIFF
--- a/WordPress/Classes/Utility/FormattableContent/DefaultFormattableContentAction.swift
+++ b/WordPress/Classes/Utility/FormattableContent/DefaultFormattableContentAction.swift
@@ -2,8 +2,12 @@ class DefaultFormattableContentAction: FormattableContentAction {
     var enabled: Bool
 
     var on: Bool {
-        didSet {
-            command?.on = on
+        set {
+            command?.on = newValue
+        }
+
+        get {
+            return command?.on ?? false
         }
     }
 
@@ -14,10 +18,9 @@ class DefaultFormattableContentAction: FormattableContentAction {
     }
 
     init(on: Bool, command: FormattableContentActionCommand) {
-        self.on = on
         self.enabled = true
         self.command = command
-        self.command?.on = on
+        self.on = on
     }
 
     func execute(context: ActionContext) {


### PR DESCRIPTION
Fixes #9770 

During the review of #9765 we noticed that the cell containing the comment notification was not being refreshed.

This PR addresses that by ensuring that the action associated with the notification return the `on` of the associated command when asked for it

To test:
- Approve / unapproved a comment. 
- The cell containing the comment should refresh and update its colours after the approve / unapproved command has been propagated to the backend and the comment has been effectively approved / unapproved

![notif mov](https://user-images.githubusercontent.com/2722505/42743908-db1d42c0-88fa-11e8-84ff-523b17fe83f4.gif)

Please note this PR is not against the feature branch, but against the previous PR, as it builds upon it.