### PR TITLE
Universal Links: Add analytics

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def shared_with_all_pods
-    pod 'WordPressShared', '1.0.8'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '924689b554d6414050e743081b8fcd734aed4a4e'
     pod 'CocoaLumberjack', '3.4.2'
     pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
     pod 'NSObject-SafeExpectations', '0.0.3'

--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def shared_with_all_pods
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '924689b554d6414050e743081b8fcd734aed4a4e'
+    pod 'WordPressShared', '1.0.9'
     pod 'CocoaLumberjack', '3.4.2'
     pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
     pod 'NSObject-SafeExpectations', '0.0.3'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -126,7 +126,7 @@ PODS:
     - UIDeviceIdentifier (~> 0.4)
     - WordPressShared (~> 1.0.3)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.0.8):
+  - WordPressShared (1.0.9):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.0.6)
@@ -168,7 +168,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.0.0-beta.23)
   - WordPressAuthenticator (= 1.0.4)
   - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `c2ae16bbc3fb759e0684fc9e5642d52390d00285`)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `924689b554d6414050e743081b8fcd734aed4a4e`)
+  - WordPressShared (= 1.0.9)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `7a5b1a3fb44f62416fbc2e5f0de623b87b613aae`)
   - WPMediaPicker (= 1.1)
   - wpxmlrpc (= 0.8.3)
@@ -204,6 +204,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
@@ -215,9 +216,6 @@ EXTERNAL SOURCES:
   WordPressKit:
     :commit: c2ae16bbc3fb759e0684fc9e5642d52390d00285
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-  WordPressShared:
-    :commit: 924689b554d6414050e743081b8fcd734aed4a4e
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -229,9 +227,6 @@ CHECKOUT OPTIONS:
   WordPressKit:
     :commit: c2ae16bbc3fb759e0684fc9e5642d52390d00285
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
-  WordPressShared:
-    :commit: 924689b554d6414050e743081b8fcd734aed4a4e
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -267,12 +262,12 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 4f46c2fa98f3017e9e39ad30ba9f03dbd6612ce4
   WordPressAuthenticator: 2825f0c56f83a17470564dbec427991fa5cac5af
   WordPressKit: a24baaa783c3a221f2d9a51c19318cbb27333373
-  WordPressShared: 063e1e8b1a7aaf635abf17f091a2d235a068abdc
+  WordPressShared: e5ea8a1ed3329735e40bd6623830960f63dd10fd
   WordPressUI: af141587ec444f9af753a00605bd0d3f14d8d8a3
   WPMediaPicker: 5cc9386a4720f906d8fb79c7c4090d216b9f2348
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 4a850f5712cfddddbdf29fb2d56a4bdcd444044b
+PODFILE CHECKSUM: d49dbb4ef6438960438d031aeea9531ce0dc843b
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -168,7 +168,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.0.0-beta.23)
   - WordPressAuthenticator (= 1.0.4)
   - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `c2ae16bbc3fb759e0684fc9e5642d52390d00285`)
-  - WordPressShared (= 1.0.8)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `924689b554d6414050e743081b8fcd734aed4a4e`)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `7a5b1a3fb44f62416fbc2e5f0de623b87b613aae`)
   - WPMediaPicker (= 1.1)
   - wpxmlrpc (= 0.8.3)
@@ -204,7 +204,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
@@ -216,6 +215,9 @@ EXTERNAL SOURCES:
   WordPressKit:
     :commit: c2ae16bbc3fb759e0684fc9e5642d52390d00285
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+  WordPressShared:
+    :commit: 924689b554d6414050e743081b8fcd734aed4a4e
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -227,6 +229,9 @@ CHECKOUT OPTIONS:
   WordPressKit:
     :commit: c2ae16bbc3fb759e0684fc9e5642d52390d00285
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
+  WordPressShared:
+    :commit: 924689b554d6414050e743081b8fcd734aed4a4e
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -268,6 +273,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 51eab55af02e93883a5ec1a6718ee4ab024f81b9
+PODFILE CHECKSUM: 4a850f5712cfddddbdf29fb2d56a4bdcd444044b
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -312,6 +312,12 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatCreateSiteSetThemeFailed:
             eventName = @"create_site_set_theme_failed";
             break;
