### PR TITLE
Improve screenshot onboarding

### DIFF
--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -44,8 +44,11 @@ class WordPressScreenshotGeneration: XCTestCase {
         loginButton.tap()
         app.buttons["Self Hosted Login Button"].tap()
 
-        let username = ""
-        let password = ""
+        // Use the same login here that you did when you created an App
+        // in the WordPress.com Application Manager. If you're not sure how to do that,
+        // you can read more here: https://github.com/wordpress-mobile/WordPress-iOS#setup-credentials
+        let username: String = <# Your Wordpress.com Email #>
+        let password: String = <# Your Wordpress.com Password #>
 
         // We have to login by site address, due to security issues with the
         // shared testing account which prevent us from signing in by email address.


### PR DESCRIPTION
If someone new to the project wants to work on screenshots, they can run the `WordPressScreenshotGeneration` test or use `fastlane snapshot`. However, if they haven’t set their WordPress.com username and password, it’ll fail with an unhelpful error:

>WordPressScreenshotGeneration.testGenerateScreenshots() failed: failed - Failed to find "Continue" Button after 30.0 seconds.

This is because by default the username and password are set to empty strings, which are technically valid code. 

After this commit, if someone takes the same steps, it’ll instead tell them:
>WordPressScreenshotGeneration.swift:50:32: Editor placeholder in source file

This points them to the exact place they need to make a change in order to continue, which should hopefully ease the onboarding process. As a bonus, in Xcode it even shows a nice little placeholder!

Additionally, this change makes it possible to script the population of these values a little more easily – even if the variable names change, the tokens don't have to, and finding / replacing project-wide for these types of values becomes possible.

To test:

Try checking out the project from scratch and running the screenshots - now you'll get a slightly more helpful error telling you why your screenshot generation failed.