### PR TITLE
No Results View: refactor hiding view

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -230,10 +230,9 @@ extension ActivityListViewController {
 private extension ActivityListViewController {
 
     func updateNoResults() {
+        noResultsViewController?.removeFromView()
         if let noResultsViewModel = viewModel.noResultsViewModel() {
             showNoResults(noResultsViewModel)
-        } else {
-            hideNoResults()
         }
     }
 
@@ -257,16 +256,6 @@ private extension ActivityListViewController {
         addChildViewController(noResultsViewController)
         noResultsViewController.didMove(toParentViewController: self)
 
-    }
-
-    func hideNoResults() {
-
-        guard let noResultsViewController = noResultsViewController else {
-            return
-        }
-
-        noResultsViewController.view.removeFromSuperview()
-        noResultsViewController.removeFromParentViewController()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -245,7 +245,7 @@ static NSInteger HideSearchMinSites = 3;
     NSUInteger visibleSitesCount = self.dataSource.visibleBlogsCount;
     
     // Ensure No Results VC is not shown. Will be shown later if necessary.
-    [self removeNoResultsFromView];
+    [self.noResultsViewController removeFromView];
     
     // If the user has sites, but they're all hidden...
     if (count > 0 && visibleSitesCount == 0 && !self.isEditing) {
@@ -255,14 +255,6 @@ static NSInteger HideSearchMinSites = 3;
     }
     
     [self updateSplitViewAppearanceForSiteCount:count];
-}
-
-- (void)removeNoResultsFromView
-{
-    if (self.noResultsViewController) {
-        [self.noResultsViewController.view removeFromSuperview];
-        [self.noResultsViewController removeFromParentViewController];
-    }
 }
 
 - (void)addNoResultsToView
@@ -282,7 +274,7 @@ static NSInteger HideSearchMinSites = 3;
     // If we've gone from no results to having just one site, the user has
     // added a new site so we should auto-select it
     if (self.noResultsViewController.beingPresented && siteCount == 1) {
-        [self removeNoResultsFromView];
+        [self.noResultsViewController removeFromView];
         [self bypassBlogListViewController];
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -101,6 +101,13 @@ import WordPressAuthenticator
         accessorySubview = accessoryView
     }
 
+    /// Public method to remove No Results View from parent view.
+    ///
+    @objc func removeFromView() {
+        view.removeFromSuperview()
+        removeFromParentViewController()
+    }
+
     /// Public method to show a 'Dismiss' button in the navigation bar in place of the 'Back' button.
     ///
     func showDismissButton() {

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -104,6 +104,7 @@ import WordPressAuthenticator
     /// Public method to remove No Results View from parent view.
     ///
     @objc func removeFromView() {
+        willMove(toParentViewController: nil)
         view.removeFromSuperview()
         removeFromParentViewController()
     }

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationDomainsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationDomainsTableViewController.swift
@@ -287,8 +287,7 @@ private extension SiteCreationDomainsTableViewController {
     func removeNoResultsFromView() {
         noSuggestions = false
         tableView.reloadSections(IndexSet(integer: Sections.suggestions.rawValue), with: .automatic)
-        noResultsViewController?.view.removeFromSuperview()
-        noResultsViewController?.removeFromParentViewController()
+        noResultsViewController?.removeFromView()
     }
 
     func instantiateNoResultsViewController() {

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -300,18 +300,14 @@ extension PlanDetailViewController: UITableViewDataSource, UITableViewDelegate {
 private extension PlanDetailViewController {
 
     func updateNoResults() {
-        removeNoResultsFromView()
+        noResultsViewController?.removeFromView()
+        self.noResultsViewModel = nil
+
         if let noResultsViewModel = viewModel.noResultsViewModel {
             self.noResultsViewModel = noResultsViewModel
-        } else {
-            self.noResultsViewModel = nil
         }
     }
 
-    func removeNoResultsFromView() {
-        noResultsViewController?.view.removeFromSuperview()
-        noResultsViewController?.removeFromParentViewController()
-    }
 
     func noResultsCell() -> UITableViewCell {
         let cell = UITableViewCell()
@@ -320,7 +316,7 @@ private extension PlanDetailViewController {
     }
 
     func addNoResultsTo(cell: UITableViewCell) {
-        removeNoResultsFromView()
+        noResultsViewController?.removeFromView()
 
         if noResultsViewController == nil {
             noResultsViewController = NoResultsViewController.controller()

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -88,7 +88,7 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
     // MARK: - NoResults Handling
 
     private func updateNoResults() {
-        hideNoResults()
+        noResultsViewController?.removeFromView()
         if let noResultsViewModel = viewModel.noResultsViewModel {
             showNoResults(noResultsViewModel)
         }
@@ -110,17 +110,6 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
         tableView.addSubview(withFadeAnimation: noResultsViewController.view)
         addChildViewController(noResultsViewController)
         noResultsViewController.didMove(toParentViewController: self)
-
-    }
-
-    private func hideNoResults() {
-
-        guard let noResultsViewController = noResultsViewController else {
-            return
-        }
-
-        noResultsViewController.view.removeFromSuperview()
-        noResultsViewController.removeFromParentViewController()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -210,13 +210,13 @@
 
 - (void)preview:(PostPreviewGenerator *)generator loadHTML:(NSString *)html {
     [self.webView loadHTMLString:html baseURL:nil];
-    [self hideNoResults];
+    [self.noResultsViewController removeFromView];
 }
 
 - (void)preview:(PostPreviewGenerator *)generator attemptRequest:(NSURLRequest *)request {
     [self startLoading];
     [self.webView loadRequest:request];
-    [self hideNoResults];
+    [self.noResultsViewController removeFromView];
 }
 
 - (void)previewFailed:(PostPreviewGenerator *)generator message:(NSString *)message {
@@ -228,7 +228,7 @@
 
 - (void)actionButtonPressed {
     [self stopWaitingForConnectionRestored];
-    [self hideNoResults];
+    [self.noResultsViewController removeFromView];
     [self refreshWebView];
 }
 
@@ -246,11 +246,6 @@
     [self.view addSubview:self.noResultsViewController.view];
     self.noResultsViewController.view.frame = self.view.bounds;
     [self.noResultsViewController didMoveToParentViewController:self];
-}
-
-- (void)hideNoResults {
-    [self.noResultsViewController.view removeFromSuperview];
-    [self.noResultsViewController removeFromParentViewController];
 }
 
 #pragma mark - Custom UI elements

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -916,8 +916,7 @@ private extension ThemeBrowserViewController {
             return
         }
 
-        noResultsViewController?.view.removeFromSuperview()
-        noResultsViewController?.removeFromParentViewController()
+        noResultsViewController?.removeFromView()
 
         if searchController.isActive {
             collectionView?.reloadData()


### PR DESCRIPTION
Ref #9504 

This adds a `NoResultsViewController:removeFromView` method to remove the NRV from the parent view. View controllers that show the NoResultsViewController now call this method instead of doing it within each VC.

To test:

Since all the VCs use the same logic, we'll just sanity check some of the cases.

---

Activity List:
- Go to site details > Activity.
- Verify the 'Loading Activities' view is removed when the Activities are loaded.

---

Theme Browser:
- Go to Site > Themes > Search.
- Enter a search term that returns no results.
  - Verify the 'No Themes Found' view is displayed.
- Enter a valid keyword.
  - Verify the 'No Themes Found' view is removed.

---

Blog List:
- Hide all sites.
  - Verify the 'You have x hidden WordPress sites' view appears.
- Unhide a site.
  - Verify the 'You have x hidden WordPress sites' view is removed. 


