### PR TITLE
Universal Links: Bounce back to Safari if navigation fails

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -103,6 +103,7 @@ extension WordPressAppDelegate {
         guard AccountHelper.isLoggedIn,
             activity.activityType == NSUserActivityTypeBrowsingWeb,
             let url = activity.webpageURL else {
+                FailureNavigationAction().failAndBounce(activity.webpageURL)
                 return
         }
 

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -19,6 +19,7 @@ protocol NavigationAction {
 extension NavigationAction {
     /// Fails the navigation and attempts to bounce the user back to Safari
     /// - returns: True if we attempted to launch the URL, otherwise false
+    @discardableResult
     func failAndBounce(_ values: [String: String]?) -> Bool {
         guard let urlString = values?[MatchedRouteURLComponentKey.url.rawValue],
             let url = URL(string: urlString) else {
@@ -27,6 +28,20 @@ extension NavigationAction {
 
         UIApplication.shared.open(url, options: [:], completionHandler: nil)
         return true
+    }
+}
+
+struct FailureNavigationAction: NavigationAction {
+    func perform(_ values: [String: String]?) {
+        // This navigation action exists only to fail navigations
+    }
+
+    /// Convenience method to allow us to bounce a URL that hasn't been
+    /// matched to a route and converted into a values dictionary.
+    func failAndBounce(_ url: URL?) {
+        if let url = url {
+            failAndBounce([MatchedRouteURLComponentKey.url.rawValue: url.absoluteString])
+        }
     }
 }
 

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -16,6 +16,20 @@ protocol NavigationAction {
     func perform(_ values: [String: String]?)
 }
 
+extension NavigationAction {
+    /// Fails the navigation and attempts to bounce the user back to Safari
+    /// - returns: True if we attempted to launch the URL, otherwise false
+    func failAndBounce(_ values: [String: String]?) -> Bool {
+        guard let urlString = values?[MatchedRouteURLComponentKey.url.rawValue],
+            let url = URL(string: urlString) else {
+                return false
+        }
+
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        return true
+    }
+}
+
 // MARK: - Route helper methods
 
 extension Route {

--- a/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
+++ b/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
@@ -51,6 +51,9 @@ class RouteMatcher {
                 values[MatchedRouteURLComponentKey.fragment.rawValue] = fragment
             }
 
+            // Add in the original URL
+            values[MatchedRouteURLComponentKey.url.rawValue] = url.absoluteString
+
             return route.matched(with: values)
         })
     }
@@ -104,4 +107,5 @@ extension Route {
 
 enum MatchedRouteURLComponentKey: String {
     case fragment = "matched-route-fragment"
+    case url = "matched-route-url"
 }

--- a/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
+++ b/WordPress/Classes/Utility/Universal Links/RouteMatcher.swift
@@ -26,13 +26,11 @@ class RouteMatcher {
         let pathComponents = url.pathComponents
 
         return routes.compactMap({ route in
+            let values = valuesDictionary(forURL: url)
+
             // If the paths are the same, we definitely have a match
             if route.path == url.path {
-                if let fragment = url.fragment {
-                    return route.matched(with: [MatchedRouteURLComponentKey.fragment.rawValue: fragment])
-                } else {
-                    return route.matched()
-                }
+                return route.matched(with: values)
             }
 
             let routeComponents = route.components
@@ -42,20 +40,28 @@ class RouteMatcher {
                 return nil
             }
 
-            guard var values = placeholderDictionary(forKeyComponents: routeComponents,
-                                                     valueComponents: pathComponents) else {
-                                                        return nil
+            guard let placeholderValues = placeholderDictionary(forKeyComponents: routeComponents,
+                                                                valueComponents: pathComponents) else {
+                                                                    return nil
             }
 
-            if let fragment = url.fragment {
-                values[MatchedRouteURLComponentKey.fragment.rawValue] = fragment
-            }
+            let allValues = values.merging(placeholderValues,
+                                           uniquingKeysWith: { (current, _) in current })
 
-            // Add in the original URL
-            values[MatchedRouteURLComponentKey.url.rawValue] = url.absoluteString
-
-            return route.matched(with: values)
+            return route.matched(with: allValues)
         })
+    }
+
+    private func valuesDictionary(forURL url: URL) -> [String: String] {
+        var values: [String: String] = [
+            MatchedRouteURLComponentKey.url.rawValue: url.absoluteString
+        ]
+
+        if let fragment = url.fragment {
+            values[MatchedRouteURLComponentKey.fragment.rawValue] = fragment
+        }
+
+        return values
     }
 
     private func isPlaceholder(_ component: String) -> Bool {

--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -27,6 +27,8 @@ extension AppBannerRoute: NavigationAction {
         // Convert the fragment into a URL and ask the link router to handle
         // it like a normal route.
         var components = URLComponents()
+        components.scheme = "https"
+        components.host = "wordpress.com"
         components.path = fragment
 
         if let url = components.url {

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -46,10 +46,13 @@ extension MySitesRoute: NavigationAction {
         }
 
         guard let blog = blog(from: values) else {
-            coordinator.showMySites()
-            postFailureNotice(title: NSLocalizedString("Site not found",
-                                                       comment: "Error notice shown if the app can't find a specific site belonging to the user"))
             WPAppAnalytics.track(.deepLinkFailed, withProperties: ["route": path])
+
+            if failAndBounce(values) == false {
+                coordinator.showMySites()
+                postFailureNotice(title: NSLocalizedString("Site not found",
+                                                           comment: "Error notice shown if the app can't find a specific site belonging to the user"))
+            }
             return
         }
 

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -56,6 +56,10 @@ extension ReaderRoute: NavigationAction {
             return
         }
 
+        coordinator.failureBlock = {
+            self.failAndBounce(values)
+        }
+
         switch self {
         case .root:
             coordinator.showReaderTab()

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -80,7 +80,8 @@ extension StatsRoute: NavigationAction {
             if let blog = blog(from: values) {
                 coordinator.showActivityLog(for: blog)
             } else {
-                showMySitesAndFailureNotice(using: coordinator)
+                showMySitesAndFailureNotice(using: coordinator,
+                                            values: values)
             }
         }
     }
@@ -92,15 +93,20 @@ extension StatsRoute: NavigationAction {
             coordinator.showStats(for: blog,
                                   timePeriod: timePeriod)
         } else {
-            showMySitesAndFailureNotice(using: coordinator)
+            showMySitesAndFailureNotice(using: coordinator,
+                                        values: values)
         }
     }
 
-    private func showMySitesAndFailureNotice(using coordinator: MySitesCoordinator) {
-        coordinator.showMySites()
-        postFailureNotice(title: NSLocalizedString("Site not found",
-                                                   comment: "Error notice shown if the app can't find a specific site belonging to the user"))
+    private func showMySitesAndFailureNotice(using coordinator: MySitesCoordinator,
+                                             values: [String: String]?) {
         WPAppAnalytics.track(.deepLinkFailed, withProperties: ["route": path])
+
+        if failAndBounce(values) == false {
+            coordinator.showMySites()
+            postFailureNotice(title: NSLocalizedString("Site not found",
+                                                       comment: "Error notice shown if the app can't find a specific site belonging to the user"))
+        }
     }
 
     private func showStatsForDefaultBlog(from values: [String: String]?,

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -328,7 +328,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             }, failure: {[weak self] (error: Error?) in
                 DDLogError("Error fetching post for detail: \(String(describing: error?.localizedDescription))")
                 self?.configureAndDisplayLoadingView(title: LoadingText.errorLoadingTitle)
-                self?.postLoadFailureBlock?()
+                self?.reportPostLoadFailure()
             }
         )
     }
@@ -936,6 +936,13 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         }
 
         SearchManager.shared.indexItem(post)
+    }
+
+    private func reportPostLoadFailure() {
+        postLoadFailureBlock?()
+
+        // We'll nil out the failure block so we don't perform multiple callbacks
+        postLoadFailureBlock = nil
     }
 
     // MARK: - Analytics

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -28,6 +28,10 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     // MARK: - Properties & Accessors
 
+    // Callbacks
+    /// Called if the view controller's post fails to load
+    var postLoadFailureBlock: (() -> Void)? = nil
+
     // Footer views
     @IBOutlet fileprivate weak var footerView: UIView!
     @IBOutlet fileprivate weak var tagButton: UIButton!
@@ -324,6 +328,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
             }, failure: {[weak self] (error: Error?) in
                 DDLogError("Error fetching post for detail: \(String(describing: error?.localizedDescription))")
                 self?.configureAndDisplayLoadingView(title: LoadingText.errorLoadingTitle)
+                self?.postLoadFailureBlock?()
             }
         )
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -299,7 +299,7 @@ import WordPressFlux
                 guard let objectID = objectID, let topic = (try? context.existingObject(with: objectID)) as? ReaderAbstractTopic else {
                     DDLogError("Reader: Error retriving an existing site topic by its objectID")
                     self?.displayLoadingStreamFailed()
-                    self?.streamLoadFailureBlock?()
+                    self?.reportStreamLoadFailure()
                     return
                 }
                 self?.readerTopic = topic
@@ -307,7 +307,7 @@ import WordPressFlux
             },
             failure: { [weak self] (error: Error?) in
                 self?.displayLoadingStreamFailed()
-                self?.streamLoadFailureBlock?()
+                self?.reportStreamLoadFailure()
             })
     }
 
