### PR TITLE
Notifications: In-app deep linking for Reader posts and feeds

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -84,6 +84,11 @@ struct DefaultContentCoordinator: ContentCoordinator {
     }
 
     func displayWebViewWithURL(_ url: URL) {
+        if UniversalLinkRouter(routes: UniversalLinkRouter.ReaderRoutes).canHandle(url: url) {
+            UniversalLinkRouter(routes: UniversalLinkRouter.ReaderRoutes).handle(url: url, source: controller)
+            return
+        }
+
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
         let navController = UINavigationController(rootViewController: webViewController)
         controller?.present(navController, animated: true, completion: nil)


### PR DESCRIPTION
This PR continues from #10075. It extends the in-app deep linking for Reader posts and streams to also work for links within Notifications.

![reader-links-3](https://user-images.githubusercontent.com/4780/44859708-97525180-ac6c-11e8-8899-5b2a6d9f2ea4.gif)

**To test**

* Add a comment to a post that will show up in your notifications. You could paste in the following text, which includes a link for each of the things we want to test:

```
Feed: https://wordpress.com/read/feeds/20787116

Feed post: https://wordpress.com/read/feeds/20787116/posts/1972532749

Blog: https://wordpress.com/read/blogs/53424024

Blog post: https://wordpress.com/read/blogs/53424024/posts/34894
```

* Build and run the app, and navigate to that notification
* Tap each of the links in the notification, and check that the appropriate Reader view is pushed.