### PR TITLE
More tests to FormattableContent

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
@@ -60,7 +60,7 @@ class NotificationTextContent: FormattableTextContent, FormattableMediaContent {
         if let firstMedia = media.first, (firstMedia.kind == .image || firstMedia.kind == .badge) {
             return .image
         }
-        return .text
+        return super.kind
     }
 
     required init(dictionary: [String: AnyObject], actions commandActions: [FormattableContentAction], ranges: [FormattableContentRange], parent note: FormattableContentParent) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -556,6 +556,7 @@
 		7ECD5B8120C4D823001AEBC5 /* MediaPreviewHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ECD5B8020C4D823001AEBC5 /* MediaPreviewHelper.swift */; };
 		7ED3695520A9F091007B0D56 /* Blog+ImageSourceInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7ED3695420A9F091007B0D56 /* Blog+ImageSourceInformation.swift */; };
 		7EDAB3F420B046FE002D1A76 /* CircularProgressView+ActivityIndicatorType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EDAB3F320B046FE002D1A76 /* CircularProgressView+ActivityIndicatorType.swift */; };
+		7EF2EEA0210A67B60007A76B /* notifications-unapproved-comment.json in Resources */ = {isa = PBXBuildFile; fileRef = 7EF2EE9F210A67B60007A76B /* notifications-unapproved-comment.json */; };
 		7EFF208620EAD918009C4699 /* FormattableUserContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208520EAD918009C4699 /* FormattableUserContent.swift */; };
 		7EFF208A20EADCB6009C4699 /* NotificationTextContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208920EADCB6009C4699 /* NotificationTextContent.swift */; };
 		7EFF208C20EADF68009C4699 /* FormattableCommentContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208B20EADF68009C4699 /* FormattableCommentContent.swift */; };
@@ -2082,6 +2083,7 @@
 		7ECD5B8020C4D823001AEBC5 /* MediaPreviewHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPreviewHelper.swift; sourceTree = "<group>"; };
 		7ED3695420A9F091007B0D56 /* Blog+ImageSourceInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+ImageSourceInformation.swift"; sourceTree = "<group>"; };
 		7EDAB3F320B046FE002D1A76 /* CircularProgressView+ActivityIndicatorType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CircularProgressView+ActivityIndicatorType.swift"; sourceTree = "<group>"; };
+		7EF2EE9F210A67B60007A76B /* notifications-unapproved-comment.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "notifications-unapproved-comment.json"; sourceTree = "<group>"; };
 		7EFF208520EAD918009C4699 /* FormattableUserContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableUserContent.swift; sourceTree = "<group>"; };
 		7EFF208920EADCB6009C4699 /* NotificationTextContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTextContent.swift; sourceTree = "<group>"; };
 		7EFF208B20EADF68009C4699 /* FormattableCommentContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableCommentContent.swift; sourceTree = "<group>"; };
@@ -5230,6 +5232,7 @@
 			children = (
 				7E987F57210811CC00CAFB88 /* NotificationContentRouterTests.swift */,
 				D821C81C21004724002ED995 /* NotificationBlockTests.swift */,
+				D8BA274C20FDEA2E007A5C77 /* NotificationTextContentTests.swift */,
 				D821C81A21003AE9002ED995 /* FormattableContentGroupTests.swift */,
 				D821C816210036D9002ED995 /* ActivityContentFactoryTests.swift */,
 				D848CC1820FF3A2400A9038F /* FormattableNotIconTests.swift */,
@@ -5237,7 +5240,6 @@
 				D848CC0220FF04FA00A9038F /* FormattableUserContentTests.swift */,
 				D848CBFE20FF010F00A9038F /* FormattableCommentContentTests.swift */,
 				D848CBF820FEF82100A9038F /* NotificationsContentFactoryTests.swift */,
-				D8BA274C20FDEA2E007A5C77 /* NotificationTextContentTests.swift */,
 				D81C2F6920F8B449002AE1F1 /* NotificationActionParserTest.swift */,
 				D81C2F6520F8ACCD002AE1F1 /* FormattableContentFormatterTests.swift */,
 				D81C2F6120F89632002AE1F1 /* EditCommentActionTests.swift */,
@@ -5435,6 +5437,7 @@
 				748BD8841F19234300813F9A /* notifications-mark-as-read.json */,
 				B5AEEC771ACACFDA008BF2A4 /* notifications-new-follower.json */,
 				B5AEEC781ACACFDA008BF2A4 /* notifications-replied-comment.json */,
