### PR TITLE
Improve screenshot reliability

### DIFF
--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -2,6 +2,7 @@ import UIKit
 import XCTest
 
 class WordPressScreenshotGeneration: XCTestCase {
+    let imagesWaitTime: UInt32 = 10
 
     override func setUp() {
         super.setUp()
@@ -89,7 +90,7 @@ class WordPressScreenshotGeneration: XCTestCase {
         if UIDevice.current.userInterfaceIdiom == .pad {
             blogDetailsTable.cells["Blog Post Row"].tap()
             waitForElementToExist(element: app.tables["PostsTable"])
-            sleep(5) // Wait for posts to load
+            sleep(imagesWaitTime) // Wait for post images to load
         }
         snapshot("3-My-Site")
 
@@ -102,7 +103,7 @@ class WordPressScreenshotGeneration: XCTestCase {
 
         let editorNavigationBar = app.navigationBars["Azctec Editor Navigation Bar"]
         XCTAssert(editorNavigationBar.exists, "Post editor not found")
-        sleep(5) // wait for post images to load
+        sleep(imagesWaitTime) // wait for post images to load
         // The title field gets focus automatically
         snapshot("1-PostEditor")
 
@@ -138,7 +139,7 @@ class WordPressScreenshotGeneration: XCTestCase {
         discoverCell.tap() // tap Discover
 
         waitForElementToExist(element: app.tables["Reader"])
-        sleep(5) // Wait for content to load
+        sleep(imagesWaitTime) // Wait for images to load
         snapshot("2-Reader")
 
         // Get Notifications screenshot

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -38,10 +38,7 @@ class WordPressScreenshotGeneration: XCTestCase {
 
         // Logout first if needed
         if !loginButton.waitForExistence(timeout: 3.0) {
-            // Log out
-            app.tabBars["Main Navigation"].buttons["meTabButton"].tap()
-            app.tables.element(boundBy: 0).cells.element(boundBy: 5).tap() // Tap disconnect
-            app.alerts.element(boundBy: 0).buttons.element(boundBy: 1).tap() // Tap disconnect
+            logout()
         }
 
         loginButton.tap()
@@ -78,6 +75,28 @@ class WordPressScreenshotGeneration: XCTestCase {
         if cancelAlertButton.waitForExistence(timeout: 3.0) {
             cancelAlertButton.tap()
         }
+    }
+
+    func logout() {
+        let app = XCUIApplication()
+        app.tabBars["Main Navigation"].buttons["meTabButton"].tap()
+
+        let loginButton = app.buttons["Log In Button"]
+        let logoutButton = app.tables.element(boundBy: 0).cells.element(boundBy: 5)
+        let logoutAlert = app.alerts.element(boundBy: 0)
+
+        // The order of cancel and log out in the alert varies by language
+        // There is no way to set accessibility identifers on them, so we must try both
+        logoutButton.tap()
+        logoutAlert.buttons.buttons.element(boundBy: 1).tap()
+
+        if !loginButton.waitForExistence(timeout: 3.0) {
+            // Still not logged out, try the other button
+            logoutButton.tap()
+            logoutAlert.buttons.buttons.element(boundBy: 0).tap()
+        }
+
+        waitForElementToExist(element: loginButton)
     }
 
     func testGenerateScreenshots() {


### PR DESCRIPTION
This makes two small changes to improve reliability:

- Wait time for image loading has been increased.
- Log out now works for all locales. This was previously unreliable because button order varies.

Another step towards fixing https://github.com/wordpress-mobile/WordPress-iOS/issues/9720

To test:
- `fastlane snapshot` will still work.
- More time is now allowed for images to load

