### PR TITLE
Quick Tour: Feature Flag & Initial Commit

### DIFF
--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -20,6 +20,10 @@ struct Notice {
     /// the app isn't in the foreground.
     let notificationInfo: NoticeNotificationInfo?
 
+    /// Style used to configure visual style when displayed
+    ///
+    let style: Style
+
     /// A title for an optional action button that can be displayed as part of
     /// a notice
     let actionTitle: String?
@@ -28,22 +32,29 @@ struct Notice {
     /// is tapped, if you've provided an action title
     let actionHandler: (() -> Void)?
 
-    init(title: String, message: String? = nil, feedbackType: UINotificationFeedbackType? = nil, notificationInfo: NoticeNotificationInfo? = nil) {
+    init(title: String, message: String? = nil, feedbackType: UINotificationFeedbackType? = nil, notificationInfo: NoticeNotificationInfo? = nil, style: Style = .normal) {
         self.title = title
         self.message = message
         self.feedbackType = feedbackType
         self.notificationInfo = notificationInfo
         self.actionTitle = nil
         self.actionHandler = nil
+        self.style = style
     }
 
-    init(title: String, message: String? = nil, feedbackType: UINotificationFeedbackType? = nil, notificationInfo: NoticeNotificationInfo? = nil, actionTitle: String, actionHandler: @escaping (() -> Void)) {
+    init(title: String, message: String? = nil, feedbackType: UINotificationFeedbackType? = nil, notificationInfo: NoticeNotificationInfo? = nil, style: Style = .normal, actionTitle: String, actionHandler: @escaping (() -> Void)) {
         self.title = title
         self.message = message
         self.feedbackType = feedbackType
         self.notificationInfo = notificationInfo
         self.actionTitle = actionTitle
         self.actionHandler = actionHandler
+        self.style = style
+    }
+
+    public enum Style {
+        case normal
+        case quickStart
     }
 }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.h
+++ b/WordPress/Classes/System/WordPressAppDelegate.h
@@ -4,6 +4,7 @@
 @class NotificationsViewController;
 @class WordPressAuthenticationManager;
 @class HockeyManager;
+@class NoticePresenter;
 @class Reachability;
 @class ReaderPostsViewController;
 @class WPUserAgent;
@@ -26,6 +27,7 @@
 @property (nonatomic, strong, readwrite) Reachability                   *internetReachability;
 @property (nonatomic, strong, readwrite) WordPressAuthenticationManager *authManager;
 @property (nonatomic, assign, readwrite) BOOL                           connectionAvailable;
+@property (nonatomic, strong, readwrite) NoticePresenter                *noticePresenter;
 
 + (WordPressAppDelegate *)sharedInstance;
 

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -52,7 +52,6 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
 @property (nonatomic, assign, readwrite) BOOL                           shouldRestoreApplicationState;
 @property (nonatomic, strong, readwrite) PingHubManager                 *pinghubManager;
 @property (nonatomic, strong, readwrite) WP3DTouchShortcutCreator       *shortcutCreator;
-@property (nonatomic, strong, readwrite) NoticePresenter                *noticePresenter;
 
 @end
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -7,6 +7,7 @@ enum FeatureFlag: Int {
     case saveForLater
     case gifSupportInReaderDetail
     case extractNotifications
+    case whatsNext
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -20,6 +21,8 @@ enum FeatureFlag: Int {
         case .gifSupportInReaderDetail:
             return true
         case .extractNotifications:
+            return BuildConfiguration.current == .localDeveloper
+        case .whatsNext:
             return BuildConfiguration.current == .localDeveloper
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1117,7 +1117,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)startTour
 {
-    [QuickStartTourGuide.shared showTestQuickStartNotice];
+    // find the tour guide
+    BlogNavigationController *blogNC = (BlogNavigationController *)self.navigationController;
+    QuickStartTourGuide *tourGuide = blogNC.tourGuide;
+
+    [tourGuide showTestQuickStartNotice];
 }
 
 - (void)showActivity

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1117,8 +1117,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)startTour
 {
-    BlogNavigationController *blogNav = (BlogNavigationController *) self.navigationController;
-    [blogNav showTestQuickStartNotice];
+    [QuickStartTourGuide.shared showTestQuickStartNotice];
 }
 
 - (void)showActivity

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -438,6 +438,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
+
+    if ([Feature enabled:FeatureFlagWhatsNext]) {
+        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Quick Start", @"Name of the Quick Start feature that guides users through a few tasks to setup their new website.")
+                                                        image:[Gridicon iconOfType:GridiconTypeStatsAlt]
+                                                     callback:^{
+                                                         [weakSelf startTour];
+                                                     }]];
+    }
+
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
                                                     image:[Gridicon iconOfType:GridiconTypeStatsAlt]
                                                  callback:^{
@@ -1104,6 +1113,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     } else {
         [self showDetailViewController:statsView sender:self];
     }
+}
+
+- (void)startTour
+{
+    BlogNavigationController *blogNav = (BlogNavigationController *) self.navigationController;
+    [blogNav showTestQuickStartNotice];
 }
 
 - (void)showActivity

