### PR TITLE
Reader Comments: Refresh No Results view when the keyboard shows and hides.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -176,10 +176,10 @@ import WordPressAuthenticator
         return boxView
     }
 
-    /// Public method to always hide the image view.
+    /// Public method to hide/show the image view.
     ///
-    func hideImageView() {
-        hideImage = true
+    @objc func hideImageView(_ hide: Bool = true) {
+        hideImage = hide
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -612,7 +612,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     }
 }
 
-
 - (void)refreshNoResultsView
 {
     [self.noResultsViewController removeFromView];
@@ -629,6 +628,8 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
                                                image:@"wp-illustration-empty-results"
                                        accessoryView:[self noResultsAccessoryView]];
 
+    [self.noResultsViewController hideImageView:WPDeviceIdentification.isiPhone];
+    
     [self.noResultsViewController.view setBackgroundColor:[UIColor clearColor]];
     [self addChildViewController:self.noResultsViewController];
     [self.view addSubviewWithFadeAnimation:self.noResultsViewController.view];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -350,8 +350,13 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
                                                       bottomLayoutConstraint:self.replyTextViewBottomConstraint];
 
     __weak UITableView *weakTableView = self.tableView;
+    __weak ReaderCommentsViewController *weakSelf = self;
     self.keyboardManager.onWillHide = ^{
         [weakTableView deselectSelectedRowWithAnimation:YES];
+        [weakSelf refreshNoResultsView];
+    };
+    self.keyboardManager.onWillShow = ^{
+        [weakSelf refreshNoResultsView];
     };
 }
 


### PR DESCRIPTION
Fixes #10062 

To test:

- Go to Reader > Followed Sites > Manage.
- Select a site that has a post with no comments.
- On the post with no comments, press the comment icon.
- Show and hide the keyboard.
- Verify the No Results view adjusts accordingly, and the 'Reply to post...' bar is not obscured.

Keyboard:
![keyboard](https://user-images.githubusercontent.com/1816888/44755648-46afec80-aae4-11e8-958a-1aeaa27dc684.png)

No keyboard:
![no_keyboard](https://user-images.githubusercontent.com/1816888/44755645-44e62900-aae4-11e8-9fd5-99db877c7576.png)






