### PR TITLE
Time Zone selector: replace No Results view

### DIFF
--- a/WordPress/Classes/ViewRelated/Tools/TimeZoneSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/TimeZoneSelectorViewController.swift
@@ -82,7 +82,7 @@ struct TimeZoneSelectorViewModel: Observable {
     var noResultsViewModel: NoResultsViewController.Model? {
         switch state {
         case .loading:
-            return NoResultsViewController.Model(title: LocalizedText.loadingTitle)
+            return NoResultsViewController.Model(title: LocalizedText.loadingTitle, accessoryView: noResultsAccessoryView())
         case .ready:
             return nil
         case .error:
@@ -96,6 +96,12 @@ struct TimeZoneSelectorViewModel: Observable {
                                                      subtitle: LocalizedText.noConnectionSubtitle)
             }
         }
+    }
+
+    func noResultsAccessoryView() -> UIView {
+        let animatedBox = WPAnimatedBox()
+        animatedBox.animate(afterDelay: 0.1)
+        return animatedBox
     }
 
     struct LocalizedText {


### PR DESCRIPTION
Fixes #9955 

In Site Settings > Time Zone selector, replace `WPNoResultsView` with `NoResultsViewController`.

The No Results view is displayed in these cases:
- Loading time zones
- No connection
- Loading error

To test:

---
**Loading Time Zones:**
- On a slow network, go to Site > Settings > Time Zone.
- Verify the view is:
![loading](https://user-images.githubusercontent.com/1816888/43930850-ee6edb48-9bf8-11e8-9121-9be5d145b32d.png)

---
**No Connection:**
- Disable internet connection.
- Go to Site > Settings > Time Zone.
- Verify the view is:
![no_connection](https://user-images.githubusercontent.com/1816888/43930981-70155b90-9bf9-11e8-97bb-e37e507bf57c.png)

---
**Loading Error:**
- This may require some hacking to show the error view. My suggestion:
  - In `TimeZoneSelectorViewController:noResultsViewModel`, always return the "Oops" view for the `error` case.
- Disable internet connection (assuming you used the above hack).
- Go to Site > Settings > Time Zone.
- Verify the view is:
![error](https://user-images.githubusercontent.com/1816888/43931016-9a8cf388-9bf9-11e8-8ee8-296ea3d575a6.png)
