### PR TITLE
Explicitly exclude superfluous activity types when a user shares logs

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/ActivityLogDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/ActivityLogDetailViewController.m
@@ -46,8 +46,8 @@
     self.textView = textView;
 
     UIBarButtonItem *shareButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAction
-                                                                target:self
-                                                                action:@selector(showShareOptions:)];
+                                                                                 target:self
+                                                                                 action:@selector(showShareOptions:)];
     self.navigationItem.rightBarButtonItem = shareButton;
 }
 
@@ -58,18 +58,64 @@
     [self.textView scrollRectToVisible:CGRectMake(0, 0, 1, 1) animated:NO];
 }
 
-- (void)viewWillDisappear:(BOOL)animated
-{
-    [super viewWillDisappear:animated];
-
-}
-
 - (void)showShareOptions:(id)sender
 {
     UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:@[self.logText]
                                                                                          applicationActivities:nil];
     activityViewController.modalPresentationStyle = UIModalPresentationPopover;
     activityViewController.popoverPresentationController.barButtonItem = sender;
+
+    activityViewController.excludedActivityTypes = [self assembleExcludedSupportTypes];
+
     [self presentViewController:activityViewController animated:YES completion:nil];
 }
+
+/**
+ Returns a collection of activity types currently supported by `UIActivityViewController`.
+ Were we using Swift 4.2, it might be possible to replace this with `CaseIterable`.
+
+ @return a collection of all supported activity types
+ */
+- (NSArray<UIActivityType> *)allActivityTypes {
+    NSArray<UIActivityType> *defaultActivityTypes = @[
+                                                      UIActivityTypePostToFacebook,
+                                                      UIActivityTypePostToTwitter,
+                                                      UIActivityTypePostToWeibo,
+                                                      UIActivityTypeMessage,
+                                                      UIActivityTypeMail,
+                                                      UIActivityTypePrint,
+                                                      UIActivityTypeCopyToPasteboard,
+                                                      UIActivityTypeAssignToContact,
+                                                      UIActivityTypeSaveToCameraRoll,
+                                                      UIActivityTypeAddToReadingList,
+                                                      UIActivityTypePostToFlickr,
+                                                      UIActivityTypePostToVimeo,
+                                                      UIActivityTypePostToTencentWeibo,
+                                                      UIActivityTypeAirDrop,
+                                                      UIActivityTypeOpenInIBooks,
+                                                      ];
+
+    NSMutableArray<UIActivityType> *activityTypes = [NSMutableArray arrayWithArray:defaultActivityTypes];
+
+    if (@available(iOS 11, *)) {
+        [activityTypes addObject:UIActivityTypeMarkupAsPDF];
+    }
+
+    return activityTypes;
+}
+
+/**
+ Specifies the activity types that should be excluded when the view controller is presented.
+
+ @return in practice, this should only return `UIActivityTypeCopyToPasteboard`.
+ */
+- (NSArray<UIActivityType> *)assembleExcludedSupportTypes {
+    NSMutableSet<UIActivityType> *activityTypes = [NSMutableSet setWithArray:[self allActivityTypes]];
+
+    NSSet<UIActivityType> *supportedActivityTypes = [NSSet setWithArray:@[UIActivityTypeCopyToPasteboard]];
+    [activityTypes minusSet:supportedActivityTypes];
+
+    return [activityTypes allObjects];
+}
+
 @end

--- a/WordPress/Classes/ViewRelated/Me/ActivityLogDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/ActivityLogDetailViewController.m
@@ -1,5 +1,7 @@
 #import "ActivityLogDetailViewController.h"
 
+#import "WordPress-Swift.h"
+
 @interface ActivityLogDetailViewController ()
 
 @property (nonatomic, strong) NSString *logText;
@@ -77,29 +79,31 @@
  @return a collection of all supported activity types
  */
 - (NSArray<UIActivityType> *)allActivityTypes {
-    NSArray<UIActivityType> *defaultActivityTypes = @[
-                                                      UIActivityTypePostToFacebook,
-                                                      UIActivityTypePostToTwitter,
-                                                      UIActivityTypePostToWeibo,
-                                                      UIActivityTypeMessage,
-                                                      UIActivityTypeMail,
-                                                      UIActivityTypePrint,
-                                                      UIActivityTypeCopyToPasteboard,
-                                                      UIActivityTypeAssignToContact,
-                                                      UIActivityTypeSaveToCameraRoll,
-                                                      UIActivityTypeAddToReadingList,
-                                                      UIActivityTypePostToFlickr,
-                                                      UIActivityTypePostToVimeo,
-                                                      UIActivityTypePostToTencentWeibo,
-                                                      UIActivityTypeAirDrop,
-                                                      UIActivityTypeOpenInIBooks,
-                                                      ];
+    NSArray<UIActivityType> *systemActivityTypes = @[
+                                                     UIActivityTypePostToFacebook,
+                                                     UIActivityTypePostToTwitter,
+                                                     UIActivityTypePostToWeibo,
+                                                     UIActivityTypeMessage,
+                                                     UIActivityTypeMail,
+                                                     UIActivityTypePrint,
+                                                     UIActivityTypeCopyToPasteboard,
+                                                     UIActivityTypeAssignToContact,
+                                                     UIActivityTypeSaveToCameraRoll,
+                                                     UIActivityTypeAddToReadingList,
+                                                     UIActivityTypePostToFlickr,
+                                                     UIActivityTypePostToVimeo,
+                                                     UIActivityTypePostToTencentWeibo,
+                                                     UIActivityTypeAirDrop,
+                                                     UIActivityTypeOpenInIBooks,
+                                                     ];
 
-    NSMutableArray<UIActivityType> *activityTypes = [NSMutableArray arrayWithArray:defaultActivityTypes];
+    NSMutableArray<UIActivityType> *activityTypes = [NSMutableArray arrayWithArray:systemActivityTypes];
 
     if (@available(iOS 11, *)) {
         [activityTypes addObject:UIActivityTypeMarkupAsPDF];
     }
+
+    [activityTypes addObject:[SharePost activityType]];
 
     return activityTypes;
 }