--- a/WordPress/Classes/ViewRelated/Blog/BlogNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogNavigationController.swift
@@ -1,11 +1,48 @@
 import WordPressFlux
 
-class BlogNavigationController: UINavigationController {
+public var holder: QuickStartTourGuide?
+
+open class QuickStartTourGuide: NSObject, UINavigationControllerDelegate {
+    @objc public static var shared = QuickStartTourGuide() {
+        didSet {
+            holder = shared
+        }
+    }
+
+    @objc
+    public func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
+        print("blach")
+
+    }
+
+    public func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        NSLog("oh my")
+
+
+        switch viewController {
+        case is StatsViewController:
+            dismissTestQuickStartNotice()
+        default:
+            break
+        }
+    }
 
     // MARK: Quick Start methods
     @objc
     func showTestQuickStartNotice() {
-        let notice = Notice(title: "Test Quick Start Notice", message: "Quick start tour notices will look similar to this", style: .quickStart)
+        let notice = Notice(title: "Test Quick Start Notice", message: "Tap stats to dismiss this example message.", style: .quickStart)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
+    }
+
+    private func findNoticePresenter() -> NoticePresenter? {
+        return (UIApplication.shared.delegate as? WordPressAppDelegate)?.noticePresenter
+    }
+
+    func dismissTestQuickStartNotice() {
+        guard let presenter = findNoticePresenter() else {
+            return
+        }
+
+        presenter.dismissCurrentNotice()
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogNavigationController.swift
@@ -1,0 +1,11 @@
+import WordPressFlux
+
+class BlogNavigationController: UINavigationController {
+
+    // MARK: Quick Start methods
+    @objc
+    func showTestQuickStartNotice() {
+        let notice = Notice(title: "Test Quick Start Notice", message: "Quick start tour notices will look similar to this", style: .quickStart)
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartNoticeView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartNoticeView.swift
@@ -1,0 +1,9 @@
+//
+//  QuickStartNoticeView.swift
+//  WordPress
+//
+//  Created by Nate Heagy on 2018-07-11.
+//  Copyright © 2018 WordPress. All rights reserved.
+//
+
+import Foundation

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartNoticeView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartNoticeView.swift
@@ -1,9 +1,9 @@
-//
-//  QuickStartNoticeView.swift
-//  WordPress
-//
-//  Created by Nate Heagy on 2018-07-11.
-//  Copyright © 2018 WordPress. All rights reserved.
-//
-
-import Foundation
+class QuickStartNoticeView: NoticeView {
+//    override enum Appearance {
+//        static let actionBackgroundColor = UIColor.black.withAlphaComponent(0.5)
+//        static let shadowColor: UIColor = .black
+//        static let shadowOpacity: Float = 0.25
+//        static let shadowRadius: CGFloat = 8.0
+//        static let shadowOffset = CGSize(width: 0.0, height: 2.0)
+//    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -1,0 +1,33 @@
+import WordPressFlux
+
+@objc
+open class QuickStartTourGuide: NSObject, UINavigationControllerDelegate {
+
+    public func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+        switch viewController {
+        case is StatsViewController:
+            dismissTestQuickStartNotice()
+        default:
+            break
+        }
+    }
+
+    // MARK: Quick Start methods
+    @objc
+    func showTestQuickStartNotice() {
+        let notice = Notice(title: "Test Quick Start Notice", message: "Tap stats to dismiss this example message.", style: .quickStart)
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
+    }
+
+    private func findNoticePresenter() -> NoticePresenter? {
+        return (UIApplication.shared.delegate as? WordPressAppDelegate)?.noticePresenter
+    }
+
+    func dismissTestQuickStartNotice() {
+        guard let presenter = findNoticePresenter() else {
+            return
+        }
+
+        presenter.dismissCurrentNotice()
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -43,7 +43,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)showNotificationsTab;
 - (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia;
 - (void)showReaderTabForPost:(NSNumber *)postId onBlog:(NSNumber *)blogId;
-
 - (void)switchMySitesTabToAddNewSite;
 - (void)switchMySitesTabToStatsViewForBlog:(Blog *)blog;
 - (void)switchMySitesTabToMediaForBlog:(Blog *)blog;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -204,7 +204,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     }
 
     self.blogListViewController = [[BlogListViewController alloc] init];
-    _blogListNavigationController = [[UINavigationController alloc] initWithRootViewController:self.blogListViewController];
+    _blogListNavigationController = [[BlogNavigationController alloc] initWithRootViewController:self.blogListViewController];
     _blogListNavigationController.navigationBar.translucent = NO;
     UIImage *mySitesTabBarImage = [UIImage imageNamed:@"icon-tab-mysites"];
     _blogListNavigationController.tabBarItem.image = mySitesTabBarImage;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -205,7 +205,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     }
 
     self.blogListViewController = [[BlogListViewController alloc] init];
-    _blogListNavigationController = [[UINavigationController alloc] initWithRootViewController:self.blogListViewController];
+    _blogListNavigationController = [[BlogNavigationController alloc] initWithRootViewController:self.blogListViewController];
     _blogListNavigationController.navigationBar.translucent = NO;
     self.tourGuide = [[QuickStartTourGuide alloc] init];
     _blogListNavigationController.delegate = self.tourGuide;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -53,6 +53,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 @property (nonatomic, strong) UIViewController *newPostViewController;
 
 @property (nonatomic, strong) UINavigationController *blogListNavigationController;
+@property (nonatomic, strong) QuickStartTourGuide *tourGuide;
 @property (nonatomic, strong) UINavigationController *readerNavigationController;
 @property (nonatomic, strong) UINavigationController *notificationsNavigationController;
 @property (nonatomic, strong) UINavigationController *meNavigationController;
@@ -204,8 +205,11 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     }
 
     self.blogListViewController = [[BlogListViewController alloc] init];
-    _blogListNavigationController = [[BlogNavigationController alloc] initWithRootViewController:self.blogListViewController];
+    _blogListNavigationController = [[UINavigationController alloc] initWithRootViewController:self.blogListViewController];
     _blogListNavigationController.navigationBar.translucent = NO;
+    self.tourGuide = [[QuickStartTourGuide alloc] init];
+    _blogListNavigationController.delegate = self.tourGuide;
+
     UIImage *mySitesTabBarImage = [UIImage imageNamed:@"icon-tab-mysites"];
     _blogListNavigationController.tabBarItem.image = mySitesTabBarImage;
     _blogListNavigationController.tabBarItem.selectedImage = mySitesTabBarImage;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		433432541E9EE0B100915988 /* EpilogueSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433432531E9EE0B100915988 /* EpilogueSegue.swift */; };
 		433A550220F693A100757928 /* BlogNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433A550120F693A100757928 /* BlogNavigationController.swift */; };
 		433A550420F6AC5600757928 /* QuickStartNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433A550320F6AC5600757928 /* QuickStartNoticeView.swift */; };
