### PR TITLE
Updates Aztec to 1.0.1.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -37,7 +37,7 @@ def aztec
     ## When using a commit number (during development) you should provide the same commit number for both pods.
     ##
     ## pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '14846f9550e24993d61d24df76cee84f3363ee91'
-    pod 'WordPress-Editor-iOS', '1.0.0'
+    pod 'WordPress-Editor-iOS', '1.0.1'
 end
 
 ## WordPress iOS

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -103,9 +103,9 @@ PODS:
   - Starscream (3.0.4)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.0)
-  - WordPress-Editor-iOS (1.0.0):
-    - WordPress-Aztec-iOS (= 1.0.0)
+  - WordPress-Aztec-iOS (1.0.1)
+  - WordPress-Editor-iOS (1.0.1):
+    - WordPress-Aztec-iOS (= 1.0.1)
   - WordPressAuthenticator (1.0.6):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.2)
@@ -169,7 +169,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.4)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Editor-iOS (= 1.0.0)
+  - WordPress-Editor-iOS (= 1.0.1)
   - WordPressAuthenticator (= 1.0.6)
   - WordPressKit (= 1.4.0)
   - WordPressShared (= 1.0.10)
@@ -254,8 +254,8 @@ SPEC CHECKSUMS:
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: cea2bedf9b807d862ad331a080c98292e355f144
-  WordPress-Editor-iOS: c997f66a110cdee3317ccaaa5e6b2a09a2e5444a
+  WordPress-Aztec-iOS: 17508c8438fbd9f5733f518500a2f8f2fc3dbadc
+  WordPress-Editor-iOS: 4b3495b53e5392f93b5c8c7435296a6f13142586
   WordPressAuthenticator: 56538a229185640b41912c10c3f1891c2cc9bbb9
   WordPressKit: 5d4b9840aed4329d61b3efbe40714c9dce719309
   WordPressShared: 5915565faa46e096016aefed0dc67783afbc323a
@@ -264,6 +264,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: e2d9245bc42fb4782eff959219ce4d6bdae13b64
 
-PODFILE CHECKSUM: 8afea31f17d9306e43a925e749aed28f9ec50bbc
+PODFILE CHECKSUM: 90740a6add92889023a6b670dd88a778abb5c812
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Integrates Aztec v1.0.1 into WPiOS.

This release fixes [an issue which was causing edits to Gutenberg posts to be lost](https://github.com/wordpress-mobile/WordPress-iOS/issues/10135).
Make sure that editing a Gutenberg post, and adding text to it, works.