### PR TITLE
Gather coverage from all binary targets

### DIFF
--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -40,7 +40,53 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+            BuildableName = "WordPress.app"
+            BlueprintName = "WordPress"
+            ReferencedContainer = "container:WordPress.xcodeproj">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "74576671202B558C00F42E40"
+            BuildableName = "WordPressDraftActionExtension.appex"
+            BlueprintName = "WordPressDraftActionExtension"
+            ReferencedContainer = "container:WordPress.xcodeproj">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "932225A61C7CE50300443B02"
+            BuildableName = "WordPressShareExtension.appex"
+            BlueprintName = "WordPressShareExtension"
+            ReferencedContainer = "container:WordPress.xcodeproj">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "93E5283919A7741A003A1A9C"
+            BuildableName = "WordPressTodayWidget.appex"
+            BlueprintName = "WordPressTodayWidget"
+            ReferencedContainer = "container:WordPress.xcodeproj">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "931CFFC71EBCB016005E6BB4"
+            BuildableName = "WordPressComStatsiOS.framework"
+            BlueprintName = "WordPressComStatsiOS"
+            ReferencedContainer = "container:../WordPressComStatsiOS/WordPressComStatsiOS.xcodeproj">
+         </BuildableReference>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E12F96E81FBC67AC00329E2E"
+            BuildableName = "WordPressFlux.framework"
+            BlueprintName = "WordPressFlux"
+            ReferencedContainer = "container:../WordPressFlux/WordPressFlux.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
There is no issue for these changes.

While working on out current project, we noticed that an increase in the number of tests did not seem to increase the coverage reported by buddybuild.

In this PR:
- Edit the WordPress scheme, updating the options for testing, to specify the targets we want to collect coverage data from.

To test:
- The project should build as usual.
- Check how [this build's](https://dashboard.buddybuild.com/apps/57a120bbe0f5520100e11c19/build/5b5581f551b17a0001ba9a60) coverage (after updating the scheme, and with 170 tests more than `develop`) is greater that [this other build's](https://dashboard.buddybuild.com/apps/57a120bbe0f5520100e11c19/build/5b553fe9361c3000014f41ac)
