### PR TITLE
Quick Start: add checklist

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -494,7 +494,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     if ([Feature enabled:FeatureFlagQuickStart]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Quick Start", @"Name of the Quick Start feature that guides users through a few tasks to setup their new website.")
-                                                        image:[Gridicon iconOfType:GridiconTypeStatsAlt]
+                                                        image:[Gridicon iconOfType:GridiconTypeListCheckmark]
                                                      callback:^{
                                                          [weakSelf startTour];
                                                      }]];
@@ -1179,13 +1179,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     QuickStartChecklistView *checklist = [[QuickStartChecklistView alloc] init];
     [self.navigationController pushViewController:checklist animated:YES];
-
-
-//    UIViewController *blogNC = self.navigationController;
-//    if ([blogNC isKindOfClass:[ManyDelegateNavigationController class]]) {
-//        QuickStartTourGuide *tourGuide = ((ManyDelegateNavigationController *) blogNC).tourGuide;
-//        [tourGuide showTestQuickStartNotice];
-//    }
 }
 
 - (void)showActivity

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1177,6 +1177,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [tourGuide showTestQuickStartNotice];
     }
 
+    QuickStartChecklistView *checklist = [[QuickStartChecklistView alloc] init];
+    [self.navigationController pushViewController:checklist animated:YES];
+
+
 //    UIViewController *blogNC = self.navigationController;
 //    if ([blogNC isKindOfClass:[ManyDelegateNavigationController class]]) {
 //        QuickStartTourGuide *tourGuide = ((ManyDelegateNavigationController *) blogNC).tourGuide;

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
@@ -1,0 +1,5 @@
+class QuickStartChecklistCell: UITableViewCell {
+    @IBOutlet var titleLabel: UILabel?
+    @IBOutlet var descriptionLabel: UILabel?
+    @IBOutlet var iconView: UIImageView?
+}

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
@@ -7,7 +7,7 @@ class QuickStartChecklistCell: UITableViewCell {
         didSet {
             titleLabel?.text = tour?.title
             descriptionLabel?.text = tour?.description
-            iconView?.image = tour?.icon
+            iconView?.image = tour?.icon.imageWithTintColor(WPStyleGuide.greyLighten10())
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
@@ -8,6 +8,7 @@ class QuickStartChecklistCell: UITableViewCell {
             titleLabel?.text = tour?.title
             descriptionLabel?.text = tour?.description
             iconView?.image = tour?.icon.imageWithTintColor(WPStyleGuide.greyLighten10())
+            accessoryType = .disclosureIndicator
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
@@ -2,4 +2,14 @@ class QuickStartChecklistCell: UITableViewCell {
     @IBOutlet var titleLabel: UILabel?
     @IBOutlet var descriptionLabel: UILabel?
     @IBOutlet var iconView: UIImageView?
+
+    public var tour: QuickStartTour? {
+        didSet {
+            titleLabel?.text = tour?.title
+            descriptionLabel?.text = tour?.description
+            iconView?.image = tour?.icon
+        }
+    }
+
+    static let reuseIdentifier = "QuickStartChecklistCell"
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.xib
@@ -30,8 +30,8 @@
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="SR9-Tv-UFi"/>
                         </constraints>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                        <nil key="textColor"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                        <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cuP-SF-wj2">

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.xib
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="106" id="AyJ-E5-JK1" customClass="QuickStartChecklistCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="106"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AyJ-E5-JK1" id="fK0-aP-tbW">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="105.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Yvc-lh-rUl">
+                        <rect key="frame" x="26" y="14" width="24" height="24"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="24" id="HAq-BL-gGI"/>
+                            <constraint firstAttribute="width" constant="24" id="bUQ-qI-IP2"/>
+                        </constraints>
+                    </imageView>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5f3-X4-wWJ">
+                        <rect key="frame" x="72" y="16" width="257" height="21"/>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="21" id="SR9-Tv-UFi"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cuP-SF-wj2">
+                        <rect key="frame" x="72" y="41" width="257" height="18"/>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="18" id="lEg-z3-K9b"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                        <color key="textColor" red="0.40000000000000002" green="0.55686274509803924" blue="0.66666666666666663" alpha="1" colorSpace="calibratedRGB"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="5f3-X4-wWJ" firstAttribute="top" secondItem="fK0-aP-tbW" secondAttribute="top" constant="16" id="1fh-Z6-jax"/>
+                    <constraint firstAttribute="trailing" secondItem="cuP-SF-wj2" secondAttribute="trailing" constant="46" id="EkB-9E-RZr"/>
+                    <constraint firstItem="cuP-SF-wj2" firstAttribute="top" secondItem="5f3-X4-wWJ" secondAttribute="bottom" constant="4" id="Rvm-ei-SOB"/>
+                    <constraint firstItem="5f3-X4-wWJ" firstAttribute="leading" secondItem="fK0-aP-tbW" secondAttribute="leading" constant="72" id="TAn-xf-ehs"/>
+                    <constraint firstItem="cuP-SF-wj2" firstAttribute="leading" secondItem="fK0-aP-tbW" secondAttribute="leading" constant="72" id="hgg-zP-NRN"/>
+                    <constraint firstItem="Yvc-lh-rUl" firstAttribute="leading" secondItem="fK0-aP-tbW" secondAttribute="leading" constant="26" id="nl4-xF-75s"/>
+                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="cuP-SF-wj2" secondAttribute="bottom" constant="16" id="rKf-3h-SNi"/>
+                    <constraint firstAttribute="trailing" secondItem="5f3-X4-wWJ" secondAttribute="trailing" constant="46" id="xmV-9M-wWV"/>
+                    <constraint firstItem="Yvc-lh-rUl" firstAttribute="top" secondItem="fK0-aP-tbW" secondAttribute="top" constant="14" id="zCC-Cf-aVE"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="descriptionLabel" destination="cuP-SF-wj2" id="pat-g8-4be"/>
+                <outlet property="iconView" destination="Yvc-lh-rUl" id="gVa-Vf-obo"/>
+                <outlet property="titleLabel" destination="5f3-X4-wWJ" id="jdQ-2B-dXh"/>
+            </connections>
+            <point key="canvasLocation" x="-156.5" y="-20"/>
+        </tableViewCell>
+        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UuR-wD-UfE">
+            <rect key="frame" x="0.0" y="0.0" width="42" height="21"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+            <nil key="textColor"/>
+            <nil key="highlightedColor"/>
+        </label>
+    </objects>
+</document>

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.xib
@@ -63,12 +63,5 @@
             </connections>
             <point key="canvasLocation" x="-156.5" y="-20"/>
         </tableViewCell>
-        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="UuR-wD-UfE">
-            <rect key="frame" x="0.0" y="0.0" width="42" height="21"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-            <nil key="textColor"/>
-            <nil key="highlightedColor"/>
-        </label>
     </objects>
 </document>

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistView.swift
@@ -1,0 +1,28 @@
+class QuickStartChecklistView: UITableViewController {
+    private let dataSource = QuickStartChecklistDataSource()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let tableView = UITableView(frame: .zero)
+        tableView.dataSource = dataSource
+        self.tableView = tableView
+        
+        let cellNib = UINib(nibName: "QuickStartChecklistCell", bundle: Bundle(for: QuickStartChecklistCell.self))
+        tableView.register(cellNib, forCellReuseIdentifier: QuickStartChecklistCell.reuseIdentifier)
+    }
+}
+
+private class QuickStartChecklistDataSource: NSObject, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return QuickStartTourGuide.checklistTours.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if let cell = tableView.dequeueReusableCell(withIdentifier: QuickStartChecklistCell.reuseIdentifier) as? QuickStartChecklistCell {
+            cell.tour = QuickStartTourGuide.checklistTours[indexPath.row]
+            return cell
+        }
+        return UITableViewCell()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistView.swift
@@ -7,7 +7,7 @@ class QuickStartChecklistView: UITableViewController {
         let tableView = UITableView(frame: .zero)
         tableView.dataSource = dataSource
         self.tableView = tableView
-        
+
         let cellNib = UINib(nibName: "QuickStartChecklistCell", bundle: Bundle(for: QuickStartChecklistCell.self))
         tableView.register(cellNib, forCellReuseIdentifier: QuickStartChecklistCell.reuseIdentifier)
     }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -30,4 +30,14 @@ open class QuickStartTourGuide: NSObject, UINavigationControllerDelegate {
 
         presenter.dismissCurrentNotice()
     }
+
+    static let checklistTours: [QuickStartTour] = [
+        QuickStartCreateTour(),
+        QuickStartViewTour(),
+        QuickStartThemeTour(),
+        QuickStartCustomizeTour(),
+        QuickStartShareTour(),
+        QuickStartPublishTour(),
+        QuickStartFollowTour()
+    ]
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -1,0 +1,57 @@
+import Gridicons
+
+protocol QuickStartTour {
+    var key: String { get }
+    var title: String { get }
+    var description: String { get }
+    var icon: UIImage { get }
+}
+
+struct QuickStartCreateTour: QuickStartTour {
+    let key = "quick-start-create-tour"
+    let title = NSLocalizedString("Create your site", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("Get your site up and running", comment: "Description of a Quick Start Tour")
+    let icon = Gridicon.iconOfType(.globe)
+}
+
+struct QuickStartViewTour: QuickStartTour {
+    let key = "quick-start-view-tour"
+    let title = NSLocalizedString("View your site", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("Preview your new site to see what your visitors will see.", comment: "Description of a Quick Start Tour")
+    let icon = Gridicon.iconOfType(.globe)
+}
+
+struct QuickStartThemeTour: QuickStartTour {
+    let key = "quick-start-theme-tour"
+    let title = NSLocalizedString("Choose a theme", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("Browse all our themes to find your perfect fit.", comment: "Description of a Quick Start Tour")
+    let icon = Gridicon.iconOfType(.themes)
+}
+
+struct QuickStartCustomizeTour: QuickStartTour {
+    let key = "quick-start-customize-tour"
+    let title = NSLocalizedString("Customize your site", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("Change colors, fonts, and images for a perfectly personalized site.", comment: "Description of a Quick Start Tour")
+    let icon = Gridicon.iconOfType(.themes)
+}
+
+struct QuickStartShareTour: QuickStartTour {
+    let key = "quick-start-share-tour"
+    let title = NSLocalizedString("Share your site", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("Connect to your social media accounts -- your site will automatically share new posts.", comment: "Description of a Quick Start Tour")
+    let icon = Gridicon.iconOfType(.share)
+}
+
+struct QuickStartPublishTour: QuickStartTour {
+    let key = "quick-start-publish-tour"
+    let title = NSLocalizedString("Publish a post", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("It's time! Draft and publish your very first post.", comment: "Description of a Quick Start Tour")
+    let icon = Gridicon.iconOfType(.create)
+}
+
+struct QuickStartFollowTour: QuickStartTour {
+    let key = "quick-start-follow-tour"
+    let title = NSLocalizedString("Follow other sites", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("Find sites that speak to you, and follow them to get updates when they publish.", comment: "Description of a Quick Start Tour")
+    let icon = Gridicon.iconOfType(.reader)
+}

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -11,14 +11,14 @@ struct QuickStartCreateTour: QuickStartTour {
     let key = "quick-start-create-tour"
     let title = NSLocalizedString("Create your site", comment: "Title of a Quick Start Tour")
     let description = NSLocalizedString("Get your site up and running", comment: "Description of a Quick Start Tour")
-    let icon = Gridicon.iconOfType(.globe)
+    let icon = Gridicon.iconOfType(.plus)
 }
 
 struct QuickStartViewTour: QuickStartTour {
     let key = "quick-start-view-tour"
     let title = NSLocalizedString("View your site", comment: "Title of a Quick Start Tour")
     let description = NSLocalizedString("Preview your new site to see what your visitors will see.", comment: "Description of a Quick Start Tour")
-    let icon = Gridicon.iconOfType(.globe)
+    let icon = Gridicon.iconOfType(.external)
 }
 
 struct QuickStartThemeTour: QuickStartTour {
@@ -32,7 +32,7 @@ struct QuickStartCustomizeTour: QuickStartTour {
     let key = "quick-start-customize-tour"
     let title = NSLocalizedString("Customize your site", comment: "Title of a Quick Start Tour")
     let description = NSLocalizedString("Change colors, fonts, and images for a perfectly personalized site.", comment: "Description of a Quick Start Tour")
-    let icon = Gridicon.iconOfType(.themes)
+    let icon = Gridicon.iconOfType(.customize)
 }
 
 struct QuickStartShareTour: QuickStartTour {
@@ -53,5 +53,5 @@ struct QuickStartFollowTour: QuickStartTour {
     let key = "quick-start-follow-tour"
     let title = NSLocalizedString("Follow other sites", comment: "Title of a Quick Start Tour")
     let description = NSLocalizedString("Find sites that speak to you, and follow them to get updates when they publish.", comment: "Description of a Quick Start Tour")
-    let icon = Gridicon.iconOfType(.reader)
+    let icon = Gridicon.iconOfType(.readerFollow)
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -246,6 +246,7 @@
 		437542E31DD4E19E00D6B727 /* EditPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 437542E21DD4E19E00D6B727 /* EditPostViewController.swift */; };
 		4388FEFE20A4E0B900783948 /* NotificationsViewController+AppRatings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4388FEFD20A4E0B900783948 /* NotificationsViewController+AppRatings.swift */; };
 		4388FF0020A4E19C00783948 /* NotificationsViewController+PushPrimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4388FEFF20A4E19C00783948 /* NotificationsViewController+PushPrimer.swift */; };
+		4395A1592106389800844E8E /* QuickStartTours.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4395A1582106389800844E8E /* QuickStartTours.swift */; };
 		43AB7C5E1D3E70510066CB6A /* PostListFilterSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */; };
 		43D54D131DCAA070007F575F /* PostPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D54D121DCAA070007F575F /* PostPostViewController.swift */; };
 		43DC0EF12040B23200896C9C /* SignupUsernameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DC0EF02040B23200896C9C /* SignupUsernameViewController.swift */; };
@@ -1613,6 +1614,7 @@
 		437542E21DD4E19E00D6B727 /* EditPostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditPostViewController.swift; sourceTree = "<group>"; };
 		4388FEFD20A4E0B900783948 /* NotificationsViewController+AppRatings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsViewController+AppRatings.swift"; sourceTree = "<group>"; };
 		4388FEFF20A4E19C00783948 /* NotificationsViewController+PushPrimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsViewController+PushPrimer.swift"; sourceTree = "<group>"; };
+		4395A1582106389800844E8E /* QuickStartTours.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartTours.swift; sourceTree = "<group>"; };
 		43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostListFilterSettings.swift; sourceTree = "<group>"; };
 		43D54D121DCAA070007F575F /* PostPostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostPostViewController.swift; sourceTree = "<group>"; };
 		43DC0EF02040B23200896C9C /* SignupUsernameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupUsernameViewController.swift; sourceTree = "<group>"; };
@@ -4721,6 +4723,7 @@
 				433A550120F693A100757928 /* ManyDelegateNavigationController.swift */,
 				4348C88221002FBD00735DC0 /* QuickStartTourGuide.swift */,
 				433A550320F6AC5600757928 /* QuickStartNoticeView.swift */,
+				4395A1582106389800844E8E /* QuickStartTours.swift */,
 			);
 			path = Blog;
 			sourceTree = "<group>";
@@ -7137,6 +7140,7 @@
 				74FA4BE51FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */,
 				986CC4D220E1B2F6004F300E /* CustomLogFormatter.swift in Sources */,
 				433432521E9ED18900915988 /* LoginEpilogueViewController.swift in Sources */,
+				4395A1592106389800844E8E /* QuickStartTours.swift in Sources */,
 				E1DD4CCB1CAE41B800C3863E /* PagedViewController.swift in Sources */,
 				B549BA681CF7447E0086C608 /* InvitePersonViewController.swift in Sources */,
 				B535209B1AF7BBB800B33BA8 /* PushAuthenticationManager.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -247,6 +247,8 @@
 		4388FEFE20A4E0B900783948 /* NotificationsViewController+AppRatings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4388FEFD20A4E0B900783948 /* NotificationsViewController+AppRatings.swift */; };
 		4388FF0020A4E19C00783948 /* NotificationsViewController+PushPrimer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4388FEFF20A4E19C00783948 /* NotificationsViewController+PushPrimer.swift */; };
 		4395A1592106389800844E8E /* QuickStartTours.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4395A1582106389800844E8E /* QuickStartTours.swift */; };
+		4395A15B21066DCD00844E8E /* QuickStartChecklistCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4395A15A21066DCD00844E8E /* QuickStartChecklistCell.xib */; };
+		4395A15D2106718900844E8E /* QuickStartChecklistCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4395A15C2106718900844E8E /* QuickStartChecklistCell.swift */; };
 		43AB7C5E1D3E70510066CB6A /* PostListFilterSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */; };
 		43D54D131DCAA070007F575F /* PostPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D54D121DCAA070007F575F /* PostPostViewController.swift */; };
 		43DC0EF12040B23200896C9C /* SignupUsernameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DC0EF02040B23200896C9C /* SignupUsernameViewController.swift */; };
