### PR TITLE
Update SearchAdsAttribution logic

### DIFF
--- a/WordPress/Classes/Utility/iAds/SearchAdsAttribution.swift
+++ b/WordPress/Classes/Utility/iAds/SearchAdsAttribution.swift
@@ -26,6 +26,7 @@ import AutomatticTracks
     private static let userDefaultsLimitedAdTrackingKey = "search_ads_limited_tracking"
 
     private let searchAdsApiVersion = "Version3.1"
+    private let searchAdsAttributionKey = "iad_attribution"
 
     /// Is ad tracking limited?
     /// If the user has limited ad tracking, and this API won't return data
@@ -87,10 +88,23 @@ import AutomatticTracks
         guard let details = details?[searchAdsApiVersion] as? [String: Any] else {
             return
         }
-        let parameters = sanitize(details)
 
-        WPAnalytics.track(.searchAdsAttribution, withProperties: parameters)
+        sendAttributionDetailsToTracksIfNeeded(sanitize(details))
         isAttributionDetailsSent = true
+    }
+
+    /// Send SearchAds data to Tracks if needed
+    ///
+    private func sendAttributionDetailsToTracksIfNeeded(_ parameters: [String: Any]) {
+        guard let didTapSearchAd = parameters[searchAdsAttributionKey] as? String else {
+            return
+        }
+
+        // Only send SearchAds attribution details to Tracks if the "iad_attribution" parameter is true (which means
+        // the user actually tapped on a SearchAd within the last 30 days).
+        if didTapSearchAd.lowercased() == "true" {
+            WPAnalytics.track(.searchAdsAttribution, withProperties: parameters)
+        }
     }
 
     /// Fix key format to send to Tracks


### PR DESCRIPTION
This PR updates when SearchAds attribution data is sent to Tracks. Currently, we send attribution data even if the user did not tap on a SearchAd. Now with this update, we will only send Tracks the data if the user actually taps on a SearchAd (determined be inspecting the `iad_attribution` param — see the issue for more details 👇 ).

Fixes #10133

**To test:**

* Make sure the app builds and runs
* Inspect my logic thoroughly 😄 

_Testing beyond this may be a little difficult because of the new filtering put in place on the `wpios_searchads_attribution_detail_received` event._ 

@etoledom Would you mind taking a quick peek at this! Thank you!!!!

/cc @loremattei 


