### PR TITLE
Post Editor: replace No Results view

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -66,7 +66,7 @@ target 'WordPress' do
     pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
     pod 'Gridicons', '0.16'
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', '1.2'
+    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '9858f1b79d1a28b95ae831cce004276a3a38927b'
     pod 'WordPressAuthenticator', '1.0.5'
     pod 'WordPress-Aztec-iOS', '=1.0.0-beta.24'
 	  pod 'WordPress-Editor-iOS', '=1.0.0-beta.24'

--- a/Podfile
+++ b/Podfile
@@ -66,7 +66,7 @@ target 'WordPress' do
     pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
     pod 'Gridicons', '0.16'
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'a759bc226194cb4a9d8f733f85de386a42a2b9b6'
+    pod 'WPMediaPicker', '1.3'
     pod 'WordPressAuthenticator', '1.0.5'
     pod 'WordPress-Aztec-iOS', '=1.0.0-beta.24'
 	  pod 'WordPress-Editor-iOS', '=1.0.0-beta.24'

--- a/Podfile
+++ b/Podfile
@@ -66,7 +66,7 @@ target 'WordPress' do
     pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
     pod 'Gridicons', '0.16'
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '9858f1b79d1a28b95ae831cce004276a3a38927b'
+    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'a759bc226194cb4a9d8f733f85de386a42a2b9b6'
     pod 'WordPressAuthenticator', '1.0.5'
     pod 'WordPress-Aztec-iOS', '=1.0.0-beta.24'
 	  pod 'WordPress-Editor-iOS', '=1.0.0-beta.24'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -170,7 +170,7 @@ DEPENDENCIES:
   - WordPressKit (= 1.2.1)
   - WordPressShared (= 1.0.9)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `7a5b1a3fb44f62416fbc2e5f0de623b87b613aae`)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `9858f1b79d1a28b95ae831cce004276a3a38927b`)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `a759bc226194cb4a9d8f733f85de386a42a2b9b6`)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
 
@@ -217,7 +217,7 @@ EXTERNAL SOURCES:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
   WPMediaPicker:
-    :commit: 9858f1b79d1a28b95ae831cce004276a3a38927b
+    :commit: a759bc226194cb4a9d8f733f85de386a42a2b9b6
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
@@ -228,7 +228,7 @@ CHECKOUT OPTIONS:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
   WPMediaPicker:
-    :commit: 9858f1b79d1a28b95ae831cce004276a3a38927b
+    :commit: a759bc226194cb4a9d8f733f85de386a42a2b9b6
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
@@ -268,6 +268,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 6529d93621bc1d57924583909d210fdb95ed9725
+PODFILE CHECKSUM: ef89c1d3d69195056739a734cd152af19273a5ef
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -170,7 +170,7 @@ DEPENDENCIES:
   - WordPressKit (= 1.2.1)
   - WordPressShared (= 1.0.9)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `7a5b1a3fb44f62416fbc2e5f0de623b87b613aae`)
-  - WPMediaPicker (= 1.2)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `9858f1b79d1a28b95ae831cce004276a3a38927b`)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
 
@@ -206,7 +206,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
-    - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
 
@@ -217,6 +216,9 @@ EXTERNAL SOURCES:
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
+  WPMediaPicker:
+    :commit: 9858f1b79d1a28b95ae831cce004276a3a38927b
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -225,6 +227,9 @@ CHECKOUT OPTIONS:
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
+  WPMediaPicker:
+    :commit: 9858f1b79d1a28b95ae831cce004276a3a38927b
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -263,6 +268,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: f15aff095a2e79b9e141bb4bdb392e217ea7dafb
+PODFILE CHECKSUM: 6529d93621bc1d57924583909d210fdb95ed9725
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -130,7 +130,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.0.6)
-  - WPMediaPicker (1.2)
+  - WPMediaPicker (1.3)
   - wpxmlrpc (0.8.3)
   - ZendeskSDK (1.11.2.1):
     - ZendeskSDK/Providers (= 1.11.2.1)
@@ -170,7 +170,7 @@ DEPENDENCIES:
   - WordPressKit (= 1.2.1)
   - WordPressShared (= 1.0.9)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `7a5b1a3fb44f62416fbc2e5f0de623b87b613aae`)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `a759bc226194cb4a9d8f733f85de386a42a2b9b6`)
+  - WPMediaPicker (= 1.3)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 1.11.2.1)
 
@@ -206,6 +206,7 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
+    - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
 