@@ -1615,6 +1617,8 @@
 		4388FEFD20A4E0B900783948 /* NotificationsViewController+AppRatings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsViewController+AppRatings.swift"; sourceTree = "<group>"; };
 		4388FEFF20A4E19C00783948 /* NotificationsViewController+PushPrimer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NotificationsViewController+PushPrimer.swift"; sourceTree = "<group>"; };
 		4395A1582106389800844E8E /* QuickStartTours.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartTours.swift; sourceTree = "<group>"; };
+		4395A15A21066DCD00844E8E /* QuickStartChecklistCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuickStartChecklistCell.xib; sourceTree = "<group>"; };
+		4395A15C2106718900844E8E /* QuickStartChecklistCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartChecklistCell.swift; sourceTree = "<group>"; };
 		43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostListFilterSettings.swift; sourceTree = "<group>"; };
 		43D54D121DCAA070007F575F /* PostPostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostPostViewController.swift; sourceTree = "<group>"; };
 		43DC0EF02040B23200896C9C /* SignupUsernameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupUsernameViewController.swift; sourceTree = "<group>"; };
@@ -4724,6 +4728,8 @@
 				4348C88221002FBD00735DC0 /* QuickStartTourGuide.swift */,
 				433A550320F6AC5600757928 /* QuickStartNoticeView.swift */,
 				4395A1582106389800844E8E /* QuickStartTours.swift */,
