### PR TITLE
Feature/9925 newscard tracks

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def shared_with_all_pods
-    pod 'WordPressShared', '1.0.9'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'c51f53ef91127b5225064023e7207fad66b02ea4'
     pod 'CocoaLumberjack', '3.4.2'
     pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
     pod 'NSObject-SafeExpectations', '0.0.3'
@@ -134,7 +134,7 @@ target 'WordPressNotificationServiceExtension' do
 	inherit! :search_paths
 
 	pod 'WordPressKit', '1.2.1'
-	pod 'WordPressShared', '1.0.9'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'c51f53ef91127b5225064023e7207fad66b02ea4'
 end
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -168,7 +168,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.0.0-beta.25)
   - WordPressAuthenticator (= 1.0.6)
   - WordPressKit (= 1.2.1)
-  - WordPressShared (= 1.0.9)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `c51f53ef91127b5225064023e7207fad66b02ea4`)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `7a5b1a3fb44f62416fbc2e5f0de623b87b613aae`)
   - WPMediaPicker (= 1.3)
   - wpxmlrpc (= 0.8.3)
@@ -205,7 +205,6 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
-    - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
@@ -214,6 +213,9 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPressShared:
+    :commit: c51f53ef91127b5225064023e7207fad66b02ea4
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -222,6 +224,9 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPressShared:
+    :commit: c51f53ef91127b5225064023e7207fad66b02ea4
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -263,6 +268,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: c1d1aefacdd6ab6445d7415f1d04af2503a527c1
+PODFILE CHECKSUM: 6722f636f2fcab0fde24c4f4441e761ecb648e8a
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -687,6 +687,15 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatMySitesTabAccessed:
             eventName = @"my_site_tab_accessed";
             break;
+        case WPAnalyticsStatNewsCardViewed:
+            eventName = @"news_card_shown";
+            break;
+        case WPAnalyticsStatNewsCardDismissed:
+            eventName = @"news_card_dismissed";
+            break;
+        case WPAnalyticsStatNewsCardRequestedExtendedInfo:
+            eventName = @"news_card_extended_info_requested";
+            break;
         case WPAnalyticsStatNotificationsCommentApproved:
             eventName = @"notifications_approved";
             break;

--- a/WordPress/Classes/ViewRelated/Reader/NewsStats.swift
+++ b/WordPress/Classes/ViewRelated/Reader/NewsStats.swift
@@ -1,9 +1,11 @@
+/// Abstract stats tracking
 protocol NewsStats {
     func trackPresented(news: Result<NewsItem>?)
     func trackDismissed(news: Result<NewsItem>?)
     func trackRequestedExtendedInfo(news: Result<NewsItem>?)
 }
 
