### PR TITLE
Filter unsupported notification types from service extension processing

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Notifiable.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Notifiable.swift
@@ -1,6 +1,11 @@
 import WordPressKit
 
 /// Known kinds of Notifications
+import Foundation
+
+// MARK: - NotificationKind
+
+/// Characterizes the known types of notification types
 enum NotificationKind: String {
     case comment        = "comment"
     case commentLike    = "comment_like"
@@ -12,6 +17,23 @@ enum NotificationKind: String {
     case user           = "user"
     case unknown        = "unknown"
 }
+
+extension NotificationKind {
+    /// Enumerates the Kinds that currently provide Rich Notification support
+    private static var kindsWithRichNotificationSupport: Set<NotificationKind> = [
+        .comment
+    ]
+
+    /// Indicates whether or not a given kind has rich notification support.
+    ///
+    /// - Parameter kind: the notification type to evaluate
+    /// - Returns: `true` if the kind supports rich notifications; `false` otherwise
+    static func isSupportedByRichNotifications(_ kind: NotificationKind) -> Bool {
+        return kindsWithRichNotificationSupport.contains(kind)
+    }
+}
+
+// MARK: - Notifiable
 
 /// This protocol represents the traits of a local or remote notification.
 protocol Notifiable {
@@ -33,6 +55,8 @@ extension Notifiable {
         return kind
     }
 }
+
+// MARK: - RemoteNotification
 
 /// RemoteNotification is located in WordPressKit
 extension RemoteNotification: Notifiable {

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationContent/UNNotificationContent+RemoteNotification.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationContent/UNNotificationContent+RemoteNotification.swift
@@ -25,7 +25,8 @@ extension UNNotificationContent {
 // MARK: - Describes userInfo keys used to exchange data between extension types
 
 private extension CodingUserInfoKey {
-    static let noteIdentifier = CodingUserInfoKey(rawValue: "note_id")!
+    static let noteIdentifier   = CodingUserInfoKey(rawValue: "note_id")!
+    static let type             = CodingUserInfoKey(rawValue: "type")!
 }
 
 // MARK: - Supports APNS notification related to `RemoteNotification`
@@ -37,5 +38,10 @@ extension UNNotificationContent {
             return nil
         }
         return String(rawNoteId)
+    }
+
+    /// the value of the `type` from the APNS payload if it exists; `nil` otherwise
+    var type: String? {
+        return userInfo[CodingUserInfoKey.type.rawValue] as? String
     }
 }

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -34,9 +34,18 @@ class NotificationService: UNNotificationServiceExtension {
         guard let notificationContent = self.bestAttemptContent,
             let apsAlert = notificationContent.apsAlert,
             let noteID = notificationContent.noteID,
+            let notificationType = notificationContent.type,
+            let notificationKind = NotificationKind(rawValue: notificationType),
             token != nil else {
 
             contentHandler(request.content)
+            return
+        }
+
+        guard NotificationKind.isSupportedByRichNotifications(notificationKind) else {
+            tracks.trackNotificationDiscarded(notificationType: notificationType)
+
+            contentHandler(notificationContent)
             return
         }
 
@@ -54,8 +63,7 @@ class NotificationService: UNNotificationServiceExtension {
 
             guard let remoteNotifications = notifications,
                 remoteNotifications.count == 1,
-                let notification = remoteNotifications.first,
-                notification.kind == .comment else {
+                let notification = remoteNotifications.first else {
 
                 return
             }

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -31,13 +31,11 @@ class NotificationService: UNNotificationServiceExtension {
         let token = readExtensionToken()
         tracks.trackExtensionLaunched(token != nil)
 
-        guard
-            let notificationContent = self.bestAttemptContent,
+        guard let notificationContent = self.bestAttemptContent,
             let apsAlert = notificationContent.apsAlert,
             let noteID = notificationContent.noteID,
-            token != nil
-        else
-        {
+            token != nil else {
+
             contentHandler(request.content)
             return
         }
@@ -54,19 +52,19 @@ class NotificationService: UNNotificationServiceExtension {
                 return
             }
 
-            guard
-                let remoteNotifications = notifications,
+            guard let remoteNotifications = notifications,
                 remoteNotifications.count == 1,
                 let notification = remoteNotifications.first,
-                notification.kind == .comment
-            else
-            {
+                notification.kind == .comment else {
+
                 return
             }
 
             let contentFormatter = RichNotificationContentFormatter(notification: notification)
 
-            guard let bodyText = contentFormatter.formatBody() else { return }
+            guard let bodyText = contentFormatter.formatBody() else {
+                return
+            }
             notificationContent.body = bodyText
 
             let viewModel = RichNotificationViewModel(
@@ -99,14 +97,12 @@ class NotificationService: UNNotificationServiceExtension {
     /// - Returns: the token if found; `nil` otherwise
     ///
     private func readExtensionToken() -> String? {
-        guard
-            let oauthToken = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainTokenKey,
-                                                                           andServiceName: WPNotificationServiceExtensionKeychainServiceName,
-                                                                           accessGroup: WPAppKeychainAccessGroup)
-        else
-        {
-            debugPrint("Unable to retrieve Notification Service Extension OAuth token")
-            return nil
+        guard let oauthToken = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainTokenKey,
+                                                                             andServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                                                                             accessGroup: WPAppKeychainAccessGroup) else {
+
+                                                                                debugPrint("Unable to retrieve Notification Service Extension OAuth token")
+                                                                                return nil
         }
 
         return oauthToken
@@ -117,14 +113,12 @@ class NotificationService: UNNotificationServiceExtension {
     /// - Returns: the username if found; `nil` otherwise
     ///
     private func readExtensionUsername() -> String? {
-        guard
-            let username = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainUsernameKey,
-                                                                         andServiceName: WPNotificationServiceExtensionKeychainServiceName,
-                                                                         accessGroup: WPAppKeychainAccessGroup)
-            else
-        {
-            debugPrint("Unable to retrieve Notification Service Extension username")
-            return nil
+        guard let username = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainUsernameKey,
+                                                                           andServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                                                                           accessGroup: WPAppKeychainAccessGroup) else {
+
+                                                                            debugPrint("Unable to retrieve Notification Service Extension username")
+                                                                            return nil
         }
 
         return username

--- a/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
@@ -34,7 +34,7 @@ extension Tracks {
     /// - Parameter notificationType: the value of the `note_id` from the APNS payload
     func trackNotificationDiscarded(notificationType: String) {
         let properties = [
-            "note_type": notificationType
+            "type": notificationType
         ]
         trackEvent(ServiceExtensionEvents.discarded, properties: properties as [String: AnyObject]?)
     }


### PR DESCRIPTION
## Description
Fixes #9971, with two commits that address the following changes:

- Tidies up some `guard / let` formatting, based on feedback from an [unrelated PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/10066).
- Introduces functionality to parse `type` key-value pair from notification, and juxtapose it with supported types. The types honored (via `NotificationKind`) were introduced via `FormattableContent` implementation.
- Integrated analytics event for notifications received that are not currently captured by analytics.

## To test:
First, verify that the branch builds & existing tests pass.

Next, while debugging the **service** extension, manually push payloads to exercise the following three scenarios:

1. **Payload not modified** : The "rich" notification should no longer be displayed. It _should_ resemble what's seen in production today.
1. **Add `"type":"comment"` to payload** : the _Short Look_ & _Long Look_ variants of the rich notification should be displayed as before.
1. **Specify currently unsupported push notification type (e.g., `"type":"automattcher"`) in payload** : a rich notification should not be visible. Moreover, the `wpios_notification_service_extension_discarded` event should be found in _Tracks Live View_.

_Instructions for manually testing push notifications can be found here: #9924._ 