### PR TITLE
Reader Post Detail: replace No Results view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -138,6 +138,14 @@ import WordPressAuthenticator
         return noResultsView.frame.height
     }
 
+    /// Public method to get an animated box to show while loading.
+    ///
+    func loadingAccessoryView() -> UIView {
+        let boxView = WPAnimatedBox()
+        boxView.animate(afterDelay: 0.3)
+        return boxView
+    }
+
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         setAccessoryViewsVisibility()


### PR DESCRIPTION
Fixes #10010 

In Reader > Post details, replace `WPNoResultsView` with `NoResultsViewController`.

The No Results view displayed when:
- loading the post
- error loading the post

To test:
- Not _every_ post will attempt to load, as some posts are pre-loaded and passed into the VC. It may take trying a couple of different posts. I found that most of the 'Discover' posts will do it, i.e. the ones with a header like:
<img width="330" alt="discover_post" src="https://user-images.githubusercontent.com/1816888/44290799-afbb7880-a237-11e8-986f-c9196b29bca0.png">


---
**Loading post:**
- On a slow network, go to Reader > Followed Sites > select a Post.
- Verify the view is:
![loading](https://user-images.githubusercontent.com/1816888/44290900-3e2ffa00-a238-11e8-8eaf-3b239ce1492c.png)

---
**Loading error:**
- This will probably require some hacking. Suggestion:
  - In `ReaderDetailViewController:setupWithPostID`, in the `service.fetchPost` `success` block, comment out what's there and replace it with this method call from the `failure` block:
``` self?.configureAndDisplayLoadingView(title: LoadingText.errorLoadingTitle)```

- Go to Reader > Followed Sites > select a Post.
- Verify the view is:
![error_loading](https://user-images.githubusercontent.com/1816888/44291010-e645c300-a238-11e8-8ba4-6ee5aecc3764.png)
