### PR TITLE
Notification detail routing using FormattableContentGroups

### DIFF
--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -177,6 +177,24 @@ class Notification: NSManagedObject {
 
         return nil
     }
+
+    /// Attempts to find the Notification Range associated with a given URL.
+    ///
+    func contentRange(with url: URL) -> FormattableContentRange? {
+        var groups = bodyContentGroups
+        if let headerBlockGroup = headerContentGroup {
+            groups.append(headerBlockGroup)
+        }
+
+        let blocks = groups.flatMap { $0.blocks }
+        for block in blocks {
+            if let range = block.range(with: url) {
+                return range
+            }
+        }
+
+        return nil
+    }
 }
 
 // MARK: - Notification Computed Properties

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentRouter.swift
@@ -4,7 +4,7 @@ struct ActivityContentRouter: ContentRouter {
     private let activity: FormattableActivity
 
     init(activity: FormattableActivity, coordinator: ContentCoordinator) {
-        self.coordinator = coordinator// ContentCoordinator(controller: controller, context: context)
+        self.coordinator = coordinator
         self.activity = activity
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
@@ -1,0 +1,45 @@
+
+struct NotificationContentRouter {
+    private let coordinator: ContentCoordinator
+    private let notification: Notification
+    private let expirationFiveMinutes = TimeInterval(60 * 5)
+
+    init(activity: Notification, coordinator: ContentCoordinator) {
+        self.coordinator = coordinator
+        self.notification = activity
+    }
+
+    func routeTo(_ url: URL) throws {
+        guard let range = getRange(with: url) else {
+            return
+        }
+        try displayContent(of: range, with: url)
+    }
+
+    private func displayContent(of range: FormattableContentRange, with url: URL) throws {
+        guard let range = range as? NotificationContentRange else {
+            throw DefaultContentCoordinator.DisplayError.missingParameter
+        }
+
+        switch range.kind {
+        case .site:
+            try coordinator.displayStreamWithSiteID(range.siteID)
+        case .post:
+            try coordinator.displayReaderWithPostId(range.postID, siteID: range.siteID)
+        case .comment:
+            try coordinator.displayCommentsWithPostId(range.postID, siteID: range.siteID)
+        case .stats:
+            try coordinator.displayStatsWithSiteID(range.siteID)
+        case .follow:
+            try coordinator.displayFollowersWithSiteID(range.siteID, expirationTime: expirationFiveMinutes)
+        case .user:
+            try coordinator.displayStreamWithSiteID(range.siteID)
+        default:
+            throw DefaultContentCoordinator.DisplayError.unsupportedType
+        }
+    }
+
+    private func getRange(with url: URL) -> FormattableContentRange? {
+        return notification.contentRange(with: url)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Groups/BodyContentGroup.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Groups/BodyContentGroup.swift
@@ -20,7 +20,8 @@ class BodyContentGroup: FormattableContentGroup {
             if isFooter {
                 return FooterContentGroup(blocks: [block])
             }
-            return FormattableContentGroup(blocks: [block], kind: .text)
+
+            return FormattableContentGroup(blocks: [block], kind: Kind(block.kind.rawValue))
         }
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -543,6 +543,8 @@
 		7E846FF120FD0A0500881F5A /* ContentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */; };
 		7E846FF320FD37BD00881F5A /* ActivityCommentRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */; };
 		7E987F562108017B00CAFB88 /* NotificationContentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */; };
+		7E987F58210811CC00CAFB88 /* NotificationContentRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E987F57210811CC00CAFB88 /* NotificationContentRouterTests.swift */; };
+		7E987F5A2108122A00CAFB88 /* NotificationUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E987F592108122A00CAFB88 /* NotificationUtility.swift */; };
 		7EAD7CD0206D761200BEDCFD /* MediaExternalExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */; };
 		7EB5824720EC41B200002702 /* NotificationContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB5824620EC41B200002702 /* NotificationContentFactory.swift */; };
 		7EBB4126206C388100012D98 /* StockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBB4125206C388100012D98 /* StockPhotosService.swift */; };
