### PR TITLE
Fix duplicate prime for push request

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -109,7 +109,6 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
 
         setupNavigationBar()
         setupTableView()
-        setupInlinePrompt()
         setupTableHeaderView()
         setupTableFooterView()
         setupConstraints()
@@ -123,6 +122,8 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        setupInlinePrompt()
 
         // Manually deselect the selected row. 
         if splitViewControllerIsHorizontallyCompact {


### PR DESCRIPTION
Fixes this error: when logging in, a push notification primer is displayed. If notifications are allowed, the primer at the top of the notification tab is still shown.

This PR hides that second primer in this case.

![fix inline primer teaser](https://user-images.githubusercontent.com/517257/45138817-a5b7d600-b162-11e8-83bd-a6906a332585.jpg)

To test:
- remove and reinstall the app
- login to wpcom
- when the notification primer appears, Allow Notifications > Allow
- switch to the notifications tab
- ensure the primer is NOT shown

