### PR TITLE
Try adding Swiftlint to Danger again

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,6 +1,0 @@
-swift:
-    config_file: .swiftlint.yml
-ruby:
-  enabled: false
-
-fail_on_violations: true

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,35 +1,22 @@
 # Project configuration
-included:
-  - WordPress
+excluded:
+  - Pods
+  - Scripts
+  - vendor
+  
+#included:
+#  - WordPress
 
 # Rules
 whitelist_rules:
-  # Closing brace with closing parenthesis should not have any whitespaces in
-  # the middle.
-  # - closing_brace
-
   # Colons should be next to the identifier when specifying a type.
   - colon
 
   # There should be no space before and one after any comma.
   - comma
 
-  # Repeated `let` statements in conditional binding cascade should be avoided.
-  # - conditional_binding_cascade
-
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
-
-  # Create custom rules by providing a regex string. Optionally specify what
-  # syntax kinds to match against, the severity level, and what message to
-  # display.
-  # - custom_rules
-
-  # Complexity of function bodies should be limited.
-  # - cyclomatic_complexity
-
-  # Prefer checking `isEmpty` over comparing `count` to zero.
-  # - empty_count
 
   # Arguments can be omitted when matching enums with associated types if they
   # are not used.
@@ -38,66 +25,12 @@ whitelist_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
-  # Files should not span too many lines.
-  # - file_length
-
-  # Force casts should be avoided.
-  # - force_cast
-
-  # Force tries should be avoided.
-  # - force_try
-
-  # Force unwrapping should be avoided.
-  # - force_unwrapping
-
-  # Functions bodies should not span too many lines.
-  # - function_body_length
-
-  # Number of function parameters should be low.
-  # - function_parameter_count
-
-  # Files should not contain leading whitespace.
-  # - leading_whitespace
-
-  # Struct extension properties and methods are preferred over legacy functions
-  # - legacy_cggeometry_functions
-
-  # Struct-scoped constants are preferred over legacy global constants.
-  # - legacy_constant
-
-  # Swift constructors are preferred over legacy convenience functions.
-  # - legacy_constructor
-
-  # Lines should not span too many characters.
-  # - line_length
-
   # MARK comment should be in valid format.
   - mark
-
-  # Public declarations should be documented.
-  # - missing_docs
-
-  # Types should be nested at most 1 level deep, and statements should be nested
-  # at most 5 levels deep.
-  # - nesting
 
   # Opening braces should be preceded by a single space and on the same line as
   # the declaration.
   - opening_brace
-
-  # Operators should be surrounded by a single whitespace when defining them.
-  # - operator_whitespace
-
-  # Return arrow and return type should be separated by a single space or on a
-  # separate line.
-  # - return_arrow_whitespace
-
-  # Else and catch should be on the same line, one space after the previous
-  # declaration.
-  # - statement_position
-
-  # TODOs and FIXMEs should be avoided.
-  # - todo
 
   # Files should have a single trailing newline.
   - trailing_newline
@@ -107,23 +40,6 @@ whitelist_rules:
 
   # Lines should not have trailing whitespace.
   - trailing_whitespace
-
-  # Type bodies should not span too many lines.
-  # - type_body_length
-
-  # Type name should only contain alphanumeric characters, start with an
-  # uppercase character and span between 3 and 40 characters in length.
-  # - type_name
-
-  # Documented declarations should be valid.
-  # - valid_docs
-
-  # Variable names should only contain alphanumeric characters and start with a
-  # lowercase character or should only contain capital letters. In an exception
-  # to the above, variable names may start with a capital letter when they are
-  # declared static and immutable. Variable names should not be too long or too
-  # short.
-  # - variable_name
 
   - custom_rules
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -19,4 +19,5 @@ has_modified_model = git.modified_files.include? "WordPress/Classes/WordPress.xc
 warn("Core Data: Do not edit an existing model in a release branch unless it hasn't been released to testers yet. Instead create a new model version and merge back to develop soon.") if has_modified_model
 
 # SwiftLint, requires https://github.com/ashfurrow/danger-swiftlint
