### PR TITLE
Issue/10069 autosave drafts

### DIFF
--- a/WordPress/Classes/Utility/Debouncer.swift
+++ b/WordPress/Classes/Utility/Debouncer.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+//From : https://github.com/webadnan/swift-debouncer
+
+final class Debouncer {
+    var callback: (() -> Void)?
+    var delay: Double
+    weak var timer: Timer?
+    
+    init(delay: Double, callback: (() -> Void)? = nil) {
+        self.delay = delay
+        self.callback = callback
+    }
+    
+    func call() {
+        timer?.invalidate()
+        let nextTimer = Timer.scheduledTimer(timeInterval: delay, target: self, selector: #selector(Debouncer.fireNow), userInfo: nil, repeats: false)
+        timer = nextTimer
+    }
+    
+    @objc func fireNow() {
+        self.callback?()
+    }
+}
+

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1043,7 +1043,6 @@ extension AztecPostViewController {
             generator.notificationOccurred(.error)
         } else if let uploadedPost = post {
             self.post = uploadedPost
-            
             generator.notificationOccurred(.success)
         }
         
@@ -1316,13 +1315,19 @@ extension AztecPostViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         mapUIContentToPostAndSave()
         refreshPlaceholderVisibility()
-        shouldAutoSave = true
-        autoSaveDebouncer.call()
-        autoSaveDebouncer.callback = { [weak self] in
-            self?.publishPost() { [weak self] uploadedPost, error in
-                self?.publishPostCompletion(dismissWhenDone: false, post: uploadedPost, error)
+        if post.hasLocalChanges() && textView.text.count > 1 {
+            if !post.hasRemote() {
+                post.status = .draft
+                shouldAutoSave = true
+                autoSaveDebouncer.call()
+                autoSaveDebouncer.callback = { [weak self] in
+                    self?.publishPost() { [weak self] uploadedPost, error in
+                        self?.publishPostCompletion(dismissWhenDone: false, post: uploadedPost, error)
+                    }
+                }
             }
         }
+
         switch textView {
         case titleTextField:
             updateTitleHeight()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
 		296890780FE971DC00770264 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296890770FE971DC00770264 /* Security.framework */; };
+		2F2A4B5F214786E4007BE67E /* Debouncer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F2A4B5E214786E4007BE67E /* Debouncer.swift */; };
 		2FAE97090E33B21600CA8540 /* defaultPostTemplate_old.html in Resources */ = {isa = PBXBuildFile; fileRef = 2FAE97040E33B21600CA8540 /* defaultPostTemplate_old.html */; };
 		2FAE970C0E33B21600CA8540 /* xhtml1-transitional.dtd in Resources */ = {isa = PBXBuildFile; fileRef = 2FAE97070E33B21600CA8540 /* xhtml1-transitional.dtd */; };
 		2FAE970D0E33B21600CA8540 /* xhtmlValidatorTemplate.xhtml in Resources */ = {isa = PBXBuildFile; fileRef = 2FAE97080E33B21600CA8540 /* xhtmlValidatorTemplate.xhtml */; };
@@ -1230,6 +1231,7 @@
 		292CECFF1027259000BD407D /* SFHFKeychainUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFHFKeychainUtils.m; sourceTree = "<group>"; };
 		296890770FE971DC00770264 /* Security.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		2F2A4B5E214786E4007BE67E /* Debouncer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debouncer.swift; sourceTree = "<group>"; };
 		2F970F970DF929B8006BD934 /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		2FAE97040E33B21600CA8540 /* defaultPostTemplate_old.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = defaultPostTemplate_old.html; path = Resources/HTML/defaultPostTemplate_old.html; sourceTree = "<group>"; };
 		2FAE97070E33B21600CA8540 /* xhtml1-transitional.dtd */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; name = "xhtml1-transitional.dtd"; path = "Resources/HTML/xhtml1-transitional.dtd"; sourceTree = "<group>"; };
@@ -3536,6 +3538,7 @@
 				85B125431B02937E008A3D95 /* UIAlertControllerProxy.h */,
 				85B125441B02937E008A3D95 /* UIAlertControllerProxy.m */,
 				E12E6E321C21BA170033C5D0 /* FeatureFlag.swift */,
+				2F2A4B5E214786E4007BE67E /* Debouncer.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -6419,6 +6422,7 @@
 				E14200781C117A2E00B3B115 /* ManagedAccountSettings.swift in Sources */,
 				08B6D6F31C8F7DCE0052C52B /* PostType.m in Sources */,
 				59A9AB351B4C33A500A433DC /* ThemeService.m in Sources */,
+				2F2A4B5F214786E4007BE67E /* Debouncer.swift in Sources */,
 				5D6C4B111B604190005E3C43 /* NSAttributedString+RichTextView.swift in Sources */,
 				820ADD721F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift in Sources */,
 				82B85DF91EDDB807004FD510 /* SiteIconPickerPresenter.swift in Sources */,


### PR DESCRIPTION
Auto saving drafts

When the user starts editing a post (recognized in textViewDidChange) we check to see if there are any changes to the post and if it has remote (so to save as local draft)
and then if so, we start a debuncer. The debunker will execute a call back in a given delay (500 ms in this case).
the call back is the same code we used for saving and updating a draft when the user tapped (save draft) from the secondary menu. 

Fixes #

To test:


