### PR TITLE
Update WordPressKit to 1.4.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ def shared_with_networking_pods
     pod 'AFNetworking', '3.2.1'
     pod 'Alamofire', '4.7.2'
     pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', '1.4.0-beta.3'
+    pod 'WordPressKit', '1.4.0'
 end
 
 def shared_test_pods
@@ -150,7 +150,7 @@ target 'WordPressNotificationServiceExtension' do
     inherit! :search_paths
 
     pod 'Gridicons', '0.16'
-    pod 'WordPressKit', '1.4.0-beta.3'
+    pod 'WordPressKit', '1.4.0'
     pod 'WordPressShared', '1.0.10'
     pod 'WordPressUI', '1.0.7'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -120,7 +120,7 @@ PODS:
     - WordPressShared (~> 1.0)
     - WordPressUI (~> 1.0)
     - wpxmlrpc (~> 0.8)
-  - WordPressKit (1.4.0-beta.3):
+  - WordPressKit (1.4.0):
     - Alamofire (~> 4.7)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -171,7 +171,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Editor-iOS (= 1.0.0)
   - WordPressAuthenticator (= 1.0.6)
-  - WordPressKit (= 1.4.0-beta.3)
+  - WordPressKit (= 1.4.0)
   - WordPressShared (= 1.0.10)
   - WordPressUI (= 1.0.7)
   - WPMediaPicker (= 1.3)
@@ -257,13 +257,13 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: cea2bedf9b807d862ad331a080c98292e355f144
   WordPress-Editor-iOS: c997f66a110cdee3317ccaaa5e6b2a09a2e5444a
   WordPressAuthenticator: 56538a229185640b41912c10c3f1891c2cc9bbb9
-  WordPressKit: f392054a3938f794374498c4eb56baf8caa7ae9c
+  WordPressKit: 5d4b9840aed4329d61b3efbe40714c9dce719309
   WordPressShared: 5915565faa46e096016aefed0dc67783afbc323a
   WordPressUI: cfcac4a2a033e3ed5def6504bb8e28447c54423b
   WPMediaPicker: c54791e04af3b41e473e9b340784be48a505bb38
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: e2d9245bc42fb4782eff959219ce4d6bdae13b64
 
-PODFILE CHECKSUM: a04814a769ee237200505203f7f6c58c6d1ed913
+PODFILE CHECKSUM: 8afea31f17d9306e43a925e749aed28f9ec50bbc
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
This PR updates WordPressKit to the latest release 1.4.0.
There's no change in the pod itself from the latest beta 3 (just pushing to an official release before WPiOS code freeze).

To Test:
 - update the pods;
 - check that Podfile.lock doesn't change
 - verify that the build has no error.