@@ -2062,6 +2064,8 @@
 		7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCoordinator.swift; sourceTree = "<group>"; };
 		7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityCommentRange.swift; sourceTree = "<group>"; };
 		7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentRouter.swift; sourceTree = "<group>"; };
+		7E987F57210811CC00CAFB88 /* NotificationContentRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentRouterTests.swift; sourceTree = "<group>"; };
+		7E987F592108122A00CAFB88 /* NotificationUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationUtility.swift; sourceTree = "<group>"; };
 		7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExternalExporter.swift; sourceTree = "<group>"; };
 		7EB5824620EC41B200002702 /* NotificationContentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentFactory.swift; sourceTree = "<group>"; };
 		7EBB4125206C388100012D98 /* StockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosService.swift; sourceTree = "<group>"; };
@@ -5202,6 +5206,7 @@
 		B5416CF81C17542900006DD8 /* Notifications */ = {
 			isa = PBXGroup;
 			children = (
+				7E987F57210811CC00CAFB88 /* NotificationContentRouterTests.swift */,
 				D821C81C21004724002ED995 /* NotificationBlockTests.swift */,
 				D821C81A21003AE9002ED995 /* FormattableContentGroupTests.swift */,
 				D821C816210036D9002ED995 /* ActivityContentFactoryTests.swift */,
@@ -5224,6 +5229,7 @@
 				85B125401B028E34008A3D95 /* PushAuthenticationManagerTests.swift */,
 				85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */,
 				B5416CFD1C1756B900006DD8 /* PushNotificationsManagerTests.m */,
+				7E987F592108122A00CAFB88 /* NotificationUtility.swift */,
 			);
 			name = Notifications;
 			sourceTree = "<group>";
@@ -8438,6 +8444,7 @@
 				FF7C89A31E3A1029000472A8 /* MediaLibraryPickerDataSourceTests.swift in Sources */,
 				D81C2F5E20F88CE5002AE1F1 /* MarkAsSpamActionTests.swift in Sources */,
 				D848CC1520FF33FC00A9038F /* NotificationContentRangeTests.swift in Sources */,
+				7E987F58210811CC00CAFB88 /* NotificationContentRouterTests.swift in Sources */,
 				E1C9AA561C10427100732665 /* MathTest.swift in Sources */,
 				93A379EC19FFBF7900415023 /* KeychainTest.m in Sources */,
 				D800D874209997DB00E7C7E5 /* FollowingMenuItemCreatorTests.swift in Sources */,
@@ -8485,6 +8492,7 @@
 				BEA0E4851BD83565000AEE81 /* WP3DTouchShortcutCreatorTests.swift in Sources */,
 				D81C2F5820F86CEA002AE1F1 /* NetworkStatus.swift in Sources */,
 				E1C545801C6C79BB001CEB0E /* MediaSettingsTests.swift in Sources */,
+				7E987F5A2108122A00CAFB88 /* NotificationUtility.swift in Sources */,
 				7E442FC720F677CB00DEACA5 /* ActivityLogRangesTest.swift in Sources */,
 				D80EE63A203DEE1B0094C34C /* ReaderFollowedSitesStreamHeaderTests.swift in Sources */,
 				08E77F471EE9D72F006F9515 /* MediaThumbnailExporterTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -542,6 +542,7 @@
 		7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */; };
 		7E846FF120FD0A0500881F5A /* ContentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */; };
 		7E846FF320FD37BD00881F5A /* ActivityCommentRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */; };
+		7E987F562108017B00CAFB88 /* NotificationContentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */; };
 		7EAD7CD0206D761200BEDCFD /* MediaExternalExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */; };
 		7EB5824720EC41B200002702 /* NotificationContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EB5824620EC41B200002702 /* NotificationContentFactory.swift */; };
 		7EBB4126206C388100012D98 /* StockPhotosService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBB4125206C388100012D98 /* StockPhotosService.swift */; };
@@ -2060,6 +2061,7 @@
 		7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonHeaderCell.swift; sourceTree = "<group>"; };
 		7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCoordinator.swift; sourceTree = "<group>"; };
 		7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityCommentRange.swift; sourceTree = "<group>"; };