@@ -216,9 +217,6 @@ EXTERNAL SOURCES:
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
-  WPMediaPicker:
-    :commit: a759bc226194cb4a9d8f733f85de386a42a2b9b6
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -227,9 +225,6 @@ CHECKOUT OPTIONS:
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
-  WPMediaPicker:
-    :commit: a759bc226194cb4a9d8f733f85de386a42a2b9b6
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -264,10 +259,10 @@ SPEC CHECKSUMS:
   WordPressKit: a4a3849684f631a3abf579f6d3f15a32677cbb30
   WordPressShared: e5ea8a1ed3329735e40bd6623830960f63dd10fd
   WordPressUI: af141587ec444f9af753a00605bd0d3f14d8d8a3
-  WPMediaPicker: 29301fca060194b6b70187e4a0884759139cf64f
+  WPMediaPicker: c54791e04af3b41e473e9b340784be48a505bb38
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: ef89c1d3d69195056739a734cd152af19273a5ef
+PODFILE CHECKSUM: 40e1e7aa3ac0c01c26e74ae9812b8eb2c6afe56f
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -445,7 +445,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     /// The view to show when media picker has no assets to show.
     ///
-    fileprivate let noResultsView = MediaNoResultsView()
+    fileprivate let noResultsView = NoResultsViewController.controller()
 
     fileprivate var mediaLibraryChangeObserverKey: NSObjectProtocol? = nil
 
@@ -517,6 +517,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         configureNavigationBar()
         configureView()
         configureSubviews()
+        noResultsView.configureForNoAssets(userCanUploadMedia: false)
 
         // UI elements might get their properties reset when the view is effectively loaded. Refresh it all!
         refreshInterface()
@@ -920,7 +921,8 @@ class AztecPostViewController: UIViewController, PostEditor {
             let hasNoAssets = self?.mediaLibraryDataSource.numberOfAssets() == 0
 
             if isNotSearching && hasNoAssets {
-                self?.noResultsView.updateForNoAssets(userCanUploadMedia: false)
+                self?.noResultsView.removeFromView()
+                self?.noResultsView.configureForNoAssets(userCanUploadMedia: false)
             }
         })
     }
@@ -3702,7 +3704,7 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
 //
 extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
 
-    func emptyView(forMediaPickerController picker: WPMediaPickerViewController) -> UIView? {
+    func emptyViewController(forMediaPickerController picker: WPMediaPickerViewController) -> UIViewController? {
         if picker != mediaPickerInputViewController?.mediaPicker {
             return noResultsView
         }
@@ -3711,18 +3713,20 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, didUpdateSearchWithAssetCount assetCount: Int) {
         if let searchQuery = mediaLibraryDataSource.searchQuery {
-            noResultsView.updateForNoSearchResult(with: searchQuery)
+            noResultsView.removeFromView()
+            noResultsView.configureForNoSearchResult(with: searchQuery)
         }
     }
 
     func mediaPickerControllerWillBeginLoadingData(_ picker: WPMediaPickerViewController) {
         updateSearchBar(mediaPicker: picker)
-        noResultsView.updateForFetching()
+        noResultsView.configureForFetching()
     }
 
     func mediaPickerControllerDidEndLoadingData(_ picker: WPMediaPickerViewController) {
         updateSearchBar(mediaPicker: picker)
-        noResultsView.updateForNoAssets(userCanUploadMedia: false)
+        noResultsView.removeFromView()
+        noResultsView.configureForNoAssets(userCanUploadMedia: false)
     }
 
     func mediaPickerControllerDidCancel(_ picker: WPMediaPickerViewController) {


### PR DESCRIPTION
Fixes #9940 

In the Post Editor media selection, replace `WPNoResultsView` with `NoResultsViewController`.

The No Results view is displayed when:
- The user has no WordPress media.
- Media is being fetched.
- No results from searching the WordPress media library.

To note, there are associated `MediaPicker` changes (https://github.com/wordpress-mobile/MediaPicker-iOS/pull/304). I will update this `podfile` when that has been merged.

**To test:**

---
**No Media:**
- Select a site with no WordPress media.
- Edit/create a post.
- Tap on the WordPress media button.
- Verify the view is:
![no_media](https://user-images.githubusercontent.com/1816888/43863616-7e8c8ebc-9b1a-11e8-8378-f98ab5f9042a.png)

---
**Fetching:**
- On a slow network, edit/create a post.
  - To note, you may have to select another site, or do a fresh install, since media is cached.
- Tap on the WordPress media button.
- Verify the view is:
![fetching](https://user-images.githubusercontent.com/1816888/43863691-b6a73e3c-9b1a-11e8-85fb-b4bf934739fb.png)

---
**No Results:**
- Select a site with WordPress media.
- Edit/create a post.
- Tap on the WordPress media button.
- Enter an invalid search string.
- Verify the view is:
![no_results](https://user-images.githubusercontent.com/1816888/43863757-e3d15b04-9b1a-11e8-89ae-a7bcb51962e2.png)




