### PR TITLE
Site People: replace No Results view

### DIFF
--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -23,7 +23,8 @@ open class PeopleViewController: UITableViewController, NSFetchedResultsControll
 
     /// NoResults Helper
     ///
-    fileprivate let noResultsView = WPNoResultsView()
+    private let noResultsViewController = NoResultsViewController.controller()
+
 
     /// Indicates whether there are more results that can be retrieved, or not.
     ///
@@ -338,17 +339,20 @@ open class PeopleViewController: UITableViewController, NSFetchedResultsControll
 
     // MARK: - No Results Helpers
 
-    fileprivate func refreshNoResultsView() {
+    private func refreshNoResultsView() {
+
+        noResultsViewController.removeFromView()
+
         guard resultsController.fetchedObjects?.count == 0 else {
-            noResultsView.removeFromSuperview()
             return
         }
 
-        noResultsView.titleText = noResultsTitle()
+        noResultsViewController.configure(title: noResultsTitle(), buttonTitle: nil, subtitle: nil, attributedSubtitle: nil, image: nil, accessoryView: nil)
 
-        if noResultsView.superview == nil {
-            tableView.addSubview(withFadeAnimation: noResultsView)
-        }
+        addChildViewController(noResultsViewController)
+        tableView.addSubview(withFadeAnimation: noResultsViewController.view)
+        noResultsViewController.view.frame = tableView.bounds
+        noResultsViewController.didMove(toParentViewController: self)
     }
 
     private func noResultsTitle() -> String {

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -347,7 +347,12 @@ open class PeopleViewController: UITableViewController, NSFetchedResultsControll
             return
         }
 
-        noResultsViewController.configure(title: noResultsTitle(), buttonTitle: nil, subtitle: nil, attributedSubtitle: nil, image: nil, accessoryView: nil)
+        noResultsViewController.configure(title: noResultsTitle(),
+                                          buttonTitle: nil,
+                                          subtitle: nil,
+                                          attributedSubtitle: nil,
+                                          image: "wp-illustration-empty-results",
+                                          accessoryView: nil)
 
         addChildViewController(noResultsViewController)
         tableView.addSubview(withFadeAnimation: noResultsViewController.view)
@@ -356,13 +361,11 @@ open class PeopleViewController: UITableViewController, NSFetchedResultsControll
     }
 
     private func noResultsTitle() -> String {
-        let noPeopleFormat = NSLocalizedString("No %@ Yet",
-            comment: "Empty state message (People Management). %@ can be Users or Followers")
-        let noPeople = String(format: noPeopleFormat, filter.title)
+        let noPeopleFormat = NSLocalizedString("No %@ yet",
+            comment: "Empty state message (People Management). %@ can be 'users' or 'followers'")
+        let noPeople = String(format: noPeopleFormat, filter.title.lowercased())
 
-        let noNetwork = noConnectionMessage()
-
-        return connectionAvailable() ? noPeople : noNetwork
+        return connectionAvailable() ? noPeople : noConnectionMessage()
     }
 
     private func handleLoadError(_ forError: Error) {

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -348,11 +348,7 @@ open class PeopleViewController: UITableViewController, NSFetchedResultsControll
         }
 
         noResultsViewController.configure(title: noResultsTitle(),
-                                          buttonTitle: nil,
-                                          subtitle: nil,
-                                          attributedSubtitle: nil,
-                                          image: "wp-illustration-empty-results",
-                                          accessoryView: nil)
+                                          image: "wp-illustration-empty-results")
 
         addChildViewController(noResultsViewController)
         tableView.addSubview(withFadeAnimation: noResultsViewController.view)


### PR DESCRIPTION
Fixes #9953 

In Site Settings > People, replace `WPNoResultsView` with `NoResultsViewController`.

The No Results view is displayed when:
- There are no Users.
- There are no Followers.
- There is no internet connection.

To test:

---
**No Users/Followers:**
- On a site with no Users/Followers, go to Site > People.
- Select `Users`/`Followers` from the nav bar dropdown.
- Verify the view is:
![no_followers](https://user-images.githubusercontent.com/1816888/43927087-943fa35a-9be9-11e8-8a01-35c6880b0274.png)

---
**No Connection:**
- Disable internet connection.
- Go to Site > People.
- Verify the view is:
![no_connection](https://user-images.githubusercontent.com/1816888/43927112-a6761158-9be9-11e8-91bd-131d8cf51c8c.png)
