### PR TITLE
Specify rubyzip version to address vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ source 'https://rubygems.org' do
   gem 'octokit', "~> 4.0"
   gem 'fastlane'
   gem 'dotenv'
+  gem 'rubyzip', "~> 1.2.2"
 end
 
 plugins_path = File.join(File.dirname(__FILE__), 'Scripts/fastlane', 'Pluginfile')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
     retriable (2.1.0)
     rouge (1.11.1)
     ruby-macho (1.2.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
@@ -234,6 +234,7 @@ DEPENDENCIES
   fastlane-plugin-wpmreleasetoolkit!
   octokit (~> 4.0)!
   rake!
+  rubyzip (~> 1.2.2)!
   xcpretty-travis-formatter!
 
 BUNDLED WITH


### PR DESCRIPTION
Github flagged a vulnerability in the version of rubyzip showing up in our Gemfile.lock. Its a dependency of Fastlane and it looks like we have some discretion of which version it will accept so let's increment to what Github recomments and see if it fixes the issue.

<img width="1090" alt="screen shot 2018-09-27 at 2 35 00 pm" src="https://user-images.githubusercontent.com/1435271/46171206-77ab4a80-c265-11e8-8aa2-59b8ad89bcda.png">

<img width="760" alt="screen shot 2018-09-27 at 2 36 06 pm" src="https://user-images.githubusercontent.com/1435271/46171212-7d089500-c265-11e8-969d-6c1a46dcb99e.png">