@@ -327,7 +327,7 @@ import WordPressFlux
                 guard let objectID = objectID, let topic = (try? context.existingObject(with: objectID)) as? ReaderAbstractTopic else {
                     DDLogError("Reader: Error retriving an existing tag topic by its objectID")
                     self?.displayLoadingStreamFailed()
-                    self?.streamLoadFailureBlock?()
+                    self?.reportStreamLoadFailure()
                     return
                 }
                 self?.readerTopic = topic
@@ -335,7 +335,7 @@ import WordPressFlux
             },
             failure: { [weak self] (error: Error?) in
                 self?.displayLoadingStreamFailed()
-                self?.streamLoadFailureBlock?()
+                self?.reportStreamLoadFailure()
             })
     }
 
@@ -1178,8 +1178,15 @@ extension ReaderStreamViewController: WPContentSyncHelperDelegate {
         if let count = content.content?.count,
             count == 0 {
             displayLoadingStreamFailed()
-            streamLoadFailureBlock?()
+            reportStreamLoadFailure()
         }
+    }
+
+    fileprivate func reportStreamLoadFailure() {
+        streamLoadFailureBlock?()
+
+        // We'll nil out the failure block so we don't perform multiple callbacks
+        streamLoadFailureBlock = nil
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -22,6 +22,9 @@ import WordPressFlux
 
     // MARK: - Properties
 
+    /// Called if the stream or tag fails to load
+    var streamLoadFailureBlock: (() -> Void)? = nil
+
     fileprivate var tableView: UITableView!
     fileprivate var refreshControl: UIRefreshControl!
     fileprivate var syncHelper: WPContentSyncHelper!
@@ -296,6 +299,7 @@ import WordPressFlux
                 guard let objectID = objectID, let topic = (try? context.existingObject(with: objectID)) as? ReaderAbstractTopic else {
                     DDLogError("Reader: Error retriving an existing site topic by its objectID")
                     self?.displayLoadingStreamFailed()
+                    self?.streamLoadFailureBlock?()
                     return
                 }
                 self?.readerTopic = topic
@@ -303,6 +307,7 @@ import WordPressFlux
             },
             failure: { [weak self] (error: Error?) in
                 self?.displayLoadingStreamFailed()
+                self?.streamLoadFailureBlock?()
             })
     }
 
