### PR TITLE
BlogService: Don't double-filter blogs when searching by hostname

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -49,13 +49,7 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
 {
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"url CONTAINS %@", hostname];
     NSArray <Blog *>* blogs = [self blogsWithPredicate:predicate];
-    for (Blog *blog in blogs) {
-        if ([blog.hostname isEqualToString:hostname]) {
-            return blog;
-        }
-    }
-
-    return nil;
+    return [blogs firstObject];
 }
 
 - (Blog *)lastUsedOrFirstBlog


### PR DESCRIPTION
Fixes #10016.

When navigating to the app via a universal link for a blog with a custom domain, the universal link router often couldn't find the right site. 

This seems to be because sites with custom domains may use their `*.wordpress.com` URL in their XMLRPC property (which is used by the `Blog.hostname` method). In `BlogService.blogByHostname` we were likely finding the correct site by searching by URL, but then filtering out the site we wanted by re-filtering the list based on hostname. I'm pretty certain the `url` property should contain the correct hostname for the site (the same that'll be used in Safari) so I don't think the extra filtering is necessary.

**To test:**

**Note:** Universal links only work on a device, not in the simulator.

* Visit a WordPress.com-hosted site with a custom domain in Safari. Ensure you're logged into an account with access to that site in the app, too.
* Tap the W menu in the masterbar, and choose Posts
* Pull down on the page slightly to reveal the "Open in App" bar at the top of the screen
* Tap "OPEN" in the bar
* The app should launch and you should see the posts list for the site you were using.
* Prior to this PR, you'd see the "Site not found" notice at the bottom of the screen