### PR TITLE
Gravatar Picker: replace No Results view

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
@@ -74,7 +74,7 @@ class GravatarPickerViewController: UIViewController, WPMediaPickerViewControlle
     func mediaPickerControllerDidCancel(_ picker: WPMediaPickerViewController) {
         onCompletion?(nil)
     }
-    
+
     func emptyViewController(forMediaPickerController picker: WPMediaPickerViewController) -> UIViewController? {
         let noResultsView = NoResultsViewController.controller()
         noResultsView.configureForNoAssets(userCanUploadMedia: false)

--- a/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
@@ -74,9 +74,11 @@ class GravatarPickerViewController: UIViewController, WPMediaPickerViewControlle
     func mediaPickerControllerDidCancel(_ picker: WPMediaPickerViewController) {
         onCompletion?(nil)
     }
-
-    func emptyView(forMediaPickerController picker: WPMediaPickerViewController) -> UIView? {
-        return MediaNoResultsView()
+    
+    func emptyViewController(forMediaPickerController picker: WPMediaPickerViewController) -> UIViewController? {
+        let noResultsView = NoResultsViewController.controller()
+        noResultsView.configureForNoAssets(userCanUploadMedia: false)
+        return noResultsView
     }
 
     // MARK: - Private Methods


### PR DESCRIPTION
Fixes #9902 

In the Gravatar Picker, replace `WPNoResultsView` with `NoResultsViewController`.

The No Results view is displayed when the user has no media.

The idea here is to replace `MediaNoResultsView` with `NoResultsViewController+MediaLibrary` (which was introduced in #9897). `MediaNoResultsView` will be removed once all relevant ViewControllers are updated.

**To test:**

---
**No Media - device with camera:**
- On an actual device, go to Me and tap on the user icon.
- The initial view is Selfies. If you don't have any, you'll see the following view. 
- If you do have Selfies, tap Albums and pick one that has no media.

<img width="250" alt="camera_new_nrv" src="https://user-images.githubusercontent.com/1816888/43615302-2fe4fc90-9674-11e8-8505-ac08c192469a.png">

---
**No Media - device with no camera (or simulator):**
- Follow the same steps as above.
- Verify the view is:

![no_camera_new_nrv](https://user-images.githubusercontent.com/1816888/43615401-bd9b9cc4-9674-11e8-94cb-5a131ff9516e.png)
