### PR TITLE
Feature/9784 route activity log app

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -1,10 +1,21 @@
 
 import WordPressComStatsiOS
 
+protocol ContentCoordinator {
+    func displayReaderWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws
+    func displayCommentsWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws
+    func displayStatsWithSiteID(_ siteID: NSNumber?) throws
+    func displayFollowersWithSiteID(_ siteID: NSNumber?, expirationTime: TimeInterval) throws
+    func displayStreamWithSiteID(_ siteID: NSNumber?) throws
+    func displayWebViewWithURL(_ url: URL)
+    func displayFullscreenImage(_ image: UIImage)
+}
+
+
 /// `ContentCoordinator` is intended to be used to easily navigate and display common elements natively
 /// like Posts, Site streams, Comments, etc...
 ///
-struct ContentCoordinator {
+struct DefaultContentCoordinator: ContentCoordinator {
 
     enum DisplayError: Error {
         case missingParameter

--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -1,10 +1,10 @@
 
 import WordPressComStatsiOS
 
-/// `Router` is intended to be used to easily navigate and display common elements natively
+/// `ContentCoordinator` is intended to be used to easily navigate and display common elements natively
 /// like Posts, Site streams, Comments, etc...
 ///
-struct Router {
+struct ContentCoordinator {
 
     enum DisplayError: Error {
         case missingParameter

--- a/WordPress/Classes/Utility/FormattableContent/ContentRouter.swift
+++ b/WordPress/Classes/Utility/FormattableContent/ContentRouter.swift
@@ -1,0 +1,8 @@
+
+/// This protocol is intended to be used as an extraction of a class that takes an internal URL (reader post, plugins, etc...)
+/// and presents it with the corresponding native element.
+/// This plays good with LinkContentRange, where the url represent an specific post, comment, plugin, etc...
+///
+protocol ContentRouter {
+    func routeTo(_ url: URL)
+}

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContent.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContent.swift
@@ -40,7 +40,7 @@ extension FormattableContent {
     func range(with url: URL) -> FormattableContentRange? {
         let linkRanges = ranges.compactMap { $0 as? LinkContentRange }
         for range in linkRanges {
-            if let rangeURL = range.url, (rangeURL as URL == url) {
+            if range.url == url {
                 return range as? FormattableContentRange
             }
         }

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContent.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContent.swift
@@ -36,4 +36,15 @@ extension FormattableContent {
             $0.identifier == id
         }.first
     }
+
+    func range(with url: URL) -> FormattableContentRange? {
+        let linkRanges = ranges.compactMap { $0 as? LinkContentRange }
+        for range in linkRanges {
+            if let rangeURL = range.url, (rangeURL as URL == url) {
+                return range as? FormattableContentRange
+            }
+        }
+
+        return nil
+    }
 }

--- a/WordPress/Classes/Utility/Router.swift
+++ b/WordPress/Classes/Utility/Router.swift
@@ -1,6 +1,9 @@
 
 import WordPressComStatsiOS
 
+/// `Router` is intended to be used to easily navigate and display common elements natively
+/// like Posts, Site streams, Comments, etc...
+///
 struct Router {
 
     enum DisplayError: Error {

--- a/WordPress/Classes/Utility/Router.swift
+++ b/WordPress/Classes/Utility/Router.swift
@@ -13,7 +13,7 @@ struct Router {
     }
 
     private let mainContext: NSManagedObjectContext
-    private let controller: UIViewController
+    private weak var controller: UIViewController?
 
     init(controller: UIViewController, context: NSManagedObjectContext) {
         self.controller = controller
@@ -26,7 +26,7 @@ struct Router {
         }
 
         let readerViewController = ReaderDetailViewController.controllerWithPostID(postID, siteID: siteID)
-        controller.navigationController?.pushFullscreenViewController(readerViewController, animated: true)
+        controller?.navigationController?.pushFullscreenViewController(readerViewController, animated: true)
     }
 
     func displayCommentsWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws {
@@ -36,7 +36,7 @@ struct Router {
 
         let commentsViewController = ReaderCommentsViewController(postID: postID, siteID: siteID)
         commentsViewController?.allowsPushingPostDetails = true
-        controller.navigationController?.pushViewController(commentsViewController!, animated: true)
+        controller?.navigationController?.pushViewController(commentsViewController!, animated: true)
     }
 
     func displayStatsWithSiteID(_ siteID: NSNumber?) throws {
@@ -46,7 +46,7 @@ struct Router {
 
         let statsViewController = StatsViewController()
         statsViewController.blog = blog
-        controller.navigationController?.pushViewController(statsViewController, animated: true)
+        controller?.navigationController?.pushViewController(statsViewController, animated: true)
     }
 
     func displayFollowersWithSiteID(_ siteID: NSNumber?, expirationTime: TimeInterval) throws {
@@ -59,7 +59,7 @@ struct Router {
         statsViewController.statsSection = .followers
         statsViewController.statsSubSection = .followersDotCom
         statsViewController.statsService = newStatsServiceWithBlog(blog, expirationTime: expirationTime)
-        controller.navigationController?.pushViewController(statsViewController, animated: true)
+        controller?.navigationController?.pushViewController(statsViewController, animated: true)
     }
 
     func displayStreamWithSiteID(_ siteID: NSNumber?) throws {
@@ -68,20 +68,20 @@ struct Router {
         }
 
         let browseViewController = ReaderStreamViewController.controllerWithSiteID(siteID, isFeed: false)
-        controller.navigationController?.pushViewController(browseViewController, animated: true)
+        controller?.navigationController?.pushViewController(browseViewController, animated: true)
     }
 
     func displayWebViewWithURL(_ url: URL) {
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
         let navController = UINavigationController(rootViewController: webViewController)
-        controller.present(navController, animated: true, completion: nil)
+        controller?.present(navController, animated: true, completion: nil)
     }
 
     func displayFullscreenImage(_ image: UIImage) {
         let imageViewController = WPImageViewController(image: image)
         imageViewController.modalTransitionStyle = .crossDissolve
         imageViewController.modalPresentationStyle = .fullScreen
-        controller.present(imageViewController, animated: true, completion: nil)
+        controller?.present(imageViewController, animated: true, completion: nil)
     }
 
     private func blogWithBlogID(_ blogID: NSNumber?) -> Blog? {

--- a/WordPress/Classes/Utility/Router.swift
+++ b/WordPress/Classes/Utility/Router.swift
@@ -1,0 +1,109 @@
+
+import WordPressComStatsiOS
+
+struct Router {
+
+    enum DisplayError: Error {
+        case missingParameter
+        case unsupportedFeature
+        case unsupportedType
+    }
+
+    private let mainContext: NSManagedObjectContext
+    private let controller: UIViewController
+
+    init(controller: UIViewController, context: NSManagedObjectContext) {
+        self.controller = controller
+        mainContext = context
+    }
+
+    func displayReaderWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws {
+        guard let postID = postID, let siteID = siteID else {
+            throw DisplayError.missingParameter
+        }
+
+        let readerViewController = ReaderDetailViewController.controllerWithPostID(postID, siteID: siteID)
+        controller.navigationController?.pushFullscreenViewController(readerViewController, animated: true)
+    }
+
+    func displayCommentsWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws {
+        guard let postID = postID, let siteID = siteID else {
+            throw DisplayError.missingParameter
+        }
+
+        let commentsViewController = ReaderCommentsViewController(postID: postID, siteID: siteID)
+        commentsViewController?.allowsPushingPostDetails = true
+        controller.navigationController?.pushViewController(commentsViewController!, animated: true)
+    }
+
+    func displayStatsWithSiteID(_ siteID: NSNumber?) throws {
+        guard let blog = blogWithBlogID(siteID), blog.supports(.stats) else {
+            throw DisplayError.missingParameter
+        }
+
+        let statsViewController = StatsViewController()
+        statsViewController.blog = blog
+        controller.navigationController?.pushViewController(statsViewController, animated: true)
+    }
+
+    func displayFollowersWithSiteID(_ siteID: NSNumber?, expirationTime: TimeInterval) throws {
+        guard let blog = blogWithBlogID(siteID) else {
+            throw DisplayError.missingParameter
+        }
+
+        let statsViewController = newStatsViewController()
+        statsViewController.selectedDate = Date()
+        statsViewController.statsSection = .followers
+        statsViewController.statsSubSection = .followersDotCom
+        statsViewController.statsService = newStatsServiceWithBlog(blog, expirationTime: expirationTime)
+        controller.navigationController?.pushViewController(statsViewController, animated: true)
+    }
+
+    func displayStreamWithSiteID(_ siteID: NSNumber?) throws {
+        guard let siteID = siteID else {
+            throw DisplayError.missingParameter
+        }
+
+        let browseViewController = ReaderStreamViewController.controllerWithSiteID(siteID, isFeed: false)
+        controller.navigationController?.pushViewController(browseViewController, animated: true)
+    }
+
+    func displayWebViewWithURL(_ url: URL) {
+        let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
+        let navController = UINavigationController(rootViewController: webViewController)
+        controller.present(navController, animated: true, completion: nil)
+    }
+
+    func displayFullscreenImage(_ image: UIImage) {
+        let imageViewController = WPImageViewController(image: image)
+        imageViewController.modalTransitionStyle = .crossDissolve
+        imageViewController.modalPresentationStyle = .fullScreen
+        controller.present(imageViewController, animated: true, completion: nil)
+    }
+
+    private func blogWithBlogID(_ blogID: NSNumber?) -> Blog? {
+        guard let blogID = blogID else {
+            return nil
+        }
+
+        let service = BlogService(managedObjectContext: mainContext)
+        return service.blog(byBlogId: blogID)
+    }
+
+    private func newStatsServiceWithBlog(_ blog: Blog, expirationTime: TimeInterval) -> WPStatsService {
+        let blogService = BlogService(managedObjectContext: mainContext)
+        return WPStatsService(siteId: blog.dotComID,
+                              siteTimeZone: blogService.timeZone(for: blog),
+                              oauth2Token: blog.authToken,
+                              andCacheExpirationInterval: expirationTime)
+    }
+
+    private func newStatsViewController() -> StatsViewAllTableViewController {
+        let statsBundle = Bundle(for: WPStatsViewController.self)
+        let storyboard = UIStoryboard(name: "SiteStats", bundle: statsBundle)
+        let identifier = StatsViewAllTableViewController.classNameWithoutNamespaces()
+        let statsViewController = storyboard.instantiateViewController(withIdentifier: identifier)
+
+        return statsViewController as! StatsViewAllTableViewController
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -177,8 +177,24 @@ class ActivityDetailViewController: UIViewController {
         static let gridiconSize: CGSize = CGSize(width: 24, height: 24)
     }
 
+    func getRange(from url: URL) -> FormattableContentRange? {
+        return formattableActivity?.range(with: url)
+    }
+
     func routeTo(_ url: URL) {
-        router.displayWebViewWithURL(url)
+        guard let range = getRange(from: url) else {
+            return
+        }
+
+        switch range.kind {
+        case .post:
+            guard let postRange = range as? ActivityPostRange else {
+                fallthrough
+            }
+            try? router.displayReaderWithPostId(postRange.postID as NSNumber, siteID: postRange.siteID as NSNumber)
+        default:
+            router.displayWebViewWithURL(url)
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -191,7 +191,16 @@ class ActivityDetailViewController: UIViewController {
             guard let postRange = range as? ActivityPostRange else {
                 fallthrough
             }
-            try? router.displayReaderWithPostId(postRange.postID as NSNumber, siteID: postRange.siteID as NSNumber)
+            let postID = postRange.postID as NSNumber
+            let siteID = postRange.siteID as NSNumber
+            try? router.displayReaderWithPostId(postID, siteID: siteID)
+        case .comment:
+            guard let commentRange = range as? ActivityCommentRange else {
+                fallthrough
+            }
+            let postID = commentRange.postID as NSNumber
+            let siteID = commentRange.siteID as NSNumber
+            try? router.displayCommentsWithPostId(postID, siteID: siteID)
         default:
             router.displayWebViewWithURL(url)
         }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -39,8 +39,8 @@ class ActivityDetailViewController: UIViewController {
 
     private var activity: Activity?
 
-    lazy var router: Router = {
-        return Router(controller: self, context: ContextManager.sharedInstance().mainContext)
+    lazy var router: ContentCoordinator = {
+        return ContentCoordinator(controller: self, context: ContextManager.sharedInstance().mainContext)
     }()
 
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -176,12 +176,12 @@ class ActivityDetailViewController: UIViewController {
     private enum Constants {
         static let gridiconSize: CGSize = CGSize(width: 24, height: 24)
     }
+}
 
-    func getRange(from url: URL) -> FormattableContentRange? {
-        return formattableActivity?.range(with: url)
-    }
+// MARK: - Navigation
 
-    func routeTo(_ url: URL) {
+extension ActivityDetailViewController {
+    private func routeTo(_ url: URL) {
         guard let range = getRange(from: url) else {
             return
         }
@@ -205,7 +205,13 @@ class ActivityDetailViewController: UIViewController {
             router.displayWebViewWithURL(url)
         }
     }
+
+    private func getRange(from url: URL) -> FormattableContentRange? {
+        return formattableActivity?.range(with: url)
+    }
 }
+
+// MARK: - UITextViewDelegate
 
 extension ActivityDetailViewController: UITextViewDelegate {
     func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange) -> Bool {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -169,7 +169,10 @@ class ActivityDetailViewController: UIViewController {
             router = nil
             return
         }
-        router = ActivityContentRouter(controller: self, activity: activity, context: ContextManager.sharedInstance().mainContext)
+        let coordinator = DefaultContentCoordinator(controller: self, context: ContextManager.sharedInstance().mainContext)
+        router = ActivityContentRouter(
+            activity: activity,
+            coordinator: coordinator)
     }
 
     func setupActivity() {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -21,7 +21,11 @@ class ActivityDetailViewController: UIViewController {
     @IBOutlet private var timeLabel: UILabel!
     @IBOutlet private var dateLabel: UILabel!
 
-    @IBOutlet weak var textView: UITextView!
+    @IBOutlet weak var textView: UITextView! {
+        didSet {
+            textView.delegate = self
+        }
+    }
     @IBOutlet private var textLabel: UILabel!
     @IBOutlet private var summaryLabel: UILabel!
 
@@ -34,6 +38,10 @@ class ActivityDetailViewController: UIViewController {
     @IBOutlet private var rewindButton: UIButton!
 
     private var activity: Activity?
+
+    lazy var router: Router = {
+        return Router(controller: self, context: ContextManager.sharedInstance().mainContext)
+    }()
 
     override func viewDidLoad() {
         setupFonts()
@@ -155,7 +163,6 @@ class ActivityDetailViewController: UIViewController {
                 }
             }
         }
-
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -170,4 +177,14 @@ class ActivityDetailViewController: UIViewController {
         static let gridiconSize: CGSize = CGSize(width: 24, height: 24)
     }
 
+    func routeTo(_ url: URL) {
+        router.displayWebViewWithURL(url)
+    }
+}
+
+extension ActivityDetailViewController: UITextViewDelegate {
+    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange) -> Bool {
+        routeTo(URL)
+        return false
+    }
 }

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
@@ -2,12 +2,9 @@
 struct ActivityContentRouter: ContentRouter {
     private let coordinator: ContentCoordinator
     private let activity: FormattableActivity
-    private let readerCoordinator: ReaderCoordinator
 
     init(controller: UIViewController, activity: FormattableActivity, context: NSManagedObjectContext) {
         coordinator = ContentCoordinator(controller: controller, context: context)
-        readerCoordinator = ReaderCoordinator(
-            readerNavigationController: controller.navigationController!)
         self.activity = activity
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
@@ -1,0 +1,45 @@
+
+struct ActivityContentRouter: ContentRouter {
+    private let coordinator: ContentCoordinator
+    private let activity: FormattableActivity
+    private let readerCoordinator: ReaderCoordinator
+
+    init(controller: UIViewController, activity: FormattableActivity, context: NSManagedObjectContext) {
+        coordinator = ContentCoordinator(controller: controller, context: context)
+        readerCoordinator = ReaderCoordinator(
+            readerNavigationController: controller.navigationController!)
+        self.activity = activity
+    }
+
+    func routeTo(_ url: URL) {
+        guard let range = getRange(with: url) else {
+            return
+        }
+        displayContent(of: range, with: url)
+    }
+
+    private func displayContent(of range: FormattableContentRange, with url: URL) {
+        switch range.kind {
+        case .post:
+            guard let postRange = range as? ActivityPostRange else {
+                fallthrough
+            }
+            let postID = postRange.postID as NSNumber
+            let siteID = postRange.siteID as NSNumber
+            try? coordinator.displayReaderWithPostId(postID, siteID: siteID)
+        case .comment:
+            guard let commentRange = range as? ActivityCommentRange else {
+                fallthrough
+            }
+            let postID = commentRange.postID as NSNumber
+            let siteID = commentRange.siteID as NSNumber
+            try? coordinator.displayCommentsWithPostId(postID, siteID: siteID)
+        default:
+            coordinator.displayWebViewWithURL(url)
+        }
+    }
+
+    private func getRange(with url: URL) -> FormattableContentRange? {
+        return activity.range(with: url)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
@@ -3,8 +3,8 @@ struct ActivityContentRouter: ContentRouter {
     private let coordinator: ContentCoordinator
     private let activity: FormattableActivity
 
-    init(controller: UIViewController, activity: FormattableActivity, context: NSManagedObjectContext) {
-        coordinator = ContentCoordinator(controller: controller, context: context)
+    init(activity: FormattableActivity, coordinator: ContentCoordinator) {
+        self.coordinator = coordinator// ContentCoordinator(controller: controller, context: context)
         self.activity = activity
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/Factory/ActivityRangesFactory.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/Factory/ActivityRangesFactory.swift
@@ -29,6 +29,11 @@ struct ActivityRangesFactory: ContentRangeFactory {
                 fallthrough
             }
             return pluginRange
+        case .comment:
+            guard let commentRange = createCommentRange(with: dictionary, url: url, and: range) else {
+                fallthrough
+            }
+            return commentRange
         default:
             return ActivityRange(kind: kind, range: range, url: url)
         }
@@ -40,6 +45,16 @@ struct ActivityRangesFactory: ContentRangeFactory {
                 return nil
         }
         return ActivityPostRange(range: range, siteID: siteId, postID: postID)
+    }
+
+    private static func createCommentRange(with dictionary: [String: AnyObject], url: URL?, and range: NSRange) -> ActivityCommentRange? {
+        guard let postID = dictionary[RangeKeys.postId] as? Int,
+            let commentID = dictionary[RangeKeys.id] as? Int,
+            let siteId = dictionary[RangeKeys.siteId] as? Int,
+            let url = url else {
+                return nil
+        }
+        return ActivityCommentRange(range: range, siteID: siteId, postID: postID, commentID: commentID, url: url)
     }
 
     private static func createPluginRange(with dictionary: [String: AnyObject], and range: NSRange) -> ActivityPluginRange? {
@@ -61,6 +76,7 @@ private enum RangeKeys {
     static let uri = "uri"
     static let id = "id"
     static let siteId = "site_id"
+    static let postId = "post_id"
     static let slug = "slug"
     static let siteSlug = "site_slug"
 }

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/FormattableActivity.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/FormattableActivity.swift
@@ -16,11 +16,18 @@ class FormattableActivity {
         self.activity = activity
     }
 
-    public func formattedContent(using styles: FormattableContentStyles) -> NSAttributedString {
+    func formattedContent(using styles: FormattableContentStyles) -> NSAttributedString {
         guard let textBlock: FormattableTextContent = contentGroup?.blockOfKind(.text) else {
             return NSAttributedString()
         }
         return formatter.render(content: textBlock, with: styles)
+    }
+
+    func range(with url: URL) -> FormattableContentRange? {
+        let rangesWithURL = contentGroup?.blocks.compactMap {
+            $0.range(with: url)
+        }
+        return rangesWithURL?.first
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/Ranges/ActivityCommentRange.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/Ranges/ActivityCommentRange.swift
@@ -1,0 +1,13 @@
+
+class ActivityCommentRange: ActivityRange {
+    let commentID: Int
+    let postID: Int
+    let siteID: Int
+
+    init(range: NSRange, siteID: Int, postID: Int, commentID: Int, url: URL) {
+        self.commentID = commentID
+        self.postID = postID
+        self.siteID = siteID
+        super.init(kind: .comment, range: range, url: url)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/Ranges/ActivityPostRange.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/Ranges/ActivityPostRange.swift
@@ -1,6 +1,12 @@
 
 class ActivityPostRange: ActivityRange {
+    let postID: Int
+    let siteID: Int
+
     init(range: NSRange, siteID: Int, postID: Int) {
+        self.postID = postID
+        self.siteID = siteID
+        
         let url = ActivityPostRange.urlWith(siteID: siteID, postID: postID)
         super.init(kind: .post, range: range, url: url)
     }

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/Ranges/ActivityPostRange.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/Ranges/ActivityPostRange.swift
@@ -6,7 +6,7 @@ class ActivityPostRange: ActivityRange {
     init(range: NSRange, siteID: Int, postID: Int) {
         self.postID = postID
         self.siteID = siteID
-        
+
         let url = ActivityPostRange.urlWith(siteID: siteID, postID: postID)
         super.init(kind: .post, range: range, url: url)
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -94,8 +94,8 @@ class NotificationDetailsViewController: UIViewController {
         }
     }
 
-    lazy var router: Router = {
-        return Router(controller: self, context: mainContext)
+    lazy var router: ContentCoordinator = {
+        return ContentCoordinator(controller: self, context: mainContext)
     }()
 
     /// Whenever the user performs a destructive action, the Deletion Request Callback will be called,
@@ -1109,7 +1109,7 @@ private extension NotificationDetailsViewController {
             case .CommentLike:
                 try router.displayCommentsWithPostId(note.metaPostID, siteID: note.metaSiteID)
             default:
-                throw Router.DisplayError.unsupportedType
+                throw ContentCoordinator.DisplayError.unsupportedType
             }
         } catch {
             router.displayWebViewWithURL(resourceURL as URL)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -94,8 +94,8 @@ class NotificationDetailsViewController: UIViewController {
         }
     }
 
-    lazy var router: ContentCoordinator = {
-        return ContentCoordinator(controller: self, context: mainContext)
+    lazy var coordinator: ContentCoordinator = {
+        return DefaultContentCoordinator(controller: self, context: mainContext)
     }()
 
     /// Whenever the user performs a destructive action, the Deletion Request Callback will be called,
@@ -700,7 +700,7 @@ private extension NotificationDetailsViewController {
                 return
             }
 
-            self?.router.displayFullscreenImage(image)
+            self?.coordinator.displayFullscreenImage(image)
         }
 
         // Download the Gravatar
@@ -936,7 +936,7 @@ private extension NotificationDetailsViewController {
                 return
             }
 
-            self?.router.displayFullscreenImage(image)
+            self?.coordinator.displayFullscreenImage(image)
         }
 
         // Download the Gravatar
@@ -1082,7 +1082,7 @@ private extension NotificationDetailsViewController {
             let range = note.notificationRangeWithUrl(url)
             try displayResourceWithRange(range)
         } catch {
-            router.displayWebViewWithURL(url)
+            coordinator.displayWebViewWithURL(url)
         }
     }
 
@@ -1095,7 +1095,7 @@ private extension NotificationDetailsViewController {
         do {
             switch note.kind {
             case .Follow:
-                try router.displayStreamWithSiteID(note.metaSiteID)
+                try coordinator.displayStreamWithSiteID(note.metaSiteID)
             case .Like:
                 fallthrough
             case .Matcher:
@@ -1103,16 +1103,16 @@ private extension NotificationDetailsViewController {
             case .NewPost:
                 fallthrough
             case .Post:
-                try router.displayReaderWithPostId(note.metaPostID, siteID: note.metaSiteID)
+                try coordinator.displayReaderWithPostId(note.metaPostID, siteID: note.metaSiteID)
             case .Comment:
                 fallthrough
             case .CommentLike:
-                try router.displayCommentsWithPostId(note.metaPostID, siteID: note.metaSiteID)
+                try coordinator.displayCommentsWithPostId(note.metaPostID, siteID: note.metaSiteID)
             default:
-                throw ContentCoordinator.DisplayError.unsupportedType
+                throw DefaultContentCoordinator.DisplayError.unsupportedType
             }
         } catch {
-            router.displayWebViewWithURL(resourceURL as URL)
+            coordinator.displayWebViewWithURL(resourceURL as URL)
         }
     }
 
@@ -1127,17 +1127,17 @@ private extension NotificationDetailsViewController {
 
         switch range.kind {
         case .Site:
-            try router.displayStreamWithSiteID(range.siteID)
+            try coordinator.displayStreamWithSiteID(range.siteID)
         case .Post:
-            try router.displayReaderWithPostId(range.postID, siteID: range.siteID)
+            try coordinator.displayReaderWithPostId(range.postID, siteID: range.siteID)
         case .Comment:
-            try router.displayCommentsWithPostId(range.postID, siteID: range.siteID)
+            try coordinator.displayCommentsWithPostId(range.postID, siteID: range.siteID)
         case .Stats:
-            try router.displayStatsWithSiteID(range.siteID)
+            try coordinator.displayStatsWithSiteID(range.siteID)
         case .Follow:
-            try router.displayFollowersWithSiteID(range.siteID, expirationTime: Settings.expirationFiveMinutes)
+            try coordinator.displayFollowersWithSiteID(range.siteID, expirationTime: Settings.expirationFiveMinutes)
         case .User:
-            try router.displayStreamWithSiteID(range.siteID)
+            try coordinator.displayStreamWithSiteID(range.siteID)
         default:
             throw DisplayError.unsupportedType
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -527,6 +527,10 @@
 		7E52B7181FC89F2400B55EB8 /* MediaNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */; };
 		7E53AB0020FE55A9005796FE /* ActivityContentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E53AAFF20FE55A9005796FE /* ActivityContentRouter.swift */; };
 		7E53AB0220FE5EAE005796FE /* ContentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E53AB0120FE5EAE005796FE /* ContentRouter.swift */; };
+		7E53AB0420FE6681005796FE /* ActivityContentRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E53AB0320FE6681005796FE /* ActivityContentRouterTests.swift */; };
+		7E53AB0620FE6905005796FE /* activity-log-comment.json in Resources */ = {isa = PBXBuildFile; fileRef = 7E53AB0520FE6905005796FE /* activity-log-comment.json */; };
+		7E53AB0820FE6C9C005796FE /* activity-log-post.json in Resources */ = {isa = PBXBuildFile; fileRef = 7E53AB0720FE6C9C005796FE /* activity-log-post.json */; };
+		7E53AB0A20FE83A9005796FE /* MockContentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E53AB0920FE83A9005796FE /* MockContentCoordinator.swift */; };
 		7E729C28209A087300F76599 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C27209A087200F76599 /* ImageLoader.swift */; };
 		7E729C2A209A241100F76599 /* AbstractPost+PostInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */; };
 		7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */; };
@@ -2010,6 +2014,10 @@
 		7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaNoResultsView.swift; sourceTree = "<group>"; };
 		7E53AAFF20FE55A9005796FE /* ActivityContentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityContentRouter.swift; sourceTree = "<group>"; };
 		7E53AB0120FE5EAE005796FE /* ContentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentRouter.swift; sourceTree = "<group>"; };
+		7E53AB0320FE6681005796FE /* ActivityContentRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityContentRouterTests.swift; sourceTree = "<group>"; };
+		7E53AB0520FE6905005796FE /* activity-log-comment.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "activity-log-comment.json"; sourceTree = "<group>"; };
+		7E53AB0720FE6C9C005796FE /* activity-log-post.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "activity-log-post.json"; sourceTree = "<group>"; };
+		7E53AB0920FE83A9005796FE /* MockContentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockContentCoordinator.swift; sourceTree = "<group>"; };
 		7E729C27209A087200F76599 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+PostInformation.swift"; sourceTree = "<group>"; };
 		7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonHeaderCell.swift; sourceTree = "<group>"; };
@@ -4314,6 +4322,8 @@
 				7E4A772E20F7FDF8001C706D /* ActivityLogTestData.swift */,
 				7E442FC620F677CB00DEACA5 /* ActivityLogRangesTest.swift */,
 				7E442FCE20F6C19000DEACA5 /* ActivityLogFormattableContentTests.swift */,
+				7E53AB0320FE6681005796FE /* ActivityContentRouterTests.swift */,
+				7E53AB0920FE83A9005796FE /* MockContentCoordinator.swift */,
 			);
 			name = ActivityLog;
 			sourceTree = "<group>";
@@ -4328,6 +4338,8 @@
 				7E4A772620F7CDD5001C706D /* activity-log-settings-content.json */,
 				7E4A772A20F7E5FD001C706D /* activity-log-site-content.json */,
 				7E4A772C20F7E8D8001C706D /* activity-log-plugin-content.json */,
+				7E53AB0520FE6905005796FE /* activity-log-comment.json */,
+				7E53AB0720FE6C9C005796FE /* activity-log-post.json */,
 			);
 			name = ActivityLog;
 			sourceTree = "<group>";
@@ -6966,6 +6978,7 @@
 				7E4A772120F7BBBD001C706D /* activity-log-post-content.json in Resources */,
 				748437F01F1D4E9E00E8DDAF /* notifications-load-all.json in Resources */,
 				E11330511A13BAA300D36D84 /* me-sites-with-jetpack.json in Resources */,
+				7E53AB0820FE6C9C005796FE /* activity-log-post.json in Resources */,
 				855408861A6F105700DDBD79 /* app-review-prompt-all-enabled.json in Resources */,
 				748437F11F1D4ECC00E8DDAF /* notifications-last-seen.json in Resources */,
 				74585B9D1F0D591D00E7E667 /* domain-service-all-domain-types.json in Resources */,
@@ -6982,6 +6995,7 @@
 				08DF9C441E8475530058678C /* test-image-portrait.jpg in Resources */,
 				B5AEEC7C1ACACFDA008BF2A4 /* notifications-new-follower.json in Resources */,
 				B5AEEC791ACACFDA008BF2A4 /* notifications-badge.json in Resources */,
+				7E53AB0620FE6905005796FE /* activity-log-comment.json in Resources */,
 				93C882A41EEB18D700227A59 /* rsd.xml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -8276,6 +8290,7 @@
 				D88A64A8208D9733008AE9BC /* ThumbnailCollectionTests.swift in Sources */,
 				748437EE1F1D4A7300E8DDAF /* RichContentFormatterTests.swift in Sources */,
 				D88A649E208D82D2008AE9BC /* XCTestCase+Wait.swift in Sources */,
+				7E53AB0420FE6681005796FE /* ActivityContentRouterTests.swift in Sources */,
 				17AF92251C46634000A99CFB /* BlogSiteVisibilityHelperTest.m in Sources */,
 				1759F1721FE017F20003EC81 /* QueueTests.swift in Sources */,
 				08F8CD3B1EBD2D020049D0C0 /* MediaURLExporterTests.swift in Sources */,
@@ -8367,6 +8382,7 @@
 				E124CE721C86D27100F7BA99 /* StoreTests.swift in Sources */,
 				B5EFB1C91B333C5A007608A3 /* NotificationSettingsServiceTests.swift in Sources */,
 				E6A216931DCE857100E7DF73 /* WPRichTextFormatterTests.swift in Sources */,
+				7E53AB0A20FE83A9005796FE /* MockContentCoordinator.swift in Sources */,
 				BE1071FF1BC75FFA00906AFF /* WPStyleGuide+BlogTests.swift in Sources */,
 				932645A41E7C206600134988 /* EditorSettingsTests.swift in Sources */,
 				933D1F471EA64108009FB462 /* TestingAppDelegate.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -525,6 +525,8 @@
 		7E4A773920F80417001C706D /* ActivityPluginRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4A773320F800ED001C706D /* ActivityPluginRange.swift */; };
 		7E4A773C20F80598001C706D /* ActivityContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4A773A20F8058F001C706D /* ActivityContentFactory.swift */; };
 		7E52B7181FC89F2400B55EB8 /* MediaNoResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */; };
+		7E53AB0020FE55A9005796FE /* ActivityContentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E53AAFF20FE55A9005796FE /* ActivityContentRouter.swift */; };
+		7E53AB0220FE5EAE005796FE /* ContentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E53AB0120FE5EAE005796FE /* ContentRouter.swift */; };
 		7E729C28209A087300F76599 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C27209A087200F76599 /* ImageLoader.swift */; };
 		7E729C2A209A241100F76599 /* AbstractPost+PostInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */; };
 		7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */; };
@@ -2006,6 +2008,8 @@
 		7E4A773520F80146001C706D /* ActivityRangesFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityRangesFactory.swift; sourceTree = "<group>"; };
 		7E4A773A20F8058F001C706D /* ActivityContentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityContentFactory.swift; sourceTree = "<group>"; };
 		7E52B7171FC89F2400B55EB8 /* MediaNoResultsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaNoResultsView.swift; sourceTree = "<group>"; };
+		7E53AAFF20FE55A9005796FE /* ActivityContentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityContentRouter.swift; sourceTree = "<group>"; };
+		7E53AB0120FE5EAE005796FE /* ContentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentRouter.swift; sourceTree = "<group>"; };
 		7E729C27209A087200F76599 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+PostInformation.swift"; sourceTree = "<group>"; };
 		7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonHeaderCell.swift; sourceTree = "<group>"; };
@@ -4285,6 +4289,7 @@
 				7E4123B620F4097B00DF8486 /* FormattableContentStyles.swift */,
 				7E4123B020F4097A00DF8486 /* FormattableMediaContent.swift */,
 				7E4123B320F4097A00DF8486 /* FormattableTextContent.swift */,
+				7E53AB0120FE5EAE005796FE /* ContentRouter.swift */,
 			);
 			path = FormattableContent;
 			sourceTree = "<group>";
@@ -4296,6 +4301,7 @@
 				7E4123C920F4184200DF8486 /* ActivityContentGroup.swift */,
 				7E4123CB20F418A500DF8486 /* ActivityActionsParser.swift */,
 				7E3AB3DA20F52654001F33B6 /* ActivityContentStyles.swift */,
+				7E53AAFF20FE55A9005796FE /* ActivityContentRouter.swift */,
 				7E4A773D20F80625001C706D /* Factory */,
 				7E4A773020F80063001C706D /* Ranges */,
 			);
@@ -7427,6 +7433,7 @@
 				D8A3A5AC2069FE5B00992576 /* StockPhotosStrings.swift in Sources */,
 				C56636E91868D0CE00226AAB /* StatsViewController.m in Sources */,
 				E6805D301DCD399600168E4F /* WPRichTextEmbed.swift in Sources */,
+				7E53AB0020FE55A9005796FE /* ActivityContentRouter.swift in Sources */,
 				F128C31C1AFCC95B008C2404 /* WPNavigationMediaPickerViewController+StatusBarStyle.m in Sources */,
 				E1B9128F1BB05B1D003C25B9 /* PeopleCell.swift in Sources */,
 				313AE4A019E3F20400AAFABE /* CommentViewController.m in Sources */,
@@ -7736,6 +7743,7 @@
 				D8A3A5B7206A563900992576 /* StockPhotosPlaceholder.swift in Sources */,
 				E114D79A153D85A800984182 /* WPError.m in Sources */,
 				5926E1E31AC4468300964783 /* WPCrashlytics.m in Sources */,
+				7E53AB0220FE5EAE005796FE /* ContentRouter.swift in Sources */,
 				E16273E11B2ACEB600088AF7 /* BlogToBlog32to33.swift in Sources */,
 				E678FC151C76241000F55F55 /* WPStyleGuide+ApplicationStyles.swift in Sources */,
 				7EFF208620EAD918009C4699 /* FormattableUserContent.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -528,7 +528,7 @@
 		7E729C28209A087300F76599 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C27209A087200F76599 /* ImageLoader.swift */; };
 		7E729C2A209A241100F76599 /* AbstractPost+PostInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */; };
 		7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */; };
-		7E846FF120FD0A0500881F5A /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF020FD0A0500881F5A /* Router.swift */; };
+		7E846FF120FD0A0500881F5A /* ContentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */; };
 		7E846FF320FD37BD00881F5A /* ActivityCommentRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */; };
 		7EAD7CD0206D761200BEDCFD /* MediaExternalExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */; };
 		7EB5824720EC41B200002702 /* NotificationContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB5824620EC41B200002702 /* NotificationContentFactory.swift */; };
@@ -2009,7 +2009,7 @@
 		7E729C27209A087200F76599 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+PostInformation.swift"; sourceTree = "<group>"; };
 		7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonHeaderCell.swift; sourceTree = "<group>"; };
-		7E846FF020FD0A0500881F5A /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
+		7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCoordinator.swift; sourceTree = "<group>"; };
 		7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityCommentRange.swift; sourceTree = "<group>"; };
 		7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExternalExporter.swift; sourceTree = "<group>"; };
 		7EB5824620EC41B200002702 /* NotificationContentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentFactory.swift; sourceTree = "<group>"; };
@@ -4572,7 +4572,7 @@
 				FF28B3F01AEB251200E11AAE /* InfoPListTranslator.m */,
 				85B125431B02937E008A3D95 /* UIAlertControllerProxy.h */,
 				85B125441B02937E008A3D95 /* UIAlertControllerProxy.m */,
