### PR TITLE
Post status as draft even if Pending review was selected

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1215,7 +1215,7 @@ extension AztecPostViewController {
         let isPage = post is Page
 
         let publishBlock = { [unowned self] in
-            if action == .save || action == .saveAsDraft {
+            if action == .saveAsDraft {
                 self.post.status = .draft
             } else if action == .publish {
                 if self.post.date_created_gmt == nil {


### PR DESCRIPTION
**The Bug:**
At the moment, given a Post/Page, if a user select `Pending review` as status from the settings, the Post/Page status is forced to be `draft`.

**Fix:**
The problem was within `AztecPostViewController`, line `1218`. If the context action is `save` or `saveAsDraft` then the post status is `draft`.
Talking also with @diegoreymendez , the solution is:
- `save` should not change the status
- `save as draft` is an explicit action, so it's fine it sets the state to draft

**To test:**
- Change the Post/Page status to `Pending review`

P.S.
I'm not sure if the `save` action forced the status as draft for some reason. If so let me know so I can add some logici within the if statement. 