### PR TITLE
Fix Reader stream No Results view to display correctly with News Card

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -391,6 +391,10 @@ import WordPressFlux
             return
         }
 
+        if let tableHeaderView = tableView.tableHeaderView {
+            header.isHidden = tableHeaderView.isHidden
+        }
+
         tableView.tableHeaderView = header
 
         // This feels somewhat hacky, but it is the only way I found to insert a stack view into the header without breaking the autolayout constraints.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1424,7 +1424,7 @@ extension ReaderStreamViewController: SearchableActivityConvertable {
 private extension ReaderStreamViewController {
 
     func displayLoadingStream() {
-        configureAndDisplayResultsStatus(title: ResultsStatusText.loadingStreamTitle, accessoryView: resultsStatusAccessoryView())
+        configureAndDisplayResultsStatus(title: ResultsStatusText.loadingStreamTitle, accessoryView: resultsStatusView.loadingAccessoryView())
     }
 
     func displayLoadingStreamFailed() {
@@ -1437,7 +1437,7 @@ private extension ReaderStreamViewController {
         }
 
         tableView.tableHeaderView?.isHidden = true
-        configureAndDisplayResultsStatus(title: ResultsStatusText.fetchingPostsTitle, accessoryView: resultsStatusAccessoryView())
+        configureAndDisplayResultsStatus(title: ResultsStatusText.fetchingPostsTitle, accessoryView: resultsStatusView.loadingAccessoryView())
     }
 
     func displayNoResultsView() {
@@ -1490,12 +1490,6 @@ private extension ReaderStreamViewController {
         resultsStatusView.removeFromView()
         footerView.isHidden = false
         tableView.tableHeaderView?.isHidden = false
-    }
-
-    func resultsStatusAccessoryView() -> UIView {
-        let boxView = WPAnimatedBox()
-        boxView.animate(afterDelay: 0.3)
-        return boxView
     }
 
     struct ResultsStatusText {


### PR DESCRIPTION
Ref #9992 

This is to fix the issue @frosty discovered [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/9957#pullrequestreview-147650246) . The problem was the header was being refreshed after the NoResultsView was displayed, causing the header to show on top of the NRV. The fix checks to see if the header already exists. If so, persist the `isHidden` state.

To test:
- You may wish to enable the `newsCard` FeatureFlag as this caused the issue to be quite obvious.
- On a slow network, go to Reader > Followed Sites, or Reader > Discover.
- Verify the 'Fetching Posts' view is full screen (i.e. the header does not show).

![fetching](https://user-images.githubusercontent.com/1816888/44373252-915ab480-a4a5-11e8-8987-94ae62dfb4af.png)


