### PR TITLE
Enable AT for all build configurations.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -26,7 +26,7 @@ enum FeatureFlag: Int {
         case .giphy:
             return BuildConfiguration.current == .localDeveloper
         case .automatedTransfer:
-            return BuildConfiguration.current != .appStore
+            return true
         }
     }
 }


### PR DESCRIPTION
This enables AT for all builds configurations. Should be just a formality :)

I've left the feature flag in deliberately, in case something _does_ blow up (hopefully not!) and we need to roll it back. I'll also be working in this area next (letting users claim their free domain), so if nothing blows up I'll clean it up then.

To test:
uhhh. Look at the code and see what it does? 
Bonus scout points for actually building the site in release configuration and making sure it shows up ;)


