### PR TITLE
App Banner Universal Links: Small tweak to fragment parsing

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -19,14 +19,15 @@ struct AppBannerRoute: Route {
 
 extension AppBannerRoute: NavigationAction {
     func perform(_ values: [String: String]?) {
-        guard let fragment = values?[MatchedRouteURLComponentKey.fragment.rawValue] else {
+        guard let fragmentValue = values?[MatchedRouteURLComponentKey.fragment.rawValue],
+        let fragment = fragmentValue.removingPercentEncoding else {
             return
         }
 
         // Convert the fragment into a URL and ask the link router to handle
         // it like a normal route.
         var components = URLComponents()
-        components.path = "/" + fragment
+        components.path = fragment
 
         if let url = components.url {
             UniversalLinkRouter.shared.handle(url: url)

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -59,6 +59,8 @@ extension StatsRoute: NavigationAction {
         case .site:
             if let blog = blog(from: values) {
                 coordinator.showStats(for: blog)
+            } else {
+                showStatsForDefaultBlog(from: values, with: coordinator)
             }
         case .daySite:
             if let blog = blog(from: values) {
@@ -127,5 +129,39 @@ extension StatsRoute: NavigationAction {
         }
 
         return nil
+    }
+
+    private func showStatsForDefaultBlog(from values: [String: String]?,
+                                         with coordinator: MySitesCoordinator) {
+        // It's possible that the stats route can come in without a domain
+        // as the last component, if the user is viewing stats for "All My Sites" in Calypso.
+        // In this case, we'll check whether the last component is actually a
+        // time period, and if so we'll show that time period for the default site.
+        guard let component = values?["domain"],
+            let timePeriod = StatsPeriodType.fromString(component),
+            let blog = defaultBlog() else {
+            return
+        }
+
+        coordinator.showStats(for: blog, timePeriod: timePeriod)
+    }
+}
+
+private extension StatsPeriodType {
+    static func fromString(_ string: String) -> StatsPeriodType? {
+        switch string {
+        case "day":
+            return .days
+        case "week":
+            return .weeks
+        case "month":
+            return .months
+        case "year":
+            return .years
+        case "insights":
+            return .insights
+        default:
+            return nil
+        }
     }
 }


### PR DESCRIPTION
This PR makes a small change to the way URL fragments are parsed for app banner universal links.

**Previously:**

* App banner universal links were of the form: `https://apps.wordpress.com/get#stats/day/discover.wordpress.com`
* The fragment consisted of a WordPress.com URL, with the leading slash stripped

**Now:**

* These links are of the form: `https://apps.wordpress.com/get#%2Fstats%2Fday%2Fdiscover.wordpress.com`
* The leading slash is kept as part of the fragment
* The fragment is URL encoded

**To test:**

* Add an `applinks` entitlement for `apps.wordpress.com`, and build to your device.
* Visit https://calypso.live/?branch=update/app-banner-ios-urls on your device, and check that the banners launch you into the app correctly. As a reminder, there are banners in the Stats, Reader, Notifications, and Editor sections.

