### PR TITLE
Issue/link to existing content

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -103,6 +103,30 @@ class PostCoordinator: NSObject {
         return controller
     }
 
+    func titleOfPost(withPermaLink value: String, in blog: Blog) -> String? {
+        let context = self.mainContext
+        let fetchRequest = NSFetchRequest<AbstractPost>(entityName: "AbstractPost")
+
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "date_created_gmt", ascending: false)]
+
+        let blogPredicate = NSPredicate(format: "blog == %@", blog)
+        let urlPredicate = NSPredicate(format: "permaLink == %@", value)
+        let noVersionPredicate = NSPredicate(format: "original == NULL")
+        let compoundPredicates = [blogPredicate, urlPredicate, noVersionPredicate]
+
+        let resultPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: compoundPredicates)
+
+        fetchRequest.predicate = resultPredicate
+
+        let result = try? context.fetch(fetchRequest)
+
+        guard let post = result?.first else {
+            return nil
+        }
+
+        return post.titleForDisplay()
+    }
+
     /// Retries the upload and save of the post and any associated media with it.
     ///
     /// - Parameter post: the post to retry the upload

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -77,6 +77,32 @@ class PostCoordinator: NSObject {
         return post.remoteStatus == .pushing
     }
 
+    func posts(for blog: Blog, wichTitleContains value: String) -> NSFetchedResultsController<AbstractPost> {
+        let context = self.mainContext
+        let fetchRequest = NSFetchRequest<AbstractPost>(entityName: "AbstractPost")
+
+        fetchRequest.sortDescriptors = [NSSortDescriptor(key: "date_created_gmt", ascending: false)]
+
+        let blogPredicate = NSPredicate(format: "blog == %@", blog)
+        let urlPredicate = NSPredicate(format: "permaLink != NULL")
+        let noVersionPredicate = NSPredicate(format: "original == NULL")
+        var compoundPredicates = [blogPredicate, urlPredicate, noVersionPredicate]
+        if !value.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).isEmpty {
+            compoundPredicates.append(NSPredicate(format: "postTitle contains[c] %@", value))
+        }
+        let resultPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: compoundPredicates)
+
+        fetchRequest.predicate = resultPredicate
+
+        let controller = NSFetchedResultsController(fetchRequest: fetchRequest, managedObjectContext: context, sectionNameKeyPath: nil, cacheName: nil)
+        do {
+            try controller.performFetch()
+        } catch {
+            fatalError("Failed to fetch entities: \(error)")
+        }
+        return controller
+    }
+
     /// Retries the upload and save of the post and any associated media with it.
     ///
     /// - Parameter post: the post to retry the upload

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1993,6 +1993,7 @@ extension AztecPostViewController {
                     strongSelf.richTextView.becomeFirstResponder()
             }
         })
