### PR TITLE
Giphy: Add animated detail preview of gifs

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -459,7 +459,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     /// Helps choosing the correct view controller for previewing a media asset
     ///
-    private let mediaPreviewHelper = MediaPreviewHelper()
+    private var mediaPreviewHelper: MediaPreviewHelper? = nil
 
 
     // MARK: - Initializers
@@ -3755,7 +3755,8 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, previewViewControllerFor assets: [WPMediaAsset], selectedIndex selected: Int) -> UIViewController? {
-        return mediaPreviewHelper.previewViewController(for: assets, selectedIndex: selected)
+        mediaPreviewHelper = MediaPreviewHelper(assets: assets)
+        return mediaPreviewHelper?.previewViewController(selectedIndex: selected)
     }
 
     private func updateFormatBarInsertAssetCount() {

--- a/WordPress/Classes/ViewRelated/Media/Giphy/GiphyMedia.swift
+++ b/WordPress/Classes/ViewRelated/Media/Giphy/GiphyMedia.swift
@@ -85,6 +85,14 @@ extension GiphyMedia: WPMediaAsset {
     }
 }
 
+// MARK: - ExportableAsset conformance
+
+//extension GiphyMedia: ExportableAsset {
+//    var assetMediaType: MediaType {
+//        return .image
+//    }
+//}
+
 //// MARK: - MediaExternalAsset conformance
 //
 extension GiphyMedia: MediaExternalAsset {

--- a/WordPress/Classes/ViewRelated/Media/Giphy/GiphyMedia.swift
+++ b/WordPress/Classes/ViewRelated/Media/Giphy/GiphyMedia.swift
@@ -1,35 +1,40 @@
 import WPMediaPicker
 import MobileCoreServices
 
+struct GiphyImageCollection {
+    private(set) var largeURL: URL
+    private(set) var previewURL: URL
+    private(set) var staticThumbnailURL: URL
+    private(set) var largeSize: CGSize
+}
+
 /// Models a Giphy image
-/// Currently just stores a reference to a single size image
 ///
 final class GiphyMedia: NSObject {
     private(set) var id: String
-    private(set) var url: String
-    private(set) var size: CGSize
+    private(set) var name: String
+    private(set) var caption: String
     private let updatedDate: Date
+    private let images: GiphyImageCollection
 
-    init(id: String, url: String, size: CGSize, date: Date? = nil) {
+    init(id: String, name: String, caption: String, images: GiphyImageCollection, date: Date? = nil) {
         self.id = id
-        self.url = url
-        self.size = size
+        self.name = name
+        self.caption = caption
         self.updatedDate = date ?? Date()
+        self.images = images
     }
 }
 
 extension GiphyMedia: WPMediaAsset {
     func image(with size: CGSize, completionHandler: @escaping WPMediaImageBlock) -> WPMediaRequestID {
+        let url = imageURL(with: size)
 
         DispatchQueue.global().async {
             do {
-                if let url = URL(string: self.url) {
-                    let data = try Data(contentsOf: url)
-                    let image = UIImage(data: data)
-                    completionHandler(image, nil)
-                } else {
-                    completionHandler(nil, nil)
-                }
+                let data = try Data(contentsOf: url)
+                let image = UIImage(data: data)
+                completionHandler(image, nil)
             } catch {
                 completionHandler(nil, error)
             }
@@ -37,6 +42,10 @@ extension GiphyMedia: WPMediaAsset {
 
         // Giphy API doesn't return a numerical ID value
         return 0
+    }
+
+    private func imageURL(with size: CGSize) -> URL {
+        return size == .zero ? images.previewURL : images.staticThumbnailURL
     }
 
     func cancelImageRequest(_ requestID: WPMediaRequestID) {
@@ -68,7 +77,7 @@ extension GiphyMedia: WPMediaAsset {
     }
 
     func pixelSize() -> CGSize {
-        return size
+        return images.largeSize
     }
 
     func utTypeIdentifier() -> String? {

--- a/WordPress/Classes/ViewRelated/Media/Giphy/GiphyMedia.swift
+++ b/WordPress/Classes/ViewRelated/Media/Giphy/GiphyMedia.swift
@@ -84,3 +84,11 @@ extension GiphyMedia: WPMediaAsset {
         return String(kUTTypeGIF)
     }
 }
+
+//// MARK: - MediaExternalAsset conformance
+//
+extension GiphyMedia: MediaExternalAsset {
+    var URL: URL {
+        return images.previewURL
+    }
+}

--- a/WordPress/Classes/ViewRelated/Media/Giphy/GiphyPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/Giphy/GiphyPicker.swift
@@ -17,7 +17,7 @@ final class GiphyPicker: NSObject {
 
     /// Helps choosing the correct view controller for previewing a media asset
     ///
-    private let mediaPreviewHelper = MediaPreviewHelper()
+    private var mediaPreviewHelper: MediaPreviewHelper!
 
     weak var delegate: GiphyPickerDelegate?
     private var blog: Blog?
@@ -125,7 +125,8 @@ extension GiphyPicker: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, previewViewControllerFor assets: [WPMediaAsset], selectedIndex selected: Int) -> UIViewController? {
-        return mediaPreviewHelper.previewViewController(for: assets, selectedIndex: selected)
+        mediaPreviewHelper = MediaPreviewHelper(assets: assets)
+        return mediaPreviewHelper.previewViewController(selectedIndex: selected)
     }
 
     private func hideKeyboard(from view: UIView?) {

--- a/WordPress/Classes/ViewRelated/Media/Giphy/GiphyPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/Giphy/GiphyPicker.swift
@@ -15,6 +15,10 @@ final class GiphyPicker: NSObject {
         return GiphyService()
     }()
 
+    /// Helps choosing the correct view controller for previewing a media asset
+    ///
+    private let mediaPreviewHelper = MediaPreviewHelper()
+
     weak var delegate: GiphyPickerDelegate?
     private var blog: Blog?
     private var observerToken: NSObjectProtocol?
@@ -118,6 +122,10 @@ extension GiphyPicker: WPMediaPickerViewControllerDelegate {
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, didDeselect asset: WPMediaAsset) {
         hideKeyboard(from: picker.searchBar)
+    }
+
+    func mediaPickerController(_ picker: WPMediaPickerViewController, previewViewControllerFor assets: [WPMediaAsset], selectedIndex selected: Int) -> UIViewController? {
+        return mediaPreviewHelper.previewViewController(for: assets, selectedIndex: selected)
     }
 
     private func hideKeyboard(from view: UIView?) {

--- a/WordPress/Classes/ViewRelated/Media/Giphy/GiphyService.swift
+++ b/WordPress/Classes/ViewRelated/Media/Giphy/GiphyService.swift
@@ -41,20 +41,45 @@ struct GiphyService {
     }
 }
 
+// MARK: GPHMedia Parsing
+
+extension GiphyImageCollection {
+    init?(gphMedia: GPHMedia) {
+        guard let images = gphMedia.images,
+            let thumbnail = images.fixedHeightStill?.gifUrl,
+            let thumbnailURL = URL(string: thumbnail),
+            let downsizedURLString = images.downsized?.gifUrl,
+            let downsizedURL = URL(string: downsizedURLString),
+            let large = images.downsizedLarge,
+            let largeURLString = large.gifUrl,
+            let largeURL = URL(string: largeURLString) else {
+                return nil
+        }
+
+        let size = CGSize(width: large.width, height: large.height)
+
+        self.init(largeURL: largeURL,
+                  previewURL: downsizedURL,
+                  staticThumbnailURL: thumbnailURL,
+                  largeSize: size)
+    }
+}
+
 extension GiphyMedia {
     convenience init?(gphMedia: GPHMedia) {
-        guard let image = gphMedia.images?.fixedHeightStill,
-            let imageURL = image.gifUrl  else {
+        guard let images = GiphyImageCollection(gphMedia: gphMedia) else {
             return nil
         }
 
         self.init(id: gphMedia.id,
-                  url: imageURL,
-                  size: CGSize(width: image.width, height: image.height),
+                  name: gphMedia.title ?? "",
+                  caption: gphMedia.caption ?? "",
+                  images: images,
                   date: gphMedia.updateDate)
     }
 }
 
+// Allows us to mock out the pagination in tests
 protocol GPHPaginationType {
     /// Total Result Count.
     var totalCount: Int { get }

--- a/WordPress/Classes/ViewRelated/Media/MediaPreviewHelper.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPreviewHelper.swift
@@ -51,6 +51,10 @@ class MediaPreviewHelper: NSObject {
             let imageController =  WPImageViewController(asset: phasset)
             imageController.shouldDismissWithGestures = false
             return imageController
+        } else if let mediaAsset = asset as? MediaExternalAsset {
+            let imageController =  WPImageViewController(externalMediaURL: mediaAsset.URL)
+            imageController.shouldDismissWithGestures = false
+            return imageController
         }
 
         return nil

--- a/WordPress/Classes/ViewRelated/Media/MediaPreviewHelper.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPreviewHelper.swift
@@ -7,14 +7,19 @@ import WPMediaPicker
 ///
 class MediaPreviewHelper: NSObject {
 
+    let assets: [WPMediaAsset]
+
+    init(assets: [WPMediaAsset]) {
+        self.assets = assets
+        super.init()
+    }
 
     /// Return a controller to show the given assets.
     ///
     /// - Parameters:
-    ///   - assets: The media assets to be displayed in the controller.
     ///   - selected: The selected index to be displayed by default.
     /// - Returns: The controller to be displayed or nil if the asset is not an image.
-    func previewViewController(for assets: [WPMediaAsset], selectedIndex selected: Int) -> UIViewController? {
+    func previewViewController(selectedIndex selected: Int) -> UIViewController? {
         guard assets.count > 0, selected < assets.endIndex else {
             return nil
         }
@@ -52,7 +57,8 @@ class MediaPreviewHelper: NSObject {
             imageController.shouldDismissWithGestures = false
             return imageController
         } else if let mediaAsset = asset as? MediaExternalAsset {
-            let imageController =  WPImageViewController(externalMediaURL: mediaAsset.URL)
+            let imageController =  WPImageViewController(externalMediaURL: mediaAsset.URL,
+                                                         andAsset: asset)
             imageController.shouldDismissWithGestures = false
             return imageController
         }
@@ -70,7 +76,6 @@ extension MediaPreviewHelper: WPCarouselAssetsViewControllerDelegate {
         guard
             let imageViewController = viewController as? WPImageViewController,
             let asset = imageViewController.mediaAsset else {
-
                 fatalError()
         }
         return asset

--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithMedia:(Media *)media;
 - (instancetype)initWithAsset:(PHAsset *)asset;
 - (instancetype)initWithGifData:(NSData *)data;
+- (instancetype)initWithExternalMediaURL:(NSURL *)url;
 
 - (instancetype)initWithImage:(nullable UIImage *)image andURL:(nullable NSURL *)url;
 - (instancetype)initWithImage:(nullable UIImage *)image andMedia:(nullable Media *)media;

--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAsset:(PHAsset *)asset;
 - (instancetype)initWithGifData:(NSData *)data;
 - (instancetype)initWithExternalMediaURL:(NSURL *)url;
+- (instancetype)initWithExternalMediaURL:(NSURL *)url andAsset:(id<WPMediaAsset>)asset;
 
 - (instancetype)initWithImage:(nullable UIImage *)image andURL:(nullable NSURL *)url;
 - (instancetype)initWithImage:(nullable UIImage *)image andMedia:(nullable Media *)media;

--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
@@ -14,6 +14,7 @@ static CGFloat const MinimumZoomScale = 0.1;
 @property (nonatomic, strong) UIImage *image;
 @property (nonatomic, strong) Media *media;
 @property (nonatomic, strong) PHAsset *asset;
+@property (nonatomic, strong) id<WPMediaAsset> mediaAsset;
 @property (nonatomic, strong) NSData *data;
 @property (nonatomic) BOOL isExternal;
 
@@ -98,6 +99,19 @@ static CGFloat const MinimumZoomScale = 0.1;
     if (self) {
         _image = nil;
         _url = url;
+        _isExternal = YES;
+        [self commonInit];
+    }
+    return self;
+}
+
+- (instancetype)initWithExternalMediaURL:(NSURL *)url andAsset:(id<WPMediaAsset>)asset
+{
+    self = [super init];
+    if (self) {
+        _image = nil;
+        _url = url;
+        _mediaAsset = asset;
         _isExternal = YES;
         [self commonInit];
     }
@@ -349,12 +363,17 @@ static CGFloat const MinimumZoomScale = 0.1;
 
 - (id<WPMediaAsset>)mediaAsset
 {
+    if (_mediaAsset) {
+        return _mediaAsset;
+    }
+
     if (self.asset) {
         return self.asset;
     }
     if (self.media) {
         return self.media;
     }
+
     return nil;
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
@@ -15,6 +15,7 @@ static CGFloat const MinimumZoomScale = 0.1;
 @property (nonatomic, strong) Media *media;
 @property (nonatomic, strong) PHAsset *asset;
 @property (nonatomic, strong) NSData *data;
+@property (nonatomic) BOOL isExternal;
 
 @property (nonatomic, assign) BOOL isLoadingImage;
 @property (nonatomic, assign) BOOL isFirstLayout;
@@ -86,6 +87,18 @@ static CGFloat const MinimumZoomScale = 0.1;
     if (self) {
         _image = [image copy];
         _media = media;
+        [self commonInit];
+    }
+    return self;
+}
+
+- (instancetype)initWithExternalMediaURL:(NSURL *)url
+{
+    self = [super init];
+    if (self) {
+        _image = nil;
+        _url = url;
+        _isExternal = YES;
         [self commonInit];
     }
     return self;
@@ -200,6 +213,8 @@ static CGFloat const MinimumZoomScale = 0.1;
 
     if (self.image != nil) {
         [self updateImageView];
+    } else if (self.url && self.isExternal) {
+        [self loadImageFromExternalURL];
     } else if (self.url) {
         [self loadImageFromURL];
     } else if (self.media) {
@@ -261,7 +276,6 @@ static CGFloat const MinimumZoomScale = 0.1;
         [weakSelf updateImageView];
     } error:^(NSError * _Nullable error) {
         [weakSelf.activityIndicatorView showError];
-        [weakSelf.activityIndicatorView showError];
         DDLogError(@"Error loading image: %@", error);
     }];
 }
@@ -280,6 +294,22 @@ static CGFloat const MinimumZoomScale = 0.1;
             weakSelf.isLoadingImage = NO;
         });
     }];
+}
+
+- (void)loadImageFromExternalURL
+{
+    self.isLoadingImage = YES;
+
+    __weak __typeof__(self) weakSelf = self;
+    [self.imageLoader loadImageWithURL:self.url
+                               success:^{
+                                   weakSelf.isLoadingImage = NO;
+                                   weakSelf.image = weakSelf.imageView.image;
+                                   [weakSelf updateImageView];
+                               } error:^(NSError * _Nullable error) {
+                                   [weakSelf.activityIndicatorView showError];
+                                   DDLogError(@"Error loading image: %@", error);
+                               }];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
@@ -209,6 +209,7 @@ static CGFloat const MinimumZoomScale = 0.1;
 {
     self.imageView = [[CachedAnimatedImageView alloc] initWithFrame:frame];
     self.imageView.gifStrategy = GIFStrategyLargeGIFs;
+    self.imageView.contentMode = UIViewContentModeScaleAspectFit;
     self.imageView.shouldShowLoadingIndicator = NO;
     self.imageView.userInteractionEnabled = YES;
     [self.scrollView addSubview:self.imageView];


### PR DESCRIPTION
Implements #10087. This PR adds support for previewing Giphy GIFs after performing a search. Our implementation currently _does not_ support actually importing the GIFs – so the 'add' button when you have some selected won't work.

![giphy-detail-1](https://user-images.githubusercontent.com/4780/45031837-eb33b080-b047-11e8-909c-fe33c3d64fd9.gif)

**To test:**

* Build and run
* Navigate to Media > Tap + >Choose Giphy
* Perform a search, and when the results have loaded:
  * Test previewing a single item from the results
  * Test previewing a single item by 3d touching
  * Test previewing multiple items and swiping between them in the carousel

@bummytime would you be able to review this one, as you worked on gif support? Let me know if you're stacked with other stuff and I can assign someone else instead!