@@ -107,13 +111,17 @@
 /**
  Specifies the activity types that should be excluded when the view controller is presented.
 
- @return in practice, this should only return `UIActivityTypeCopyToPasteboard`.
+ @return in practice, this should only return `UIActivityTypeCopyToPasteboard` & `UIActivityTypeMail`.
  */
 - (NSArray<UIActivityType> *)assembleExcludedSupportTypes {
     NSMutableSet<UIActivityType> *activityTypes = [NSMutableSet setWithArray:[self allActivityTypes]];
 
-    NSSet<UIActivityType> *supportedActivityTypes = [NSSet setWithArray:@[UIActivityTypeCopyToPasteboard]];
-    [activityTypes minusSet:supportedActivityTypes];
+    NSArray<UIActivityType> *supportedActivityTypes = @[
+                                                        UIActivityTypeCopyToPasteboard,
+                                                        UIActivityTypeMail
+                                                        ];
+    NSSet<UIActivityType> *supportedActivityTypeSet = [NSSet setWithArray:supportedActivityTypes];
+    [activityTypes minusSet:supportedActivityTypeSet];
 
     return [activityTypes allObjects];
 }

--- a/WordPress/Classes/ViewRelated/Me/ActivityLogDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/ActivityLogDetailViewController.m
@@ -111,7 +111,7 @@
 /**
  Specifies the activity types that should be excluded when the view controller is presented.
 
- @return in practice, this should only return `UIActivityTypeCopyToPasteboard` & `UIActivityTypeMail`.
+ @return in practice, this will return all but `UIActivityTypeCopyToPasteboard` & `UIActivityTypeMail`.
  */
 - (NSArray<UIActivityType> *)assembleExcludedSupportTypes {
     NSMutableSet<UIActivityType> *activityTypes = [NSMutableSet setWithArray:[self allActivityTypes]];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3985,17 +3985,17 @@
 				93069F54176237A4000C966D /* ActivityLogViewController.h */,
 				93069F55176237A4000C966D /* ActivityLogViewController.m */,
 				FFA162301CB7031A00E2E110 /* AppSettingsViewController.swift */,
-				E1ADE0EA20A9EF6200D6AADC /* PrivacySettingsViewController.swift */,
 				B53B02B21CAC3AAC003190A0 /* GravatarPickerViewController.swift */,
+				43FF64EE20DAA0840060A69A /* GravatarUploader.swift */,
 				315FC2C31A2CB29300E7CDA2 /* MeHeaderView.h */,
 				315FC2C41A2CB29300E7CDA2 /* MeHeaderView.m */,
 				E1A8CACA1C22FF7C0038689E /* MeViewController.swift */,
 				CE1CCB2C204DDD18000EE3AC /* MyProfileHeaderView.swift */,
+				CE1CCB2E2050502B000EE3AC /* MyProfileHeaderView.xib */,
 				E1B23B071BFB3B370006559B /* MyProfileViewController.swift */,
+				E1ADE0EA20A9EF6200D6AADC /* PrivacySettingsViewController.swift */,
 				E14B40FE1C58B93F005046F6 /* SettingsCommon.swift */,
 				98BDFF6A20D0732900C72C58 /* SupportTableViewController+Activity.swift */,
-				CE1CCB2E2050502B000EE3AC /* MyProfileHeaderView.xib */,
-				43FF64EE20DAA0840060A69A /* GravatarUploader.swift */,
 			);
 			path = Me;
 			sourceTree = "<group>";


### PR DESCRIPTION
## Description
Fixes the first portion of #9780, which simplifies how a user shares logs via the Support interface. I also took the liberty to alphabetize the existing contents of this folder.

## To test:
- Verify that the existing branch builds & tests pass.
- Run the branch and confirm that you see something similar to the screenshots below. One callout, depending on what's enabled in `...`, you may see more options.

_Before_
![9870-1-before](https://user-images.githubusercontent.com/221062/44685696-edbb5800-aa00-11e8-9959-4a9bcb9affa4.PNG)

_After_:
![9870-1-after](https://user-images.githubusercontent.com/221062/44685698-f0b64880-aa00-11e8-9b2a-695de0499076.PNG)