+        linkController.blog = self.post.blog
 
         let navigationController = UINavigationController(rootViewController: linkController)
         navigationController.modalPresentationStyle = .popover

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
@@ -140,7 +140,7 @@ class LinkSettingsViewController: UITableViewController {
         guard let blog = blog else {
             return
         }
-        let selectPostViewController = SelectPostViewController(blog: blog, callback: { [weak self] (url, title) in
+        let selectPostViewController = SelectPostViewController(blog: blog, selectedLink: linkSettings.url, callback: { [weak self] (url, title) in
             guard let strongSelf = self else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
@@ -70,6 +70,15 @@ class LinkSettingsViewController: UITableViewController {
         }
     }
 
+    private func titleOfExistingContent() -> String {
+        var titleOfPost: String = ""
+        let permaLink = linkSettings.url
+        if let blog = blog, !permaLink.isEmpty {
+            titleOfPost = PostCoordinator.shared.titleOfPost(withPermaLink: linkSettings.url, in: blog) ?? ""
+        }
+        return titleOfPost
+    }
+
     private func setupViewModel() {
         ImmuTable.registerRows([EditableTextRow.self, SwitchRow.self, DestructiveButtonRow.self], tableView: tableView)
 
@@ -83,8 +92,9 @@ class LinkSettingsViewController: UITableViewController {
                                            value: linkSettings.openInNewWindow,
                                            onChange: editOpenInNewWindow)
 
+
         let linkToExistingContentRow = EditableTextRow(title: NSLocalizedString("Link to existing content", comment: "Action. Label for navigate and display links to other posts on the site"),
-                                      value: "",
+                                      value: titleOfExistingContent(),
                                       action: selectExistingContent)
 
         let removeLinkRow = DestructiveButtonRow(title: NSLocalizedString("Remove Link", comment: "Label action for removing a link from the editor"),

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
@@ -31,6 +31,8 @@ class LinkSettingsViewController: UITableViewController {
     private var viewModel: ImmuTable!
     private var viewHandler: ImmuTableViewHandler!
 
+    public var blog: Blog?
+
     typealias LinkCallback = (_ action: LinkAction, _ settings: LinkSettings) -> ()
 
     private var callback: LinkCallback?
@@ -83,7 +85,7 @@ class LinkSettingsViewController: UITableViewController {
 
         let linkToExistingContentRow = EditableTextRow(title: NSLocalizedString("Link to existing content", comment: "Action. Label for navigate and display links to other posts on the site"),
                                       value: "",
-                                      action: editTitle)
+                                      action: selectExistingContent)
 
         let removeLinkRow = DestructiveButtonRow(title: NSLocalizedString("Remove Link", comment: "Label action for removing a link from the editor"),
                                               action: removeLink,
@@ -132,6 +134,25 @@ class LinkSettingsViewController: UITableViewController {
 
     private func removeLink(row: ImmuTableRow) {
         callback?(.remove, linkSettings)
+    }
+
+    private func selectExistingContent(row: ImmuTableRow) {
+        guard let blog = blog else {
+            return
+        }
+        let selectPostViewController = SelectPostViewController(blog: blog, callback: { [weak self] (url, title) in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.linkSettings.url = url
+            if strongSelf.linkSettings.text.isEmpty {
+                strongSelf.linkSettings.text = title
+            }
+            strongSelf.navigationController?.popViewController(animated: true)
+            strongSelf.reloadViewModel()
+        })
+        selectPostViewController.title = NSLocalizedString("Link to existing content", comment: "Action. Label for navigate and display links to other posts on the site")
+        navigationController?.pushViewController(selectPostViewController, animated: true)
     }
 
     private func pushSettingsController(for row: EditableTextRow, hint: String? = nil, onValueChanged: @escaping SettingsTextChanged, mode: SettingsTextModes = .text) {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
@@ -81,11 +81,15 @@ class LinkSettingsViewController: UITableViewController {
                                            value: linkSettings.openInNewWindow,
                                            onChange: editOpenInNewWindow)
 
+        let linkToExistingContentRow = EditableTextRow(title: NSLocalizedString("Link to existing content", comment: "Action. Label for navigate and display links to other posts on the site"),
+                                      value: "",
+                                      action: editTitle)
+
         let removeLinkRow = DestructiveButtonRow(title: NSLocalizedString("Remove Link", comment: "Label action for removing a link from the editor"),
                                               action: removeLink,
                                               accessibilityIdentifier: "RemoveLink")
 
-        let editSection = ImmuTableSection(rows: [urlRow, textRow, openInNewWindowRow])
+        let editSection = ImmuTableSection(rows: [urlRow, textRow, openInNewWindowRow, linkToExistingContentRow])
         var sections = [editSection]
         if !linkSettings.isNewLink {
             sections.append(ImmuTableSection(rows: [removeLinkRow]))

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
@@ -91,8 +91,9 @@ class LinkSettingsViewController: UITableViewController {
                                               action: removeLink,
                                               accessibilityIdentifier: "RemoveLink")
 
-        let editSection = ImmuTableSection(rows: [urlRow, textRow, openInNewWindowRow, linkToExistingContentRow])
-        var sections = [editSection]
+        let editSection = ImmuTableSection(rows: [urlRow, textRow, openInNewWindowRow])
+        let linkSection = ImmuTableSection(rows: [linkToExistingContentRow])
+        var sections = [editSection, linkSection]
         if !linkSettings.isNewLink {
             sections.append(ImmuTableSection(rows: [removeLinkRow]))
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
@@ -4,6 +4,8 @@ class SelectPostViewController: UITableViewController, UISearchResultsUpdating {
 
     private var blog: Blog!
 
+    private var selectedLink: String?
+
     private lazy var searchController: UISearchController = {
         let searchController = UISearchController(searchResultsController: nil)
         searchController.searchResultsUpdater = self
@@ -21,8 +23,9 @@ class SelectPostViewController: UITableViewController, UISearchResultsUpdating {
 
     private var callback: SelectPostCallback?
 
-    init(blog: Blog, callback: SelectPostCallback? = nil) {
+    init(blog: Blog, selectedLink: String? = nil, callback: SelectPostCallback? = nil) {
         self.blog = blog
+        self.selectedLink = selectedLink
         self.callback = callback
         super.init(style: .plain)
     }
@@ -34,7 +37,6 @@ class SelectPostViewController: UITableViewController, UISearchResultsUpdating {
         super.viewDidLoad()
 
         self.tableView.tableHeaderView = searchController.searchBar
-        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "PostCell")
     }
 
     // MARK: - Table view data source
@@ -55,9 +57,27 @@ class SelectPostViewController: UITableViewController, UISearchResultsUpdating {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "PostCell", for: indexPath)
+        var reusableCell = tableView.dequeueReusableCell(withIdentifier: "PostCell")
+        if reusableCell == nil {
+            reusableCell = UITableViewCell(style: .subtitle, reuseIdentifier: "PostCell")
+            WPStyleGuide.configureTableViewCell(reusableCell)
+        }
+        guard let cell = reusableCell else {
+            preconditionFailure("Unable to create cell!")
+        }
 
-        cell.textLabel?.text = fetchController.object(at: indexPath).titleForDisplay()
+        let post = fetchController.object(at: indexPath)
+        cell.textLabel?.text = post.titleForDisplay()
+        if post is Page {
+            cell.detailTextLabel?.text = NSLocalizedString("Page", comment: "Noun. Type of content being selected is a blog page")
+        } else {
+            cell.detailTextLabel?.text = NSLocalizedString("Post", comment: "Noun. Type of content being selected is a blog post")
+        }
+        if post.permaLink == self.selectedLink {
+            cell.accessoryType = .checkmark
+        } else {
+            cell.accessoryType = .none
+        }
 
         return cell
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
@@ -1,0 +1,80 @@
+import UIKit
+
+class SelectPostViewController: UITableViewController, UISearchResultsUpdating {
+
+    private var blog: Blog!
+
+    private lazy var searchController: UISearchController = {
+        let searchController = UISearchController(searchResultsController: nil)
+        searchController.searchResultsUpdater = self
+        searchController.hidesNavigationBarDuringPresentation = false
+        searchController.dimsBackgroundDuringPresentation = false
+        searchController.searchBar.sizeToFit()
+        return searchController
+    }()
+
+    private lazy var fetchController: NSFetchedResultsController<AbstractPost> = {
+        return PostCoordinator.shared.posts(for: self.blog, wichTitleContains: "")
+    }()
+
+    typealias SelectPostCallback = (_ url: String, _ title: String) -> ()
+
+    private var callback: SelectPostCallback?
+
+    init(blog: Blog, callback: SelectPostCallback? = nil) {
+        self.blog = blog
+        self.callback = callback
+        super.init(style: .plain)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        self.tableView.tableHeaderView = searchController.searchBar
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: "PostCell")
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        if let count =  fetchController.sections?.count {
+            return count
+        }
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard let sections = self.fetchController.sections else {
+            return 0
+        }
+        let sectionInfo = sections[section]
+        return sectionInfo.numberOfObjects
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "PostCell", for: indexPath)
+
+        cell.textLabel?.text = fetchController.object(at: indexPath).titleForDisplay()
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+
+        let post = fetchController.object(at: indexPath)
+        guard let title = post.titleForDisplay(), let url = post.permaLink else {
+            return
+        }
+
+        callback?(url, title)
+    }
+
+    func updateSearchResults(for searchController: UISearchController) {
+        let searchText = searchController.searchBar.text ?? ""
+        fetchController = PostCoordinator.shared.posts(for: self.blog, wichTitleContains: searchText)
+        self.tableView.reloadData()
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1384,6 +1384,7 @@
 		FFA0B7D71CAC1F9F00533B9D /* MainNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA0B7D61CAC1F9F00533B9D /* MainNavigationTests.swift */; };
 		FFA162311CB7031A00E2E110 /* AppSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA162301CB7031A00E2E110 /* AppSettingsViewController.swift */; };
 		FFABD800213423F1003C65B6 /* LinkSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFABD7FF213423F1003C65B6 /* LinkSettingsViewController.swift */; };
+		FFABD80821370496003C65B6 /* SelectPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFABD80721370496003C65B6 /* SelectPostViewController.swift */; };
 		FFB1FA9E1BF0EB840090C761 /* UIImage+Exporters.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1FA9D1BF0EB840090C761 /* UIImage+Exporters.swift */; };
 		FFB1FAA01BF0EC4E0090C761 /* PHAsset+Exporters.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB1FA9F1BF0EC4E0090C761 /* PHAsset+Exporters.swift */; };
 		FFB7B8201A0012E80032E723 /* ApiCredentials.m in Sources */ = {isa = PBXBuildFile; fileRef = FFB7B81D1A0012E80032E723 /* ApiCredentials.m */; };
@@ -3229,6 +3230,7 @@
 		FFA162301CB7031A00E2E110 /* AppSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppSettingsViewController.swift; sourceTree = "<group>"; };
 		FFA40D4D1CB3EDD5001CB1FB /* WordPress 48.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 48.xcdatamodel"; sourceTree = "<group>"; };
 		FFABD7FF213423F1003C65B6 /* LinkSettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkSettingsViewController.swift; sourceTree = "<group>"; };
+		FFABD80721370496003C65B6 /* SelectPostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectPostViewController.swift; sourceTree = "<group>"; };
 		FFB1FA9D1BF0EB840090C761 /* UIImage+Exporters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Exporters.swift"; sourceTree = "<group>"; };
 		FFB1FA9F1BF0EC4E0090C761 /* PHAsset+Exporters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PHAsset+Exporters.swift"; sourceTree = "<group>"; };
 		FFB3132E204D59F400C177E7 /* WordPress 73.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 73.xcdatamodel"; sourceTree = "<group>"; };
@@ -5265,6 +5267,7 @@
 				B50C0C5D1EF42A4A00372C65 /* AztecPostViewController.swift */,
 				B538F3881EF46EC8001003D5 /* UnknownEditorViewController.swift */,
 				FFABD7FF213423F1003C65B6 /* LinkSettingsViewController.swift */,
+				FFABD80721370496003C65B6 /* SelectPostViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -8432,6 +8435,7 @@
 				173F6DFC21232F2A00A4C8E2 /* NoResultsGiphyConfiguration.swift in Sources */,
 				0815CF461E96F22600069916 /* MediaImportService.swift in Sources */,
 				B56F25881FBDE502005C33E4 /* NSAttributedStringKey+Conversion.swift in Sources */,
+				FFABD80821370496003C65B6 /* SelectPostViewController.swift in Sources */,
 				D8212CBD20AA7A7A008E8AE8 /* ReaderVisitSiteAction.swift in Sources */,
 				E148362F1C6DF7D8005ACF53 /* Product.swift in Sources */,
 				082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */,


### PR DESCRIPTION
Refs: #10059 #7670 

This PR adds the interface to the Link UI to allow link to existing content in the blog.

<img width="1008" alt="screen shot 2018-08-30 at 11 31 48" src="https://user-images.githubusercontent.com/651601/44846700-09b13a80-ac49-11e8-9126-de1a91baf09d.png">
<img width="1008" alt="screen shot 2018-08-30 at 11 37 39" src="https://user-images.githubusercontent.com/651601/44846732-277e9f80-ac49-11e8-8705-72a383401479.png">
<img width="1008" alt="screen shot 2018-08-30 at 11 37 49" src="https://user-images.githubusercontent.com/651601/44846737-2c435380-ac49-11e8-9284-42037ecf3a9c.png">


To test:
 - Open the app
 - Start a post in a blog with other content
 - Tap on insert a link
 - Select the option `link to existing content`
 - Select one of the existing post
 - See if the the post url is selected 
 - Optional if no text for the link is selected, the title get's update with the title of the post
 - Go again inside the 'link to existing content' screen
 - Check if there is a checkmark showing the current selecte post
 - Check if the search bar filters the content correctly.


