### PR TITLE
Use new Xcode build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ WordPress/WordPress.xcodeproj/xcuserdata
 WordPress/InfoPlist.h
 WordPress/InfoPlist-alpha.h
 WordPress/InfoPlist-internal.h
+WordPress/Derived Sources/
 # coverage.py
 */CoverageData/*
 WordPress/Images.xcassets/AppIcon-Internal.appiconset

--- a/WordPress.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/WordPress.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-</dict>
+<dict/>
 </plist>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -6767,9 +6767,8 @@
 				FF27169E1CAAF5060006E2D4 /* WPUITestCredentials.swift */,
 				FFB7B81D1A0012E80032E723 /* ApiCredentials.m */,
 			);
-			name = "Derived Sources";
-			path = /private/tmp/WordPress.build;
-			sourceTree = "<absolute>";
+			path = "Derived Sources";
+			sourceTree = "<group>";
 		};
 		E1A03EDF17422DBC0085D192 /* 10-11 */ = {
 			isa = PBXGroup;
@@ -7918,11 +7917,11 @@
 			);
 			name = "Generate Credentials";
 			outputPaths = (
-				/tmp/WordPress.build/WPUITestCredentials.swift,
+				"$(SRCROOT)/Derived Sources/WPUITestCredentials.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "DERIVED_TMP_DIR=/tmp/WordPress.build\n\necho \"Generating credentials file in ${DERIVED_TMP_DIR}/WPUICredentials.swift\"\n\nruby \"${SOURCE_ROOT}/WordPressUITests/gencredentials.rb\" > ${DERIVED_TMP_DIR}/WPUITestCredentials.swift";
+			shellScript = "DERIVED_SOURCES_DIR=\"${SOURCE_ROOT}/Derived Sources\"\n\necho \"Generating credentials file in ${DERIVED_SOURCES_DIR}/WPUICredentials.swift\"\n\nruby \"${SOURCE_ROOT}/WordPressUITests/gencredentials.rb\" > \"${DERIVED_SOURCES_DIR}/WPUITestCredentials.swift\"\n";
 		};
 		928885381E5E057F001F9637 /* Reset Simulator */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -8052,11 +8051,11 @@
 			);
 			name = "Generate API credentials";
 			outputPaths = (
-				/tmp/WordPress.build/ApiCredentials.m,
+				"$(SRCROOT)/Derived Sources/ApiCredentials.m",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "DERIVED_TMP_DIR=/tmp/WordPress.build\ncp \"${SOURCE_ROOT}/Credentials/ApiCredentials.m\" ${DERIVED_TMP_DIR}/ApiCredentials.m\n\necho \"Checking for WordPress.com Oauth App Secret in $WPCOM_CONFIG\"\nif [ -a $WPCOM_CONFIG ]\nthen\necho \"Config found\"\nsource $WPCOM_CONFIG\nelse\necho \"No config found\"\nexit 0\nfi\n\nif [ -z $WPCOM_APP_ID ]\nthen\necho \"warning: Missing WPCOM_APP_ID\"\nexit 1\nfi\nif [ -z $WPCOM_APP_SECRET ]\nthen\necho \"warning: Missing WPCOM_APP_SECRET\"\nexit 1\nfi\n\necho \"Generating credentials file in ${DERIVED_TMP_DIR}/ApiCredentials.m\"\nruby \"${SOURCE_ROOT}/Credentials/gencredentials.rb\" > ${DERIVED_TMP_DIR}/ApiCredentials.m\n";
+			shellScript = "DERIVED_SOURCES_DIR=\"${SOURCE_ROOT}/Derived Sources\"\ncp \"${SOURCE_ROOT}/Credentials/ApiCredentials.m\" \"${DERIVED_SOURCES_DIR}/ApiCredentials.m\"\n\necho \"Checking for WordPress.com Oauth App Secret in $WPCOM_CONFIG\"\nif [ -a $WPCOM_CONFIG ]\nthen\necho \"Config found\"\nsource $WPCOM_CONFIG\nelse\necho \"No config found\"\nexit 0\nfi\n\nif [ -z $WPCOM_APP_ID ]\nthen\necho \"warning: Missing WPCOM_APP_ID\"\nexit 1\nfi\nif [ -z $WPCOM_APP_SECRET ]\nthen\necho \"warning: Missing WPCOM_APP_SECRET\"\nexit 1\nfi\n\necho \"Generating credentials file in ${DERIVED_SOURCES_DIR}/ApiCredentials.m\"\nruby \"${SOURCE_ROOT}/Credentials/gencredentials.rb\" > \"${DERIVED_SOURCES_DIR}/ApiCredentials.m\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E1CCFB31175D62320016BD8A /* Run Fabric/Crashlytics */ = {


### PR DESCRIPTION
Fixes: Compatibility with the new Xcode build system

To test: Building all targets should pass both locally and on CI

-----------------

This PR is my proposal to fix compatibility with the new build system. Derived sources have been moved from `/tmp/WordPress.build/` to a new gitignored directory: `WordPress/Derived Sources/`.

I haven't completely figured out why but the new build system seems to choke on the existing absolute path. It seems to put the sources in `/private/tmp/WordPress.build/` so they're not found.

The reason this was working locally but not on CI is that `/tmp/WordPress.build/` already had working contents when changing to the new build system locally but CI was starting fresh.

Its very possible (maybe likely 😄) that I am missing context here and this is a bad idea, but I would love to hear thoughts.

