### PR TITLE
Quick Start: Add never button to alert

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -42,11 +42,11 @@ end
 
 def wordpress_ui
     ## for production:
-    pod 'WordPressUI', '1.0.8-beta.2'
+    ## pod 'WordPressUI', '1.0.8-beta.2'
     ## for development:
     ## pod 'WordPressUI', :path => '../WordPressUI-iOS'
     ## while PR is in review:
-    ## pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '5c3660bdd971bcdd5f232d701b6e2df6830ef880'
+    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '5ec2be1533a86335710221ec20df5b4ba78b06e4'
 end
 
 ## WordPress iOS

--- a/Podfile
+++ b/Podfile
@@ -42,11 +42,11 @@ end
 
 def wordpress_ui
     ## for production:
-    ## pod 'WordPressUI', '1.0.8-beta.2'
+    pod 'WordPressUI', '1.0.8-beta.3'
     ## for development:
     ## pod 'WordPressUI', :path => '../WordPressUI-iOS'
     ## while PR is in review:
-    pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '5ec2be1533a86335710221ec20df5b4ba78b06e4'
+    ## pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '5ec2be1533a86335710221ec20df5b4ba78b06e4'
 end
 
 ## WordPress iOS

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -173,7 +173,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (= 1.0.6)
   - WordPressKit (= 1.4.0)
   - WordPressShared (= 1.0.10)
-  - WordPressUI (= 1.0.8-beta.2)
+  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `5ec2be1533a86335710221ec20df5b4ba78b06e4`)
   - WPMediaPicker (= 1.3)
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 2.1.0)
@@ -211,7 +211,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
-    - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
@@ -220,11 +219,17 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPressUI:
+    :commit: 5ec2be1533a86335710221ec20df5b4ba78b06e4
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPressUI:
+    :commit: 5ec2be1533a86335710221ec20df5b4ba78b06e4
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -264,6 +269,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: e2d9245bc42fb4782eff959219ce4d6bdae13b64
 
-PODFILE CHECKSUM: d08615d60b668dfbf99e70a4e11e3869879ca70d
+PODFILE CHECKSUM: b9f9d9437873327830b21a032d8afab19476c95b
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -272,7 +272,6 @@ private extension SignupEpilogueViewController {
 
 // MARK: - User Defaults
 
-@objc
 extension UserDefaults {
     var quickStartWasDismissedPermanently: Bool {
         get {

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -274,16 +274,12 @@ private extension SignupEpilogueViewController {
 
 @objc
 extension UserDefaults {
-    private enum Keys: String {
-        case quickStartWasDismissedPermanently = "QuickStartWasDismissedPermanently"
-    }
-
     var quickStartWasDismissedPermanently: Bool {
         get {
-            return bool(forKey: Keys.quickStartWasDismissedPermanently.rawValue)
+            return bool(forKey: #function)
         }
         set {
-            set(newValue, forKey: Keys.quickStartWasDismissedPermanently.rawValue)
+            set(newValue, forKey: #function)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -269,3 +269,21 @@ private extension SignupEpilogueViewController {
         static let primary = NSLocalizedString("Continue", comment: "Button text on site creation epilogue page to proceed to My Sites.")
     }
 }
+
+// MARK: - User Defaults
+
+@objc
+extension UserDefaults {
+    private enum Keys: String {
+        case quickStartWasDismissedPermanently = "QuickStartWasDismissedPermanently"
+    }
+
+    var quickStartWasDismissedPermanently: Bool {
+        get {
+            return bool(forKey: Keys.quickStartWasDismissedPermanently.rawValue)
+        }
+        set {
+            set(newValue, forKey: Keys.quickStartWasDismissedPermanently.rawValue)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationEpilogueViewController.swift
@@ -69,9 +69,14 @@ extension SiteCreationEpilogueViewController: NUXButtonViewControllerDelegate {
     }
 
     private func showQuickStartAlert() {
+        guard !UserDefaults.standard.quickStartWasDismissedPermanently else {
+            return
+        }
+
         guard let siteToShow = siteToShow, let tabBar = WPTabBarController.sharedInstance() else {
             return
         }
+
         tabBar.switchMySitesTabToBlogDetails(for: siteToShow)
         let fancyAlert = FancyAlertViewController.makeQuickStartAlertController()
         fancyAlert.modalPresentationStyle = .custom

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
@@ -39,6 +39,7 @@ extension FancyAlertViewController {
                                                      dividerPosition: .bottom,
                                                      defaultButton: allowButton,
                                                      cancelButton: notNowButton,
+                                                     neverButton: neverButton,
                                                      appearAction: {},
                                                      dismissAction: {})
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
@@ -4,6 +4,7 @@ extension FancyAlertViewController {
         static let bodyText = NSLocalizedString("Our Quick Start checklist walks you through the basics of setting up a new website.", comment: "Body text of alert asking if users want to try out the quick start checklist.")
         static let allowButtonText = NSLocalizedString("Yes", comment: "Allow button title shown in alert asking if users want to try out the quick start checklist.")
         static let notNowText = NSLocalizedString("Not This Time", comment: "Not this time button title shown in alert asking if users want to try out the quick start checklist.")
+        static let neverText = NSLocalizedString("Never", comment: "Never button title shown in alert asking if users want to try out the quick start checklist.")
     }
 
     private struct Analytics {
@@ -22,6 +23,11 @@ extension FancyAlertViewController {
         }
 
         let notNowButton = ButtonConfig(Strings.notNowText) { controller, _ in
+            controller.dismiss(animated: true, completion: nil)
+        }
+
+        let neverButton = ButtonConfig(Strings.neverText) { controller, _ in
+            UserDefaults.standard.quickStartWasDismissedPermanently = true
             controller.dismiss(animated: true, completion: nil)
         }
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
@@ -19,16 +19,16 @@ extension FancyAlertViewController {
     @objc static func makeQuickStartAlertController() -> FancyAlertViewController {
 
         let allowButton = ButtonConfig(Strings.allowButtonText) { controller, _ in
-            controller.dismiss(animated: true, completion: nil)
+            controller.dismiss(animated: true)
         }
 
         let notNowButton = ButtonConfig(Strings.notNowText) { controller, _ in
-            controller.dismiss(animated: true, completion: nil)
+            controller.dismiss(animated: true)
         }
 
         let neverButton = ButtonConfig(Strings.neverText) { controller, _ in
             UserDefaults.standard.quickStartWasDismissedPermanently = true
-            controller.dismiss(animated: true, completion: nil)
+            controller.dismiss(animated: true)
         }
 
         let image = UIImage(named: "wp-illustration-checklist")


### PR DESCRIPTION
Refs #9447

This adds the third "never" option to the quick start alert.

![simulator screen shot - iphone x - 2018-09-19 at 14 17 20](https://user-images.githubusercontent.com/517257/45786768-e6b1ef00-bc26-11e8-8b71-6fe4e143e41c.png)

To test:
- create a new `wpcom` site
- after you're done, the alert should appear, ensure it has all three buttons
- tap "never"
- create another site
- ensure that the alert does _not_ appear, as it is now dismissed forever.