@@ -322,6 +327,7 @@ import WordPressFlux
                 guard let objectID = objectID, let topic = (try? context.existingObject(with: objectID)) as? ReaderAbstractTopic else {
                     DDLogError("Reader: Error retriving an existing tag topic by its objectID")
                     self?.displayLoadingStreamFailed()
+                    self?.streamLoadFailureBlock?()
                     return
                 }
                 self?.readerTopic = topic
@@ -329,6 +335,7 @@ import WordPressFlux
             },
             failure: { [weak self] (error: Error?) in
                 self?.displayLoadingStreamFailed()
+                self?.streamLoadFailureBlock?()
             })
     }
 
@@ -1171,6 +1178,7 @@ extension ReaderStreamViewController: WPContentSyncHelperDelegate {
         if let count = content.content?.count,
             count == 0 {
             displayLoadingStreamFailed()
+            streamLoadFailureBlock?()
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -77,10 +77,7 @@ class ReaderCoordinator: NSObject {
         prepareToNavigate()
 
         let streamViewController = ReaderStreamViewController.controllerWithTopic(topic)
-
-        streamViewController.streamLoadFailureBlock = { [failureBlock] in
-            failureBlock?()
-        }
+        streamViewController.streamLoadFailureBlock = failureBlock
 
         readerSplitViewController.showDetailViewController(streamViewController, sender: nil)
         readerMenuViewController.deselectSelectedRow(animated: false)
@@ -92,10 +89,7 @@ class ReaderCoordinator: NSObject {
         let remote = ReaderTopicServiceRemote(wordPressComRestApi: WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress()))
         let slug = remote.slug(forTopicName: tagName) ?? tagName.lowercased()
         let controller = ReaderStreamViewController.controllerWithTagSlug(slug)
-
-        controller.streamLoadFailureBlock = { [failureBlock] in
-            failureBlock?()
-        }
+        controller.streamLoadFailureBlock = failureBlock
 
         readerSplitViewController.showDetailViewController(controller, sender: nil)
         readerMenuViewController.deselectSelectedRow(animated: false)
@@ -105,10 +99,7 @@ class ReaderCoordinator: NSObject {
         prepareToNavigate()
 
         let controller = ReaderStreamViewController.controllerWithSiteID(NSNumber(value: siteID), isFeed: isFeed)
-
-        controller.streamLoadFailureBlock = { [failureBlock] in
-            failureBlock?()
-        }
+        controller.streamLoadFailureBlock = failureBlock
 
         readerSplitViewController.showDetailViewController(controller, sender: nil)
         readerMenuViewController.deselectSelectedRow(animated: false)

--- a/WordPress/WordPressTest/RouteMatcherTests.swift
+++ b/WordPress/WordPressTest/RouteMatcherTests.swift
@@ -60,22 +60,24 @@ class RouteMatcherTests: XCTestCase {
 
     // MARK: - Placeholders
 
+    func testMatchedRoutesHaveTheOriginalURLAsAValue() {
+        routes = [ TestRoute(path: "/me") ]
+        matcher = RouteMatcher(routes: routes)
+
+        let matches = matcher.routesMatching(URL(string: "https://wordpress.com/me")!)
+        let values = matches.first!.values
+        XCTAssert(values.count == 1)
+        XCTAssertEqual(values[MatchedRouteURLComponentKey.url.rawValue], "https://wordpress.com/me")
+    }
+
     func testMatchedRouteWithSinglePlaceholdersHasPopulatedValue() {
         routes = [ TestRoute(path: "/me/:account") ]
         matcher = RouteMatcher(routes: routes)
 
         let matches = matcher.routesMatching(URL(string: "/me/bobsmith")!)
         let values = matches.first!.values
-        XCTAssert(values.count == 1)
+        XCTAssert(values.count == 2)
         XCTAssertEqual(values["account"], "bobsmith")
-    }
-
-    func testMatchedRouteWithNoPlaceholdersHasNoValues() {
-        routes = [ TestRoute(path: "/me") ]
-        matcher = RouteMatcher(routes: routes)
-
-        let matches = matcher.routesMatching(URL(string: "/me")!)
-        XCTAssert(matches.first!.values.count == 0)
     }
 
     func testLongerRouteDoesntMatchPartial() {
@@ -92,7 +94,7 @@ class RouteMatcherTests: XCTestCase {
 
         let matches = matcher.routesMatching(URL(string: "/me/bobsmith/share/group")!)
         let values = matches.first!.values
-        XCTAssert(values.count == 2)
+        XCTAssert(values.count == 3)
         XCTAssertEqual(values["account"], "bobsmith")
         XCTAssertEqual(values["type"], "group")
     }
@@ -107,10 +109,10 @@ class RouteMatcherTests: XCTestCase {
         XCTAssert(matches.count == 2)
 
         let values1 = matches.first!.values
-        XCTAssert(values1.count == 2)
+        XCTAssert(values1.count == 3)
 
         let values2 = matches.last!.values
-        XCTAssert(values2.count == 2)
+        XCTAssert(values2.count == 3)
 
         XCTAssertEqual(values1["account"], "bobsmith")
         XCTAssertEqual(values1["type"], "group")


### PR DESCRIPTION
In the current implementation of universal links, if we fail to locate a site to navigate to, or if the user is logged out, we current either fail silently or display a "Site not found" notice.

This PR changes that so that we now bounce the user back to Safari in the event that we can't navigate them to the correct content.

![universal-bounce-2](https://user-images.githubusercontent.com/4780/44718722-e48dc200-aab8-11e8-8a9b-f9d7a493cf57.gif)

### To test

* Build and run to a *device*.

**Logged out**

* Log out of the app and ensure you're logged in in Safari.
* Trigger a universal link from one of your sites in Safari – for example from the Posts or Stats pages. Scroll the page down a little to see the 'OPEN' banner at the top, and tap open. You should be taken to the app, and then back to Safari.

**Different account**

* Log back into the app, using a different account than you're logged into Safari with.
* Attempt the same universal link navigation, and check you're bounced back to Safari.

**Different account, non-site-specific navigation**
* Back in Safari, navigate to a Reader post, and trigger the universal link navigation.
* Despite being logged into a different account, you should be taken to the correct post in the Reader in the app (as this isn't reliant on being logged in with a specific account).

**App banners**
* If you have the WordPress.com custom app banner for Stats visible on the stats page in Safari (at the bottom of the screen), tap that and ensure you're bounced back to Safari correctly.

**Extra credit**
* When logged into both Safari and the app with the _same_ account, ensure navigation to these items still works as expected.