### PR TITLE
Site Icon Picker: replace No Results view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
@@ -18,7 +18,7 @@ class SiteIconPickerPresenter: NSObject {
 
     /// MARK: - Private Properties
 
-    fileprivate let noResultsView = MediaNoResultsView()
+    fileprivate let noResultsView = NoResultsViewController.controller()
     fileprivate var mediaLibraryChangeObserverKey: NSObjectProtocol? = nil
 
     /// Media Library Data Source
@@ -55,6 +55,7 @@ class SiteIconPickerPresenter: NSObject {
     ///
     @objc init(blog: Blog) {
         self.blog = blog
+        noResultsView.configureForNoAssets(userCanUploadMedia: false)
         super.init()
     }
 
@@ -139,7 +140,8 @@ class SiteIconPickerPresenter: NSObject {
             let hasNoAssets = self?.mediaLibraryDataSource.numberOfAssets() == 0
 
             if isNotSearching && hasNoAssets {
-                self?.noResultsView.updateForNoAssets(userCanUploadMedia: false)
+                self?.noResultsView.removeFromView()
+                self?.noResultsView.configureForNoAssets(userCanUploadMedia: false)
             }
         })
     }
@@ -170,17 +172,19 @@ extension SiteIconPickerPresenter: WPMediaPickerViewControllerDelegate {
 
     func mediaPickerControllerWillBeginLoadingData(_ picker: WPMediaPickerViewController) {
         updateSearchBar(mediaPicker: picker)
-        noResultsView.updateForFetching()
+        noResultsView.configureForFetching()
     }
 
     func mediaPickerControllerDidEndLoadingData(_ picker: WPMediaPickerViewController) {
-        noResultsView.updateForNoAssets(userCanUploadMedia: false)
+        noResultsView.removeFromView()
+        noResultsView.configureForNoAssets(userCanUploadMedia: false)
         updateSearchBar(mediaPicker: picker)
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, didUpdateSearchWithAssetCount assetCount: Int) {
         if let searchQuery = mediaLibraryDataSource.searchQuery {
-            noResultsView.updateForNoSearchResult(with: searchQuery)
+            noResultsView.removeFromView()
+            noResultsView.configureForNoSearchResult(with: searchQuery)
         }
     }
 
@@ -237,7 +241,7 @@ extension SiteIconPickerPresenter: WPMediaPickerViewControllerDelegate {
         }
     }
 
-    func emptyView(forMediaPickerController picker: WPMediaPickerViewController) -> UIView? {
+    func emptyViewController(forMediaPickerController picker: WPMediaPickerViewController) -> UIViewController? {
         return noResultsView
     }
 }


### PR DESCRIPTION
Fixes #9938 

In the Site Icon Picker, replace `WPNoResultsView` with `NoResultsViewController`.

The No Results view is displayed when:
- The user has no media.
- Media is being fetched.
- No results from searching the WordPress media library.

**To test:**

---
**No Media:**
- On a site with no WordPress media, click on the site icon.
- Select 'Change Site Icon'.
- Select the 'WordPress Media' album.
- Verify the view is:
![no_media](https://user-images.githubusercontent.com/1816888/43857798-9967d324-9b09-11e8-9765-dea64755b718.png)

---
**Fetching:**
- On a slow network, click on the site icon.
  - To note, you may have to select another site, or do a fresh install, since media is cached.
- Select 'Change Site Icon'.
- While the message `counting media items` is still displayed on an album, select it.
- Verify the view is:
![fetching](https://user-images.githubusercontent.com/1816888/43857926-eb0a5760-9b09-11e8-9c20-8684cfa26e7c.png)

---
**No Results:**
- On a site with WordPress media, click on the site icon.
- Select 'Change Site Icon'.
- Select the 'WordPress Media' album.
- Enter an invalid search string.
- Verify the view is:
![no_results](https://user-images.githubusercontent.com/1816888/43858278-d83fabe8-9b0a-11e8-970b-c55076657d38.png)

