### PR TITLE
Updates plan table footer text

### DIFF
--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
@@ -95,7 +95,7 @@ enum PlanListViewModel {
                 ImmuTableSection(
                     headerText: NSLocalizedString("WordPress.com Plans", comment: "Title for the Plans list header"),
                     rows: rows,
-                    footerText: NSLocalizedString("Manage your plan at WordPress.com/plans", comment: "Footer for Plans list"))
+                    footerText: String())
                 ])
         }
     }


### PR DESCRIPTION
![3](https://user-images.githubusercontent.com/154014/42971419-d125cf66-8b71-11e8-8828-dee283049efe.png)

Fixes #9810 

## Testing

Build and run the app. Verify the footer text in plans is empty.


