### PR TITLE
Reader Post Comments: replace No Results view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -140,7 +140,7 @@ import WordPressAuthenticator
 
     /// Public method to get an animated box to show while loading.
     ///
-    func loadingAccessoryView() -> UIView {
+    @objc func loadingAccessoryView() -> UIView {
         let boxView = WPAnimatedBox()
         boxView.animate(afterDelay: 0.3)
         return boxView

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -13,7 +13,6 @@
 #import "SuggestionService.h"
 #import "WordPress-Swift.h"
 #import "WPAppAnalytics.h"
-#import <WordPressShared/WPNoResultsView.h>
 #import <WordPressUI/WordPressUI.h>
 
 
@@ -44,7 +43,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 @property (nonatomic, strong) WPContentSyncHelper *syncHelper;
 @property (nonatomic, strong) UITableView *tableView;
 @property (nonatomic, strong) WPTableViewHandler *tableViewHandler;
-@property (nonatomic, strong) WPNoResultsView *noResultsView;
+@property (nonatomic, strong) NoResultsViewController *noResultsViewController;
 @property (nonatomic, strong) ReplyTextView *replyTextView;
 @property (nonatomic, strong) KeyboardDismissHelper *keyboardManager;
 @property (nonatomic, strong) SuggestionsTableView *suggestionsTableView;
@@ -182,10 +181,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator
 {
-    // Remove the no results view or else the position will abruptly adjust after rotation
-    // due to the table view sizing for image preloading
-    [self refreshNoResultsView];
-
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
 
     [coordinator animateAlongsideTransition:nil completion:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
@@ -198,7 +193,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 #pragma clang diagnostic pop
             [self.tableView selectRowAtIndexPath:selectedIndexPath animated:NO scrollPosition:UITableViewScrollPositionNone];
         }
-        [self refreshNoResultsView];
     }];
 }
 
@@ -308,10 +302,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
 - (void)configureNoResultsView
 {
-    self.noResultsView = [[WPNoResultsView alloc] init];
-    self.noResultsView.hidden = YES;
-    self.noResultsView.translatesAutoresizingMaskIntoConstraints = NO;
-    [self.view addSubview:self.noResultsView];
+    self.noResultsViewController = [NoResultsViewController controller];
 }
 
 - (void)configureReplyTextView
@@ -462,6 +453,15 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     return NSLocalizedString(@"Be the first to leave a comment.", @"Message shown encouraging the user to leave a comment on a post in the reader.");
 }
 
+- (UIView *)noResultsAccessoryView
+{
+    UIView *loadingAccessoryView = nil;
+    if (self.isLoadingPost || self.syncHelper.isSyncing) {
+        loadingAccessoryView = [self.noResultsViewController loadingAccessoryView];
+    }
+    return loadingAccessoryView;
+}
+
 - (void)checkIfLoggedIn
 {
     self.isLoggedIn = [AccountHelper isDotcomAvailable];
@@ -610,22 +610,25 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
 - (void)refreshNoResultsView
 {
+    [self.noResultsViewController removeFromView];
+
     BOOL isTableViewEmpty = (self.tableViewHandler.resultsController.fetchedObjects.count == 0);
-    BOOL shouldPerformAnimation = self.noResultsView.hidden;
-    
-    self.noResultsView.hidden = !isTableViewEmpty;
-    
     if (!isTableViewEmpty) {
         return;
     }
-    
-    // Refresh the NoResultsView Properties
-    self.noResultsView.titleText = self.noResultsTitleText;
-    [self.noResultsView centerInSuperview];
-    
-    if (shouldPerformAnimation) {
-        [self.noResultsView fadeInWithAnimation];
-    }
+
+    [self.noResultsViewController configureWithTitle:self.noResultsTitleText
+                                         buttonTitle:nil
+                                            subtitle:nil
+                                  attributedSubtitle:nil
+                                               image:@"wp-illustration-empty-results"
+                                       accessoryView:[self noResultsAccessoryView]];
+
+    [self.noResultsViewController.view setBackgroundColor:[UIColor clearColor]];
+    [self addChildViewController:self.noResultsViewController];
+    [self.view addSubviewWithFadeAnimation:self.noResultsViewController.view];
+    self.noResultsViewController.view.frame = self.tableView.frame;
+    [self.noResultsViewController didMoveToParentViewController:self];
 }
 
 


### PR DESCRIPTION
Fixes #10012 

In Reader > Post > Comments, replace `WPNoResultsView` with `NoResultsViewController`.

The No Results view displayed when:
- there are no post comments
- loading post comments
- error loading post comments

To test:

---
**No Post Comments:**
- Go to Reader > Followed Sites > Manage.
- Select a site that has a post with no comments.
- Press the comment icon on the post with no comments.
<img width="200" alt="no_comments_icon" src="https://user-images.githubusercontent.com/1816888/44366000-82b1d480-a488-11e8-90f3-b46fb9b3c2ea.png">

- Verify the view is:
![no_comments](https://user-images.githubusercontent.com/1816888/44365810-08815000-a488-11e8-8279-2e76ac7f816b.png)

---
**Loading Post Comments:**
- On a slow network, in the Reader, press the comment icon on a post with comments.
<img width="200" alt="comments_icon" src="https://user-images.githubusercontent.com/1816888/44366116-efc56a00-a488-11e8-966b-63933e16873f.png">

- Verify the view is:
![fetching](https://user-images.githubusercontent.com/1816888/44366168-184d6400-a489-11e8-918d-122733d29f79.png)

---
**Loading Error:**
- This may require some hacking. Suggestion:
  - In `ReaderCommentsViewController:syncContentEnded`, comment out all it's contents and call `[self syncContentFailed:syncHelper];`.
- In the Reader, press the comment icon on a post with comments.
- Verify the view is:
![error](https://user-images.githubusercontent.com/1816888/44365717-d8d24800-a487-11e8-8951-e1706cdda007.png)
