### PR TITLE
Update the new extensions plists to get the common bundle versions

### DIFF
--- a/WordPress/WordPressNotificationContentExtension/Info-Alpha.plist
+++ b/WordPress/WordPressNotificationContentExtension/Info-Alpha.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>${VERSION_SHORT}</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>${VERSION_LONG}</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/WordPress/WordPressNotificationContentExtension/Info-Internal.plist
+++ b/WordPress/WordPressNotificationContentExtension/Info-Internal.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>${VERSION_SHORT}</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>${VERSION_LONG}</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/WordPress/WordPressNotificationContentExtension/Info.plist
+++ b/WordPress/WordPressNotificationContentExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>${VERSION_SHORT}</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>${VERSION_LONG}</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>

--- a/WordPress/WordPressNotificationServiceExtension/Info-Alpha.plist
+++ b/WordPress/WordPressNotificationServiceExtension/Info-Alpha.plist
@@ -17,9 +17,9 @@
         <key>CFBundlePackageType</key>
         <string>XPC!</string>
         <key>CFBundleShortVersionString</key>
-        <string>1.0</string>
+        <string>${VERSION_SHORT}</string>
         <key>CFBundleVersion</key>
-        <string>1</string>
+        <string>${VERSION_LONG}</string>
         <key>NSExtension</key>
         <dict>
             <key>NSExtensionPointIdentifier</key>

--- a/WordPress/WordPressNotificationServiceExtension/Info-Internal.plist
+++ b/WordPress/WordPressNotificationServiceExtension/Info-Internal.plist
@@ -17,9 +17,9 @@
         <key>CFBundlePackageType</key>
         <string>XPC!</string>
         <key>CFBundleShortVersionString</key>
-        <string>1.0</string>
+        <string>${VERSION_SHORT}</string>
         <key>CFBundleVersion</key>
-        <string>1</string>
+        <string>${VERSION_LONG}</string>
         <key>NSExtension</key>
         <dict>
             <key>NSExtensionPointIdentifier</key>

--- a/WordPress/WordPressNotificationServiceExtension/Info.plist
+++ b/WordPress/WordPressNotificationServiceExtension/Info.plist
@@ -17,9 +17,9 @@
         <key>CFBundlePackageType</key>
         <string>XPC!</string>
         <key>CFBundleShortVersionString</key>
-        <string>1.0</string>
+        <string>${VERSION_SHORT}</string>
         <key>CFBundleVersion</key>
-        <string>1</string>
+        <string>${VERSION_LONG}</string>
         <key>NSExtension</key>
         <dict>
             <key>NSExtensionPointIdentifier</key>


### PR DESCRIPTION
This PR updates the plists files of WordPressNotificationContentExtension and WordPressNotificationServiceExtension to make them use the VERSION_SHORT and VERSION_LONG variables to get the bundle version strings.

## To Test:
Build the project from scratch and verify that no error is raised. 


