### PR TITLE
Fix the check for isAutomatedTransfer and properly cast the returned option value

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -111,7 +111,8 @@ NSString * const OptionsKeyIsAutomatedTransfer = @"is_automated_transfer";
 
 - (BOOL)isAutomatedTransfer
 {
-    return [self getOptionValue:OptionsKeyIsAutomatedTransfer];
+    NSNumber *value = (NSNumber *)[self getOptionValue:OptionsKeyIsAutomatedTransfer];
+    return [value boolValue];
 }
 
 - (NSString *)icon


### PR DESCRIPTION
Fixes and issue reported by @rachelmcr on p5T066-FX-p2 where the auto-update toggle was being hidden for plugins on all Jetpack sites, not just Atomic sites.  The culprit was an improperly cast boolean which was always evaluating to true.

To test:
Check Plugins on a Jetpack site and confirm that the auto update toggle is available. 
Check Plugins on an Atomic (AT) site and confirm that the auto update toggle is *not* available.

@jleandroperez its been ages sir.  Could I trouble you with this one? 