### PR TITLE
Newscard readable margins

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
@@ -33,16 +33,16 @@
                 <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Ewo-7I-oMB">
                     <rect key="frame" x="0.0" y="8" width="375" height="184"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" horizontalCompressionResistancePriority="740" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9hi-UA-p04">
+                        <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" verticalHuggingPriority="275" horizontalCompressionResistancePriority="740" verticalCompressionResistancePriority="740" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9hi-UA-p04">
                             <rect key="frame" x="16" y="20" width="149" height="91"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aSK-uI-6js" userLabel="NewsTitle">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aSK-uI-6js" userLabel="NewsTitle">
                                     <rect key="frame" x="0.0" y="0.0" width="149" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="900" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gf2-Wv-Ozo" userLabel="NewsSubtitle">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gf2-Wv-Ozo" userLabel="NewsSubtitle">
                                     <rect key="frame" x="0.0" y="30.5" width="149" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
@@ -50,6 +50,9 @@
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WFs-AW-Uc0">
                                     <rect key="frame" x="0.0" y="61" width="149" height="30"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="30" id="m6f-Pp-yMs"/>
+                                    </constraints>
                                     <state key="normal" title="Button"/>
                                 </button>
                             </subviews>
@@ -70,10 +73,6 @@
                             <state key="normal" title="Button"/>
                         </button>
                     </subviews>
-                    <constraints>
-                        <constraint firstAttribute="bottom" secondItem="9hi-UA-p04" secondAttribute="bottom" id="4l3-YZ-ohk"/>
-                        <constraint firstItem="9hi-UA-p04" firstAttribute="top" secondItem="Ewo-7I-oMB" secondAttribute="top" id="sjJ-gO-bpU"/>
-                    </constraints>
                     <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
                 </stackView>
             </subviews>

--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
@@ -7,7 +7,6 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -23,69 +22,65 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" id="i5M-Pr-FkT">
             <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Cb-NM-WoN" userLabel="BorderedView">
-                    <rect key="frame" x="0.0" y="6" width="375" height="188"/>
+                    <rect key="frame" x="-1" y="-1" width="375" height="194"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                </view>
+                <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Ewo-7I-oMB">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="192"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Ewo-7I-oMB">
-                            <rect key="frame" x="6" y="6" width="365" height="174"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9hi-UA-p04">
+                            <rect key="frame" x="16" y="28" width="46" height="91"/>
                             <subviews>
-                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9hi-UA-p04">
-                                    <rect key="frame" x="0.0" y="0.0" width="46" height="91"/>
-                                    <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aSK-uI-6js" userLabel="NewsTitle">
-                                            <rect key="frame" x="0.0" y="0.0" width="46" height="20.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="900" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gf2-Wv-Ozo" userLabel="NewsSubtitle">
-                                            <rect key="frame" x="0.0" y="30.5" width="46" height="20.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WFs-AW-Uc0">
-                                            <rect key="frame" x="0.0" y="61" width="46" height="30"/>
-                                            <state key="normal" title="Button"/>
-                                        </button>
-                                    </subviews>
-                                </stackView>
-                                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="58s-bz-Teb">
-                                    <rect key="frame" x="56" y="0.0" width="130" height="130"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" secondItem="58s-bz-Teb" secondAttribute="height" multiplier="1:1" id="Hdv-k8-lBE"/>
-                                        <constraint firstAttribute="width" constant="130" id="mBb-U9-zfe"/>
-                                    </constraints>
-                                </imageView>
-                                <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="900" verticalCompressionResistancePriority="900" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0k3-KZ-dKQ">
-                                    <rect key="frame" x="196" y="0.0" width="169" height="30"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aSK-uI-6js" userLabel="NewsTitle">
+                                    <rect key="frame" x="0.0" y="0.0" width="46" height="20.5"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="900" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gf2-Wv-Ozo" userLabel="NewsSubtitle">
+                                    <rect key="frame" x="0.0" y="30.5" width="46" height="20.5"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WFs-AW-Uc0">
+                                    <rect key="frame" x="0.0" y="61" width="46" height="30"/>
                                     <state key="normal" title="Button"/>
                                 </button>
                             </subviews>
                         </stackView>
