### PR TITLE
Fix formatting issue on Reader post

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
@@ -119,10 +119,22 @@ class WPRichTextFormatter {
             let attachmentString = NSMutableAttributedString(attributedString: NSAttributedString(attachment: attachment))
             attachmentString.addAttributes(attributes, range: NSRange(location: 0, length: attachmentString.length))
 
+            if needsAppendNewLine(to: str, at: range) {
+                attachmentString.append(NSAttributedString(string: "\n"))
+            }
+
             attrString.replaceCharacters(in: range, with: attachmentString)
         }
 
         return attrString
+    }
+
+    func needsAppendNewLine(to string: String, at nsRange: NSRange) -> Bool {
+        let nextCharRange = NSRange(location: nsRange.location + nsRange.length, length: 1)
+        guard let range = Range(nextCharRange, in: string) else {
+            return false
+        }
+        return string[range] != "\n"
     }
 
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
@@ -119,7 +119,7 @@ class WPRichTextFormatter {
             let attachmentString = NSMutableAttributedString(attributedString: NSAttributedString(attachment: attachment))
             attachmentString.addAttributes(attributes, range: NSRange(location: 0, length: attachmentString.length))
 
-            if needsAppendNewLine(to: str, at: range) {
+            if needsAppendNewLineAfterHR(at: range, in: str) {
                 attachmentString.append(NSAttributedString(string: "\n"))
             }
 
@@ -129,7 +129,7 @@ class WPRichTextFormatter {
         return attrString
     }
 
-    func needsAppendNewLine(to string: String, at nsRange: NSRange) -> Bool {
+    func needsAppendNewLineAfterHR(at nsRange: NSRange, in string: String) -> Bool {
         let nextCharRange = NSRange(location: nsRange.location + nsRange.length, length: 1)
         guard let range = Range(nextCharRange, in: string) else {
             return false


### PR DESCRIPTION
Fixes #9564 

This issue was a bit tricky. It was described as "Lines overlapping each other".
After a quick check, I notice that also an image was missing.

This specific issue (with this posts in particular) is related to three components: **HR**, **IMG**, **Paragraph**

```html
    ....
    <p>
        <em>David Llewellyn Dodds, Guest Editor
        </em>
    </p>
    <!-- Issue start here -->
    <hr>
    <a href="http://apilgriminnarnia.com/?attachment_id=7546">
        <img class="aligncenter wp-image-7546 " src="https://stephencwinter.files.wordpress.com/2018/01/james-archer-le-mort-arthur-e1516801625681.jpg?w=562&#038;h=343" height="343" width="562">
    </a>
    It may feel, for the inhabitants of the British Isles, that recent years have been particularly unsettled. The referendum…
```
None of those components are surrounded by `<p>` tags, but all the other components are.
I'm not sure if that is a bug by itself or how was that possible.

A fast test injecting surrounding `<p>` tags to the `img` and `paragraph` solved the issue, so it's clear that the issue is related to that.

With some debugging I pinpoint the problem to the [replaceHorizontalRuleMarkers](https://github.com/wordpress-mobile/WordPress-iOS/blob/51d6c867ea76b5b0b2adb62650ff92e4efd982ab/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift#L94) method.

Another fast test shows that deleting the line `107` (`mParagraphStyle.maximumLineHeight = 1.0`) partially solves the problem.

With that information I assume that, when converting the html code to attributed text without the `<p>` tags, the `NSAttributedText` instance assumes that those three elements are in the same paragraph, and when adding the HR paragraph styles specifying a maximum height of `1`, the three elements in it are affected.

Finally, I noticed that a _"healthy"_ HR placeholder looks like this:
`WPHORIZONTALRULEIDENTIFIER\nSomething else`
With a `\n` after the `WPHORIZONTALRULEIDENTIFIER`

And the HR placeholder with the problem looks like this:
`WPHORIZONTALRULEIDENTIFIERIt may feel, for `

### The solution

This proposed solution is to check if the character after the placeholder is a `\n`, and if not, we insert it. This separates the HR paragraph from whatever is next, solving the issue.

![before_after](https://user-images.githubusercontent.com/9772967/44858683-ef775c80-ac48-11e8-9d83-619768ecff40.png)


To test:

- Open [this post](https://wordpress.com/read/feeds/27083162/posts/1746290142) that has the problem.
- Check that it renders correctly.
- Open [this post](https://wordpress.com/read/feeds/75463728/posts/1977737837) that has a few "normal" HR.
- Check that it renders exactly as before.