### PR TITLE
Fix pages list including blog predicate

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
@@ -13,7 +13,7 @@ final class PageListTableViewHandler: WPTableViewHandler {
     private lazy var publishedResultController: NSFetchedResultsController<NSFetchRequestResult> = {
         let publishedFilter = PostListFilter.publishedFilter()
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: Page.entityName())
-        let predicate = NSPredicate(format: "blog = %@ && revision = nil", blog)
+        let predicate = NSPredicate(format: "\(#keyPath(Page.blog)) = %@ && \(#keyPath(Page.revision)) = nil", blog)
         let predicates = [predicate, publishedFilter.predicateForFetchRequest]
         fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         fetchRequest.sortDescriptors = publishedFilter.sortDescriptors

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewHandler.swift
@@ -9,11 +9,13 @@ final class PageListTableViewHandler: WPTableViewHandler {
     }
 
     private var pages: [Page] = []
-
+    private let blog: Blog
     private lazy var publishedResultController: NSFetchedResultsController<NSFetchRequestResult> = {
         let publishedFilter = PostListFilter.publishedFilter()
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: Page.entityName())
-        fetchRequest.predicate = publishedFilter.predicateForFetchRequest
+        let predicate = NSPredicate(format: "blog = %@ && revision = nil", blog)
+        let predicates = [predicate, publishedFilter.predicateForFetchRequest]
+        fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         fetchRequest.sortDescriptors = publishedFilter.sortDescriptors
         return resultsController(with: fetchRequest, context: managedObjectContext())
     }()
@@ -25,6 +27,12 @@ final class PageListTableViewHandler: WPTableViewHandler {
     private lazy var flatResultsController: NSFetchedResultsController<NSFetchRequestResult> = {
         return resultsController(with: fetchRequest(), context: managedObjectContext(), performFetch: true)
     }()
+
+
+    init(tableView: UITableView, blog: Blog) {
+        self.blog = blog
+        super.init(tableView: tableView)
+    }
 
     override var resultsController: NSFetchedResultsController<NSFetchRequestResult> {
         return groupResults ? groupedResultsController : flatResultsController

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -21,7 +21,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }()
 
     @objc private lazy var _tableViewHandler: PageListTableViewHandler = {
-        let tableViewHandler = PageListTableViewHandler(tableView: self.tableView)
+        let tableViewHandler = PageListTableViewHandler(tableView: self.tableView, blog: self.blog)
         tableViewHandler.cacheRowHeights = false
         tableViewHandler.delegate = self
         tableViewHandler.listensForContentChanges = false


### PR DESCRIPTION
This PR fix #10254 

@rachelmcr found a bug related to the *Set Parent* action: *on that screen, the pages list for setting a parent page includes pages from other sites I own.*

**To test:**
- Try to set a parent page
- You should see only published pages for that specific blog


