### PR TITLE
ReaderCoordinator: Ensure that VCs are opened in correct split view pane

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -421,6 +421,11 @@ import WordPressShared
         dismiss(animated: true, completion: nil)
     }
 
+    func deselectSelectedRow(animated: Bool) {
+        tableView.deselectSelectedRowWithAnimation(animated)
+        restorableSelectedIndexPath = defaultIndexPath
+    }
+
     // MARK: - Tag Wrangling
 
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -3,12 +3,15 @@ import UIKit
 @objc
 class ReaderCoordinator: NSObject {
     let readerNavigationController: UINavigationController
+    let readerSplitViewController: WPSplitViewController
     let readerMenuViewController: ReaderMenuViewController
 
     @objc
     init(readerNavigationController: UINavigationController,
+         readerSplitViewController: WPSplitViewController,
          readerMenuViewController: ReaderMenuViewController) {
         self.readerNavigationController = readerNavigationController
+        self.readerSplitViewController = readerSplitViewController
         self.readerMenuViewController = readerMenuViewController
 
         super.init()
@@ -16,7 +19,7 @@ class ReaderCoordinator: NSObject {
     private func prepareToNavigate() {
         WPTabBarController.sharedInstance().showReaderTab()
 
-        readerNavigationController.popToRootViewController(animated: false)
+        topNavigationController.popToRootViewController(animated: false)
     }
 
     func showReaderTab() {
@@ -55,7 +58,7 @@ class ReaderCoordinator: NSObject {
 
         readerMenuViewController.showSectionForDefaultMenuItem(withOrder: .followed, animated: false)
 
-        if let followedViewController = readerNavigationController.topViewController as? ReaderStreamViewController {
+        if let followedViewController = topNavigationController.topViewController as? ReaderStreamViewController {
             followedViewController.showManageSites(animated: false)
         }
     }
@@ -71,8 +74,7 @@ class ReaderCoordinator: NSObject {
         prepareToNavigate()
 
         let streamViewController = ReaderStreamViewController.controllerWithTopic(topic)
-        readerNavigationController.pushViewController(streamViewController,
-                                                      animated: false)
+        readerSplitViewController.showDetailViewController(streamViewController, sender: nil)
     }
 
     func showTag(named tagName: String) {
@@ -82,14 +84,14 @@ class ReaderCoordinator: NSObject {
         let slug = remote.slug(forTopicName: tagName) ?? tagName.lowercased()
         let controller = ReaderStreamViewController.controllerWithTagSlug(slug)
 
-        readerNavigationController.pushViewController(controller, animated: true)
+        readerSplitViewController.showDetailViewController(controller, sender: nil)
     }
 
     func showStream(with siteID: Int, isFeed: Bool) {
         prepareToNavigate()
 
         let controller = ReaderStreamViewController.controllerWithSiteID(NSNumber(value: siteID), isFeed: isFeed)
-        readerNavigationController.pushViewController(controller, animated: false)
+        readerSplitViewController.showDetailViewController(controller, sender: nil)
     }
 
     func showPost(with postID: Int, for feedID: Int, isFeed: Bool) {
@@ -98,7 +100,17 @@ class ReaderCoordinator: NSObject {
         let detailViewController = ReaderDetailViewController.controllerWithPostID(postID as NSNumber,
                                                                                        siteID: feedID as NSNumber,
                                                                                        isFeed: isFeed)
-        readerNavigationController.pushFullscreenViewController(detailViewController, animated: true)
+
+        topNavigationController.pushFullscreenViewController(detailViewController, animated: false)
+    }
+
+    private var topNavigationController: UINavigationController {
+        if readerMenuViewController.splitViewControllerIsHorizontallyCompact == false,
+            let navigationController = readerSplitViewController.topDetailViewController?.navigationController {
+            return navigationController
+        }
+
+        return readerNavigationController
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -75,6 +75,7 @@ class ReaderCoordinator: NSObject {
 
         let streamViewController = ReaderStreamViewController.controllerWithTopic(topic)
         readerSplitViewController.showDetailViewController(streamViewController, sender: nil)
+        readerMenuViewController.deselectSelectedRow(animated: false)
     }
 
     func showTag(named tagName: String) {
@@ -85,6 +86,7 @@ class ReaderCoordinator: NSObject {
         let controller = ReaderStreamViewController.controllerWithTagSlug(slug)
 
         readerSplitViewController.showDetailViewController(controller, sender: nil)
+        readerMenuViewController.deselectSelectedRow(animated: false)
     }
 
     func showStream(with siteID: Int, isFeed: Bool) {
@@ -92,6 +94,7 @@ class ReaderCoordinator: NSObject {
 
         let controller = ReaderStreamViewController.controllerWithSiteID(NSNumber(value: siteID), isFeed: isFeed)
         readerSplitViewController.showDetailViewController(controller, sender: nil)
+        readerMenuViewController.deselectSelectedRow(animated: false)
     }
 
     func showPost(with postID: Int, for feedID: Int, isFeed: Bool) {
@@ -102,6 +105,7 @@ class ReaderCoordinator: NSObject {
                                                                                        isFeed: isFeed)
 
         topNavigationController.pushFullscreenViewController(detailViewController, animated: false)
+        readerMenuViewController.deselectSelectedRow(animated: false)
     }
 
     private var topNavigationController: UINavigationController {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -466,6 +466,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (ReaderCoordinator *)readerCoordinator
 {
     return [[ReaderCoordinator alloc] initWithReaderNavigationController:self.readerNavigationController
+                                               readerSplitViewController:self.readerSplitViewController
                                                 readerMenuViewController:self.readerMenuViewController];
 }
 


### PR DESCRIPTION
Fixes #10014.

Previously, some universal links that opened the Reader on iPad would open in the wrong pane – showing post detail or a stream in the left pane of the split view:

![img_0322](https://user-images.githubusercontent.com/4780/44453466-01c21c80-a5f1-11e8-830c-c0ae89b50e6a.PNG)

This PR slightly adjusts the logic of `ReaderCoordinator` to ensure that the correct pane is selected to display content.

**To test:**

* Build and run to a **device**
* Tap each of the following links, and ensure that the view is correct in the app:
    * https://wordpress.com/read/blogs/146091842/posts/548006 – should open a post in a full width view
  * https://wordpress.com/read/blogs/146091842 - should open the 9to5mac feed in the right pane, with the Reader menu visible in the left pane
