### PR TITLE
Enable universal links for wordpress.com and apps.wordpress.com (retarget PR)

### DIFF
--- a/WordPress/WordPress.entitlements
+++ b/WordPress/WordPress.entitlements
@@ -7,6 +7,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:wordpress.com</string>
+		<string>applinks:wordpress.com</string>
+		<string>applinks:apps.wordpress.com</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>


### PR DESCRIPTION
It seems to be one of those days... my original PR, #9802 targetted a different branch, which I accidentally merged before I pulled this one in.

This PR is identical to #9802, just targeting `develop`.

Really sorry, @etoledom, would you mind just double checking this one?