+        case WPAnalyticsStatDeepLinked:
+            eventName = @"deep_linked";
+            break;
+        case WPAnalyticsStatDeepLinkFailed:
+            eventName = @"deep_link_failed";
+            break;
         case WPAnalyticsStatEditorAddedPhotoViaLocalLibrary:
             eventName = @"editor_photo_added";
             eventProperties = @{ @"via" : @"local_library" };

--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -30,7 +30,9 @@ extension AppBannerRoute: NavigationAction {
         components.path = fragment
 
         if let url = components.url {
-            UniversalLinkRouter.shared.handle(url: url)
+            // We disable tracking when passing the URL back through the router,
+            // otherwise we'd be posting two stats events.
+            UniversalLinkRouter.shared.handle(url: url, shouldTrack: false)
         }
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -49,6 +49,7 @@ extension MySitesRoute: NavigationAction {
             coordinator.showMySites()
             postFailureNotice(title: NSLocalizedString("Site not found",
                                                        comment: "Error notice shown if the app can't find a specific site belonging to the user"))
+            WPAppAnalytics.track(.deepLinkFailed, withProperties: ["route": path])
             return
         }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -100,6 +100,7 @@ extension StatsRoute: NavigationAction {
         coordinator.showMySites()
         postFailureNotice(title: NSLocalizedString("Site not found",
                                                    comment: "Error notice shown if the app can't find a specific site belonging to the user"))
+        WPAppAnalytics.track(.deepLinkFailed, withProperties: ["route": path])
     }
 
     private func showStatsForDefaultBlog(from values: [String: String]?,

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -84,11 +84,21 @@ struct UniversalLinkRouter {
     /// Attempts to find a Route that matches the url's path, and perform its
     /// associated action.
     ///
-    func handle(url: URL) {
+    /// - parameter url: The URL to match against a route.
+    /// - parameter track: If false, don't post an analytics event for this URL.
+    ///
+    /// - returns: True if the route was handled, or false if it didn't match any routes.
+    ///
+    func handle(url: URL, shouldTrack track: Bool = true) {
         let matches = matcher.routesMatching(url)
 
         for matchedRoute in matches {
             matchedRoute.action.perform(matchedRoute.values)
+        }
+
+        if track && matches.count > 0 {
+            WPAppAnalytics.track(.deepLinked,
+                                 withProperties: ["url": url.absoluteString])
         }
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -92,13 +92,19 @@ struct UniversalLinkRouter {
     func handle(url: URL, shouldTrack track: Bool = true) {
         let matches = matcher.routesMatching(url)
 
+        if track {
+            trackDeepLink(matchCount: matches.count, url: url)
+        }
+
         for matchedRoute in matches {
             matchedRoute.action.perform(matchedRoute.values)
         }
+    }
 
-        if track && matches.count > 0 {
-            WPAppAnalytics.track(.deepLinked,
-                                 withProperties: ["url": url.absoluteString])
-        }
+    private func trackDeepLink(matchCount: Int, url: URL) {
+        let stat: WPAnalyticsStat = (matchCount > 0) ? .deepLinked : .deepLinkFailed
+        let properties = ["url": url.absoluteString]
+
+        WPAppAnalytics.track(stat, withProperties: properties)
     }
 }


### PR DESCRIPTION
Implements #9799.

This PR adds analytics events for universal links:

* `WPAnalyticsStatDeepLinked`
  * Matches the WPAndroid event used to track when a deep link is handled by the app. Triggered when a universal link is matched to a 'route' within the app.
* `WPAnalyticsStatDeepLinkFailed`
  * Used to track if a deep link is triggered for a specific site, but that site cannot be found within the app (this may occur if a user is logged into Safari with a different account to the app).

This PR relies on a [branch](https://github.com/wordpress-mobile/WordPress-iOS-Shared/tree/add/universal-links-stats) of WordPressShared, which should be merged before this PR is merged.

**To test**

* Build and run this PR to a device.
* Load this page in Safari, and tap the following links:
    * https://wordpress.com/notifications – should load notifications in the app, and you should see `🔵 Tracked: deep_linked` in the console.
    * https://wordpress.com/posts/mycoastaladventures.wordpress.com - should open the app to My Sites, but you should see a 'Site not found' notice and `🔵 Tracked: deep_link_failed` in the console.