### PR TITLE
iOS Screenshots: Remove notification banner

### DIFF
--- a/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
+++ b/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
@@ -52,6 +52,7 @@ class AppFeedbackPromptView: UIView {
         leftButton.tintColor = .white
         leftButton.setTitleColor(UIColor.white, for: .normal)
         leftButton.titleLabel?.font = textFont
+        leftButton.accessibilityIdentifier = "yes-button"
         buttonStack.addArrangedSubview(leftButton)
 
         // Could be Better Button
@@ -60,6 +61,7 @@ class AppFeedbackPromptView: UIView {
         rightButton.tintColor = .white
         rightButton.setTitleColor(UIColor.white, for: .normal)
         rightButton.titleLabel?.font = textFont
+        rightButton.accessibilityIdentifier = "no-button"
         buttonStack.addArrangedSubview(rightButton)
 
         setupConstraints()

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -164,6 +164,13 @@ class WordPressScreenshotGeneration: XCTestCase {
         // Get Notifications screenshot
         app.tabBars["Main Navigation"].buttons["notificationsTabButton"].tap()
         XCTAssert(app.tables["Notifications Table"].exists, "Notifications Table not found")
+        
+        //Tap the "Not Now" button to dismiss the notifications prompt
+        let notNowButton = app.buttons["no-button"]
+        if notNowButton.exists{
+            notNowButton.tap()
+        }
+        
         snapshot("5-Notifications")
     }
 }

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -164,13 +164,13 @@ class WordPressScreenshotGeneration: XCTestCase {
         // Get Notifications screenshot
         app.tabBars["Main Navigation"].buttons["notificationsTabButton"].tap()
         XCTAssert(app.tables["Notifications Table"].exists, "Notifications Table not found")
-        
+
         //Tap the "Not Now" button to dismiss the notifications prompt
         let notNowButton = app.buttons["no-button"]
-        if notNowButton.exists{
+        if notNowButton.exists {
             notNowButton.tap()
         }
-        
+
         snapshot("5-Notifications")
     }
 }


### PR DESCRIPTION
The simplest fix was to just click the "Not Now" button. Because the button labels may change (and with RTL support, the order may as well), it was necessary to add accessibility identifiers to the buttons. 

Fixes #9868

To test:
- Screenshots should no longer have the notification banner in them
- Adding the accessibility identifier to the buttons in `AppFeedbackPromptView` shouldn't have any side effects that'll affect app stability.