### PR TITLE
Plugin List: replace No Results view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -141,9 +141,9 @@ import WordPressAuthenticator
         return noResultsView.frame.height
     }
 
-    /// Public method to get an animated box to show while loading.
+    /// Public class method to get an animated box to show while loading.
     ///
-    @objc func loadingAccessoryView() -> UIView {
+    @objc class func loadingAccessoryView() -> UIView {
         let boxView = WPAnimatedBox()
         boxView.animate(afterDelay: 0.3)
         return boxView

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewModel.swift
@@ -96,7 +96,7 @@ class PluginDirectoryViewModel: Observable {
 
         if isFetching(for: query) {
             model = NoResultsViewController.Model(title: NSLocalizedString("Loading plugins...", comment: "Messaged displayed when fetching plugins."),
-                                                  accessoryView: noResultsView.loadingAccessoryView())
+                                                  accessoryView: NoResultsViewController.loadingAccessoryView())
         } else {
             model = NoResultsViewController.Model(title: NSLocalizedString("Error loading plugins", comment: "Messaged displayed when fetching plugins failed."),
                                                   buttonText: NSLocalizedString("Try again", comment: "Button that lets users try to reload the plugin directory after loading failure"))

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
@@ -13,7 +13,7 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
     fileprivate var viewModel: PluginListViewModel
     fileprivate var tableViewModel = ImmuTable.Empty
 
-    fileprivate let noResultsView = WPNoResultsView()
+    private let noResultsViewController = NoResultsViewController.controller()
     var viewModelStateChangeReceipt: Receipt?
     var viewModelChangeReceipt: Receipt?
 
@@ -25,7 +25,7 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
         super.init(style: .grouped)
 
         title = viewModel.title
-        noResultsView.delegate = self
+        noResultsViewController.delegate = self
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -61,25 +61,19 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
         viewModel.refresh()
     }
 
-    func updateNoResults() {
+    private func updateNoResults() {
+        noResultsViewController.removeFromView()
+
         if let noResultsViewModel = viewModel.noResultsViewModel {
             showNoResults(noResultsViewModel)
-        } else {
-            hideNoResults()
         }
     }
 
-    func showNoResults(_ viewModel: WPNoResultsView.Model) {
-        noResultsView.bindViewModel(viewModel)
-        if noResultsView.isDescendant(of: tableView) {
-            noResultsView.centerInSuperview()
-        } else {
-            tableView.addSubview(withFadeAnimation: noResultsView)
-        }
-    }
-
-    func hideNoResults() {
-        noResultsView.removeFromSuperview()
+    private func showNoResults(_ viewModel: NoResultsViewController.Model) {
+        noResultsViewController.bindViewModel(viewModel)
+        tableView.addSubview(withFadeAnimation: noResultsViewController.view)
+        addChildViewController(noResultsViewController)
+        noResultsViewController.didMove(toParentViewController: self)
     }
 
     func refreshModel(change: PluginListViewModel.StateChange) {
@@ -148,10 +142,10 @@ extension PluginListViewController {
     }
 }
 
-// MARK: - WPNoResultsViewDelegate
+// MARK: - NoResultsViewControllerDelegate
 
-extension PluginListViewController: WPNoResultsViewDelegate {
-    func didTap(_ noResultsView: WPNoResultsView!) {
+extension PluginListViewController: NoResultsViewControllerDelegate {
+    func actionButtonPressed() {
         let supportVC = SupportTableViewController()
         supportVC.showFromTabBar()
     }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
@@ -73,6 +73,18 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
         noResultsViewController.bindViewModel(viewModel)
         tableView.addSubview(withFadeAnimation: noResultsViewController.view)
         addChildViewController(noResultsViewController)
+        
+        // Adjust view to center it vertically
+        if case .feed(let feedType) = query, case .search = feedType {
+            // If searching, use tableView.bounds to account for the search bar.
+            noResultsViewController.view.frame = tableView.bounds
+        } else {
+            // Otherwise use the tableView.frame
+            noResultsViewController.view.frame = tableView.frame
+            // And since the tableView doesn't start at the top, adjust the NRV accordingly.
+            noResultsViewController.view.frame.origin.y = 0
+        }
+
         noResultsViewController.didMove(toParentViewController: self)
     }
 

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
@@ -37,6 +37,8 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
 
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
         ImmuTable.registerRows(PluginListViewModel.immutableRows, tableView: tableView)
+        setupRefreshControl()
+
         viewModelStateChangeReceipt = viewModel.onStateChange { [weak self] (change) in
             self?.refreshModel(change: change)
         }
@@ -47,8 +49,6 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
         tableView.rowHeight = UITableViewAutomaticDimension
         tableView.estimatedRowHeight = 72
 
-        refreshModel(change: .replace)
-        setupRefreshControl()
         updateRefreshControl()
     }
 
@@ -86,11 +86,18 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
             let indexPaths = changedRows.map({ IndexPath(row: $0, section: 0) })
             tableView.reloadRows(at: indexPaths, with: .none)
         }
+        setupRefreshControl()
         updateNoResults()
     }
 
     private func setupRefreshControl() {
+        if viewModel.currentState == .loading {
+            refreshControl = nil
+            return
+        }
+
         if case .feed(let feedType) = query, case .search = feedType {
+            refreshControl = nil
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
@@ -73,7 +73,7 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
         noResultsViewController.bindViewModel(viewModel)
         tableView.addSubview(withFadeAnimation: noResultsViewController.view)
         addChildViewController(noResultsViewController)
-        
+
         // Adjust view to center it vertically
         if case .feed(let feedType) = query, case .search = feedType {
             // If searching, use tableView.bounds to account for the search bar.

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewModel.swift
@@ -90,6 +90,11 @@ class PluginListViewModel: Observable {
             stateChangeDispatcher.dispatch(State.changed(from: oldValue, to: state))
         }
     }
+
+    var currentState: State {
+        return state
+    }
+
     private(set) var refreshing = false {
         didSet {
             if refreshing != oldValue {

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewModel.swift
@@ -175,7 +175,7 @@ class PluginListViewModel: Observable {
     var noResultsViewModel: NoResultsViewController.Model? {
         switch state {
         case .loading:
-            return NoResultsViewController.Model(title: NoResultsText.loadingTitle, accessoryView: nil)
+            return NoResultsViewController.Model(title: NoResultsText.loadingTitle, accessoryView: NoResultsViewController.loadingAccessoryView())
 
         case .ready(let plugins):
             guard case .feed(let feedType) = query,

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewModel.swift
@@ -167,53 +167,30 @@ class PluginListViewModel: Observable {
         }
     }
 
-    var noResultsViewModel: WPNoResultsView.Model? {
+    var noResultsViewModel: NoResultsViewController.Model? {
         switch state {
         case .loading:
-
-            let accessoryView: UIView?
-            if case .feed(let feedType) = query,
-                case .search = feedType {
-                let activityView = UIActivityIndicatorView(activityIndicatorStyle: .gray)
-                activityView.startAnimating()
-
-                accessoryView = activityView
-            } else {
-                accessoryView = nil
-            }
-
-            // pull-to-refresh doesn't make sense as a interface in search, so there's no `UIRefreshcControl`
-            // for search queries, but we still want to show nice animated spinner.
-            // other feeds animate the UIRefreshControl
-
-            return WPNoResultsView.Model(
-                title: NSLocalizedString("Loading Plugins...", comment: "Text displayed while loading plugins for a site"),
-                accessoryView: accessoryView)
+            return NoResultsViewController.Model(title: NoResultsText.loadingTitle, accessoryView: nil)
 
         case .ready(let plugins):
             guard case .feed(let feedType) = query,
                 case .search = feedType,
                 case .directory(let result) = plugins,
                 result.count == 0 else {
-                return nil
+                    return nil
             }
 
-            return WPNoResultsView.Model(
-                title: NSLocalizedString("No plugins found", comment: "Text displayed when search for plugins returns no results")
-            )
+            return NoResultsViewController.Model(title: NoResultsText.noResultsTitle)
+
         case .error:
             let appDelegate = WordPressAppDelegate.sharedInstance()
             if (appDelegate?.connectionAvailable)! {
-                return WPNoResultsView.Model(
-                    title: NSLocalizedString("Oops", comment: "An informal exclaimation that means `something went wrong`."),
-                    message: NSLocalizedString("There was an error loading plugins", comment: "Text displayed when there is a failure loading plugins"),
-                    buttonTitle: NSLocalizedString("Contact support", comment: "Button label for contacting support")
-                )
+                return NoResultsViewController.Model(title: NoResultsText.errorTitle,
+                                                     subtitle: NoResultsText.errorSubtitle,
+                                                     buttonText: NoResultsText.errorButtonText)
             } else {
-                return WPNoResultsView.Model(
-                    title: NSLocalizedString("No connection", comment: "Title for the error view when there's no connection"),
-                    message: NSLocalizedString("An active internet connection is required to view plugins", comment: "Error message shown when trying to view the Plugins feature and there is no internet connection.")
-                )
+                return NoResultsViewController.Model(title: NoResultsText.noConnectionTitle,
+                                                     subtitle: NoResultsText.noConnectionSubtitle)
             }
         }
     }
@@ -327,4 +304,15 @@ class PluginListViewModel: Observable {
             return nil
         }
     }
+
+    private struct NoResultsText {
+        static let loadingTitle = NSLocalizedString("Loading Plugins...", comment: "Text displayed while loading plugins for a site")
+        static let noResultsTitle = NSLocalizedString("No plugins found", comment: "Text displayed when search for plugins returns no results")
+        static let errorTitle = NSLocalizedString("Oops", comment: "An informal exclaimation that means `something went wrong`.")
+        static let errorSubtitle = NSLocalizedString("There was an error loading plugins", comment: "Text displayed when there is a failure loading plugins")
+        static let errorButtonText = NSLocalizedString("Contact support", comment: "Button label for contacting support")
+        static let noConnectionTitle = NSLocalizedString("No connection", comment: "Title for the error view when there's no connection")
+        static let noConnectionSubtitle = NSLocalizedString("An active internet connection is required to view plugins", comment: "Error message shown when trying to view the Plugins feature and there is no internet connection.")
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -457,7 +457,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 {
     UIView *loadingAccessoryView = nil;
     if (self.isLoadingPost || self.syncHelper.isSyncing) {
-        loadingAccessoryView = [self.noResultsViewController loadingAccessoryView];
+        loadingAccessoryView = [NoResultsViewController loadingAccessoryView];
     }
     return loadingAccessoryView;
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -306,7 +306,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     @objc open func setupWithPostID(_ postID: NSNumber, siteID: NSNumber, isFeed: Bool) {
 
-        configureAndDisplayLoadingView(title: LoadingText.loadingTitle, accessoryView: noResultsViewController.loadingAccessoryView())
+        configureAndDisplayLoadingView(title: LoadingText.loadingTitle, accessoryView: NoResultsViewController.loadingAccessoryView())
 
         textView.alpha = 0.0
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -263,7 +263,7 @@ private extension ReaderFollowedSitesViewController {
         }
 
         if isSyncing {
-            noResultsViewController.configure(title: NoResultsText.loadingTitle, accessoryView: noResultsViewController.loadingAccessoryView())
+            noResultsViewController.configure(title: NoResultsText.loadingTitle, accessoryView: NoResultsViewController.loadingAccessoryView())
         } else {
             noResultsViewController.configure(title: NoResultsText.noResultsTitle, subtitle: NoResultsText.noResultsMessage, image: "wp-illustration-empty-results")
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
@@ -225,7 +225,7 @@ private extension ReaderSiteSearchViewController {
     }
 
     func showLoadingView() {
-        configureAndDisplayStatus(title: StatusText.loadingTitle, accessoryView: statusViewController.loadingAccessoryView())
+        configureAndDisplayStatus(title: StatusText.loadingTitle, accessoryView: NoResultsViewController.loadingAccessoryView())
     }
 
     func showLoadingFailedView() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1427,7 +1427,7 @@ extension ReaderStreamViewController: SearchableActivityConvertable {
 private extension ReaderStreamViewController {
 
     func displayLoadingStream() {
-        configureAndDisplayResultsStatus(title: ResultsStatusText.loadingStreamTitle, accessoryView: resultsStatusView.loadingAccessoryView())
+        configureAndDisplayResultsStatus(title: ResultsStatusText.loadingStreamTitle, accessoryView: NoResultsViewController.loadingAccessoryView())
     }
 
     func displayLoadingStreamFailed() {
@@ -1440,7 +1440,7 @@ private extension ReaderStreamViewController {
         }
 
         tableView.tableHeaderView?.isHidden = true
-        configureAndDisplayResultsStatus(title: ResultsStatusText.fetchingPostsTitle, accessoryView: resultsStatusView.loadingAccessoryView())
+        configureAndDisplayResultsStatus(title: ResultsStatusText.fetchingPostsTitle, accessoryView: NoResultsViewController.loadingAccessoryView())
     }
 
     func displayNoResultsView() {


### PR DESCRIPTION
Fixes #10026 

In the Plugin List, replace `WPNoResultsView` with `NoResultsViewController`.

The No Results view is displayed when:
- Loading plugins.
- No results from plugin search.
- Error loading plugins.
- No connection.

To test:

---
**Loading plugins:**
- On a slow network, go to Site > Plugins > Manage.
- Verify the view is:
![loading](https://user-images.githubusercontent.com/1816888/44492250-0e5e6900-a621-11e8-9388-98c50c3038e8.png)

---
**Search no results:**
- Go to Site > Plugins > Search.
- Enter an invalid search term.
- Verify the view is:
![search](https://user-images.githubusercontent.com/1816888/44492278-27671a00-a621-11e8-837e-06db6c0a33a5.png)

---
**Loading error:**
- This might require a hack to show. Suggestion:
  - In `BlogDetailsViewController:configurationSectionViewModel` comment out this if check: `if ([self.blog supports:BlogFeaturePluginManagement])`.
- On a site that does not support plugins, go to Site > Plugins > Manage.
- Verify the view is:
![error](https://user-images.githubusercontent.com/1816888/44492414-abb99d00-a621-11e8-974e-f2353fa58b68.png)

---
**No connection:**
- Disable internet connection.
- Go to Site > Plugins > Manage.
- Verify the view is:
![no_connection](https://user-images.githubusercontent.com/1816888/44492309-44035200-a621-11e8-90dc-203ab8b61087.png)