+                        <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="58s-bz-Teb">
+                            <rect key="frame" x="72" y="28" width="130" height="130"/>
+                            <constraints>
+                                <constraint firstAttribute="width" secondItem="58s-bz-Teb" secondAttribute="height" multiplier="1:1" id="Hdv-k8-lBE"/>
+                                <constraint firstAttribute="width" constant="130" id="mBb-U9-zfe"/>
+                            </constraints>
+                        </imageView>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="900" verticalCompressionResistancePriority="900" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0k3-KZ-dKQ">
+                            <rect key="frame" x="212" y="28" width="147" height="30"/>
+                            <state key="normal" title="Button"/>
+                        </button>
                     </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstItem="Ewo-7I-oMB" firstAttribute="top" secondItem="7Cb-NM-WoN" secondAttribute="top" constant="6" id="BAq-Af-FVe"/>
-                        <constraint firstAttribute="trailing" secondItem="Ewo-7I-oMB" secondAttribute="trailing" constant="4" id="E0T-Xu-Q6G"/>
-                        <constraint firstAttribute="bottom" secondItem="Ewo-7I-oMB" secondAttribute="bottom" constant="8" id="oYE-ro-nHj"/>
-                        <constraint firstItem="Ewo-7I-oMB" firstAttribute="leading" secondItem="7Cb-NM-WoN" secondAttribute="leading" constant="6" id="tch-Na-yH9"/>
-                    </constraints>
-                </view>
+                    <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
+                </stackView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="7Cb-NM-WoN" secondAttribute="trailing" id="P0M-DD-7Dt"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="7Cb-NM-WoN" secondAttribute="bottom" constant="6" id="T95-Ed-fHv"/>
-                <constraint firstItem="7Cb-NM-WoN" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="6" id="kkG-td-wVU"/>
-                <constraint firstItem="7Cb-NM-WoN" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="qpB-34-98o"/>
+                <constraint firstItem="7Cb-NM-WoN" firstAttribute="top" secondItem="Ewo-7I-oMB" secondAttribute="top" constant="-1" id="4ZG-58-EAl"/>
+                <constraint firstItem="Ewo-7I-oMB" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="4yq-Z2-bkB"/>
+                <constraint firstItem="7Cb-NM-WoN" firstAttribute="bottom" secondItem="Ewo-7I-oMB" secondAttribute="bottom" constant="1" id="GTd-qW-n5p"/>
+                <constraint firstItem="7Cb-NM-WoN" firstAttribute="leading" secondItem="Ewo-7I-oMB" secondAttribute="leading" constant="-1" id="l44-WK-Rum"/>
+                <constraint firstAttribute="trailing" secondItem="Ewo-7I-oMB" secondAttribute="trailing" id="mnd-4c-EBW"/>
+                <constraint firstItem="7Cb-NM-WoN" firstAttribute="trailing" secondItem="Ewo-7I-oMB" secondAttribute="trailing" constant="-1" id="oW9-JR-dWT"/>
+                <constraint firstAttribute="bottom" secondItem="Ewo-7I-oMB" secondAttribute="bottom" constant="8" id="x1K-a6-Z74"/>
+                <constraint firstItem="Ewo-7I-oMB" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="zBC-Lb-dpV"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="33.5" y="69"/>
         </view>
     </objects>

--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
@@ -30,39 +30,43 @@
                     <rect key="frame" x="-1" y="0.0" width="375" height="193"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
-                <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" distribution="fillProportionally" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Ewo-7I-oMB">
+                <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Ewo-7I-oMB">
                     <rect key="frame" x="0.0" y="8" width="375" height="184"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9hi-UA-p04">
