### PR TITLE
Add missing universal links

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -4,6 +4,8 @@ import WordPressComStatsiOS
 enum MySitesRoute {
     case pages
     case posts
+    case media
+    case comments
 }
 
 extension MySitesRoute: Route {
@@ -17,6 +19,10 @@ extension MySitesRoute: Route {
             return "/pages/:domain"
         case .posts:
             return "/posts/:domain"
+        case .media:
+            return "/media/:domain"
+        case .comments:
+            return "/comments/:domain"
         }
     }
 }
@@ -33,6 +39,10 @@ extension MySitesRoute: NavigationAction {
             coordinator.showPages(for: blog)
         case .posts:
             coordinator.showPosts(for: blog)
+        case .media:
+            coordinator.showMedia(for: blog)
+        case .comments:
+            coordinator.showComments(for: blog)
         }
     }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -9,6 +9,7 @@ enum MySitesRoute {
     case sharing
     case people
     case plugins
+    case managePlugins
 }
 
 extension MySitesRoute: Route {
@@ -32,6 +33,8 @@ extension MySitesRoute: Route {
             return "/people/:domain"
         case .plugins:
             return "/plugins/:domain"
+        case .managePlugins:
+            return "/plugins/manage/:domain"
         }
     }
 }
@@ -58,6 +61,8 @@ extension MySitesRoute: NavigationAction {
             coordinator.showPeople(for: blog)
         case .plugins:
             coordinator.showPlugins(for: blog)
+        case .managePlugins:
+            coordinator.showManagePlugins(for: blog)
         }
     }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -1,0 +1,49 @@
+import Foundation
+import WordPressComStatsiOS
+
+enum MySitesRoute {
+    case pages
+    case posts
+}
+
+extension MySitesRoute: Route {
+    var action: NavigationAction {
+        return self
+    }
+
+    var path: String {
+        switch self {
+        case .pages:
+            return "/pages/:domain"
+        case .posts:
+            return "/posts/:domain"
+        }
+    }
+}
+
+extension MySitesRoute: NavigationAction {
+    func perform(_ values: [String: String]?) {
+        guard let coordinator = WPTabBarController.sharedInstance().mySitesCoordinator,
+            let blog = blog(from: values) else {
+            return
+        }
+
+        switch self {
+        case .pages:
+            coordinator.showPages(for: blog)
+        case .posts:
+            coordinator.showPosts(for: blog)
+        }
+    }
+
+    private func blog(from values: [String: String]?) -> Blog? {
+        guard let domain = values?["domain"] else {
+            return nil
+        }
+
+        let context = ContextManager.sharedInstance().mainContext
+        let service = BlogService(managedObjectContext: context)
+
+        return service.blog(byHostname: domain)
+    }
+}

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -6,6 +6,9 @@ enum MySitesRoute {
     case posts
     case media
     case comments
+    case sharing
+    case people
+    case plugins
 }
 
 extension MySitesRoute: Route {
@@ -23,6 +26,12 @@ extension MySitesRoute: Route {
             return "/media/:domain"
         case .comments:
             return "/comments/:domain"
+        case .sharing:
+            return "/sharing/:domain"
+        case .people:
+            return "/people/:domain"
+        case .plugins:
+            return "/plugins/:domain"
         }
     }
 }
@@ -43,6 +52,12 @@ extension MySitesRoute: NavigationAction {
             coordinator.showMedia(for: blog)
         case .comments:
             coordinator.showComments(for: blog)
+        case .sharing:
+            coordinator.showSharing(for: blog)
+        case .people:
+            coordinator.showPeople(for: blog)
+        case .plugins:
+            coordinator.showPlugins(for: blog)
         }
     }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -9,6 +9,8 @@ enum ReaderRoute {
     case manageFollowing
     case list
     case tag
+    case feed
+    case blog
     case feedsPost
     case blogsPost
 }
