### PR TITLE
Extract interface from FormattableContent for use with both Notification & RemoteNotification

### DIFF
--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -566,3 +566,9 @@ extension Notification {
         static let Home     = "home"
     }
 }
+
+extension Notification: NotificationIdentifiable {
+    var notificationIdentifier: String {
+        return notificationId
+    }
+}

--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -83,7 +83,7 @@ class Notification: NSManagedObject {
     /// Header + Body Blocks Transient Storage.
     ///
     fileprivate var cachedHeaderAndBodyBlockGroups: [NotificationBlockGroup]?
-    fileprivate var cachedHeaderAndBodyContentGroup: [FormattableContentGroup]?
+    fileprivate var cachedHeaderAndBodyContentGroups: [FormattableContentGroup]?
 
     /// Array that contains the Cached Property Names
     ///
@@ -133,7 +133,7 @@ class Notification: NSManagedObject {
             cachedBodyContentGroups = nil
             cachedHeaderContentGroup = nil
             cachedSubjectContentGroup = nil
-            cachedHeaderAndBodyContentGroup = nil
+            cachedHeaderAndBodyContentGroups = nil
         } else {
             cachedSubjectBlockGroup = nil
             cachedHeaderBlockGroup = nil
@@ -453,7 +453,7 @@ extension Notification {
 
 
     var headerAndBodyContentGroups: [FormattableContentGroup] {
-        if let groups = cachedHeaderAndBodyContentGroup {
+        if let groups = cachedHeaderAndBodyContentGroups {
             return groups
         }
 
@@ -463,7 +463,7 @@ extension Notification {
         }
 
         mergedGroups.append(contentsOf: bodyContentGroups)
-        cachedHeaderAndBodyContentGroup = mergedGroups
+        cachedHeaderAndBodyContentGroups = mergedGroups
 
         return mergedGroups
     }

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/FormattableCommentContent.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/FormattableCommentContent.swift
@@ -21,7 +21,8 @@ class FormattableCommentContent: NotificationTextContent {
 
 extension FormattableCommentContent: Equatable {
     static func == (lhs: FormattableCommentContent, rhs: FormattableCommentContent) -> Bool {
-        return lhs.isEqual(to: rhs) && lhs.parent == rhs.parent
+        return lhs.isEqual(to: rhs) &&
+            lhs.parent.notificationIdentifier == rhs.parent.notificationIdentifier
     }
 
     private func isEqual(to other: FormattableTextContent) -> Bool {
@@ -32,7 +33,7 @@ extension FormattableCommentContent: Equatable {
 
 extension FormattableCommentContent: ActionableObject {
     var notificationID: String? {
-        return parent.notificationId
+        return parent.notificationIdentifier
     }
 
     var metaSiteID: NSNumber? {

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/FormattableUserContent.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/FormattableUserContent.swift
@@ -31,7 +31,7 @@ class FormattableUserContent: NotificationTextContent {
 
 extension FormattableUserContent: ActionableObject {
     var notificationID: String? {
-        return parent.notificationId
+        return parent.notificationIdentifier
     }
 
     var metaSiteID: NSNumber? {
@@ -49,7 +49,8 @@ extension FormattableUserContent: ActionableObject {
 
 extension FormattableUserContent: Equatable {
     static func == (lhs: FormattableUserContent, rhs: FormattableUserContent) -> Bool {
-        return lhs.isEqual(to: rhs) && lhs.parent.isEqual(rhs.parent)
+        return lhs.isEqual(to: rhs) &&
+            lhs.parent.notificationIdentifier == rhs.parent.notificationIdentifier
     }
 
     private func isEqual(to other: FormattableUserContent) -> Bool {

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationContentFactory.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationContentFactory.swift
@@ -16,7 +16,7 @@ extension Notification {
 
 class NotificationContentFactory: FormattableContentFactory {
 
-    static func content(from blocks: [[String: AnyObject]], actionsParser parser: FormattableContentActionParser, parent: Notification) -> [FormattableContent] {
+    static func content(from blocks: [[String: AnyObject]], actionsParser parser: FormattableContentActionParser, parent: NotificationIdentifiable) -> [FormattableContent] {
         return blocks.compactMap { rawBlock in
             let actions = parser.parse(rawBlock[Constants.Actions] as? [String: AnyObject])
             let ranges = rangesFrom(rawBlock)
@@ -29,12 +29,12 @@ class NotificationContentFactory: FormattableContentFactory {
     }
 
     private static func rangesFrom(_ rawBlock: [String: AnyObject]) -> [FormattableContentRange] {
-        let rawRanges   = rawBlock[Constants.Ranges] as? [[String: AnyObject]]
+        let rawRanges = rawBlock[Constants.Ranges] as? [[String: AnyObject]]
         let parsed = rawRanges?.compactMap(NotificationContentRangeFactory.contentRange)
         return parsed ?? []
     }
 
-    private static func content(for type: String, with rawBlock: [String: AnyObject], actions: [FormattableContentAction], ranges: [FormattableContentRange], parent: Notification) -> FormattableContent? {
+    private static func content(for type: String, with rawBlock: [String: AnyObject], actions: [FormattableContentAction], ranges: [FormattableContentRange], parent: NotificationIdentifiable) -> FormattableContent? {
         guard let type = Notification.ContentType(rawValue: type) else {
             return NotificationTextContent(dictionary: rawBlock, actions: actions, ranges: ranges, parent: parent)
         }

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
@@ -54,6 +54,13 @@ protocol NotificationIdentifiable {
     var notificationIdentifier: String { get }
 }
 
+/// RemoteNotification is located in WordPressKit
+extension RemoteNotification: NotificationIdentifiable {
+    var notificationIdentifier: String {
+        return notificationId
+    }
+}
+
 class NotificationTextContent: FormattableTextContent, FormattableMediaContent {
     var textOverride: String?
     let media: [FormattableMediaItem]

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/NotificationTextContent.swift
@@ -48,10 +48,16 @@ extension FormattableMediaContent where Self: FormattableContent {
     }
 }
 
+/// This protocol represents the identifying traits of a local or remote notification.
+protocol NotificationIdentifiable {
+    /// the unique identifier for the notification
+    var notificationIdentifier: String { get }
+}
+
 class NotificationTextContent: FormattableTextContent, FormattableMediaContent {
     var textOverride: String?
     let media: [FormattableMediaItem]
-    let parent: Notification
+    let parent: NotificationIdentifiable
     let meta: [String: AnyObject]?
 
     override var text: String? {
@@ -65,7 +71,7 @@ class NotificationTextContent: FormattableTextContent, FormattableMediaContent {
         return super.kind
     }
 
-    init(dictionary: [String: AnyObject], actions commandActions: [FormattableContentAction], ranges: [FormattableContentRange], parent note: Notification) {
+    init(dictionary: [String: AnyObject], actions commandActions: [FormattableContentAction], ranges: [FormattableContentRange], parent note: NotificationIdentifiable) {
         let rawMedia = dictionary[Constants.BlockKeys.Media] as? [[String: AnyObject]]
         let text = dictionary[Constants.BlockKeys.Text] as? String ?? ""
 

--- a/WordPress/WordPressTest/FormattableCommentContentTests.swift
+++ b/WordPress/WordPressTest/FormattableCommentContentTests.swift
@@ -74,7 +74,7 @@ final class FormattableCommentContentTests: XCTestCase {
 
         let parent = subject?.parent
 
-        XCTAssertEqual(parent?.notificationId, injectedParent.notificationId)
+        XCTAssertEqual(parent?.notificationIdentifier, injectedParent.notificationIdentifier)
     }
 
     func testApproveCommentActionIsOn() {

--- a/WordPress/WordPressTest/FormattableUserContentTests.swift
+++ b/WordPress/WordPressTest/FormattableUserContentTests.swift
@@ -88,7 +88,7 @@ final class FormattableUserContentTests: XCTestCase {
 
         let parent = subject?.parent
 
-        XCTAssertEqual(parent?.notificationId, injectedParent.notificationId)
+        XCTAssertEqual(parent?.notificationIdentifier, injectedParent.notificationIdentifier)
     }
 
     func testApproveCommentActionIsOn() {

--- a/WordPress/WordPressTest/NotificationTextContentTests.swift
+++ b/WordPress/WordPressTest/NotificationTextContentTests.swift
@@ -59,7 +59,7 @@ final class NotificationTextContentTests: XCTestCase {
 
         let parent = subject?.parent
 
-        XCTAssertEqual(parent?.notificationId, injectedParent.notificationId)
+        XCTAssertEqual(parent?.notificationIdentifier, injectedParent.notificationIdentifier)
     }
 
     func testApproveCommentActionIsOn() {


### PR DESCRIPTION
Fixes #9935, which paves the way for `FormattableContent` to be used with rich notifications. The changes are broken down into granular commits:

1. I noticed an issue with naming of a field within `Notification`; I took the liberty to make `cachedHeaderAndBodyContentGroup` plural to underscore that its an `Array`.
1. Defined a new interface - `NotificationIdentifiable` - that `Notification` implements. It consists of one parameter. The implications of this were propagated throughout the existing code.
1. Extended `RemoteNotification` to conform to this new interface. It will be manipulated further in #9936.

## To test: 

- Given that this is a basic refactoring, checkout branch and verify that it builds and tests continue to pass. 
- Manual testing should reveal no regressions regarding the formatting of Notifications or Activity Log entries.

