### PR TITLE
 Reduce reliance on sleep in screenshot tests by using waits where possible

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		17F0E1DA20EBDC0A001E9514 /* Routes+Me.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F0E1D920EBDC0A001E9514 /* Routes+Me.swift */; };
 		17F67C56203D81430072001E /* PostCardStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F67C55203D81430072001E /* PostCardStatusViewModel.swift */; };
 		17FCA6811FD84B4600DBA9C8 /* NoticeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */; };
+		1AA2EFDB2101D75C00734283 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA2EFDA2101D75C00734283 /* XCTest+Extensions.swift */; };
 		1D3623260D0F684500981E51 /* WordPressAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1D3623250D0F684500981E51 /* WordPressAppDelegate.m */; };
 		1D60589B0D05DD56006BFB54 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
@@ -1522,6 +1523,7 @@
 		17F2A5D020ACC70D00F0BE10 /* WordPress 76.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 76.xcdatamodel"; sourceTree = "<group>"; };
 		17F67C55203D81430072001E /* PostCardStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardStatusViewModel.swift; sourceTree = "<group>"; };
 		17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStore.swift; sourceTree = "<group>"; };
+		1AA2EFDA2101D75C00734283 /* XCTest+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Extensions.swift"; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D3623240D0F684500981E51 /* WordPressAppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressAppDelegate.h; sourceTree = "<group>"; };
 		1D3623250D0F684500981E51 /* WordPressAppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = WordPressAppDelegate.m; sourceTree = "<group>"; usesTabs = 0; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -4205,6 +4207,7 @@
 				8511CFC41C60884400B7CEED /* SnapshotHelper.swift */,
 				8511CFC31C60884300B7CEED /* WordPressScreenshotGeneration-Bridging-Header.h */,
 				8511CFC61C60894200B7CEED /* WordPressScreenshotGeneration.swift */,
+				1AA2EFDA2101D75C00734283 /* XCTest+Extensions.swift */,
 			);
 			path = WordPressScreenshotGeneration;
 			sourceTree = "<group>";
