### PR TITLE
Site creation: Hide Get Started bar in webview

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationSitePreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationSitePreviewViewController.swift
@@ -87,7 +87,16 @@ extension SiteCreationSitePreviewViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         siteLoaded = true
+        hideGetStartedBar()
         showSite()
+    }
+
+    func hideGetStartedBar() {
+        let javascript = """
+        document.querySelector('html').style.cssText += '; margin-top: 0 !important;';
+        document.getElementById('wpadminbar').style.display = 'none';
+        """
+        webView?.evaluateJavaScript(javascript, completionHandler: nil)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationSitePreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationSitePreviewViewController.swift
@@ -93,8 +93,8 @@ extension SiteCreationSitePreviewViewController: WKNavigationDelegate {
 
     func hideGetStartedBar() {
         let javascript = """
-        document.querySelector('html').style.cssText += '; margin-top: 0 !important;';
-        document.getElementById('wpadminbar').style.display = 'none';
+        document.querySelector('html').style.cssText += '; margin-top: 0 !important;';\n
+        document.getElementById('wpadminbar').style.display = 'none';\n
         """
         webView?.evaluateJavaScript(javascript, completionHandler: nil)
     }


### PR DESCRIPTION
A new site displayed in the web view in the site creation flow shows a very prominent "Get Started" call to action at the top of the page:

![img_34571](https://user-images.githubusercontent.com/4780/44579281-c4df5c80-a78d-11e8-97e6-e61422b5ba26.png)

Until we have a way to switch this off directly, why don't we just hide it using JavaScript?

![simulator screen shot - iphone 8 - 2018-08-24 at 10 41 37](https://user-images.githubusercontent.com/4780/44579174-7f229400-a78d-11e8-9a7f-2fc53afb2703.png)

**To test:**

* Create a new site in the app
* After the 'congratulations' screen, check that the preview webview doesn't show the Get Started bar at the top.
* If you like, maybe check with a couple of different site themes.