-				7E846FF020FD0A0500881F5A /* Router.swift */,
+				7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -8019,7 +8019,7 @@
 				08216FCD1CDBF96000304BA7 /* MenuItemPagesViewController.m in Sources */,
 				43D54D131DCAA070007F575F /* PostPostViewController.swift in Sources */,
 				7E3E7A5B20E44D950075D159 /* RichTextContentStyles.swift in Sources */,
-				7E846FF120FD0A0500881F5A /* Router.swift in Sources */,
+				7E846FF120FD0A0500881F5A /* ContentCoordinator.swift in Sources */,
 				B54E1DF41A0A7BBF00807537 /* NotificationMediaDownloader.swift in Sources */,
 				178EDE701C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift in Sources */,
 				73713583208EA4B900CCDFC8 /* Blog+Files.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -528,6 +528,7 @@
 		7E729C28209A087300F76599 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C27209A087200F76599 /* ImageLoader.swift */; };
 		7E729C2A209A241100F76599 /* AbstractPost+PostInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */; };
 		7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */; };
+		7E846FF120FD0A0500881F5A /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF020FD0A0500881F5A /* Router.swift */; };
 		7EAD7CD0206D761200BEDCFD /* MediaExternalExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */; };
 		7EB5824720EC41B200002702 /* NotificationContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB5824620EC41B200002702 /* NotificationContentFactory.swift */; };
 		7EBB4126206C388100012D98 /* StockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBB4125206C388100012D98 /* StockPhotosService.swift */; };