+				7EF2EE9F210A67B60007A76B /* notifications-unapproved-comment.json */,
 				B5EFB1D01B33630C007608A3 /* notifications-settings.json */,
 				D848CBF620FEEE7F00A9038F /* notifications-text-content.json */,
 				D848CBFA20FEFA4800A9038F /* notifications-comment-content.json */,
@@ -7099,6 +7102,7 @@
 				93C882A11EEB18D700227A59 /* html_page_with_link_to_rsd_non_standard.html in Resources */,
 				8554088A1A6F107D00DDBD79 /* app-review-prompt-global-disable.json in Resources */,
 				7E4A772B20F7E5FD001C706D /* activity-log-site-content.json in Resources */,
+				7EF2EEA0210A67B60007A76B /* notifications-unapproved-comment.json in Resources */,
 				748437EC1F1D4A4800E8DDAF /* gallery-reader-post-public.json in Resources */,
 				7E4A772720F7CDD5001C706D /* activity-log-settings-content.json in Resources */,
 				B5AEEC7A1ACACFDA008BF2A4 /* notifications-like.json in Resources */,

--- a/WordPress/WordPressTest/FormattableContentGroupTests.swift
+++ b/WordPress/WordPressTest/FormattableContentGroupTests.swift
@@ -54,43 +54,6 @@ final class FormattableContentGroupTests: XCTestCase {
         XCTAssertNil(obtainedBlock)
     }
 
-    func testBadgeNotificationProperlyLoadsItsSubjectContent() {
-        let note = utility.loadBadgeNotification()
-
-        XCTAssert(note.subjectContentGroup?.blocks.count == 1)
-        XCTAssertNotNil(note.subjectContentGroup?.blocks.first)
-        XCTAssertNotNil(note.renderSubject())
-    }
-
-    func testBadgeNotificationContainsOneImageContentGroup() {
-        let note = utility.loadBadgeNotification()
-        let group = note.contentGroup(ofKind: .image)
-        XCTAssertNotNil(group)
-
-        let imageBlock = group?.blocks.first as? FormattableMediaContent
-        XCTAssertNotNil(imageBlock)
-
-        let media = imageBlock?.media.first
-        XCTAssertNotNil(media)
-        XCTAssertNotNil(media?.mediaURL)
-    }
-
-    func testLikeNotificationContainsUserContentGroupsInTheBody() {
-        let note = utility.loadLikeNotification()
-        for group in note.bodyContentGroups {
-            XCTAssertTrue(group.kind == .user)
-        }
-    }
-
-    func testFollowerNotificationContainsUserAndFooterGroupsInTheBody() {
-        let note = utility.loadFollowerNotification()
-
-        // Note: Account for 'View All Followers'
-        for group in note.bodyContentGroups {
-            XCTAssertTrue(group.kind == .user || group.kind == .footer)
-        }
-    }
-
     private func mockContent() -> FormattableTextContent {
         return FormattableTextContent(dictionary: mockActivity(), actions: [], ranges: [], parent: mockParent())
     }