-                            <rect key="frame" x="16" y="20" width="64.5" height="91"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" horizontalCompressionResistancePriority="740" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9hi-UA-p04">
+                            <rect key="frame" x="16" y="20" width="149" height="91"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aSK-uI-6js" userLabel="NewsTitle">
-                                    <rect key="frame" x="0.0" y="0.0" width="64.5" height="20.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="149" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="900" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gf2-Wv-Ozo" userLabel="NewsSubtitle">
-                                    <rect key="frame" x="0.0" y="30.5" width="64.5" height="20.5"/>
+                                    <rect key="frame" x="0.0" y="30.5" width="149" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WFs-AW-Uc0">
-                                    <rect key="frame" x="0.0" y="61" width="64.5" height="30"/>
+                                    <rect key="frame" x="0.0" y="61" width="149" height="30"/>
                                     <state key="normal" title="Button"/>
                                 </button>
                             </subviews>
                         </stackView>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="58s-bz-Teb">
-                            <rect key="frame" x="90.5" y="20" width="156" height="156"/>
+                            <rect key="frame" x="175" y="20" width="130" height="130"/>
                             <constraints>
                                 <constraint firstAttribute="width" secondItem="58s-bz-Teb" secondAttribute="height" multiplier="1:1" id="Hdv-k8-lBE"/>
                                 <constraint firstAttribute="width" constant="130" id="mBb-U9-zfe"/>
                             </constraints>
                         </imageView>
-                        <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="900" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0k3-KZ-dKQ">
-                            <rect key="frame" x="256.5" y="20" width="102.5" height="30"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalCompressionResistancePriority="900" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0k3-KZ-dKQ">
+                            <rect key="frame" x="315" y="20" width="44" height="44"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="44" id="3Uq-t0-qSi"/>
+                                <constraint firstAttribute="width" constant="44" id="wEy-Hh-F2m"/>
+                            </constraints>
                             <state key="normal" title="Button"/>
                         </button>
                     </subviews>

--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
@@ -27,52 +27,56 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Cb-NM-WoN" userLabel="BorderedView">
-                    <rect key="frame" x="-1" y="-1" width="375" height="194"/>
+                    <rect key="frame" x="-1" y="0.0" width="375" height="193"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
-                <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Ewo-7I-oMB">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="192"/>
+                <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" distribution="fillProportionally" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Ewo-7I-oMB">
+                    <rect key="frame" x="0.0" y="8" width="375" height="184"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9hi-UA-p04">
-                            <rect key="frame" x="16" y="28" width="46" height="91"/>
+                            <rect key="frame" x="16" y="20" width="64.5" height="91"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aSK-uI-6js" userLabel="NewsTitle">
-                                    <rect key="frame" x="0.0" y="0.0" width="46" height="20.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="64.5" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="900" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gf2-Wv-Ozo" userLabel="NewsSubtitle">
-                                    <rect key="frame" x="0.0" y="30.5" width="46" height="20.5"/>
+                                    <rect key="frame" x="0.0" y="30.5" width="64.5" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WFs-AW-Uc0">
-                                    <rect key="frame" x="0.0" y="61" width="46" height="30"/>
+                                    <rect key="frame" x="0.0" y="61" width="64.5" height="30"/>
                                     <state key="normal" title="Button"/>
                                 </button>
                             </subviews>
                         </stackView>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="58s-bz-Teb">
-                            <rect key="frame" x="72" y="28" width="130" height="130"/>
+                            <rect key="frame" x="90.5" y="20" width="156" height="156"/>
                             <constraints>
                                 <constraint firstAttribute="width" secondItem="58s-bz-Teb" secondAttribute="height" multiplier="1:1" id="Hdv-k8-lBE"/>
                                 <constraint firstAttribute="width" constant="130" id="mBb-U9-zfe"/>
                             </constraints>
                         </imageView>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="900" verticalCompressionResistancePriority="900" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0k3-KZ-dKQ">
