### PR TITLE
[Activity Log] Fix a crash that would happen when opening AL on slower devices.

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -66,6 +66,8 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        refreshModel()
+
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
 
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
@@ -76,7 +78,6 @@ class ActivityListViewController: UITableViewController, ImmuTablePresenter {
         // Magic to avoid cell separators being displayed while a plain table loads
         tableView.tableFooterView = UIView()
 
-        refreshModel()
         WPAnalytics.track(.activityLogViewed)
     }
 


### PR DESCRIPTION
We got a few crash reports of AL crashing on launch. This fixes it! 

Turns out, setting a `tableFooterView` on a `UITableView` kicks off a bunch of internal methods that end up asking `delegate` for things like number of items in the first section. Turns out, when you don't _have_ a first section, this can blow up in ImmuTable ;) 

Moving the `refreshModel()` call sets up the `ImmuTable.viewModel` properly earlier in the lifecycle, so we don't run into this issue.

p2 ref: p4a5px-2fc-p2