### PR TITLE
Fix crash on ReaderStreamViewController (#9997)

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -21,21 +20,7 @@
                     <view key="view" contentMode="scaleToFill" id="nFH-eq-cvg">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="437"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n2H-rP-0mh">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="437"/>
-                                <connections>
-                                    <segue destination="ojY-lw-Nq8" kind="embed" id="HkI-vX-JZt"/>
-                                </connections>
-                            </containerView>
-                        </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstItem="n2H-rP-0mh" firstAttribute="leading" secondItem="nFH-eq-cvg" secondAttribute="leading" id="Cvv-ls-4WN"/>
-                            <constraint firstAttribute="trailing" secondItem="n2H-rP-0mh" secondAttribute="trailing" id="FBj-uE-3SV"/>
-                            <constraint firstItem="n2H-rP-0mh" firstAttribute="top" secondItem="Pyc-Kx-lnt" secondAttribute="bottom" id="KUX-1E-nEH"/>
-                            <constraint firstItem="icf-FG-h6u" firstAttribute="top" secondItem="n2H-rP-0mh" secondAttribute="bottom" id="T9p-L4-71W"/>
-                        </constraints>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <navigationItem key="navigationItem" title="Reader" id="3YL-eA-YLl">
@@ -529,28 +514,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cfm-tk-192" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="687" y="1811"/>
-        </scene>
-        <!--Table View Controller-->
-        <scene sceneID="Xc2-1X-rOR">
-            <objects>
-                <tableViewController id="ojY-lw-Nq8" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="22" sectionFooterHeight="22" id="8GD-qV-397">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="437"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <connections>
-                            <outlet property="dataSource" destination="ojY-lw-Nq8" id="6Fm-hZ-zEP"/>
-                            <outlet property="delegate" destination="ojY-lw-Nq8" id="W3n-bb-rFj"/>
-                        </connections>
-                    </tableView>
-                    <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="1cY-Qf-N9S">
-                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </refreshControl>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="ch4-jL-nh9" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="1368" y="470"/>
         </scene>
         <!--Reader Search View Controller-->
         <scene sceneID="Y2l-5f-pGm">

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -96,6 +96,11 @@ import WordPressFlux
     }
 
 
