### PR TITLE
Site Comments: replace No Results view

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -524,7 +524,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
                                          buttonTitle:nil
                                             subtitle:nil
                                   attributedSubtitle:nil
-                                               image:nil
+                                               image:@"wp-illustration-empty-results"
                                        accessoryView:nil];
     
     [self addChildViewController:self.noResultsViewController];

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -529,7 +529,15 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     
     [self addChildViewController:self.noResultsViewController];
     [self.tableView addSubviewWithFadeAnimation:self.noResultsViewController.view];
-    self.noResultsViewController.view.frame = self.tableView.bounds;
+    self.noResultsViewController.view.frame = self.tableView.frame;
+
+    // Adjust the NRV placement based on the tableHeader to accommodate for the refreshControl.
+    if (!self.tableView.tableHeaderView) {
+        CGRect noResultsFrame = self.noResultsViewController.view.frame;
+        noResultsFrame.origin.y -= self.refreshControl.frame.size.height;
+        self.noResultsViewController.view.frame = noResultsFrame;
+    }
+    
     [self.noResultsViewController didMoveToParentViewController:self];
 }
 


### PR DESCRIPTION
Fixes #9951 

In Site Settings > Comments, replace `WPNoResultsView` with `NoResultsViewController`.

The No Results view is displayed when:
- There are no site comments.
- There is no internet connection.

To test:

---
**No Comments:**
- On a site with no comments, go to Site > Comments.
- Verify the view is:
![no_comments](https://user-images.githubusercontent.com/1816888/43923077-f680ad0e-9bdd-11e8-883a-4c0072d6e566.png)

---
**No Connection:**
- Disable internet connection.
- Go to Site > Comments.
- Verify the view is:
![no_connection](https://user-images.githubusercontent.com/1816888/43923119-102328ea-9bde-11e8-9da4-460060af9f85.png)

