### PR TITLE
Issue/10208 site creation tracks

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,7 @@ end
 ## ===================================
 ##
 def shared_with_all_pods
-    pod 'WordPressShared', '1.1.1-beta.2'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '6e807ed'
     pod 'CocoaLumberjack', '3.4.2'
     pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
     pod 'NSObject-SafeExpectations', '0.0.3'
@@ -157,7 +157,7 @@ target 'WordPressNotificationContentExtension' do
 
     inherit! :search_paths
 
-    pod 'WordPressShared', '1.1.1-beta.2'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '6e807ed'
 
     wordpress_ui
 end
@@ -175,7 +175,7 @@ target 'WordPressNotificationServiceExtension' do
     pod 'Gridicons', '0.16'
 
     pod 'WordPressKit', '1.4.1-beta.2'
-    pod 'WordPressShared', '1.1.1-beta.2'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '6e807ed'
 
     wordpress_ui
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -172,7 +172,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.0.2)
   - WordPressAuthenticator (= 1.1.0-beta.1)
   - WordPressKit (= 1.4.1-beta.2)
-  - WordPressShared (= 1.1.1-beta.2)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `6e807ed`)
   - WordPressUI (= 1.0.8-beta.3)
   - WPMediaPicker (= 1.3.1-beta.1)
   - wpxmlrpc (= 0.8.3)
@@ -210,7 +210,6 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -220,11 +219,17 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPressShared:
+    :commit: 6e807ed
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPressShared:
+    :commit: 6e807ed
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -264,6 +269,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 19933583a2667632ace7cbfa17fac42a750e5f44
+PODFILE CHECKSUM: f4d9d5693ff58d99468fb95f318711962db4947e
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -330,8 +330,23 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatCreatedSite:
             eventName = @"site_created";
             break;
-        case WPAnalyticsStatCreateSiteValidationFailed:
-            eventName = @"create_site_validation_failed";
+        case WPAnalyticsStatCreateSiteProcessBegun:
+            eventName = @"create_site_process_begun";
+            break;
+        case WPAnalyticsStatCreateSiteCategoryViewed:
+            eventName = @"create_site_category_viewed";
+            break;
+        case WPAnalyticsStatCreateSiteDetailsViewed:
+            eventName = @"create_site_details_viewed";
+            break;
+        case WPAnalyticsStatCreateSiteDomainViewed:
+            eventName = @"create_site_domain_viewed";
+            break;
+        case WPAnalyticsStatCreateSiteThemeViewed:
+            eventName = @"create_site_theme_viewed";
+            break;
+        case WPAnalyticsStatCreateSiteRequestInitiated:
+            eventName = @"create_site_request_initiated";
             break;
         case WPAnalyticsStatCreateSiteCreationFailed:
             eventName = @"create_site_creation_failed";
@@ -341,6 +356,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             break;
         case WPAnalyticsStatCreateSiteSetThemeFailed:
             eventName = @"create_site_set_theme_failed";
+            break;
+        case WPAnalyticsStatCreateSiteValidationFailed:
+            eventName = @"create_site_validation_failed";
             break;
         case WPAnalyticsStatDeepLinked:
             eventName = @"deep_linked";

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.h
@@ -1,4 +1,4 @@
-#import <UIKit/UIKit.h>
+@import UIKit;
 
 @class Blog;
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -1,20 +1,6 @@
 #import "BlogListViewController.h"
-#import "WordPressAppDelegate.h"
-#import "BlogDetailsViewController.h"
-#import "WPBlogTableViewCell.h"
-#import "ContextManager.h"
-#import "Blog.h"
-#import "WPAccount.h"
-#import "AccountService.h"
-#import "BlogService.h"
-#import "TodayExtensionService.h"
-#import "WPTabBarController.h"
-#import "WordPress-Swift.h"
-#import "WPGUIConstants.h"
-#import <WordPressShared/WPFontManager.h>
-#import <WordPressShared/WPTableViewCell.h>
-#import <WordPressUI/WordPressUI.h>
 
+#import "WordPress-Swift.h"
 
 static CGFloat const BLVCHeaderViewLabelPadding = 10.0;
 
@@ -910,6 +896,8 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)showAddNewWordPressController
 {
+    [WPAppAnalytics track:WPAnalyticsStatCreateSiteProcessBegun];
+
     [self setEditing:NO animated:NO];
     
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"SiteCreation" bundle:nil];

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationCategoryTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationCategoryTableViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressAuthenticator
+import WordPressShared
 
 
 class SiteCreationCategoryTableViewController: NUXTableViewController {
@@ -20,6 +21,11 @@ class SiteCreationCategoryTableViewController: NUXTableViewController {
         super.viewWillAppear(animated)
         setupTable()
         setupNavBar()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        WPAppAnalytics.track(.createSiteCategoryViewed)
     }
 
     func setupTable() {

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationCreateSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationCreateSiteViewController.swift
@@ -181,6 +181,8 @@ private extension SiteCreationCreateSiteViewController {
             self.performSegue(withIdentifier: Constants.errorSegueIdentifier, sender: self)
         }
 
+        WPAppAnalytics.track(.createSiteRequestInitiated)
+
         // Start the site creation process
         let service = SiteCreationService(managedObjectContext: ContextManager.sharedInstance().mainContext)
         service.createSite(siteURL: siteCreationFields.domain,

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationDomainsViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationDomainsViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressAuthenticator
+import WordPressShared
 
 
 class SiteCreationDomainsViewController: NUXViewController {
@@ -44,6 +45,11 @@ class SiteCreationDomainsViewController: NUXViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         showButtonView(show: false, withAnimation: false)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        WPAppAnalytics.track(.createSiteDomainViewed)
     }
 
     private func configureView() {

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationSiteDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationSiteDetailsViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressAuthenticator
+import WordPressShared
 
 
 class SiteCreationSiteDetailsViewController: NUXViewController, NUXKeyboardResponder {
@@ -42,8 +43,10 @@ class SiteCreationSiteDetailsViewController: NUXViewController, NUXKeyboardRespo
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+
         registerForKeyboardEvents(keyboardWillShowAction: #selector(handleKeyboardWillShow(_:)),
                                   keyboardWillHideAction: #selector(handleKeyboardWillHide(_:)))
+        WPAppAnalytics.track(.createSiteDetailsViewed)
     }
 
     override func viewWillDisappear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationThemeSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationThemeSelectionViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import SVProgressHUD
 import WordPressAuthenticator
+import WordPressShared
 
 
 class SiteCreationThemeSelectionViewController: NUXCollectionViewController, UICollectionViewDelegateFlowLayout, WPContentSyncHelperDelegate {
@@ -30,6 +31,11 @@ class SiteCreationThemeSelectionViewController: NUXCollectionViewController, UIC
         configureView()
         setupThemesSyncHelper()
         syncContent()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        WPAppAnalytics.track(.createSiteThemeViewed)
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
Fixes #10208.

### To test

1. Checkout the branch and validate that existing tests pass
1. Navigate to the _My Sites_ tab, and exercise the "happy path" to `Create WordPress.com site`.
1. For the preceding step, validate that the following new events can be found in _Tracks Live View_:

- `wpios_create_site_process_begun`
- `wpios_create_site_category_viewed`
- `wpios_create_site_details_viewed`
- `wpios_create_site_domain_viewed`
- `wpios_create_site_theme_viewed`
- `wpios_create_site_request_initiated`

### Before Merging

- [ ] Review & approve [upstream change](https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/153) in `WordPressShared`
- [ ] Create corresponding Beta release to `WordPressShared`
- [ ] Update `Podfile` entries in this PR to reference that version