### PR TITLE
Update notifications segmented control

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -238,8 +238,8 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     fileprivate func decodeSelectedSegmentIndex(with coder: NSCoder) {
         restorableSelectedSegmentIndex = coder.decodeInteger(forKey: type(of: self).selectedSegmentIndexRestorationIdentifier)
 
-        if let filterTabBar = filterTabBar {
-            filterTabBar.setSelectedIndex(restorableSelectedSegmentIndex)
+        if filterTabBar.selectedIndex != restorableSelectedSegmentIndex {
+            filterTabBar.setSelectedIndex(restorableSelectedSegmentIndex, animated: false)
         }
     }
 
@@ -429,7 +429,6 @@ private extension NotificationsViewController {
         filterTabBar.dividerColor = WPStyleGuide.greyLighten20()
 
         filterTabBar.items = Filter.allFilters.map { $0.title }
-//        filterTabBar.setSelectedIndex(restorableSelectedSegmentIndex)
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -238,7 +238,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     fileprivate func decodeSelectedSegmentIndex(with coder: NSCoder) {
         restorableSelectedSegmentIndex = coder.decodeInteger(forKey: type(of: self).selectedSegmentIndexRestorationIdentifier)
 
-        if filterTabBar.selectedIndex != restorableSelectedSegmentIndex {
+        if let filterTabBar = filterTabBar, filterTabBar.selectedIndex != restorableSelectedSegmentIndex {
             filterTabBar.setSelectedIndex(restorableSelectedSegmentIndex, animated: false)
         }
     }
@@ -843,19 +843,6 @@ extension NotificationsViewController {
 
         selectFirstNotificationIfAppropriate()
     }
-
-//    @objc func segmentedControlDidChange(_ sender: UISegmentedControl) {
-//        selectedNotification = nil
-//
-//        let properties = [Stats.selectedFilter: filter.title]
-//        WPAnalytics.track(.notificationsTappedSegmentedControl, withProperties: properties)
-//
-//        updateUnreadNotificationsForSegmentedControlChange()
-//
-//        reloadResultsController()
-//
-//        selectFirstNotificationIfAppropriate()
-//    }
 
     @objc func selectFirstNotificationIfAppropriate() {
         // If we don't currently have a selected notification and there is a notification

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -827,7 +827,7 @@ extension NotificationsViewController: NetworkStatusDelegate {
     }
 }
 
-// MARK: - UISegmentedControl Methods
+// MARK: - FilterTabBar Methods
 //
 extension NotificationsViewController {
 
@@ -837,7 +837,7 @@ extension NotificationsViewController {
         let properties = [Stats.selectedFilter: filter.title]
         WPAnalytics.track(.notificationsTappedSegmentedControl, withProperties: properties)
 
-        updateUnreadNotificationsForSegmentedControlChange()
+        updateUnreadNotificationsForFilterTabChange()
 
         reloadResultsController()
 
@@ -860,7 +860,7 @@ extension NotificationsViewController {
         }
     }
 
-    @objc func updateUnreadNotificationsForSegmentedControlChange() {
+    @objc func updateUnreadNotificationsForFilterTabChange() {
         if filter == .unread {
             refreshUnreadNotifications(reloadingResultsController: false)
         } else {

--- a/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
+++ b/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="doV-5W-Rtg">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.13.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="doV-5W-Rtg">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.9"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,7 +14,7 @@
             <objects>
                 <tableViewController storyboardIdentifier="NotificationsViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="doV-5W-Rtg" customClass="NotificationsViewController" customModule="WordPress" sceneMemberID="viewController">
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="XCV-Uv-qac">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <inset key="separatorInset" minX="12" minY="0.0" maxX="0.0" maxY="0.0"/>
@@ -21,7 +24,7 @@
                         </connections>
                     </tableView>
                     <connections>
-                        <outlet property="filtersSegmentedControl" destination="W2i-rX-Pc4" id="Ewf-g4-EIc"/>
+                        <outlet property="filterTabBar" destination="LBU-zb-iai" id="qqB-Tp-xXt"/>
                         <outlet property="inlinePromptSpaceConstraint" destination="MBK-Ez-h7B" id="NJj-XL-4AG"/>
                         <outlet property="inlinePromptView" destination="ZnY-3K-upT" id="lUG-fd-Stc"/>
                         <outlet property="tableHeaderView" destination="Uvo-9e-l6I" id="dxx-mK-msp"/>
@@ -42,26 +45,17 @@
                         <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pEF-oN-cih" userLabel="Filters View">
                             <rect key="frame" x="0.0" y="100" width="600" height="44"/>
                             <subviews>
-                                <segmentedControl opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="left" contentVerticalAlignment="top" apportionsSegmentWidthsByContent="YES" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="W2i-rX-Pc4">
-                                    <rect key="frame" x="20" y="8" width="560" height="29"/>
-                                    <segments>
-                                        <segment title="All"/>
-                                        <segment title="Unread"/>
-                                        <segment title="Comments"/>
-                                        <segment title="Follows"/>
-                                        <segment title="Likes"/>
-                                    </segments>
-                                    <connections>
-                                        <action selector="segmentedControlDidChange:" destination="doV-5W-Rtg" eventType="valueChanged" id="DJb-vF-ycf"/>
-                                    </connections>
-                                </segmentedControl>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LBU-zb-iai" customClass="FilterTabBar" customModule="WordPress" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </view>
                             </subviews>
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
-                                <constraint firstItem="W2i-rX-Pc4" firstAttribute="top" secondItem="pEF-oN-cih" secondAttribute="topMargin" id="5Uj-Sc-fd3"/>
-                                <constraint firstAttribute="trailingMargin" secondItem="W2i-rX-Pc4" secondAttribute="trailing" id="Hd9-33-6h0"/>
-                                <constraint firstItem="W2i-rX-Pc4" firstAttribute="leading" secondItem="pEF-oN-cih" secondAttribute="leadingMargin" id="ZuC-wG-15P"/>
-                                <constraint firstAttribute="bottomMargin" secondItem="W2i-rX-Pc4" secondAttribute="bottom" id="fLC-a5-Sxh"/>
+                                <constraint firstAttribute="bottom" secondItem="LBU-zb-iai" secondAttribute="bottom" id="6uy-tW-55g"/>
+                                <constraint firstItem="LBU-zb-iai" firstAttribute="leading" secondItem="pEF-oN-cih" secondAttribute="leading" id="9sh-kF-RQv"/>
+                                <constraint firstItem="LBU-zb-iai" firstAttribute="top" secondItem="pEF-oN-cih" secondAttribute="top" id="Ib2-7V-nPZ"/>
+                                <constraint firstAttribute="trailing" secondItem="LBU-zb-iai" secondAttribute="trailing" id="Zhl-Rn-WR6"/>
                             </constraints>
                         </view>
                     </subviews>
@@ -91,14 +85,14 @@
                         <viewControllerLayoutGuide type="bottom" id="6LW-NS-qSh"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="lvM-1n-Dgf">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="t2r-NP-ili">
-                                <rect key="frame" x="0.0" y="20" width="600" height="580"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
                                     <tableView opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Dcn-Il-AtN" customClass="IntrinsicTableView" customModule="WordPress">
-                                        <rect key="frame" x="0.0" y="0.0" width="600" height="580"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="647"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <gestureRecognizers/>
                                         <inset key="separatorInset" minX="12" minY="0.0" maxX="0.0" maxY="0.0"/>

--- a/WordPress/Classes/ViewRelated/Post/Posts.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Posts.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.13.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.9"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>


### PR DESCRIPTION
Fixes parts of #9779

This PR replaces the old segmented control on top of the Notifications sections with the new `FilterTabBar` component used on Posts and Pages.

![before_after](https://user-images.githubusercontent.com/9772967/44935416-000dfc80-ad47-11e8-829b-801ca80bfafe.png)


To test:
- Navigate to the Notifications section.
- Check that the filters work properly.

I had a small issue with restoration, where the selected tab was scrolled full to the left, please test that too:
- Run the app from Xcode.
- Select the Likes tab.
- Send the app to the background pressing the device's home button.
- Re-run the app from Xcode.
- Check that the same tab is still selected and the tab bar looks fine.
