### PR TITLE
Reader: Display wpcom blog links in Reader detail views

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ def shared_with_networking_pods
     pod 'AFNetworking', '3.2.1'
     pod 'Alamofire', '4.7.2'
     pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'add/reader-post-by-url'
+    pod 'WordPressKit', '1.4.0-beta.2'
 end
 
 def shared_test_pods

--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ def shared_with_networking_pods
     pod 'AFNetworking', '3.2.1'
     pod 'Alamofire', '4.7.2'
     pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', '1.2.1'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'add/reader-post-by-url'
 end
 
 def shared_test_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -169,7 +169,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `8d412d58945d0cc25791415651a5a63fd57eb9c6`)
   - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `8d412d58945d0cc25791415651a5a63fd57eb9c6`)
   - WordPressAuthenticator (= 1.0.6)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `add/reader-post-by-url`)
+  - WordPressKit (= 1.4.0-beta.2)
   - WordPressShared (= 1.0.10)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `7a5b1a3fb44f62416fbc2e5f0de623b87b613aae`)
   - WPMediaPicker (= 1.3)
@@ -205,6 +205,7 @@ SPEC REPOS:
     - SVProgressHUD
     - UIDeviceIdentifier
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -220,9 +221,6 @@ EXTERNAL SOURCES:
   WordPress-Editor-iOS:
     :commit: 8d412d58945d0cc25791415651a5a63fd57eb9c6
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WordPressKit:
-    :branch: add/reader-post-by-url
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -237,9 +235,6 @@ CHECKOUT OPTIONS:
   WordPress-Editor-iOS:
     :commit: 8d412d58945d0cc25791415651a5a63fd57eb9c6
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WordPressKit:
-    :commit: f30580140dcd38ce49e2b2fb45fe19ac544fbdfc
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :commit: 7a5b1a3fb44f62416fbc2e5f0de623b87b613aae
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -282,6 +277,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 064d247124fcb8c03d11277b454eff98c3589473
+PODFILE CHECKSUM: 48a95b64f2aa8a6e2faef8ffde4fa55fd70effd4
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -120,7 +120,7 @@ PODS:
     - WordPressShared (~> 1.0)
     - WordPressUI (~> 1.0)
     - wpxmlrpc (~> 0.8)
-  - WordPressKit (1.2.1):
+  - WordPressKit (1.4.0-beta.2):
     - Alamofire (~> 4.7)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -169,7 +169,7 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (= 1.0.0-beta.25)
   - WordPress-Editor-iOS (= 1.0.0-beta.25)
   - WordPressAuthenticator (= 1.0.6)
-  - WordPressKit (= 1.2.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `add/reader-post-by-url`)
   - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `c51f53ef91127b5225064023e7207fad66b02ea4`)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `7a5b1a3fb44f62416fbc2e5f0de623b87b613aae`)
   - WPMediaPicker (= 1.3)
@@ -207,7 +207,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
@@ -216,6 +215,9 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPressKit:
+    :branch: add/reader-post-by-url
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :commit: c51f53ef91127b5225064023e7207fad66b02ea4
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
@@ -227,6 +229,9 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPressKit:
+    :commit: f30580140dcd38ce49e2b2fb45fe19ac544fbdfc
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressShared:
     :commit: c51f53ef91127b5225064023e7207fad66b02ea4
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
@@ -265,13 +270,13 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 99dbfb3dbf14c2d33771f562c506e42fdd4880d6
   WordPress-Editor-iOS: ff5815378c280ab5176a8e4af4591fed9b0dd484
   WordPressAuthenticator: 56538a229185640b41912c10c3f1891c2cc9bbb9
-  WordPressKit: a4a3849684f631a3abf579f6d3f15a32677cbb30
+  WordPressKit: e093b8ed3e3bee79bb62f4ef96d9650bcbe2cc48
   WordPressShared: e5ea8a1ed3329735e40bd6623830960f63dd10fd
   WordPressUI: af141587ec444f9af753a00605bd0d3f14d8d8a3
   WPMediaPicker: c54791e04af3b41e473e9b340784be48a505bb38
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 2cda4db2ba6b10ba89aeb8dddaa94e97c85946a0
 
-PODFILE CHECKSUM: 8ef93d71dd6db77fc9097186dab43d7d8ab0599a
+PODFILE CHECKSUM: a2cdbb84ee1b1475619f537618f3988dbbd7b83e
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -139,6 +139,12 @@ extension URL {
 
         return host.contains("wordpress.com")
     }
+
+    var isWordPressDotComPost: Bool {
+        // year, month, day, slug
+        let components = pathComponents.filter({ $0 != "/" })
+        return components.count == 4 && hasWordPressDotComHostname
+    }
 }
 
 extension NSURL {

--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -131,6 +131,14 @@ extension URL {
         /////
         return components.url
     }
+
+    var hasWordPressDotComHostname: Bool {
+        guard let host = host else {
+            return false
+        }
+
+        return host.contains("wordpress.com")
+    }
 }
 
 extension NSURL {

--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -77,6 +77,16 @@ extern NSString * const ReaderPostServiceToggleSiteFollowingState;
           success:(void (^)(ReaderPost *post))success
           failure:(void (^)(NSError *error))failure;
 
+/**
+ Fetches a specific post from the specified URL
+
+ @param postURL The URL of the post to fetch
+ @param success block called on a successful fetch.
+ @param failure block called if there is any error. `error` can be any underlying network error.
+ */
+- (void)fetchPostAtURL:(NSURL *)postURL
+          success:(void (^)(ReaderPost *post))success
+          failure:(void (^)(NSError *error))failure;
 
 /**
  Silently refresh posts for the followed sites topic.


### PR DESCRIPTION
This PR enables the Reader to load blog posts at WordPress.com subdomains in native Reader detail views, instead of web views. 

![reader-links-4](https://user-images.githubusercontent.com/4780/44923337-db625680-ad3f-11e8-901c-0cc6020271fa.gif)

This works for blog posts hosted at sites with WordPress.com subdomains. In the event we can't load the post, we'll show a no results view, with a button to try and display the post in a web view.

To implement this, I added a new method to `ReaderPostServiceRemote` in `WordPressKit`, which you can find here: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/32

**To test:**

* Create a post in a site you follow with a link to another wp.com post. Also add a fake link to a post or site that doesn't exist. See the gif above for an example of this.
* View the post in the Reader and tap each link in turn, checking that they are loaded (or not) in a Reader detail view