@@ -2007,6 +2008,7 @@
 		7E729C27209A087200F76599 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+PostInformation.swift"; sourceTree = "<group>"; };
 		7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonHeaderCell.swift; sourceTree = "<group>"; };
+		7E846FF020FD0A0500881F5A /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExternalExporter.swift; sourceTree = "<group>"; };
 		7EB5824620EC41B200002702 /* NotificationContentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentFactory.swift; sourceTree = "<group>"; };
 		7EBB4125206C388100012D98 /* StockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosService.swift; sourceTree = "<group>"; };
@@ -4567,6 +4569,7 @@
 				FF28B3F01AEB251200E11AAE /* InfoPListTranslator.m */,
 				85B125431B02937E008A3D95 /* UIAlertControllerProxy.h */,
 				85B125441B02937E008A3D95 /* UIAlertControllerProxy.m */,
+				7E846FF020FD0A0500881F5A /* Router.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -8012,6 +8015,7 @@
 				08216FCD1CDBF96000304BA7 /* MenuItemPagesViewController.m in Sources */,
 				43D54D131DCAA070007F575F /* PostPostViewController.swift in Sources */,
 				7E3E7A5B20E44D950075D159 /* RichTextContentStyles.swift in Sources */,
+				7E846FF120FD0A0500881F5A /* Router.swift in Sources */,
 				B54E1DF41A0A7BBF00807537 /* NotificationMediaDownloader.swift in Sources */,
 				178EDE701C74CE7F008C5C14 /* PlanPostPurchaseViewController.swift in Sources */,
 				73713583208EA4B900CCDFC8 /* Blog+Files.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -529,6 +529,7 @@
 		7E729C2A209A241100F76599 /* AbstractPost+PostInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */; };
 		7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */; };
 		7E846FF120FD0A0500881F5A /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF020FD0A0500881F5A /* Router.swift */; };