+				4395A15A21066DCD00844E8E /* QuickStartChecklistCell.xib */,
+				4395A15C2106718900844E8E /* QuickStartChecklistCell.swift */,
 			);
 			path = Blog;
 			sourceTree = "<group>";
@@ -6596,6 +6602,7 @@
 				85ED988817DFA00000090D0B /* Images.xcassets in Resources */,
 				E149771A1C0DCB6F0057CD60 /* MediaSizeSliderCell.xib in Resources */,
 				E65219F91B8D10C2000B1217 /* ReaderBlockedSiteCell.xib in Resources */,
+				4395A15B21066DCD00844E8E /* QuickStartChecklistCell.xib in Resources */,
 				E6D2E15F1B8A9C830000ED14 /* ReaderSiteStreamHeader.xib in Resources */,
 				B5C66B7A1ACF074600F68370 /* NoteBlockUserTableViewCell.xib in Resources */,
 				E6D2E1631B8AAA340000ED14 /* ReaderListStreamHeader.xib in Resources */,
@@ -7629,6 +7636,7 @@
 				FF0A4FEA1F16C9BD00D6CC69 /* ImageAttachment+WordPress.swift in Sources */,
 				B5B68BD41C19AAED00EB59E0 /* InteractiveNotificationsManager.swift in Sources */,
 				B54E1DF01A0A7BAA00807537 /* ReplyBezierView.swift in Sources */,