-swiftlint.lint_files
+swiftlint.verbose = true
+swiftlint.lint_files inline_mode: true

--- a/Dangerfile
+++ b/Dangerfile
@@ -19,4 +19,5 @@ has_modified_model = git.modified_files.include? "WordPress/Classes/WordPress.xc
 warn("Core Data: Do not edit an existing model in a release branch unless it hasn't been released to testers yet. Instead create a new model version and merge back to develop soon.") if has_modified_model
 
 # SwiftLint, requires https://github.com/ashfurrow/danger-swiftlint
+swiftlint.verbose = true
 swiftlint.lint_files

--- a/Dangerfile
+++ b/Dangerfile
@@ -19,4 +19,4 @@ has_modified_model = git.modified_files.include? "WordPress/Classes/WordPress.xc
 warn("Core Data: Do not edit an existing model in a release branch unless it hasn't been released to testers yet. Instead create a new model version and merge back to develop soon.") if has_modified_model
 
 # SwiftLint, requires https://github.com/ashfurrow/danger-swiftlint
-swiftlint.lint_files inline_mode: true
+swiftlint.lint_files

--- a/Dangerfile
+++ b/Dangerfile
@@ -17,3 +17,6 @@ target_release_branch = github.branch_for_base.start_with? "release"
 has_modified_model = git.modified_files.include? "WordPress/Classes/WordPress.xcdatamodeld/*/contents"
 
 warn("Core Data: Do not edit an existing model in a release branch unless it hasn't been released to testers yet. Instead create a new model version and merge back to develop soon.") if has_modified_model
+
+# SwiftLint, requires https://github.com/ashfurrow/danger-swiftlint
+swiftlint.lint_files inline_mode: true

--- a/Dangerfile
+++ b/Dangerfile
@@ -19,5 +19,4 @@ has_modified_model = git.modified_files.include? "WordPress/Classes/WordPress.xc
 warn("Core Data: Do not edit an existing model in a release branch unless it hasn't been released to testers yet. Instead create a new model version and merge back to develop soon.") if has_modified_model
 
 # SwiftLint, requires https://github.com/ashfurrow/danger-swiftlint
-swiftlint.verbose = true
-swiftlint.lint_files inline_mode: true
+swiftlint.lint_files

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org' do
   gem 'cocoapods', '1.5.3'
   gem 'xcpretty-travis-formatter'
   gem 'danger'
+  gem 'danger-swiftlint'
   gem 'octokit', "~> 4.0"
   gem 'fastlane'
   gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,10 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