+		7E846FF320FD37BD00881F5A /* ActivityCommentRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */; };
 		7EAD7CD0206D761200BEDCFD /* MediaExternalExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */; };
 		7EB5824720EC41B200002702 /* NotificationContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB5824620EC41B200002702 /* NotificationContentFactory.swift */; };
 		7EBB4126206C388100012D98 /* StockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBB4125206C388100012D98 /* StockPhotosService.swift */; };
@@ -2009,6 +2010,7 @@
 		7E729C29209A241100F76599 /* AbstractPost+PostInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+PostInformation.swift"; sourceTree = "<group>"; };
 		7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonHeaderCell.swift; sourceTree = "<group>"; };
 		7E846FF020FD0A0500881F5A /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
+		7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityCommentRange.swift; sourceTree = "<group>"; };
 		7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExternalExporter.swift; sourceTree = "<group>"; };
 		7EB5824620EC41B200002702 /* NotificationContentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentFactory.swift; sourceTree = "<group>"; };
 		7EBB4125206C388100012D98 /* StockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosService.swift; sourceTree = "<group>"; };
@@ -4330,6 +4332,7 @@
 				7E442FCB20F6AACB00DEACA5 /* ActivityRange.swift */,
 				7E4A773120F800CB001C706D /* ActivityPostRange.swift */,
 				7E4A773320F800ED001C706D /* ActivityPluginRange.swift */,
