### PR TITLE
Corrected Hound configuration

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,7 @@
+fail_on_violations: true
+
+ruby:
+  enabled: false
+  
+swiftlint:
+  config_file: .swiftlint.yml

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,6 +1,6 @@
 fail_on_violations: true
 
-ruby:
+rubocop:
   enabled: false
   
 swiftlint:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,9 +3,6 @@ excluded:
   - Pods
   - Scripts
   - vendor
-  
-#included:
-#  - WordPress
 
 # Rules
 whitelist_rules:


### PR DESCRIPTION
## Description

After conversing with staff at Hound, they noted that our previous `.hound.yml` (intact since January) differs from what they expect. Apparently they have updated their [documentation](https://intercom.help/hound/configuration/swiftlint) today (and behavior, presumably) to use a different key (i.e., `swiftlint` instead of `swift`).

The new file closely resembles the [previous one](https://github.com/wordpress-mobile/WordPress-iOS/blob/release/10.9/.hound.yml).

In addition to this change, I have also restored the GitHub webhook.

We can continue to evaluate `danger-swiftlint`, with inline comments as our ideal end state.

## References:

- https://intercom.help/hound/configuration/rubocop
- https://intercom.help/hound/configuration/swiftlint