### PR TITLE
Plugin Directory: replace No Results view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -10,7 +10,9 @@ import WordPressAuthenticator
 /// A view to show when there are no results for a given situation.
 /// Ex: My Sites > account has no sites; My Sites > all sites are hidden.
 /// The title will always show.
-/// The image will always show unless an accessoryView is provided.
+/// The image will always show unless:
+///     - an accessoryView is provided.
+///     - hideImage is set to true.
 /// The action button is shown by default, but will be hidden if button title is not provided.
 /// The subtitle is optional and will only show if provided.
 ///

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -33,6 +33,7 @@ import WordPressAuthenticator
     private var buttonText: String?
     private var imageName: String?
     private var accessorySubview: UIView?
+    private var hideImage = false
 
     // MARK: - View
 
@@ -146,6 +147,12 @@ import WordPressAuthenticator
         return boxView
     }
 
+    /// Public method to always hide the image view.
+    ///
+    func hideImageView() {
+        hideImage = true
+    }
+
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         setAccessoryViewsVisibility()
@@ -209,9 +216,9 @@ private extension NoResultsViewController {
             accessoryView.isHidden = true
         } else {
             // If there is an accessory view, show that.
-            // Otherwise, show the image view.
             accessoryView.isHidden = accessorySubview == nil
-            imageView.isHidden = !accessoryView.isHidden
+            // Otherwise, show the image view, unless it's set never to show.
+            imageView.isHidden = (hideImage == true) ? true : !accessoryView.isHidden
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
@@ -137,19 +137,20 @@ class CollectionViewContainerCell: UITableViewCell {
                     return
             }
 
-            let containerView = UIView(frame: .zero)
+            let containerView = UIView(frame: collectionView.frame)
             containerView.translatesAutoresizingMaskIntoConstraints = false
 
-            noResultsView.view.backgroundColor = .white
+            noResultsView.view.backgroundColor = .clear
             noResultsView.view.frame = containerView.frame
+            noResultsView.view.frame.origin.y = 0
 
             containerView.addSubview(noResultsView.view)
             addSubview(containerView)
 
-            containerView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.spacing * 3).isActive = true
-            containerView.bottomAnchor.constraint(equalTo: collectionView.bottomAnchor, constant: -Constants.spacing).isActive = true
-            containerView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
-            containerView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
+            containerView.topAnchor.constraint(equalTo: collectionView.topAnchor).isActive = true
+            containerView.bottomAnchor.constraint(equalTo: collectionView.bottomAnchor).isActive = true
+            containerView.leadingAnchor.constraint(equalTo: collectionView.leadingAnchor).isActive = true
+            containerView.trailingAnchor.constraint(equalTo: collectionView.trailingAnchor).isActive = true
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
@@ -15,7 +15,7 @@ struct CollectionViewContainerRow<CollectionViewCellType: UICollectionViewCell, 
     let title: String
     let secondaryTitle: String?
     let action: ImmuTableAction?
-    let noResultsView: WPNoResultsView?
+    let noResultsView: NoResultsViewController?
 
     private let helper: CollectionViewHandler
 
@@ -47,7 +47,7 @@ struct CollectionViewContainerRow<CollectionViewCellType: UICollectionViewCell, 
     init(title: String,
          secondaryTitle: String?,
          action: ImmuTableAction?,
-         noResultsView: WPNoResultsView) {
+         noResultsView: NoResultsViewController) {
         self.title = title
         self.secondaryTitle = secondaryTitle
         self.action = action
@@ -60,7 +60,6 @@ struct CollectionViewContainerRow<CollectionViewCellType: UICollectionViewCell, 
                                        configureCollectionCellBlock: configurationBlock,
                                        collectionCellSeletectedBlock: selectionBlock)
     }
-
 
     func configureCell(_ cell: UITableViewCell) {
         let cell = cell as! CellType
@@ -83,7 +82,6 @@ struct CollectionViewContainerRow<CollectionViewCellType: UICollectionViewCell, 
         cell.collectionView.dataSource = helper
     }
 
-
 }
 
 /// Generic Swift classes can't be made `@objc`, so we're using this helper object to be a `UICollectionView[DataSource|Delegate]`
@@ -102,7 +100,6 @@ struct CollectionViewContainerRow<CollectionViewCellType: UICollectionViewCell, 
         self.configureCollectionCellBlock = configureCollectionCellBlock
         self.collectionCellSeletectedBlock = collectionCellSeletectedBlock
     }
