### PR TITLE
Remove unused method declaration from WPTabBarController.h

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -47,7 +47,6 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 - (void)showMeTab;
 - (void)showNotificationsTab;
 - (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia;
-- (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia blog:(Blog *)blog onClose:(void (^)(void))onClose;
 - (void)showReaderTabForPost:(NSNumber *)postId onBlog:(NSNumber *)blogId;
 - (void)switchMySitesTabToAddNewSite;
 - (void)switchMySitesTabToStatsViewForBlog:(Blog *)blog;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -542,7 +542,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia blog:(Blog *)blog
 {
-    [self showPostTabAnimated:animated toMedia:openToMedia blog:blog onClose:nil];
+    [self showPostTabAnimated:animated toMedia:openToMedia blog:blog afterDismiss:nil];
 }
 
 - (void)showPostTabAnimated:(BOOL)animated toMedia:(BOOL)openToMedia blog:(Blog *)blog afterDismiss:(void (^)(void))afterDismiss


### PR DESCRIPTION
Fixes a warning that my last PR introduced.

Hound and I had a fight, hound died, I assumed that meant I won.

Hound's ghost got the last laugh.

To test:
- build
- find no warnings about `WPTabBarController.h`

