### PR TITLE
Use the URL keyboard when adding a followed site

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -108,6 +108,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         UITextField.appearance(whenContainedInInstancesOf: [UISearchBar.self, ReaderFollowedSitesViewController.self]).defaultTextAttributes = textAttributes
 
         searchBar.autocapitalizationType = .none
+        searchBar.keyboardType = .URL
         searchBar.isTranslucent = false
         searchBar.tintColor = WPStyleGuide.grey()
         searchBar.barTintColor = WPStyleGuide.greyLighten30()


### PR DESCRIPTION
To test:

**Before:**
In Reader > Followed Sites > Manage, when a user types a URL into the search bar to add it to the list, it doesn't use the URL keyboard, which is a minor annoyance.

**After**
Now the user gets a nice URL keyboard instead.