### PR TITLE
Formattable content code organization

### DIFF
--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentStyles.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentStyles.swift
@@ -1,8 +1,14 @@
 
+/// Styles definition to be applied to a single FormattableContent entity.
 public protocol FormattableContentStyles {
+    /// Base attributes applied to the full text.
     var attributes: [NSAttributedStringKey: Any] { get }
+    /// Styles to apply to quotes found in the text or nil to not apply any.
     var quoteStyles: [NSAttributedStringKey: Any]? { get }
+    /// Styles definition for a specific set of ranges identified by their kind or nil to not apply any.
     var rangeStylesMap: [FormattableRangeKind: [NSAttributedStringKey: Any]]? { get }
+    /// Color for text that represent a link or nil to not apply any.
     var linksColor: UIColor? { get }
+    /// Key to be used for caching the resulting attributed string. It needs to be unique.
     var key: String { get }
 }

--- a/WordPress/Classes/Utility/FormattableContent/FormattableRangesFactory.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableRangesFactory.swift
@@ -1,0 +1,29 @@
+
+protocol FormattableRangesFactory {
+    static func contentRange(from dictionary: [String: AnyObject]) -> FormattableContentRange?
+}
+
+extension FormattableRangesFactory {
+    static func rangeFrom(_ dictionary: [String: AnyObject]) -> NSRange? {
+        guard let indices = dictionary[RangeKeys.indices] as? [Int],
+            let start = indices.first,
+            let end = indices.last else {
+                return nil
+        }
+        return NSMakeRange(start, end - start)
+    }
+
+    static func kindString(from dictionary: [String: AnyObject]) -> String? {
+        return dictionary[RangeKeys.rawType] as? String
+    }
+}
+
+private enum RangeKeys {
+    static let rawType = "type"
+    static let url = "url"
+    static let indices = "indices"
+    static let id = "id"
+    static let value = "value"
+    static let siteId = "site_id"
+    static let postId = "post_id"
+}

--- a/WordPress/Classes/Utility/FormattableContent/FormattableTextContent.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableTextContent.swift
@@ -24,12 +24,6 @@ class FormattableTextContent: FormattableContent {
         actions = commandActions
         self.ranges = ranges
     }
