### PR TITLE
App extensions: fix for tracks errors

### DIFF
--- a/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
@@ -313,7 +313,13 @@ extension ShareExtensionSessionManager: URLSessionDelegate {
     func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
         if let error = error {
             DDLogError("Background session invalidated by the system. Session:\(session) Error:\(error).")
-            WPAppAnalytics.track(.shareExtensionError, error: error)
+
+            // We are only going to send errors to Tracks that are NOT related to the "lite" tracks client
+            // in the share extension. See https://github.com/wordpress-mobile/WordPress-iOS/issues/9789
+            // for more details.
+            if (error as NSError).description.contains("tracks/record") == false {
+                WPAppAnalytics.track(.shareExtensionError, error: error)
+            }
         } else {
             DDLogError("Background session explicitly invalidated by WPiOS. Session:\(session).")
         }

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -818,6 +818,12 @@ fileprivate extension ShareModularViewController {
     }
 
     fileprivate func prepareForPublishing() {
+        // We are preemptively logging the Tracks posted event here because if handled in a completion handler,
+        // there is a good chance iOS will invalidate that network call and the event is never received server-side.
+        // See https://github.com/wordpress-mobile/WordPress-iOS/issues/9789 for more details.
+        self.tracks.trackExtensionPosted(self.shareData.postStatus.rawValue)
+        ////
+
         isPublishingPost = true
         sitesTableView.refreshControl = nil
         clearSiteDataAndRefreshSitesTable()
@@ -836,7 +842,6 @@ fileprivate extension ShareModularViewController {
                                          status: shareData.postStatus.rawValue,
                                          siteID: siteID,
                                          onComplete: {
-                                            self.tracks.trackExtensionPosted(self.shareData.postStatus.rawValue)
                                             self.dismiss()
         }, onFailure: {
             let error = self.createErrorWithDescription("Failed to save and upload post with no media.")
@@ -869,7 +874,6 @@ fileprivate extension ShareModularViewController {
                                     siteID: siteID,
                                     localMediaFileURLs: localImageURLs,
                                     requestEnqueued: {
-                                        self.tracks.trackExtensionPosted(self.shareData.postStatus.rawValue)
                                         self.dismiss()
         }, onFailure: {
             let error = self.createErrorWithDescription("Failed to save and upload post with media.")


### PR DESCRIPTION
This PR attempts to address the large amount of Tracks errors in the app extensions. See #9789 for more details. Things done:

1. In the `ShareExtensionSessionManager` we are only logging invalidated sessions that are _not_ tracks-specific.
2. `ShareModularViewController` is logging the `wpios_share_extension_posted` or `wpios_draft_extension_posted` events prior to actually firing the background NSURLSession which saves the media/post. We are doing this first because @astralbodies and I have a hunch the tracks network call is getting invalidated when fired in the save completion handler.

Fixes #9789 

## Testing

_Test both the draft and share extensions sharing an image and also just text._

1. Build and run on a device (no sim) and disconnect XCode
2. Share text/image
3. Verify the media/text is shared in a new post
4. In Tracks live view, search for `wpios_%_extension_%` and your username - verify you see the appropriate events - you should not see any unexpected `wpios_draft_extension_error` events
(this may take a few minutes to appear)

Ping me if you have any questions with testing! 😄 