+    danger-swiftlint (0.17.3)
+      danger
+      rake (> 10)
+      thor (~> 0.19)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.5.0)
@@ -196,6 +200,7 @@ GEM
     terminal-notifier (1.8.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
+    thor (0.20.0)
     thread_safe (0.3.6)
     tty-screen (0.5.1)
     tzinfo (1.2.5)
@@ -223,6 +228,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (= 1.5.3)!
   danger!
+  danger-swiftlint!
   dotenv!
   fastlane!
   fastlane-plugin-wpmreleasetoolkit!
@@ -231,4 +237,4 @@ DEPENDENCIES
   xcpretty-travis-formatter!
 
 BUNDLED WITH
-   1.16.1
+   1.16.5

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -11,7 +11,7 @@ extension WordPressAppDelegate {
     @objc func configureAnalytics() {
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)
-    
+
         analytics = WPAppAnalytics(accountService: accountService,
                                    lastVisibleScreenBlock: { [weak self] in
             return self?.currentlySelectedScreen
@@ -52,7 +52,7 @@ extension WordPressAppDelegate {
         internetReachability = Reachability.forInternetConnection()
 
         let reachabilityBlock: NetworkReachable = { [weak self] reachability in
-            guard let reachability = reachability else{
+            guard let reachability = reachability else {
                 return
             }
 
@@ -195,10 +195,6 @@ extension WordPressAppDelegate {
         let crashCount = UserDefaults.standard.integer(forKey: "crashCount")
 
         let extraDebug = UserDefaults.standard.bool(forKey: "extra_debug")
-		
-		if (extraDebug == true) {
-			print("Test")
-		}
 
         let context = ContextManager.sharedInstance().mainContext
         let blogService = BlogService(managedObjectContext: context)

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -11,7 +11,7 @@ extension WordPressAppDelegate {
     @objc func configureAnalytics() {
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)
-
+    
         analytics = WPAppAnalytics(accountService: accountService,
                                    lastVisibleScreenBlock: { [weak self] in
             return self?.currentlySelectedScreen
@@ -52,7 +52,7 @@ extension WordPressAppDelegate {
         internetReachability = Reachability.forInternetConnection()
 
         let reachabilityBlock: NetworkReachable = { [weak self] reachability in
-            guard let reachability = reachability else {
+            guard let reachability = reachability else{
                 return
             }
 
@@ -195,6 +195,10 @@ extension WordPressAppDelegate {
         let crashCount = UserDefaults.standard.integer(forKey: "crashCount")
 
         let extraDebug = UserDefaults.standard.bool(forKey: "extra_debug")
+		
+		if (extraDebug == true) {
+			print("Test")
+		}
 
         let context = ContextManager.sharedInstance().mainContext
         let blogService = BlogService(managedObjectContext: context)

--- a/WordPress/Classes/Utility/Debouncer.swift
+++ b/WordPress/Classes/Utility/Debouncer.swift
@@ -6,18 +6,18 @@ final class Debouncer {
     var callback: (() -> Void)?
     var delay: Double
     weak var timer: Timer?
-    
+
     init(delay: Double, callback: (() -> Void)? = nil) {
         self.delay = delay
         self.callback = callback
     }
-    
+
     func call() {
         timer?.invalidate()
         let nextTimer = Timer.scheduledTimer(timeInterval: delay, target: self, selector: #selector(Debouncer.fireNow), userInfo: nil, repeats: false)
         timer = nextTimer
     }
-    
+
     @objc func fireNow() {
         self.callback?()
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3910,7 +3910,7 @@ extension AztecPostViewController {
             static let formatBarMediaButtonRotationDuration: TimeInterval = 0.3
             static let formatBarMediaButtonRotationAngle: CGFloat = .pi / 4.0
         }
-        
+
         static let autoSavingDelay = Double(0.5)
     }
 
@@ -3998,7 +3998,7 @@ extension AztecPostViewController {
         static let title = NSLocalizedString("Unable to play video", comment: "Dialog box title for when the user is cancelling an upload.")
         static let message = NSLocalizedString("Something went wrong. Please check your connectivity and try again.", comment: "This prompt is displayed when the user attempts to play a video in the editor but for some reason we are unable to retrieve from the server.")
     }
-    
+
 }
 
 extension AztecPostViewController: UIViewControllerTransitioningDelegate {


### PR DESCRIPTION
## Description
This PR continues work started [previously](https://github.com/wordpress-mobile/WordPress-iOS/pull/10072). It integrates [`danger-swiftlint`](https://github.com/ashfurrow/danger-swiftlint) with our existing `Dangerfile`, paving the way for the retirement of Hound.

I made a few changes to `.swiftlint.yml`; namely, I removed some superfluous comments and I modified the lists of `included` & `excluded` project directories. Without this change, BuddyBuild was reporting the following error:
```
No lintable files found at path '/private/tmp/sandbox/workspace/WordPress/<path_to_Swift_file>'
```

At the moment, some fabricated Hound violations were added to the PR. These should be addressed prior to merging the change.

Finally, Danger SwiftLint offers both a default and an "inline" mode for reporting results. I prefer the default mode, as the paths generated by BuddyBuild in inline mode are incorrect.

## Screenshots

_**Inline:**_
<img width="679" alt="10201a_inline" src="https://user-images.githubusercontent.com/221062/46123144-95c76b00-c1d1-11e8-8c0c-06909e60f6d5.png">

_**Default:**_
<img width="680" alt="10201b_default" src="https://user-images.githubusercontent.com/221062/46123145-96600180-c1d1-11e8-942a-c7aca8efddfd.png">
