### PR TITLE
Make sure that we don't accidentally overlay multiple accessory views in NoResultsViewController.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -241,6 +241,7 @@ private extension NoResultsViewController {
         }
 
         if let accessorySubview = accessorySubview {
+            accessoryView.subviews.forEach { $0.removeFromSuperview() }
             accessoryView.addSubview(accessorySubview)
         }
 


### PR DESCRIPTION
I came across this while playing around with the iPhone Xs Max simulator — I noticed that fans in my MBP started going wild and tracked it down to a `WPAnimatedBox` doing it's thing again.

During debugging I noticed that the culprit was an orphaned WPAnimatedBox, that didn't have any parents other than the superview holding it. I _think_ I tracked _that_ down to `ReaderStreamViewController` reusing the same NRVC when displaying the loading animation, but I haven't been able to reproduce it since 😬 .

Nonetheless, I think this still is an obvious improvement: currently, we were never removing "old" `accessoryViews` when `configure()`ing a NRVS — this helps clean this up!