### PR TITLE
Fix crash caused by posting a notice off the main thread

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -201,7 +201,13 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
             let notice = Notice(title: title,
                                 message: url.host,
                                 feedbackType: .error)
-            self?.post(notice)
+
+            // The underlying services for `followSite` don't consistently run the callback
+            // on the main thread, so we'll ensure that we post the notice on the main
+            // thread to prevent crashes.
+            DispatchQueue.main.async {
+                self?.post(notice)
+            }
         })
     }
 


### PR DESCRIPTION
When we call `post` in ReaderFollowedSitesViewController off of the main thread, it causes a crash over in https://github.com/wordpress-mobile/WordPress-iOS/blob/4ac54edd8c4db2978a0122f97e137c755e627d4a/WordPressFlux/WordPressFlux/Sources/Dispatcher.swift#L61 due to an unmet assertion.

To test:

**Before** 
In the current version of the app, navigate to Reader > Manage and in the "Enter the URL..." box, type a completely garbage URL that won't resolve.

The app will attempt to add that site to the reader, then will crash.

**After**
The app will show a warning message, typically saying "A server with the specific hostname could not be found".

**Next Steps**
The error message from `error.localizedDescription` can be pretty verbose, and it's cut off when the bottom prompt shows up.