### PR TITLE
Aztec Async Promo: Update strings for scheduling and for pages

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1212,6 +1212,8 @@ extension AztecPostViewController {
             return
         }
 
+        let isPage = post is Page
+
         let publishBlock = { [unowned self] in
             if action == .save || action == .saveAsDraft {
                 self.post.status = .draft
@@ -1246,7 +1248,7 @@ extension AztecPostViewController {
         let promoBlock = { [unowned self] in
             UserDefaults.standard.asyncPromoWasDisplayed = true
 
-            let controller = FancyAlertViewController.makeAsyncPostingAlertController(publishAction: publishBlock)
+            let controller = FancyAlertViewController.makeAsyncPostingAlertController(action: action, isPage: isPage, onConfirm: publishBlock)
             controller.modalPresentationStyle = .custom
             controller.transitioningDelegate = self
             self.present(controller, animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+Async.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+Async.swift
@@ -1,31 +1,59 @@
 import UIKit
 import SafariServices
 
+private protocol AlertStrings {
+    static var titleText: String { get }
+    static var bodyText: String { get }
+    static var confirmTitle: String { get }
+}
+
 extension FancyAlertViewController {
 
     typealias ButtonConfig = FancyAlertViewController.Config.ButtonConfig
 
-    private struct Strings {
+    private struct PublishPostStrings: AlertStrings {
         static let titleText = NSLocalizedString("Publish with Confidence", comment: "Title of alert informing users about the async publishing feature.")
         static let bodyText = NSLocalizedString("You can now leave the editor and your post will save and publish behind the scenes! Give it a try!", comment: "Body text of alert informing users about the async publishing feature.")
-        static let publishNow = NSLocalizedString("Publish Now", comment: "Publish button shown in alert informing users about the async publishing feature.")
-        static let keepEditing = NSLocalizedString("Keep Editing", comment: "Button title shown in alert informing users about the async publishing feature.")
-        static let moreHelp = NSLocalizedString("How does it work?", comment: "Title of the more help button on alert helping users understand their site address")
+        static let confirmTitle = NSLocalizedString("Publish Now", comment: "Publish button shown in alert informing users about the async publishing feature.")
     }
 
-    static func makeAsyncPostingAlertController(publishAction: @escaping (() -> Void)) -> FancyAlertViewController {
+    private struct SchedulePostStrings: AlertStrings {
+        static let titleText = NSLocalizedString("Schedule with Confidence", comment: "Title of alert informing users about the async publishing feature, when scheduling a post.")
+        static let bodyText = NSLocalizedString("You can now leave the editor and your post will save and schedule behind the scenes! Give it a try!", comment: "Body text of alert informing users about the async publishing feature, when scheduling a post.")
+        static let confirmTitle = NSLocalizedString("Schedule Now", comment: "Schedule button shown in alert informing users about the async publishing feature.")
+    }
 
-        let publishButton = ButtonConfig(Strings.publishNow) { controller, _ in
+    private struct PublishPageStrings: AlertStrings {
+        static let titleText = NSLocalizedString("Publish with Confidence", comment: "Title of alert informing users about the async publishing feature.")
+        static let bodyText = NSLocalizedString("You can now leave the editor and your page will save and publish behind the scenes! Give it a try!", comment: "Body text of alert informing users about the async publishing feature, when publishing a page.")
+        static let confirmTitle = NSLocalizedString("Publish Now", comment: "Publish button shown in alert informing users about the async publishing feature.")
+    }
+
+    private struct SchedulePageStrings: AlertStrings {
+        static let titleText = NSLocalizedString("Schedule with Confidence", comment: "Title of alert informing users about the async publishing feature, when scheduling a page.")
+        static let bodyText = NSLocalizedString("You can now leave the editor and your page will save and schedule behind the scenes! Give it a try!", comment: "Body text of alert informing users about the async publishing feature, when scheduling a page.")
+        static let confirmTitle = NSLocalizedString("Schedule Now", comment: "Schedule button shown in alert informing users about the async publishing feature.")
+    }
+
+    private struct GeneralStrings {
+        static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Button title shown in alert informing users about the async publishing feature.")
+        static let moreHelpTitle = NSLocalizedString("How does it work?", comment: "Title of the more help button on alert helping users understand their site address")
+    }
+
+    static func makeAsyncPostingAlertController(action: PostEditorAction, isPage: Bool, onConfirm: @escaping (() -> Void)) -> FancyAlertViewController {
+        let strings = self.strings(for: action, isPage: isPage)
+
+        let confirmButton = ButtonConfig(strings.confirmTitle) { controller, _ in
             controller.dismiss(animated: true, completion: {
-                publishAction()
+                onConfirm()
             })
         }
 
-        let dismissButton = ButtonConfig(Strings.keepEditing) { controller, _ in
+        let dismissButton = ButtonConfig(GeneralStrings.keepEditingTitle) { controller, _ in
             controller.dismiss(animated: true, completion: nil)
         }
 
-        let moreHelpButton = ButtonConfig(Strings.moreHelp) { controller, _ in
+        let moreHelpButton = ButtonConfig(GeneralStrings.moreHelpTitle) { controller, _ in
             guard let url = URL(string: "http://en.blog.wordpress.com/2018/04/23/ios-nine-point-eight/") else {
                 return
             }
@@ -37,11 +65,11 @@ extension FancyAlertViewController {
 
         let image = UIImage(named: "wp-illustration-easy-async")
 
-        let config = FancyAlertViewController.Config(titleText: Strings.titleText,
-                                                     bodyText: Strings.bodyText,
+        let config = FancyAlertViewController.Config(titleText: strings.titleText,
+                                                     bodyText: strings.bodyText,
                                                      headerImage: image,
                                                      dividerPosition: .bottom,
-                                                     defaultButton: publishButton,
+                                                     defaultButton: confirmButton,
                                                      cancelButton: dismissButton,
                                                      moreInfoButton: moreHelpButton,
                                                      titleAccessoryButton: nil,
@@ -49,6 +77,19 @@ extension FancyAlertViewController {
 
         let controller = FancyAlertViewController.controllerWithConfiguration(configuration: config)
         return controller
+    }
+
+    private static func strings(for action: PostEditorAction, isPage: Bool) -> AlertStrings.Type {
+        switch (action, isPage) {
+        case (.schedule, true):
+            return SchedulePageStrings.self
+        case (.schedule, false):
+            return SchedulePostStrings.self
+        case (_, true):
+            return PublishPageStrings.self
+        case (_, false):
+            return PublishPostStrings.self
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #10068. This PR introduces slightly different strings for the Aztec 'async publishing' promo screen when scheduling posts and when working with pages.

![simulator screen shot - iphone 8 - 2018-09-12 at 14 20 11](https://user-images.githubusercontent.com/4780/45428432-1dbd5900-b699-11e8-848f-4cebff6aa358.png)
![simulator screen shot - iphone 8 - 2018-09-12 at 14 20 26](https://user-images.githubusercontent.com/4780/45428433-1dbd5900-b699-11e8-9ad6-37d4c558c29f.png)
![simulator screen shot - iphone 8 - 2018-09-12 at 14 20 43](https://user-images.githubusercontent.com/4780/45428434-1dbd5900-b699-11e8-845f-8f139e96fbf3.png)
![simulator screen shot - iphone 8 - 2018-09-12 at 14 20 52](https://user-images.githubusercontent.com/4780/45428435-1dbd5900-b699-11e8-90b7-f6d4aaa04161.png)

**To test:**

* Update the `UserDefaults.standard.asyncPromoWasDisplayed` check at the end of `publishPost:action:dismissWhenDone:analyticsStat:` in `AztecPostViewController` so that the promo is always shown – this'll make testing easier!
* Build and run

**Publishing a post**
* Start a new post. Tap Publish, and check the promo reads correctly. It should reference publishing a post.

**Scheduling a post**
* Start a new post. In Post Settings, change the date to the future. Tap Schedule, and check the promo reads correctly. It should reference scheduling a post.

**Publishing a page**
* Start a new **page**. Tap Publish, and check the promo reads correctly. It should reference publishing a page.

**Scheduling a page**
* Start a new **page**. In Post Settings, change the date to the future. Tap Schedule, and check the promo reads correctly. It should reference scheduling a page.