### PR TITLE
Universal Links: Improve failure cases

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -153,16 +153,6 @@ extension WordPressAppDelegate {
 // MARK: - Helpers
 
 extension WordPressAppDelegate {
-    @objc var noSelfHostedBlogs: Bool {
-        let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-
-        return blogService.blogCountSelfHosted() == 0 && blogService.hasAnyJetpackBlogs() == false
-    }
-
-    @objc var noWordPressDotComAccount: Bool {
-        return !AccountHelper.isDotcomAvailable()
-    }
 
     @objc var currentlySelectedScreen: String {
         // Check if the post editor or login view is up
@@ -255,7 +245,7 @@ extension WordPressAppDelegate {
     }
 
     @objc func toggleExtraDebuggingIfNeeded() {
-        if noSelfHostedBlogs && noWordPressDotComAccount {
+        if !AccountHelper.isLoggedIn {
             // When there are no blogs in the app the settings screen is unavailable.
             // In this case, enable extra_debugging by default to help troubleshoot any issues.
             guard UserDefaults.standard.object(forKey: "orig_extra_debug") == nil else {

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -100,7 +100,8 @@ extension WordPressAppDelegate {
     }
 
     @objc func handleWebActivity(_ activity: NSUserActivity) {
-        guard activity.activityType == NSUserActivityTypeBrowsingWeb,
+        guard AccountHelper.isLoggedIn,
+            activity.activityType == NSUserActivityTypeBrowsingWeb,
             let url = activity.webpageURL else {
                 return
         }

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -412,7 +412,7 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     // Configure Extensions
     [self setupWordPressExtensions];
 
-    [self.shortcutCreator createShortcutsIf3DTouchAvailable:[self isLoggedIn]];
+    [self.shortcutCreator createShortcutsIf3DTouchAvailable:[AccountHelper isLoggedIn]];
     
     self.window.rootViewController = [WPTabBarController sharedInstance];
 
@@ -459,14 +459,9 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
 
 #pragma mark - Custom methods
 
-- (BOOL)isLoggedIn
-{
-    return !([self noSelfHostedBlogs] && [self noWordPressDotComAccount]);
-}
-
 - (void)showWelcomeScreenIfNeededAnimated:(BOOL)animated
 {
-    if ([self isWelcomeScreenVisible] || !([self noSelfHostedBlogs] && [self noWordPressDotComAccount])) {
+    if ([self isWelcomeScreenVisible] || AccountHelper.isLoggedIn) {
         return;
     }
     
@@ -553,7 +548,7 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
 
 - (void)trackLogoutIfNeeded
 {
-    if (![self isLoggedIn]) {
+    if (![AccountHelper isLoggedIn]) {
         [WPAnalytics track:WPAnalyticsStatLogout];
     }
 }

--- a/WordPress/Classes/Utility/AccountHelper.swift
+++ b/WordPress/Classes/Utility/AccountHelper.swift
@@ -17,4 +17,21 @@ import Foundation
 
         return available
     }
+
+    @objc static var isLoggedIn: Bool {
+        get {
+            return !(noSelfHostedBlogs && noWordPressDotComAccount)
+        }
+    }
+
+    @objc static var noSelfHostedBlogs: Bool {
+        let context = ContextManager.sharedInstance().mainContext
+        let blogService = BlogService(managedObjectContext: context)
+
+        return blogService.blogCountSelfHosted() == 0 && blogService.hasAnyJetpackBlogs() == false
+    }
+
+    @objc static var noWordPressDotComAccount: Bool {
+        return !AccountHelper.isDotcomAvailable()
+    }
 }

--- a/WordPress/Classes/Utility/Universal Links/NavigationActionHelpers.swift
+++ b/WordPress/Classes/Utility/Universal Links/NavigationActionHelpers.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressFlux
 
 extension NavigationAction {
     func defaultBlog() -> Blog? {
@@ -26,5 +27,12 @@ extension NavigationAction {
         }
 
         return nil
+    }
+
+    func postFailureNotice(title: String) {
+        let notice = Notice(title: title,
+                            feedbackType: .error,
+                            notificationInfo: nil)
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/NavigationActionHelpers.swift
+++ b/WordPress/Classes/Utility/Universal Links/NavigationActionHelpers.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+extension NavigationAction {
+    func defaultBlog() -> Blog? {
+        let context = ContextManager.sharedInstance().mainContext
+        let service = BlogService(managedObjectContext: context)
+
+        return service.lastUsedOrFirstBlog()
+    }
+
+    func blog(from values: [String: String]?) -> Blog? {
+        guard let domain = values?["domain"] else {
+            return nil
+        }
+
+        let context = ContextManager.sharedInstance().mainContext
+        let service = BlogService(managedObjectContext: context)
+
+        if let blog = service.blog(byHostname: domain) {
+            return blog
+        }
+
+        // Some stats URLs use a site ID instead
+        if let siteIDValue = Int(domain) {
+            return service.blog(byBlogId: NSNumber(value: siteIDValue))
+        }
+
+        return nil
+    }
+}

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -41,8 +41,13 @@ extension MySitesRoute: Route {
 
 extension MySitesRoute: NavigationAction {
     func perform(_ values: [String: String]?) {
-        guard let coordinator = WPTabBarController.sharedInstance().mySitesCoordinator,
-            let blog = blog(from: values) else {
+        guard let coordinator = WPTabBarController.sharedInstance().mySitesCoordinator else {
+            return
+        }
+
+        guard let blog = blog(from: values) else {
+            coordinator.showMySites()
+            postFailureNotice(title: NSLocalizedString("Site not found", comment: "Error notice shown if the app can't find a specific site belonging to the user"))
             return
         }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -47,7 +47,8 @@ extension MySitesRoute: NavigationAction {
 
         guard let blog = blog(from: values) else {
             coordinator.showMySites()
-            postFailureNotice(title: NSLocalizedString("Site not found", comment: "Error notice shown if the app can't find a specific site belonging to the user"))
+            postFailureNotice(title: NSLocalizedString("Site not found",
+                                                       comment: "Error notice shown if the app can't find a specific site belonging to the user"))
             return
         }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -65,15 +65,4 @@ extension MySitesRoute: NavigationAction {
             coordinator.showManagePlugins(for: blog)
         }
     }
-
-    private func blog(from values: [String: String]?) -> Blog? {
-        guard let domain = values?["domain"] else {
-            return nil
-        }
-
-        let context = ContextManager.sharedInstance().mainContext
-        let service = BlogService(managedObjectContext: context)
-
-        return service.blog(byHostname: domain)
-    }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
@@ -6,23 +6,16 @@ struct NewPostRoute: Route {
 }
 
 struct NewPostForSiteRoute: Route {
-    let path = "/post/:\(NewPostRoutePlaceholder.site.rawValue)"
+    let path = "/post/:domain"
     let action: NavigationAction = NewPostNavigationAction()
 }
 
 struct NewPostNavigationAction: NavigationAction {
     func perform(_ values: [String: String]? = nil) {
-        if let site = values?[NewPostRoutePlaceholder.site.rawValue] {
-            let context = ContextManager.sharedInstance().mainContext
-            let service = BlogService(managedObjectContext: context)
-            let blog = service.blog(byHostname: site)
+        if let blog = blog(from: values) {
             WPTabBarController.sharedInstance().showPostTab(for: blog)
         } else {
             WPTabBarController.sharedInstance().showPostTab()
         }
     }
-}
-
-private enum NewPostRoutePlaceholder: String {
-    case site
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -104,33 +104,6 @@ extension StatsRoute: NavigationAction {
         }
     }
 
-    private func defaultBlog() -> Blog? {
-        let context = ContextManager.sharedInstance().mainContext
-        let service = BlogService(managedObjectContext: context)
-
-        return service.lastUsedOrFirstBlog()
-    }
-
-    private func blog(from values: [String: String]?) -> Blog? {
-        guard let domain = values?["domain"] else {
-            return nil
-        }
-
-        let context = ContextManager.sharedInstance().mainContext
-        let service = BlogService(managedObjectContext: context)
-
-        if let blog = service.blog(byHostname: domain) {
-            return blog
-        }
-
-        // Some stats URLs use a site ID instead
-        if let siteIDValue = Int(domain) {
-            return service.blog(byBlogId: NSNumber(value: siteIDValue))
-        }
-
-        return nil
-    }
-
     private func showStatsForDefaultBlog(from values: [String: String]?,
                                          with coordinator: MySitesCoordinator) {
         // It's possible that the stats route can come in without a domain

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -63,45 +63,43 @@ extension StatsRoute: NavigationAction {
                 showStatsForDefaultBlog(from: values, with: coordinator)
             }
         case .daySite:
-            if let blog = blog(from: values) {
-                coordinator.showStats(for: blog,
-                                      timePeriod: StatsPeriodType.days)
-            }
+            showStatsForBlog(from: values, timePeriod: .days, using: coordinator)
         case .weekSite:
-            if let blog = blog(from: values) {
-                coordinator.showStats(for: blog,
-                                      timePeriod: StatsPeriodType.weeks)
-            }
+            showStatsForBlog(from: values, timePeriod: .weeks, using: coordinator)
         case .monthSite:
-            if let blog = blog(from: values) {
-                coordinator.showStats(for: blog,
-                                      timePeriod: StatsPeriodType.months)
-            }
+            showStatsForBlog(from: values, timePeriod: .months, using: coordinator)
         case .yearSite:
-            if let blog = blog(from: values) {
-                coordinator.showStats(for: blog,
-                                      timePeriod: StatsPeriodType.years)
-            }
+            showStatsForBlog(from: values, timePeriod: .years, using: coordinator)
         case .insights:
-            if let blog = blog(from: values) {
-                coordinator.showStats(for: blog,
-                                      timePeriod: StatsPeriodType.insights)
-            }
+            showStatsForBlog(from: values, timePeriod: .insights, using: coordinator)
         case .dayCategory:
-            if let blog = blog(from: values) {
-                coordinator.showStats(for: blog,
-                                      timePeriod: StatsPeriodType.days)
-            }
+            showStatsForBlog(from: values, timePeriod: .days, using: coordinator)
         case .annualStats:
-            if let blog = blog(from: values) {
-                coordinator.showStats(for: blog,
-                                      timePeriod: StatsPeriodType.years)
-            }
+            showStatsForBlog(from: values, timePeriod: .years, using: coordinator)
         case .activityLog:
             if let blog = blog(from: values) {
                 coordinator.showActivityLog(for: blog)
+            } else {
+                showMySitesAndFailureNotice(using: coordinator)
             }
         }
+    }
+
+    private func showStatsForBlog(from values: [String: String]?,
+                                  timePeriod: StatsPeriodType,
+                                  using coordinator: MySitesCoordinator) {
+        if let blog = blog(from: values) {
+            coordinator.showStats(for: blog,
+                                  timePeriod: timePeriod)
+        } else {
+            showMySitesAndFailureNotice(using: coordinator)
+        }
+    }
+
+    private func showMySitesAndFailureNotice(using coordinator: MySitesCoordinator) {
+        coordinator.showMySites()
+        postFailureNotice(title: NSLocalizedString("Site not found",
+                                                   comment: "Error notice shown if the app can't find a specific site belonging to the user"))
     }
 
     private func showStatsForDefaultBlog(from values: [String: String]?,

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -24,6 +24,10 @@ class MySitesCoordinator: NSObject {
         mySitesNavigationController.viewControllers = [blogListViewController]
     }
 
+    func showMySites() {
+        prepareToNavigate()
+    }
+
     func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection? = nil) {
         prepareToNavigate()
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		17B7C8C120EE2A870042E260 /* Routes+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B7C8C020EE2A870042E260 /* Routes+Notifications.swift */; };
 		17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */; };
 		17BD4A0820F76A4700975AC3 /* Routes+Banners.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */; };
+		17BD4A192101D31B00975AC3 /* NavigationActionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BD4A182101D31B00975AC3 /* NavigationActionHelpers.swift */; };
 		17BEE0041FC867C20074C124 /* WordPressAppDelegate+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BEE0031FC867C20074C124 /* WordPressAppDelegate+Swift.swift */; };
 		17CE77ED20C6C2F3001DEA5A /* ReaderSiteSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */; };
 		17CE77EF20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */; };
@@ -1509,6 +1510,7 @@
 		17B7C8C020EE2A870042E260 /* Routes+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Notifications.swift"; sourceTree = "<group>"; };
 		17BB26AD1E6D8321008CD031 /* MediaLibraryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaLibraryViewController.swift; sourceTree = "<group>"; };
 		17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Banners.swift"; sourceTree = "<group>"; };
+		17BD4A182101D31B00975AC3 /* NavigationActionHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationActionHelpers.swift; sourceTree = "<group>"; };
 		17BEE0031FC867C20074C124 /* WordPressAppDelegate+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAppDelegate+Swift.swift"; sourceTree = "<group>"; };
 		17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchService.swift; sourceTree = "<group>"; };
 		17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchViewController.swift; sourceTree = "<group>"; };
@@ -3311,6 +3313,7 @@
 				1703D04B20ECD93800D292E9 /* Routes+Post.swift */,
 				17A4A36820EE51870071C2CA /* Routes+Reader.swift */,
 				1715179120F4B2EB002C4A38 /* Routes+Stats.swift */,
+				17BD4A182101D31B00975AC3 /* NavigationActionHelpers.swift */,
 				17BD4A0720F76A4700975AC3 /* Routes+Banners.swift */,
 				1714F8CF20E6DA8900226DCB /* RouteMatcher.swift */,
 				17B7C89D20EC1D0D0042E260 /* UniversalLinkRouter.swift */,
@@ -7250,6 +7253,7 @@
 				ADF544C2195A0F620092213D /* CustomHighlightButton.m in Sources */,
 				17B7C89E20EC1D0D0042E260 /* UniversalLinkRouter.swift in Sources */,
 				40A2777F20191AA500D078D5 /* PluginDirectoryCollectionViewCell.swift in Sources */,
+				17BD4A192101D31B00975AC3 /* NavigationActionHelpers.swift in Sources */,
 				B55FFCFA1F034F1A0070812C /* String+Ranges.swift in Sources */,
 				FF8791BB1FBAF4B500AD86E6 /* MediaService+Swift.swift in Sources */,
 				D8212CB920AA77AD008E8AE8 /* ReaderActionHelpers.swift in Sources */,


### PR DESCRIPTION
This PR improves handling of some failure cases for universal links:

* Universal links won't be triggered at all if the user isn't logged into the app, to avoid unnecessary navigation behind the login screen.
* My Sites and Stats routes will now just display the root of the My Sites section and an error notice if the specified site can't be found in the app – for example, if the user is logged into Safari with a different account.

We're almost there, @etoledom! Sorry for all these PRs! I think this might be the last one! 🎉 

### To test

* Add an `applink` entry for WordPress.com. Build and run to your device.

**Logged out**

* Ensure you're logged out of the app.
* Open a WordPress.com page in mobile safari that triggers universal links – for example, Notifications.
* Scroll the page down slightly to reveal the 'open in app' banner at the top of the screen, and tap it to launch the app.
* The app should launch but remain on the login screen.
* If you like, you could set a breakpoint in `handleWebActivity` in `WordPressAppDelegate+Swift` and check that the UniversalLinkRouter isn't triggered.

**My Sites**

* Log into the app with a different account to mobile Safari.
* Open a site in mobile Safari that you don't have access to in the app.
* Visit the Posts section in mobile Safari, and tap the open in app banner at the top of the screen.
* The app should launch to My Sites, and you'll see a "Site not found" notice presented.

**Stats**

* Repeat the above steps but instead navigate into Stats
* The app should launch to My Sites, and you'll see a "Site not found" notice presented.

### Design help required

The failure notice that's currently displayed is a bit bare-bones. This should only be displayed if a user attempts to deep link into the app and they happen to be logged into different accounts in Safari vs the app:

![file 20-07-2018 11 40 30](https://user-images.githubusercontent.com/4780/42998360-cbf5872a-8c11-11e8-978e-5886b272083c.jpeg)

Could we improve this notice somehow? We could also add subtitle text to clarify the error.