### PR TITLE
Fix a crash when generating credentials

### DIFF
--- a/WordPress/WordPressUITests/gencredentials.rb
+++ b/WordPress/WordPressUITests/gencredentials.rb
@@ -24,7 +24,16 @@ def extract_variables()
   variables = {}
   get_file().each_line do |l|
     k, v = l.split("=")
-    variables[k] = v.chomp
+
+    if k == nil or k.strip.empty?
+        next
+    end
+
+    if v != nil
+        variables[k] = v.chomp
+    else
+        variables[k] = ""
+    end
   end
   variables
 end


### PR DESCRIPTION
If a user has a configuration file that looks like:

`key=` (no space following the `=`)

the script crashes, as there’s no second element.

This fixes that issue.

One side-effect: blank lines aren’t preserved when generating the output .swift file.

**To test:** 

Try adding a key in your ~/.wp_com_test_credentials (or similar file) that looks like:

`foo=` (no space after the equals sign).

That'll cause a crash.

Run it with this patch, and it'll just add the key with an empty value.

