### PR TITLE
Use No Results View loadingAccessoryView

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -326,14 +326,14 @@ private extension NoResultsViewController {
 
     // MARK: - `WPAnimatedBox` resource management
 
-    private func startAnimatingIfNeeded() {
+    func startAnimatingIfNeeded() {
         guard let animatedBox = accessorySubview as? WPAnimatedBox else {
             return
         }
         animatedBox.animate(afterDelay: 0.1)
     }
 
-    private func stopAnimatingIfNeeded() {
+    func stopAnimatingIfNeeded() {
         guard let animatedBox = accessorySubview as? WPAnimatedBox else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
@@ -86,7 +86,7 @@ import WordPressShared
                                       comment: "Title of an error message. There were no third-party service accounts found to setup sharing.")
         let message = NSLocalizedString("Sorry. The social service did not tell us which account could be used for sharing.",
                                         comment: "An error message shown if a third-party social service does not specify any accounts that an be used with publicize sharing.")
-        noResultsViewController.configure(title: title, buttonTitle: nil, subtitle: message, image: nil, accessoryView: nil)
+        noResultsViewController.configure(title: title, subtitle: message)
     }
 
 
@@ -95,7 +95,7 @@ import WordPressShared
                                        comment: "Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages.")
 
         let buttonTitle = NSLocalizedString("Learn more", comment: "A button title.")
-        noResultsViewController.configure(title: "", buttonTitle: buttonTitle, subtitle: message, image: nil, accessoryView: nil)
+        noResultsViewController.configure(title: "", buttonTitle: buttonTitle, subtitle: message)
         noResultsViewController.delegate = self
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -399,7 +399,7 @@ private extension SiteTagsViewController {
 
     func setupLoadingView() {
         noResultsViewController.configure(title: loadingMessage(),
-                                           accessoryView: loadingAccessoryView())
+                                           accessoryView: NoResultsViewController.loadingAccessoryView())
     }
 
     func setupEmptyResultsView() {
@@ -441,11 +441,6 @@ private extension SiteTagsViewController {
 
     func loadingMessage() -> String {
         return NSLocalizedString("Loading...", comment: "Loading tags.")
-    }
-
-    func loadingAccessoryView() -> UIView {
-        let animatedBox = WPAnimatedBox()
-        return animatedBox
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
+++ b/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
@@ -4,17 +4,17 @@ extension NoResultsViewController {
 
     @objc func configureForNoAssets(userCanUploadMedia: Bool) {
         let buttonTitle = userCanUploadMedia ? LocalizedText.uploadButtonTitle : nil
-        configure(title: LocalizedText.noAssetsTitle, buttonTitle: buttonTitle, subtitle: nil, attributedSubtitle: nil, image: Constants.imageName, accessoryView: nil)
+        configure(title: LocalizedText.noAssetsTitle, buttonTitle: buttonTitle, subtitle: nil, attributedSubtitle: nil, image: Constants.imageName)
     }
 
     @objc func configureForFetching() {
         let animatedBox = WPAnimatedBox()
-        configure(title: LocalizedText.fetchingTitle, buttonTitle: nil, subtitle: nil, attributedSubtitle: nil, image: nil, accessoryView: animatedBox)
+        configure(title: LocalizedText.fetchingTitle, buttonTitle: nil, subtitle: nil, attributedSubtitle: nil, image: nil, accessoryView: NoResultsViewController.loadingAccessoryView())
         view.layoutIfNeeded()
     }
 
     @objc func configureForNoSearchResult(with searchQuery: String) {
-        configure(title: LocalizedText.noResultsTitle, buttonTitle: nil, subtitle: searchQuery, attributedSubtitle: nil, image: Constants.imageName, accessoryView: nil)
+        configure(title: LocalizedText.noResultsTitle, buttonTitle: nil, subtitle: searchQuery, attributedSubtitle: nil, image: Constants.imageName)
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
+++ b/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
@@ -4,7 +4,7 @@ extension NoResultsViewController {
 
     @objc func configureForNoAssets(userCanUploadMedia: Bool) {
         let buttonTitle = userCanUploadMedia ? LocalizedText.uploadButtonTitle : nil
-        configure(title: LocalizedText.noAssetsTitle, buttonTitle: buttonTitle, subtitle: nil, attributedSubtitle: nil, image: Constants.imageName)
+        configure(title: LocalizedText.noAssetsTitle, buttonTitle: buttonTitle, image: Constants.imageName)
     }
 
     @objc func configureForFetching() {

--- a/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
+++ b/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
@@ -8,7 +8,6 @@ extension NoResultsViewController {
     }
 
     @objc func configureForFetching() {
-        let animatedBox = WPAnimatedBox()
         configure(title: LocalizedText.fetchingTitle, buttonTitle: nil, subtitle: nil, attributedSubtitle: nil, image: nil, accessoryView: NoResultsViewController.loadingAccessoryView())
         view.layoutIfNeeded()
     }

--- a/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
+++ b/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
@@ -8,12 +8,12 @@ extension NoResultsViewController {
     }
 
     @objc func configureForFetching() {
-        configure(title: LocalizedText.fetchingTitle, buttonTitle: nil, subtitle: nil, attributedSubtitle: nil, image: nil, accessoryView: NoResultsViewController.loadingAccessoryView())
+        configure(title: LocalizedText.fetchingTitle, accessoryView: NoResultsViewController.loadingAccessoryView())
         view.layoutIfNeeded()
     }
 
     @objc func configureForNoSearchResult(with searchQuery: String) {
-        configure(title: LocalizedText.noResultsTitle, buttonTitle: nil, subtitle: searchQuery, attributedSubtitle: nil, image: Constants.imageName)
+        configure(title: LocalizedText.noResultsTitle, subtitle: searchQuery, image: Constants.imageName)
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -528,9 +528,9 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
     [self.noResultsViewController removeFromView];
 
     // If loading, show an animation.
-    WPAnimatedBox *accessoryView = nil;
+    UIView *accessoryView = nil;
     if ([title isEqualToString:[self noResultsLoadingTitle]]) {
-        accessoryView = [[WPAnimatedBox alloc] init];
+        accessoryView = [NoResultsViewController loadingAccessoryView];
     }
 
     [self.noResultsViewController configureWithTitle:title

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -21,8 +21,6 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
     // MARK: - GUI
 
-    fileprivate let animatedBox = WPAnimatedBox()
-
     @IBOutlet weak var filterTabBarTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var filterTabBariOS10TopConstraint: NSLayoutConstraint!
     @IBOutlet weak var filterTabBarBottomConstraint: NSLayoutConstraint!
@@ -600,18 +598,12 @@ private extension PageListViewController {
             return
         }
 
+        let accessoryView = syncHelper.isSyncing ? NoResultsViewController.loadingAccessoryView() : nil
+
         noResultsViewController.configure(title: noResultsTitle(),
                                           buttonTitle: noResultsButtonTitle(),
                                           image: noResultsImageName,
-                                          accessoryView: noResultsAccessoryView())
-    }
-
-    func noResultsAccessoryView() -> UIView? {
-        if syncHelper.isSyncing {
-            return animatedBox
-        }
-
-        return nil
+                                          accessoryView: accessoryView)
     }
 
     var noResultsImageName: String {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -51,10 +51,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     @IBOutlet weak var filterTabBarBottomConstraint: NSLayoutConstraint!
     @IBOutlet weak var tableViewTopConstraint: NSLayoutConstraint!
 
-    // MARK: - GUI
-
-    fileprivate let animatedBox = WPAnimatedBox()
-
     // MARK: - Convenience constructors
 
     @objc class func controllerWithBlog(_ blog: Blog) -> PostListViewController {
@@ -599,18 +595,12 @@ private extension PostListViewController {
             return
         }
 
+        let accessoryView = syncHelper.isSyncing ? NoResultsViewController.loadingAccessoryView() : nil
+
         noResultsViewController.configure(title: noResultsTitle(),
                                           buttonTitle: noResultsButtonTitle(),
                                           image: noResultsImageName,
-                                          accessoryView: noResultsAccessoryView())
-    }
-
-    func noResultsAccessoryView() -> UIView? {
-        if syncHelper.isSyncing {
-            return animatedBox
-        }
-
-        return nil
+                                          accessoryView: accessoryView)
     }
 
     var noResultsImageName: String {

--- a/WordPress/Classes/ViewRelated/Tools/TimeZoneSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/TimeZoneSelectorViewController.swift
@@ -82,7 +82,7 @@ struct TimeZoneSelectorViewModel: Observable {
     var noResultsViewModel: NoResultsViewController.Model? {
         switch state {
         case .loading:
-            return NoResultsViewController.Model(title: LocalizedText.loadingTitle, accessoryView: noResultsAccessoryView())
+            return NoResultsViewController.Model(title: LocalizedText.loadingTitle, accessoryView: NoResultsViewController.loadingAccessoryView())
         case .ready:
             return nil
         case .error:
@@ -96,11 +96,6 @@ struct TimeZoneSelectorViewModel: Observable {
                                                      subtitle: LocalizedText.noConnectionSubtitle)
             }
         }
-    }
-
-    func noResultsAccessoryView() -> UIView {
-        let animatedBox = WPAnimatedBox()
-        return animatedBox
     }
 
     struct LocalizedText {


### PR DESCRIPTION
Ref #9504

In a [previous PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/10011), I added the class method `NoResultsViewController:loadingAccessoryView` so each VC wouldn't have to create a `WPAnimatedBox`. This PR updates relevant VCs to use this method.

NOTE: I noticed the loading view on Site Tags is vertically off-center. I'll fix that in a separate PR.

To test:
On a slow network, access each of these loading views. Verify the animated box still appears.
- [ ] Site Settings > Site Tags
- [ ] Media Library
- [ ] Menus
- [ ] Site Pages
- [ ] Blog Posts
- [ ] Site Settings > Time Zone

