### PR TITLE
Site Tags: Adjusting the No Results View to always be vertically centered.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -413,11 +413,8 @@ private extension SiteTagsViewController {
         addChildViewController(noResultsViewController)
         noResultsViewController.view.frame = tableView.frame
 
-        // If the refreshControl is showing, move the NRV up so the contents appear centered in the view.
-        if let refreshControl = refreshControl,
-            refreshControl.isHidden == false {
-            noResultsViewController.view.frame.origin.y -= refreshControl.frame.height
-        }
+        // Since the tableView doesn't always start at the top, adjust the NRV accordingly.
+        noResultsViewController.view.frame.origin.y = 0
 
         tableView.addSubview(withFadeAnimation: noResultsViewController.view)
         noResultsViewController.didMove(toParentViewController: self)


### PR DESCRIPTION
Ref #9947

In Site Settings > Tags, the loading view was not vertically centered. This addresses that.

![offcenter](https://user-images.githubusercontent.com/1816888/45123060-eb54ae80-b122-11e8-9c73-746243fbad92.png)


**To test:**
On a slow network, go to Site Settings > Tags. Verify the loading view is vertically centered:

![fixed](https://user-images.githubusercontent.com/1816888/45123107-0aebd700-b123-11e8-9c1e-20a1bb1d462d.png)