+    var isShowingResultStatusView: Bool {
+        return resultsStatusView.view.superview != nil
+    }
+
+
     /// The topic can be nil while a site or tag topic is being fetched, hence, optional.
     @objc open var readerTopic: ReaderAbstractTopic? {
         didSet {
@@ -241,7 +246,7 @@ import WordPressFlux
 
         if readerTopic != nil {
             configureControllerForTopic()
-        } else if (siteID != nil || tagSlug != nil) {//}&& resultsStatusView.view.superview == nil {
+        } else if (siteID != nil || tagSlug != nil) && isShowingResultStatusView == false {
             displayLoadingStream()
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -367,13 +367,6 @@ import WordPressFlux
         tableViewController.refreshControl = UIRefreshControl(frame: .zero)
     }
 
-    fileprivate func addTableViewControllerAsChild() {
-        addChild(tableViewController)
-        view.addSubview(tableView)
-
-        tableViewController.didMove(toParent: self)
-    }
-
     fileprivate func add(_ childController: UIViewController, asChildOf controller: UIViewController) {
         childController.removeFromParent()
         controller.addChild(childController)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -241,8 +241,6 @@ import WordPressFlux
 
         if readerTopic != nil {
             configureControllerForTopic()
-        } else if (siteID != nil || tagSlug != nil) && resultsStatusView.view.superview == nil {
-            displayLoadingStream()
         }
     }
 
@@ -251,7 +249,6 @@ import WordPressFlux
 
         syncIfAppropriate()
     }
-
 
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
@@ -281,6 +278,9 @@ import WordPressFlux
     open override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
+        if (siteID != nil || tagSlug != nil) {//}&& resultsStatusView.view.superview == nil {
+            displayLoadingStream()
+        }
         // There appears to be a scenario where this method can be called prior to
         // the view being fully setup in viewDidLoad.
         // See: https://github.com/wordpress-mobile/WordPress-iOS/issues/4419
@@ -366,6 +366,7 @@ import WordPressFlux
 
         refreshControl.addTarget(self, action: #selector(ReaderStreamViewController.handleRefresh(_:)), for: .valueChanged)
         tableConfiguration.setup(tableView)
+        tableView.layoutSubviews()
     }
 
     fileprivate func setupContentHandler() {
@@ -1538,16 +1539,27 @@ private extension ReaderStreamViewController {
                                           imageName: String? = nil,
                                           accessoryView: UIView? = nil) {
 
+        (accessoryView as? WPAnimatedBox)?.animate()
+
         resultsStatusView.configure(title: title, buttonTitle: buttonTitle, subtitle: subtitle, image: imageName, accessoryView: accessoryView)
         displayResultsStatus()
     }
 
     func displayResultsStatus() {
+
         resultsStatusView.removeFromView()
         tableViewController.addChild(resultsStatusView)
+
         tableView.insertSubview(resultsStatusView.view, belowSubview: refreshControl)
-        resultsStatusView.view.frame = tableView.frame
+
         resultsStatusView.didMove(toParent: tableViewController)
+
+        resultsStatusView.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            resultsStatusView.view.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
+            resultsStatusView.view.centerYAnchor.constraint(equalTo: tableView.centerYAnchor)
+            ])
+
         footerView.isHidden = true
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableConfiguration.swift
@@ -49,8 +49,12 @@ final class ReaderTableConfiguration {
         tableView.register(nib, forCellReuseIdentifier: readerCrossPostCellReuseIdentifier)
     }
 
-    func footer() -> Any? {
-        return Bundle.main.loadNibNamed(footerViewNibName, owner: nil, options: nil)?.first
+    func footer() -> PostListFooterView {
+        guard let footer = Bundle.main.loadNibNamed(footerViewNibName, owner: nil, options: nil)?.first as? PostListFooterView else {
+            assertionFailure("Failed to load view from nib named \(footerViewNibName)")
+            return PostListFooterView()
+        }
+        return footer
     }
 
     func estimatedRowHeight() -> CGFloat {


### PR DESCRIPTION
Fixes #9997 (and #9745 )

This PR attempts to solve a crash on the `ReaderStreamViewController` that could happen when attempting to `displayResultsStatus`. This `resultsStatusView` is a `NoResultsViewController` instance that is used to show the state of the controller (loading, no data, error, etc...).

### ReaderStreamViewController structure:
- The `ReaderStreamViewController` is a parent controller of a plane `UITableViewController`, that was being loaded from storyboard. This means that this outlet will be `nil` from the controller's init, until the `prepare(for segue:sender:)` method is called (there is where the reference is captured).

- This reference to the `tableViewController` was declared as `implicitly unwrapped`. ⚠️

- The `NoResultsViewController` instance is added as a child view controller of the aforementioned `UITableViewController`, whenever we need to show it to the user.

- The remote api call it's executed in parallel with the initialization of `ReaderStreamViewController`.

### The problem:

Whenever the api call returns faster than the period between the controller's `init` and the load of the `tableViewController` (on `prepare(for segue:sender)`), the controller will try to add the instance of `NoResultsViewController` into a yet inexistent UITableViewController reference, effectively crashing the app.

There seems to be errors that can return super fast, making this issue to surface. I'm not 100% sure what kind of errors are those, and I could reproduce this crash a couple of times but never consistently.

**The logs from Crashlytics can give us a hint:**
```
siteTopicForSiteWithID:isFeed:success:failure: 
error fetching site info for site with ID 53424024: 
Error Domain=WordPressKit.WordPressComRestApiError Code=7 "(null)"
```
This is an error after trying to open the `Discover` stream in the Reader.

There are other kind of errors too, and this crash also happens when trying to open a stream from a tag.

### The proposed solution

There are many ways to approach this issue. Ignoring the "why those errors happen?", I think we should handle this situation gracefully.

This proposal is to ensure that the UITableViewController is always present, removing optionals and the danger of encountering and unexpected "nil" reference.
In this way, the views can be setup at any given time, then presented to the user in the correct state when everything else is loaded.

There were a couple of troubles positioning the `NoResultsViewController` instance with the previous approach translating resizing masks into constraints, so I opted for using autolayout directly.

### To test

As I mentioned before, I couldn't find a way to consistently reproduce this crash, but I found a way to forced it: It is to return an error directly from the service calls.

- Setup:

`ReaderTopicService.m:438`: `- tagTopicForTagWithSlug:success:failure:` and
`ReaderTopicService.m:598`: `- siteTopicForSiteWithID:isFeed:success:failure:`
 add these lines:
```objective-c
    NSError *error = [NSError errorWithDomain:NSURLErrorDomain code:1 userInfo:nil];
    failure(error);
    return;
```

This will make the app crash every time you try to access the `Discover` Stream, or any tag from a reader post:
![img_75127b3ecbd8-1](https://user-images.githubusercontent.com/9772967/46760044-4a1fc180-cca7-11e8-845b-bbaf1f64c1a4.jpeg)

- Please be sure you can reproduce the error from `develop` branch.
  - Try to open the `Discover` Stream.
  - Try to open a tag from a reader post.
- Checkout this branch.
- Repeat previous steps trying to crash the app.
- Check that it's not crashing anymore .
- Check that the stream table view behaves how it should.
- Check that the NoResultViewController behaves how it should.

Thank you!