+/// Implementation of the NewsStats protocol that provides Tracks integration for the NewsCard
 final class TracksNewsStats: NewsStats {
     private let origin: String
 

--- a/WordPress/Classes/ViewRelated/Reader/NewsStats.swift
+++ b/WordPress/Classes/ViewRelated/Reader/NewsStats.swift
@@ -1,0 +1,49 @@
+protocol NewsStats {
+    func trackPresented(news: Result<NewsItem>?)
+    func trackDismissed(news: Result<NewsItem>?)
+    func trackRequestedExtendedInfo(news: Result<NewsItem>?)
+}
+
+final class TracksNewsStats: NewsStats {
+    private let origin: String
+
+    enum StatsKeys {
+        static let origin = "origin"
+        static let version = "version"
+    }
+
+    init(origin: String) {
+        self.origin = origin
+    }
+
+    func trackPresented(news: Result<NewsItem>?) {
+        track(event: .newsCardViewed, news: news)
+    }
+
+    func trackDismissed(news: Result<NewsItem>?) {
+        track(event: .newsCardDismissed, news: news)
+    }
+
+    func trackRequestedExtendedInfo(news: Result<NewsItem>?) {
+        track(event: .newsCardRequestedExtendedInfo, news: news)
+    }
+
+    private func eventProperties(version: Decimal) -> [AnyHashable: Any] {
+        return [StatsKeys.origin: origin,
+                StatsKeys.version: version.description]
+    }
+
+    private func track(event: WPAnalyticsStat, news: Result<NewsItem>?) {
+        guard let actualNews = news else {
+            return
+        }
+
+        switch actualNews {
+        case .error:
+            return
+        case .success(let newsItem):
+            WPAppAnalytics.track(event, withProperties: eventProperties(version: newsItem.version))
+        }
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderNewsCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderNewsCard.swift
@@ -1,10 +1,12 @@
 /// Bootstraps a news card specific for the reader.
 final class ReaderNewsCard {
     private let fileName = "News"
+    private let tracksOrigin = "reader"
 
     func newsCard(containerIdentifier: Identifier, header: ReaderStreamViewController.ReaderHeader?, container: UIViewController, delegate: NewsManagerDelegate) -> UIView? {
         let database = UserDefaults.standard
-        let newsManager = DefaultNewsManager(service: LocalNewsService(fileName: fileName), database: database, delegate: delegate)
+        let stats = TracksNewsStats(origin: tracksOrigin)
+        let newsManager = DefaultNewsManager(service: LocalNewsService(fileName: fileName), database: database, stats: stats, delegate: delegate)
 
         // News card should not be presented: return configured stream header
         guard newsManager.shouldPresentCard(contextId: containerIdentifier) else {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1024,6 +1024,7 @@
 		D82247FB2113F50600918CEB /* News.strings in Resources */ = {isa = PBXBuildFile; fileRef = D82247FA2113F50600918CEB /* News.strings */; };
 		D826D67F211D21C700A5D8FE /* NullMockUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D826D67E211D21C700A5D8FE /* NullMockUserDefaults.swift */; };
 		D826D682211D51E300A5D8FE /* ReaderNewsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D826D681211D51E300A5D8FE /* ReaderNewsCard.swift */; };
+		D8281CF1212AB34C00D09098 /* NewsStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8281CF0212AB34C00D09098 /* NewsStats.swift */; };
 		D83CA3A520842CAF0060E310 /* Pageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83CA3A420842CAF0060E310 /* Pageable.swift */; };
 		D83CA3A720842CD90060E310 /* ResultsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83CA3A620842CD90060E310 /* ResultsPage.swift */; };
 		D83CA3A920842D190060E310 /* StockPhotosPageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D83CA3A820842D190060E310 /* StockPhotosPageable.swift */; };
@@ -2733,6 +2734,7 @@
 		D82247FA2113F50600918CEB /* News.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = News.strings; sourceTree = "<group>"; };
 		D826D67E211D21C700A5D8FE /* NullMockUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullMockUserDefaults.swift; sourceTree = "<group>"; };
 		D826D681211D51E300A5D8FE /* ReaderNewsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderNewsCard.swift; sourceTree = "<group>"; };
+		D8281CF0212AB34C00D09098 /* NewsStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsStats.swift; sourceTree = "<group>"; };
 		D83CA3A420842CAF0060E310 /* Pageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pageable.swift; sourceTree = "<group>"; };
 		D83CA3A620842CD90060E310 /* ResultsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultsPage.swift; sourceTree = "<group>"; };
 		D83CA3A820842D190060E310 /* StockPhotosPageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockPhotosPageable.swift; sourceTree = "<group>"; };
@@ -5114,7 +5116,7 @@
 				1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */,
 				930284B618EAF7B600CB0BF4 /* LocalCoreDataService.h */,
 				FFC6ADD91B56F366002F3C84 /* LocalCoreDataService.m */,
-				D816B8C72112D2290052CE4D /* LocalNewsService.swift */,        
+				D816B8C72112D2290052CE4D /* LocalNewsService.swift */,
 				17876B1C1F9A131200F774C7 /* MediaCoordinator.swift */,
 				0815CF451E96F22600069916 /* MediaImportService.swift */,
 				5DA3EE141925090A00294E0B /* MediaService.h */,
@@ -5126,7 +5128,7 @@
 				087EBFA71F02313E001F7ACE /* MediaThumbnailService.swift */,
 				08AAD69D1CBEA47D002B2418 /* MenusService.h */,
 				08AAD69E1CBEA47D002B2418 /* MenusService.m */,
-				D816B8C12112CEBE0052CE4D /* NewsService.swift */,        
+				D816B8C12112CEBE0052CE4D /* NewsService.swift */,
 				B5015C571D4FDBB300C9449E /* NotificationActionsService.swift */,
 				B5EFB1C11B31B98E007608A3 /* NotificationSettingsService.swift */,
 				73ACDF982114FE4500233AD4 /* NotificationSupportService.swift */,
