### PR TITLE
Enable Universal Links

### DIFF
--- a/WordPress/WordPress.entitlements
+++ b/WordPress/WordPress.entitlements
@@ -7,6 +7,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:wordpress.com</string>
+		<string>applinks:wordpress.com</string>
+		<string>applinks:apps.wordpress.com</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>


### PR DESCRIPTION
Fixes #9798. This PR shouldn't be merged until #9797 is merged.

This PR enables universal links in the app by adding `applinks` Associated Domain capabilities for `wordpress.com` and `apps.wordpress.com`.

**To test:**

* To test WordPress.com universal links, build this branch to a device and visit WordPress.com in mobile Safari.
  * If you visit any of the paths specified in https://wordpress.com/apple-app-site-association and scroll the page down, you should see an 'open in app' banner at the top of the page.
  * You can also try tapping one of the links below, which should launch the app:
    * https://wordpress.com/stats
    * https://wordpress.com/discover
    * https://wordpress.com/notifications
    * https://wordpress.com/post
* To test apps.wordpress.com links, build to your device and then visit https://calypso.live/?branch=update/app-banner-ios-urls in mobile Safari. Find one of the custom app banners – either in Stats, Reader, Notifications, or the editor. Tap the "Open in app" button, and ensure the app opens to the correct section (this should have been tested for #9797 already).