### PR TITLE
FilterBar style

### DIFF
--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -339,8 +339,8 @@ class FilterTabBar: UIControl {
         selectionIndicatorLeadingConstraint?.isActive = false
         selectionIndicatorTrailingConstraint?.isActive = false
 
-        let leadingConstant = (tabSizingStyle == .equalWidths) ? 0.0 : tab.contentEdgeInsets.left
-        let trailingConstant = (tabSizingStyle == .equalWidths) ? 0.0 : -tab.contentEdgeInsets.right
+        let leadingConstant = (tabSizingStyle == .equalWidths) ? 0.0 : (tab.contentEdgeInsets.left - AppearanceMetrics.buttonInsets.left)
+        let trailingConstant = (tabSizingStyle == .equalWidths) ? 0.0 : (-tab.contentEdgeInsets.right + AppearanceMetrics.buttonInsets.right)
 
         selectionIndicatorLeadingConstraint = selectionIndicator.leadingAnchor.constraint(equalTo: tab.leadingAnchor, constant: leadingConstant)
         selectionIndicatorTrailingConstraint = selectionIndicator.trailingAnchor.constraint(equalTo: tab.trailingAnchor, constant: trailingConstant)
@@ -351,9 +351,9 @@ class FilterTabBar: UIControl {
 
     private enum AppearanceMetrics {
         static let height: CGFloat = 46.0
-        static let bottomDividerHeight: CGFloat = 1.0
+        static let bottomDividerHeight: CGFloat = 0.5
         static let selectionIndicatorHeight: CGFloat = 2.0
-        static let horizontalPadding: CGFloat = 4.0
+        static let horizontalPadding: CGFloat = 0.0
         static let buttonInsets = UIEdgeInsets(top: 14.0, left: 12.0, bottom: 14.0, right: 12.0)
     }
 
@@ -373,7 +373,7 @@ private class TabBarButton: UIButton {
         super.traitCollectionDidChange(previousTraitCollection)
 
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote, maximumPointSize: TabFont.maxSize)
+            titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote, symbolicTraits: .traitBold, maximumPointSize: TabFont.maxSize)
         }
     }
 }


### PR DESCRIPTION
Based on discussion by Ministry of Magic i changed some UI Appearance aspects fo the FilterBar.
These are the changes:
On Filterbar `fitting` mode:
- Bottom divider 0.5 pt
- Selection Indicator width as the whole button width
- No horizontal padding

- Text with bold trait

![filterbar](https://user-images.githubusercontent.com/912252/45692663-3cb56280-bb53-11e8-9433-766701708268.jpg)

@SylvesterWilmott 
