### PR TITLE
Try/swiftlint rule for localization

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -151,3 +151,9 @@ custom_rules:
     regex: '\.textAlignment(\s*)=(\s*).right'
     message: "When forcing text alignment to the right, be sure to handle the Right-to-Left layout case properly, and then silence this warning with this line `// swiftlint:disable:next inverse_text_alignment`"
     severity: warning
+
+  localization_missing_comment:
+    name: "Localization Missing Comment"
+    regex: 'NSLocalizedString([^,]+,\s+comment:\s*"")'
+    message: "Localized strings should include a description giving context for how the string is used."
+    severity: warning

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -152,8 +152,8 @@ custom_rules:
     message: "When forcing text alignment to the right, be sure to handle the Right-to-Left layout case properly, and then silence this warning with this line `// swiftlint:disable:next inverse_text_alignment`"
     severity: warning
 
-  localization_missing_comment:
-    name: "Localization Missing Comment"
+  localization_comment:
+    name: "Localization Comment"
     regex: 'NSLocalizedString([^,]+,\s+comment:\s*"")'
     message: "Localized strings should include a description giving context for how the string is used."
     severity: warning

--- a/WordPress/Classes/Extensions/WPStyleGuide+Search.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+Search.swift
@@ -4,7 +4,7 @@ import WordPressShared
 extension WPStyleGuide {
 
     @objc public class func configureSearchBar(_ searchBar: UISearchBar) {
-        searchBar.accessibilityIdentifier = NSLocalizedString("Search", comment: "")
+        searchBar.accessibilityIdentifier = "Search"
         searchBar.autocapitalizationType = .none
         searchBar.autocorrectionType = .no
         searchBar.isTranslucent = false

--- a/WordPress/Classes/Models/BlogSettings+Discussion.swift
+++ b/WordPress/Classes/Models/BlogSettings+Discussion.swift
@@ -45,15 +45,15 @@ extension BlogSettings {
         // MARK: - Private Properties
 
         fileprivate static let descriptionMap = [
-            disabled.rawValue: NSLocalizedString("No comments", comment: ""),
-            fromKnownUsers.rawValue: NSLocalizedString("Known user's comments", comment: ""),
-            everything.rawValue: NSLocalizedString("All comments", comment: "")
+            disabled.rawValue: NSLocalizedString("No comments", comment: "An option in a list. Automatically approve no comments."),
+            fromKnownUsers.rawValue: NSLocalizedString("Known user's comments", comment: "An option in a list. Automatically approve comments from known users."),
+            everything.rawValue: NSLocalizedString("All comments", comment: "An option in a list. Automatically approve all comments")
         ]
 
         fileprivate static let hintsMap = [
-            disabled.rawValue: NSLocalizedString("Require manual approval for everyone's comments.", comment: ""),
-            fromKnownUsers.rawValue: NSLocalizedString("Automatically approve if the user has a previously approved comment.", comment: ""),
-            everything.rawValue: NSLocalizedString("Automatically approve everyone's comments.", comment: "")
+            disabled.rawValue: NSLocalizedString("Require manual approval for everyone's comments.", comment: "Explains the effect of the 'No comments' auto approval setting."),
+            fromKnownUsers.rawValue: NSLocalizedString("Automatically approve if the user has a previously approved comment.", comment: "Explains the effect of the 'Known users' auto approval setting"),
+            everything.rawValue: NSLocalizedString("Automatically approve everyone's comments.", comment: "Explains the effect of the 'All comments' auto approval setting")
         ]
     }
 
@@ -172,7 +172,7 @@ extension BlogSettings {
             let descriptionFormat = NSLocalizedString("%@ levels", comment: "Comments Threading Levels")
             var optionsMap = [Int: String]()
 
-            optionsMap[disabledValue] = NSLocalizedString("Disabled", comment: "")
+            optionsMap[disabledValue] = NSLocalizedString("Disabled", comment: "Adjective. Comment threading is disabled.")
 
             for currentLevel in minimumValue...maximumValue {
                 let level = NumberFormatter.localizedString(from: NSNumber(value: currentLevel), number: .spellOut)

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -387,7 +387,7 @@ private extension InteractiveNotificationsManager {
                 return UNTextInputNotificationAction(identifier: identifier,
                                                      title: description,
                                                      options: notificationActionOptions,
-                                                     textInputButtonTitle: NSLocalizedString("Reply", comment: ""),
+                                                     textInputButtonTitle: NSLocalizedString("Reply", comment: "Verb. Button title. Reply to a comment."),
                                                      textInputPlaceholder: NSLocalizedString("Write a reply…", comment: "Placeholder text for inline compose view"))
             default:
                 return UNNotificationAction(identifier: identifier, title: description, options: notificationActionOptions)

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -188,7 +188,7 @@ extension ActivityListViewController: ActivityRewindPresenter {
         let alertController = UIAlertController(title: title,
                                                 message: message,
                                                 preferredStyle: .alert)
-        alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: ""))
+        alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Verb. A button title."))
         alertController.addDestructiveActionWithTitle(NSLocalizedString("Confirm Rewind",
                                                                         comment: "Confirm Rewind button title"),
                                                       handler: { action in

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -65,7 +65,7 @@ class ActivityListViewModel: Observable {
                                                  buttonText: NSLocalizedString("Contact support", comment: "Button label for contacting support"))
         } else {
             return NoResultsViewController.Model(title: NSLocalizedString("No connection", comment: "Title for the error view when there's no connection"),
-                                                 subtitle: NSLocalizedString("An active internet connection is required to view activities", comment: ""))
+                                                 subtitle: NSLocalizedString("An active internet connection is required to view activities", comment: "Error message shown when trying to view the Activity Log feature and there is no internet connection."))
 
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -289,8 +289,8 @@ open class DiscussionSettingsViewController: UITableViewController {
         pickerViewController.switchVisible      = true
         pickerViewController.switchOn           = settings.commentsPagingEnabled
         pickerViewController.switchText         = NSLocalizedString("Paging", comment: "Discussion Settings")
-        pickerViewController.selectionText      = NSLocalizedString("Comments per page", comment: "")
-        pickerViewController.pickerHint         = NSLocalizedString("Break comment threads into multiple pages.", comment: "")
+        pickerViewController.selectionText      = NSLocalizedString("Comments per page", comment: "A label title.")
+        pickerViewController.pickerHint         = NSLocalizedString("Break comment threads into multiple pages.", comment: "Text snippet summarizing what comment paging does.")
         pickerViewController.pickerMinimumValue = commentsPagingMinimumValue
         pickerViewController.pickerMaximumValue = commentsPagingMaximumValue
         pickerViewController.pickerSelectedValue = settings.commentsPageSize as? Int
@@ -324,8 +324,8 @@ open class DiscussionSettingsViewController: UITableViewController {
         let pickerViewController                = SettingsPickerViewController(style: .grouped)
         pickerViewController.title              = NSLocalizedString("Links in comments", comment: "Comments Paging")
         pickerViewController.switchVisible      = false
-        pickerViewController.selectionText      = NSLocalizedString("Links in comments", comment: "")
-        pickerViewController.pickerHint         = NSLocalizedString("Require manual approval for comments that include more than this number of links.", comment: "")
+        pickerViewController.selectionText      = NSLocalizedString("Links in comments", comment: "A label title")
+        pickerViewController.pickerHint         = NSLocalizedString("Require manual approval for comments that include more than this number of links.", comment: "An explaination of a setting.")
         pickerViewController.pickerMinimumValue = commentsLinksMinimumValue
         pickerViewController.pickerMaximumValue = commentsLinksMaximumValue
         pickerViewController.pickerSelectedValue = settings.commentsMaximumLinks as? Int

--- a/WordPress/Classes/ViewRelated/Blog/JetpackConnectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackConnectionViewController.swift
@@ -78,7 +78,7 @@ open class JetpackConnectionViewController: UITableViewController {
             let alertController = UIAlertController(title: nil,
                                                     message: message,
                                                     preferredStyle: .alert)
-            alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: ""))
+            alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Verb. A button title. Tapping cancels an action."))
             alertController.addDestructiveActionWithTitle(NSLocalizedString("Disconnect",
                                                                             comment: "Title for button that disconnects Jetpack from the site"),
                                                           handler: { action in

--- a/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
@@ -125,8 +125,8 @@ import WordPressShared
         var title =  NSLocalizedString("Connecting %@", comment: "Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name")
         title = NSString(format: title as NSString, publicizeService.label) as String
 
-        let manyAccountFooter = NSLocalizedString("Select the account you would like to authorize. Note that your posts will be automatically shared to the selected account.", comment: "")
-        let oneAccountFooter = NSLocalizedString("Confirm this is the account you would like to authorize. Note that your posts will be automatically shared to this account.", comment: "")
+        let manyAccountFooter = NSLocalizedString("Select the account you would like to authorize. Note that your posts will be automatically shared to the selected account.", comment: "Instructional text about the Sharing feature.")
+        let oneAccountFooter = NSLocalizedString("Confirm this is the account you would like to authorize. Note that your posts will be automatically shared to this account.", comment: "Instructional text about the Sharing feature.")
         let footer = rows.count > 1 ? manyAccountFooter : oneAccountFooter
 
         return ImmuTableSection(headerText: title, rows: rows, footerText: footer)

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -525,7 +525,7 @@ private extension MeViewController {
                                                             comment: "Warning displayed before logging out. The %d placeholder will contain the number of local posts (SINGULAR!)")
         static let unsavedTitlePlural = NSLocalizedString("You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?",
                                                           comment: "Warning displayed before logging out. The %d placeholder will contain the number of local posts (PLURAL!)")
-        static let cancelAction = NSLocalizedString("Cancel", comment: "")
+        static let cancelAction = NSLocalizedString("Cancel", comment: "Verb. A button title. Tapping cancels an action.")
         static let logoutAction = NSLocalizedString("Log Out", comment: "Button for confirming logging out from WordPress.com account")
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/ImageCropViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/ImageCropViewController.swift
@@ -29,7 +29,7 @@ class ImageCropViewController: UIViewController, UIScrollViewDelegate {
         super.viewDidLoad()
 
         // Title
-        title = NSLocalizedString("Resize & Crop", comment: "")
+        title = NSLocalizedString("Resize & Crop", comment: "Screen title. Resize and crop an image.")
 
         // Setup: NavigationItem
         let useButtonTitle = NSLocalizedString("Use", comment: "Use the current image")

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -266,7 +266,7 @@ class MediaItemViewController: UITableViewController {
 
         let alertController = UIAlertController(title: nil,
                                                 message: NSLocalizedString("Are you sure you want to permanently delete this item?", comment: "Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso."), preferredStyle: .alert)
-        alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: ""))
+        alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Verb. Button title. Tapping cancels an action."))
         alertController.addDestructiveActionWithTitle(NSLocalizedString("Delete", comment: "Title for button that permanently deletes a media item (photo / video)"), handler: { action in
             self.deleteMediaItem()
         })

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -265,7 +265,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         let alertController = UIAlertController(title: nil,
                                                 message: message,
                                                 preferredStyle: .alert)
-        alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: ""))
+        alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Verb. Button title. Tapping cancels an action."))
         alertController.addDestructiveActionWithTitle(NSLocalizedString("Delete", comment: "Title for button that permanently deletes one or more media items (photos / videos)"), handler: { action in
             self.deleteSelectedItems()
         })

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -325,7 +325,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             }
         }
 
-        alertController.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: ""))
+        alertController.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: "Verb. Button title. Tapping dismisses a prmopt."))
 
         present(alertController, animated: true, completion: nil)
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -384,7 +384,7 @@ extension NotificationDetailsViewController {
         let replyTextView = ReplyTextView(width: view.frame.width)
 
         replyTextView.placeholder = NSLocalizedString("Write a reply…", comment: "Placeholder text for inline compose view")
-        replyTextView.replyText = NSLocalizedString("Reply", comment: "").localizedUppercase
+        replyTextView.replyText = NSLocalizedString("Reply", comment: "Verb. A button title. Reply to a comment.").localizedUppercase
         replyTextView.text = previousReply
         replyTextView.accessibilityIdentifier = NSLocalizedString("Reply Text", comment: "Notifications Reply Accessibility Identifier")
         replyTextView.delegate = self

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -314,7 +314,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
     }
 
     private func handleUpdateError() {
-        let title       = NSLocalizedString("Oops!", comment: "")
+        let title       = NSLocalizedString("Oops!", comment: "An informal exclaimation meaning `something went wrong`.")
         let message     = NSLocalizedString("There has been an unexpected error while updating your Notification Settings",
                                             comment: "Displayed after a failed Notification Settings call")
         let cancelText  = NSLocalizedString("Cancel", comment: "Cancel. Action.")

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -150,7 +150,7 @@ open class NotificationSettingsViewController: UIViewController {
     // MARK: - Error Handling
 
     fileprivate func handleLoadError() {
-        let title       = NSLocalizedString("Oops!", comment: "")
+        let title       = NSLocalizedString("Oops!", comment: "An informal exclaimation meaning `something went wrong`.")
         let message     = NSLocalizedString("There has been a problem while loading your Notification Settings",
                                             comment: "Displayed after Notification Settings failed to load")
         let cancelText  = NSLocalizedString("Cancel", comment: "Cancel. Action.")

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -41,7 +41,7 @@ class PlanDetailViewController: UIViewController {
         let label = UILabel()
         label.font = WPFontManager.systemSemiBoldFont(ofSize: 13.0)
         label.textColor = WPStyleGuide.validGreen()
-        label.text = NSLocalizedString("Current Plan", comment: "").localizedUppercase
+        label.text = NSLocalizedString("Current Plan", comment: "Label title. Refers to the current WordPress.com plan for a user's site.").localizedUppercase
         label.translatesAutoresizingMaskIntoConstraints = false
 
         // Wrapper view required for spacing to work out correctly, as the header stackview

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewModel.swift
@@ -87,11 +87,11 @@ struct PlanDetailViewModel {
 
     private struct LocalizedText {
         static let loadingTitle = NSLocalizedString("Loading Plan...", comment: "Text displayed while loading plans details")
-        static let errorTitle = NSLocalizedString("Oops", comment: "")
+        static let errorTitle = NSLocalizedString("Oops", comment: "An informal exclaimation that means `something went wrong`.")
         static let errorSubtitle = NSLocalizedString("There was an error loading the plan", comment: "Text displayed when there is a failure loading the plan details")
         static let errorButtonText = NSLocalizedString("Contact support", comment: "Button label for contacting support")
-        static let noConnectionTitle = NSLocalizedString("No connection", comment: "")
-        static let noConnectionSubtitle = NSLocalizedString("An active internet connection is required to view plans", comment: "")
+        static let noConnectionTitle = NSLocalizedString("No connection", comment: "An error message title shown when there is no internet connection.")
+        static let noConnectionSubtitle = NSLocalizedString("An active internet connection is required to view plans", comment: "An error message shown when there is no internet connection.")
         static let price = NSLocalizedString("%@ per year", comment: "Plan yearly price")
     }
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
@@ -54,7 +54,7 @@ struct PlanListRow: ImmuTableRow {
                     .font: WPFontManager.systemSemiBoldFont(ofSize: 11.0),
                     .foregroundColor: WPStyleGuide.validGreen()
                 ]
-                let currentPlan = NSLocalizedString("Current Plan", comment: "").localizedUppercase
+                let currentPlan = NSLocalizedString("Current Plan", comment: "Label title. Refers to the current WordPress.com plan for a user's site.").localizedUppercase
                 let attributedCurrentPlan = NSAttributedString(string: currentPlan, attributes: currentPlanAttributes)
                 attributedTitle.append(attributedCurrentPlan)
             } else if !price.isEmpty {

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
@@ -18,12 +18,12 @@ enum PlanListViewModel {
         case .error:
             let appDelegate = WordPressAppDelegate.sharedInstance()
             if (appDelegate?.connectionAvailable)! {
-                return NoResultsViewController.Model(title: NSLocalizedString("Oops", comment: ""),
-                                                     subtitle: NSLocalizedString("There was an error loading plans", comment: ""),
-                                                     buttonText: NSLocalizedString("Contact support", comment: ""))
+                return NoResultsViewController.Model(title: NSLocalizedString("Oops", comment: "An informal exclaimation that means `something went wrong`."),
+                                                     subtitle: NSLocalizedString("There was an error loading plans", comment: "Text displayed when there is a failure loading the plan list"),
+                                                     buttonText: NSLocalizedString("Contact support", comment: "Button label for contacting support"))
             } else {
                 return NoResultsViewController.Model(title: NSLocalizedString("No connection", comment: "Title for the error view when there's no connection"),
-                                                     subtitle: NSLocalizedString("An active internet connection is required to view plans", comment: ""))
+                                                     subtitle: NSLocalizedString("An active internet connection is required to view plans", comment: "An error message shown when there is no internet connection."))
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewModel.swift
@@ -205,14 +205,14 @@ class PluginListViewModel: Observable {
             let appDelegate = WordPressAppDelegate.sharedInstance()
             if (appDelegate?.connectionAvailable)! {
                 return WPNoResultsView.Model(
-                    title: NSLocalizedString("Oops", comment: ""),
-                    message: NSLocalizedString("There was an error loading plugins", comment: ""),
-                    buttonTitle: NSLocalizedString("Contact support", comment: "")
+                    title: NSLocalizedString("Oops", comment: "An informal exclaimation that means `something went wrong`."),
+                    message: NSLocalizedString("There was an error loading plugins", comment: "Text displayed when there is a failure loading plugins"),
+                    buttonTitle: NSLocalizedString("Contact support", comment: "Button label for contacting support")
                 )
             } else {
                 return WPNoResultsView.Model(
                     title: NSLocalizedString("No connection", comment: "Title for the error view when there's no connection"),
-                    message: NSLocalizedString("An active internet connection is required to view plugins", comment: "")
+                    message: NSLocalizedString("An active internet connection is required to view plugins", comment: "Error message shown when trying to view the Plugins feature and there is no internet connection.")
                 )
             }
         }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -768,7 +768,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
     }
 
     @objc func promptForPassword() {
-        let message = NSLocalizedString("The username or password stored in the app may be out of date. Please re-enter your password in the settings and try again.", comment: "")
+        let message = NSLocalizedString("The username or password stored in the app may be out of date. Please re-enter your password in the settings and try again.", comment: "Error message informing a user about an invalid password.")
 
         // bad login/pass combination
         let editSiteViewController = SiteSettingsViewController(blog: blog)
@@ -779,7 +779,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         navController.modalTransitionStyle = .crossDissolve
         navController.modalPresentationStyle = .formSheet
 
-        WPError.showAlert(withTitle: NSLocalizedString("Unable to Connect", comment: ""), message: message, withSupportButton: true) { _ in
+        WPError.showAlert(withTitle: NSLocalizedString("Unable to Connect", comment: "An error message."), message: message, withSupportButton: true) { _ in
             self.present(navController, animated: true, completion: nil)
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/FakePreviewBuilder.swift
+++ b/WordPress/Classes/ViewRelated/Post/FakePreviewBuilder.swift
@@ -41,12 +41,12 @@ class FakePreviewBuilder: NSObject {
 
 private extension FakePreviewBuilder {
     var previewTitle: String {
-        return title?.nonEmptyString() ?? NSLocalizedString("(no title)", comment: "")
+        return title?.nonEmptyString() ?? NSLocalizedString("(no title)", comment: "Placeholder text shown when a post does not have a title.")
     }
 
     var previewContent: String {
         guard var contentText = content?.nonEmptyString() else {
-            let placeholder = NSLocalizedString("No Description available for this Post", comment: "")
+            let placeholder = NSLocalizedString("No Description available for this Post", comment: "Informs the user there is no description for a post being previewed.")
             return "<h1>\(placeholder)</h1>"
         }
         contentText = contentText.replacingOccurrences(of: "\n", with: "<br>")
@@ -54,12 +54,12 @@ private extension FakePreviewBuilder {
     }
 
     var previewTags: String {
-        let tagsLabel = NSLocalizedString("Tags: %@", comment: "")
+        let tagsLabel = NSLocalizedString("Tags: %@", comment: "A label title. Tags associated with a post are shown in order after the colon.  The %@ is a placeholder for the tags.")
         return String(format: tagsLabel, tags.joined(separator: ", "))
     }
 
     var previewCategories: String {
-        let categoriesLabel = NSLocalizedString("Categories: %@", comment: "")
+        let categoriesLabel = NSLocalizedString("Categories: %@", comment: "A label title. Categories associated with a post are shown in order after the colon.  The %@ is a placeholder for the categories.")
         return String(format: categoriesLabel, categories.joined(separator: ", "))
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
@@ -26,7 +26,7 @@ class PostPreviewGenerator: NSObject {
         }
 
         guard WordPressAppDelegate.sharedInstance().connectionAvailable else {
-            delegate?.previewFailed(self, message: NSLocalizedString("The internet connection appears to be offline.", comment: ""))
+            delegate?.previewFailed(self, message: NSLocalizedString("The internet connection appears to be offline.", comment: "An error message."))
             return
         }
 
@@ -34,7 +34,7 @@ class PostPreviewGenerator: NSObject {
     }
 
     @objc func previewRequestFailed(error: NSError) {
-        delegate?.previewFailed(self, message: NSLocalizedString("There has been an error while trying to reach your site.", comment: ""))
+        delegate?.previewFailed(self, message: NSLocalizedString("There has been an error while trying to reach your site.", comment: "An error message."))
     }
 
     @objc func interceptRedirect(request: URLRequest) -> URLRequest? {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -119,7 +119,7 @@ import WordPressShared
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.title = NSLocalizedString("Reader", comment: "")
+        navigationItem.title = NSLocalizedString("Reader", comment: "Noun. Title of the Reader feature in the app.")
 
         configureTableView()
         syncTopics()

--- a/WordPress/Classes/ViewRelated/Tools/TimeZoneSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/TimeZoneSelectorViewController.swift
@@ -93,7 +93,7 @@ struct TimeZoneSelectorViewModel: Observable {
                 return WPNoResultsView.Model(
                     title: NSLocalizedString("Oops", comment: "Title for the view when there's an error loading time zones"),
                     message: NSLocalizedString("There was an error loading time zones", comment: "Error message when time zones can't be loaded"),
-                    buttonTitle: NSLocalizedString("Contact support", comment: "")
+                    buttonTitle: NSLocalizedString("Contact support", comment: "Title of a button. A call to action to contact support for assistance.")
                 )
             } else {
                 return WPNoResultsView.Model(

--- a/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
@@ -79,7 +79,7 @@ class PushAuthenticationManagerTests: XCTestCase {
         pushAuthenticationManager!.handleAuthenticationNotification(expiredAuthenticationDictionary)
 
         XCTAssertTrue(mockAlertControllerProxy.showWithTitleCalled, "Should show the login expired alert if the notification has expired")
-        XCTAssertEqual(mockAlertControllerProxy.titlePassedIn, NSLocalizedString("Login Request Expired", comment: ""), "")
+        XCTAssertEqual(mockAlertControllerProxy.titlePassedIn, NSLocalizedString("Login Request Expired", comment: "Error message shown when a user is trying to login."), "")
     }
 
     func testHandlePushAuthenticationNotificationDoesNotShowTheLoginExpiredAlertIfNotificationHasNotExpired() {
@@ -107,7 +107,7 @@ class PushAuthenticationManagerTests: XCTestCase {
         pushAuthenticationManager!.handleAuthenticationNotification(validAuthenticationDictionary)
 
         XCTAssertTrue(mockAlertControllerProxy.showWithTitleCalled, "Should show the login verification")
-        XCTAssertEqual(mockAlertControllerProxy.titlePassedIn, NSLocalizedString("Verify Log In", comment: ""), "")
+        XCTAssertEqual(mockAlertControllerProxy.titlePassedIn, NSLocalizedString("Verify Log In", comment: "Title of a prompt. A user must verify their login attempt."), "")
     }
 
     func testHandlePushAuthenticationNotificationShouldAttemptToAuthorizeTheLoginIfTheUserIndicatesTheyWantTo() {


### PR DESCRIPTION
I had a bit of free time so I whipped up this PR to add a new swiftlint rule to check for missing localization comments.

Specifically, the rule added to `.swiftlint.yml` has regex to check that the `comment` argument in `NSLocalizedString` is not empty.  It seems to work (it caught over 40 matches) but there might be room for improvement.
I've also added comments to any NSLocalizedStrings that the new rule flagged so we're not suddenly spammed with warnings.

To test:
Check out the branch
cd into the project and run `swiftlint` or `rake lint`
There should be no warnings for localized strings missing comments. 
Edit a file and either add a new NSLocalizedString call without a comment, or remove a comment from an existing NSLocalizedString call.
Run the linter again and confirm it caught the missing comment.

@etoledom would you be game to review this one? 