### PR TITLE
Fix problem when a page is saved as Draft

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
@@ -31,6 +31,10 @@ final class PageListTableViewHandler: WPTableViewHandler {
     }
 
     override func refreshTableView() {
+        refreshTableView(at: nil)
+    }
+
+    func refreshTableView(at indexPath: IndexPath?) {
         super.clearCachedRowHeights()
 
         do {
@@ -40,7 +44,11 @@ final class PageListTableViewHandler: WPTableViewHandler {
             DDLogError("Error fetching pages after refreshing the table: \(error)")
         }
 
-        tableView.reloadData()
+        if let indexPath = indexPath {
+            tableView.reloadSections(IndexSet(integer: indexPath.section), with: .fade)
+        } else {
+            tableView.reloadData()
+        }
     }
 
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -392,7 +392,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         alertController.presentFromRootViewController()
     }
 
-    fileprivate func draftPage(_ apost: AbstractPost) {
+    fileprivate func draftPage(_ apost: AbstractPost, at indexPath: IndexPath?) {
         WPAnalytics.track(.postListDraftAction, withProperties: propertiesForAnalytics())
 
         let previousStatus = apost.status
@@ -401,7 +401,11 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let contextManager = ContextManager.sharedInstance()
         let postService = PostService(managedObjectContext: contextManager.mainContext)
 
-        postService.uploadPost(apost, success: nil) { [weak self] (error) in
+        postService.uploadPost(apost, success: { [weak self] _ in
+            DispatchQueue.main.async {
+                self?._tableViewHandler.refreshTableView(at: indexPath)
+            }
+        }) { [weak self] (error) in
             apost.status = previousStatus
 
             if let strongSelf = self {
@@ -469,7 +473,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
                         return
                 }
 
-                strongSelf.draftPage(page)
+                strongSelf.draftPage(page, at: indexPath)
             })
 
             alertController.addActionWithTitle(deleteButtonTitle, style: .default, handler: { [weak self] (action) in
@@ -508,7 +512,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
                             return
                     }
 
-                    strongSelf.draftPage(page)
+                    strongSelf.draftPage(page, at: indexPath)
                 })
             }
 


### PR DESCRIPTION
This PR fix a bug when you try to move a page to Draft from the Publish filter: the list doesn't reload.

**To test:**
- From the pages list -> filter Published -> Set a page as Draft. You should see the table updated correctly.

@loremattei can we include this fix into 11.0?

