### PR TITLE
Fix auto layout warning in News Card

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
@@ -98,6 +98,7 @@ final class NewsCard: UIViewController {
     }
 
     private func styleReadMoreButton() {
+        readMore.naturalContentHorizontalAlignment = .leading
         let title = NSLocalizedString("Read More", comment: "Button providing More information in the News Card")
         readMore.setTitle(title, for: .normal)
     }

--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
@@ -49,7 +49,7 @@
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WFs-AW-Uc0">
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WFs-AW-Uc0">
                                     <rect key="frame" x="0.0" y="126" width="149" height="30"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="30" id="m6f-Pp-yMs"/>
@@ -76,7 +76,6 @@
                     </subviews>
                     <constraints>
                         <constraint firstAttribute="bottom" secondItem="9hi-UA-p04" secondAttribute="bottom" constant="8" id="vRM-Gi-O9J"/>
-                        <constraint firstItem="9hi-UA-p04" firstAttribute="top" secondItem="Ewo-7I-oMB" secondAttribute="top" id="yLc-D6-vge"/>
                     </constraints>
                     <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
                 </stackView>


### PR DESCRIPTION
Fixes #10183 

Clears an auto layout warning:
> warning: Attribute Unavailable: Leading or Trailing horizontal alignment before iOS 11.0

The fix: changing the Read More button's constraints from this:

<img width="267" alt="screen shot 2018-09-20 at 2 08 49 pm" src="https://user-images.githubusercontent.com/2722505/45799470-3dc7ca80-bce0-11e8-80e9-7328e32ff7ad.png">

to this:
<img width="266" alt="screen shot 2018-09-20 at 2 08 57 pm" src="https://user-images.githubusercontent.com/2722505/45799474-41f3e800-bce0-11e8-9fea-9d538a5a013a.png">


To test:
- Checkout the branch and build. There should not be any auto layout warnings

cc @elibud 
