### PR TITLE
Added Action sheet title that shows word and character count

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -467,12 +467,11 @@ class AztecPostViewController: UIViewController, PostEditor {
     var debouncer = Debouncer(delay: Constants.autoSavingDelay)
 
     fileprivate var wordsCount: UInt {
-        return mode == .richText ? richTextView.text.wordCount() : htmlTextView.text.wordCount()
+        return richTextView.text.wordCount()
     }
 
     fileprivate var charactersCount: Int {
-        let textView = mode == .richText ? richTextView : htmlTextView
-        guard let text = textView.text else {
+        guard let text = richTextView.text else {
             return 0
         }
         return text.count
@@ -1465,12 +1464,13 @@ private extension AztecPostViewController {
 
     func displayMoreSheet() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        if mode == .richText {
+            let textCounterTitle: String = {
+                return String(format: NSLocalizedString("%li words, %li characters", comment: "Displays the number of words and characters in text"), wordsCount, charactersCount)
+            }()
 
-        let textCounterTitle: String = {
-            return String(format: NSLocalizedString("%li words, %li characters", comment: "Displays the number of words and characters in text"), wordsCount, charactersCount)
-        }()
-
-        alert.title = textCounterTitle
+            alert.title = textCounterTitle
+        }
 
         if postEditorStateContext.isSecondaryPublishButtonShown,
             let buttonTitle = postEditorStateContext.secondaryPublishButtonText {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -466,6 +466,18 @@ class AztecPostViewController: UIViewController, PostEditor {
     ///
     var debouncer = Debouncer(delay: Constants.autoSavingDelay)
 
+    fileprivate var wordsCount: UInt {
+        return mode == .richText ? richTextView.text.wordCount() : htmlTextView.text.wordCount()
+    }
+
+    fileprivate var charactersCount: Int {
+        let textView = mode == .richText ? richTextView : htmlTextView
+        guard let text = textView.text else {
+            return 0
+        }
+        return text.count
+    }
+
     // MARK: - Initializers
 
     /// Initializer
@@ -1453,6 +1465,12 @@ private extension AztecPostViewController {
 
     func displayMoreSheet() {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+
+        let textCounterTitle: String = {
+            return String(format: NSLocalizedString("%li words, %li characters", comment: "Displays the number of words and characters in text"), wordsCount, charactersCount)
+        }()
+
+        alert.title = textCounterTitle
 
         if postEditorStateContext.isSecondaryPublishButtonShown,
             let buttonTitle = postEditorStateContext.secondaryPublishButtonText {


### PR DESCRIPTION
Fixes #10176  

To test:
• New Post *	
-      Create a new post
-      Type something in title
-      Type something in text view.
-      Tap on the 3 dots menu in the top right corner.
-      See the title of the action sheet shows the number of words and characters .

• Editing post *
-      open an existing post
-      Tap on the 3 dots menu in the top right corner
-      See the title of the action sheet shows the number of words and characters .
-      Continue editing.
-      Tap on the 3 dots menu in the top right corner.
-      See the title of the action sheet shows the updated number of words and characters.

![word_counting1](https://user-images.githubusercontent.com/1335657/46777515-86154f80-ccc4-11e8-891d-9f93fb0a31b1.gif)

