### PR TITLE
Update Podfile to reference an official Zendesk release

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -83,7 +83,7 @@ target 'WordPress' do
     pod 'MGSwipeTableCell', '1.6.7'
     pod 'lottie-ios', '2.5.0'
     pod 'Starscream', '3.0.4'
-    pod 'ZendeskSDK', :git => 'https://github.com/zendesk/zendesk_sdk_ios.git', :branch => 'xcode10-beta'
+    pod 'ZendeskSDK', '2.2.0'
 
 
     ## Automattic libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -133,13 +133,13 @@ PODS:
   - WordPressUI (1.0.8-beta.3)
   - WPMediaPicker (1.3.1-beta.1)
   - wpxmlrpc (0.8.3)
-  - ZendeskSDK (2.1.0):
-    - ZendeskSDK/Providers (= 2.1.0)
-    - ZendeskSDK/UI (= 2.1.0)
-  - ZendeskSDK/Core (2.1.0)
-  - ZendeskSDK/Providers (2.1.0):
+  - ZendeskSDK (2.2.0):
+    - ZendeskSDK/Providers (= 2.2.0)
+    - ZendeskSDK/UI (= 2.2.0)
+  - ZendeskSDK/Core (2.2.0)
+  - ZendeskSDK/Providers (2.2.0):
     - ZendeskSDK/Core
-  - ZendeskSDK/UI (2.1.0):
+  - ZendeskSDK/UI (2.2.0):
     - ZendeskSDK/Core
     - ZendeskSDK/Providers
 
@@ -176,7 +176,7 @@ DEPENDENCIES:
   - WordPressUI (= 1.0.8-beta.3)
   - WPMediaPicker (= 1.3.1-beta.1)
   - wpxmlrpc (= 0.8.3)
-  - ZendeskSDK (from `https://github.com/zendesk/zendesk_sdk_ios.git`, branch `xcode10-beta`)
+  - ZendeskSDK (= 2.2.0)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -214,22 +214,17 @@ SPEC REPOS:
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
+    - ZendeskSDK
 
 EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  ZendeskSDK:
-    :branch: xcode10-beta
-    :git: https://github.com/zendesk/zendesk_sdk_ios.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  ZendeskSDK:
-    :commit: 00559895d059ec1936f8a08006b9253afdb148b1
-    :git: https://github.com/zendesk/zendesk_sdk_ios.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -267,8 +262,8 @@ SPEC CHECKSUMS:
   WordPressUI: 284ce2bbec477210eb22feb5d8a1129fc6c4273a
   WPMediaPicker: 53f40b5af4a4e29880f1a3475ffcea928559c477
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
-  ZendeskSDK: 54b4f8ef7c368ba5a29b2ad6c69fa8c912355190
+  ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: d7be24115189b578a929ab09a0eb3020a4a21e29
+PODFILE CHECKSUM: 19933583a2667632ace7cbfa17fac42a750e5f44
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Zendesk has released a [new framework version](https://github.com/zendesk/zendesk_sdk_ios/releases/tag/2.2.0) with explicit support for Xcode 10. This PR updates the `Podfile` to account for this.

The branch should build and existing tests should pass.