### PR TITLE
Rich Notifications : Integrated Tracks events for notification service extension

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -389,6 +389,8 @@
 		73ACDF9C2118AF7000233AD4 /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		73ACDF9D2118AF7D00233AD4 /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CC05F51962150600975CAC /* Constants.m */; };
 		73BFDA8A211D054800907245 /* Notifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BFDA89211D054800907245 /* Notifiable.swift */; };
+		73E40D8921238BF50012ABA6 /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
+		73E40D8C21238C520012ABA6 /* Tracks+ServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E40D8B21238C520012ABA6 /* Tracks+ServiceExtension.swift */; };
 		740219FE202E12F4006CC39F /* UploadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741E22441FC0CC55007967AB /* UploadOperation.swift */; };
 		740219FF202E12F4006CC39F /* PostUploadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AF4D711FE417D200E3EBFE /* PostUploadOperation.swift */; };
 		74021A00202E12F4006CC39F /* MediaUploadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AF4D6D1FE417D200E3EBFE /* MediaUploadOperation.swift */; };
@@ -1982,6 +1984,7 @@
 		73ACDF982114FE4500233AD4 /* NotificationSupportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSupportService.swift; sourceTree = "<group>"; };
 		73ACDF9F2118B03700233AD4 /* WordPressNotificationServiceExtension-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WordPressNotificationServiceExtension-Bridging-Header.h"; sourceTree = "<group>"; };
 		73BFDA89211D054800907245 /* Notifiable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Notifiable.swift; sourceTree = "<group>"; };
+		73E40D8B21238C520012ABA6 /* Tracks+ServiceExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tracks+ServiceExtension.swift"; sourceTree = "<group>"; };
 		73FEFF1991AE9912FB2DA9BC /* Pods-WordPressNotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationServiceExtension.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationServiceExtension/Pods-WordPressNotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		740516882087B73400252FD0 /* SearchableActivityConvertable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchableActivityConvertable.swift; sourceTree = "<group>"; };
 		740BD8331A0D4C3600F04D18 /* WPUploadStatusButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPUploadStatusButton.h; sourceTree = "<group>"; };
@@ -4357,10 +4360,19 @@
 			isa = PBXGroup;
 			children = (
 				7335AC55212202E30012EF2D /* FormattableContent */,
+				73E40D8A21238C400012ABA6 /* Tracks */,
 				7396FE65210F730600496D0D /* NotificationService.swift */,
 				73ACDF9F2118B03700233AD4 /* WordPressNotificationServiceExtension-Bridging-Header.h */,
 			);
 			path = Sources;
