### PR TITLE
Remove `gifSupportInReaderDetail` feature flag and related conditional code.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -5,7 +5,6 @@ enum FeatureFlag: Int {
     case exampleFeature
     case jetpackDisconnect
     case saveForLater
-    case gifSupportInReaderDetail
     case extractNotifications
 
     /// Returns a boolean indicating if the feature is enabled
@@ -16,8 +15,6 @@ enum FeatureFlag: Int {
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .saveForLater:
-            return true
-        case .gifSupportInReaderDetail:
             return true
         case .extractNotifications:
             return BuildConfiguration.current == .localDeveloper


### PR DESCRIPTION
This PR removes the `gifSupportInReaderDetail` feature flag, and all the related conditional code with the old paths of execution.

**note**:
I noticed that after removing this code, the class `WPTableImageSource` is not being used anywhere else in the project, and seems to be safe to be deleted.

I'm not sure if it's better to leave it if it's needed in the future, or if there's already a new class that replaces it.
If we decide to delete it, I can do it on a next PR.

cc @nheagy 

To test:
- Go to the Reader.
- Open a post with gifs. (You can go to search posts and search for `gif`).
- Check that gifs and static images display correctly.