### PR TITLE
Media searches: update no results view

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -82,7 +82,13 @@ target 'WordPress' do
     pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
     pod 'Gridicons', '0.16'
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', '1.3'
+    
+    ## for production:
+    ## pod 'WPMediaPicker', '1.3'
+    ## while PR is in review:
+    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '82f798c0dc18b17a11dfafa37f1fd39eb508b29b'
+    
+
     pod 'WordPressAuthenticator', '1.0.6'
     aztec
     wordpress_ui

--- a/Podfile
+++ b/Podfile
@@ -84,9 +84,9 @@ target 'WordPress' do
     pod 'NSURL+IDN', '0.3'
     
     ## for production:
-    ## pod 'WPMediaPicker', '1.3'
+    pod 'WPMediaPicker', '1.3.1-beta.1'
     ## while PR is in review:
-    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '82f798c0dc18b17a11dfafa37f1fd39eb508b29b'
+    ## pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '82f798c0dc18b17a11dfafa37f1fd39eb508b29b'
     
 
     pod 'WordPressAuthenticator', '1.0.6'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -174,7 +174,7 @@ DEPENDENCIES:
   - WordPressKit (= 1.4.0)
   - WordPressShared (= 1.0.10)
   - WordPressUI (= 1.0.8-beta.2)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `82f798c0dc18b17a11dfafa37f1fd39eb508b29b`)
+  - WPMediaPicker (= 1.3.1-beta.1)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 2.1.0)
 
@@ -212,6 +212,7 @@ SPEC REPOS:
     - WordPressKit
     - WordPressShared
     - WordPressUI
+    - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
 
@@ -219,17 +220,11 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  WPMediaPicker:
-    :commit: 82f798c0dc18b17a11dfafa37f1fd39eb508b29b
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  WPMediaPicker:
-    :commit: 82f798c0dc18b17a11dfafa37f1fd39eb508b29b
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -269,6 +264,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: e2d9245bc42fb4782eff959219ce4d6bdae13b64
 
-PODFILE CHECKSUM: 7540e8c7902e1c0a4f20f6c075fa6f618203048c
+PODFILE CHECKSUM: a48db6045e9bd6cf30b7c9da9f32099ff87a774b
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -131,7 +131,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.0.8-beta.2)
-  - WPMediaPicker (1.3)
+  - WPMediaPicker (1.3.1-beta.1)
   - wpxmlrpc (0.8.3)
   - ZendeskSDK (2.1.0):
     - ZendeskSDK/Providers (= 2.1.0)
@@ -174,7 +174,7 @@ DEPENDENCIES:
   - WordPressKit (= 1.4.0)
   - WordPressShared (= 1.0.10)
   - WordPressUI (= 1.0.8-beta.2)
-  - WPMediaPicker (= 1.3)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `82f798c0dc18b17a11dfafa37f1fd39eb508b29b`)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 2.1.0)
 
@@ -212,7 +212,6 @@ SPEC REPOS:
     - WordPressKit
     - WordPressShared
     - WordPressUI
-    - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
 
@@ -220,11 +219,17 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WPMediaPicker:
+    :commit: 82f798c0dc18b17a11dfafa37f1fd39eb508b29b
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WPMediaPicker:
+    :commit: 82f798c0dc18b17a11dfafa37f1fd39eb508b29b
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -260,10 +265,10 @@ SPEC CHECKSUMS:
   WordPressKit: 5d4b9840aed4329d61b3efbe40714c9dce719309
   WordPressShared: 5915565faa46e096016aefed0dc67783afbc323a
   WordPressUI: 68c3cede2f50fa81d22d7c5e88863a5c4fc00a4d
-  WPMediaPicker: c54791e04af3b41e473e9b340784be48a505bb38
+  WPMediaPicker: 53f40b5af4a4e29880f1a3475ffcea928559c477
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: e2d9245bc42fb4782eff959219ce4d6bdae13b64
 