-
 
     func numberOfSections(in collectionView: UICollectionView) -> Int {
         return 1
@@ -132,29 +129,27 @@ class CollectionViewContainerCell: UITableViewCell {
     private(set) var collectionView: UICollectionView!
     private(set) var titleLabel: UILabel!
     private(set) var actionButton: UIButton!
-    fileprivate var noResultsView: WPNoResultsView? {
+    fileprivate var noResultsView: NoResultsViewController? {
         didSet {
-            oldValue?.superview?.removeFromSuperview()
+            oldValue?.removeFromView()
 
-            guard let noResults = noResultsView else {
-                return
+            guard let noResultsView = noResultsView else {
+                    return
             }
 
             let containerView = UIView(frame: .zero)
-
             containerView.translatesAutoresizingMaskIntoConstraints = false
-            noResultsView?.translatesAutoresizingMaskIntoConstraints = false
 
-            containerView.addSubview(noResults)
-            containerView.pinSubviewAtCenter(noResults)
+            noResultsView.view.backgroundColor = .white
+            noResultsView.view.frame = containerView.frame
+
+            containerView.addSubview(noResultsView.view)
             addSubview(containerView)
 
-            containerView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.spacing).isActive = true
+            containerView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.spacing * 3).isActive = true
             containerView.bottomAnchor.constraint(equalTo: collectionView.bottomAnchor).isActive = true
             containerView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
             containerView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
-
-            noResultsView?.centerInSuperview()
         }
     }
 
@@ -229,7 +224,7 @@ class CollectionViewContainerCell: UITableViewCell {
     }
 
     override func prepareForReuse() {
-        noResultsView?.superview?.removeFromSuperview()
+        noResultsView?.removeFromView()
         noResultsView = nil
     }
 

--- a/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
@@ -147,10 +147,12 @@ class CollectionViewContainerCell: UITableViewCell {
             containerView.addSubview(noResultsView.view)
             addSubview(containerView)
 
-            containerView.topAnchor.constraint(equalTo: collectionView.topAnchor).isActive = true
-            containerView.bottomAnchor.constraint(equalTo: collectionView.bottomAnchor).isActive = true
-            containerView.leadingAnchor.constraint(equalTo: collectionView.leadingAnchor).isActive = true
-            containerView.trailingAnchor.constraint(equalTo: collectionView.trailingAnchor).isActive = true
+            NSLayoutConstraint.activate([
+                containerView.topAnchor.constraint(equalTo: collectionView.topAnchor),
+                containerView.bottomAnchor.constraint(equalTo: collectionView.bottomAnchor),
+                containerView.leadingAnchor.constraint(equalTo: collectionView.leadingAnchor),
+                containerView.trailingAnchor.constraint(equalTo: collectionView.trailingAnchor)
+                ])
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
@@ -147,7 +147,7 @@ class CollectionViewContainerCell: UITableViewCell {
             addSubview(containerView)
 
             containerView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.spacing * 3).isActive = true
-            containerView.bottomAnchor.constraint(equalTo: collectionView.bottomAnchor).isActive = true
+            containerView.bottomAnchor.constraint(equalTo: collectionView.bottomAnchor, constant: -Constants.spacing).isActive = true
             containerView.leadingAnchor.constraint(equalTo: leadingAnchor).isActive = true
             containerView.trailingAnchor.constraint(equalTo: trailingAnchor).isActive = true
         }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
@@ -179,8 +179,8 @@ extension PluginDirectoryViewController: UISearchResultsUpdating {
     }
 }
 
-extension PluginDirectoryViewController: WPNoResultsViewDelegate {
-    func didTap(_ noResultsView: WPNoResultsView!) {
+extension PluginDirectoryViewController: NoResultsViewControllerDelegate {
+    func actionButtonPressed() {
         viewModel.reloadFailed()
     }
 }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewModel.swift
@@ -12,7 +12,7 @@ class PluginDirectoryViewModel: Observable {
 
     let changeDispatcher = Dispatcher<Void>()
 
-    weak var noResultsDelegate: WPNoResultsViewDelegate?
+    weak var noResultsDelegate: NoResultsViewControllerDelegate?
 
     private let store: PluginStore
 
@@ -84,25 +84,21 @@ class PluginDirectoryViewModel: Observable {
         }
     }
 
-    private func noResultsView(for query: PluginQuery) -> WPNoResultsView? {
+    private func noResultsView(for query: PluginQuery) -> NoResultsViewController? {
         guard hasResults(for: query) == false else {
             return nil
         }
 
-        let noResultsView = WPNoResultsView()
+        let noResultsView = NoResultsViewController.controller()
         noResultsView.delegate = noResultsDelegate
-        let model: WPNoResultsView.Model
+        let model: NoResultsViewController.Model
 
         if isFetching(for: query) {
-            let indicatorView = UIActivityIndicatorView(activityIndicatorStyle: .gray)
-            indicatorView.startAnimating()
-
-            model = WPNoResultsView.Model(title: "",
-                                          accessoryView: indicatorView)
-
+            model = NoResultsViewController.Model(title: NSLocalizedString("Loading plugins...", comment: "Messaged displayed when fetching plugins."),
+                                                  accessoryView: noResultsView.loadingAccessoryView())
         } else {
-            model = WPNoResultsView.Model(title: NSLocalizedString("Error loading plugins.", comment: "Messaged displayed when fetching plugins failed."),
-                                          buttonTitle: NSLocalizedString("Try again", comment: "Button that lets users try to reload the plugin directory after loading failure"))
+            model = NoResultsViewController.Model(title: NSLocalizedString("Error loading plugins", comment: "Messaged displayed when fetching plugins failed."),
+                                                  buttonText: NSLocalizedString("Try again", comment: "Button that lets users try to reload the plugin directory after loading failure"))
         }
 
         noResultsView.bindViewModel(model)
@@ -367,7 +363,7 @@ private extension CollectionViewContainerRow where Item == Any, CollectionViewCe
          secondaryTitle: String?,
          site: JetpackSiteRef,
          listViewQuery: PluginQuery?,
-         noResultsView: WPNoResultsView,
+         noResultsView: NoResultsViewController,
          presenter: PluginPresenter & PluginListPresenter) {
 
         let actionClosure: ImmuTableAction = { [weak presenter] _ in

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewModel.swift
@@ -91,6 +91,7 @@ class PluginDirectoryViewModel: Observable {
 
         let noResultsView = NoResultsViewController.controller()
         noResultsView.delegate = noResultsDelegate
+        noResultsView.hideImageView()
         let model: NoResultsViewController.Model
 
         if isFetching(for: query) {

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -39,7 +39,7 @@ class NoticeView: UIView {
         if notice.actionTitle != nil {
             configureActionButton()
         }
-        
+
         if notice.style.isDismissable {
             configureDismissRecognizer()
         }

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -42,7 +42,7 @@
                                             </imageView>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Stack View">
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Button Stack View">
                                         <rect key="frame" x="0.0" y="226" width="355" height="118.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -20,25 +20,30 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ae-eX-ae9" userLabel="No Results View">
-                                <rect key="frame" x="10" y="211.5" width="355" height="264.5"/>
+                                <rect key="frame" x="10" y="172" width="355" height="344"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="czl-5D-gem" userLabel="Accessory View">
-                                        <rect key="frame" x="127.5" y="0.5" width="100" height="100"/>
-                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="100" id="AYV-Gw-aKL"/>
-                                            <constraint firstAttribute="width" secondItem="czl-5D-gem" secondAttribute="height" multiplier="1:1" id="OOu-9J-9cx"/>
-                                        </constraints>
-                                    </view>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="mysites-nosites" translatesAutoresizingMaskIntoConstraints="NO" id="Fwm-rl-dKS" userLabel="Image View">
-                                        <rect key="frame" x="64.5" y="10.5" width="226" height="116"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="Fwm-rl-dKS" secondAttribute="height" multiplier="113:58" id="LtV-EW-4bR"/>
-                                            <constraint firstAttribute="width" constant="226" id="zgJ-Vl-MiN"/>
-                                        </constraints>
-                                    </imageView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w">
-                                        <rect key="frame" x="0.0" y="146.5" width="355" height="118.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-LB-oOz" userLabel="Accessory Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="355" height="216"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="czl-5D-gem" userLabel="Accessory View">
+                                                <rect key="frame" x="127.5" y="0.0" width="100" height="100"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="100" id="AYV-Gw-aKL"/>
+                                                    <constraint firstAttribute="width" secondItem="czl-5D-gem" secondAttribute="height" multiplier="1:1" id="OOu-9J-9cx"/>
+                                                </constraints>
+                                            </view>
+                                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="mysites-nosites" translatesAutoresizingMaskIntoConstraints="NO" id="Fwm-rl-dKS" userLabel="Image View">
+                                                <rect key="frame" x="64.5" y="100" width="226" height="116"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="Fwm-rl-dKS" secondAttribute="height" multiplier="113:58" id="LtV-EW-4bR"/>
+                                                    <constraint firstAttribute="width" constant="226" id="zgJ-Vl-MiN"/>
+                                                </constraints>
+                                            </imageView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Stack View">
+                                        <rect key="frame" x="0.0" y="226" width="355" height="118.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">
                                                 <rect key="frame" x="93" y="0.0" width="169.5" height="54.5"/>
@@ -79,31 +84,13 @@
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="gjj-bC-32w" secondAttribute="bottom" id="9L8-n3-tw3"/>
-                                    <constraint firstItem="gjj-bC-32w" firstAttribute="top" secondItem="Fwm-rl-dKS" secondAttribute="bottom" constant="20" id="BdA-bk-oTl"/>
-                                    <constraint firstItem="gjj-bC-32w" firstAttribute="top" secondItem="0Ae-eX-ae9" secondAttribute="top" id="D2z-6C-CJE"/>
-                                    <constraint firstItem="Fwm-rl-dKS" firstAttribute="top" secondItem="0Ae-eX-ae9" secondAttribute="top" constant="10" id="Q94-Bc-Rfs"/>
                                     <constraint firstItem="gjj-bC-32w" firstAttribute="leading" secondItem="0Ae-eX-ae9" secondAttribute="leading" id="UZP-FI-0Fk"/>
-                                    <constraint firstItem="czl-5D-gem" firstAttribute="centerX" secondItem="0Ae-eX-ae9" secondAttribute="centerX" id="V5P-Iz-hPa"/>
-                                    <constraint firstItem="Fwm-rl-dKS" firstAttribute="centerX" secondItem="0Ae-eX-ae9" secondAttribute="centerX" id="jdr-4Z-YKV"/>
+                                    <constraint firstAttribute="trailing" secondItem="3Mp-LB-oOz" secondAttribute="trailing" id="fy4-as-vTK"/>
+                                    <constraint firstItem="3Mp-LB-oOz" firstAttribute="leading" secondItem="0Ae-eX-ae9" secondAttribute="leading" id="guT-w9-2ZG"/>
+                                    <constraint firstItem="3Mp-LB-oOz" firstAttribute="top" secondItem="0Ae-eX-ae9" secondAttribute="top" id="h6n-h9-V55"/>
                                     <constraint firstAttribute="trailing" secondItem="gjj-bC-32w" secondAttribute="trailing" id="mCf-TP-NhY"/>
-                                    <constraint firstItem="czl-5D-gem" firstAttribute="top" secondItem="0Ae-eX-ae9" secondAttribute="top" id="zNe-un-uU0"/>
+                                    <constraint firstItem="gjj-bC-32w" firstAttribute="top" secondItem="3Mp-LB-oOz" secondAttribute="bottom" constant="10" id="uMU-Y3-ncz"/>
                                 </constraints>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="BdA-bk-oTl"/>
-                                        <exclude reference="D2z-6C-CJE"/>
-                                    </mask>
-                                </variation>
-                                <variation key="heightClass=compact">
-                                    <mask key="constraints">
-                                        <include reference="D2z-6C-CJE"/>
-                                    </mask>
-                                </variation>
-                                <variation key="heightClass=regular">
-                                    <mask key="constraints">
-                                        <include reference="BdA-bk-oTl"/>
-                                    </mask>
-                                </variation>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
Fixes #10020 

The No Results view is displayed when:
- Error loading plugins.
- Fetching plugins.

Due to lack of space (as in the original implementation), the NRV image does not show. However, I did add the loading animation since, while loading, there is enough room for that.

NOTE: The constraint warnings are pre-existing and unrelated to the NRV.

To test:

---
**Error loading plugins:**
- This might require a hack to show. Suggestion:
  - In `BlogDetailsViewController:configurationSectionViewModel` comment out this if check: `if ([self.blog supports:BlogFeaturePluginManagement])`.
- On a site that does not support plugins, go to Site > Plugins.
- Verify the view is:
![plugins_error](https://user-images.githubusercontent.com/1816888/44435839-32617200-a56f-11e8-9884-2d8c2444236a.png)

---
**Loading plugins:**
- On a slow network, go to Site > Plugins.
- Verify the view is:
![plugins_loading](https://user-images.githubusercontent.com/1816888/44435854-486f3280-a56f-11e8-8c3d-3e52a4d6004d.png)