+				7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */,
 			);
 			path = Ranges;
 			sourceTree = "<group>";
@@ -7536,6 +7539,7 @@
 				17B7C89E20EC1D0D0042E260 /* UniversalLinkRouter.swift in Sources */,
 				40A2777F20191AA500D078D5 /* PluginDirectoryCollectionViewCell.swift in Sources */,
 				B55FFCFA1F034F1A0070812C /* String+Ranges.swift in Sources */,
+				7E846FF320FD37BD00881F5A /* ActivityCommentRange.swift in Sources */,
 				FF8791BB1FBAF4B500AD86E6 /* MediaService+Swift.swift in Sources */,
 				D8212CB920AA77AD008E8AE8 /* ReaderActionHelpers.swift in Sources */,
 				B52C4C7D199D4CD3009FD823 /* NoteBlockUserTableViewCell.swift in Sources */,

--- a/WordPress/WordPressTest/ActivityContentRouterTests.swift
+++ b/WordPress/WordPressTest/ActivityContentRouterTests.swift
@@ -14,7 +14,7 @@ final class ActivityContentRouterTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
     }
-    
+
     func testRouteToComment() {
         let commentActivity = getCommentActivity()
         let router = ActivityContentRouter(activity: commentActivity, coordinator: testCoordinator)

--- a/WordPress/WordPressTest/ActivityContentRouterTests.swift
+++ b/WordPress/WordPressTest/ActivityContentRouterTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import WordPress
+
+final class ActivityContentRouterTests: XCTestCase {
+
+    let testData = ActivityLogTestData()
+    var testCoordinator: MockContentCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        testCoordinator = MockContentCoordinator()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testRouteToComment() {
+        let commentActivity = getCommentActivity()
+        let router = ActivityContentRouter(activity: commentActivity, coordinator: testCoordinator)
+
+        router.routeTo(commentURL)
+
+        XCTAssertTrue(testCoordinator.commentsWasDisplayed)
+        XCTAssertEqual(testCoordinator.commentPostID?.intValue, testData.testPostID)
+        XCTAssertEqual(testCoordinator.commentSiteID?.intValue, testData.testSiteID)
+    }
+
+    func testRouteToPost() {
+        let activity = getPostActivity()
+        let router = ActivityContentRouter(activity: activity, coordinator: testCoordinator)
+
+        router.routeTo(postURL)
+
+        XCTAssertTrue(testCoordinator.readerWasDisplayed)
+        XCTAssertEqual(testCoordinator.readerPostID?.intValue, testData.testPostID)
+        XCTAssertEqual(testCoordinator.readerSiteID?.intValue, testData.testSiteID)
+    }
+}
+
+// MARK: - Helpers
+
+extension ActivityContentRouterTests {
+    var postURL: URL {
+        return URL(string: testData.testPostUrl)!
+    }
+
+    var commentURL: URL {
+        return URL(string: testData.testCommentURL)!
+    }
+
+    func getCommentActivity() -> FormattableActivity {
+        let activity = try! Activity(dictionary: testData.getCommentEventDictionary())
+        return FormattableActivity(with: activity)
+    }
+
+    func getPostActivity() -> FormattableActivity {
+        let activity = try! Activity(dictionary: testData.getPostEventDictionary())
+        return FormattableActivity(with: activity)
+    }
+}

--- a/WordPress/WordPressTest/ActivityLogRangesTest.swift
+++ b/WordPress/WordPressTest/ActivityLogRangesTest.swift
@@ -43,9 +43,9 @@ final class ActivityLogRangesTests: XCTestCase {
         let range = ActivityRangesFactory.contentRange(from: commentRangeRaw)
 
         XCTAssertNotNil(range)
-        XCTAssertTrue(range is ActivityRange)
+        XCTAssertTrue(range is ActivityCommentRange)
 
-        let commentRange = range as? ActivityRange
+        let commentRange = range as? ActivityCommentRange
 
         XCTAssertEqual(commentRange?.kind, .comment)
         XCTAssertNotNil(commentRange?.url)

--- a/WordPress/WordPressTest/ActivityLogTestData.swift
+++ b/WordPress/WordPressTest/ActivityLogTestData.swift
@@ -23,8 +23,20 @@ class ActivityLogTestData {
         return "https://wordpress.com/plugins/\(testPluginSlug)/\(testSiteSlug)"
     }
 
+    var testCommentURL: String {
+        return "https://etoledom.wordpress.com/2018/06/02/hola-lima/comment-page-1/#comment-7"
+    }
+
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
         return contextManager.object(withContentOfFile: fileName) as! [String: AnyObject]
+    }
+
+    func getCommentEventDictionary() -> [String: AnyObject] {
+        return getDictionaryFromFile(named: "activity-log-comment.json")
+    }
+
+    func getPostEventDictionary() -> [String: AnyObject] {
+        return getDictionaryFromFile(named: "activity-log-post.json")
     }
 
     func getPingbackDictionary() -> [String: AnyObject] {

--- a/WordPress/WordPressTest/MockContentCoordinator.swift
+++ b/WordPress/WordPressTest/MockContentCoordinator.swift
@@ -1,0 +1,43 @@
+
+@testable import WordPress
+
+class MockContentCoordinator: ContentCoordinator {
+
+    var readerWasDisplayed = false
+    var readerPostID: NSNumber?
+    var readerSiteID: NSNumber?
+    func displayReaderWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws {
+        readerWasDisplayed = true
+        readerPostID = postID
+        readerSiteID = siteID
+    }
+
+    var commentsWasDisplayed = false
+    var commentPostID: NSNumber?
+    var commentSiteID: NSNumber?
+    func displayCommentsWithPostId(_ postID: NSNumber?, siteID: NSNumber?) throws {
+        commentsWasDisplayed = true
+        commentPostID = postID
+        commentSiteID = siteID
+    }
+
+    func displayStatsWithSiteID(_ siteID: NSNumber?) throws {
+
+    }
+
+    func displayFollowersWithSiteID(_ siteID: NSNumber?, expirationTime: TimeInterval) throws {
+
+    }
+
+    func displayStreamWithSiteID(_ siteID: NSNumber?) throws {
+
+    }
+
+    func displayWebViewWithURL(_ url: URL) {
+
+    }
+
+    func displayFullscreenImage(_ image: UIImage) {
+
+    }
+}

--- a/WordPress/WordPressTest/Test Data/activity-log-comment.json
+++ b/WordPress/WordPressTest/Test Data/activity-log-comment.json
@@ -1,0 +1,66 @@
+{
+    "summary": "Comment approved",
+    "content": {
+        "text": "Comment by aaaaaaaaaa on Hola Lima! 🇵🇪: Great post! True talent!",
+        "ranges": [
+                   {
+                   "type": "comment",
+                   "indices": [
+                               0,
+                               7
+                               ],
+                   "url": "https://etoledom.wordpress.com/2018/06/02/hola-lima/comment-page-1/#comment-7",
+                   "site_id": 137726971,
+                   "post_id": 441,
+                   "id": 7
+                   },
+                   {
+                   "type": "post",
+                   "indices": [
+                               25,
+                               40
+                               ],
+                   "url": "Array",
+                   "site_id": 137726971,
+                   "id": 441
+                   }
+                   ]
+    },
+    "name": "comment__approved",
+    "actor": {
+        "type": "Person",
+        "name": "etoledom",
+        "external_user_id": 0,
+        "wpcom_user_id": 129935412,
+        "icon": {
+            "type": "Image",
+            "url": "https://secure.gravatar.com/avatar/8e06b8f61330e7bc0e5eb4e67aa68e0f?s=96&d=identicon&r=g",
+            "width": 96,
+            "height": 96
+        },
+        "role": "administrator"
+    },
+    "type": "Accept",
+    "published": "2018-06-29T20:38:55.277+00:00",
+    "generator": {
+        "jetpack_version": 0,
+        "blog_id": 137726971
+    },
+    "is_rewindable": false,
+    "rewind_id": "1530304735.2771",
+    "gridicon": "comment",
+    "status": null,
+    "activity_id": "AWRNRTAUjEqjFGbx8DZj",
+    "object": {
+        "type": "Comment",
+        "object_id": 7
+    },
+    "target": {
+        "type": "Article",
+        "name": "Hola Lima! 🇵🇪",
+        "post_id": 229,
+        "post_type": "post",
+        "post_status": "publish"
+    },
+    "is_discarded": false
+}

--- a/WordPress/WordPressTest/Test Data/activity-log-post.json
+++ b/WordPress/WordPressTest/Test Data/activity-log-post.json
@@ -1,0 +1,51 @@
+{
+    "summary": "Post published",
+    "content": {
+        "text": "Tren de Machu Picchu a Cusco",
+        "ranges": [
+                   {
+                   "type": "post",
+                   "indices": [
+                               0,
+                               28
+                               ],
+                   "url": "Array",
+                   "site_id": 137726971,
+                   "id": 441
+                   }
+                   ]
+    },
+    "name": "post__published",
+    "actor": {
+        "type": "Person",
+        "name": "etoledom",
+        "external_user_id": 0,
+        "wpcom_user_id": 129935412,
+        "icon": {
+            "type": "Image",
+            "url": "https://secure.gravatar.com/avatar/8e06b8f61330e7bc0e5eb4e67aa68e0f?s=96&d=identicon&r=g",
+            "width": 96,
+            "height": 96
+        },
+        "role": "administrator"
+    },
+    "type": "Update",
+    "published": "2018-07-07T02:42:38.620+00:00",
+    "generator": {
+        "jetpack_version": 0,
+        "blog_id": 137726971
+    },
+    "is_rewindable": false,
+    "rewind_id": "1530931358.6198",
+    "gridicon": "posts",
+    "status": "success",
+    "activity_id": "AWRynrApjEqjFGbxm6qj",
+    "object": {
+        "type": "Article",
+        "name": "Tren de Machu Picchu a Cusco",
+        "object_id": 441,
+        "object_type": "post",
+        "object_status": "publish"
+    },
+    "is_discarded": false
+}


### PR DESCRIPTION
Fixes #9783 

Part of #9748 

This PR extracts the navigation logic from `NotificationDetailsViewController` into a `Router`, and uses it on `ActivityDetailViewController` to present native elements to display: 

- Posts.
- Comments.
- Internal WebView for anything else.

![activity_nav](https://user-images.githubusercontent.com/9772967/42786131-ff2d5560-8922-11e8-9dda-8f2dc44d8226.gif)

To test:

The easiest way to test is finding a comment event, since it has both a comment range and a post range:
- Find a comment event and open it.
- Tap con the `Comment` link.
- Check that it opens the corresponding internal Comments component.
- Go back and search for an event with a post link.
- Tap on the `Post` link.
- Check that it opens the corresponding internal Post component.