### PR TITLE
Added missing tracking events

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,8 @@ end
 ## ===================================
 ##
 def shared_with_all_pods
-    pod 'WordPressShared', '1.1.1-beta.4'
+    ## while PR is in review:
+    pod 'WordPressShared', :git => 'https://github.com/yaelirub/WordPress-iOS-Shared.git', :commit => '4d1f6e0864a894487a676ebcbb28f3bd03c20381'
     pod 'CocoaLumberjack', '3.4.2'
     pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
     pod 'NSObject-SafeExpectations', '0.0.3'
@@ -157,8 +158,8 @@ target 'WordPressNotificationContentExtension' do
 
     inherit! :search_paths
 
-    pod 'WordPressShared', '1.1.1-beta.4'
-
+    ## while PR is in review:
+    pod 'WordPressShared', :git => 'https://github.com/yaelirub/WordPress-iOS-Shared.git', :commit => '4d1f6e0864a894487a676ebcbb28f3bd03c20381'
     wordpress_ui
 end
 

--- a/Podfile
+++ b/Podfile
@@ -22,8 +22,7 @@ end
 ## ===================================
 ##
 def shared_with_all_pods
-    ## while PR is in review:
-    pod 'WordPressShared', :git => 'https://github.com/yaelirub/WordPress-iOS-Shared.git', :commit => '4d1f6e0864a894487a676ebcbb28f3bd03c20381'
+    pod 'WordPressShared', '1.1.1-beta.5'
     pod 'CocoaLumberjack', '3.4.2'
     pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
     pod 'NSObject-SafeExpectations', '0.0.3'
@@ -158,8 +157,7 @@ target 'WordPressNotificationContentExtension' do
 
     inherit! :search_paths
 
-    ## while PR is in review:
-    pod 'WordPressShared', :git => 'https://github.com/yaelirub/WordPress-iOS-Shared.git', :commit => '4d1f6e0864a894487a676ebcbb28f3bd03c20381'
+    pod 'WordPressShared', '1.1.1-beta.5'
     wordpress_ui
 end
 
@@ -175,7 +173,7 @@ target 'WordPressNotificationServiceExtension' do
 
     pod 'Gridicons', '0.16'
     pod 'WordPressKit', '1.4.1'
-    pod 'WordPressShared', '1.1.1-beta.4'
+    pod 'WordPressShared', '1.1.1-beta.5'
 
     wordpress_ui
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -170,19 +170,11 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Editor-iOS (= 1.0.2)
-<<<<<<< HEAD
   - WordPressAuthenticator (= 1.1.1)
   - WordPressKit (= 1.4.1)
   - WordPressShared (= 1.1.1-beta.4)
   - WordPressUI (= 1.0.8)
   - WPMediaPicker (= 1.3.1)
-=======
-  - WordPressAuthenticator (= 1.1.0-beta.1)
-  - WordPressKit (= 1.4.1-beta.2)
-  - WordPressShared (from `https://github.com/yaelirub/WordPress-iOS-Shared.git`, commit `4d1f6e0864a894487a676ebcbb28f3bd03c20381`)
-  - WordPressUI (= 1.0.8-beta.3)
-  - WPMediaPicker (= 1.3.1-beta.1)
->>>>>>> Updating pods
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 2.2.0)
 
@@ -230,9 +222,6 @@ EXTERNAL SOURCES:
   WordPressShared:
     :commit: 4d1f6e0864a894487a676ebcbb28f3bd03c20381
     :git: https://github.com/yaelirub/WordPress-iOS-Shared.git
-  ZendeskSDK:
-    :branch: xcode10-beta
-    :git: https://github.com/zendesk/zendesk_sdk_ios.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -241,9 +230,6 @@ CHECKOUT OPTIONS:
   WordPressShared:
     :commit: 4d1f6e0864a894487a676ebcbb28f3bd03c20381
     :git: https://github.com/yaelirub/WordPress-iOS-Shared.git
-  ZendeskSDK:
-    :commit: 00559895d059ec1936f8a08006b9253afdb148b1
-    :git: https://github.com/zendesk/zendesk_sdk_ios.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -283,11 +269,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-<<<<<<< HEAD
 PODFILE CHECKSUM: 3c23827ae53a7547d7736ba7bc90671a040224fc
-=======
-
-PODFILE CHECKSUM: 75e27d2c7da75fc7301380a43c93948a97209f8a
->>>>>>> Rebase with Develop now won Swift 4.2
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -170,11 +170,19 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Editor-iOS (= 1.0.2)
+<<<<<<< HEAD
   - WordPressAuthenticator (= 1.1.1)
   - WordPressKit (= 1.4.1)
   - WordPressShared (= 1.1.1-beta.4)
   - WordPressUI (= 1.0.8)
   - WPMediaPicker (= 1.3.1)
