### PR TITLE
Remove navigation bar button when empty view has an action button

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -57,5 +57,5 @@ extension BlogDetailsViewController {
             self?.tabBarController?.present(alert, animated: true, completion: nil)
         }
     }
-    
+
 }

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -65,7 +65,6 @@ final class SiteTagsViewController: UITableViewController {
         applyStyleGuide()
         applyTitle()
         setupTable()
-        setupNavigationBar()
 
         refreshTags()
         refreshResultsController(predicate: defaultPredicate)
@@ -144,14 +143,14 @@ final class SiteTagsViewController: UITableViewController {
         }
     }
 
-    private func setupNavigationBar() {
-        configureRightButton()
-    }
-
     private func configureRightButton() {
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add,
-                                                            target: self,
-                                                            action: #selector(createTag))
+        if let count = resultsController.fetchedObjects?.count, count > 0 {
+            navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add,
+                                                                target: self,
+                                                                action: #selector(createTag))
+        } else {
+            navigationItem.rightBarButtonItem = nil
+        }
     }
 
     private func setupSearchBar() {
@@ -381,6 +380,9 @@ extension SiteTagsViewController {
 private extension SiteTagsViewController {
 
     func refreshNoResultsView() {
+
+        configureRightButton()
+
         if let count = resultsController.fetchedObjects?.count, count == 0 {
             showNoResults()
         } else {

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -143,8 +143,8 @@ final class SiteTagsViewController: UITableViewController {
         }
     }
 
-    private func configureRightButton() {
-        if let count = resultsController.fetchedObjects?.count, count > 0 {
+    private func showRightBarButton(_ show: Bool) {
+        if show {
             navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add,
                                                                 target: self,
                                                                 action: #selector(createTag))
@@ -380,10 +380,10 @@ extension SiteTagsViewController {
 private extension SiteTagsViewController {
 
     func refreshNoResultsView() {
+        let noResults = resultsController.fetchedObjects?.count == 0
+        showRightBarButton(!noResults)
 
-        configureRightButton()
-
-        if let count = resultsController.fetchedObjects?.count, count == 0 {
+        if noResults {
             showNoResults()
         } else {
             hideNoResults()

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -47,6 +47,7 @@ final class MediaLibraryMediaPickingCoordinator {
         menuAlert.addAction(cancelAction())
 
         menuAlert.popoverPresentationController?.sourceView = fromView
+        menuAlert.popoverPresentationController?.sourceRect = fromView.bounds
         menuAlert.popoverPresentationController?.barButtonItem = buttonItem
 
         origin.present(menuAlert, animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -142,7 +142,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
 
             var barButtonItems = [UIBarButtonItem]()
 
-            if blog.userCanUploadMedia {
+            if blog.userCanUploadMedia && assetCount > 0 {
                 let addButton = UIBarButtonItem(barButtonSystemItem: .add, target: self, action: #selector(addTapped))
                 barButtonItems.append(addButton)
             }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -254,13 +254,12 @@ class MediaLibraryViewController: WPMediaPickerViewController {
 
     private func showOptionsMenu() {
 
-        let pickingContext: MediaPickingContext = {
-            if pickerDataSource.totalAssetCount > 0 {
-                return MediaPickingContext(origin: self, view: view, barButtonItem: navigationItem.rightBarButtonItem, blog: blog)
-            } else {
-                return MediaPickingContext(origin: self, view: noResultsView.actionButton, blog: blog)
-            }
-        }()
+        let pickingContext: MediaPickingContext
+        if pickerDataSource.totalAssetCount > 0 {
+            pickingContext = MediaPickingContext(origin: self, view: view, barButtonItem: navigationItem.rightBarButtonItem, blog: blog)
+        } else {
+            pickingContext = MediaPickingContext(origin: self, view: noResultsView.actionButton, blog: blog)
+        }
 
         mediaPickingCoordinator.present(context: pickingContext)
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -253,7 +253,15 @@ class MediaLibraryViewController: WPMediaPickerViewController {
     }
 
     private func showOptionsMenu() {
-        let pickingContext = MediaPickingContext(origin: self, view: view, barButtonItem: navigationItem.rightBarButtonItem, blog: blog)
+
+        let pickingContext: MediaPickingContext = {
+            if pickerDataSource.totalAssetCount > 0 {
+                return MediaPickingContext(origin: self, view: view, barButtonItem: navigationItem.rightBarButtonItem, blog: blog)
+            } else {
+                return MediaPickingContext(origin: self, view: noResultsView.actionButton, blog: blog)
+            }
+        }()
+
         mediaPickingCoordinator.present(context: pickingContext)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -379,6 +379,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
 
     private func hideNoResultsView() {
         postListFooterView.isHidden = false
+        rightBarButtonView.isHidden = false
         noResultsViewController.removeFromView()
     }
 
@@ -389,6 +390,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         }
 
         postListFooterView.isHidden = true
+        rightBarButtonView.isHidden = true
         refreshNoResultsViewController(noResultsViewController)
 
         // Only add no results view if it isn't already in the table view


### PR DESCRIPTION
Fixes #10182

On views where the empty view contains an action button, this removes the '+' button from the navigation bar.

- [ ] No site tags.
- [ ] No media.
- [ ] No site pages.
- [ ] No blog posts.

To test:
All these views should behave the same way.
- If there is no content, or content is removed, the nav bar add button does not appear. The empty view action button handles that.
- When there is content, or content is added, the nav bar add button appears.

---
**Site Tags and Media Library:**
- Add/remove content. 
- Verify the nav bar add button shows accordingly.

![tags_none](https://user-images.githubusercontent.com/1816888/45834642-f08a2f80-bcc4-11e8-8df5-174be3dc28e1.png)

![tags_content](https://user-images.githubusercontent.com/1816888/45834646-f3852000-bcc4-11e8-9524-64f02c866d8c.png)

---
**Site Pages and Blog Posts:**
- Add/remove content. 
- Select the different filters across the top.
- Verify the nav bar add button shows accordingly.

![pages_none](https://user-images.githubusercontent.com/1816888/45834687-10215800-bcc5-11e8-89de-7313b726e592.png)

![pages_content](https://user-images.githubusercontent.com/1816888/45834696-144d7580-bcc5-11e8-8949-8863f69dbf66.png)