### PR TITLE
Fix Undo action 

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -4,7 +4,7 @@ import WordPressShared
 
 
 class PageListViewController: AbstractPostListViewController, UIViewControllerRestoration {
-
+    fileprivate static let HTTPErrorCodeForbidden = Int(403)
     fileprivate static let pageSectionHeaderHeight = CGFloat(40.0)
     fileprivate static let pageCellEstimatedRowHeight = CGFloat(47.0)
     fileprivate static let pagesViewControllerRestorationKey = "PagesViewControllerRestorationKey"
@@ -423,6 +423,65 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         }
     }
 
+    func restorePost(_ apost: AbstractPost, at indexPath: IndexPath?) {
+        WPAnalytics.track(.postListRestoreAction, withProperties: propertiesForAnalytics())
+
+        // if the post was recently deleted, update the status helper and reload the cell to display a spinner
+        let postObjectID = apost.objectID
+
+        if let index = recentlyTrashedPostObjectIDs.index(of: postObjectID) {
+            recentlyTrashedPostObjectIDs.remove(at: index)
+        }
+
+        let postService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        postService.restore(apost, success: { [weak self] in
+            guard let strongSelf = self else {
+                return
+            }
+
+            var apost: AbstractPost
+
+            // Make sure the post still exists.
+            do {
+                apost = try strongSelf.managedObjectContext().existingObject(with: postObjectID) as! AbstractPost
+            } catch {
+                DDLogError("\(error)")
+                return
+            }
+
+            DispatchQueue.main.async {
+                strongSelf._tableViewHandler.refreshTableView(at: indexPath)
+            }
+
+            if let postStatus = apost.status {
+                // If the post was restored, see if it appears in the current filter.
+                // If not, prompt the user to let it know under which filter it appears.
+                let filter = strongSelf.filterSettings.filterThatDisplaysPostsWithStatus(postStatus)
+                if filter.filterType == strongSelf.filterSettings.currentPostListFilter().filterType {
+                    return
+                }
+
+                strongSelf.promptThatPostRestoredToFilter(filter)
+
+                // Reindex the restored post in spotlight
+                SearchManager.shared.indexItem(apost)
+            }
+        }) { [weak self] (error) in
+            guard let strongSelf = self else {
+                return
+            }
+
+            if let error = error as NSError?,
+                error.code == type(of: strongSelf).HTTPErrorCodeForbidden {
+                strongSelf.promptForPassword()
+            } else {
+                WPError.showXMLRPCErrorAlert(error)
+            }
+
+            strongSelf.recentlyTrashedPostObjectIDs.append(postObjectID)
+        }
+    }
+
     override func promptThatPostRestoredToFilter(_ filter: PostListFilter) {
         var message = NSLocalizedString("Page Restored to Drafts", comment: "Prompts the user that a restored page was moved to the drafts list.")
 
@@ -633,7 +692,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     fileprivate func handleRestoreAction(fromCell cell: UITableViewCell, forPage page: AbstractPost) {
-        restorePost(page)
+        restorePost(page, at: tableView.indexPath(for: cell))
     }
 
     // MARK: - UISearchControllerDelegate

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -423,65 +423,6 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         }
     }
 
-    func restorePost(_ apost: AbstractPost, at indexPath: IndexPath?) {
-        WPAnalytics.track(.postListRestoreAction, withProperties: propertiesForAnalytics())
-
-        // if the post was recently deleted, update the status helper and reload the cell to display a spinner
-        let postObjectID = apost.objectID
-
-        if let index = recentlyTrashedPostObjectIDs.index(of: postObjectID) {
-            recentlyTrashedPostObjectIDs.remove(at: index)
-        }
-
-        let postService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        postService.restore(apost, success: { [weak self] in
-            guard let strongSelf = self else {
-                return
-            }
-
-            var apost: AbstractPost
-
-            // Make sure the post still exists.
-            do {
-                apost = try strongSelf.managedObjectContext().existingObject(with: postObjectID) as! AbstractPost
-            } catch {
-                DDLogError("\(error)")
-                return
-            }
-
-            DispatchQueue.main.async {
-                strongSelf._tableViewHandler.refreshTableView(at: indexPath)
-            }
-
-            if let postStatus = apost.status {
-                // If the post was restored, see if it appears in the current filter.
-                // If not, prompt the user to let it know under which filter it appears.
-                let filter = strongSelf.filterSettings.filterThatDisplaysPostsWithStatus(postStatus)
-                if filter.filterType == strongSelf.filterSettings.currentPostListFilter().filterType {
-                    return
-                }
-
-                strongSelf.promptThatPostRestoredToFilter(filter)
-
-                // Reindex the restored post in spotlight
-                SearchManager.shared.indexItem(apost)
-            }
-        }) { [weak self] (error) in
-            guard let strongSelf = self else {
-                return
-            }
-
-            if let error = error as NSError?,
-                error.code == type(of: strongSelf).HTTPErrorCodeForbidden {
-                strongSelf.promptForPassword()
-            } else {
-                WPError.showXMLRPCErrorAlert(error)
-            }
-
-            strongSelf.recentlyTrashedPostObjectIDs.append(postObjectID)
-        }
-    }
-
     override func promptThatPostRestoredToFilter(_ filter: PostListFilter) {
         var message = NSLocalizedString("Page Restored to Drafts", comment: "Prompts the user that a restored page was moved to the drafts list.")
 
@@ -692,7 +633,9 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     fileprivate func handleRestoreAction(fromCell cell: UITableViewCell, forPage page: AbstractPost) {
-        restorePost(page, at: tableView.indexPath(for: cell))
+        restorePost(page) { [weak self] in
+            self?._tableViewHandler.refreshTableView(at: self?.tableView.indexPath(for: cell))
+        }
     }
 
     // MARK: - UISearchControllerDelegate

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -4,7 +4,6 @@ import WordPressShared
 
 
 class PageListViewController: AbstractPostListViewController, UIViewControllerRestoration {
-    fileprivate static let HTTPErrorCodeForbidden = Int(403)
     fileprivate static let pageSectionHeaderHeight = CGFloat(40.0)
     fileprivate static let pageCellEstimatedRowHeight = CGFloat(47.0)
     fileprivate static let pagesViewControllerRestorationKey = "PagesViewControllerRestorationKey"

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -976,7 +976,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         })
     }
 
-    @objc func restorePost(_ apost: AbstractPost) {
+    @objc func restorePost(_ apost: AbstractPost, completion: (() -> Void)? = nil) {
         WPAnalytics.track(.postListRestoreAction, withProperties: propertiesForAnalytics())
 
         // if the post was recently deleted, update the status helper and reload the cell to display a spinner
@@ -1002,6 +1002,10 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
             } catch {
                 DDLogError("\(error)")
                 return
+            }
+
+            DispatchQueue.main.async {
+                completion?()
             }
 
             if let postStatus = apost.status {


### PR DESCRIPTION
This PR fix a problem related to the Undo action after a page has been moved to the trash:

*Problem:*
Given a Page, if a user decide to move it to Trash, then decide to Undo, the tableview doesn't reload.

**To test:**
1. Move a page to Trash
2. Press on Undo
3. The tableview should reload and you should see the Page cell again