+=======
+  - WordPressAuthenticator (= 1.1.0-beta.1)
+  - WordPressKit (= 1.4.1-beta.2)
+  - WordPressShared (from `https://github.com/yaelirub/WordPress-iOS-Shared.git`, commit `4d1f6e0864a894487a676ebcbb28f3bd03c20381`)
+  - WordPressUI (= 1.0.8-beta.3)
+  - WPMediaPicker (= 1.3.1-beta.1)
+>>>>>>> Updating pods
   - wpxmlrpc (= 0.8.3)
   - ZendeskSDK (= 2.2.0)
 
@@ -210,7 +218,6 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -220,11 +227,23 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  ZendeskSDK:
+    :branch: xcode10-beta
+    :git: https://github.com/zendesk/zendesk_sdk_ios.git
+  WordPressShared:
+    :commit: 4d1f6e0864a894487a676ebcbb28f3bd03c20381
+    :git: https://github.com/yaelirub/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  ZendeskSDK:
+    :commit: 00559895d059ec1936f8a08006b9253afdb148b1
+    :git: https://github.com/zendesk/zendesk_sdk_ios.git
+  WordPressShared:
+    :commit: 4d1f6e0864a894487a676ebcbb28f3bd03c20381
+    :git: https://github.com/yaelirub/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -227,23 +227,23 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  ZendeskSDK:
-    :branch: xcode10-beta
-    :git: https://github.com/zendesk/zendesk_sdk_ios.git
   WordPressShared:
     :commit: 4d1f6e0864a894487a676ebcbb28f3bd03c20381
     :git: https://github.com/yaelirub/WordPress-iOS-Shared.git
+  ZendeskSDK:
+    :branch: xcode10-beta
+    :git: https://github.com/zendesk/zendesk_sdk_ios.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  ZendeskSDK:
-    :commit: 00559895d059ec1936f8a08006b9253afdb148b1
-    :git: https://github.com/zendesk/zendesk_sdk_ios.git
   WordPressShared:
     :commit: 4d1f6e0864a894487a676ebcbb28f3bd03c20381
     :git: https://github.com/yaelirub/WordPress-iOS-Shared.git
+  ZendeskSDK:
+    :commit: 00559895d059ec1936f8a08006b9253afdb148b1
+    :git: https://github.com/zendesk/zendesk_sdk_ios.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -283,6 +283,11 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
+<<<<<<< HEAD
 PODFILE CHECKSUM: 3c23827ae53a7547d7736ba7bc90671a040224fc
+=======
+
+PODFILE CHECKSUM: 75e27d2c7da75fc7301380a43c93948a97209f8a
+>>>>>>> Rebase with Develop now won Swift 4.2
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -127,7 +127,7 @@ PODS:
     - UIDeviceIdentifier (~> 0.4)
     - WordPressShared (~> 1.1.1-beta.4)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.1.1-beta.4):
+  - WordPressShared (1.1.1-beta.5):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.0.8)
@@ -172,7 +172,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.0.2)
   - WordPressAuthenticator (= 1.1.1)
   - WordPressKit (= 1.4.1)
-  - WordPressShared (= 1.1.1-beta.4)
+  - WordPressShared (= 1.1.1-beta.5)
   - WordPressUI (= 1.0.8)
   - WPMediaPicker (= 1.3.1)
   - wpxmlrpc (= 0.8.3)
@@ -210,6 +210,7 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -219,17 +220,11 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  WordPressShared:
-    :commit: 4d1f6e0864a894487a676ebcbb28f3bd03c20381
-    :git: https://github.com/yaelirub/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  WordPressShared:
-    :commit: 4d1f6e0864a894487a676ebcbb28f3bd03c20381
-    :git: https://github.com/yaelirub/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -263,12 +258,12 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 571e9a168881af4cbe6cc909af603c278a5f0fe3
   WordPressAuthenticator: 6e9cdd8f492ec771f9cb352e62a94059166f15c1
   WordPressKit: d95804a925e3d23f6a8cc0d47424c673253a65b6
-  WordPressShared: fc613aa29351c73677c421daacb36eacf53f100d
+  WordPressShared: 66c7de16e1f0266d5eb4359803eb371b1c2ec4de
   WordPressUI: e50965adee24b4f10da398f6cdbdd3a822274158
   WPMediaPicker: ea92f84950843c7baf6a7325caed72ad7852418d
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 3c23827ae53a7547d7736ba7bc90671a040224fc
+PODFILE CHECKSUM: 67364678800a1603af85806b9854b34f7a3e5acf
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1048,6 +1048,15 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatReaderArticleCommentedOn:
             eventName = @"reader_article_commented_on";
             break;