+		7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentRouter.swift; sourceTree = "<group>"; };
 		7EAD7CCF206D761200BEDCFD /* MediaExternalExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaExternalExporter.swift; sourceTree = "<group>"; };
 		7EB5824620EC41B200002702 /* NotificationContentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentFactory.swift; sourceTree = "<group>"; };
 		7EBB4125206C388100012D98 /* StockPhotosService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosService.swift; sourceTree = "<group>"; };
@@ -5683,6 +5685,7 @@
 				B5DBE4FD1D21A700002E81D3 /* NotificationsViewController.swift */,
 				4388FEFD20A4E0B900783948 /* NotificationsViewController+AppRatings.swift */,
 				B5120B371D47CC6C0059361A /* NotificationDetailsViewController.swift */,
+				7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */,
 				B522C4F71B3DA79B00E47B59 /* NotificationSettingsViewController.swift */,
 				B52F8CD71B43260C00D36025 /* NotificationSettingStreamsViewController.swift */,
 				B5899ADD1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift */,
@@ -8027,6 +8030,7 @@
 				E1F391EF1FF25E0C00DB32A3 /* JetpackConnectionWebViewController.swift in Sources */,
 				E64ECA4D1CE62041000188A0 /* ReaderSearchViewController.swift in Sources */,
 				E14977181C0DC0770057CD60 /* MediaSizeSliderCell.swift in Sources */,
+				7E987F562108017B00CAFB88 /* NotificationContentRouter.swift in Sources */,
 				177076211EA206C000705A4A /* PlayIconView.swift in Sources */,
 				E1468DE71E794A4D0044D80F /* LanguageSelectorViewController.swift in Sources */,
 				E14694071F3459E2004052C8 /* PluginListViewController.swift in Sources */,

--- a/WordPress/WordPressTest/FormattableContentGroupTests.swift
+++ b/WordPress/WordPressTest/FormattableContentGroupTests.swift
@@ -11,11 +11,13 @@ final class FormattableContentGroupTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        ContextManager.overrideSharedInstance(nil)
         subject = FormattableContentGroup(blocks: [mockContent()], kind: Constants.kind)
     }
 
     override func tearDown() {
         subject = nil
+        ContextManager.overrideSharedInstance(nil)
         super.tearDown()
     }
 