-
-
-    private static func rangesFrom(_ rawRanges: [[String: AnyObject]]?) -> [FormattableContentRange] {
-        let parsed = rawRanges?.compactMap(NotificationContentRangeFactory.contentRange)
-        return parsed ?? []
-    }
 }
 
 extension FormattableMediaItem {

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/Factory/ActivityRangesFactory.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/Factory/ActivityRangesFactory.swift
@@ -1,5 +1,5 @@
 
-struct ActivityRangesFactory: ContentRangeFactory {
+struct ActivityRangesFactory: FormattableRangesFactory {
     static func contentRange(from dictionary: [String: AnyObject]) -> FormattableContentRange? {
         guard let range = rangeFrom(dictionary) else {
             return nil

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
@@ -85,6 +85,11 @@ class NotificationTextContent: FormattableTextContent, FormattableMediaContent {
 
         return nil
     }
+
+    private static func rangesFrom(_ rawRanges: [[String: AnyObject]]?) -> [FormattableContentRange] {
+        let parsed = rawRanges?.compactMap(NotificationContentRangeFactory.contentRange)
+        return parsed ?? []
+    }
 }
 
 private enum Constants {

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Ranges/NotificationContentRangeFactory.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Ranges/NotificationContentRangeFactory.swift
@@ -1,34 +1,5 @@
 
-protocol ContentRangeFactory {
-    static func contentRange(from dictionary: [String: AnyObject]) -> FormattableContentRange?
-}
-
-extension ContentRangeFactory {
-    static func rangeFrom(_ dictionary: [String: AnyObject]) -> NSRange? {
-        guard let indices = dictionary[RangeKeys.indices] as? [Int],
-            let start = indices.first,
-            let end = indices.last else {
-                return nil
-        }
-        return NSMakeRange(start, end - start)
-    }
-
-    static func kindString(from dictionary: [String: AnyObject]) -> String? {
-        return dictionary[RangeKeys.rawType] as? String
-    }
-}
-
-private enum RangeKeys {
-    static let rawType = "type"
-    static let url = "url"
-    static let indices = "indices"
-    static let id = "id"
-    static let value = "value"
-    static let siteId = "site_id"
-    static let postId = "post_id"
-}
-
-struct NotificationContentRangeFactory: ContentRangeFactory {
+struct NotificationContentRangeFactory: FormattableRangesFactory {
     static func contentRange(from dictionary: [String: AnyObject]) -> FormattableContentRange? {
         guard let range = rangeFrom(dictionary) else {
             return nil

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -548,6 +548,7 @@
 		7E846FF120FD0A0500881F5A /* ContentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */; };
 		7E846FF320FD37BD00881F5A /* ActivityCommentRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */; };
 		7E92828921090E9A00BBD8A3 /* notifications-pingback.json in Resources */ = {isa = PBXBuildFile; fileRef = 7E92828821090E9A00BBD8A3 /* notifications-pingback.json */; };
+		7E929CD12110D4F200BCAD88 /* FormattableRangesFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E929CD02110D4F200BCAD88 /* FormattableRangesFactory.swift */; };
 		7E987F562108017B00CAFB88 /* NotificationContentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */; };
 		7E987F58210811CC00CAFB88 /* NotificationContentRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E987F57210811CC00CAFB88 /* NotificationContentRouterTests.swift */; };
 		7E987F5A2108122A00CAFB88 /* NotificationUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E987F592108122A00CAFB88 /* NotificationUtility.swift */; };
@@ -2076,6 +2077,7 @@
 		7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCoordinator.swift; sourceTree = "<group>"; };
 		7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityCommentRange.swift; sourceTree = "<group>"; };
 		7E92828821090E9A00BBD8A3 /* notifications-pingback.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "notifications-pingback.json"; sourceTree = "<group>"; };
+		7E929CD02110D4F200BCAD88 /* FormattableRangesFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableRangesFactory.swift; sourceTree = "<group>"; };
 		7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentRouter.swift; sourceTree = "<group>"; };
 		7E987F57210811CC00CAFB88 /* NotificationContentRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentRouterTests.swift; sourceTree = "<group>"; };
 		7E987F592108122A00CAFB88 /* NotificationUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationUtility.swift; sourceTree = "<group>"; };
@@ -4394,6 +4396,7 @@
 				7E4123B020F4097A00DF8486 /* FormattableMediaContent.swift */,
 				7E4123B320F4097A00DF8486 /* FormattableTextContent.swift */,
 				7E53AB0120FE5EAE005796FE /* ContentRouter.swift */,
+				7E929CD02110D4F200BCAD88 /* FormattableRangesFactory.swift */,
 			);
 			path = FormattableContent;
 			sourceTree = "<group>";
@@ -8062,6 +8065,7 @@
 				5DAFEAB81AF2CA6E00B3E1D7 /* PostMetaButton.m in Sources */,
 				40ADB15520686870009A9161 /* PluginStore+Persistence.swift in Sources */,
 				D83CA3A720842CD90060E310 /* ResultsPage.swift in Sources */,
+				7E929CD12110D4F200BCAD88 /* FormattableRangesFactory.swift in Sources */,
 				08D978551CD2AF7D0054F19A /* Menu+ViewDesign.m in Sources */,
 				E142007A1C117A3B00B3B115 /* ManagedAccountSettings+CoreDataProperties.swift in Sources */,
 				B535209D1AF7EB9F00B33BA8 /* PushAuthenticationService.swift in Sources */,


### PR DESCRIPTION
Fixes part of #9758 

This PR is a small organization of code and documentation:
- Moving `FormattableRangesFactory` to its own file.
- Moving `rangesFrom()` function from `FormattableTextContent` to `NotificationTextContent`.
- Adding documentation to `FormattableContentStyles`

To test:

- Build and run.
- Check that Notifications works as it should.

@ctarda this is the last one! Sorry for the late PR.
I just couldn't leave this details there. 😅