### PR TITLE
Fix Login Crash: Revert WordPressUI to 1.0.7

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -76,7 +76,7 @@ target 'WordPress' do
     pod 'WPMediaPicker', '1.3'
     pod 'WordPressAuthenticator', '1.0.6'
     aztec
-    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '0456236d5b6d71ce8a93f988c27bcdc2eb0835d6'
+    pod 'WordPressUI', '1.0.7'
 
     target 'WordPressTest' do
         inherit! :search_paths
@@ -95,7 +95,7 @@ target 'WordPress' do
         shared_with_all_pods
         shared_with_networking_pods
         aztec
-        pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '0456236d5b6d71ce8a93f988c27bcdc2eb0835d6'
+        pod 'WordPressUI', '1.0.7'
         pod 'Gridicons', '0.16'
     end
 
@@ -109,7 +109,7 @@ target 'WordPress' do
         shared_with_all_pods
         shared_with_networking_pods
         aztec
-        pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '0456236d5b6d71ce8a93f988c27bcdc2eb0835d6'
+        pod 'WordPressUI', '1.0.7'
         pod 'Gridicons', '0.16'
     end
 
@@ -132,11 +132,11 @@ end
 ##
 target 'WordPressNotificationContentExtension' do
     project 'WordPress/WordPress.xcodeproj'
-    
+
     inherit! :search_paths
-    
+
     pod 'WordPressShared', '1.0.10'
-    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '0456236d5b6d71ce8a93f988c27bcdc2eb0835d6' 
+    pod 'WordPressUI', '1.0.7'
 end
 
 
@@ -146,13 +146,13 @@ end
 ##
 target 'WordPressNotificationServiceExtension' do
     project 'WordPress/WordPress.xcodeproj'
-    
+
     inherit! :search_paths
 
     pod 'Gridicons', '0.16'
     pod 'WordPressKit', '1.4.0-beta.3'
     pod 'WordPressShared', '1.0.10'
-    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '0456236d5b6d71ce8a93f988c27bcdc2eb0835d6'
+    pod 'WordPressUI', '1.0.7'
 end
 
 
@@ -169,7 +169,7 @@ target 'WordPressComStatsiOS' do
     ## Automattic libraries
     ## ====================
     ##
-    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '0456236d5b6d71ce8a93f988c27bcdc2eb0835d6'
+    pod 'WordPressUI', '1.0.7'
 
     target 'WordPressComStatsiOSTests' do
         inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -173,7 +173,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (= 1.0.6)
   - WordPressKit (= 1.4.0-beta.3)
   - WordPressShared (= 1.0.10)
-  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `0456236d5b6d71ce8a93f988c27bcdc2eb0835d6`)
+  - WordPressUI (= 1.0.7)
   - WPMediaPicker (= 1.3)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 2.1.0)
@@ -211,6 +211,7 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
+    - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
@@ -219,17 +220,11 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  WordPressUI:
-    :commit: 0456236d5b6d71ce8a93f988c27bcdc2eb0835d6
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  WordPressUI:
-    :commit: 0456236d5b6d71ce8a93f988c27bcdc2eb0835d6
-    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -269,6 +264,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: e2d9245bc42fb4782eff959219ce4d6bdae13b64
 
-PODFILE CHECKSUM: 9becfc61dfcad2a32fb6339f45bbb0ce993fbfc5
+PODFILE CHECKSUM: a04814a769ee237200505203f7f6c58c6d1ed913
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -93,7 +93,7 @@ extension EpilogueUserInfoCell: GravatarUploader {
         gravatarStatus = status
         switch status {
         case .uploading(image: let newImage):
-            gravatarView.updateGravatar(image: newImage, email: email)
+            gravatarView.image = newImage
             gravatarActivityIndicator.startAnimating()
         case .idle, .finished:
             gravatarActivityIndicator.stopAnimating()


### PR DESCRIPTION
Fixes #10137.

After some investigation, it turns out that gravatar changes introduced since 1.0.7 were causing a crash on launch. I narrowed down the issue to here, where we override `UIImageView`'s `removeFromSuperview()` method: https://github.com/wordpress-mobile/WordPressUI-iOS/blob/develop/WordPressUI/Extensions/UIImageView%2BGravatar.swift#L82

I guess this has two issues – 1) it doesn't call the `super` implementation, but also 2) because it's an extension and not a subclass it also knocks out whatever `UIImageView`'s implementation of that method is.

We'll have to find an alternative solution to unregistering from notifications – I guess potentially swizzling out that method and ensuring we also call the original could work. cc @nheagy.

For now, I'm reverting this change, to fix the crash.

**To test:**

* Build and run WPiOS (clean install)
* Attempt a login. Perhaps try a few accounts, as it didn't crash with every account I tried.
* After logging in, you should see the login epilogue, with no crash.