### PR TITLE
Post Settings > Set Featured Image: replace No Results view

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
+++ b/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
@@ -2,19 +2,19 @@
 
 extension NoResultsViewController {
 
-    func configureForNoAssets(userCanUploadMedia: Bool) {
+    @objc func configureForNoAssets(userCanUploadMedia: Bool) {
         let buttonTitle = userCanUploadMedia ? LocalizedText.uploadButtonTitle : nil
         configure(title: LocalizedText.noAssetsTitle, buttonTitle: buttonTitle, subtitle: nil, attributedSubtitle: nil, image: Constants.imageName, accessoryView: nil)
     }
 
-    func configureForFetching() {
+    @objc func configureForFetching() {
         let animatedBox = WPAnimatedBox()
         animatedBox.animate(afterDelay: Constants.animatedBoxDelay)
         configure(title: LocalizedText.fetchingTitle, buttonTitle: nil, subtitle: nil, attributedSubtitle: nil, image: nil, accessoryView: animatedBox)
         view.layoutIfNeeded()
     }
 
-    func configureForNoSearchResult(with searchQuery: String) {
+    @objc func configureForNoSearchResult(with searchQuery: String) {
         configure(title: LocalizedText.noResultsTitle, buttonTitle: nil, subtitle: searchQuery, attributedSubtitle: nil, image: Constants.imageName, accessoryView: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -88,7 +88,7 @@ FeaturedImageViewControllerDelegate>
 @property (nonatomic, strong) PostGeolocationCell *postGeoLocationCell;
 @property (nonatomic, strong) WPTableViewCell *setGeoLocationCell;
 
-@property (nonatomic, strong) MediaNoResultsView *noResultsView;
+@property (nonatomic, strong) NoResultsViewController *noResultsView;
 @property (nonatomic, strong) NSObject *mediaLibraryChangeObserverKey;
 
 #pragma mark - Properties: Services
@@ -148,7 +148,6 @@ FeaturedImageViewControllerDelegate>
     [self.tableView registerNib:[UINib nibWithNibName:@"WPTableViewActivityCell" bundle:nil] forCellReuseIdentifier:TableViewActivityCellIdentifier];
     [self.tableView registerClass:[WPProgressTableViewCell class] forCellReuseIdentifier:TableViewProgressCellIdentifier];
     [self.tableView registerClass:[PostFeaturedImageCell class] forCellReuseIdentifier:TableViewFeaturedImageCellIdentifier];
-
 
     self.tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, 0.0, 44.0)]; // add some vertical padding
 
@@ -1350,10 +1349,10 @@ FeaturedImageViewControllerDelegate>
     return NSLocalizedString(@"Public", @"Privacy setting for posts set to 'Public' (default). Should be the same as in core WP.");
 }
 
-- (MediaNoResultsView *)noResultsView
+- (NoResultsViewController *)noResultsView
 {
     if (!_noResultsView) {
-        _noResultsView = [[MediaNoResultsView alloc] init];
+        _noResultsView = [NoResultsViewController controller];
     }
     return _noResultsView;
 }
@@ -1369,7 +1368,8 @@ FeaturedImageViewControllerDelegate>
         BOOL hasNoAsset = [weakSelf.mediaDataSource numberOfAssets] == 0;
 
         if (hasNoAsset && isNotSearching) {
-            [weakSelf.noResultsView updateForNoMediaAssetsShowingUploadMediaButton:NO];
+            [weakSelf.noResultsView removeFromView];
+            [weakSelf.noResultsView configureForNoAssetsWithUserCanUploadMedia:NO];
         }
     }];
 }
@@ -1451,7 +1451,7 @@ FeaturedImageViewControllerDelegate>
 
 #pragma mark - WPMediaPickerViewControllerDelegate methods
 
-- (UIView *)emptyViewForMediaPickerController:(WPMediaPickerViewController *)picker
+- (UIViewController *)emptyViewControllerForMediaPickerController:(WPMediaPickerViewController *)picker
 {
     return self.noResultsView;
 }
@@ -1459,19 +1459,21 @@ FeaturedImageViewControllerDelegate>
 - (void)mediaPickerControllerWillBeginLoadingData:(WPMediaPickerViewController *)picker
 {
     [self updateSearchBarForPicker:picker];
-    [self.noResultsView updateForFetching];
+    [self.noResultsView configureForFetching];
 }
 
 - (void)mediaPickerControllerDidEndLoadingData:(WPMediaPickerViewController *)picker
 {
     [self updateSearchBarForPicker:picker];
-    [self.noResultsView updateForNoMediaAssetsShowingUploadMediaButton:NO];
+    [self.noResultsView removeFromView];
+    [self.noResultsView configureForNoAssetsWithUserCanUploadMedia:NO];
 }
 
 - (void)mediaPickerController:(WPMediaPickerViewController *)picker didUpdateSearchWithAssetCount:(NSInteger)assetCount
 {
     if (self.mediaDataSource.searchQuery) {
-        [self.noResultsView updateForNoSearchResultWith:self.mediaDataSource.searchQuery];
+        [self.noResultsView removeFromView];
+        [self.noResultsView configureForNoSearchResultWith:self.mediaDataSource.searchQuery];
     }
 }
 


### PR DESCRIPTION
Fixes #9945 

For Post Settings > Set Featured Image, replace `WPNoResultsView` with `NoResultsViewController`.

The No Results view is displayed when:
- The user has no media.
- Media is being fetched.
- No results from searching the WordPress media library.

**To test:**

---
**No Media:**
- On a site with no WordPress media, edit/create a post.
- Go to Post Settings > Set Featured Image.
- Select the 'WordPress Media' album.
- Verify the view is:
![no_media](https://user-images.githubusercontent.com/1816888/43867862-41f41d36-9b28-11e8-94b8-752125c581fb.png)

---
**Fetching:**
- On a slow network, edit/create a post.
- Go to Post Settings > Set Featured Image.
- While the message `counting media items` is still displayed on an album, select it.
- Verify the view is:
![fetching](https://user-images.githubusercontent.com/1816888/43867896-61e7febe-9b28-11e8-8dba-c0be5c3129e1.png)

---
**No Results:**
- On a site with WordPress media, edit/create a post.
- Go to Post Settings > Set Featured Image.
- Select the 'WordPress Media' album.
- Enter an invalid search string.
- Verify the view is:
![no_results](https://user-images.githubusercontent.com/1816888/43867934-7de94230-9b28-11e8-9d6d-6aabd4beed0c.png)





