### PR TITLE
Feature/notification block rollback actions

### DIFF
--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -244,13 +244,20 @@ extension Notification {
     //// Check if this note is a comment and in 'Unapproved' status
     ///
     @objc var isUnapprovedComment: Bool {
-        guard let block = blockGroupOfKind(.comment)?.blockOfKind(.comment) else {
-            return false
+        if FeatureFlag.extractNotifications.enabled {
+            guard let block: FormattableCommentContent = contentGroup(ofKind: .comment)?.blockOfKind(.comment) else {
+                return false
+            }
+            let commandId = ApproveCommentAction.actionIdentifier()
+            return block.isActionEnabled(id: commandId) && !block.isActionOn(id: commandId)
+        } else {
+            guard let block = blockGroupOfKind(.comment)?.blockOfKind(.comment) else {
+                return false
+            }
+
+            return block.isActionEnabled(.Approve) && !block.isActionOn(.Approve)
         }
 
-        //return block.isActionEnabled(.Approve) && !block.isActionOn(.Approve)
-        let commandId = ApproveCommentAction.actionIdentifier()
-        return block.isActionEnabled(id: commandId) && !block.isActionOn(id: commandId)
     }
 
     var kind: ParentKind {

--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -152,6 +152,16 @@ class Notification: NSManagedObject {
 
     /// Returns the first BlockGroup of the specified type, if any.
     ///
+    func contentGroup(ofKind kind: FormattableContentGroup.Kind) -> FormattableContentGroup? {
+        for contentGroup in bodyContentGroups where contentGroup.kind == kind {
+            return contentGroup
+        }
+
+        return nil
+    }
+
+    /// Returns the first BlockGroup of the specified type, if any.
+    ///
     func blockGroupOfKind(_ kind: NotificationBlockGroup.Kind) -> NotificationBlockGroup? {
         for blockGroup in bodyBlockGroups where blockGroup.kind == kind {
             return blockGroup

--- a/WordPress/Classes/Models/Notifications/NotificationBlock.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationBlock.swift
@@ -331,7 +331,7 @@ extension NotificationBlock {
 }
 
 extension NotificationBlock: ActionableObject {
-    
+
 }
 
 

--- a/WordPress/Classes/Services/NotificationActionsService.swift
+++ b/WordPress/Classes/Services/NotificationActionsService.swift
@@ -1,9 +1,6 @@
 import Foundation
 import CocoaLumberjack
 
-extension NotificationBlock: ActionableObject {
-}
-
 /// This service encapsulates all of the Actions that can be performed with a NotificationBlock
 ///
 class NotificationActionsService: LocalCoreDataService {

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentAction.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentAction.swift
@@ -7,7 +7,6 @@ protocol ActionableObject: AnyObject {
     var isCommentApproved: Bool { get }
     var text: String? { get }
     var textOverride: String? { get set }
-    func action(id: Identifier) -> FormattableContentAction?
 }
 
 protocol FormattableContentActionParser {

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
@@ -82,31 +82,32 @@ public class FormattableCommentRange: NotificationContentRange {
     }
 }
 
-public class FormattableNoticonRange: NotificationContentRange {
+public class FormattableNoticonRange: FormattableContentRange {
+    public var kind: FormattableRangeKind = .noticon
+    public var range: NSRange
     public let value: String
 
     private var noticon: String {
         return value + " "
     }
 
-    public init(value: String, properties: Properties) {
+    public init(value: String, range: NSRange) {
         self.value = value
-        super.init(kind: .noticon, properties: properties)
+        self.range = range
     }
 
-    public func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) -> Shift {
-
+    public func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) -> FormattableContentRange.Shift {
         let shiftedRange = rangeShifted(by: shift)
-        string.replaceCharacters(in: shiftedRange, with: noticon)
+        insertIcon(to: string, at: shiftedRange)
 
-        let superShift = super.apply(styles, to: string, withShift: shift)
+        let longerRange = NSMakeRange(shiftedRange.location, shiftedRange.length + noticon.count)
+        apply(styles, to: string, at: longerRange)
 
-        return noticon.count + superShift
+        return noticon.count
     }
 
-    func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, at shiftedRange: NSRange) {
-        let longerRange = NSMakeRange(shiftedRange.location, shiftedRange.length + noticon.count)
-        super.apply(styles, to: string, at: longerRange)
+    func insertIcon(to string: NSMutableAttributedString, at shiftedRange: NSRange) {
+        string.replaceCharacters(in: shiftedRange, with: noticon)
     }
 }
 

--- a/WordPress/Classes/Utility/FormattableContent/FormattableMediaContent.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableMediaContent.swift
@@ -30,7 +30,7 @@ public class FormattableMediaItem {
                 return nil
         }
 
-        kind = Kind(rawValue: type) ?? .Image
+        kind = Kind(rawValue: type) ?? .image
         range = NSMakeRange(start, end - start)
 
         if let url = dictionary[MediaKeys.URL] as? String {
@@ -65,8 +65,8 @@ public extension FormattableMediaItem {
     /// Known kinds of Media Entities
     ///
     public enum Kind: String {
-        case Image              = "image"
-        case Badge              = "badge"
+        case image              = "image"
+        case badge              = "badge"
     }
 
     /// Parsing Keys

--- a/WordPress/Classes/Utility/FormattableContent/FormattableTextContent.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableTextContent.swift
@@ -30,7 +30,7 @@ class FormattableTextContent: FormattableContent {
         meta = dictionary[Constants.BlockKeys.Meta] as? [String: AnyObject]
     }
 
-    init(text: String, ranges: [NotificationContentRange]) {
+    init(text: String, ranges: [FormattableContentRange]) {
         self.internalText = text
         self.ranges = ranges
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -246,7 +246,7 @@ extension NotificationDetailsViewController: UIViewControllerRestoration {
         let context = ContextManager.sharedInstance().mainContext
         guard let noteURI = coder.decodeObject(forKey: Restoration.noteIdKey) as? URL,
             let objectID = context.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: noteURI) else {
-            return nil
+                return nil
         }
 
         let notification = try? context.existingObject(with: objectID)
@@ -544,7 +544,7 @@ private extension NotificationDetailsViewController {
             suggestionsTableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             suggestionsTableView.topAnchor.constraint(equalTo: view.topAnchor),
             suggestionsTableView.bottomAnchor.constraint(equalTo: replyTextView.topAnchor)
-        ])
+            ])
     }
 
     var shouldAttachSuggestionsView: Bool {
@@ -677,8 +677,8 @@ private extension NotificationDetailsViewController {
         cell.accessoryType = hasHomeURL ? .disclosureIndicator : .none
         cell.name = userBlock.text
         cell.blogTitle = hasHomeTitle ? userBlock.metaTitlesHome : userBlock.metaLinksHome?.host
-        cell.isFollowEnabled = userBlock.isActionEnabled(id: FollowAction.actionIdentifier())
-        cell.isFollowOn = userBlock.isActionOn(id: FollowAction.actionIdentifier())
+        cell.isFollowEnabled = userBlock.isActionEnabled(.Follow)
+        cell.isFollowOn = userBlock.isActionOn(.Follow)
 
         cell.onFollowClick = { [weak self] in
             self?.followSiteWithBlock(userBlock)
@@ -758,14 +758,14 @@ private extension NotificationDetailsViewController {
         // Setup: Properties
         // Note: Approve Action is actually a synonym for 'Edit' (Based on Calypso's basecode)
         //
-        cell.isReplyEnabled     = UIDevice.isPad() && commentBlock.isActionOn(id: ReplyToCommentAction.actionIdentifier())
-        cell.isLikeEnabled      = commentBlock.isActionEnabled(id: LikeCommentAction.actionIdentifier())
-        cell.isApproveEnabled   = commentBlock.isActionEnabled(id: ApproveCommentAction.actionIdentifier())
-        cell.isTrashEnabled     = commentBlock.isActionEnabled(id: TrashCommentAction.actionIdentifier())
-        cell.isSpamEnabled      = commentBlock.isActionEnabled(id: MarkAsSpamAction.actionIdentifier())
-        cell.isEditEnabled      = commentBlock.isActionOn(id: ApproveCommentAction.actionIdentifier())
-        cell.isLikeOn           = commentBlock.isActionOn(id: LikeCommentAction.actionIdentifier())
-        cell.isApproveOn        = commentBlock.isActionOn(id: ApproveCommentAction.actionIdentifier())
+        cell.isReplyEnabled     = UIDevice.isPad() && commentBlock.isActionOn(.Reply)
+        cell.isLikeEnabled      = commentBlock.isActionEnabled(.Like)
+        cell.isApproveEnabled   = commentBlock.isActionEnabled(.Approve)
+        cell.isTrashEnabled     = commentBlock.isActionEnabled(.Trash)
+        cell.isSpamEnabled      = commentBlock.isActionEnabled(.Spam)
+        cell.isEditEnabled      = commentBlock.isActionOn(.Approve)
+        cell.isLikeOn           = commentBlock.isActionOn(.Like)
+        cell.isApproveOn        = commentBlock.isActionOn(.Approve)
 
         // Setup: Callbacks
         cell.onReplyClick = { [weak self] _ in
@@ -914,7 +914,7 @@ private extension NotificationDetailsViewController {
         cell.isFollowEnabled = userBlock.isActionEnabled(id: FollowAction.actionIdentifier())
         cell.isFollowOn = userBlock.isActionOn(id: FollowAction.actionIdentifier())
 
-         cell.onFollowClick = { [weak self] in
+        cell.onFollowClick = { [weak self] in
             self?.followSiteWithBlock(userBlock)
         }
 
@@ -1076,6 +1076,7 @@ private extension NotificationDetailsViewController {
 }
 
 
+
 // MARK: - Notification Helpers
 //
 extension NotificationDetailsViewController {
@@ -1213,7 +1214,7 @@ private extension NotificationDetailsViewController {
             //
             UIView.animate(withDuration: Media.duration, delay: Media.delay, options: Media.options, animations: { [weak self] in
                 self?.tableView.reloadRows(at: [indexPath], with: .fade)
-            }, completion: nil)
+                }, completion: nil)
         }
 
         mediaDownloader.downloadMedia(urls: imageUrls, maximumWidth: maxMediaEmbedWidth, completion: completion)
@@ -1252,19 +1253,19 @@ private extension NotificationDetailsViewController {
 // MARK: - Action Handlers
 //
 private extension NotificationDetailsViewController {
-    func followSiteWithBlock(_ block: ActionableObject) {
+    func followSiteWithBlock(_ block: FormattableUserContent) {
         UINotificationFeedbackGenerator().notificationOccurred(.success)
 
         actionsService.followSiteWithBlock(block)
         WPAppAnalytics.track(.notificationsSiteFollowAction, withBlogID: block.metaSiteID)
     }
 
-    func unfollowSiteWithBlock(_ block: ActionableObject) {
+    func unfollowSiteWithBlock(_ block: FormattableUserContent) {
         actionsService.unfollowSiteWithBlock(block)
         WPAppAnalytics.track(.notificationsSiteUnfollowAction, withBlogID: block.metaSiteID)
     }
 
-    func likeCommentWithBlock(_ block: ActionableObject) {
+    func likeCommentWithBlock(_ block: FormattableCommentContent) {
         guard let likeAction = block.action(id: LikeCommentAction.actionIdentifier()) else {
             return
         }
@@ -1273,7 +1274,7 @@ private extension NotificationDetailsViewController {
         WPAppAnalytics.track(.notificationsCommentLiked, withBlogID: block.metaSiteID)
     }
 
-    func unlikeCommentWithBlock(_ block: ActionableObject) {
+    func unlikeCommentWithBlock(_ block: FormattableCommentContent) {
         guard let likeAction = block.action(id: LikeCommentAction.actionIdentifier()) else {
             return
         }
@@ -1282,7 +1283,7 @@ private extension NotificationDetailsViewController {
         WPAppAnalytics.track(.notificationsCommentUnliked, withBlogID: block.metaSiteID)
     }
 
-    func approveCommentWithBlock(_ block: ActionableObject) {
+    func approveCommentWithBlock(_ block: FormattableCommentContent) {
         guard let approveAction = block.action(id: ApproveCommentAction.actionIdentifier()) else {
             return
         }
@@ -1292,7 +1293,7 @@ private extension NotificationDetailsViewController {
         WPAppAnalytics.track(.notificationsCommentApproved, withBlogID: block.metaSiteID)
     }
 
-    func unapproveCommentWithBlock(_ block: ActionableObject) {
+    func unapproveCommentWithBlock(_ block: FormattableCommentContent) {
         guard let approveAction = block.action(id: ApproveCommentAction.actionIdentifier()) else {
             return
         }
@@ -1302,7 +1303,7 @@ private extension NotificationDetailsViewController {
         WPAppAnalytics.track(.notificationsCommentUnapproved, withBlogID: block.metaSiteID)
     }
 
-    func spamCommentWithBlock(_ block: ActionableObject) {
+    func spamCommentWithBlock(_ block: FormattableCommentContent) {
         precondition(onDeletionRequestCallback != nil)
 
         guard let spamAction = block.action(id: MarkAsSpamAction.actionIdentifier()) else {
@@ -1323,7 +1324,7 @@ private extension NotificationDetailsViewController {
         _ = navigationController?.popToRootViewController(animated: true)
     }
 
-    func trashCommentWithBlock(_ block: ActionableObject) {
+    func trashCommentWithBlock(_ block: FormattableCommentContent) {
         precondition(onDeletionRequestCallback != nil)
 
         guard let trashAction = block.action(id: TrashCommentAction.actionIdentifier()) else {
@@ -1344,7 +1345,7 @@ private extension NotificationDetailsViewController {
         _ = navigationController?.popToRootViewController(animated: true)
     }
 
-    func replyCommentWithBlock(_ block: ActionableObject, content: String) {
+    func replyCommentWithBlock(_ block: FormattableCommentContent, content: String) {
         guard let replyAction = block.action(id: ReplyToCommentAction.actionIdentifier()) else {
             return
         }
@@ -1359,14 +1360,14 @@ private extension NotificationDetailsViewController {
                 SVProgressHUD.showDismissibleSuccess(withStatus: message)
             } else {
                 generator.notificationOccurred(.error)
-                self?.displayReplyErrorWithBlock(block, content: content)
+                self?.displayReplyError(with: block, content: content)
             }
         }
 
         replyAction.execute(context: actionContext)
     }
 
-    func updateCommentWithBlock(_ block: ActionableObject, content: String) {
+    func updateCommentWithBlock(_ block: FormattableCommentContent, content: String) {
         guard let editCommentAction = block.action(id: EditCommentAction.actionIdentifier()) else {
             return
         }
@@ -1388,15 +1389,142 @@ private extension NotificationDetailsViewController {
     }
 }
 
+// MARK: - OLD Action Handlers
+//
+private extension NotificationDetailsViewController {
+    func followSiteWithBlock(_ block: NotificationBlock) {
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+
+        actionsService.followSiteWithBlock(block)
+        WPAppAnalytics.track(.notificationsSiteFollowAction, withBlogID: block.metaSiteID)
+    }
+
+    func unfollowSiteWithBlock(_ block: NotificationBlock) {
+        actionsService.unfollowSiteWithBlock(block)
+        WPAppAnalytics.track(.notificationsSiteUnfollowAction, withBlogID: block.metaSiteID)
+    }
+
+    func likeCommentWithBlock(_ block: NotificationBlock) {
+        actionsService.likeCommentWithBlock(block)
+        WPAppAnalytics.track(.notificationsCommentLiked, withBlogID: block.metaSiteID)
+    }
+
+    func unlikeCommentWithBlock(_ block: NotificationBlock) {
+        actionsService.unlikeCommentWithBlock(block)
+        WPAppAnalytics.track(.notificationsCommentUnliked, withBlogID: block.metaSiteID)
+    }
+
+    func approveCommentWithBlock(_ block: NotificationBlock) {
+        actionsService.approveCommentWithBlock(block)
+        WPAppAnalytics.track(.notificationsCommentApproved, withBlogID: block.metaSiteID)
+    }
+
+    func unapproveCommentWithBlock(_ block: NotificationBlock) {
+        actionsService.unapproveCommentWithBlock(block)
+        WPAppAnalytics.track(.notificationsCommentUnapproved, withBlogID: block.metaSiteID)
+    }
+
+    func spamCommentWithBlock(_ block: NotificationBlock) {
+        precondition(onDeletionRequestCallback != nil)
+
+        let request = NotificationDeletionRequest(kind: .spamming, action: { onCompletion in
+            let mainContext = ContextManager.sharedInstance().mainContext
+            let service = NotificationActionsService(managedObjectContext: mainContext)
+            service.spamCommentWithBlock(block) { (success) in
+                onCompletion(success)
+            }
+
+            WPAppAnalytics.track(.notificationsCommentFlaggedAsSpam, withBlogID: block.metaSiteID)
+        })
+
+        onDeletionRequestCallback?(request)
+
+        // We're thru
+        _ = navigationController?.popToRootViewController(animated: true)
+    }
+
+    func trashCommentWithBlock(_ block: NotificationBlock) {
+        precondition(onDeletionRequestCallback != nil)
+
+        // Hit the DeletionRequest Callback
+        let request = NotificationDeletionRequest(kind: .deletion, action: { onCompletion in
+            let mainContext = ContextManager.sharedInstance().mainContext
+            let service = NotificationActionsService(managedObjectContext: mainContext)
+            service.deleteCommentWithBlock(block) { (success) in
+                onCompletion(success)
+            }
+
+            WPAppAnalytics.track(.notificationsCommentTrashed, withBlogID: block.metaSiteID)
+        })
+
+        onDeletionRequestCallback?(request)
+
+        // We're thru
+        _ = navigationController?.popToRootViewController(animated: true)
+    }
+
+    func replyCommentWithBlock(_ block: NotificationBlock, content: String) {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(.success)
+
+        actionsService.replyCommentWithBlock(block, content: content, completion: { success in
+            guard success else {
+                generator.notificationOccurred(.error)
+                self.displayReplyErrorWithBlock(block, content: content)
+                return
+            }
+
+            let message = NSLocalizedString("Reply Sent!", comment: "The app successfully sent a comment")
+            SVProgressHUD.showDismissibleSuccess(withStatus: message)
+        })
+    }
+
+    func updateCommentWithBlock(_ block: NotificationBlock, content: String) {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(.success)
+
+        actionsService.updateCommentWithBlock(block, content: content, completion: { success in
+            guard success == false else {
+                return
+            }
+
+            generator.notificationOccurred(.error)
+            self.displayCommentUpdateErrorWithBlock(block, content: content)
+        })
+    }
+}
+
 
 // MARK: - Replying Comments
 //
 private extension NotificationDetailsViewController {
-    func focusOnReplyTextViewWithBlock(_ block: ActionableObject) {
+    func focusOnReplyTextViewWithBlock(_ content: FormattableContent) {
         let _ = replyTextView.becomeFirstResponder()
     }
 
-    func displayReplyErrorWithBlock(_ block: ActionableObject, content: String) {
+    func focusOnReplyTextViewWithBlock(_ block: NotificationBlock) {
+        let _ = replyTextView.becomeFirstResponder()
+    }
+
+    func displayReplyError(with block: FormattableCommentContent, content: String) {
+        let message     = NSLocalizedString("There has been an unexpected error while sending your reply",
+                                            comment: "Reply Failure Message")
+        let cancelTitle = NSLocalizedString("Cancel", comment: "Cancels an Action")
+        let retryTitle  = NSLocalizedString("Try Again", comment: "Retries sending a reply")
+
+        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(cancelTitle)
+        alertController.addDefaultActionWithTitle(retryTitle) { action in
+            self.replyCommentWithBlock(block, content: content)
+        }
+
+        // Note: This viewController might not be visible anymore
+        alertController.presentFromRootViewController()
+    }
+
+    func displayReplyErrorWithBlock(_ block: NotificationBlock, content: String) {
         let message     = NSLocalizedString("There has been an unexpected error while sending your reply",
                                             comment: "Reply Failure Message")
         let cancelTitle = NSLocalizedString("Cancel", comment: "Cancels an Action")
@@ -1418,6 +1546,15 @@ private extension NotificationDetailsViewController {
 // MARK: - Editing Comments
 //
 private extension NotificationDetailsViewController {
+
+    func updateComment(with object: ActionableObject, content: String) {
+        if let block = object as? NotificationBlock {
+            self.updateCommentWithBlock(block, content: content)
+        } else if let block = object as? FormattableCommentContent {
+            self.updateCommentWithBlock(block, content: content)
+        }
+    }
+
     func displayCommentEditorWithBlock(_ block: ActionableObject) {
         let editViewController = EditCommentViewController.newEdit()
         editViewController?.content = block.text
@@ -1426,8 +1563,8 @@ private extension NotificationDetailsViewController {
                 guard hasNewContent else {
                     return
                 }
-
-                self.updateCommentWithBlock(block, content: newContent!)
+                let newContent = newContent ?? ""
+                self.updateComment(with: block, content: newContent)
             })
         }
 
@@ -1451,7 +1588,7 @@ private extension NotificationDetailsViewController {
             self.refreshInterface()
         }
         alertController.addDefaultActionWithTitle(retryTitle) { action in
-            self.updateCommentWithBlock(block, content: content)
+            self.updateComment(with: block, content: content)
         }
 
         // Note: This viewController might not be visible anymore

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -503,12 +503,18 @@ extension NotificationDetailsViewController {
     var shouldAttachReplyView: Bool {
         // Attach the Reply component only if the noficiation has a comment, and it can be replied-to
         //
-        guard let block = note.blockGroupOfKind(.comment)?.blockOfKind(.comment) else {
-            return false
+        if FeatureFlag.extractNotifications.enabled == true {
+            guard let block: FormattableCommentContent = note.contentGroup(ofKind: .comment)?.blockOfKind(.comment) else {
+                return false
+            }
+            return block.action(id: ReplyToCommentAction.actionIdentifier())?.on ?? false
+        } else {
+            guard let block = note.blockGroupOfKind(.comment)?.blockOfKind(.comment) else {
+                return false
+            }
+            return block.isActionOn(.Reply)
         }
 
-        //return block.isActionOn(.Reply)
-        return block.action(id: ReplyToCommentAction.actionIdentifier())?.on ?? false
     }
 
     func storeNotificationReplyIfNeeded() {
@@ -602,9 +608,14 @@ private extension NotificationDetailsViewController {
 
 
 
-// MARK: - UITableViewCell Subclass Setup
+// MARK: - UITableViewCell Subclass Setup (To be removed)
 //
 private extension NotificationDetailsViewController {
+    private func rememberRemoveExtension() {
+        //Please remove this whole extension when the Notification extraction feature flag is removed
+        _ = FeatureFlag.extractNotifications.enabled
+    }
+
     func setupCell(_ cell: NoteBlockTableViewCell, blockGroup: NotificationBlockGroup) {
         switch cell {
         case let cell as NoteBlockHeaderTableViewCell:

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Groups/BodyContentGroup.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Groups/BodyContentGroup.swift
@@ -89,8 +89,8 @@ class BodyContentGroup: FormattableContentGroup {
         var properties = NotificationContentRange.Properties(range: textRange)
         properties.url = url
 
-        let ranges = [
-            FormattableNoticonRange(value: "\u{f442}", properties: NotificationContentRange.Properties(range: zeroRange)),
+        let ranges: [FormattableContentRange] = [
+            FormattableNoticonRange(value: "\u{f442}", range: zeroRange),
             NotificationContentRange(kind: .link, properties: properties)
         ]
 

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationContentRangeFactory.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationContentRangeFactory.swift
@@ -54,7 +54,7 @@ struct NotificationContentRangeFactory: ContentRangeFactory {
         return properties
     }
 
-    private static func contentRange(ofKind type: String, with properties: NotificationContentRange.Properties, from dictionary: [String: AnyObject]) -> NotificationContentRange? {
+    private static func contentRange(ofKind type: String, with properties: NotificationContentRange.Properties, from dictionary: [String: AnyObject]) -> FormattableContentRange? {
         var properties = properties
         let kind = FormattableRangeKind(type)
 
@@ -66,7 +66,7 @@ struct NotificationContentRangeFactory: ContentRangeFactory {
             guard let value = dictionary[RangeKeys.value] as? String else {
                 fallthrough
             }
-            return FormattableNoticonRange(value: value, properties: properties)
+            return FormattableNoticonRange(value: value, range: properties.range)
         case .post:
             properties.postID = dictionary[RangeKeys.id] as? NSNumber
             return NotificationContentRange(kind: kind, properties: properties)

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
@@ -18,7 +18,7 @@ protocol FormattableMediaContent {
 extension FormattableMediaContent where Self: FormattableContent {
     var imageUrls: [URL] {
         return media.compactMap {
-            guard $0.kind == .Image && $0.mediaURL != nil else {
+            guard $0.kind == .image && $0.mediaURL != nil else {
                 return nil
             }
 
@@ -57,7 +57,7 @@ class NotificationTextContent: FormattableTextContent, FormattableMediaContent {
     }
 
     override var kind: FormattableContentKind {
-        if let firstMedia = media.first, (firstMedia.kind == .Image || firstMedia.kind == .Badge) {
+        if let firstMedia = media.first, (firstMedia.kind == .image || firstMedia.kind == .badge) {
             return .image
         }
         return .text

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -546,6 +546,7 @@
 		7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */; };
 		7E846FF120FD0A0500881F5A /* ContentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */; };
 		7E846FF320FD37BD00881F5A /* ActivityCommentRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */; };
+		7E92828921090E9A00BBD8A3 /* notifications-pingback.json in Resources */ = {isa = PBXBuildFile; fileRef = 7E92828821090E9A00BBD8A3 /* notifications-pingback.json */; };
 		7E987F562108017B00CAFB88 /* NotificationContentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */; };
 		7E987F58210811CC00CAFB88 /* NotificationContentRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E987F57210811CC00CAFB88 /* NotificationContentRouterTests.swift */; };
 		7E987F5A2108122A00CAFB88 /* NotificationUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E987F592108122A00CAFB88 /* NotificationUtility.swift */; };
@@ -2071,6 +2072,7 @@
 		7E7B4CF720459E21001463D6 /* PersonHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PersonHeaderCell.swift; sourceTree = "<group>"; };
 		7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCoordinator.swift; sourceTree = "<group>"; };
 		7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityCommentRange.swift; sourceTree = "<group>"; };
+		7E92828821090E9A00BBD8A3 /* notifications-pingback.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "notifications-pingback.json"; sourceTree = "<group>"; };
 		7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentRouter.swift; sourceTree = "<group>"; };
 		7E987F57210811CC00CAFB88 /* NotificationContentRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentRouterTests.swift; sourceTree = "<group>"; };
 		7E987F592108122A00CAFB88 /* NotificationUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationUtility.swift; sourceTree = "<group>"; };
@@ -5425,6 +5427,7 @@
 				E150275E1E03E51500B847E3 /* notes-action-delete.json */,
 				E150275F1E03E51500B847E3 /* notes-action-push.json */,
 				E15027601E03E51500B847E3 /* notes-action-unsupported.json */,
+				7E92828821090E9A00BBD8A3 /* notifications-pingback.json */,
 				B5AEEC741ACACFDA008BF2A4 /* notifications-badge.json */,
 				748BD8881F1923D500813F9A /* notifications-last-seen.json */,
 				B5AEEC751ACACFDA008BF2A4 /* notifications-like.json */,
@@ -7092,6 +7095,7 @@
 				855408881A6F106800DDBD79 /* app-review-prompt-notifications-disabled.json in Resources */,
 				D88A64A4208D8FB6008AE9BC /* stock-photos-search-response.json in Resources */,
 				D88A64AE208D9CF5008AE9BC /* stock-photos-pageable.json in Resources */,
+				7E92828921090E9A00BBD8A3 /* notifications-pingback.json in Resources */,
 				93C882A11EEB18D700227A59 /* html_page_with_link_to_rsd_non_standard.html in Resources */,
 				8554088A1A6F107D00DDBD79 /* app-review-prompt-global-disable.json in Resources */,
 				7E4A772B20F7E5FD001C706D /* activity-log-site-content.json in Resources */,

--- a/WordPress/WordPressTest/FormattableCommentContentTests.swift
+++ b/WordPress/WordPressTest/FormattableCommentContentTests.swift
@@ -6,6 +6,7 @@ final class FormattableCommentContentTests: XCTestCase {
     private let entityName = Notification.classNameWithoutNamespaces()
 
     private var subject: FormattableCommentContent?
+    private var utility = NotificationUtility()
 
     private struct Expectations {
         static let text = "This is an unapproved comment"
@@ -18,11 +19,13 @@ final class FormattableCommentContentTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        utility.setUp()
         subject = FormattableCommentContent(dictionary: mockDictionary(), actions: mockedActions(), ranges: [], parent: loadLikeNotification())
     }
 
     override func tearDown() {
         subject = nil
+        utility.tearDown()
         super.tearDown()
     }
 
@@ -112,6 +115,24 @@ final class FormattableCommentContentTests: XCTestCase {
         XCTAssertEqual(id, Expectations.metaSiteId)
     }
 
+    func testCommentNotificationHasActions() {
+        let commentNotification = utility.loadCommentNotification()
+        let commentContent: FormattableCommentContent? = commentNotification.contentGroup(ofKind: .comment)?.blockOfKind(.comment)
+        XCTAssertNotNil(commentContent)
+
+        let trashAction = commentContent?.action(id: TrashCommentAction.actionIdentifier())
+        let approveAction = commentContent?.action(id: ApproveCommentAction.actionIdentifier())
+        let replyAction = commentContent?.action(id: ReplyToCommentAction.actionIdentifier())
+        let likeAction = commentContent?.action(id: LikeCommentAction.actionIdentifier())
+        let markAsSpam = commentContent?.action(id: MarkAsSpamAction.actionIdentifier())
+
+        XCTAssertNotNil(trashAction)
+        XCTAssertNotNil(approveAction)
+        XCTAssertNotNil(replyAction)
+        XCTAssertNotNil(likeAction)
+        XCTAssertNotNil(markAsSpam)
+    }
+
     private func mockDictionary() -> [String: AnyObject] {
         return getDictionaryFromFile(named: "notifications-comment-content.json")
     }
@@ -121,7 +142,7 @@ final class FormattableCommentContentTests: XCTestCase {
     }
 
     private func loadLikeNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-like.json") as! WordPress.Notification
+        return utility.loadLikeNotification()
     }
 
     private func loadMeta() -> [String: AnyObject] {

--- a/WordPress/WordPressTest/FormattableContentFormatterTests.swift
+++ b/WordPress/WordPressTest/FormattableContentFormatterTests.swift
@@ -1,8 +1,10 @@
 import XCTest
 @testable import WordPress
+import Foundation
 
 final class FormattableContentFormatterTests: XCTestCase {
     private var subject: FormattableContentFormatter?
+    private let formatter = FormattableContentFormatter()
 
     override func setUp() {
         super.setUp()
@@ -48,4 +50,23 @@ final class FormattableContentFormatterTests: XCTestCase {
 
         XCTAssertNil(fetchedObject)
     }
+
+    func testNoticonRangeIsFormattedCorrectly() {
+        let content = contentWithNoticon()
+        let formattedText = formatter.render(content: content, with: RichTextContentStyles())
+
+        XCTAssertEqual(formattedText.string, Constants.textExpectation)
+    }
+
+    private func contentWithNoticon() -> FormattableTextContent {
+        let range = FormattableNoticonRange(value: Constants.noticon, range: Constants.range)
+        return FormattableTextContent(text: Constants.text, ranges: [range])
+    }
+}
+
+private enum Constants {
+    static let noticon = "\u{f442}"
+    static let text = "Hello world"
+    static let textExpectation = noticon + " " + text
+    static let range = NSRange(location: 0, length: 0)
 }

--- a/WordPress/WordPressTest/FormattableContentGroupTests.swift
+++ b/WordPress/WordPressTest/FormattableContentGroupTests.swift
@@ -4,6 +4,7 @@ import XCTest
 final class FormattableContentGroupTests: XCTestCase {
     private let contextManager = TestContextManager()
     private var subject: FormattableContentGroup?
+    private let utility = NotificationUtility()
 
     private struct Constants {
         static let kind: FormattableContentGroup.Kind = .activity
@@ -11,11 +12,13 @@ final class FormattableContentGroupTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        utility.setUp()
         ContextManager.overrideSharedInstance(nil)
         subject = FormattableContentGroup(blocks: [mockContent()], kind: Constants.kind)
     }
 
     override func tearDown() {
+        utility.tearDown()
         subject = nil
         ContextManager.overrideSharedInstance(nil)
         super.tearDown()
@@ -51,32 +54,41 @@ final class FormattableContentGroupTests: XCTestCase {
         XCTAssertNil(obtainedBlock)
     }
 
+    func testBadgeNotificationProperlyLoadsItsSubjectContent() {
+        let note = utility.loadBadgeNotification()
+
+        XCTAssert(note.subjectContentGroup?.blocks.count == 1)
+        XCTAssertNotNil(note.subjectContentGroup?.blocks.first)
+        XCTAssertNotNil(note.renderSubject())
+    }
+
+    func testBadgeNotificationContainsOneImageContentGroup() {
+        let note = utility.loadBadgeNotification()
+        let group = note.contentGroup(ofKind: .image)
+        XCTAssertNotNil(group)
+
+        let imageBlock = group?.blocks.first as? FormattableMediaContent
+        XCTAssertNotNil(imageBlock)
+
+        let media = imageBlock?.media.first
+        XCTAssertNotNil(media)
+        XCTAssertNotNil(media?.mediaURL)
+    }
+
     func testLikeNotificationContainsUserContentGroupsInTheBody() {
-        let note = loadLikeNotification()
+        let note = utility.loadLikeNotification()
         for group in note.bodyContentGroups {
             XCTAssertTrue(group.kind == .user)
         }
     }
 
     func testFollowerNotificationContainsUserAndFooterGroupsInTheBody() {
-        let note = loadFollowerNotification()
+        let note = utility.loadFollowerNotification()
 
         // Note: Account for 'View All Followers'
         for group in note.bodyContentGroups {
             XCTAssertTrue(group.kind == .user || group.kind == .footer)
         }
-    }
-
-    var entityName: String {
-        return Notification.classNameWithoutNamespaces()
-    }
-
-    func loadLikeNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-like.json") as! WordPress.Notification
-    }
-
-    func loadFollowerNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-new-follower.json") as! WordPress.Notification
     }
 
     private func mockContent() -> FormattableTextContent {

--- a/WordPress/WordPressTest/FormattableNotIconTests.swift
+++ b/WordPress/WordPressTest/FormattableNotIconTests.swift
@@ -10,14 +10,11 @@ final class FormattableNotIconTests: XCTestCase {
         static let kind = FormattableRangeKind("noticon")
         static let icon = "🦄"
         static let range = NSRange(location: 32, length: 41)
-        static let userId = NSNumber(integerLiteral: 1)
-        static let siteId = NSNumber(integerLiteral: 2)
-        static let postId = NSNumber(integerLiteral: 3)
     }
 
     override func setUp() {
         super.setUp()
-        subject = FormattableNoticonRange(value: Constants.icon, properties: mockProperties())
+        subject = FormattableNoticonRange(value: Constants.icon, range: Constants.range)
     }
 
     override func tearDown() {
@@ -33,27 +30,11 @@ final class FormattableNotIconTests: XCTestCase {
         XCTAssertEqual(subject?.range, Constants.range)
     }
 
-    func testUserIDIsNotMutated() {
-        XCTAssertEqual(subject?.userID, Constants.userId)
-    }
-
-    func testSiteIDIsNotMutated() {
-        XCTAssertEqual(subject?.siteID, Constants.siteId)
-    }
-
-    func testPostIDIsNotMutated() {
-        XCTAssertEqual(subject?.postID, Constants.postId)
-    }
-
     func testNoticonReturnsExpectedValue() {
         XCTAssertEqual(subject?.value, Constants.icon)
     }
 
     private func mockProperties() -> NotificationContentRange.Properties {
-        var properties = NotificationContentRange.Properties(range: Constants.range)
-        properties.userID = Constants.userId
-        properties.siteID = Constants.siteId
-        properties.postID = Constants.postId
-        return properties
+        return NotificationContentRange.Properties(range: Constants.range)
     }
 }

--- a/WordPress/WordPressTest/LikeCommentActionTests.swift
+++ b/WordPress/WordPressTest/LikeCommentActionTests.swift
@@ -25,7 +25,6 @@ final class LikeCommentActionTests: XCTestCase {
     }
 
     private var action: LikeComment?
-    private var utility = NotificationUtility()
 
     private struct Constants {
         static let initialStatus: Bool = false
@@ -33,7 +32,6 @@ final class LikeCommentActionTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        utility.setUp()
         action = TestableLikeComment(on: Constants.initialStatus)
         makeNetworkAvailable()
     }
@@ -41,7 +39,6 @@ final class LikeCommentActionTests: XCTestCase {
     override func tearDown() {
         action = nil
         makeNetworkUnavailable()
-        utility.tearDown()
         super.tearDown()
     }
 
@@ -163,23 +160,5 @@ final class LikeCommentActionTests: XCTestCase {
         action?.execute(context: mockActionContext())
 
         XCTAssertEqual(action?.icon?.accessibilityHint, LikeComment.TitleHints.unlike)
-    }
-
-    func testCommentNotificationHasActions() {
-        let commentNotification = utility.loadCommentNotification()
-        let commentContent: FormattableCommentContent? = commentNotification.contentGroup(ofKind: .comment)?.blockOfKind(.comment)
-        XCTAssertNotNil(commentContent)
-
-        let trashAction = commentContent?.action(id: TrashCommentAction.actionIdentifier())
-        let approveAction = commentContent?.action(id: ApproveCommentAction.actionIdentifier())
-        let replyAction = commentContent?.action(id: ReplyToCommentAction.actionIdentifier())
-        let likeAction = commentContent?.action(id: LikeCommentAction.actionIdentifier())
-        let markAsSpam = commentContent?.action(id: MarkAsSpamAction.actionIdentifier())
-
-        XCTAssertNotNil(trashAction)
-        XCTAssertNotNil(approveAction)
-        XCTAssertNotNil(replyAction)
-        XCTAssertNotNil(likeAction)
-        XCTAssertNotNil(markAsSpam)
     }
 }

--- a/WordPress/WordPressTest/LikeCommentActionTests.swift
+++ b/WordPress/WordPressTest/LikeCommentActionTests.swift
@@ -25,6 +25,7 @@ final class LikeCommentActionTests: XCTestCase {
     }
 
     private var action: LikeComment?
+    private var utility = NotificationUtility()
 
     private struct Constants {
         static let initialStatus: Bool = false
@@ -32,6 +33,7 @@ final class LikeCommentActionTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        utility.setUp()
         action = TestableLikeComment(on: Constants.initialStatus)
         makeNetworkAvailable()
     }
@@ -39,6 +41,7 @@ final class LikeCommentActionTests: XCTestCase {
     override func tearDown() {
         action = nil
         makeNetworkUnavailable()
+        utility.tearDown()
         super.tearDown()
     }
 
@@ -160,5 +163,17 @@ final class LikeCommentActionTests: XCTestCase {
         action?.execute(context: mockActionContext())
 
         XCTAssertEqual(action?.icon?.accessibilityHint, LikeComment.TitleHints.unlike)
+    }
+
+    func testCommentNotificationHasTrashAction() {
+        let commentNotification = utility.loadCommentNotification()
+        let commentContent: FormattableCommentContent? = commentNotification.contentGroup(ofKind: .comment)?.blockOfKind(.comment)
+        XCTAssertNotNil(commentContent)
+
+        let trashAction = commentContent?.action(id: TrashCommentAction.actionIdentifier())
+        let approveAction = commentContent?.action(id: ApproveCommentAction.actionIdentifier())
+
+        XCTAssertNotNil(trashAction)
+        XCTAssertNotNil(approveAction)
     }
 }

--- a/WordPress/WordPressTest/LikeCommentActionTests.swift
+++ b/WordPress/WordPressTest/LikeCommentActionTests.swift
@@ -165,15 +165,21 @@ final class LikeCommentActionTests: XCTestCase {
         XCTAssertEqual(action?.icon?.accessibilityHint, LikeComment.TitleHints.unlike)
     }
 
-    func testCommentNotificationHasTrashAction() {
+    func testCommentNotificationHasActions() {
         let commentNotification = utility.loadCommentNotification()
         let commentContent: FormattableCommentContent? = commentNotification.contentGroup(ofKind: .comment)?.blockOfKind(.comment)
         XCTAssertNotNil(commentContent)
 
         let trashAction = commentContent?.action(id: TrashCommentAction.actionIdentifier())
         let approveAction = commentContent?.action(id: ApproveCommentAction.actionIdentifier())
+        let replyAction = commentContent?.action(id: ReplyToCommentAction.actionIdentifier())
+        let likeAction = commentContent?.action(id: LikeCommentAction.actionIdentifier())
+        let markAsSpam = commentContent?.action(id: MarkAsSpamAction.actionIdentifier())
 
         XCTAssertNotNil(trashAction)
         XCTAssertNotNil(approveAction)
+        XCTAssertNotNil(replyAction)
+        XCTAssertNotNil(likeAction)
+        XCTAssertNotNil(markAsSpam)
     }
 }

--- a/WordPress/WordPressTest/NotificationBlockTests.swift
+++ b/WordPress/WordPressTest/NotificationBlockTests.swift
@@ -19,7 +19,7 @@ final class NotificationBlockTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        subject = NotificationBlock(dictionary: mockDictionary(), actions: mockActions(), parent: loadLikeNotification())
+        subject = NotificationBlock(dictionary: mockDictionary(), parent: loadLikeNotification())
     }
 
     override func tearDown() {
@@ -49,15 +49,6 @@ final class NotificationBlockTests: XCTestCase {
         let textOverride = subject?.textOverride
 
         XCTAssertNil(textOverride)
-    }
-
-    func testActionsContainsActionsProvided() {
-        let actions = subject!.actions
-
-        let actionIds = actions!.map { $0.identifier }
-        let mockActionIds = mockActions().map { $0.identifier }
-
-        XCTAssertEqual(actionIds, mockActionIds)
     }
 
     func testKindReturnsExpectedKind() {
@@ -106,27 +97,6 @@ final class NotificationBlockTests: XCTestCase {
         let notificationID = subject!.notificationID
 
         XCTAssertEqual(notificationID, Expectations.notificationID)
-    }
-
-    func testActionReturnsExpectedAction() {
-        let approveIdentifier = Expectations.approveAction.identifier
-        let action = subject!.action(id: approveIdentifier)
-
-        XCTAssertEqual(action?.identifier, approveIdentifier)
-    }
-
-    func testActionOnReturnsExpectation() {
-        let approveIdentifier = Expectations.approveAction.identifier
-        let on = subject!.isActionOn(id: approveIdentifier)
-
-        XCTAssertEqual(on, Expectations.approveAction.on)
-    }
-
-    func testActionEnabledReturnsExpectation() {
-        let approveIdentifier = Expectations.approveAction.identifier
-        let enabled = subject!.isActionEnabled(id: approveIdentifier)
-
-        XCTAssertEqual(enabled, Expectations.approveAction.enabled)
     }
 
     private func mockDictionary() -> [String: AnyObject] {

--- a/WordPress/WordPressTest/NotificationTests.swift
+++ b/WordPress/WordPressTest/NotificationTests.swift
@@ -215,6 +215,17 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(range)
     }
 
+    func testPingbackNotificationIsPingback() {
+        let notification = utility.loadPingbackNotification()
+        XCTAssertTrue(notification.isPingback)
+    }
+
+    func testPingbackBodyContainsFooter() {
+        let notification = utility.loadPingbackNotification()
+        let footer = notification.bodyContentGroups.filter { $0.kind == .footer }
+        XCTAssertEqual(footer.count, 1)
+    }
+
 
     // MARK: - Helpers
 

--- a/WordPress/WordPressTest/NotificationUtility.swift
+++ b/WordPress/WordPressTest/NotificationUtility.swift
@@ -35,4 +35,8 @@ class NotificationUtility {
     func loadCommentNotification() -> WordPress.Notification {
         return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-replied-comment.json") as! WordPress.Notification
     }
+
+    func loadPingbackNotification() -> WordPress.Notification {
+        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-pingback.json") as! WordPress.Notification
+    }
 }

--- a/WordPress/WordPressTest/Test Data/notifications-pingback.json
+++ b/WordPress/WordPressTest/Test Data/notifications-pingback.json
@@ -1,0 +1,142 @@
+{
+    "notificationId": "3450358781",
+    "type": "comment",
+    "read": 1,
+    "noticon": "",
+    "timestamp": "2018-07-07T02:42:41+00:00",
+    "icon": "https://www.gravatar.com/avatar/ad516503a11cd5ca435acc9bb6523536?s=128",
+    "url": "https://etoledom.wordpress.com/2018/06/09/camino-a-machu-picchu/",
+    "subject": [
+                {
+                "text": "Tren de Machu Picchu a Cusco – eToledo linked to your post Camino a Machu Picchu.",
+                "ranges": [
+                           {
+                           "type": "site",
+                           "indices": [
+                                       0,
+                                       38
+                                       ],
+                           "url": "https://etoledom.wordpress.com/2018/07/06/tren-de-machu-picchu-a-cusco/"
+                           },
+                           {
+                           "type": "post",
+                           "indices": [
+                                       59,
+                                       80
+                                       ],
+                           "url": "https://etoledom.wordpress.com/2018/06/09/camino-a-machu-picchu/",
+                           "site_id": 137726971,
+                           "id": 347
+                           }
+                           ]
+                }
+                ],
+    "body": [
+             {
+             "text": "https://etoledom.wordpress.com/2018/07/06/tren-de-machu-picchu-a-cusco/",
+             "ranges": [
+                        {
+                        "type": "post",
+                        "indices": [
+                                    0,
+                                    71
+                                    ],
+                        "url": "https://etoledom.wordpress.com/2018/07/06/tren-de-machu-picchu-a-cusco/"
+                        }
+                        ],
+             "media": [
+                       {
+                       "type": "image",
+                       "indices": [
+                                   0,
+                                   0
+                                   ],
+                       "height": "256",
+                       "width": "256",
+                       "url": "https://www.gravatar.com/avatar/ad516503a11cd5ca435acc9bb6523536?s=128"
+                       }
+                       ],
+             "meta": {
+             "links": {
+             "home": "https://etoledom.wordpress.com/2018/07/06/tren-de-machu-picchu-a-cusco/"
+             },
+             "titles": {
+             "home": ""
+             }
+             },
+             "type": "user"
+             },
+             {
+             "text": "[…] Rail ofrece un muy buen servicio, como mencioné antes, con lujosos trenes en los techos para poder ver el impresionante paisaje del trayecto junto con […]..",
+             "actions": {
+             "spam-comment": false,
+             "trash-comment": false,
+             "approve-comment": true,
+             "edit-comment": true,
+             "replyto-comment": true,
+             "like-comment": false
+             },
+             "meta": {
+             "ids": {
+             "comment": 9,
+             "post": 347,
+             "site": 137726971
+             },
+             "links": {
+             "comment": "https://public-api.wordpress.com/rest/v1/comments/9",
+             "post": "https://public-api.wordpress.com/rest/v1/posts/347",
+             "site": "https://public-api.wordpress.com/rest/v1/sites/137726971"
+             }
+             },
+             "type": "comment",
+             "nest_level": 0,
+             "edit_comment_link": "https://wordpress.com/comment/etoledom.wordpress.com/9?action=edit"
+             }
+             ],
+    "meta": {
+        "ids": {
+            "site": 137726971,
+            "post": 347,
+            "comment": 9
+        },
+        "links": {
+            "site": "https://public-api.wordpress.com/rest/v1/sites/137726971",
+            "post": "https://public-api.wordpress.com/rest/v1/posts/347",
+            "comment": "https://public-api.wordpress.com/rest/v1/comments/9"
+        }
+    },
+    "title": "Link",
+    "header": [
+               {
+               "text": "etoledom",
+               "ranges": [
+                          {
+                          "type": "user",
+                          "indices": [
+                                      0,
+                                      8
+                                      ],
+                          "url": "http://etoledom.wordpress.com",
+                          "site_id": 137726971,
+                          "email": "eduardo.toledo@automattic.com",
+                          "id": 129935412
+                          }
+                          ],
+               "media": [
+                         {
+                         "type": "image",
+                         "indices": [
+                                     0,
+                                     0
+                                     ],
+                         "height": "256",
+                         "width": "256",
+                         "url": "https://2.gravatar.com/avatar/8e06b8f61330e7bc0e5eb4e67aa68e0f?s=256&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D256&r=G"
+                         }
+                         ]
+               },
+               {
+               "text": "Camino a Machu Picchu"
+               }
+               ]
+}


### PR DESCRIPTION
Fixes #9853 

This PR rolls back the changes made to `NotificationBlock` regarding actions, with the objective of effectively using `FormattableContentActions` to manage the actions under the feature flag.

This also enables us to run the old `NotificationBlock` code as it was before this project if the feature flag is disabled.

While working on this, I found some other places where we were using always `NotificationBlocks`, for example: `isUnapprovedComment` property on `Notification`.

All these properties that search on blocks are now using the feature flag to run `NotificationBlock` or `FormattableContent` code.

**Note**:
To be able to do this separation of code execution, it was necessary to reimplement many of the old actions handling code on `NotificationDetailsViewController`. I tried to mark them as `old` and adding reminders to be deleted with the feature flag is removed.

**Sorry for mixing multiple things on a single PR:**
- I also found a small bug with Noticons, where they were not showing properly.

To test:
- The notification sections should be working exactly as before.
- Please take a deeper look into actions.
  - It would be great to also test them disabling the feature flag.
- Check that notions are showing properly.

![img_3626](https://user-images.githubusercontent.com/9772967/43229844-295d7c1c-9034-11e8-898e-5a2e5b59ce6e.png)

![img_3627](https://user-images.githubusercontent.com/9772967/43229879-43a5a888-9034-11e8-8a48-b7eceea4174f.png)

