### PR TITLE
Added rich notification support for Mentions

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Notifiable.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Notifiable.swift
@@ -21,7 +21,8 @@ enum NotificationKind: String {
 extension NotificationKind {
     /// Enumerates the Kinds that currently provide Rich Notification support
     private static var kindsWithRichNotificationSupport: Set<NotificationKind> = [
-        .comment
+        .comment,
+        .matcher
     ]
 
     /// Indicates whether or not a given kind has rich notification support.

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Notifiable.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Notifiable.swift
@@ -32,6 +32,20 @@ extension NotificationKind {
     static func isSupportedByRichNotifications(_ kind: NotificationKind) -> Bool {
         return kindsWithRichNotificationSupport.contains(kind)
     }
+
+    /// Returns a client-side notification category. The category provides a match to ensure that the Long Look
+    /// can be presented.
+    ///
+    /// NB: These should all be set on the server, but in practice, they are not.
+    ///
+    var contentExtensionCategoryIdentifier: String? {
+        switch self {
+        case .matcher:
+            return rawValue
+        default:
+            return nil
+        }
+    }
 }
 
 // MARK: - Notifiable

--- a/WordPress/WordPressNotificationContentExtension/Info-Alpha.plist
+++ b/WordPress/WordPressNotificationContentExtension/Info-Alpha.plist
@@ -30,6 +30,7 @@
 				<string>like-comment</string>
 				<string>replyto-comment</string>
 				<string>replyto-like-comment</string>
+				<string>automattcher</string>
 			</array>
 			<key>UNNotificationExtensionDefaultContentHidden</key>
 			<true/>
@@ -41,9 +42,9 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.usernotifications.content-extension</string>
 	</dict>
-    <key>UIAppFonts</key>
-    <array>
-        <string>Noticons.ttf</string>
-    </array>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Noticons.ttf</string>
+	</array>
 </dict>
 </plist>

--- a/WordPress/WordPressNotificationContentExtension/Info-Internal.plist
+++ b/WordPress/WordPressNotificationContentExtension/Info-Internal.plist
@@ -30,6 +30,7 @@
 				<string>like-comment</string>
 				<string>replyto-comment</string>
 				<string>replyto-like-comment</string>
+				<string>automattcher</string>
 			</array>
 			<key>UNNotificationExtensionDefaultContentHidden</key>
 			<true/>
@@ -41,9 +42,9 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.usernotifications.content-extension</string>
 	</dict>
-    <key>UIAppFonts</key>
-    <array>
-        <string>Noticons.ttf</string>
-    </array>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Noticons.ttf</string>
+	</array>
 </dict>
 </plist>

--- a/WordPress/WordPressNotificationContentExtension/Info.plist
+++ b/WordPress/WordPressNotificationContentExtension/Info.plist
@@ -30,6 +30,7 @@
 				<string>like-comment</string>
 				<string>replyto-comment</string>
 				<string>replyto-like-comment</string>
+				<string>automattcher</string>
 			</array>
 			<key>UNNotificationExtensionDefaultContentHidden</key>
 			<true/>
@@ -41,9 +42,9 @@
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.usernotifications.content-extension</string>
 	</dict>
-    <key>UIAppFonts</key>
-    <array>
-        <string>Noticons.ttf</string>
-    </array>
+	<key>UIAppFonts</key>
+	<array>
+		<string>Noticons.ttf</string>
+	</array>
 </dict>
 </plist>

--- a/WordPress/WordPressNotificationServiceExtension/Sources/FormattableContent/RemoteNotificationStyles.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/FormattableContent/RemoteNotificationStyles.swift
@@ -79,7 +79,7 @@ class RemoteNotificationStyles: FormattableContentStyles {
             .blockquote: [ .font: prevailingItalicizedFont ],
             .comment: [ .font: prevailingItalicizedFont ],
             .follow: [:],
-            .italic: [:],
+            .italic: [ .font: prevailingItalicizedFont ],
             .link: [:],
             .match: [:],
             .noticon: [ .font: noticonFont ],

--- a/WordPress/WordPressNotificationServiceExtension/Sources/FormattableContent/RemoteNotificationStyles.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/FormattableContent/RemoteNotificationStyles.swift
@@ -3,7 +3,7 @@ import Foundation
 import WordPressShared
 import WordPressUI
 
-// MARK: - FormattableContentStyles
+// MARK: - RemoteNotificationStyles
 
 /// Describes how Notifications should appear in the Long Look.
 /// Influenced by both SnippetsContentStyles & SubjectContentStyles.

--- a/WordPress/WordPressNotificationServiceExtension/Sources/FormattableContent/RichNotificationContentFormatter.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/FormattableContent/RichNotificationContentFormatter.swift
@@ -45,9 +45,9 @@ private extension RichNotificationContentFormatter {
     func formatBody() {
         guard let body = notification.body,
             let bodyBlocks = body as? [[String: AnyObject]],
-            !bodyBlocks.isEmpty else {
+            bodyBlocks.isEmpty == false else {
 
-                return
+            return
         }
 
         let blocks = NotificationContentFactory.content(from: bodyBlocks, actionsParser: parser, parent: notification)
@@ -59,7 +59,7 @@ private extension RichNotificationContentFormatter {
             let bodyContentGroup = FormattableContentGroup(blocks: blocks, kind: .text)
             let bodyContentBlocks = bodyContentGroup.blocks
 
-            if !bodyContentBlocks.isEmpty,
+            if bodyContentBlocks.isEmpty == false,
                 let bodyContentBlock = bodyContentBlocks.first {
 
                 formattableContent = bodyContentBlock
@@ -71,7 +71,7 @@ private extension RichNotificationContentFormatter {
         guard let validContent = formattableContent,
             let bodyText = validContent.text else {
 
-                return
+            return
         }
 
         let trimmedText = replaceCommonWhitespaceIssues(in: bodyText)
@@ -93,20 +93,20 @@ private extension RichNotificationContentFormatter {
     func formatAttributedSubject() {
         guard let subject = notification.subject,
             let subjectBlocks = subject as? [[String: AnyObject]],
-            !subjectBlocks.isEmpty else {
+            subjectBlocks.isEmpty == false else {
 
-                return
+            return
         }
 
         let blocks = NotificationContentFactory.content(from: subjectBlocks, actionsParser: parser, parent: notification)
         let subjectContentGroup = FormattableContentGroup(blocks: blocks, kind: .subject)
         let subjectContentBlocks = subjectContentGroup.blocks
 
-        guard !subjectContentBlocks.isEmpty,
+        guard subjectContentBlocks.isEmpty == false,
             let subjectContentBlock = subjectContentBlocks.first,
             let subjectText = subjectContentBlock.text else {
 
-                return
+            return
         }
 
         let trimmedText = replaceCommonWhitespaceIssues(in: subjectText)

--- a/WordPress/WordPressNotificationServiceExtension/Sources/FormattableContent/RichNotificationContentFormatter.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/FormattableContent/RichNotificationContentFormatter.swift
@@ -27,26 +27,19 @@ class RichNotificationContentFormatter {
     ///
     /// - Returns: the formatted body of the notification if it exists; `nil` otherwise
     func formatAttributedBody() -> NSAttributedString? {
-        guard
-            let body = notification.body,
+        guard let body = notification.body,
             let bodyBlocks = body as? [[String: AnyObject]],
-            !bodyBlocks.isEmpty
-        else
-        {
+            !bodyBlocks.isEmpty else {
+
             return nil
         }
 
-        let blocks = NotificationContentFactory.content(
-            from: bodyBlocks,
-            actionsParser: parser,
-            parent: notification)
+        let blocks = NotificationContentFactory.content(from: bodyBlocks, actionsParser: parser, parent: notification)
 
-        guard
-            let comment: FormattableCommentContent = FormattableContentGroup.blockOfKind(.comment, from: blocks),
+        guard let comment: FormattableCommentContent = FormattableContentGroup.blockOfKind(.comment, from: blocks),
             let commentText = comment.text,
-            !commentText.isEmpty
-        else
-        {
+            !commentText.isEmpty else {
+
             return nil
         }
 
@@ -66,29 +59,21 @@ class RichNotificationContentFormatter {
     ///
     /// - Returns: the formatted subject of the notification if it exists; `nil` otherwise
     func formatAttributedSubject() -> NSAttributedString? {
-        guard
-            let subject = notification.subject,
+        guard let subject = notification.subject,
             let subjectBlocks = subject as? [[String: AnyObject]],
-            !subjectBlocks.isEmpty
-        else
-        {
+            !subjectBlocks.isEmpty else {
+
             return nil
         }
 
-        let blocks = NotificationContentFactory.content(
-            from: subjectBlocks,
-            actionsParser: parser,
-            parent: notification)
-
+        let blocks = NotificationContentFactory.content(from: subjectBlocks, actionsParser: parser, parent: notification)
         let subjectContentGroup = FormattableContentGroup(blocks: blocks, kind: .subject)
         let subjectContentBlocks = subjectContentGroup.blocks
 
-        guard
-            !subjectContentBlocks.isEmpty,
+        guard !subjectContentBlocks.isEmpty,
             let subjectContentBlock = subjectContentBlocks.first,
-            let subjectText = subjectContentBlock.text
-        else
-        {
+            let subjectText = subjectContentBlock.text else {
+
             return nil
         }
 
@@ -108,25 +93,18 @@ class RichNotificationContentFormatter {
     ///
     /// - Returns: a plain-text representation of the notification body if successful; `nil` otherwise
     func formatBody() -> String? {
-        guard
-            let body = notification.body,
-            let bodyBlocks = body as? [[String: AnyObject]]
-        else
-        {
+        guard let body = notification.body,
+            let bodyBlocks = body as? [[String: AnyObject]] else {
+
             return nil
         }
 
-        let blocks = NotificationContentFactory.content(
-            from: bodyBlocks,
-            actionsParser: parser,
-            parent: notification)
+        let blocks = NotificationContentFactory.content(from: bodyBlocks, actionsParser: parser, parent: notification)
 
-        guard
-            let comment: FormattableCommentContent = FormattableContentGroup.blockOfKind(.comment, from: blocks),
+        guard let comment: FormattableCommentContent = FormattableContentGroup.blockOfKind(.comment, from: blocks),
             let commentText = comment.text,
-            !commentText.isEmpty
-        else
-        {
+            !commentText.isEmpty else {
+
             return nil
         }
 
@@ -136,13 +114,13 @@ class RichNotificationContentFormatter {
 
 // MARK: FormattableContentFormatter adaptation; importing it directly is problematic
 
-extension RichNotificationContentFormatter {
+private extension RichNotificationContentFormatter {
     /// Replaces some common extra whitespace with hairline spaces so that comments display better
     ///
     /// - Parameter baseString: string of the comment body before attributes are added
     /// - Returns: string of same length
     /// - Note: the length must be maintained or the formatting will break
-    private func replaceCommonWhitespaceIssues(in baseString: String) -> String {
+    func replaceCommonWhitespaceIssues(in baseString: String) -> String {
         var newString: String
         // \u{200A} = hairline space (very skinny space).
         // we use these so that the ranges are still in the right position, but the extra space basically disappears

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -2,6 +2,8 @@ import UserNotifications
 
 import WordPressKit
 
+// MARK: - NotificationService
+
 /// Responsible for enrich the content of designated push notifications.
 class NotificationService: UNNotificationServiceExtension {
 
@@ -10,14 +12,14 @@ class NotificationService: UNNotificationServiceExtension {
     /// Manages analytics calls via Tracks
     private let tracks = Tracks(appGroupName: WPAppGroupName)
 
-    /// The service used to retrieve remote notifications
-    private var notificationService: NotificationSyncServiceRemote?
-
     /// The content handler received from the extension
     private var contentHandler: ((UNNotificationContent) -> Void)?
 
     /// The pending rich notification content
     private var bestAttemptContent: UNMutableNotificationContent?
+
+    /// The service used to retrieve remote notifications
+    private var notificationService: NotificationSyncServiceRemote?
 
     // MARK: UNNotificationServiceExtension
 
@@ -97,20 +99,21 @@ class NotificationService: UNNotificationServiceExtension {
             contentHandler(bestAttemptContent)
         }
     }
+}
 
-    // MARK: Private behavior
+// MARK: - Keychain support
 
+private extension NotificationService {
     /// Retrieves the WPCOM OAuth Token, meant for Extension usage.
     ///
     /// - Returns: the token if found; `nil` otherwise
     ///
-    private func readExtensionToken() -> String? {
+    func readExtensionToken() -> String? {
         guard let oauthToken = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainTokenKey,
                                                                              andServiceName: WPNotificationServiceExtensionKeychainServiceName,
                                                                              accessGroup: WPAppKeychainAccessGroup) else {
-
-                                                                                debugPrint("Unable to retrieve Notification Service Extension OAuth token")
-                                                                                return nil
+            debugPrint("Unable to retrieve Notification Service Extension OAuth token")
+            return nil
         }
 
         return oauthToken
@@ -120,13 +123,12 @@ class NotificationService: UNNotificationServiceExtension {
     ///
     /// - Returns: the username if found; `nil` otherwise
     ///
-    private func readExtensionUsername() -> String? {
+    func readExtensionUsername() -> String? {
         guard let username = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainUsernameKey,
                                                                            andServiceName: WPNotificationServiceExtensionKeychainServiceName,
                                                                            accessGroup: WPAppKeychainAccessGroup) else {
-
-                                                                            debugPrint("Unable to retrieve Notification Service Extension username")
-                                                                            return nil
+            debugPrint("Unable to retrieve Notification Service Extension username")
+            return nil
         }
 
         return username

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -51,6 +51,10 @@ class NotificationService: UNNotificationServiceExtension {
             return
         }
 
+        if let category = notificationKind.contentExtensionCategoryIdentifier {
+            notificationContent.categoryIdentifier = category
+        }
+
         notificationContent.title = apsAlert
 
         let api = WordPressComRestApi(oAuthToken: token)

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -72,14 +72,14 @@ class NotificationService: UNNotificationServiceExtension {
 
             let contentFormatter = RichNotificationContentFormatter(notification: notification)
 
-            guard let bodyText = contentFormatter.formatBody() else {
+            guard let bodyText = contentFormatter.body else {
                 return
             }
             notificationContent.body = bodyText
 
             let viewModel = RichNotificationViewModel(
-                attributedBody: contentFormatter.formatAttributedBody(),
-                attributedSubject: contentFormatter.formatAttributedSubject(),
+                attributedBody: contentFormatter.attributedBody,
+                attributedSubject: contentFormatter.attributedSubject,
                 gravatarURLString: notification.icon,
                 noticon: notification.noticon)
             viewModel.encodeToUserInfo(notificationContent: notificationContent)


### PR DESCRIPTION
### Description 
Fixes #10101, which allows _Mentions_ to join _Comments_ in the class of rich notifications we support. 

This PR consists of the following changes:

1. Tidies up some code formatting for consistency, particular with regard to multiline control statements. Team convention was point out to me [elsewhere](https://github.com/wordpress-mobile/WordPress-iOS/pull/10066).
1. Modifies the formattable content styling to account for more notification types.
1. Exposes `automattcher` as a category identifier so that _Mention_ notifications can be presented in the Long Look.

### Testing
First, confirm that the branch builds & existing test pass. Next, validate the successful receipt & rendering of _Mention_ notifications.

Push notifications tend to require manual testing. This can be exercised by triggering various notifications or by manually pushing an APNS payload.

The former requires you to configure Notification settings for a site you follow in the app. The latter involves the use of [Pusher](https://github.com/noodlewerk/NWPusher) or similar; instructions can be found [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/9924). I'm happy to furnish you with sample payloads and/or the P12 file necessary to do this with fabricated payloads; feel free to contact me via Slack for assistance.

### Screenshots
The following screenshots depict the expected results for a fabricated APNS payload. The _Long Look_ is presented by Force Touch on the _Short Look_.
![Short Look](https://user-images.githubusercontent.com/221062/46820897-2490c780-cd3c-11e8-9fe7-10649b40a4bb.png)
![Long Look](https://user-images.githubusercontent.com/221062/46821072-9e28b580-cd3c-11e8-960d-31718a85ae66.png)

_Please note that the Long Look renders fine, but the screenshot has been partially obfuscated._