@@ -32,6 +34,10 @@ extension ReaderRoute: Route {
             return "/read/list/:username/:list_name"
         case .tag:
             return "/tag/:tag_name"
+        case .feed:
+            return "/read/feeds/:feed_id"
+        case .blog:
+            return "/read/blogs/:blog_id"
         case .feedsPost:
             return "/read/feeds/:feed_id/posts/:post_id"
         case .blogsPost:
@@ -71,6 +77,16 @@ extension ReaderRoute: NavigationAction {
         case .tag:
             if let tagName = values?["tag_name"] {
                 coordinator.showTag(named: tagName)
+            }
+        case .feed:
+            if let feedIDValue = values?["feed_id"],
+                let feedID = Int(feedIDValue) {
+                coordinator.showStream(with: feedID, isFeed: true)
+            }
+        case .blog:
+            if let blogIDValue = values?["blog_id"],
+                let blogID = Int(blogIDValue) {
+                coordinator.showStream(with: blogID, isFeed: false)
             }
         case .feedsPost:
             if let (feedID, postID) = feedAndPostID(from: values) {

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -117,6 +117,15 @@ extension StatsRoute: NavigationAction {
         let context = ContextManager.sharedInstance().mainContext
         let service = BlogService(managedObjectContext: context)
 
-        return service.blog(byHostname: domain)
+        if let blog = service.blog(byHostname: domain) {
+            return blog
+        }
+
+        // Some stats URLs use a site ID instead
+        if let siteIDValue = Int(domain) {
+            return service.blog(byBlogId: NSNumber(value: siteIDValue))
+        }
+
+        return nil
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -20,6 +20,7 @@ struct UniversalLinkRouter {
         NotificationsRoutes +
         ReaderRoutes +
         StatsRoutes +
+        MySitesRoutes +
         AppBannerRoutes)
 
     private static let MeRoutes: [Route] = [
@@ -63,6 +64,11 @@ struct UniversalLinkRouter {
         StatsRoute.dayCategory,
         StatsRoute.annualStats,
         StatsRoute.activityLog
+    ]
+
+    private static let MySitesRoutes: [Route] = [
+        MySitesRoute.pages,
+        MySitesRoute.posts
     ]
 
     private static let AppBannerRoutes: [Route] = [

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -73,7 +73,8 @@ struct UniversalLinkRouter {
         MySitesRoute.comments,
         MySitesRoute.sharing,
         MySitesRoute.people,
-        MySitesRoute.plugins
+        MySitesRoute.plugins,
+        MySitesRoute.managePlugins
     ]
 
     private static let AppBannerRoutes: [Route] = [

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -68,7 +68,9 @@ struct UniversalLinkRouter {
 
     private static let MySitesRoutes: [Route] = [
         MySitesRoute.pages,
-        MySitesRoute.posts
+        MySitesRoute.posts,
+        MySitesRoute.media,
+        MySitesRoute.comments
     ]
 
     private static let AppBannerRoutes: [Route] = [

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -70,7 +70,10 @@ struct UniversalLinkRouter {
         MySitesRoute.pages,
         MySitesRoute.posts,
         MySitesRoute.media,
-        MySitesRoute.comments
+        MySitesRoute.comments,
+        MySitesRoute.sharing,
+        MySitesRoute.people,
+        MySitesRoute.plugins
     ]
 
     private static let AppBannerRoutes: [Route] = [

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -46,6 +46,8 @@ struct UniversalLinkRouter {
         ReaderRoute.manageFollowing,
         ReaderRoute.list,
         ReaderRoute.tag,
+        ReaderRoute.feed,
+        ReaderRoute.blog,
         ReaderRoute.feedsPost,
         ReaderRoute.blogsPost
     ]

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
@@ -10,7 +10,10 @@ typedef NS_ENUM(NSUInteger, BlogDetailsSubsection) {
     BlogDetailsSubsectionMedia,
     BlogDetailsSubsectionPages,
     BlogDetailsSubsectionActivity,
-    BlogDetailsSubsectionComments
+    BlogDetailsSubsectionComments,
+    BlogDetailsSubsectionSharing,
+    BlogDetailsSubsectionPeople,
+    BlogDetailsSubsectionPlugins
 };
 
 @interface BlogDetailsViewController : UITableViewController <UIViewControllerRestoration> {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
@@ -9,7 +9,8 @@ typedef NS_ENUM(NSUInteger, BlogDetailsSubsection) {
     BlogDetailsSubsectionThemes,
     BlogDetailsSubsectionMedia,
     BlogDetailsSubsectionPages,
-    BlogDetailsSubsectionActivity
+    BlogDetailsSubsectionActivity,
+    BlogDetailsSubsectionComments
 };
 
 @interface BlogDetailsViewController : UITableViewController <UIViewControllerRestoration> {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -365,6 +365,33 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                   scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
             [self showComments];
             break;
+        case BlogDetailsSubsectionSharing:
+            if ([self.blog supports:BlogFeatureSharing]) {
+                self.restorableSelectedIndexPath = indexPath;
+                [self.tableView selectRowAtIndexPath:indexPath
+                                            animated:NO
+                                      scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
+                [self showSharing];
+            }
+            break;
+        case BlogDetailsSubsectionPeople:
+            if ([self.blog supports:BlogFeaturePeople]) {
+                self.restorableSelectedIndexPath = indexPath;
+                [self.tableView selectRowAtIndexPath:indexPath
+                                            animated:NO
+                                      scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
+                [self showPeople];
+            }
+            break;
+        case BlogDetailsSubsectionPlugins:
+            if ([self.blog supports:BlogFeaturePluginManagement]) {
+                self.restorableSelectedIndexPath = indexPath;
+                [self.tableView selectRowAtIndexPath:indexPath
+                                            animated:NO
+                                      scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
+                [self showPlugins];
+            }
+            break;
     }
 }
 
@@ -386,6 +413,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             return [NSIndexPath indexPathForRow:0 inSection:0];
         case BlogDetailsSubsectionComments:
             return [NSIndexPath indexPathForRow:3 inSection:1];
+        case BlogDetailsSubsectionSharing:
+            return [NSIndexPath indexPathForRow:0 inSection:3];
+        case BlogDetailsSubsectionPeople:
+            return [NSIndexPath indexPathForRow:1 inSection:3];
+        case BlogDetailsSubsectionPlugins:
+            return [NSIndexPath indexPathForRow:2 inSection:3];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -358,6 +358,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                 [self showActivity];
             }
             break;
+        case BlogDetailsSubsectionComments:
+            self.restorableSelectedIndexPath = indexPath;
+            [self.tableView selectRowAtIndexPath:indexPath
+                                        animated:NO
+                                  scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
+            [self showComments];
+            break;
     }
 }
 
@@ -377,6 +384,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             return [NSIndexPath indexPathForRow:2 inSection:1];
         case BlogDetailsSubsectionPages:
             return [NSIndexPath indexPathForRow:0 inSection:0];
+        case BlogDetailsSubsectionComments:
+            return [NSIndexPath indexPathForRow:3 inSection:1];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -94,6 +94,10 @@ class MySitesCoordinator: NSObject {
     }
 
     func showManagePlugins(for blog: Blog) {
+        guard blog.supports(.pluginManagement) else {
+            return
+        }
+
         // PerformWithoutAnimation is required here, otherwise the view controllers
         // potentially get added to the navigation controller out of order
         // (ShowDetailViewController, used by BlogDetailsViewController is animated)

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -21,18 +21,21 @@ class MySitesCoordinator: NSObject {
         mySitesNavigationController.viewControllers = [blogListViewController]
     }
 
-    func showBlogDetails(for blog: Blog) {
+    func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection? = nil) {
         prepareToNavigate()
 
         blogListViewController.setSelectedBlog(blog, animated: false)
+
+        if let subsection = subsection,
+            let blogDetailsViewController = mySitesNavigationController.topViewController as? BlogDetailsViewController {
+            blogDetailsViewController.showDetailView(for: subsection)
+        }
     }
 
-    func showStats(for blog: Blog) {
-        showBlogDetails(for: blog)
+    // MARK: - Stats
 
-        if let blogDetailsViewController = mySitesNavigationController.topViewController as? BlogDetailsViewController {
-            blogDetailsViewController.showDetailView(for: .stats)
-        }
+    func showStats(for blog: Blog) {
+        showBlogDetails(for: blog, then: .stats)
     }
 
     func showStats(for blog: Blog, timePeriod: StatsPeriodType) {
@@ -52,12 +55,18 @@ class MySitesCoordinator: NSObject {
     }
 
     func showActivityLog(for blog: Blog) {
-        showBlogDetails(for: blog)
-
-        if let blogDetailsViewController = mySitesNavigationController.topViewController as? BlogDetailsViewController {
-            blogDetailsViewController.showDetailView(for: .activity)
-        }
+        showBlogDetails(for: blog, then: .activity)
     }
 
     private static let statsPeriodTypeDefaultsKey = "LastSelectedStatsPeriodType"
+
+    // MARK: - My Sites
+
+    func showPages(for blog: Blog) {
+        showBlogDetails(for: blog, then: .pages)
+    }
+
+    func showPosts(for blog: Blog) {
+        showBlogDetails(for: blog, then: .posts)
+    }
 }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -3,12 +3,15 @@ import WordPressComStatsiOS
 
 @objc
 class MySitesCoordinator: NSObject {
+    let mySitesSplitViewController: WPSplitViewController
     let mySitesNavigationController: UINavigationController
     let blogListViewController: BlogListViewController
 
     @objc
-    init(mySitesNavigationController: UINavigationController,
+    init(mySitesSplitViewController: WPSplitViewController,
+         mySitesNavigationController: UINavigationController,
          blogListViewController: BlogListViewController) {
+        self.mySitesSplitViewController = mySitesSplitViewController
         self.mySitesNavigationController = mySitesNavigationController
         self.blogListViewController = blogListViewController
 
@@ -88,5 +91,24 @@ class MySitesCoordinator: NSObject {
 
     func showPlugins(for blog: Blog) {
         showBlogDetails(for: blog, then: .plugins)
+    }
+
+    func showManagePlugins(for blog: Blog) {
+        // PerformWithoutAnimation is required here, otherwise the view controllers
+        // potentially get added to the navigation controller out of order
+        // (ShowDetailViewController, used by BlogDetailsViewController is animated)
+        UIView.performWithoutAnimation {
+            showBlogDetails(for: blog, then: .plugins)
+        }
+
+        guard let site = JetpackSiteRef(blog: blog),
+            let navigationController = mySitesSplitViewController.topDetailViewController?.navigationController else {
+            return
+        }
+
+        let query = PluginQuery.all(site: site)
+        let listViewController = PluginListViewController(site: site, query: query)
+
+        navigationController.pushViewController(listViewController, animated: false)
     }
 }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -69,4 +69,12 @@ class MySitesCoordinator: NSObject {
     func showPosts(for blog: Blog) {
         showBlogDetails(for: blog, then: .posts)
     }
+
+    func showMedia(for blog: Blog) {
+        showBlogDetails(for: blog, then: .media)
+    }
+
+    func showComments(for blog: Blog) {
+        showBlogDetails(for: blog, then: .comments)
+    }
 }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -77,4 +77,16 @@ class MySitesCoordinator: NSObject {
     func showComments(for blog: Blog) {
         showBlogDetails(for: blog, then: .comments)
     }
+
+    func showSharing(for blog: Blog) {
+        showBlogDetails(for: blog, then: .sharing)
+    }
+
+    func showPeople(for blog: Blog) {
+        showBlogDetails(for: blog, then: .people)
+    }
+
+    func showPlugins(for blog: Blog) {
+        showBlogDetails(for: blog, then: .plugins)
+    }
 }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -85,6 +85,13 @@ class ReaderCoordinator: NSObject {
         readerNavigationController.pushViewController(controller, animated: true)
     }
 
+    func showStream(with siteID: Int, isFeed: Bool) {
+        prepareToNavigate()
+
+        let controller = ReaderStreamViewController.controllerWithSiteID(NSNumber(value: siteID), isFeed: isFeed)
+        readerNavigationController.pushViewController(controller, animated: false)
+    }
+
     func showPost(with postID: Int, for feedID: Int, isFeed: Bool) {
         prepareToNavigate()
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -454,8 +454,9 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (MySitesCoordinator *)mySitesCoordinator
 {
-    return [[MySitesCoordinator alloc] initWithMySitesNavigationController:self.blogListNavigationController
-                                                    blogListViewController:self.blogListViewController];
+    return [[MySitesCoordinator alloc] initWithMySitesSplitViewController:self.blogListSplitViewController
+                                              mySitesNavigationController:self.blogListNavigationController
+                                                   blogListViewController:self.blogListViewController];
 }
 
 - (ReaderCoordinator *)readerCoordinator

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		17D2FDC21C6A468A00944265 /* PlanComparisonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */; };
 		17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */; };
 		17D975AF1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */; };
+		17E24F5420FCF1D900BD70A3 /* Routes+MySites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E24F5320FCF1D900BD70A3 /* Routes+MySites.swift */; };
 		17F0AE301F091563007D5A6B /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F0AE2F1F091563007D5A6B /* ConfettiView.swift */; };
 		17F0E1DA20EBDC0A001E9514 /* Routes+Me.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F0E1D920EBDC0A001E9514 /* Routes+Me.swift */; };
 		17F67C56203D81430072001E /* PostCardStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F67C55203D81430072001E /* PostCardStatusViewModel.swift */; };
@@ -1514,6 +1515,7 @@
 		17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanComparisonViewController.swift; sourceTree = "<group>"; };
 		17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProgressCoordinatorNoticeViewModel.swift; sourceTree = "<group>"; };
 		17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Aztec.swift"; sourceTree = "<group>"; };
+		17E24F5320FCF1D900BD70A3 /* Routes+MySites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+MySites.swift"; sourceTree = "<group>"; };
 		17E553B520910791000D3005 /* WordPress 75.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 75.xcdatamodel"; sourceTree = "<group>"; };
 		17F0AE2F1F091563007D5A6B /* ConfettiView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfettiView.swift; sourceTree = "<group>"; };
 		17F0E1D920EBDC0A001E9514 /* Routes+Me.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Me.swift"; sourceTree = "<group>"; };
@@ -3304,6 +3306,7 @@
 			children = (
 				17B7C89F20EC1D6A0042E260 /* Route.swift */,
 				17F0E1D920EBDC0A001E9514 /* Routes+Me.swift */,
+				17E24F5320FCF1D900BD70A3 /* Routes+MySites.swift */,
 				17B7C8C020EE2A870042E260 /* Routes+Notifications.swift */,
 				1703D04B20ECD93800D292E9 /* Routes+Post.swift */,
 				17A4A36820EE51870071C2CA /* Routes+Reader.swift */,
@@ -7061,6 +7064,7 @@
 				B587798619B799EB00E57C5A /* Notification+Interface.swift in Sources */,
 				175A650C20B6F7280023E71B /* ReaderSaveForLater+Analytics.swift in Sources */,
 				984B4EF320742FCC00F87888 /* ZendeskUtils.swift in Sources */,
+				17E24F5420FCF1D900BD70A3 /* Routes+MySites.swift in Sources */,
 				0828D7FA1E6E09AE00C7C7D4 /* WPAppAnalytics+Media.swift in Sources */,
 				7ED3695520A9F091007B0D56 /* Blog+ImageSourceInformation.swift in Sources */,
 				591AA5011CEF9BF20074934F /* Post.swift in Sources */,


### PR DESCRIPTION
This PR adds a number of universal links we missed out the first time around, as identified in https://github.com/wordpress-mobile/WordPress-iOS/issues/9753#issuecomment-404896050.

* Reader feeds: `/read/feeds/:feed_id`
* Reader feeds: `/read/blogs/:blog_id`
* Site > Posts: `/posts/:domain`
* Site > Pages: `/pages/:domain`
* Site > Media: `/media/:domain`
* Site > Comments: `/comments/:domain`
* Site > Sharing: `/sharing/:domain`
* Site > People `/people/team/:domain`
* Site > Plugins `/plugins/:domain`
* Site > Manage Plugins `/plugins/manage/domain`

It also tweaks the existing Stats routes so that they can handle a site ID instead of a domain name in the path.

**To test:**

* This one will need to use the original testing instructions, as these routes haven't yet been added to the WordPress.com `apple-app-site-association` file.
* I've added entries for each of the paths above to the testing website.
* Please also test one of the Stats route by adding a site ID in the domain field instead of a domain.