### PR TITLE
Reader Manage Sites: replace No Results view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -263,7 +263,7 @@ private extension ReaderFollowedSitesViewController {
         }
 
         if isSyncing {
-            noResultsViewController.configure(title: NoResultsText.loadingTitle, accessoryView: loadingAccessoryView())
+            noResultsViewController.configure(title: NoResultsText.loadingTitle, accessoryView: noResultsViewController.loadingAccessoryView())
         } else {
             noResultsViewController.configure(title: NoResultsText.noResultsTitle, subtitle: NoResultsText.noResultsMessage, image: "wp-illustration-empty-results")
         }
@@ -276,12 +276,6 @@ private extension ReaderFollowedSitesViewController {
         tableView.addSubview(withFadeAnimation: noResultsViewController.view)
         noResultsViewController.view.frame = tableView.frame
         noResultsViewController.didMove(toParentViewController: tableViewController)
-    }
-
-    func loadingAccessoryView() -> UIView {
-        let boxView = WPAnimatedBox()
-        boxView.animate(afterDelay: 0.3)
-        return boxView
     }
 
     struct NoResultsText {


### PR DESCRIPTION
Fixes #10008 

In Reader > manage followed sites, replace `WPNoResultsView` with `NoResultsViewController`.

The No Results view displayed when:
- there are no followed sites
- fetching sites

To test:

---
**No followed sites:**
- On a site that has not followed sites, go to Reader > Followed Sites > Manage Sites.
- Verify the view is:
![no_sites](https://user-images.githubusercontent.com/1816888/44286533-9d850e80-a226-11e8-9b68-ca3fb9a6544c.png)

--- 
**Fetching sites:**
- On a slow network, go to Reader > Followed Sites > Manage Sites.
- Verify the view is:
![fetching](https://user-images.githubusercontent.com/1816888/44286551-b1c90b80-a226-11e8-8425-a75347059a63.png)
