### PR TITLE
Add Giphy to the credentials process

### DIFF
--- a/WordPress/Credentials/ApiCredentials.h
+++ b/WordPress/Credentials/ApiCredentials.h
@@ -6,6 +6,7 @@
 + (NSString *)pocketConsumerKey;
 + (NSString *)crashlyticsApiKey;
 + (NSString *)hockeyappAppId;
++ (NSString *)giphyAppId;
 + (NSString *)googlePlusClientId;
 + (NSString *)googleLoginClientId;
 + (NSString *)googleLoginSchemeId;

--- a/WordPress/Credentials/gencredentials.rb
+++ b/WordPress/Credentials/gencredentials.rb
@@ -73,6 +73,14 @@ print <<-EOF
 EOF
 end
 
+def print_giphy(giphy)
+print <<-EOF
++ (NSString *)giphyAppId {
+    return @"#{giphy}";
+}
+EOF
+end
+
 def print_googleplus(googleplus)
 print <<-EOF
 + (NSString *)googlePlusClientId {
@@ -137,7 +145,7 @@ print <<-EOF
 EOF
 end
 
-def print_class(client, secret, pocket, crashlytics, hockeyapp, googleplus, google_client, google_scheme, google_login_server, debugging_key, zendesk_app_id, zendesk_url, zendesk_client_id)
+def print_class(client, secret, pocket, crashlytics, hockeyapp, giphy, googleplus, google_client, google_scheme, google_login_server, debugging_key, zendesk_app_id, zendesk_url, zendesk_client_id)
   print <<-EOF
 #import "ApiCredentials.h"
 @implementation ApiCredentials
@@ -147,6 +155,7 @@ EOF
   print_pocket(pocket)
   print_crashlytics(crashlytics)
   print_hockeyapp(hockeyapp)
+  print_giphy(giphy)
   print_googleplus(googleplus)
   print_google_login_client(google_client)
   print_google_login_scheme(google_scheme)
@@ -175,6 +184,7 @@ secret = nil
 pocket = nil
 crashlytics = nil
 hockeyapp = nil
+giphy = nil
 googleplus = nil
 google_client = nil
 google_scheme = nil
@@ -198,6 +208,8 @@ File.open(path) do |f|
       crashlytics = value
     elsif k == "HOCKEYAPP_APP_ID"
       hockeyapp = value
+    elsif k == "GIPHY_APP_ID"
+      giphy = value
     elsif k == "GOOGLE_PLUS_CLIENT_ID"
       googleplus = value
     elsif k == "GOOGLE_LOGIN_CLIENT_ID"
@@ -262,4 +274,4 @@ if !configuration.nil? && ["Release", "Release-Internal"].include?(configuration
   end
 end
 
-print_class(client, secret, pocket, crashlytics, hockeyapp, googleplus, google_client, google_scheme, google_login_server, debugging_key, zendesk_app_id, zendesk_url, zendesk_client_id)
+print_class(client, secret, pocket, crashlytics, hockeyapp, giphy, googleplus, google_client, google_scheme, google_login_server, debugging_key, zendesk_app_id, zendesk_url, zendesk_client_id)


### PR DESCRIPTION
Implements #9995.

This PR adds Giphy to the credentials process for our upcoming Giphy integration.

**To test:**

* I'll send you the latest credentials file on Slack. Replace the existing one.
* Add a line into `runStartupSequenceWithLaunchOptions:` in the app delegate, to log out the new key:

```
NSLog(@"GIPHY: %@", [ApiCredentials giphyAppId]);
```
* Build and run and check you see the key in the console!