### PR TITLE
Fix screenshots: Use explicit accessibilityIdentifier for stats row

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -501,6 +501,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
 
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
+                                  accessibilityIdentifier:@"Stats Row"
                                                     image:[Gridicon iconOfType:GridiconTypeStatsAlt]
                                                  callback:^{
                                                      [weakSelf showStats];

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -118,7 +118,7 @@ class WordPressScreenshotGeneration: XCTestCase {
         if UIDevice.current.userInterfaceIdiom == .phone {
             app.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0).tap() // back button
         }
-        blogDetailsTable.cells.element(boundBy: 0).tap() // tap Stats
+        blogDetailsTable.cells["Stats Row"].tap() // tap Stats
         app.segmentedControls.element(boundBy: 0).buttons.element(boundBy: 1).tap() // tap Days
 
         // Wait for stats to be loaded


### PR DESCRIPTION
Screenshots automation was broken since the order of cells in the blog details table changed. This is an update to use accessibility identifiers so that we are not dependent on order.

To test: `fastlane snapshot` now runs successfully.