+				4395A15D2106718900844E8E /* QuickStartChecklistCell.swift in Sources */,
 				8261B4CC1EA8E13700668298 /* SVProgressHUD+Dismiss.m in Sources */,
 				596C035E1B84F21D00899EEB /* ThemeBrowserViewController.swift in Sources */,
 				E2E7EB46185FB140004F5E72 /* WPBlogSelectorButton.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		4395A15B21066DCD00844E8E /* QuickStartChecklistCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4395A15A21066DCD00844E8E /* QuickStartChecklistCell.xib */; };
 		4395A15D2106718900844E8E /* QuickStartChecklistCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4395A15C2106718900844E8E /* QuickStartChecklistCell.swift */; };
 		43AB7C5E1D3E70510066CB6A /* PostListFilterSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */; };
+		43C9908E21067E22009EFFEB /* QuickStartChecklistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C9908D21067E22009EFFEB /* QuickStartChecklistView.swift */; };
 		43D54D131DCAA070007F575F /* PostPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D54D121DCAA070007F575F /* PostPostViewController.swift */; };
 		43DC0EF12040B23200896C9C /* SignupUsernameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DC0EF02040B23200896C9C /* SignupUsernameViewController.swift */; };
 		43FB3F411EBD215C00FC8A62 /* LoginEpilogueBlogCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43FB3F401EBD215C00FC8A62 /* LoginEpilogueBlogCell.swift */; };
