### PR TITLE
Danger: Add a rule for PRs tagged 'DO NOT MERGE'

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,6 +1,9 @@
 # A PR should have at least one label
 warn("PR is missing at least one label.") if github.pr_labels.empty?
 
+# A PR shouldn't be merged with the 'DO NOT MERGE' label
+fail("This PR is tagged with 'DO NOT MERGE'.") if github.pr_labels.include? "[Status] DO NOT MERGE"
+
 # Warn when there is a big PR
 warn("PR has more than 500 lines of code changing. Consider splitting into smaller PRs if possible.") if git.lines_of_code > 500
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -2,7 +2,7 @@
 warn("PR is missing at least one label.") if github.pr_labels.empty?
 
 # A PR shouldn't be merged with the 'DO NOT MERGE' label
-fail("This PR is tagged with 'DO NOT MERGE'.") if github.pr_labels.include? "[Status] DO NOT MERGE"
+warn("This PR is tagged with 'DO NOT MERGE'.") if github.pr_labels.include? "[Status] DO NOT MERGE"
 
 # Warn when there is a big PR
 warn("PR has more than 500 lines of code changing. Consider splitting into smaller PRs if possible.") if git.lines_of_code > 500

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 chruby 2.3.1
 bundle install
-bundle exec danger --fail-on-errors=false
+bundle exec danger --fail-on-errors=true

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 chruby 2.3.1
 bundle install
-bundle exec danger --fail-on-errors=true
+bundle exec danger --fail-on-errors=false


### PR DESCRIPTION
This PR adds a new Danger rule to fail PRs that are tagged with the 'DO NOT MERGE' label.

**To test**

* Check that this PR fails while it has the DO NOT MERGE label applied.