### PR TITLE
Automated Transfer analytics.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def shared_with_all_pods
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'c51f53ef91127b5225064023e7207fad66b02ea4'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '76a6f82f1cb3820bf03a35b60daa818aa9cd8424'
     pod 'CocoaLumberjack', '3.4.2'
     pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
     pod 'NSObject-SafeExpectations', '0.0.3'
@@ -135,7 +135,7 @@ target 'WordPressNotificationServiceExtension' do
 	inherit! :search_paths
 
     pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '9160e00'
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'c51f53ef91127b5225064023e7207fad66b02ea4'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '76a6f82f1cb3820bf03a35b60daa818aa9cd8424'
 end
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -170,7 +170,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.0.0-beta.25)
   - WordPressAuthenticator (= 1.0.6)
   - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `9160e00`)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `c51f53ef91127b5225064023e7207fad66b02ea4`)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `76a6f82f1cb3820bf03a35b60daa818aa9cd8424`)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `7a5b1a3fb44f62416fbc2e5f0de623b87b613aae`)
   - WPMediaPicker (= 1.3)
   - wpxmlrpc (= 0.8.3)
@@ -219,7 +219,7 @@ EXTERNAL SOURCES:
     :commit: '9160e00'
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
-    :commit: c51f53ef91127b5225064023e7207fad66b02ea4
+    :commit: 76a6f82f1cb3820bf03a35b60daa818aa9cd8424
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
@@ -233,7 +233,7 @@ CHECKOUT OPTIONS:
     :commit: '9160e00'
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
-    :commit: c51f53ef91127b5225064023e7207fad66b02ea4
+    :commit: 76a6f82f1cb3820bf03a35b60daa818aa9cd8424
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
@@ -277,6 +277,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: c3adf682bb903a9b7d4f8ff868687f087387341f
+PODFILE CHECKSUM: 88b7f8db853daef305c679cfd5e3c042b0cd0d6a
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -282,6 +282,36 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatAppSettingsVideoOptimizationChanged:
             eventName = @"app_settings_video_optimization_changed";
             break;
+        case WPAnalyticsStatAutomatedTransferDialogShown:
+            eventName = @"automated_transfer_confirm_dialog_shown";
+            break;
+        case WPAnalyticsStatAutomatedTransferDialogCancelled:
+            eventName = @"automated_transfer_confirm_dialog_cancelled";
+            break;
+        case WPAnalyticsStatAutomatedTransferEligibilityCheckInitiated:
+            eventName = @"automated_transfer_check_eligibility";
+            break;
+        case WPAnalyticsStatAutomatedTransferSiteIneligible:
+            eventName = @"automated_transfer_not_eligible";
+            break;
+        case WPAnalyticsStatAutomatedTransferInitiate:
+            eventName = @"automated_transfer_initiate";
+            break;
+        case WPAnalyticsStatAutomatedTransferInitiated:
+            eventName = @"automated_transfer_initiated";
+            break;
+        case WPAnalyticsStatAutomatedTransferInitiationFailed:
+            eventName = @"automated_transfer_initiation_failed";
+            break;
+        case WPAnalyticsStatAutomatedTransferStatusComplete:
+            eventName = @"automated_transfer_status_complete";
+            break;
+        case WPAnalyticsStatAutomatedTransferStatusFailed:
+            eventName = @"automated_transfer_status_failed";
+            break;
+        case WPAnalyticsStatAutomatedTransferFlowComplete:
+            eventName = @"automated_transfer_flow_complete";
+            break;
         case WPAnalyticsStatCreateAccountInitiated:
             eventName = @"account_create_initiated";
             break;
@@ -1478,6 +1508,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatPerformedCoreDataMigrationFixFor45:
         case WPAnalyticsStatMaxValue:
             return nil;
+
     }
 
     TracksEventPair *eventPair = [TracksEventPair new];

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -176,6 +176,8 @@ class PluginViewModel: Observable {
                             return
                         }
 
+                        WPAnalytics.track(.automatedTransferDialogShown)
+
                         let alertController = atHelper.automatedTransferConfirmationPrompt()
                         self.present?(alertController)
                     }


### PR DESCRIPTION
Adds analytics to Automated Transfer.

Events are copied from Android app, for parity.

Testing steps are as per #10039, just with added caveat of "also watch out for console to make sure correct stuff gets tracked."

Would be grateful if you could tackle this one as well, @nheagy  :)