### PR TITLE
Disable Crashlytics if user opts-out of tracking

### DIFF
--- a/WordPress/Classes/Utility/WPCrashlytics.h
+++ b/WordPress/Classes/Utility/WPCrashlytics.h
@@ -15,7 +15,7 @@
 #pragma mark - User Opt Out
 
 /**
- *  @brief      Call this method to know if the user has opted out of crashalytics tracking.
+ *  @brief      Call this method to know if the user has opted out of Crashlytics tracking.
  *
  *  @returns    YES if the user has opted out, NO otherwise.
  */

--- a/WordPress/Classes/Utility/WPCrashlytics.h
+++ b/WordPress/Classes/Utility/WPCrashlytics.h
@@ -8,6 +8,24 @@
  */
 @interface WPCrashlytics : NSObject
 
+#pragma mark - Init
+
 - (instancetype)initWithAPIKey:(NSString *)apiKey;
+
+#pragma mark - User Opt Out
+
+/**
+ *  @brief      Call this method to know if the user has opted out of crashalytics tracking.
+ *
+ *  @returns    YES if the user has opted out, NO otherwise.
+ */
++ (BOOL)userHasOptedOut;
+
+/**
+ *  @brief      Sets user opt out ON or OFF
+ *
+ *  @param      optedOut   The new status for user opt out.
+ */
+- (void)setUserHasOptedOut:(BOOL)optedOut;
 
 @end

--- a/WordPress/Classes/Utility/WPCrashlytics.m
+++ b/WordPress/Classes/Utility/WPCrashlytics.m
@@ -69,7 +69,7 @@ NSString * const WPCrashlyticsKeyNumberOfBlogs = @"number_of_blogs";
     }
 
     if ([[NSUserDefaults standardUserDefaults] boolForKey:WPAppAnalyticsDefaultsUserOptedOut] == YES) {
-        // If the user has already explicitly disabled tracking for analytics, let's ensure we turn off crashalytics tracking as well
+        // If the user has already explicitly disabled tracking for analytics, let's ensure we turn off Crashlytics tracking as well
         [self setUserHasOptedOutValue:YES];
     } else {
         [self setUserHasOptedOutValue:NO];

--- a/WordPress/Classes/Utility/WPCrashlytics.m
+++ b/WordPress/Classes/Utility/WPCrashlytics.m
@@ -33,7 +33,8 @@ NSString * const WPCrashlyticsKeyNumberOfBlogs = @"number_of_blogs";
     self = [super init];
     
     if (self) {
-        [self initializeCrashlytics];
+        [[Crashlytics sharedInstance] setDelegate:self];
+        [self startupCrashlyticsIfNeeded];
         [self startObservingNotifications];
     }
     
@@ -43,17 +44,18 @@ NSString * const WPCrashlyticsKeyNumberOfBlogs = @"number_of_blogs";
 #pragma mark - Init helpers
 
 /**
- *  @brief      Initializes crashlytics for WPiOS.
+ *  @brief      Start crashlytics for WPiOS
  */
-- (void)initializeCrashlytics
+- (void)startupCrashlyticsIfNeeded
 {
     [self initializeOptOutTracking];
-    [[Crashlytics sharedInstance] setDelegate:self];
 
     BOOL userHasOptedOut = [WPCrashlytics userHasOptedOut];
     if (!userHasOptedOut) {
-        // Crashalytics opt-in per: https://docs.fabric.io/apple/crashlytics/advanced-setup.html#enable-opt-in-reporting
-        [Fabric with:@[CrashlyticsKit]];
+        // FYI: This method may get called mutiple times (e.g. user toggles the privacy settings on-off-on).
+        // Per the docs, only the first call is honored and subsequent calls are no-ops.
+        [Fabric with:@[CrashlyticsKit]];        
+
         [self setCommonCrashlyticsParameters];
     }
 }
@@ -103,7 +105,7 @@ NSString * const WPCrashlyticsKeyNumberOfBlogs = @"number_of_blogs";
     if (optedOut) {
         [self clearCommonCrashlyticsParameters];
     } else {
-        [self setCommonCrashlyticsParameters];
+        [self startupCrashlyticsIfNeeded];
     }
 }
 

--- a/WordPress/Classes/Utility/WPCrashlytics.m
+++ b/WordPress/Classes/Utility/WPCrashlytics.m
@@ -52,6 +52,7 @@ NSString * const WPCrashlyticsKeyNumberOfBlogs = @"number_of_blogs";
 
     BOOL userHasOptedOut = [WPCrashlytics userHasOptedOut];
     if (!userHasOptedOut) {
+        // Crashalytics opt-in per: https://docs.fabric.io/apple/crashlytics/advanced-setup.html#enable-opt-in-reporting
         [Fabric with:@[CrashlyticsKit]];
         [self setCommonCrashlyticsParameters];
     }

--- a/WordPress/Classes/Utility/WPCrashlytics.m
+++ b/WordPress/Classes/Utility/WPCrashlytics.m
@@ -65,7 +65,7 @@ NSString * const WPCrashlyticsKeyNumberOfBlogs = @"number_of_blogs";
         return;
     }
 
