### PR TITLE
Reader: In-app deep linking for Reader posts and feeds

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -32,7 +32,7 @@ extension NavigationAction {
 }
 
 struct FailureNavigationAction: NavigationAction {
-    func perform(_ values: [String: String]?) {
+    func perform(_ values: [String: String]?, source: UIViewController?) {
         // This navigation action exists only to fail navigations
     }
 

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -13,7 +13,7 @@ protocol Route {
 }
 
 protocol NavigationAction {
-    func perform(_ values: [String: String]?)
+    func perform(_ values: [String: String]?, source: UIViewController?)
 }
 
 extension NavigationAction {

--- a/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Banners.swift
@@ -18,7 +18,7 @@ struct AppBannerRoute: Route {
 }
 
 extension AppBannerRoute: NavigationAction {
-    func perform(_ values: [String: String]?) {
+    func perform(_ values: [String: String]?, source: UIViewController? = nil) {
         guard let fragmentValue = values?[MatchedRouteURLComponentKey.fragment.rawValue],
         let fragment = fragmentValue.removingPercentEncoding else {
             return

--- a/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
@@ -20,7 +20,7 @@ enum MeNavigationAction: NavigationAction {
     case accountSettings
     case notificationSettings
 
-    func perform(_ values: [String: String]? = nil) {
+    func perform(_ values: [String: String]? = nil, source: UIViewController? = nil) {
         switch self {
         case .root:
             WPTabBarController.sharedInstance().showMeTab()

--- a/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+MySites.swift
@@ -40,7 +40,7 @@ extension MySitesRoute: Route {
 }
 
 extension MySitesRoute: NavigationAction {
-    func perform(_ values: [String: String]?) {
+    func perform(_ values: [String: String]?, source: UIViewController? = nil) {
         guard let coordinator = WPTabBarController.sharedInstance().mySitesCoordinator else {
             return
         }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Notifications.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Notifications.swift
@@ -6,7 +6,7 @@ struct NotificationsRoute: Route {
 }
 
 struct NotificationsNavigationAction: NavigationAction {
-    func perform(_ values: [String: String]?) {
+    func perform(_ values: [String: String]?, source: UIViewController? = nil) {
         WPTabBarController.sharedInstance().showNotificationsTab()
         WPTabBarController.sharedInstance().popNotificationsTabToRoot()
     }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Post.swift
@@ -11,7 +11,7 @@ struct NewPostForSiteRoute: Route {
 }
 
 struct NewPostNavigationAction: NavigationAction {
-    func perform(_ values: [String: String]? = nil) {
+    func perform(_ values: [String: String]? = nil, source: UIViewController? = nil) {
         if let blog = blog(from: values) {
             WPTabBarController.sharedInstance().showPostTab(for: blog)
         } else {

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -51,7 +51,7 @@ extension ReaderRoute: Route {
 }
 
 extension ReaderRoute: NavigationAction {
-    func perform(_ values: [String: String]?) {
+    func perform(_ values: [String: String]?, source: UIViewController? = nil) {
         guard let coordinator = WPTabBarController.sharedInstance().readerCoordinator else {
             return
         }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -60,6 +60,8 @@ extension ReaderRoute: NavigationAction {
             self.failAndBounce(values)
         }
 
+        coordinator.source = source
+
         switch self {
         case .root:
             coordinator.showReaderTab()

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -56,11 +56,15 @@ extension ReaderRoute: NavigationAction {
             return
         }
 
-        coordinator.failureBlock = {
-            self.failAndBounce(values)
-        }
-
         coordinator.source = source
+
+        if source == nil {
+            // If we're not navigating internally,
+            // we want to bounce back to Safari on failure
+            coordinator.failureBlock = {
+                self.failAndBounce(values)
+            }
+        }
 
         switch self {
         case .root:

--- a/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Stats.swift
@@ -46,7 +46,7 @@ extension StatsRoute: Route {
 }
 
 extension StatsRoute: NavigationAction {
-    func perform(_ values: [String: String]?) {
+    func perform(_ values: [String: String]?, source: UIViewController? = nil) {
         guard let coordinator = WPTabBarController.sharedInstance().mySitesCoordinator else {
             return
         }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -89,7 +89,7 @@ struct UniversalLinkRouter {
     ///
     /// - returns: True if the route was handled, or false if it didn't match any routes.
     ///
-    func handle(url: URL, shouldTrack track: Bool = true) {
+    func handle(url: URL, shouldTrack track: Bool = true, source: UIViewController? = nil) {
         let matches = matcher.routesMatching(url)
 
         if track {
@@ -97,7 +97,7 @@ struct UniversalLinkRouter {
         }
 
         for matchedRoute in matches {
-            matchedRoute.action.perform(matchedRoute.values)
+            matchedRoute.action.perform(matchedRoute.values, source: source)
         }
     }
 

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -6,7 +6,7 @@ import Foundation
 struct UniversalLinkRouter {
     private let matcher: RouteMatcher
 
-    private init(routes: [Route]) {
+    init(routes: [Route]) {
         matcher = RouteMatcher(routes: routes)
     }
 
@@ -23,22 +23,22 @@ struct UniversalLinkRouter {
         MySitesRoutes +
         AppBannerRoutes)
 
-    private static let MeRoutes: [Route] = [
+    static let MeRoutes: [Route] = [
         MeRoute(),
         MeAccountSettingsRoute(),
         MeNotificationSettingsRoute()
     ]
 
-    private static let NewPostRoutes: [Route] = [
+    static let NewPostRoutes: [Route] = [
         NewPostRoute(),
         NewPostForSiteRoute()
     ]
 
-    private static let NotificationsRoutes: [Route] = [
+    static let NotificationsRoutes: [Route] = [
         NotificationsRoute()
     ]
 
-    private static let ReaderRoutes: [Route] = [
+    static let ReaderRoutes: [Route] = [
         ReaderRoute.root,
         ReaderRoute.discover,
         ReaderRoute.search,
@@ -53,7 +53,7 @@ struct UniversalLinkRouter {
         ReaderRoute.blogsPost
     ]
 
-    private static let StatsRoutes: [Route] = [
+    static let StatsRoutes: [Route] = [
         StatsRoute.root,
         StatsRoute.site,
         StatsRoute.daySite,
@@ -66,7 +66,7 @@ struct UniversalLinkRouter {
         StatsRoute.activityLog
     ]
 
-    private static let MySitesRoutes: [Route] = [
+    static let MySitesRoutes: [Route] = [
         MySitesRoute.pages,
         MySitesRoute.posts,
         MySitesRoute.media,
@@ -77,9 +77,23 @@ struct UniversalLinkRouter {
         MySitesRoute.managePlugins
     ]
 
-    private static let AppBannerRoutes: [Route] = [
+    static let AppBannerRoutes: [Route] = [
         AppBannerRoute()
     ]
+
+    /// - returns: True if the URL routing system can handle the given URL,
+    ///            but does not perform any actions or tracking.
+    ///
+    func canHandle(url: URL) -> Bool {
+        let matcherCanHandle = matcher.routesMatching(url).count > 0
+
+        guard let host = url.host else {
+            return matcherCanHandle
+        }
+
+        // If there's a hostname, check it's WordPress.com
+        return host == "wordpress.com" && matcherCanHandle
+    }
 
     /// Attempts to find a Route that matches the url's path, and perform its
     /// associated action.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -76,6 +76,8 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     private let noResultsViewController = NoResultsViewController.controller()
 
+    private let readerLinkRouter = UniversalLinkRouter(routes: UniversalLinkRouter.ReaderRoutes)
+
     @objc var currentPreferredStatusBarStyle = UIStatusBarStyle.lightContent {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
@@ -1179,12 +1181,10 @@ extension ReaderDetailViewController: ReaderCardDiscoverAttributionViewDelegate 
 // MARK: - UITextView/WPRichContentView Delegate Methods
 
 extension ReaderDetailViewController: WPRichContentViewDelegate {
-
     public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange) -> Bool {
         presentWebViewControllerWithURL(URL)
         return false
     }
-
 
     @available(iOS 10, *)
     public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
@@ -1193,12 +1193,13 @@ extension ReaderDetailViewController: WPRichContentViewDelegate {
             let frame = textView.frameForTextInRange(characterRange)
             let shareController = PostSharingController()
             shareController.shareURL(url: URL as NSURL, fromRect: frame, inView: textView, inViewController: self)
+        } else if readerLinkRouter.canHandle(url: URL) {
+            readerLinkRouter.handle(url: URL, shouldTrack: false, source: self)
         } else {
             presentWebViewControllerWithURL(URL)
         }
         return false
     }
-
 
     func richContentView(_ richContentView: WPRichContentView, didReceiveImageAction image: WPRichTextImage) {
         // If we have gif data availible, present that

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -82,7 +82,9 @@ class ReaderCoordinator: NSObject {
             return
         }
 
-        prepareToNavigate()
+        if !isNavigatingFromSource {
+            prepareToNavigate()
+        }
 
         let streamViewController = ReaderStreamViewController.controllerWithTopic(topic)
 
@@ -93,7 +95,9 @@ class ReaderCoordinator: NSObject {
     }
 
     func showTag(named tagName: String) {
-        prepareToNavigate()
+        if !isNavigatingFromSource {
+            prepareToNavigate()
+        }
 
         let remote = ReaderTopicServiceRemote(wordPressComRestApi: WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress()))
         let slug = remote.slug(forTopicName: tagName) ?? tagName.lowercased()
@@ -105,30 +109,37 @@ class ReaderCoordinator: NSObject {
     }
 
     func showStream(with siteID: Int, isFeed: Bool) {
-        prepareToNavigate()
-
         let controller = ReaderStreamViewController.controllerWithSiteID(NSNumber(value: siteID), isFeed: isFeed)
         controller.streamLoadFailureBlock = failureBlock
 
-        readerSplitViewController.showDetailViewController(controller, sender: nil)
-        readerMenuViewController.deselectSelectedRow(animated: false)
+        if isNavigatingFromSource {
+            topNavigationController.pushViewController(controller, animated: true)
+        } else {
+            prepareToNavigate()
+
+            readerSplitViewController.showDetailViewController(controller, sender: nil)
+            readerMenuViewController.deselectSelectedRow(animated: false)
+        }
     }
 
     func showPost(with postID: Int, for feedID: Int, isFeed: Bool) {
-        if !isNavigatingFromSource {
-            prepareToNavigate()
-        }
-
         let detailViewController = ReaderDetailViewController.controllerWithPostID(postID as NSNumber,
-                                                                                       siteID: feedID as NSNumber,
-                                                                                       isFeed: isFeed)
+                                                                                   siteID: feedID as NSNumber,
+                                                                                   isFeed: isFeed)
+
         detailViewController.postLoadFailureBlock = { [weak self, failureBlock] in
             self?.topNavigationController.popViewController(animated: false)
             failureBlock?()
         }
 
-        topNavigationController.pushFullscreenViewController(detailViewController, animated: isNavigatingFromSource)
-        readerMenuViewController.deselectSelectedRow(animated: false)
+        if isNavigatingFromSource {
+            topNavigationController.pushFullscreenViewController(detailViewController, animated: isNavigatingFromSource)
+        } else {
+            prepareToNavigate()
+
+            topNavigationController.pushFullscreenViewController(detailViewController, animated: isNavigatingFromSource)
+            readerMenuViewController.deselectSelectedRow(animated: false)
+        }
     }
 
     private var topNavigationController: UINavigationController {

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -77,6 +77,7 @@ class ReaderCoordinator: NSObject {
         prepareToNavigate()
 
         let streamViewController = ReaderStreamViewController.controllerWithTopic(topic)
+
         streamViewController.streamLoadFailureBlock = failureBlock
 
         readerSplitViewController.showDetailViewController(streamViewController, sender: nil)
@@ -111,7 +112,6 @@ class ReaderCoordinator: NSObject {
         let detailViewController = ReaderDetailViewController.controllerWithPostID(postID as NSNumber,
                                                                                        siteID: feedID as NSNumber,
                                                                                        isFeed: isFeed)
-
         detailViewController.postLoadFailureBlock = { [weak self, failureBlock] in
             self?.topNavigationController.popViewController(animated: false)
             failureBlock?()

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -8,6 +8,14 @@ class ReaderCoordinator: NSObject {
 
     var failureBlock: (() -> Void)? = nil
 
+    var source: UIViewController? = nil {
+        didSet {
+            isNavigatingFromSource = (source != nil && source == topNavigationController.topViewController)
+        }
+    }
+
+    private var isNavigatingFromSource = false
+
     @objc
     init(readerNavigationController: UINavigationController,
          readerSplitViewController: WPSplitViewController,
@@ -21,7 +29,7 @@ class ReaderCoordinator: NSObject {
     private func prepareToNavigate() {
         WPTabBarController.sharedInstance().showReaderTab()
 
-        topNavigationController.popToRootViewController(animated: false)
+        topNavigationController.popToRootViewController(animated: isNavigatingFromSource)
     }
 
     func showReaderTab() {
@@ -32,27 +40,27 @@ class ReaderCoordinator: NSObject {
         prepareToNavigate()
 
         readerMenuViewController.showSectionForDefaultMenuItem(withOrder: .discover,
-                                                               animated: false)
+                                                               animated: isNavigatingFromSource)
     }
 
     func showSearch() {
         prepareToNavigate()
 
         readerMenuViewController.showSectionForDefaultMenuItem(withOrder: .search,
-                                                               animated: false)
+                                                               animated: isNavigatingFromSource)
     }
 
     func showA8CTeam() {
         prepareToNavigate()
 
-        readerMenuViewController.showSectionForTeam(withSlug: ReaderTeamTopic.a8cTeamSlug, animated: false)
+        readerMenuViewController.showSectionForTeam(withSlug: ReaderTeamTopic.a8cTeamSlug, animated: isNavigatingFromSource)
     }
 
     func showMyLikes() {
         prepareToNavigate()
 
         readerMenuViewController.showSectionForDefaultMenuItem(withOrder: .likes,
-                                                               animated: false)
+                                                               animated: isNavigatingFromSource)
     }
 
     func showManageFollowing() {
@@ -61,7 +69,7 @@ class ReaderCoordinator: NSObject {
         readerMenuViewController.showSectionForDefaultMenuItem(withOrder: .followed, animated: false)
 
         if let followedViewController = topNavigationController.topViewController as? ReaderStreamViewController {
-            followedViewController.showManageSites(animated: false)
+            followedViewController.showManageSites(animated: isNavigatingFromSource)
         }
     }
 
@@ -107,7 +115,9 @@ class ReaderCoordinator: NSObject {
     }
 
     func showPost(with postID: Int, for feedID: Int, isFeed: Bool) {
-        prepareToNavigate()
+        if !isNavigatingFromSource {
+            prepareToNavigate()
+        }
 
         let detailViewController = ReaderDetailViewController.controllerWithPostID(postID as NSNumber,
                                                                                        siteID: feedID as NSNumber,
@@ -117,7 +127,7 @@ class ReaderCoordinator: NSObject {
             failureBlock?()
         }
 
-        topNavigationController.pushFullscreenViewController(detailViewController, animated: false)
+        topNavigationController.pushFullscreenViewController(detailViewController, animated: isNavigatingFromSource)
         readerMenuViewController.deselectSelectedRow(animated: false)
     }
 

--- a/WordPress/WordPressTest/RouteMatcherTests.swift
+++ b/WordPress/WordPressTest/RouteMatcherTests.swift
@@ -7,7 +7,7 @@ private struct TestRoute: Route {
 }
 
 private struct TestAction: NavigationAction {
-    func perform(_ values: [String: String]?) {}
+    func perform(_ values: [String: String]?, source: UIViewController?) {}
 }
 
 class RouteMatcherTests: XCTestCase {


### PR DESCRIPTION
Fixes #5149.

This PR adds support for the Reader to present Reader post and feed links in native views (`ReaderDetailViewController` and `ReaderStreamViewController`) instead of web views. To do so, I'm reusing the Reader routing code from our universal links implementation, but I've added an optional `source` view controller parameter. If the navigation is happening _within_ the app, we provide a source view controller, and the navigation can be tweaked accordingly. Both post details and streams should simply be pushed onto the Reader navigation stack.

![reader-links-2](https://user-images.githubusercontent.com/4780/44854182-cf9f6300-ac5f-11e8-9fa2-916ceca13ad5.gif)

This PR actually also enables support for other Reader links too, such as `https://wordpress.com/read/search`, which will take the user to the Search section of the Reader. Practically, I figure these kind of links will very rarely ever show up in posts, but that it couldn't hurt to leave them in for navigation.

**To test**

* Build and run – either device or simulator is fine
* In the Reader in the app, follow https://frostywptestsite5.wordpress.com
* View the latest post from that site – it contains 4 links you can test out.
* Each link should push the appropriate feed / post onto the stack.
* Also be sure to test on iPad as well as iPhone.