### PR TITLE
Fix editor being dismissed after site creation

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationEpilogueViewController.swift
@@ -6,13 +6,7 @@ class SiteCreationEpilogueViewController: NUXViewController {
 
     // MARK: - Properties
 
-    var siteToShow: Blog? {
-        didSet {
-            if let newBlog = siteToShow {
-                WPTabBarController.sharedInstance().switchMySitesTabToBlogDetails(for: newBlog)
-            }
-        }
-    }
+    var siteToShow: Blog?
 
     override var prefersStatusBarHidden: Bool {
         return true
@@ -64,6 +58,9 @@ extension SiteCreationEpilogueViewController: NUXButtonViewControllerDelegate {
 
     // 'Configure' button
     func secondaryButtonPressed() {
+        if let siteToShow = siteToShow {
+            WPTabBarController.sharedInstance().switchMySitesTabToBlogDetails(for: siteToShow)
+        }
         navigationController?.dismiss(animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
#10032 introduced a bug where the push notification primer would dismiss the editor when using the `Write first post` button on a newly created site. The fix is more complicated and will have to wait until after `10.8`, so for now this PR reverts the change.

## The problem:

![2018-08-29 16-38-13 2018-08-29 16_46_22](https://user-images.githubusercontent.com/517257/44821536-1a12d800-abab-11e8-8f74-bc7adffff026.gif)

To test:
- with a fresh install immediately create a new site (try to avoid seeing any push primers)
- at the end of the site creation process, tap "Write first post"
- ensure the editor appears