+		4348C88321002FBD00735DC0 /* QuickStartTourGuide.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4348C88221002FBD00735DC0 /* QuickStartTourGuide.swift */; };
 		435035971EDCAB99004ECF47 /* jetpack.json in Resources */ = {isa = PBXBuildFile; fileRef = 435035921EDCAB99004ECF47 /* jetpack.json */; };
 		435035981EDCAB99004ECF47 /* notifications.json in Resources */ = {isa = PBXBuildFile; fileRef = 435035931EDCAB99004ECF47 /* notifications.json */; };
 		435035991EDCAB99004ECF47 /* post.json in Resources */ = {isa = PBXBuildFile; fileRef = 435035941EDCAB99004ECF47 /* post.json */; };
@@ -1593,6 +1594,7 @@
 		433432531E9EE0B100915988 /* EpilogueSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EpilogueSegue.swift; sourceTree = "<group>"; };
 		433A550120F693A100757928 /* BlogNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogNavigationController.swift; sourceTree = "<group>"; };
 		433A550320F6AC5600757928 /* QuickStartNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartNoticeView.swift; sourceTree = "<group>"; };
+		4348C88221002FBD00735DC0 /* QuickStartTourGuide.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartTourGuide.swift; sourceTree = "<group>"; };
 		435035921EDCAB99004ECF47 /* jetpack.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = jetpack.json; sourceTree = "<group>"; };
 		435035931EDCAB99004ECF47 /* notifications.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = notifications.json; sourceTree = "<group>"; };
 		435035941EDCAB99004ECF47 /* post.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = post.json; sourceTree = "<group>"; };
@@ -4702,6 +4704,7 @@
 				FF1933FE1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m */,
 				82B85DF81EDDB807004FD510 /* SiteIconPickerPresenter.swift */,
 				433A550120F693A100757928 /* BlogNavigationController.swift */,
