### PR TITLE
Show newly created site after its creation

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationEpilogueViewController.swift
@@ -6,7 +6,13 @@ class SiteCreationEpilogueViewController: NUXViewController {
 
     // MARK: - Properties
 
-    var siteToShow: Blog?
+    var siteToShow: Blog? {
+        didSet {
+            if let newBlog = siteToShow {
+                WPTabBarController.sharedInstance().switchMySitesTabToBlogDetails(for: newBlog)
+            }
+        }
+    }
 
     override var prefersStatusBarHidden: Bool {
         return true
@@ -58,9 +64,6 @@ extension SiteCreationEpilogueViewController: NUXButtonViewControllerDelegate {
 
     // 'Configure' button
     func secondaryButtonPressed() {
-        if let siteToShow = siteToShow {
-            WPTabBarController.sharedInstance().switchMySitesTabToBlogDetails(for: siteToShow)
-        }
         navigationController?.dismiss(animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
Currently after creating a new site, tapping the "Write first post" button would drop the user at the list of sites, instead of showing details for the newly created site. This PR fixes that.

![screen recording 2018-08-22 at 12 08 09 pm](https://user-images.githubusercontent.com/517257/44485083-63d84d00-a604-11e8-8b11-7a02be57abc0.gif)

To test:
- create a new site
- tap "Write first post" when complete
- dismiss the editor
- ensure the new site is show instead of the list of sites