@@ -47,6 +49,34 @@ final class FormattableContentGroupTests: XCTestCase {
         let obtainedBlock: FormattableTextContent? = subject?.blockOfKind(.image)
 
         XCTAssertNil(obtainedBlock)
+    }
+
+    func testLikeNotificationContainsUserContentGroupsInTheBody() {
+        let note = loadLikeNotification()
+        for group in note.bodyContentGroups {
+            XCTAssertTrue(group.kind == .user)
+        }
+    }
+
+    func testFollowerNotificationContainsUserAndFooterGroupsInTheBody() {
+        let note = loadFollowerNotification()
+
+        // Note: Account for 'View All Followers'
+        for group in note.bodyContentGroups {
+            XCTAssertTrue(group.kind == .user || group.kind == .footer)
+        }
+    }
+
+    var entityName: String {
+        return Notification.classNameWithoutNamespaces()
+    }
+
+    func loadLikeNotification() -> WordPress.Notification {
+        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-like.json") as! WordPress.Notification
+    }
+
+    func loadFollowerNotification() -> WordPress.Notification {
+        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-new-follower.json") as! WordPress.Notification
     }
 
     private func mockContent() -> FormattableTextContent {

--- a/WordPress/WordPressTest/MockContentCoordinator.swift
+++ b/WordPress/WordPressTest/MockContentCoordinator.swift
@@ -29,8 +29,11 @@ class MockContentCoordinator: ContentCoordinator {
 
     }
 
+    var streamWasDisplayed = false
+    var streamSiteID: NSNumber?
     func displayStreamWithSiteID(_ siteID: NSNumber?) throws {
-
+        streamWasDisplayed = true
+        streamSiteID = siteID
     }
 
     func displayWebViewWithURL(_ url: URL) {

--- a/WordPress/WordPressTest/NotificationContentRouterTests.swift
+++ b/WordPress/WordPressTest/NotificationContentRouterTests.swift
@@ -1,0 +1,29 @@
+
+import XCTest
+@testable import WordPress
+
+class NotificationContentRouterTests: XCTestCase {
+
+    let utility = NotificationUtility()
+    var sut: NotificationContentRouter!
+    var coordinator: MockContentCoordinator!
+
+    override func setUp() {
+        super.setUp()
+        utility.setUp()
+        coordinator = MockContentCoordinator()
+    }
+
+    override func tearDown() {
+        utility.tearDown()
+        super.tearDown()
+    }
+
+    func testFollowNotificationSourceRoutesToStream() {
+        let notification = utility.loadFollowerNotification()
+        sut = NotificationContentRouter(activity: notification, coordinator: coordinator)
+        try! sut.routeToNotificationSource()
+
+        XCTAssertTrue(coordinator.streamWasDisplayed)
+    }
+}

--- a/WordPress/WordPressTest/NotificationTests.swift
+++ b/WordPress/WordPressTest/NotificationTests.swift
@@ -8,17 +8,15 @@ import XCTest
 ///
 class NotificationTests: XCTestCase {
 
-    var contextManager: TestContextManager!
+    let utility = NotificationUtility()
 
     override func setUp() {
         super.setUp()
-        contextManager = TestContextManager()
+        utility.setUp()
     }
 
     override func tearDown() {
-        // Note: We'll force TestContextManager override reset, since, for (unknown reasons) the TestContextManager
-        // might be retained more than expected, and it may break other core data based tests.
-        ContextManager.overrideSharedInstance(nil)
+        utility.tearDown()
         super.tearDown()
     }
 
@@ -220,23 +218,19 @@ class NotificationTests: XCTestCase {
 
     // MARK: - Helpers
 
-    var entityName: String {
-        return Notification.classNameWithoutNamespaces()
-    }
-
     func loadBadgeNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-badge.json") as! WordPress.Notification
+        return utility.loadBadgeNotification()
     }
 
     func loadLikeNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-like.json") as! WordPress.Notification
+        return utility.loadLikeNotification()
     }
 
     func loadFollowerNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-new-follower.json") as! WordPress.Notification
+        return utility.loadFollowerNotification()
     }
 
     func loadCommentNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-replied-comment.json") as! WordPress.Notification
+        return utility.loadCommentNotification()
     }
 }

--- a/WordPress/WordPressTest/NotificationUtility.swift
+++ b/WordPress/WordPressTest/NotificationUtility.swift
@@ -1,0 +1,38 @@
+
+import Foundation
+import XCTest
+@testable import WordPress
+
+class NotificationUtility {
+    var contextManager: TestContextManager!
+
+    func setUp() {
+        contextManager = TestContextManager()
+    }
+
+    func tearDown() {
+        // Note: We'll force TestContextManager override reset, since, for (unknown reasons) the TestContextManager
+        // might be retained more than expected, and it may break other core data based tests.
+        ContextManager.overrideSharedInstance(nil)
+    }
+
+    private var entityName: String {
+        return Notification.classNameWithoutNamespaces()
+    }
+
+    func loadBadgeNotification() -> WordPress.Notification {
+        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-badge.json") as! WordPress.Notification
+    }
+
+    func loadLikeNotification() -> WordPress.Notification {
+        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-like.json") as! WordPress.Notification
+    }
+
+    func loadFollowerNotification() -> WordPress.Notification {
+        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-new-follower.json") as! WordPress.Notification
+    }
+
+    func loadCommentNotification() -> WordPress.Notification {
+        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-replied-comment.json") as! WordPress.Notification
+    }
+}


### PR DESCRIPTION
Fixes #9847 

This PR implements routing on `NotificationDetailsViewController` using the new FormattableContent system.

The `coordinator` instance on `NotificationDetailsViewController` can be removed when the feature flag is eliminated.

A few tests were implemented to check a small bug encountered. I plan to add extra test in a future PR.

To test:
- Go to the Notification list.
- Check that each kind of content routes to the corresponding section.
- Change the `extractNotifications` feature flag to `false`.
- Check that the old code still run at it should.