+				4348C88221002FBD00735DC0 /* QuickStartTourGuide.swift */,
 				433A550320F6AC5600757928 /* QuickStartNoticeView.swift */,
 			);
 			path = Blog;
@@ -7072,6 +7075,7 @@
 				98A437B0200693C0004A8A57 /* SiteCreationDomainsViewController.swift in Sources */,
 				17F0E1DA20EBDC0A001E9514 /* Routes+Me.swift in Sources */,
 				D83CA3AB20842E5F0060E310 /* StockPhotosResultsPage.swift in Sources */,
+				4348C88321002FBD00735DC0 /* QuickStartTourGuide.swift in Sources */,
 				E102B7901E714F24007928E8 /* RecentSitesService.swift in Sources */,
 				E1D7FF381C74EB0E00E7E5E5 /* PlanService.swift in Sources */,
 				5D7DEA2919D488DD0032EE77 /* WPStyleGuide+ReaderComments.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -230,6 +230,8 @@
 		4322A20D203E1885004EA740 /* SignupUsernameTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4322A20C203E1885004EA740 /* SignupUsernameTableViewController.swift */; };
 		433432521E9ED18900915988 /* LoginEpilogueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433432511E9ED18900915988 /* LoginEpilogueViewController.swift */; };
 		433432541E9EE0B100915988 /* EpilogueSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433432531E9EE0B100915988 /* EpilogueSegue.swift */; };
+		433A550220F693A100757928 /* BlogNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433A550120F693A100757928 /* BlogNavigationController.swift */; };
+		433A550420F6AC5600757928 /* QuickStartNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 433A550320F6AC5600757928 /* QuickStartNoticeView.swift */; };
 		435035971EDCAB99004ECF47 /* jetpack.json in Resources */ = {isa = PBXBuildFile; fileRef = 435035921EDCAB99004ECF47 /* jetpack.json */; };
 		435035981EDCAB99004ECF47 /* notifications.json in Resources */ = {isa = PBXBuildFile; fileRef = 435035931EDCAB99004ECF47 /* notifications.json */; };
 		435035991EDCAB99004ECF47 /* post.json in Resources */ = {isa = PBXBuildFile; fileRef = 435035941EDCAB99004ECF47 /* post.json */; };
