### PR TITLE
SignupUsernameViewController: Removes "Back" label from back nav button

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -63,6 +63,9 @@ class SignupEpilogueViewController: NUXViewController {
             vc.currentUsername = updatedUsername ?? epilogueUserInfo?.username
             vc.displayName = updatedDisplayName ?? epilogueUserInfo?.fullName
             vc.delegate = self
+
+            // Empty Back Button
+            navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
         }
     }
 


### PR DESCRIPTION
This PR removes the title label from the backBarButtonItem on the `SignupUsernameViewController`:

![3](https://user-images.githubusercontent.com/154014/43016862-e7253bfa-8c19-11e8-8316-950ce56ef48f.png)

Fixes #9809 

## Testing

1. Sign up for a new WP account using email or Google
2. In the epilogue VC, tap the username field to change it
3. On the `SignupUsernameViewController` screen, verify the back nav button has no title.

@nheagy would you mind taking a quick peek at this?

