### PR TITLE
Activity log plugin event navigates to plugin view.

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -9,7 +9,7 @@ protocol ContentCoordinator {
     func displayStreamWithSiteID(_ siteID: NSNumber?) throws
     func displayWebViewWithURL(_ url: URL)
     func displayFullscreenImage(_ image: UIImage)
-    func displayPlugin(withSlug pluginSlug: String, on siteSlug: String)
+    func displayPlugin(withSlug pluginSlug: String, on siteSlug: String) throws
 }
 
 
@@ -96,14 +96,20 @@ struct DefaultContentCoordinator: ContentCoordinator {
         controller?.present(imageViewController, animated: true, completion: nil)
     }
 
-    func displayPlugin(withSlug pluginSlug: String, on siteSlug: String) {
-        let service = BlogService(managedObjectContext: mainContext)
-        guard let blog = service.blog(byHostname: siteSlug), let jetpack = JetpackSiteRef(blog: blog) else {
-            return
+    func displayPlugin(withSlug pluginSlug: String, on siteSlug: String) throws {
+        guard let jetpack = jetpackSiteReff(with: siteSlug) else {
+            throw DisplayError.missingParameter
         }
-
         let pluginVC = PluginViewController(slug: pluginSlug, site: jetpack)
         controller?.navigationController?.pushViewController(pluginVC, animated: true)
+    }
+
+    private func jetpackSiteReff(with slug: String) -> JetpackSiteRef? {
+        let service = BlogService(managedObjectContext: mainContext)
+        guard let blog = service.blog(byHostname: slug), let jetpack = JetpackSiteRef(blog: blog) else {
+            return nil
+        }
+        return jetpack
     }
 
     private func blogWithBlogID(_ blogID: NSNumber?) -> Blog? {

--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -9,6 +9,7 @@ protocol ContentCoordinator {
     func displayStreamWithSiteID(_ siteID: NSNumber?) throws
     func displayWebViewWithURL(_ url: URL)
     func displayFullscreenImage(_ image: UIImage)
+    func displayPlugin(withSlug pluginSlug: String, on siteSlug: String)
 }
 
 
@@ -93,6 +94,16 @@ struct DefaultContentCoordinator: ContentCoordinator {
         imageViewController.modalTransitionStyle = .crossDissolve
         imageViewController.modalPresentationStyle = .fullScreen
         controller?.present(imageViewController, animated: true, completion: nil)
+    }
+
+    func displayPlugin(withSlug pluginSlug: String, on siteSlug: String) {
+        let service = BlogService(managedObjectContext: mainContext)
+        guard let blog = service.blog(byHostname: siteSlug), let jetpack = JetpackSiteRef(blog: blog) else {
+            return
+        }
+
+        let pluginVC = PluginViewController(slug: pluginSlug, site: jetpack)
+        controller?.navigationController?.pushViewController(pluginVC, animated: true)
     }
 
     private func blogWithBlogID(_ blogID: NSNumber?) -> Blog? {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -65,7 +65,7 @@ class ActivityListViewModel: Observable {
                                                  buttonText: NSLocalizedString("Contact support", comment: "Button label for contacting support"))
         } else {
             return NoResultsViewController.Model(title: NSLocalizedString("No connection", comment: "Title for the error view when there's no connection"),
-                                                 subtitle: NSLocalizedString("An active internet connection is required to view activities", comment: ""))
+                                                 subtitle: NSLocalizedString("An active internet connection is required to view activities", comment: "Error message when the user tries to visualize the acitiviy log list without internet connection"))
 
         }
     }

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
@@ -37,7 +37,7 @@ struct ActivityContentRouter: ContentRouter {
             }
             let siteSlug = pluginRange.siteSlug
             let pluginSlug = pluginRange.pluginSlug
-            coordinator.displayPlugin(withSlug: pluginSlug, on: siteSlug)
+            try? coordinator.displayPlugin(withSlug: pluginSlug, on: siteSlug)
         default:
             coordinator.displayWebViewWithURL(url)
         }

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
@@ -31,6 +31,13 @@ struct ActivityContentRouter: ContentRouter {
             let postID = commentRange.postID as NSNumber
             let siteID = commentRange.siteID as NSNumber
             try? coordinator.displayCommentsWithPostId(postID, siteID: siteID)
+        case .plugin:
+            guard let pluginRange = range as? ActivityPluginRange else {
+                fallthrough
+            }
+            let siteSlug = pluginRange.siteSlug
+            let pluginSlug = pluginRange.pluginSlug
+            coordinator.displayPlugin(withSlug: pluginSlug, on: siteSlug)
         default:
             coordinator.displayWebViewWithURL(url)
         }

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/Ranges/ActivityPluginRange.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/Ranges/ActivityPluginRange.swift
@@ -1,8 +1,21 @@
 
 class ActivityPluginRange: ActivityRange {
+    let siteSlug: String
+    let pluginSlug: String
+
     init(range: NSRange, pluginSlug: String, siteSlug: String) {
-        let url = ActivityPluginRange.urlWith(pluginSlug: pluginSlug, siteSlug: siteSlug)
-        super.init(kind: .plugin, range: range, url: url)
+        self.pluginSlug = pluginSlug
+        self.siteSlug = siteSlug
+
+        super.init(kind: .plugin, range: range, url: nil)
+    }
+
+    override var url: URL? {
+        return URL(string: urlString)
+    }
+
+    private var urlString: String {
+        return "https://wordpress.com/plugins/\(pluginSlug)/\(siteSlug)"
     }
 
     private static func urlWith(pluginSlug: String, siteSlug: String) -> URL? {

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
@@ -136,23 +136,34 @@ private extension PluginViewController {
     }
 
     func showNoResults(_ viewModel: NoResultsViewController.Model) {
-
-        if noResultsViewController == nil {
-            noResultsViewController = NoResultsViewController.controller()
-            noResultsViewController?.delegate = self
-        }
-
-        guard let noResultsViewController = noResultsViewController else {
-            return
-        }
+        let noResultsViewController = getNoResultsViewController()
 
         noResultsViewController.bindViewModel(viewModel)
 
-        if noResultsViewController.view.superview != tableView {
-            tableView.addSubview(withFadeAnimation: noResultsViewController.view)
+        addAsSubviewIfNeeded(noResultsViewController.view)
+        addChildController(noResultsViewController)
+    }
+
+    private func addAsSubviewIfNeeded(_ view: UIView) {
+        if view.superview != tableView {
+            tableView.addSubview(withFadeAnimation: view)
+        }
+    }
+
+    private func addChildController(_ controller: UIViewController) {
+        addChildViewController(controller)
+        controller.didMove(toParentViewController: self)
+    }
+
+    private func getNoResultsViewController() -> NoResultsViewController {
+        if let noResultsViewController = self.noResultsViewController {
+            return noResultsViewController
         }
 
-        addChildViewController(noResultsViewController)
-        noResultsViewController.didMove(toParentViewController: self)
+        let noResultsViewController = NoResultsViewController.controller()
+        noResultsViewController.delegate = self
+        self.noResultsViewController = noResultsViewController
+        
+        return noResultsViewController
     }
 }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
@@ -163,7 +163,7 @@ private extension PluginViewController {
         let noResultsViewController = NoResultsViewController.controller()
         noResultsViewController.delegate = self
         self.noResultsViewController = noResultsViewController
-        
+
         return noResultsViewController
     }
 }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
@@ -10,6 +10,8 @@ class PluginViewController: UITableViewController {
     }()
 
     fileprivate let viewModel: PluginViewModel
+    private var noResultsViewController: NoResultsViewController?
+
     var viewModelReceipt: Receipt?
 
     init(plugin: Plugin, capabilities: SitePluginCapabilities, site: JetpackSiteRef) {
@@ -84,6 +86,7 @@ class PluginViewController: UITableViewController {
     private func bindViewModel() {
         handler.viewModel = viewModel.tableViewModel
         title = viewModel.title
+        updateNoResults()
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -110,5 +113,37 @@ class PluginViewController: UITableViewController {
 
     private enum Constants {
         static var tableViewHeaderHeight: CGFloat = 17.5
+    }
+}
+
+// MARK: - NoResults Handling
+
+private extension PluginViewController {
+    func updateNoResults() {
+        noResultsViewController?.removeFromView()
+        if let noResultsViewModel = viewModel.noResultsViewModel() {
+            showNoResults(noResultsViewModel)
+        }
+    }
+
+    func showNoResults(_ viewModel: NoResultsViewController.Model) {
+
+        if noResultsViewController == nil {
+            noResultsViewController = NoResultsViewController.controller()
+//            noResultsViewController?.delegate = self
+        }
+
+        guard let noResultsViewController = noResultsViewController else {
+            return
+        }
+
+        noResultsViewController.bindViewModel(viewModel)
+
+        if noResultsViewController.view.superview != tableView {
+            tableView.addSubview(withFadeAnimation: noResultsViewController.view)
+        }
+
+        addChildViewController(noResultsViewController)
+        noResultsViewController.didMove(toParentViewController: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
@@ -24,6 +24,12 @@ class PluginViewController: UITableViewController {
         commonInit()
     }
 
+    init(slug: String, site: JetpackSiteRef) {
+        viewModel = PluginViewModel(slug: slug, site: site)
+        super.init(style: .grouped)
+        commonInit()
+    }
+
     private func commonInit() {
         viewModel.present = { [weak self] viewController in
             self?.present(viewController, animated: true)

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
@@ -116,6 +116,15 @@ class PluginViewController: UITableViewController {
     }
 }
 
+// MARK: - NoResultsViewControllerDelegate
+
+extension PluginViewController: NoResultsViewControllerDelegate {
+    func actionButtonPressed() {
+        let supportVC = SupportTableViewController()
+        supportVC.showFromTabBar()
+    }
+}
+
 // MARK: - NoResults Handling
 
 private extension PluginViewController {
@@ -130,7 +139,7 @@ private extension PluginViewController {
 
         if noResultsViewController == nil {
             noResultsViewController = NoResultsViewController.controller()
-//            noResultsViewController?.delegate = self
+            noResultsViewController?.delegate = self
         }
 
         guard let noResultsViewController = noResultsViewController else {

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -44,7 +44,7 @@ class PluginViewModel: Observable {
     }
 
     private let noResultsLoadingModel = NoResultsViewController.Model(title: String.Loading.title)
-    
+
     private let noResultsUnknownErrorModel = NoResultsViewController.Model(title: String.UnknownError.title,
                                                                            subtitle: String.UnknownError.description,
                                                                            buttonText: String.UnknownError.buttonTitle)
@@ -224,7 +224,7 @@ class PluginViewModel: Observable {
         if hasConnection {
             return noResultsUnknownErrorModel
         } else {
-            return noResultsConnectivityErrorModel
+            return noResultsUnknownErrorModel
         }
     }
 
@@ -568,18 +568,17 @@ class PluginViewModel: Observable {
 
 private extension String {
     enum UnknownError {
-        static let title = NSLocalizedString("Oops", comment: "Title for the view when there's an error loading Activity Log")
-        static let description = NSLocalizedString("There was an error loading activities", comment: "Text displayed when there is a failure loading the activity feed")
+        static let title = NSLocalizedString("Oops", comment: "Title for the view when there's an error loading the plugin")
+        static let description = NSLocalizedString("There was an error loading this plugin", comment: "Text displayed when there is a failure loading the plugin")
         static let buttonTitle = NSLocalizedString("Contact support", comment: "Button label for contacting support")
     }
 
     enum NoConnectionError {
         static let title = NSLocalizedString("No connection", comment: "Title for the error view when there's no connection")
-        static let description = NSLocalizedString("An active internet connection is required to view activities", comment: "")
+        static let description = NSLocalizedString("An active internet connection is required to view plugins", comment: "")
     }
 
     enum Loading {
         static let title = NSLocalizedString("Loading Plugin...", comment: "Text displayed while loading an specific plugin")
     }
-
 }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -224,7 +224,7 @@ class PluginViewModel: Observable {
         if hasConnection {
             return noResultsUnknownErrorModel
         } else {
-            return noResultsUnknownErrorModel
+            return noResultsConnectivityErrorModel
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -575,7 +575,7 @@ private extension String {
 
     enum NoConnectionError {
         static let title = NSLocalizedString("No connection", comment: "Title for the error view when there's no connection")
-        static let description = NSLocalizedString("An active internet connection is required to view plugins", comment: "")
+        static let description = NSLocalizedString("An active internet connection is required to view plugins", comment: "Error message when the user tries to visualize a plugin without internet connection")
     }
 
     enum Loading {

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -59,14 +59,12 @@ class PluginViewModel: Observable {
     var storeReceipt: Receipt?
     let changeDispatcher = Dispatcher<Void>()
     let queryReceipt: Receipt?
-    let store: PluginStore
 
     init(plugin: Plugin, capabilities: SitePluginCapabilities, site: JetpackSiteRef, store: PluginStore = StoreContainer.shared.plugin) {
         self.state = .plugin(plugin)
         self.capabilities = capabilities
         self.site = site
         self.isInstallingPlugin = false
-        self.store = store
 
         queryReceipt = nil
         storeReceipt = store.onChange { [weak self] in
@@ -104,7 +102,6 @@ class PluginViewModel: Observable {
         self.capabilities = store.getPlugins(site: site)?.capabilities
         self.site = site
         self.isInstallingPlugin = false
-        self.store = store
 
         queryReceipt = store.query(.directoryEntry(slug: slug))
 

--- a/WordPress/WordPressTest/ActivityLogRangesTest.swift
+++ b/WordPress/WordPressTest/ActivityLogRangesTest.swift
@@ -27,6 +27,14 @@ final class ActivityLogRangesTests: XCTestCase {
         XCTAssertEqual(pluginRange.url?.absoluteString, testData.testPluginUrl)
     }
 
+    func testPluginRangeSavesSlugs() {
+        let range = NSRange(location: 0, length: 0)
+        let pluginRange = ActivityPluginRange(range: range, pluginSlug: testData.testPluginSlug, siteSlug: testData.testSiteSlug)
+
+        XCTAssertEqual(pluginRange.pluginSlug, testData.testPluginSlug)
+        XCTAssertEqual(pluginRange.siteSlug, testData.testSiteSlug)
+    }
+
     func testDefaultRange() {
         let range = NSRange(location: 0, length: 0)
         let url = URL(string: testData.testPostUrl)!

--- a/WordPress/WordPressTest/MockContentCoordinator.swift
+++ b/WordPress/WordPressTest/MockContentCoordinator.swift
@@ -40,4 +40,8 @@ class MockContentCoordinator: ContentCoordinator {
     func displayFullscreenImage(_ image: UIImage) {
 
     }
+
+    func displayPlugin(withSlug pluginSlug: String, on siteSlug: String) throws {
+
+    }
 }

--- a/WordPressFlux/WordPressFlux/Sources/QueryStore.swift
+++ b/WordPressFlux/WordPressFlux/Sources/QueryStore.swift
@@ -58,30 +58,32 @@ open class QueryStore<State, Query>: StatefulStore<State>, Unsubscribable {
                 return inMemoryState
             }
 
-            // If we purged the in-memory `State` and the `Store` is being asked to do
-            // work again, let's try to reinitialise it from disk.
-            guard let codableInitialState = initialState as? Codable else {
-                // If it's not `Codable`, there's nothing we can do.
-                return initialState
-            }
+            return initialState
 
-            do {
-                let persistenceURL = try type(of: self).persistenceURL()
-
-                if let persistedState = try type(of: codableInitialState).loadJSON(from: persistenceURL) as? State {
-                    // When reading from disk has succeeded, set the result as `inMemoryState` and return it.
-                    inMemoryState = persistedState
-                    return persistedState
-                } else {
-                    // If there isn't a state for us to read from disk, but there wasn't any error thrown,
-                    // let's just return the initial state too.
-                    return initialState
-                }
-            } catch {
-                // If reading persisted state fails, let's just fail over to `initialState`.
-                logError("[\(type(of: self)) Error] \(error)")
-                return initialState
-            }
+//            // If we purged the in-memory `State` and the `Store` is being asked to do
+//            // work again, let's try to reinitialise it from disk.
+//            guard let codableInitialState = initialState as? Codable else {
+//                // If it's not `Codable`, there's nothing we can do.
+//                return initialState
+//            }
+//
+//            do {
+//                let persistenceURL = try type(of: self).persistenceURL()
+//
+//                if let persistedState = try type(of: codableInitialState).loadJSON(from: persistenceURL) as? State {
+//                    // When reading from disk has succeeded, set the result as `inMemoryState` and return it.
+//                    inMemoryState = persistedState
+//                    return persistedState
+//                } else {
+//                    // If there isn't a state for us to read from disk, but there wasn't any error thrown,
+//                    // let's just return the initial state too.
+//                    return initialState
+//                }
+//            } catch {
+//                // If reading persisted state fails, let's just fail over to `initialState`.
+//                logError("[\(type(of: self)) Error] \(error)")
+//                return initialState
+//            }
         }
         set {
             inMemoryState = newValue


### PR DESCRIPTION
Fixes #9836 

As part of #9748, this PR adds a route to an specific plugin from an activity log event:

![activity_log_navigation](https://user-images.githubusercontent.com/9772967/43111432-3c891d76-8ebf-11e8-9a91-be91b2b28d57.gif)

**Note**:
The challenge was to adapt `PluginViewController` to be presented from other than the Plugins section, since it was prepared to accept a preloaded data fetched in the plugin list.

Now the `PluginViewController` can be loaded with just a plugin `slug` and it will fetch and display that plugin.

Since now it is loading without having any pre-fetched data, it was necessary to add a `loading` state, and since loadings can fail, also an `error` state.

Those new states are handled visually by `NoResultViewController` in the same way that it's handled in the activity log list.

![loading_plugin](https://user-images.githubusercontent.com/9772967/43111775-a9016174-8ec0-11e8-80d7-bb96b3e21a75.gif)

The possible errors look like this:
![errors](https://user-images.githubusercontent.com/9772967/43111961-b08e2002-8ec1-11e8-92d4-50955507c207.png)

**To test:**
1. Generate a plugin related event (activating, deactivating, or updating a plugin does the trick)
2. Open the plugin related event on the activity log.
3. Tap on the name of the plugin highlighted as a link.
4. **Check that it opens the plugin.**

To test the error messages the easiest way is to hack the world! (A trick I learned from @ScoutHarris )

- Go to `PluginViewModel.swift: 207`.
- On the `noResultsViewModel()` function, add an early return on line `208`:
`return noResultsConnectivityErrorModel`.
- **Check that the NoResultsView show with the connectivity message.**

- Change the return statement to `return noResultsUnknownErrorModel`.
- **Check that the NoResultsView show with the Unknown error message.**
- **Check that the action button open the help center.**

**Important**
- **Check that the plugin section works exactly as before, with and without internet connection.**

@nozomimimi - Could you please check out the error views/messages? Thank you!