@@ -7862,6 +7865,7 @@
 			files = (
 				8511CFC71C60894200B7CEED /* WordPressScreenshotGeneration.swift in Sources */,
 				8511CFC51C60884400B7CEED /* SnapshotHelper.swift in Sources */,
+				1AA2EFDB2101D75C00734283 /* XCTest+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -22,27 +22,28 @@ class WordPressScreenshotGeneration: XCTestCase {
             XCUIDevice().orientation = UIDeviceOrientation.portrait
         }
 
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+        login()
     }
 
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func login() {
         let app = XCUIApplication()
 
-        let logInExists = app.buttons["Log In Button"].exists
+        let loginButton = app.buttons["Log In Button"]
 
         // Logout first if needed
-        if !logInExists {
+        if !loginButton.waitForExistence(timeout: 3.0) {
+            // Log out
             app.tabBars["Main Navigation"].buttons["meTabButton"].tap()
             app.tables.element(boundBy: 0).cells.element(boundBy: 5).tap() // Tap disconnect
             app.alerts.element(boundBy: 0).buttons.element(boundBy: 1).tap() // Tap disconnect
         }
 
-        app.buttons["Log In Button"].tap()
+        loginButton.tap()
         app.buttons["Self Hosted Login Button"].tap()
 
         let username = ""
@@ -50,28 +51,31 @@ class WordPressScreenshotGeneration: XCTestCase {
 
         // We have to login by site address, due to security issues with the
         // shared testing account which prevent us from signing in by email address.
-        app.textFields["usernameField"].tap()
-        app.textFields["usernameField"].typeText("WordPress.com")
+        let selfHostedUsernameField = app.textFields["usernameField"]
+        waitForElementToExist(element: selfHostedUsernameField)
+        selfHostedUsernameField.tap()
+        selfHostedUsernameField.typeText("WordPress.com")
         app.buttons["Next Button"].tap()
 
-        guard app.secureTextFields["passwordField"].waitForExistence(timeout: 3.0) else {
-            XCTFail("The password field couldn't be found.")
-            return
-        }
+        let usernameField = app.textFields["usernameField"]
+        let passwordField = app.secureTextFields["passwordField"]
 
-        app.textFields["usernameField"].tap()
-        app.textFields["usernameField"].typeText(username)
-        app.secureTextFields["passwordField"].tap()
-        app.secureTextFields["passwordField"].typeText(password)
+        waitForElementToExist(element: passwordField)
+        usernameField.tap()
+        usernameField.typeText(username)
+        passwordField.tap()
+        passwordField.typeText(password)
 
         app.buttons["submitButton"].tap()
 
-        sleep(2)
-        app.buttons["Continue"].tap()
+        let continueButton = app.buttons["Continue"]
+        waitForElementToExist(element: continueButton)
+        continueButton.tap()
 
         // Wait for the notification primer, and dismiss if present
-        if app.buttons["cancelAlertButton"].waitForExistence(timeout: 3.0) {
-            app.buttons["cancelAlertButton"].tap()
+        let cancelAlertButton = app.buttons["cancelAlertButton"]
+        if cancelAlertButton.waitForExistence(timeout: 3.0) {
+            cancelAlertButton.tap()
         }
     }
 
@@ -79,25 +83,30 @@ class WordPressScreenshotGeneration: XCTestCase {
         let app = XCUIApplication()
 
         // Get My Site Screenshot
+        let blogDetailsTable = app.tables["Blog Details Table"]
+        XCTAssert(blogDetailsTable.exists, "My site view not visibile")
         // Select blog posts if on an iPad screen
         if UIDevice.current.userInterfaceIdiom == .pad {
-            app.tables.cells["Blog Post Row"].tap()
-            sleep(2)
+            blogDetailsTable.cells["Blog Post Row"].tap()
+            waitForElementToExist(element: app.tables["PostsTable"])
+            sleep(5) // Wait for posts to load
         }
         snapshot("3-My-Site")
 
         // Get Editor Screenshot
-        app.tables.cells["Blog Post Row"].tap() // tap Blog Posts
-        sleep(2)
+        blogDetailsTable.cells["Blog Post Row"].tap() // tap Blog Posts
+        waitForElementToExist(element: app.tables["PostsTable"])
 
         // Tap on the first post to bring up the editor
         app.tables["PostsTable"].tap()
 
+        let editorNavigationBar = app.navigationBars["Azctec Editor Navigation Bar"]
+        XCTAssert(editorNavigationBar.exists, "Post editor not found")
+        sleep(5) // wait for post images to load
         // The title field gets focus automatically
-        sleep(2)
         snapshot("1-PostEditor")
 
-        app.navigationBars["Azctec Editor Navigation Bar"].buttons["Close"].tap()
+        editorNavigationBar.buttons["Close"].tap()
         // Dismiss Unsaved Changes Alert if it shows up
         if app.sheets.element(boundBy: 0).exists {
             // Tap discard
@@ -109,21 +118,32 @@ class WordPressScreenshotGeneration: XCTestCase {
         if UIDevice.current.userInterfaceIdiom == .phone {
             app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap() // back button
         }
-        app.tables["Blog Details Table"].cells.element(boundBy: 0).tap() // tap Stats
+        blogDetailsTable.cells.element(boundBy: 0).tap() // tap Stats
         app.segmentedControls.element(boundBy: 0).buttons.element(boundBy: 1).tap() // tap Days
-        sleep(5)
+
+        // Wait for stats to be loaded
+        waitForElementToExist(element: app.otherElements["visitorsViewsGraph"])
+        waitForElementToNotExist(element: app.progressIndicators.firstMatch)
+
         snapshot("4-Stats")
 
         // Get Reader Screenshot
-        app.tabBars["Main Navigation"].buttons["readerTabButton"].tap(withNumberOfTaps: 2,
-                                                                      numberOfTouches: 2)
-        sleep(1)
-        app.tables.cells.element(boundBy: 1).tap() // tap Discover
-        sleep(5)
+        app.tabBars["Main Navigation"].buttons["readerTabButton"].tap()
+        // Tap the back button if on an iPhone screen
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap() // back button
+        }
+        let discoverCell = app.tables.cells.element(boundBy: 1)
+        waitForElementToExist(element: discoverCell)
+        discoverCell.tap() // tap Discover
+
+        waitForElementToExist(element: app.tables["Reader"])
+        sleep(5) // Wait for content to load
         snapshot("2-Reader")
 
         // Get Notifications screenshot
         app.tabBars["Main Navigation"].buttons["notificationsTabButton"].tap()
+        XCTAssert(app.tables["Notifications Table"].exists, "Notifications Table not found")
         snapshot("5-Notifications")
     }
 }

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -29,8 +29,8 @@ class WordPressScreenshotGeneration: XCTestCase {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-
-    func testGenerateScreenshots() {
+    
+    func login() {
         let app = XCUIApplication()
 
         let logInExists = app.buttons["Log In Button"].exists
@@ -73,6 +73,10 @@ class WordPressScreenshotGeneration: XCTestCase {
         if app.buttons["cancelAlertButton"].waitForExistence(timeout: 3.0) {
             app.buttons["cancelAlertButton"].tap()
         }
+    }
+
+    func testGenerateScreenshots() {
+        let app = XCUIApplication()
 
         // Get My Site Screenshot
         // Select blog posts if on an iPad screen

--- a/WordPress/WordPressScreenshotGeneration/XCTest+Extensions.swift
+++ b/WordPress/WordPressScreenshotGeneration/XCTest+Extensions.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+extension XCTestCase {
+    
+    public func waitForElementToExist(element: XCUIElement, timeout: TimeInterval? = nil) {
+        let timeoutValue = timeout ?? 30
+        guard element.waitForExistence(timeout: timeoutValue) else {
+            XCTFail("Failed to find \(element) after \(timeoutValue) seconds.")
+            return
+        }
+    }
+    
+    public func waitForElementToNotExist(element: XCUIElement, timeout: TimeInterval? = nil) {
+        let notExistsPredicate = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(predicate: notExistsPredicate,
+                                                    object: element)
+
+        let timeoutValue = timeout ?? 30
+        guard XCTWaiter().wait(for: [expectation], timeout: timeoutValue) == .completed else {
+            XCTFail("\(element) still exists after \(timeoutValue) seconds.")
+            return
+        }
+    }
+}

--- a/WordPress/WordPressScreenshotGeneration/XCTest+Extensions.swift
+++ b/WordPress/WordPressScreenshotGeneration/XCTest+Extensions.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 extension XCTestCase {
-    
+
     public func waitForElementToExist(element: XCUIElement, timeout: TimeInterval? = nil) {
         let timeoutValue = timeout ?? 30
         guard element.waitForExistence(timeout: timeoutValue) else {
@@ -9,7 +9,7 @@ extension XCTestCase {
             return
         }
     }
-    
+
     public func waitForElementToNotExist(element: XCUIElement, timeout: TimeInterval? = nil) {
         let notExistsPredicate = NSPredicate(format: "exists == false")
         let expectation = XCTNSPredicateExpectation(predicate: notExistsPredicate,

--- a/WordPressComStatsiOS/WordPressComStatsiOS/UI/WPStatsGraphBackgroundView.m
+++ b/WordPressComStatsiOS/WordPressComStatsiOS/UI/WPStatsGraphBackgroundView.m
@@ -12,6 +12,7 @@ static CGFloat const AxisPadding = 18.0f;
         self.backgroundColor = [UIColor whiteColor];
         self.contentMode = UIViewContentModeRedraw;
         self.accessibilityLabel = NSLocalizedString(@"Visitors and Views Graph", @"Accessibility label for visitors and views graph view");
+        self.accessibilityIdentifier = @"visitorsViewsGraph";
         self.isAccessibilityElement = YES;
     }
     return self;


### PR DESCRIPTION
This should help the reliability issues discussed in https://github.com/wordpress-mobile/WordPress-iOS/issues/9720.

To test: `fastlane snapshot` should still pass and take the correct screenshots but now should be less prone to flakiness and random failures.


