### PR TITLE
De-duplicate file references

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5070,12 +5070,9 @@
 				93DEB88019E5BF7100F9546D /* TodayExtensionService.h */,
 				93DEB88119E5BF7100F9546D /* TodayExtensionService.m */,
 				E6311C401EC9FF4A00122529 /* UsersService.swift */,
-				17876B1C1F9A131200F774C7 /* MediaCoordinator.swift */,
 				B543D2B420570B5A00D3D4CC /* WordPressComSyncService.swift */,
 				FF4C069E206560E500E0B2BC /* MediaThumbnailCoordinator.swift */,
 				FF0D8145205809C8000EE505 /* PostCoordinator.swift */,
-				D816B8C12112CEBE0052CE4D /* NewsService.swift */,
-				D816B8C72112D2290052CE4D /* LocalNewsService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";


### PR DESCRIPTION
## Description

Fixes the following issue as reported by `rake`:
```
2018-08-28 07:43:22.518 xcodebuild[69931:30554392] warning:  The file reference for "MediaCoordinator.swift" is a member of multiple groups ("Services" and "Services"); this indicates a malformed project.  Only the membership in one of the groups will be preserved (but membership in targets will be unaffected).  If you want a reference to the same file in more than one group, please add another reference to the same path.
2018-08-28 07:43:22.519 xcodebuild[69931:30554392] warning:  The file reference for "NewsService.swift" is a member of multiple groups ("Services" and "Services"); this indicates a malformed project.  Only the membership in one of the groups will be preserved (but membership in targets will be unaffected).  If you want a reference to the same file in more than one group, please add another reference to the same path.
2018-08-28 07:43:22.519 xcodebuild[69931:30554392] warning:  The file reference for "LocalNewsService.swift" is a member of multiple groups ("Services" and "Services"); this indicates a malformed project.  Only the membership in one of the groups will be preserved (but membership in targets will be unaffected).  If you want a reference to the same file in more than one group, please add another reference to the same path.
```

The root cause was discussed [previously](https://github.com/wordpress-mobile/WordPress-iOS/pull/10050).

## Duplicate Deletions

1. `LocalNewsService.swift` deleted from `5078`, as it duplicates `5023`
1. `MediaCoordinator.swift` on `5073` : `5024`
1. `NewsService.swift` on `5077` : `5034`

## To test:
- Checkout branch & validate existing tests pass.
- Confirm project opens.