-PODFILE CHECKSUM: d08615d60b668dfbf99e70a4e11e3869879ca70d
+PODFILE CHECKSUM: 7540e8c7902e1c0a4f20f6c075fa6f618203048c
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3690,10 +3690,8 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, didUpdateSearchWithAssetCount assetCount: Int) {
-        if let searchQuery = mediaLibraryDataSource.searchQuery {
-            noResultsView.removeFromView()
-            noResultsView.configureForNoSearchResult(with: searchQuery)
-        }
+        noResultsView.removeFromView()
+        noResultsView.configureForNoSearchResult()
     }
 
     func mediaPickerControllerWillBeginLoadingData(_ picker: WPMediaPickerViewController) {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -57,5 +57,5 @@ extension BlogDetailsViewController {
             self?.tabBarController?.present(alert, animated: true, completion: nil)
         }
     }
-    
+
 }

--- a/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
@@ -182,10 +182,8 @@ extension SiteIconPickerPresenter: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, didUpdateSearchWithAssetCount assetCount: Int) {
-        if let searchQuery = mediaLibraryDataSource.searchQuery {
-            noResultsView.removeFromView()
-            noResultsView.configureForNoSearchResult(with: searchQuery)
-        }
+        noResultsView.removeFromView()
+        noResultsView.configureForNoSearchResult()
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, shouldShow asset: WPMediaAsset) -> Bool {

--- a/WordPress/Classes/ViewRelated/Media/Giphy/GiphyPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/Giphy/GiphyPicker.swift
@@ -75,7 +75,7 @@ final class GiphyPicker: NSObject {
     private func updateHintView() {
         searchHint.removeFromView()
         if shouldShowNoResults() {
-            NoResultsGiphyConfiguration.configure(searchHint, asNoSearchResultsFor: dataSource.searchQuery)
+            NoResultsGiphyConfiguration.configure(searchHint)
         } else {
             NoResultsGiphyConfiguration.configureAsIntro(searchHint)
         }

--- a/WordPress/Classes/ViewRelated/Media/Giphy/GiphyStrings.swift
+++ b/WordPress/Classes/ViewRelated/Media/Giphy/GiphyStrings.swift
@@ -15,7 +15,7 @@ extension String {
     }
 
     static var giphySearchNoResult: String {
-        return NSLocalizedString("No GIFs match your search for:", comment: "Phrase to show when the user searches for GIFs but there are no result to show. This will be followed by the phrase the user used to search. (i.e. No GIFs match your search for cute kitten). This search phrase will be always appended at the end.")
+        return NSLocalizedString("No media matching your search", comment: "Phrase to show when the user searches for GIFs but there are no result to show.")
     }
 
     static var giphySearchLoading: String {

--- a/WordPress/Classes/ViewRelated/Media/Giphy/NoResultsGiphyConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Media/Giphy/NoResultsGiphyConfiguration.swift
@@ -17,11 +17,8 @@ struct NoResultsGiphyConfiguration {
         viewController.view.layoutIfNeeded()
     }
 
-    static func configure(_ viewController: NoResultsViewController, asNoSearchResultsFor string: String) {
-        viewController.configure(title: .giphySearchNoResult,
-                                 subtitle: string,
-                                 image: Constants.imageName)
-
+    static func configure(_ viewController: NoResultsViewController) {
+        viewController.configureForNoSearchResults(title: .giphySearchNoResult)
         viewController.view.layoutIfNeeded()
     }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -168,7 +168,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             noResultsView.removeFromView()
 
             if hasSearchQuery {
-                noResultsView.configureForNoSearchResult(with: pickerDataSource.searchQuery)
+                noResultsView.configureForNoSearchResult()
             } else {
                 noResultsView.configureForNoAssets(userCanUploadMedia: blog.userCanUploadMedia)
             }

--- a/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
+++ b/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
@@ -12,8 +12,8 @@ extension NoResultsViewController {
         view.layoutIfNeeded()
     }
 
-    @objc func configureForNoSearchResult(with searchQuery: String) {
-        configure(title: LocalizedText.noResultsTitle, subtitle: searchQuery, image: Constants.imageName)
+    @objc func configureForNoSearchResult() {
+        configureForNoSearchResults(title: LocalizedText.noResultsTitle)
     }
 
     private enum Constants {
@@ -24,7 +24,7 @@ extension NoResultsViewController {
         static let noAssetsTitle = NSLocalizedString("You don't have any media.", comment: "Title displayed when the user doesn't have any media in their media library. Should match Calypso.")
         static let uploadButtonTitle = NSLocalizedString("Upload Media", comment: "Title for button displayed when the user has an empty media library")
         static let fetchingTitle = NSLocalizedString("Fetching media...", comment: "Title displayed whilst fetching media from the user's media library")
-        static let noResultsTitle = NSLocalizedString("No media files match your search for:", comment: "Message displayed when no results are returned from a media library search. Should match Calypso.")
+        static let noResultsTitle = NSLocalizedString("No media matching your search", comment: "Message displayed when no results are returned from a media library search. Should match Calypso.")
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Media/Stock Photos/NoResultsStockPhotosConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Media/Stock Photos/NoResultsStockPhotosConfiguration.swift
@@ -24,14 +24,8 @@ struct NoResultsStockPhotosConfiguration {
         viewController.view.layoutIfNeeded()
     }
 
-    static func configure(_ viewController: NoResultsViewController, asNoSearchResultsFor string: String) {
-        viewController.configure(title: .freePhotosSearchNoResult,
-                                 buttonTitle: nil,
-                                 subtitle: string,
-                                 attributedSubtitle: nil,
-                                 image: Constants.imageName,
-                                 accessoryView: nil)
-
+    static func configure(_ viewController: NoResultsViewController) {
+        viewController.configureForNoSearchResults(title: .freePhotosSearchNoResult)
         viewController.view.layoutIfNeeded()
     }
 

--- a/WordPress/Classes/ViewRelated/Media/Stock Photos/StockPhotosPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/Stock Photos/StockPhotosPicker.swift
@@ -78,7 +78,7 @@ final class StockPhotosPicker: NSObject {
     private func updateHintView() {
         searchHint.removeFromView()
         if shouldShowNoResults() {
-            NoResultsStockPhotosConfiguration.configure(searchHint, asNoSearchResultsFor: dataSource.searchQuery)
+            NoResultsStockPhotosConfiguration.configure(searchHint)
         } else {
             NoResultsStockPhotosConfiguration.configureAsIntro(searchHint)
         }

--- a/WordPress/Classes/ViewRelated/Media/Stock Photos/StockPhotosStrings.swift
+++ b/WordPress/Classes/ViewRelated/Media/Stock Photos/StockPhotosStrings.swift
@@ -27,7 +27,7 @@ extension String {
     }
 
     static var freePhotosSearchNoResult: String {
-        return NSLocalizedString("No media files match your search for:", comment: "Phrase to show when the user search for images but there are no result to show. This will be followed by the phrase the user used to search. (i.e. No media files match your search for Ugly kitten). This search phrase will be always appended at the end.")
+        return NSLocalizedString("No media matching your search", comment: "Phrase to show when the user search for images but there are no result to show.")
     }
 
     static var freePhotosSearchLoading: String {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1494,10 +1494,8 @@ FeaturedImageViewControllerDelegate>
 
 - (void)mediaPickerController:(WPMediaPickerViewController *)picker didUpdateSearchWithAssetCount:(NSInteger)assetCount
 {
-    if (self.mediaDataSource.searchQuery) {
-        [self.noResultsView removeFromView];
-        [self.noResultsView configureForNoSearchResultWith:self.mediaDataSource.searchQuery];
-    }
+    [self.noResultsView removeFromView];
+    [self.noResultsView configureForNoSearchResult];
 }
 
 - (void)mediaPickerController:(WPMediaPickerViewController *)picker didFinishPickingAssets:(NSArray *)assets


### PR DESCRIPTION
Fixes #10178 

In all places one can search for Media, this updates the search no results view to only show the message.

NOTE: 
This has a corresponding `WPMediaPicker` PR - https://github.com/wordpress-mobile/MediaPicker-iOS/pull/309.
This `podfile` version will be updated when that is merged.
 
To test:
All of these searches should result in the same view. That is, a `No media matching your search` message static at the top of the view. Example:
![no_media](https://user-images.githubusercontent.com/1816888/45781005-20c9c380-bc1c-11e8-8292-bb657ca8276d.png)

Searches:
- [ ] WP Media Library (Media > search)
- [ ] Free Photo Library (Media > + > Free Photo Library > search)
- [ ] Giphy library (Media > + > Giphy > search)
- [ ] Post editor (edit post > + > WP > search)
- [ ] Post featured image (edit post > Post Settings > Set Featured Image > WordPress Media > search)
- [ ] Site icon (tap site icon > Change Site Icon > WordPress Media > search)