@@ -1620,6 +1621,7 @@
 		4395A15A21066DCD00844E8E /* QuickStartChecklistCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuickStartChecklistCell.xib; sourceTree = "<group>"; };
 		4395A15C2106718900844E8E /* QuickStartChecklistCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartChecklistCell.swift; sourceTree = "<group>"; };
 		43AB7C5D1D3E70510066CB6A /* PostListFilterSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostListFilterSettings.swift; sourceTree = "<group>"; };
+		43C9908D21067E22009EFFEB /* QuickStartChecklistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartChecklistView.swift; sourceTree = "<group>"; };
 		43D54D121DCAA070007F575F /* PostPostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostPostViewController.swift; sourceTree = "<group>"; };
 		43DC0EF02040B23200896C9C /* SignupUsernameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupUsernameViewController.swift; sourceTree = "<group>"; };
 		43FB3F401EBD215C00FC8A62 /* LoginEpilogueBlogCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEpilogueBlogCell.swift; sourceTree = "<group>"; };
@@ -3648,6 +3650,19 @@
 			path = Animations;
 			sourceTree = "<group>";
 		};
+		4395A15E210672C900844E8E /* QuickStart */ = {
+			isa = PBXGroup;
+			children = (
+				4348C88221002FBD00735DC0 /* QuickStartTourGuide.swift */,
+				433A550320F6AC5600757928 /* QuickStartNoticeView.swift */,
+				4395A1582106389800844E8E /* QuickStartTours.swift */,
+				4395A15A21066DCD00844E8E /* QuickStartChecklistCell.xib */,
+				4395A15C2106718900844E8E /* QuickStartChecklistCell.swift */,
+				43C9908D21067E22009EFFEB /* QuickStartChecklistView.swift */,
+			);
+			name = QuickStart;
+			sourceTree = "<group>";
+		};
 		45C73C23113C36F50024D0D2 /* Resources-iPad */ = {
 			isa = PBXGroup;
 			children = (
@@ -4725,11 +4740,7 @@
 				FF1933FE1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m */,
 				82B85DF81EDDB807004FD510 /* SiteIconPickerPresenter.swift */,
 				433A550120F693A100757928 /* ManyDelegateNavigationController.swift */,
-				4348C88221002FBD00735DC0 /* QuickStartTourGuide.swift */,
-				433A550320F6AC5600757928 /* QuickStartNoticeView.swift */,
-				4395A1582106389800844E8E /* QuickStartTours.swift */,
-				4395A15A21066DCD00844E8E /* QuickStartChecklistCell.xib */,
-				4395A15C2106718900844E8E /* QuickStartChecklistCell.swift */,
+				4395A15E210672C900844E8E /* QuickStart */,
 			);
 			path = Blog;
 			sourceTree = "<group>";
@@ -7750,6 +7761,7 @@
 				B518E1651CCAA19200ADFE75 /* Blog+Capabilities.swift in Sources */,
 				982BED9A1FBCF976000B848E /* SiteCreationNavigationController.swift in Sources */,
 				08216FC91CDBF96000304BA7 /* MenuItemCategoriesViewController.m in Sources */,
+				43C9908E21067E22009EFFEB /* QuickStartChecklistView.swift in Sources */,
 				082635BB1CEA69280088030C /* MenuItemsViewController.m in Sources */,
 				822876F11E929CFD00696BF7 /* ReachabilityUtils+OnlineActions.swift in Sources */,
 				E15632CC1EB9ECF40035A099 /* TableViewKeyboardObserver.swift in Sources */,


### PR DESCRIPTION
Refs #9447 

This PR adds the Quick Start checklist with all seven items.

![simulator screen shot - iphone x - 2018-07-24 at 09 30 38](https://user-images.githubusercontent.com/517257/43149890-d5c236a6-8f25-11e8-89bc-39cd247f344a.png)

Note that the tours don't work, there is no associated data storage to track progress, and that currently all sites will see the menu in developer builds. These will be addressed in future PRs.

To test:
- build the app
- view a blog's details, tap Quick Start
