### PR TITLE
Fix universal links entitlements for internal builds

### DIFF
--- a/WordPress/WordPress-Alpha.entitlements
+++ b/WordPress/WordPress-Alpha.entitlements
@@ -5,6 +5,8 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:wordpress.com</string>
+		<string>applinks:wordpress.com</string>
+		<string>applinks:apps.wordpress.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/WordPress/WordPress-Internal.entitlements
+++ b/WordPress/WordPress-Internal.entitlements
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>aps-environment</key>
-    <string>distribution</string>
-    <key>com.apple.developer.associated-domains</key>
-    <array>
-      <string>webcredentials:wordpress.com</string>
-    </array>
-    <key>com.apple.security.application-groups</key>
-    <array>
-      <string>group.org.wordpress.internal</string>
-    </array>
-    <key>keychain-access-groups</key>
-    <array>
-      <string>99KV9Z6BKV.org.wordpress.internal</string>
-    </array>
-  </dict>
+<dict>
+	<key>aps-environment</key>
+	<string>distribution</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:wordpress.com</string>
+		<string>applinks:wordpress.com</string>
+		<string>applinks:apps.wordpress.com</string>
+	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.wordpress.internal</string>
+	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>99KV9Z6BKV.org.wordpress.internal</string>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
It turns out that universal links weren't working for internal builds, as I'd missed updating the entitlements files for them.

This PR should fix that by adding the missing `applinks` entries to the internal entitlements file. I added them to alpha while I was at it too.

**To test**

* Check that the `com.apple.developer.associated-domains` section in the Alpha and Internal entitlements files match that section in `WordPress.entitlements`
* Build and run an internal build onto a device. On that device, tap this link: https://apps.wordpress.com/get. It should launch the app!