+			sourceTree = "<group>";
+		};
+		73E40D8A21238C400012ABA6 /* Tracks */ = {
+			isa = PBXGroup;
+			children = (
+				73E40D8B21238C520012ABA6 /* Tracks+ServiceExtension.swift */,
+			);
+			path = Tracks;
 			sourceTree = "<group>";
 		};
 		740C7C51202F50A3001C31B0 /* Shared UI */ = {
@@ -5081,7 +5093,7 @@
 				1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */,
 				930284B618EAF7B600CB0BF4 /* LocalCoreDataService.h */,
 				FFC6ADD91B56F366002F3C84 /* LocalCoreDataService.m */,
-				D816B8C72112D2290052CE4D /* LocalNewsService.swift */,        
+				D816B8C72112D2290052CE4D /* LocalNewsService.swift */,
 				17876B1C1F9A131200F774C7 /* MediaCoordinator.swift */,
 				0815CF451E96F22600069916 /* MediaImportService.swift */,
 				5DA3EE141925090A00294E0B /* MediaService.h */,
@@ -5093,7 +5105,7 @@
 				087EBFA71F02313E001F7ACE /* MediaThumbnailService.swift */,
 				08AAD69D1CBEA47D002B2418 /* MenusService.h */,
 				08AAD69E1CBEA47D002B2418 /* MenusService.m */,
-				D816B8C12112CEBE0052CE4D /* NewsService.swift */,        
+				D816B8C12112CEBE0052CE4D /* NewsService.swift */,
 				B5015C571D4FDBB300C9449E /* NotificationActionsService.swift */,
 				B5EFB1C11B31B98E007608A3 /* NotificationSettingsService.swift */,
 				73ACDF982114FE4500233AD4 /* NotificationSupportService.swift */,
@@ -8631,9 +8643,11 @@
 				7335AC5921220AC40012EF2D /* FormattableContent.swift in Sources */,
 				7335AC6721220EAE0012EF2D /* NotificationContentRangeFactory.swift in Sources */,
 				7396FE66210F730600496D0D /* NotificationService.swift in Sources */,
+				73E40D8921238BF50012ABA6 /* Tracks.swift in Sources */,
 				7335AC5821220AB40012EF2D /* FormattableContentGroup.swift in Sources */,
 				7335AC5E21220C630012EF2D /* Notifiable.swift in Sources */,
 				7335AC6321220E6E0012EF2D /* NotificationTextContent.swift in Sources */,
+				73E40D8C21238C520012ABA6 /* Tracks+ServiceExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -6,6 +6,8 @@ class NotificationService: UNNotificationServiceExtension {
 
     // MARK: Properties
 
+    private let tracks = Tracks(appGroupName: WPAppGroupName)
+
     private var notificationService: NotificationSyncServiceRemote?
 
     private var contentHandler: ((UNNotificationContent) -> Void)?
@@ -17,12 +19,15 @@ class NotificationService: UNNotificationServiceExtension {
         self.contentHandler = contentHandler
         self.bestAttemptContent = request.content.mutableCopy() as? UNMutableNotificationContent
 
+        let token = readExtensionToken()
+        tracks.trackExtensionLaunched(token != nil)
+
         guard
             let notificationContent = self.bestAttemptContent,
             let noteID = notificationContent.userInfo["note_id"] as? Int,
             let aps = notificationContent.userInfo["aps"] as? NSDictionary,
             let apsAlert = aps["alert"] as? String,
-            let token = readExtensionToken()
+            token != nil
         else
         {
             contentHandler(request.content)

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -41,7 +41,7 @@ class NotificationService: UNNotificationServiceExtension {
         self.notificationService = service
 
         let identifiers = [ String(noteID) ]
-        service.loadNotes(noteIds: identifiers) { error, notifications in
+        service.loadNotes(noteIds: identifiers) { [tracks] error, notifications in
             defer {
                 contentHandler(notificationContent)
             }
@@ -70,6 +70,8 @@ class NotificationService: UNNotificationServiceExtension {
 
                     notificationContent.body = notificationText
                 }
+
+                tracks.trackNotificationAssembled()
             }
         }
     }

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -47,7 +47,7 @@ class NotificationService: UNNotificationServiceExtension {
             }
 
             if let error = error {
-                debugPrint("Unable to retrieve notifications for Note ID : \(noteID) | Error : \(error.localizedDescription)")
+                tracks.trackNotificationRetrievalFailed(notificationIdentifier: noteID, errorDescription: error.localizedDescription)
                 return
             }
 

--- a/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
@@ -15,6 +15,25 @@ private enum ServiceExtensionEvents: String {
     case assembled  = "wpios_notification_service_extension_assembled"
 }
 
-// MARK: - Support for tracking notification service extension support.
+// MARK: - Supports tracking notification service extension events.
 
-extension Tracks {}
+extension Tracks {
+    /// Tracks the successful launch of the notification service extension.
+    ///
+    /// - Parameter wpcomAvailable: `true` if an OAuth token exists, `false` otherwise
+    func trackExtensionLaunched(_ wpcomAvailable: Bool) {
+        let properties = [
+            "is_configured_dotcom": wpcomAvailable
+        ]
+        trackEvent(ServiceExtensionEvents.launched, properties: properties as [String: AnyObject]?)
+    }
+
+    /// Utility method to capture an event & submit it to Tracks.
+    ///
+    /// - Parameters:
+    ///   - event: the event to track
+    ///   - properties: any accompanying metadata
+    private func trackEvent(_ event: ServiceExtensionEvents, properties: [String: AnyObject]? = nil) {
+        track(event.rawValue, properties: properties)
+    }
+}

--- a/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Characterizes the types of service extension events we're interested in tracking.
+/// The raw value corresponds to the event name in Tracks.
+///
+/// - launched: the service extension was successfully entered & launched
+/// - discarded: the service extension launched, but encountered an unsupported notification type
+/// - failed: the service extension failed to retrieve the payload
+/// - assembled: the service extension successfully prepared content
+///
+private enum ServiceExtensionEvents: String {
+    case launched   = "wpios_notification_service_extension_launched"
+    case discarded  = "wpios_notification_service_extension_discarded"
+    case failed     = "wpios_notification_service_extension_failed"
+    case assembled  = "wpios_notification_service_extension_assembled"
+}
+
+// MARK: - Support for tracking notification service extension support.
+
+extension Tracks {}

--- a/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
@@ -28,6 +28,11 @@ extension Tracks {
         trackEvent(ServiceExtensionEvents.launched, properties: properties as [String: AnyObject]?)
     }
 
+    /// Tracks the successful retrieval & assembly of a rich notification.
+    func trackNotificationAssembled() {
+        trackEvent(ServiceExtensionEvents.assembled)
+    }
+
     /// Utility method to capture an event & submit it to Tracks.
     ///
     /// - Parameters:

--- a/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
@@ -28,6 +28,17 @@ extension Tracks {
         trackEvent(ServiceExtensionEvents.launched, properties: properties as [String: AnyObject]?)
     }
 
+    /// Tracks that a notification type was discarded due to lack of support.
+    /// It will still be delivered as before, but not as a rich notification.
+    ///
+    /// - Parameter notificationType: the value of the `note_id` from the APNS payload
+    func trackNotificationDiscarded(notificationType: String) {
+        let properties = [
+            "note_type": notificationType
+        ]
+        trackEvent(ServiceExtensionEvents.discarded, properties: properties as [String: AnyObject]?)
+    }
+
     /// Tracks the failure to retrieve a notification via the REST API.
     ///
     /// - Parameters:

--- a/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
@@ -28,6 +28,19 @@ extension Tracks {
         trackEvent(ServiceExtensionEvents.launched, properties: properties as [String: AnyObject]?)
     }
 
+    /// Tracks the failure to retrieve a notification via the REST API.
+    ///
+    /// - Parameters:
+    ///   - notificationIdentifier: the value of the `note_id` from the APNS payload
+    ///   - errorDescription: description of the error encountered, ideally localized
+    func trackNotificationRetrievalFailed(notificationIdentifier: Int, errorDescription: String) {
+        let properties = [
+            "note_id": String(notificationIdentifier),
+            "error": errorDescription
+        ]
+        trackEvent(ServiceExtensionEvents.failed, properties: properties as [String: AnyObject]?)
+    }
+
     /// Tracks the successful retrieval & assembly of a rich notification.
     func trackNotificationAssembled() {
         trackEvent(ServiceExtensionEvents.assembled)


### PR DESCRIPTION
Fixes #9977, which calls for the addition of a few basic analytics events to track rich notifications events.

These events are as follows:

- Launch
- Successful notification delivery
- Failure to retrieve the payload for a specified notification
- Discarded notification; the initial iteration will only support Comment notifications. Others will be ignored by the service extension and will continue to be delivered as before. _While the event is defined here, it will be integrated via #9971.

To test:

- Verify that the branch builds & existing tests pass.
- While debugging the service extension, manually push a payload with a valid `note_id` value. Instructions for this can be found here: #9924 
- In the _Tracks Live View_, validate that events of type `wpios_notification_service_extension_%` an be found.