-                            <rect key="frame" x="212" y="28" width="147" height="30"/>
+                        <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="900" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0k3-KZ-dKQ">
+                            <rect key="frame" x="256.5" y="20" width="102.5" height="30"/>
                             <state key="normal" title="Button"/>
                         </button>
                     </subviews>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="9hi-UA-p04" secondAttribute="bottom" id="4l3-YZ-ohk"/>
+                        <constraint firstItem="9hi-UA-p04" firstAttribute="top" secondItem="Ewo-7I-oMB" secondAttribute="top" id="sjJ-gO-bpU"/>
+                    </constraints>
                     <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
                 </stackView>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="7Cb-NM-WoN" firstAttribute="top" secondItem="Ewo-7I-oMB" secondAttribute="top" constant="-1" id="4ZG-58-EAl"/>
-                <constraint firstItem="Ewo-7I-oMB" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="4yq-Z2-bkB"/>
+                <constraint firstItem="Ewo-7I-oMB" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="8" id="4yq-Z2-bkB"/>
+                <constraint firstItem="7Cb-NM-WoN" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="FZz-ss-TnJ"/>
                 <constraint firstItem="7Cb-NM-WoN" firstAttribute="bottom" secondItem="Ewo-7I-oMB" secondAttribute="bottom" constant="1" id="GTd-qW-n5p"/>
                 <constraint firstItem="7Cb-NM-WoN" firstAttribute="leading" secondItem="Ewo-7I-oMB" secondAttribute="leading" constant="-1" id="l44-WK-Rum"/>
                 <constraint firstAttribute="trailing" secondItem="Ewo-7I-oMB" secondAttribute="trailing" id="mnd-4c-EBW"/>

--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
@@ -7,6 +7,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -33,23 +34,23 @@
                 <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Ewo-7I-oMB">
                     <rect key="frame" x="0.0" y="8" width="375" height="184"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="240" verticalHuggingPriority="275" horizontalCompressionResistancePriority="740" verticalCompressionResistancePriority="740" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="9hi-UA-p04">
-                            <rect key="frame" x="16" y="20" width="149" height="91"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="275" verticalHuggingPriority="275" verticalCompressionResistancePriority="760" axis="vertical" alignment="top" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="9hi-UA-p04">
+                            <rect key="frame" x="16" y="20" width="149" height="87"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aSK-uI-6js" userLabel="NewsTitle">
-                                    <rect key="frame" x="0.0" y="0.0" width="149" height="20.5"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aSK-uI-6js" userLabel="NewsTitle">
+                                    <rect key="frame" x="0.0" y="0.0" width="42" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gf2-Wv-Ozo" userLabel="NewsSubtitle">
-                                    <rect key="frame" x="0.0" y="30.5" width="149" height="20.5"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gf2-Wv-Ozo" userLabel="NewsSubtitle">
+                                    <rect key="frame" x="0.0" y="28.5" width="42" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WFs-AW-Uc0">
-                                    <rect key="frame" x="0.0" y="61" width="149" height="30"/>
+                                    <rect key="frame" x="0.0" y="57" width="46" height="30"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="30" id="m6f-Pp-yMs"/>
                                     </constraints>


### PR DESCRIPTION
Fixes the readable margins for the news card.

I am not sure what the problem was, but a combination of activating `Preserve Superview margins`, `Follow readable guides` and `safe area relative margins` in the root view, plus removing and redoing the previous constraints seem to fix it.

![simulator screen shot - ipad pro 10 5-inch - 2018-08-23 at 10 34 07](https://user-images.githubusercontent.com/2722505/44502469-3226bb00-a6c4-11e8-92ea-a82601fb5c09.png)
![simulator screen shot - iphone 8 - 2018-08-23 at 10 11 40](https://user-images.githubusercontent.com/2722505/44502475-35ba4200-a6c4-11e8-9060-4b5b9ba18afa.png)

Caveat: this is still not ready for a design review. The stack view containing the labels does not expand vertically to use all the available space, but for my mental sanity, I need to move on to something else. One thing a time, I guess...