--- a/WordPress/WordPressTest/FormattableUserContentTests.swift
+++ b/WordPress/WordPressTest/FormattableUserContentTests.swift
@@ -15,6 +15,11 @@ final class FormattableUserContentTests: XCTestCase {
         static let metaTitlesHomeURL = URL(string: "http://someone.wordpress.com")
         static let notificationId = "11111"
         static let metaSiteId = NSNumber(integerLiteral: 136505344)
+
+        static let imageURL = URL(string: "https://2.gravatar.com/avatar/1111")!
+        static let testImage = UIImage()
+        static let imageRange = NSRange(location: 0, length: 0)
+        static let mappedMediaRanges = [NSValue(range: imageRange): testImage]
     }
 
     override func setUp() {
@@ -50,6 +55,17 @@ final class FormattableUserContentTests: XCTestCase {
         let mockActionsCount = mockedActions().count
 
         XCTAssertEqual(value?.count, mockActionsCount)
+    }
+
+    func testBuildRangesToImagesMapsCorrectly() {
+        let mediaMap = [Expectations.imageURL: Expectations.testImage]
+        let value = subject?.buildRangesToImagesMap(mediaMap)
+        XCTAssertNotNil(value)
+        XCTAssertEqual(value!, Expectations.mappedMediaRanges)
+    }
+
+    func testImageUrlsReturnExpectations() {
+        XCTAssertEqual(subject?.imageUrls, [Expectations.imageURL])
     }
 
     func testMetaReturnsExpectation() {

--- a/WordPress/WordPressTest/NotificationBlockTests.swift
+++ b/WordPress/WordPressTest/NotificationBlockTests.swift
@@ -12,7 +12,7 @@ final class NotificationBlockTests: XCTestCase {
         static let trashAction = TrashCommentAction(on: true, command: TrashComment(on: true))
         static let mediaCount = 0
         static let rangesCount = 2
-        static let text = "Jennifer Parks and 658 others liked your post Bookmark Posts with Save For Later"
+        static let text = "xxxxxx xxxxxx and 658 others liked your post Bookmark Posts with Save For Later"
         static let kind = NotificationBlock.Kind.text
         static let notificationID = "11111"
     }

--- a/WordPress/WordPressTest/NotificationTextContentTests.swift
+++ b/WordPress/WordPressTest/NotificationTextContentTests.swift
@@ -8,7 +8,7 @@ final class NotificationTextContentTests: XCTestCase {
     private var subject: NotificationTextContent?
 
     private struct Expectations {
-        static let text = "Jennifer Parks and 658 others liked your post Bookmark Posts with Save For Later"
+        static let text = "xxxxxx xxxxxx and 658 others liked your post Bookmark Posts with Save For Later"
         static let approveAction = ApproveCommentAction(on: true, command: ApproveComment(on: true))
         static let trashAction = TrashCommentAction(on: true, command: TrashComment(on: true))
     }

--- a/WordPress/WordPressTest/NotificationUtility.swift
+++ b/WordPress/WordPressTest/NotificationUtility.swift
@@ -36,6 +36,10 @@ class NotificationUtility {
         return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-replied-comment.json") as! WordPress.Notification
     }
 
+    func loadUnapprovedCommentNotification() -> WordPress.Notification {
+        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-unapproved-comment.json") as! WordPress.Notification
+    }
+
     func loadPingbackNotification() -> WordPress.Notification {
         return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-pingback.json") as! WordPress.Notification
     }

--- a/WordPress/WordPressTest/Test Data/notifications-replied-comment.json
+++ b/WordPress/WordPressTest/Test Data/notifications-replied-comment.json
@@ -22,7 +22,7 @@
                     "type": "user",
                     "indices": [
                         0,
-                        4
+                        3
                     ],
                     "url": "http:\/\/some.one.com",
                     "site_id": 4,
@@ -32,8 +32,8 @@
                 {
                     "type": "comment",
                     "indices": [
-                        29,
-                        127
+                        28,
+                        32
                     ],
                     "url": "https:\/\/some.thing.here/comment-url",
                     "site_id": 2929292929,

--- a/WordPress/WordPressTest/Test Data/notifications-text-content.json
+++ b/WordPress/WordPressTest/Test Data/notifications-text-content.json
@@ -1,7 +1,7 @@
 {
     "ranges" : [
                 {
-                "email" : "jeniferpacquing@icloud.com",
+                "email" : "xxxxxx@icloud.com",
                 "site_id" : 145434311,
                 "id" : 137920523,
                 "type" : "user",
@@ -22,5 +22,5 @@
                 "url" : "http:\/\/en.blog.wordpress.com\/2018\/06\/21\/bookmark-posts-with-save-for-later\/"
                 }
                 ],
-    "text" : "Jennifer Parks and 658 others liked your post Bookmark Posts with Save For Later"
+    "text" : "xxxxxx xxxxxx and 658 others liked your post Bookmark Posts with Save For Later"
 }

--- a/WordPress/WordPressTest/Test Data/notifications-unapproved-comment.json
+++ b/WordPress/WordPressTest/Test Data/notifications-unapproved-comment.json
@@ -1,0 +1,153 @@
+{
+    "notificationId": "3476688710",
+    "type": "comment",
+    "read": 0,
+    "noticon": "",
+    "timestamp": "2018-07-26T20:31:25+00:00",
+    "icon": "https://secure.gravatar.com/avatar/ad516503a11cd5ca435acc9bb6523536?s=256&r=G",
+    "url": "https://mysitefortestingetoledom.wordpress.com/2018/06/28/test-4/comment-page-1/#comment-8",
+    "subject": [
+                {
+                "text": "Someone commented on test 4",
+                "ranges": [
+                           {
+                           "type": "user",
+                           "indices": [
+                                       0,
+                                       7
+                                       ]
+                           },
+                           {
+                           "type": "post",
+                           "indices": [
+                                       21,
+                                       27
+                                       ],
+                           "url": "https://mysitefortestingetoledom.wordpress.com/2018/06/28/test-4/",
+                           "site_id": 138685806,
+                           "id": 444
+                           }
+                           ]
+                },
+                {
+                "text": "zap!\n",
+                "ranges": [
+                           {
+                           "type": "comment",
+                           "indices": [
+                                       0,
+                                       5
+                                       ],
+                           "url": "https://mysitefortestingetoledom.wordpress.com/2018/06/28/test-4/comment-page-1/#comment-8",
+                           "site_id": 138685806,
+                           "post_id": 444,
+                           "id": 8
+                           }
+                           ]
+                }
+                ],
+    "body": [
+             {
+             "text": "Someone",
+             "ranges": [
+                        {
+                        "type": "user",
+                        "indices": [
+                                    0,
+                                    7
+                                    ]
+                        }
+                        ],
+             "media": [
+                       {
+                       "type": "image",
+                       "indices": [
+                                   0,
+                                   0
+                                   ],
+                       "height": "256",
+                       "width": "256",
+                       "url": "https://secure.gravatar.com/avatar/ad516503a11cd5ca435acc9bb6523536?s=256&r=G"
+                       }
+                       ],
+             "meta": {
+             "links": {}
+             },
+             "type": "user"
+             },
+             {
+             "text": "zap!",
+             "actions": {
+             "spam-comment": false,
+             "trash-comment": false,
+             "approve-comment": false,
+             "edit-comment": true,
+             "replyto-comment": true,
+             "like-comment": false
+             },
+             "meta": {
+             "ids": {
+             "comment": 8,
+             "post": 444,
+             "site": 138685806
+             },
+             "links": {
+             "comment": "https://public-api.wordpress.com/rest/v1/comments/8",
+             "post": "https://public-api.wordpress.com/rest/v1/posts/444",
+             "site": "https://public-api.wordpress.com/rest/v1/sites/138685806"
+             }
+             },
+             "type": "comment",
+             "nest_level": 0,
+             "edit_comment_link": "https://wordpress.com/comment/mysitefortestingetoledom.wordpress.com/8?action=edit"
+             }
+             ],
+    "meta": {
+        "ids": {
+            "user": 0,
+            "comment": 8,
+            "post": 444,
+            "site": 138685806
+        },
+        "links": {
+            "user": "https://public-api.wordpress.com/rest/v1/users/0",
+            "comment": "https://public-api.wordpress.com/rest/v1/comments/8",
+            "post": "https://public-api.wordpress.com/rest/v1/posts/444",
+            "site": "https://public-api.wordpress.com/rest/v1/sites/138685806"
+        }
+    },
+    "header": [
+               {
+               "text": "etoledom",
+               "ranges": [
+                          {
+                          "type": "user",
+                          "indices": [
+                                      0,
+                                      8
+                                      ],
+                          "url": "http://etoledom.wordpress.com",
+                          "site_id": 137726971,
+                          "email": "eduardo.toledo@automattic.com",
+                          "id": 129935412
+                          }
+                          ],
+               "media": [
+                         {
+                         "type": "image",
+                         "indices": [
+                                     0,
+                                     0
+                                     ],
+                         "height": "256",
+                         "width": "256",
+                         "url": "https://2.gravatar.com/avatar/8e06b8f61330e7bc0e5eb4e67aa68e0f?s=256&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D256&r=G"
+                         }
+                         ]
+               },
+               {
+               "text": "test 4"
+               }
+               ],
+    "title": "Comment"
+}

--- a/WordPress/WordPressTest/Test Data/notifications-user-content.json
+++ b/WordPress/WordPressTest/Test Data/notifications-user-content.json
@@ -7,7 +7,7 @@
                             ],
                "height" : "256",
                "width" : "256",
-               "url" : "https:\/\/2.gravatar.com\/avatar\/8ef8cfd7ba86843395a0a340093b6c6f?s=256&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D256&r=G",
+               "url" : "https:\/\/2.gravatar.com\/avatar\/1111",
                "type" : "image"
                }
                ],


### PR DESCRIPTION
Part of #9758

This PR adds some Unit Tests to the Notification implementation of `FormattableContent`.
Many of the tests are copies of tests made for the old `NotificationBlocks`, but using the new content groups.

To test:

- Build and run the tests.
- All tests should pass.