### PR TITLE
View Site hotfix: comments out query string params to hide masterbar

### DIFF
--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -117,13 +117,18 @@ extension URL {
     }
 
     func appendingHideMasterbarParameters() -> URL? {
-        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
             return nil
         }
-        var queryItems = components.queryItems ?? []
-        queryItems.append(URLQueryItem(name: "preview", value: "true"))
-        queryItems.append(URLQueryItem(name: "iframe", value: "true"))
-        components.queryItems = queryItems
+        // FIXME: This code is commented out because of a menu navigation issue that can occur while
+        // viewing a site within the webview. See https://github.com/wordpress-mobile/WordPress-iOS/issues/9796
+        // for more details.
+        //
+        // var queryItems = components.queryItems ?? []
+        // queryItems.append(URLQueryItem(name: "preview", value: "true"))
+        // queryItems.append(URLQueryItem(name: "iframe", value: "true"))
+        // components.queryItems = queryItems
+        /////
         return components.url
     }
 }


### PR DESCRIPTION
This quick-fix PR comments out the code from #9544 which is causing issues navigating site menus within a webview and mobile safari (e.g. "View Site" in Settings):

![viewsite_flow_1](https://user-images.githubusercontent.com/154014/42897177-cbf64d24-8a84-11e8-9a3d-55c17ed603d6.gif)

We should investigate if there is another approach to remove the masterbar in a future PR (cc @ScoutHarris)

Fixes #9796 and targets the 10.4 branch (hotfix)

## Testing

In general test using a site that has a top-level menu. (Since the behavior shown in the issue doesn't occur on all sites, ping me in Slack if you need help finding one). 

1. In the 10.4 branch, verify you can reproduce the issue shown in #9796 
2.  In this PR's branch, build and run the app
3. Using the site identified in step 1 ☝️, navigate to Site Settings and then tap view site
4. Verify the navigation links in the menus work as expected
5. Close the webview and tap View Site again
6. Tap the launch in safari nav icon in the lower right of the screen
7. In mobile safari, verify the menu links work as expected. 

@loremattei would you mind reviewing this? 😄 

/cc @elibud 