-    if ([[NSUserDefaults standardUserDefaults] boolForKey:WPAppAnalyticsDefaultsUserOptedOut] == NO) {
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:WPAppAnalyticsDefaultsUserOptedOut] == YES) {
         // If the user has already explicitly disabled tracking for analytics, let's ensure we turn off crashalytics tracking as well
         [self setUserHasOptedOutValue:YES];
     } else {

--- a/WordPress/Classes/Utility/WPCrashlytics.m
+++ b/WordPress/Classes/Utility/WPCrashlytics.m
@@ -48,10 +48,10 @@ NSString * const WPCrashlyticsKeyNumberOfBlogs = @"number_of_blogs";
 - (void)initializeCrashlytics
 {
     [self initializeOptOutTracking];
+    [[Crashlytics sharedInstance] setDelegate:self];
 
     BOOL userHasOptedOut = [WPCrashlytics userHasOptedOut];
     if (!userHasOptedOut) {
-        [[Crashlytics sharedInstance] setDelegate:self];
         [Fabric with:@[CrashlyticsKit]];
         [self setCommonCrashlyticsParameters];
     }
@@ -168,7 +168,9 @@ NSString * const WPCrashlyticsKeyNumberOfBlogs = @"number_of_blogs";
     [defaults setInteger:crashCount forKey:@"crashCount"];
     [defaults synchronize];
     if (completionHandler) {
-        completionHandler(YES);
+        //  Invoking the completionHandler with NO will cause the detected report to be deleted and not submitted to Crashlytics.
+        BOOL shouldSubmitReportToCrashlytics = ![WPCrashlytics userHasOptedOut];
+        completionHandler(shouldSubmitReportToCrashlytics);
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
@@ -112,6 +112,9 @@ class PrivacySettingsViewController: UITableViewController {
 
             let accountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
             AccountSettingsHelper(accountService: accountService).updateTracksOptOutSetting(!enabled)
+
+            let crashalytics = WordPressAppDelegate.sharedInstance().crashlytics
+            crashalytics?.setUserHasOptedOut(!enabled)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
@@ -113,8 +113,8 @@ class PrivacySettingsViewController: UITableViewController {
             let accountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
             AccountSettingsHelper(accountService: accountService).updateTracksOptOutSetting(!enabled)
 
-            let crashalytics = WordPressAppDelegate.sharedInstance().crashlytics
-            crashalytics?.setUserHasOptedOut(!enabled)
+            let crashlytics = WordPressAppDelegate.sharedInstance().crashlytics
+            crashlytics?.setUserHasOptedOut(!enabled)
         }
     }
 


### PR DESCRIPTION
This PR configures Crashlytics to respect the "Collect information" setting on the privacy screen:

<img width="320" alt="screen shot 2018-07-16 at 4 16 21 pm" src="https://user-images.githubusercontent.com/154014/42784122-c2871998-8913-11e8-8dbb-1e7dd425faad.png">

 If OFF, Crashlytics will not report crashes. If ON, Crashalytics will report crashes. Code-wise, this PR essentially mimics the opt-out logic found in `WPAppAnalytics` and applies it to `WPCrashlytics`. 

A couple of things to note:

1. In the [Fabric documentation](https://docs.fabric.io/apple/crashlytics/advanced-setup.html#enable-opt-in-reporting), it mentions users will need to "completely quit the app in order for the change to take effect". Instead displaying a message like that to our users, I opted call the completion handler in `crashlyticsDidDetectReportForLastExecution` with a `NO` param which causes the current report to be trashed and never sent over the wire.  

_(Note that the next launch of WPiOS will **not** startup Crashlytics all all.)_

2. It is possible that `[Fabric with:@[CrashlyticsKit]];` will get called multiple times if the user toggles the privacy setting on and off a few times. Per their docs, that is ok:

> Only the first call to this method is honored. Subsequent calls are no-ops.

You will see a warning in the console, but that is about it.

Fixes #9764 

## Testing

I am not exactly sure the best way to test this beyond setting some breakpoints in `WPCrashlytics` and verifying the appropriate code is executed.  FWIW, [Crashlytics does provide an easy way to force a crash](https://support.crashlytics.com/knowledgebase/articles/92522-is-there-a-quick-way-to-force-a-crash) by putting `[[Crashlytics sharedInstance] crash];` somewhere fun. 🎉 

### Opt-in/Opt-out configuration
1. Build and run the app - you may have to [override some settings here](https://github.com/wordpress-mobile/WordPress-iOS/blob/6f146402e97af2ed55d0f64ccd681f7a082ffeed/WordPress/Classes/System/WordPressAppDelegate%2BSwift.swift#L36-L44) to force the loading of Crashlytics in `DEBUG`
2. Goto Me→App Settings→Privacy Settings and toggle the "Collect Information"
3. Verify that `WPCrashlytics.setUserHasOptedOut` is called with the appropriate values

### Startup of Crashlytics based on opt-out setting
1. Build and run the app
2. On app launch, if opt-out setting is YES: verify [the code](https://github.com/wordpress-mobile/WordPress-iOS/blob/3b8f08e23f66791e000e9d7e0d5653c8a0c034b4/WordPress/Classes/Utility/WPCrashlytics.m#L55-L59) in `WPCrashlytics.startupCrashlyticsIfNeeded` is not executed.
3. On app launch, if opt-out setting is NO: verify [the code](https://github.com/wordpress-mobile/WordPress-iOS/blob/3b8f08e23f66791e000e9d7e0d5653c8a0c034b4/WordPress/Classes/Utility/WPCrashlytics.m#L55-L59) in `WPCrashlytics.startupCrashlyticsIfNeeded` is executed.

@frosty would you be so kind to take a peek and let me know if it makes sense to you. Thanks!! 😄 

/cc @loremattei 
