### PR TITLE
Add direct download button to HockeyApp dialog

### DIFF
--- a/WordPress/Classes/Utility/HockeyManager.m
+++ b/WordPress/Classes/Utility/HockeyManager.m
@@ -17,7 +17,8 @@
                                                            delegate:self];
     [[BITHockeyManager sharedHockeyManager].authenticator setIdentificationType:BITAuthenticatorIdentificationTypeDevice];
     [[BITHockeyManager sharedHockeyManager] setDisableCrashManager: YES]; //disable crash reporting
-    [[BITHockeyManager sharedHockeyManager].updateManager setUpdateSetting: BITUpdateCheckDaily]; // Sets up daily notifications on notmandatory updates
+    [[BITHockeyManager sharedHockeyManager].updateManager setUpdateSetting: BITUpdateCheckDaily]; // Set up daily notifications on notmandatory updates
+    [[BITHockeyManager sharedHockeyManager].updateManager setShowDirectInstallOption: true]; // Show the "direct update" button in the update dialog
     [[BITHockeyManager sharedHockeyManager] startManager];
     [[BITHockeyManager sharedHockeyManager].authenticator authenticateInstallation];
 }


### PR DESCRIPTION
This PR solves https://github.com/wordpress-mobile/WordPress-iOS/issues/9942 by adding the "Install" button to the HockeyApp Update dialog. 
The updated dialog now have Install, View details and Ignore options. 

### To test
The relevant part of the HockeyApp SDK is documented [here](https://hockeyapp.net/help/sdk/ios/5.1.2/Classes/BITUpdateManager.html#/c:objc(cs)BITUpdateManager(py)showDirectInstallOption).

In order to test:
1. change the App internal version in the _xcconfig_ file  to something older (so that the update manager will show the dialog);
2. build and run the `Release-Internal` configuration ;
3. open the app and verify that all the three options are offered in the dialog.

@koke can I ask you to tackle this small review?