@@ -1589,6 +1591,8 @@
 		4322A20C203E1885004EA740 /* SignupUsernameTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupUsernameTableViewController.swift; sourceTree = "<group>"; };
 		433432511E9ED18900915988 /* LoginEpilogueViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEpilogueViewController.swift; sourceTree = "<group>"; };
 		433432531E9EE0B100915988 /* EpilogueSegue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EpilogueSegue.swift; sourceTree = "<group>"; };
+		433A550120F693A100757928 /* BlogNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogNavigationController.swift; sourceTree = "<group>"; };
+		433A550320F6AC5600757928 /* QuickStartNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartNoticeView.swift; sourceTree = "<group>"; };
 		435035921EDCAB99004ECF47 /* jetpack.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = jetpack.json; sourceTree = "<group>"; };
 		435035931EDCAB99004ECF47 /* notifications.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = notifications.json; sourceTree = "<group>"; };
 		435035941EDCAB99004ECF47 /* post.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = post.json; sourceTree = "<group>"; };
@@ -4697,6 +4701,8 @@
 				FF1933FD1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.h */,
 				FF1933FE1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m */,
 				82B85DF81EDDB807004FD510 /* SiteIconPickerPresenter.swift */,
+				433A550120F693A100757928 /* BlogNavigationController.swift */,
+				433A550320F6AC5600757928 /* QuickStartNoticeView.swift */,
 			);
 			path = Blog;
 			sourceTree = "<group>";
@@ -7473,6 +7479,7 @@
 				E240859C183D82AE002EB0EF /* WPAnimatedBox.m in Sources */,
 				17BEE0041FC867C20074C124 /* WordPressAppDelegate+Swift.swift in Sources */,
 				08472A201C727E020040769D /* PostServiceOptions.m in Sources */,
+				433A550420F6AC5600757928 /* QuickStartNoticeView.swift in Sources */,
 				08216FD21CDBF96000304BA7 /* MenuItemSourceViewController.m in Sources */,
 				74558369201A1FD3007809BB /* WPReusableTableViewCells.swift in Sources */,
 				E6DAABDD1CF632EC0069D933 /* ReaderSearchSuggestionsViewController.swift in Sources */,
@@ -7642,6 +7649,7 @@
 				08216FCA1CDBF96000304BA7 /* MenuItemEditingFooterView.m in Sources */,
 				98D60B9B1FFEE39500145190 /* SiteCreationThemeSelectionViewController.swift in Sources */,
 				E6D3E8491BEBD871002692E8 /* ReaderCrossPostCell.swift in Sources */,
+				433A550220F693A100757928 /* BlogNavigationController.swift in Sources */,
 				E10290741F30615A00DAC588 /* Role.swift in Sources */,
 				08216FD11CDBF96000304BA7 /* MenuItemSourceResultsViewController.m in Sources */,
 				E1209FA41BB4978B00D69778 /* PeopleService.swift in Sources */,
@@ -8868,7 +8876,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_alpha_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_alpha_app_credentials;
 			};
 			name = "Release-Alpha";
 		};
@@ -9350,7 +9358,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_internal_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_internal_app_credentials;
 			};
 			name = "Release-Internal";
 		};
@@ -9699,7 +9707,7 @@
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 3.0;
-				WPCOM_CONFIG = "$HOME/.wpcom_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
 			};
 			name = Debug;
 		};
@@ -9752,7 +9760,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = "$HOME/.wpcom_app_credentials";
+				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Refs: #9447

This is the initial commit for Quick Tour, aka the feature previously known as "What's Next". Currently hidden behind a feature flag.

![screen recording 2018-07-18 at 8 41 09 pm 2](https://user-images.githubusercontent.com/517257/42918724-19d85572-8acc-11e8-9d55-433947eec678.gif)

This commit demonstrates the basic idea of how Quick Tour will work: `Notice`s with style `quickTour` will be displayed by `QuickStartTourGuide`, which will look at changes from `BlogNavigationController` to sense the user progressing through each "tour".

@frosty: is this a corruption of `Notice`/`NoticePresenter`, etc? Does `NavigationControllerDelegateRepeater` feel gross and make you ill?

To test:
- tap Quick Tour in a blog details screen
- tap Stats and it should go away
- Make sure `WPSplitViewController` wasn't broken
- Make sure `Notice`s still work for everything else