@@ -6250,6 +6252,7 @@
 				D816B8D32112D6E70052CE4D /* NewsCard.xib */,
 				D816B8D82112D85F0052CE4D /* News.swift */,
 				D826D681211D51E300A5D8FE /* ReaderNewsCard.swift */,
+				D8281CF0212AB34C00D09098 /* NewsStats.swift */,
 			);
 			name = "News Card";
 			sourceTree = "<group>";
@@ -8346,6 +8349,7 @@
 				82C420761FE44BD900CFB15B /* SiteSettingsViewController+Swift.swift in Sources */,
 				E6A3384C1BB08E3F00371587 /* ReaderGapMarker.m in Sources */,
 				984B020E200D59B900179E75 /* SiteCreationService.swift in Sources */,
+				D8281CF1212AB34C00D09098 /* NewsStats.swift in Sources */,
 				E1CFC1571E0AC8FF001DF9E9 /* Pattern.swift in Sources */,
 				930F09171C7D110E00995926 /* ShareExtensionService.swift in Sources */,
 				7ECD5B8120C4D823001AEBC5 /* MediaPreviewHelper.swift in Sources */,

--- a/WordPress/WordPressTest/DefaultNewsManagerTests.swift
+++ b/WordPress/WordPressTest/DefaultNewsManagerTests.swift
@@ -48,17 +48,37 @@ final class DefaultNewsManagerTests: XCTestCase {
         }
     }
 
+    private final class MockStats: NewsStats {
+        var presentTracked = false
+        var dismissTracked = false
+        var requestExtraInfoTracked = false
+
+        func trackPresented(news: Result<NewsItem>?) {
+            presentTracked = true
+        }
+
+        func trackDismissed(news: Result<NewsItem>?) {
+            dismissTracked = true
+        }
+
+        func trackRequestedExtendedInfo(news: Result<NewsItem>?) {
+            requestExtraInfoTracked = true
+        }
+    }
+
     private var manager: NewsManager?
     private var service: NewsService?
     private var database: MockInMemoryDefaults?
     private var delegate: MockDelegate?
+    private var stats: MockStats?
 
     override func setUp() {
         super.setUp()
         service = MockNewsService()
         database = MockInMemoryDefaults()
         delegate = MockDelegate()
-        manager = DefaultNewsManager(service: service!, database: database!, delegate: delegate!)
+        stats = MockStats()
+        manager = DefaultNewsManager(service: service!, database: database!, stats: stats!, delegate: delegate!)
     }
 
     override func tearDown() {
@@ -66,6 +86,7 @@ final class DefaultNewsManagerTests: XCTestCase {
         service = nil
         database = nil
         delegate = nil
+        stats = nil
         super.tearDown()
     }
 
@@ -118,6 +139,24 @@ final class DefaultNewsManagerTests: XCTestCase {
         manager?.dismiss()
 
         XCTAssertTrue(delegate!.dismissed)
+    }
+
+    func testDismissCallsStats() {
+        manager?.dismiss()
+
+        XCTAssertTrue(stats!.dismissTracked)
+    }
+
+    func testPresentCallsStats() {
+        let _ = manager?.shouldPresentCard(contextId: Identifier(value: ""))
+
+        XCTAssertTrue(stats!.presentTracked)
+    }
+
+    func testRequestExtraInfoCallsStats() {
+        manager?.readMore()
+
+        XCTAssertTrue(stats!.requestExtraInfoTracked)
     }
 
     private static func currentBuildVersion() -> Decimal? {


### PR DESCRIPTION
Implements #9925 

This PR depends on [this PR](https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/146) to WordPress-iOS-Shared. Before merging, we should release a new tag of the pod and update the Podfile to that tag, instead to a commit as it does now.

Support for Tracks in the NewsCard, and updated unit tests

To test:
- Activate the feature flag
- Add breakpoints to the three public method in `TracksNewsStats`
- Navigate to Reader

When the card is presented, `trackPresented` should be hit
When dismissing the card, `trackDismissed` should be hit
When rapping "Read More", `trackRequestedExtendedInfo` should be hit
