### PR TITLE
Use frame instead of constraint

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -31,7 +31,7 @@
     
     [self configurePageLevel];
     
-    CGFloat indentPoints = (CGFloat)self.indentationLevel * self.indentationWidth;
+    CGFloat indentPoints = self.indentationLevel * self.indentationWidth;
     self.contentView.frame = CGRectMake(indentPoints,
                                         self.contentView.frame.origin.y,
                                         self.contentView.frame.size.width - indentPoints,
@@ -81,7 +81,7 @@
 {
     Page *page = (Page *)self.post;
     self.indentationWidth = 16.0;
-    self.indentationLevel = page.hierarchyIndex;
+    self.indentationLevel = ![page.status isEqualToString: PostStatusPublish] ? 0 : page.hierarchyIndex;
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -6,7 +6,6 @@
 
 @property (nonatomic, strong) IBOutlet UILabel *titleLabel;
 @property (nonatomic, strong) IBOutlet UIButton *menuButton;
-@property (strong, nonatomic) IBOutlet NSLayoutConstraint *leftPadding;
 
 @end
 
@@ -25,6 +24,20 @@
     
     [self applyStyles];
 }
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    
+    [self configurePageLevel];
+    
+    CGFloat indentPoints = (CGFloat)self.indentationLevel * self.indentationWidth;
+    self.contentView.frame = CGRectMake(indentPoints,
+                                        self.contentView.frame.origin.y,
+                                        self.contentView.frame.size.width - indentPoints,
+                                        self.contentView.frame.size.height);
+}
+
 
 #pragma mark - Accessors
 
@@ -67,7 +80,8 @@
 - (void)configurePageLevel
 {
     Page *page = (Page *)self.post;
-    self.leftPadding.constant = 16.0 * page.hierarchyIndex;
+    self.indentationWidth = 16.0;
+    self.indentationLevel = page.hierarchyIndex;
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -33,7 +33,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VPZ-yr-cJj">
-                                <rect key="frame" x="264" y="-2" width="56" height="47"/>
+                                <rect key="frame" x="264" y="-2" width="56" height="47.5"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="47" id="3OU-Uq-a1V"/>
                                     <constraint firstAttribute="width" constant="56" id="Smb-26-LSz"/>
@@ -68,7 +68,6 @@
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
-                <outlet property="leftPadding" destination="El0-aj-PpS" id="E2y-Pz-7xR"/>
                 <outlet property="menuButton" destination="VPZ-yr-cJj" id="yjZ-Su-mum"/>
                 <outlet property="titleLabel" destination="rQF-5A-jGg" id="HkF-g8-kZX"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -180,6 +180,13 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         super.selectedFilterDidChange(filterBar)
     }
 
+    override func updateFilterWithPostStatus(_ status: BasePost.Status) {
+        filterSettings.setFilterWithPostStatus(status)
+        _tableViewHandler.status = filterSettings.currentPostListFilter().filterType
+        _tableViewHandler.refreshTableView()
+        super.updateFilterWithPostStatus(status)
+    }
+
     override func updateAndPerformFetchRequest() {
         super.updateAndPerformFetchRequest()
 


### PR DESCRIPTION
This PR fix a problem with the cell indentation, replacing the leading constraint with frame.

**To test:**
- If a pages list (Published filter) has child pages, then it shouldn't loose indentation switching section or doing some other action.


