### PR TITLE
Activate refactor of notifications for all builds

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -20,7 +20,7 @@ enum FeatureFlag: Int {
         case .saveForLater:
             return true
         case .extractNotifications:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .quickStart:
             return BuildConfiguration.current == .localDeveloper
         case .newsCard:


### PR DESCRIPTION
Activate refactor of notifications for all builds. 

This PR is an intermediate step before actually removing all the old code.

@jklausa If you don't mind a quick review 😊 

Pinging @etoledom for tracking purposes