+        case WPAnalyticsStatReaderArticleCommentLiked:
+            eventName = @"reader_article_comment_liked";
+            break;
+        case WPAnalyticsStatReaderArticleCommentUnliked:
+            eventName = @"reader_article_comment_unliked";
+            break;
+        case WPAnalyticsStatReaderArticleCommentsOpened:
+            eventName = @"reader_article_comments_opened";
+            break;
         case WPAnalyticsStatReaderArticleLiked:
             eventName = @"reader_article_liked";
             break;
@@ -1059,6 +1068,12 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             break;
         case WPAnalyticsStatReaderArticleUnliked:
             eventName = @"reader_article_unliked";
+            break;
+        case WPAnalyticsStatReaderArticleDetailLiked:
+            eventName = @"reader_article_detail_liked";
+            break;
+        case WPAnalyticsStatReaderArticleDetailUnliked:
+            eventName = @"reader_article_detail_unliked";
             break;
         case WPAnalyticsStatReaderDiscoverViewed:
             eventName = @"reader_discover_viewed";

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -740,6 +740,7 @@ private extension NotificationDetailsViewController {
         // Setup: Callbacks
         cell.onReplyClick = { [weak self] _ in
             self?.focusOnReplyTextViewWithBlock(commentBlock)
+            WPAppAnalytics.track(.notificationsCommentRepliedTo)
         }
 
         cell.onLikeClick = { [weak self] _ in

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -220,10 +220,13 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
 -(void)trackCommentLikedOrUnliked:(Comment *) comment {
     ReaderPost *post = self.post;
-    WPAnalyticsStat stat = comment.isLiked
-    ? WPAnalyticsStatReaderArticleCommentLiked
-    : WPAnalyticsStatReaderArticleCommentUnliked;
-    
+    WPAnalyticsStat stat;
+    if (comment.isLiked) {
+        stat = WPAnalyticsStatReaderArticleCommentLiked;
+    } else {
+        stat = WPAnalyticsStatReaderArticleCommentUnliked;
+    }
+
     NSMutableDictionary *properties = [NSMutableDictionary dictionary];
     properties[WPAppAnalyticsKeyPostID] = post.postID;
     properties[WPAppAnalyticsKeyBlogID] = post.siteID;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -703,8 +703,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 - (void)sendReplyWithNewContent:(NSString *)content
 {
     __typeof(self) __weak weakSelf = self;
-    ReaderPost *post = self.post;
-    NSDictionary *railcar = post.railcarDictionary;
 
     UINotificationFeedbackGenerator *generator = [UINotificationFeedbackGenerator new];
     [generator prepare];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1425,7 +1425,7 @@ private extension ReaderDetailViewController {
         let stat: WPAnalyticsStat  = post.isLiked
             ? .readerArticleDetailLiked
             : .readerArticleDetailUnliked
-        
+
         var properties = [AnyHashable: Any]()
         properties[WPAppAnalyticsKeyBlogID] = post.siteID
         properties[WPAppAnalyticsKeyPostID] = post.postID


### PR DESCRIPTION
The following events were added:
notifications_replied_to - When a user replies to a notification comment
reader_article_comment_liked - when a user likes article comment
reader_article_comment_unliked - when a user unlikes article comment  (taps like button while it's selected)
reader_article_comments_opened - when the article comments are opened
reader_article_detail_liked - when the user opens an article and tap like
reader_article_detail_unliked - when a user opens an article and tap unlike (tap like button again while it's selected)

Fixes #10154 

To test:

*Notifications replied to*
1. Go to notifications tab
2. tap on a notification
3. write a reply
4. tap reply

*Reader Article Liked*
1. Go to Reader tab
2. Choose an article with comments
3. Tap the comments icon
4. Tap the Like icon on the comment

*Reader Article Unliked*
1. Go to Reader tab
2. Choose an article with comments
3. Tap the comments icon
4. Tap the Like icon on a comment that you previously liked

*Reader Article Comments Opened*
1. Go to Reader tab
2. Choose an article with comments
3. Tap the comments icon

*Reader Article Detail Liked*
1. Go to Reader tab
2. Tap on an article
3. Tap on the like button at the bottom

*Reader Article Detail Unliked*
1. Go to Reader tab
2. Tap on an article that you previously liked
3. Tap on the like button at the bottom
