### PR TITLE
Fix No Results View issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/NoResultsViewController+StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/NoResultsViewController+StockPhotosPicker.swift
@@ -38,21 +38,14 @@ extension NoResultsViewController {
     }
 
     func configureAsNoSearchResults(for string: String) {
-        configure(title: configureSearchResultTitle(for: string),
+        configure(title: .freePhotosSearchNoResult,
                   buttonTitle: nil,
-                  subtitle: nil,
+                  subtitle: string,
                   attributedSubtitle: nil,
                   image: Constants.imageName,
                   accessoryView: nil)
 
         view.layoutIfNeeded()
-    }
-
-    private func configureSearchResultTitle(for string: String) -> String {
-        //Translators could add an empty space at the end of this phrase.
-        let sanitizedNoResultString = String.freePhotosSearchNoResult.trimmingCharacters(in: .whitespaces)
-        let titleText = sanitizedNoResultString + " " + string
-        return titleText
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosStrings.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Stock Photos/StockPhotosStrings.swift
@@ -27,7 +27,7 @@ extension String {
     }
 
     static var freePhotosSearchNoResult: String {
-        return NSLocalizedString("No media files match your search for", comment: "Phrase to show when the user search for images but there are no result to show. This will be followed by the phrase the user used to search. (i.e. No media files match your search for Ugly kitten). This search phrase will be always appended at the end.")
+        return NSLocalizedString("No media files match your search for:", comment: "Phrase to show when the user search for images but there are no result to show. This will be followed by the phrase the user used to search. (i.e. No media files match your search for Ugly kitten). This search phrase will be always appended at the end.")
     }
 
     static var freePhotosSearchLoading: String {

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -153,6 +153,7 @@ private extension NoResultsViewController {
         titleLabel.text = titleText
 
         if let subtitleText = subtitleText {
+            subtitleTextView.attributedText = nil
             subtitleTextView.text = subtitleText
             subtitleTextView.isSelectable = false
         }

--- a/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
+++ b/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
@@ -15,8 +15,7 @@ extension NoResultsViewController {
     }
 
     func configureForNoSearchResult(with searchQuery: String) {
-        let title = String.localizedStringWithFormat(LocalizedText.noResultsTitle, searchQuery)
-        configure(title: title, buttonTitle: nil, subtitle: nil, attributedSubtitle: nil, image: Constants.imageName, accessoryView: nil)
+        configure(title: LocalizedText.noResultsTitle, buttonTitle: nil, subtitle: searchQuery, attributedSubtitle: nil, image: Constants.imageName, accessoryView: nil)
     }
 
     private enum Constants {
@@ -28,7 +27,7 @@ extension NoResultsViewController {
         static let noAssetsTitle = NSLocalizedString("You don't have any media.", comment: "Title displayed when the user doesn't have any media in their media library. Should match Calypso.")
         static let uploadButtonTitle = NSLocalizedString("Upload Media", comment: "Title for button displayed when the user has an empty media library")
         static let fetchingTitle = NSLocalizedString("Fetching media...", comment: "Title displayed whilst fetching media from the user's media library")
-        static let noResultsTitle = NSLocalizedString("No media files match your search for %@", comment: "Message displayed when no results are returned from a media library search. Should match Calypso.")
+        static let noResultsTitle = NSLocalizedString("No media files match your search for:", comment: "Message displayed when no results are returned from a media library search. Should match Calypso.")
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -20,7 +20,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ae-eX-ae9" userLabel="No Results View">
-                                <rect key="frame" x="10" y="207" width="355" height="274.5"/>
+                                <rect key="frame" x="10" y="212" width="355" height="264.5"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="czl-5D-gem" userLabel="Accessory View">
                                         <rect key="frame" x="127.5" y="0.5" width="100" height="100"/>
@@ -37,20 +37,20 @@
                                             <constraint firstAttribute="width" constant="226" id="zgJ-Vl-MiN"/>
                                         </constraints>
                                     </imageView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w">
-                                        <rect key="frame" x="0.0" y="136.5" width="355" height="138.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w">
+                                        <rect key="frame" x="0.0" y="136.5" width="355" height="128.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">
-                                                <rect key="frame" x="93" y="0.0" width="169.5" height="64.5"/>
+                                                <rect key="frame" x="93" y="0.0" width="169.5" height="54.5"/>
                                                 <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is the title text." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8BN-gx-7TL">
-                                                        <rect key="frame" x="0.0" y="0.0" width="169.5" height="24.5"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is the title text." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8BN-gx-7TL">
+                                                        <rect key="frame" x="0.0" y="0.0" width="169.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                         <color key="textColor" red="0.18039215689999999" green="0.2274509804" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="This is the subtitle text." textAlignment="center" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pAg-XC-9IM" userLabel="Subtitle Text View">
-                                                        <rect key="frame" x="0.0" y="24.5" width="169.5" height="40"/>
+                                                        <rect key="frame" x="0.0" y="20.5" width="169.5" height="34"/>
                                                         <color key="textColor" red="0.30980392159999998" green="0.4549019608" blue="0.5568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -58,7 +58,7 @@
                                                 </subviews>
                                             </stackView>
                                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CPl-cH-d7b" customClass="NUXButton" customModule="WordPressAuthenticator">
-                                                <rect key="frame" x="135.5" y="94.5" width="84" height="44"/>
+                                                <rect key="frame" x="135.5" y="84.5" width="84" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="ALu-HJ-Bk4"/>
                                                 </constraints>


### PR DESCRIPTION
Ref #9504 

When making accommodations for putting the media search string in the title field, it broke the NoResultsView for no sites and all sites hidden.

This change puts the search string in the subtitle field (which actually looks better anyway) and restores the correct UI layout for no sites and all sites hidden.

NOTE: if you notice broken constraints messages, I know. 😄 I'm working on it!

To test:

---
**All sites hidden**
- Hide all sites on account.
- Verify the view is:
<img width="250" alt="all_hidden" src="https://user-images.githubusercontent.com/1816888/43805503-3434d832-9a5d-11e8-8499-f2a33d1c1707.png">

---
**No sites**
- Log into an account with no sites.
- Verify the view is:
<img width="250" alt="no_sites" src="https://user-images.githubusercontent.com/1816888/43805524-52906b7a-9a5d-11e8-8252-c3c060c38e83.png">

---
**Media Library search**
- On a site with media, go to Media Library.
- Enter an invalid search string.
- Verify the view is:
<img width="250" alt="media_library_search" src="https://user-images.githubusercontent.com/1816888/43805577-8d26ee9e-9a5d-11e8-92be-b576bdd37159.png">

---
**Stock Photos search**
- Go to Media Library, click the + on the nav bar, and select 'Free Photo Library'.
- Enter an invalid search string:
- Verify the view is:
<img width="250" alt="stock_photos_search" src="https://user-images.githubusercontent.com/1816888/43805643-c9d7db46-9a5d-11e8-90b7-c72e4bfcbfea.png">
