### PR TITLE
Quick Start: add the last three tours

### DIFF
--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -93,6 +93,7 @@ enum NoticeAction: Action {
     case post(Notice)
     /// The currently displayed notice should be removed from the notice store
     case dismiss
+    case empty
 }
 
 
@@ -118,6 +119,8 @@ class NoticeStore: StatefulStore<NoticeStoreState> {
             enqueueNotice(notice)
         case .dismiss:
             dequeueNotice()
+        case .empty:
+            emptyQueue()
         }
     }
 
@@ -142,5 +145,9 @@ class NoticeStore: StatefulStore<NoticeStoreState> {
 
     private func dequeueNotice() {
         state.notice = pending.pop()
+    }
+
+    private func emptyQueue() {
+        pending = Queue<Notice>()
     }
 }

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -77,6 +77,7 @@
 #import "SettingsMultiTextViewController.h"
 #import "SettingTableViewCell.h"
 #import "SettingsTextViewController.h"
+#import "SharingViewController.h"
 #import "SFHFKeychainUtils.h"
 #import "SiteSettingsViewController.h"
 #import "SourcePostAttribution.h"

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -1,6 +1,17 @@
 private var alertWorkItem: DispatchWorkItem?
+private var observer: NSObjectProtocol?
 
 extension BlogDetailsViewController {
+    @objc func startObservingQuickStart() {
+        observer = NotificationCenter.default.addObserver(forName: .QuickStartTourElementChangedNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.configureTableViewData()
+            self?.reloadTableViewPreservingSelection()
+        }
+    }
+
+    @objc func stopObservingQuickStart() {
+        NotificationCenter.default.removeObserver(observer)
+    }
 
     @objc func startAlertTimer() {
         let newWorkItem = DispatchWorkItem { [weak self] in

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -10,7 +10,7 @@ extension BlogDetailsViewController {
     }
 
     @objc func stopObservingQuickStart() {
-        NotificationCenter.default.removeObserver(observer)
+        NotificationCenter.default.removeObserver(observer as Any)
     }
 
     @objc func startAlertTimer() {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
@@ -24,5 +24,6 @@ typedef NS_ENUM(NSUInteger, BlogDetailsSubsection) {
 @property (nonatomic, strong) Blog *blog;
 
 - (void)showDetailViewForSubsection:(BlogDetailsSubsection)section;
-
+- (void)reloadTableViewPreservingSelection;
+- (void)configureTableViewData;
 @end

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -652,11 +652,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     NSMutableArray *rows = [NSMutableArray array];
 
     if ([self.blog supports:BlogFeatureSharing]) {
-        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Sharing", @"Noun. Title. Links to a blog's sharing options.")
-                                                        image:[Gridicon iconOfType:GridiconTypeShare]
-                                                     callback:^{
-                                                         [weakSelf showSharing];
-                                                     }]];
+        BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Sharing", @"Noun. Title. Links to a blog's sharing options.")
+                                        image:[Gridicon iconOfType:GridiconTypeShare]
+                                     callback:^{
+                                         [weakSelf showSharing];
+                                     }];
+        row.quickStartIdentifier = QuickStartTourElementSharing;
+        [rows addObject:row];
     }
 
     if ([self.blog supports:BlogFeaturePeople]) {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -222,6 +222,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)dealloc
 {
+    [self stopObservingQuickStart];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
@@ -272,7 +273,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     [self configureBlogDetailHeader];
     [self.headerView setBlog:_blog];
-    
+    [self startObservingQuickStart];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -1230,6 +1231,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     [WPAppAnalytics track:WPAnalyticsStatOpenedSharingManagement withBlog:self.blog];
     [self showDetailViewController:controller sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementSharing];
 }
 
 - (void)showStats
@@ -1255,6 +1258,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     QuickStartChecklistViewController *checklist = [[QuickStartChecklistViewController alloc] initWithBlog:self.blog];
     [self.navigationController showDetailViewController:checklist sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementChecklist];
 }
 
 - (void)showActivity
@@ -1268,6 +1273,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatThemesAccessedThemeBrowser withBlog:self.blog];
     ThemeBrowserViewController *viewController = [ThemeBrowserViewController browserWithBlog:self.blog];
     [self showDetailViewController:viewController sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementThemes];
 }
 
 - (void)showMenus

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
@@ -39,11 +39,21 @@ class QuickStartNavigationWatcher: NSObject, UINavigationControllerDelegate {
 
         let newSpotlightView = QuickStartSpotlightView()
         newSpotlightView.translatesAutoresizingMaskIntoConstraints = false
-        readerNav.navigationBar.addSubview(newSpotlightView)
-        readerNav.navigationBar.addConstraints([
-                newSpotlightView.leadingAnchor.constraint(equalTo: readerNav.navigationBar.leadingAnchor, constant: 30.0),
-                newSpotlightView.topAnchor.constraint(equalTo: readerNav.navigationBar.topAnchor, constant: 15.0),
-            ])
+        if #available(iOS 11, *) {
+            readerNav.navigationBar.addSubview(newSpotlightView)
+            readerNav.navigationBar.addConstraints([
+                    newSpotlightView.leadingAnchor.constraint(equalTo: readerNav.navigationBar.leadingAnchor, constant: 30.0),
+                    newSpotlightView.topAnchor.constraint(equalTo: readerNav.navigationBar.topAnchor, constant: 15.0),
+                ])
+        } else {
+            if let parentView = readerNav.navigationBar.window {
+                parentView.addSubview(newSpotlightView)
+                parentView.addConstraints([
+                    newSpotlightView.leadingAnchor.constraint(equalTo: parentView.leadingAnchor, constant: 30.0),
+                    newSpotlightView.topAnchor.constraint(equalTo: parentView.topAnchor, constant: 15.0),
+                    ])
+            }
+        }
         spotlightView = newSpotlightView
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
@@ -23,6 +23,14 @@ class QuickStartNavigationWatcher: NSObject, UINavigationControllerDelegate {
         }
     }
 
+    func shouldSkipReaderBack() -> Bool {
+        guard let readerNav = readerNav else {
+            return false
+        }
+
+        return !readerNav.hasHorizontallyCompactView()
+    }
+
     private func checkToSpotlightReader() {
         guard let tourGuide = QuickStartTourGuide.find(),
             tourGuide.isCurrentElement(.readerBack) else {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
@@ -4,8 +4,6 @@ class QuickStartNavigationWatcher: NSObject, UINavigationControllerDelegate {
     private var spotlightView: QuickStartSpotlightView?
 
     func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
-
-
         guard let tourGuide = QuickStartTourGuide.find() else {
             return
         }
@@ -28,11 +26,22 @@ class QuickStartNavigationWatcher: NSObject, UINavigationControllerDelegate {
             tourGuide.visited(.readerSearch)
             fallthrough
         case is ReaderStreamViewController, is ReaderSavedPostsViewController:
-            tourGuide.readerNeedsBack = true
             readerNav = navigationController
+
+            tourGuide.readerNeedsBack = true
+            checkToSpotlightReader()
         default:
             break
         }
+    }
+
+    private func checkToSpotlightReader() {
+        guard let tourGuide = QuickStartTourGuide.find(),
+            tourGuide.isCurrentElement(.readerBack) else {
+            return
+        }
+
+        spotlightReaderBackButton()
     }
 
     func spotlightReaderBackButton() {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
@@ -1,6 +1,11 @@
 @objc
 class QuickStartNavigationWatcher: NSObject, UINavigationControllerDelegate {
-    public func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+    private weak var readerNav: UINavigationController?
+    private var spotlightView: QuickStartSpotlightView?
+
+    func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
+
+
         guard let tourGuide = QuickStartTourGuide.find() else {
             return
         }
@@ -18,13 +23,39 @@ class QuickStartNavigationWatcher: NSObject, UINavigationControllerDelegate {
         case is ReaderMenuViewController:
             tourGuide.visited(.readerBack)
             tourGuide.readerNeedsBack = false
+            removeReaderSpotlight()
         case is ReaderSearchViewController:
             tourGuide.visited(.readerSearch)
             fallthrough
         case is ReaderStreamViewController, is ReaderSavedPostsViewController:
             tourGuide.readerNeedsBack = true
+            readerNav = navigationController
         default:
             break
         }
+    }
+
+    func spotlightReaderBackButton() {
+        guard let readerNav = readerNav else {
+            return
+        }
+
+        let newSpotlightView = QuickStartSpotlightView()
+        newSpotlightView.translatesAutoresizingMaskIntoConstraints = false
+        readerNav.navigationBar.addSubview(newSpotlightView)
+        readerNav.navigationBar.addConstraints([
+                newSpotlightView.leadingAnchor.constraint(equalTo: readerNav.navigationBar.leadingAnchor, constant: 30.0),
+                newSpotlightView.topAnchor.constraint(equalTo: readerNav.navigationBar.topAnchor, constant: 15.0),
+            ])
+        spotlightView = newSpotlightView
+    }
+
+    private func removeReaderSpotlight() {
+        guard let spotlight = spotlightView else {
+            return
+        }
+
+        spotlight.removeFromSuperview()
+        spotlightView = nil
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
@@ -20,15 +20,12 @@ class QuickStartNavigationWatcher: NSObject, UINavigationControllerDelegate {
             tourGuide.visited(.sharing)
         case is ReaderMenuViewController:
             tourGuide.visited(.readerBack)
-            tourGuide.readerNeedsBack = false
             removeReaderSpotlight()
         case is ReaderSearchViewController:
             tourGuide.visited(.readerSearch)
             fallthrough
         case is ReaderStreamViewController, is ReaderSavedPostsViewController:
             readerNav = navigationController
-
-            tourGuide.readerNeedsBack = true
             checkToSpotlightReader()
         default:
             break

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
@@ -9,22 +9,13 @@ class QuickStartNavigationWatcher: NSObject, UINavigationControllerDelegate {
         }
 
         switch viewController {
-        case is QuickStartChecklistViewController:
-            tourGuide.visited(.checklist)
         case is BlogListViewController:
             tourGuide.visited(.noSuchElement)
             tourGuide.endCurrentTour()
-        case is ThemeBrowserViewController:
-            tourGuide.visited(.themes)
-        case is SharingViewController:
-            tourGuide.visited(.sharing)
         case is ReaderMenuViewController:
             tourGuide.visited(.readerBack)
             removeReaderSpotlight()
-        case is ReaderSearchViewController:
-            tourGuide.visited(.readerSearch)
-            fallthrough
-        case is ReaderStreamViewController, is ReaderSavedPostsViewController:
+        case is ReaderSearchViewController, is ReaderStreamViewController, is ReaderSavedPostsViewController:
             readerNav = navigationController
             checkToSpotlightReader()
         default:

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
@@ -11,12 +11,10 @@ class QuickStartNavigationWatcher: NSObject, UINavigationControllerDelegate {
         case is BlogListViewController:
             tourGuide.visited(.noSuchElement)
             tourGuide.endCurrentTour()
-        case is WPWebViewController:
-            fallthrough
-        case is WebKitViewController:
-            tourGuide.visited(.viewSite)
         case is ThemeBrowserViewController:
             tourGuide.visited(.themes)
+        case is SharingViewController:
+            tourGuide.visited(.sharing)
         default:
             break
         }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartNavigationWatcher.swift
@@ -15,6 +15,14 @@ class QuickStartNavigationWatcher: NSObject, UINavigationControllerDelegate {
             tourGuide.visited(.themes)
         case is SharingViewController:
             tourGuide.visited(.sharing)
+        case is ReaderMenuViewController:
+            tourGuide.visited(.readerBack)
+            tourGuide.readerNeedsBack = false
+        case is ReaderSearchViewController:
+            tourGuide.visited(.readerSearch)
+            fallthrough
+        case is ReaderStreamViewController, is ReaderSavedPostsViewController:
+            tourGuide.readerNeedsBack = true
         default:
             break
         }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartSpotlightView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartSpotlightView.swift
@@ -34,7 +34,7 @@ class QuickStartSpotlightView: UIView {
     private func setupLayers() {
         // Colors
         //
-        let backgroundColor = UIColor(red: 0.243137, green: 0.517647, blue: 0.682353, alpha: 1)
+        let backgroundColor = UIColor(red: 0.096, green: 0.44875, blue: 0.64, alpha: 1)
         let borderColor = UIColor(red: 0.126, green: 0.588984, blue: 0.84, alpha: 1)
         let backgroundColor1 = UIColor(red: 0.096, green: 0.44875, blue: 0.64, alpha: 1)
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -14,15 +14,6 @@ open class QuickStartTourGuide: NSObject {
         }
         return tourGuide
     }
-
-    // MARK: Quick Start methods
-    @objc func showTestQuickStartNotice() {
-        let exampleMessage = QuickStartChecklistTour().waypoints[0].description
-        let noticeStyle = QuickStartNoticeStyle(attributedMessage: exampleMessage)
-        let notice = Notice(title: "Test Quick Start Notice", style: noticeStyle)
-
-        ActionDispatcher.dispatch(NoticeAction.post(notice))
-    }
 }
 
 /// The API
@@ -65,12 +56,9 @@ internal extension QuickStartTourGuide {
         case let tour as QuickStartFollowTour:
             tour.setupReaderTab()
             fallthrough
-        case is QuickStartViewTour, is QuickStartThemeTour, is QuickStartCustomizeTour, is QuickStartPublishTour, is QuickStartShareTour:
+        default:
             currentTourState = TourState(tour: tour, blog: blog, step: 0)
             showCurrentStep()
-        default:
-            // this is the last use of showTestQuickStartNotice(), when it's gone delete that method
-            showTestQuickStartNotice()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -118,6 +118,8 @@ private extension QuickStartTourGuide {
 
     func completed(tourID: String, for blog: Blog) {
         blog.completeTour(tourID)
+
+        NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.tourCompleted])
     }
 
     func showCurrentStep() {
@@ -202,6 +204,7 @@ public enum QuickStartTourElement: Int {
     case readerTab
     case readerBack
     case readerSearch
+    case tourCompleted
 }
 
 private struct TourState {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -5,6 +5,7 @@ open class QuickStartTourGuide: NSObject, UINavigationControllerDelegate {
     @objc var navigationWatcher = QuickStartNavigationWatcher()
     private var currentSuggestion: QuickStartTour?
     private var currentTourState: TourState?
+    static let notificationElementKey = "QuickStartElementKey"
 
     @objc static func find() -> QuickStartTourGuide? {
         guard let tabBarController = WPTabBarController.sharedInstance(),
@@ -60,7 +61,7 @@ internal extension QuickStartTourGuide {
         dismissSuggestion()
 
         switch tour {
-        case is QuickStartViewTour, is QuickStartThemeTour, is QuickStartCustomizeTour:
+        case is QuickStartViewTour, is QuickStartThemeTour, is QuickStartCustomizeTour, is QuickStartPublishTour:
             currentTourState = TourState(tour: tour, blog: blog, step: 0)
             showCurrentStep()
         default:
@@ -132,6 +133,8 @@ private extension QuickStartTourGuide {
         }
 
         showStepNotice(waypoint.description)
+
+        NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: waypoint.element])
     }
 
     func showStepNotice(_ description: NSAttributedString) {
@@ -184,7 +187,12 @@ private extension QuickStartTourGuide {
         }
 
         presenter.dismissCurrentNotice()
+        NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.noSuchElement])
     }
+}
+
+internal extension NSNotification.Name {
+    static let QuickStartTourElementChangedNotification = NSNotification.Name(rawValue: "QuickStartTourElementChangedNotification")
 }
 
 @objc
@@ -194,6 +202,7 @@ public enum QuickStartTourElement: Int {
     case checklist
     case themes
     case customize
+    case newpost
 }
 
 private struct TourState {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -63,7 +63,10 @@ internal extension QuickStartTourGuide {
         dismissSuggestion()
 
         switch tour {
-        case is QuickStartViewTour, is QuickStartThemeTour, is QuickStartCustomizeTour, is QuickStartPublishTour, is QuickStartShareTour, is QuickStartFollowTour:
+        case let tour as QuickStartFollowTour:
+            tour.setupReaderTab()
+            fallthrough
+        case is QuickStartViewTour, is QuickStartThemeTour, is QuickStartCustomizeTour, is QuickStartPublishTour, is QuickStartShareTour:
             currentTourState = TourState(tour: tour, blog: blog, step: 0)
             showCurrentStep()
         default:

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -61,7 +61,7 @@ internal extension QuickStartTourGuide {
         dismissSuggestion()
 
         switch tour {
-        case is QuickStartViewTour, is QuickStartThemeTour, is QuickStartCustomizeTour, is QuickStartPublishTour, is QuickStartShareTour:
+        case is QuickStartViewTour, is QuickStartThemeTour, is QuickStartCustomizeTour, is QuickStartPublishTour, is QuickStartShareTour, is QuickStartFollowTour:
             currentTourState = TourState(tour: tour, blog: blog, step: 0)
             showCurrentStep()
         default:
@@ -205,6 +205,9 @@ public enum QuickStartTourElement: Int {
     case newpost
     case sharing
     case connections
+    case readerTab
+    case readerBack
+    case readerSearch
 }
 
 private struct TourState {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -95,6 +95,11 @@ internal extension QuickStartTourGuide {
         }
         currentTourState = nextStep
 
+        if currentElement() == .readerBack && navigationWatcher.shouldSkipReaderBack() {
+            visited(.readerBack)
+            return
+        }
+
         showCurrentStep()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -92,6 +92,7 @@ internal extension QuickStartTourGuide {
             let tourState = currentTourState else {
                 return
         }
+
         dismissCurrentNotice()
 
         guard let nextStep = getNextStep() else {
@@ -103,9 +104,13 @@ internal extension QuickStartTourGuide {
         }
         currentTourState = nextStep
 
-        if currentElement() == .readerBack && !readerNeedsBack {
-            visited(.readerBack)
-            return
+        if currentElement() == .readerBack {
+            if !readerNeedsBack {
+                visited(.readerBack)
+                return
+            } else {
+                navigationWatcher.spotlightReaderBackButton()
+            }
         }
 
         showCurrentStep()

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -1,10 +1,11 @@
 import WordPressFlux
 import Gridicons
 
-open class QuickStartTourGuide: NSObject, UINavigationControllerDelegate {
+open class QuickStartTourGuide: NSObject {
     @objc var navigationWatcher = QuickStartNavigationWatcher()
     private var currentSuggestion: QuickStartTour?
     private var currentTourState: TourState?
+    var readerNeedsBack = true
     static let notificationElementKey = "QuickStartElementKey"
 
     @objc static func find() -> QuickStartTourGuide? {
@@ -100,8 +101,13 @@ internal extension QuickStartTourGuide {
             // TODO: we could put a nice animation here
             return
         }
-
         currentTourState = nextStep
+
+        if currentElement() == .readerBack && !readerNeedsBack {
+            visited(.readerBack)
+            return
+        }
+
         showCurrentStep()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -192,6 +192,7 @@ private extension QuickStartTourGuide {
         }
 
         presenter.dismissCurrentNotice()
+        ActionDispatcher.dispatch(NoticeAction.empty)
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.noSuchElement])
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -59,6 +59,7 @@ internal extension QuickStartTourGuide {
     }
 
     func start(tour: QuickStartTour, for blog: Blog) {
+        endCurrentTour()
         dismissSuggestion()
 
         switch tour {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -104,13 +104,9 @@ internal extension QuickStartTourGuide {
         }
         currentTourState = nextStep
 
-        if currentElement() == .readerBack {
-            if !readerNeedsBack {
-                visited(.readerBack)
-                return
-            } else {
-                navigationWatcher.spotlightReaderBackButton()
-            }
+        if !readerNeedsBack && currentElement() == .readerBack {
+            visited(.readerBack)
+            return
         }
 
         showCurrentStep()

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -61,7 +61,7 @@ internal extension QuickStartTourGuide {
         dismissSuggestion()
 
         switch tour {
-        case is QuickStartViewTour, is QuickStartThemeTour, is QuickStartCustomizeTour, is QuickStartPublishTour:
+        case is QuickStartViewTour, is QuickStartThemeTour, is QuickStartCustomizeTour, is QuickStartPublishTour, is QuickStartShareTour:
             currentTourState = TourState(tour: tour, blog: blog, step: 0)
             showCurrentStep()
         default:
@@ -203,6 +203,8 @@ public enum QuickStartTourElement: Int {
     case themes
     case customize
     case newpost
+    case sharing
+    case connections
 }
 
 private struct TourState {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -5,7 +5,6 @@ open class QuickStartTourGuide: NSObject {
     @objc var navigationWatcher = QuickStartNavigationWatcher()
     private var currentSuggestion: QuickStartTour?
     private var currentTourState: TourState?
-    var readerNeedsBack = true
     static let notificationElementKey = "QuickStartElementKey"
 
     @objc static func find() -> QuickStartTourGuide? {
@@ -107,11 +106,6 @@ internal extension QuickStartTourGuide {
             return
         }
         currentTourState = nextStep
-
-        if !readerNeedsBack && currentElement() == .readerBack {
-            visited(.readerBack)
-            return
-        }
 
         showCurrentStep()
     }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -115,7 +115,10 @@ struct QuickStartPublishTour: QuickStartTour {
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
 
-    let waypoints = WIPwaypoints
+    var waypoints: [WayPoint] = {
+        let descriptionBase = NSLocalizedString("Tap %@ to create a new post", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+        return [(element: .newpost, description: descriptionBase.highlighting(phrase: "", icon: Gridicon.iconOfType(.create)))]
+    }()
 }
 
 struct QuickStartFollowTour: QuickStartTour {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -104,7 +104,17 @@ struct QuickStartShareTour: QuickStartTour {
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
 
-    let waypoints = WIPwaypoints
+    var waypoints: [WayPoint] = {
+        let step1DescriptionBase = NSLocalizedString("Tap %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+        let step1DescriptionTarget = NSLocalizedString("Sharing", comment: "The menu item to tap during a guided tour.")
+        let step1: WayPoint = (element: .sharing, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: Gridicon.iconOfType(.share)))
+
+        let step2DescriptionBase = NSLocalizedString("Tap the %@ to add your social media accounts", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+        let step2DescriptionTarget = NSLocalizedString("connections", comment: "The menu item to tap during a guided tour.")
+        let step2: WayPoint = (element: .connections, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: nil))
+
+        return [step1, step2]
+    }()
 }
 
 struct QuickStartPublishTour: QuickStartTour {
@@ -133,7 +143,7 @@ struct QuickStartFollowTour: QuickStartTour {
 }
 
 private extension String {
-    func highlighting(phrase: String, icon: UIImage) -> NSAttributedString {
+    func highlighting(phrase: String, icon: UIImage?) -> NSAttributedString {
         let normalParts = components(separatedBy: "%@")
         guard normalParts.count > 0 else {
             // if the provided base doesn't contain %@ then we don't know where to place the highlight
@@ -143,21 +153,25 @@ private extension String {
 
         let font = WPStyleGuide.mediumWeightFont(forStyle: .subheadline)
 
-        let iconAttachment = NSTextAttachment()
-        iconAttachment.image = icon.imageWithTintColor(Constants.highlightColor)
-        iconAttachment.bounds = CGRect(x: 0.0, y: font.descender + Constants.iconOffset, width: Constants.iconSize, height: Constants.iconSize)
-        let iconStr = NSAttributedString(attachment: iconAttachment)
-
         let highlightStr = NSAttributedString(string: phrase, attributes: [.foregroundColor: Constants.highlightColor, .font: Constants.highlightFont])
 
-        switch UIView.userInterfaceLayoutDirection(for: .unspecified) {
-        case .rightToLeft:
-            resultString.append(highlightStr)
-            resultString.append(NSAttributedString(string: " "))
-            resultString.append(iconStr)
-        default:
-            resultString.append(iconStr)
-            resultString.append(NSAttributedString(string: " "))
+        if let icon = icon {
+            let iconAttachment = NSTextAttachment()
+            iconAttachment.image = icon.imageWithTintColor(Constants.highlightColor)
+            iconAttachment.bounds = CGRect(x: 0.0, y: font.descender + Constants.iconOffset, width: Constants.iconSize, height: Constants.iconSize)
+            let iconStr = NSAttributedString(attachment: iconAttachment)
+
+            switch UIView.userInterfaceLayoutDirection(for: .unspecified) {
+            case .rightToLeft:
+                resultString.append(highlightStr)
+                resultString.append(NSAttributedString(string: " "))
+                resultString.append(iconStr)
+            default:
+                resultString.append(iconStr)
+                resultString.append(NSAttributedString(string: " "))
+                resultString.append(highlightStr)
+            }
+        } else {
             resultString.append(highlightStr)
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -12,8 +12,6 @@ protocol QuickStartTour {
     var waypoints: [WayPoint] { get }
 }
 
-private let WIPwaypoints: [QuickStartTour.WayPoint] = [(element: .noSuchElement, description: NSAttributedString(string: "This tour is under development"))]
-
 private struct Strings {
     static let notNow = NSLocalizedString("Not now", comment: "Phrase displayed to dismiss a quick start tour suggestion.")
     static let yesShowMe = NSLocalizedString("Yes, show me", comment: "Phrase displayed to begin a quick start tour that's been suggested.")
@@ -42,7 +40,7 @@ struct QuickStartCreateTour: QuickStartTour {
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
 
-    let waypoints = WIPwaypoints
+    let waypoints: [QuickStartTour.WayPoint] = [(element: .noSuchElement, description: NSAttributedString(string: "This tour should never display as interactive."))]
 }
 
 struct QuickStartViewTour: QuickStartTour {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -139,7 +139,21 @@ struct QuickStartFollowTour: QuickStartTour {
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
 
-    let waypoints = WIPwaypoints
+    var waypoints: [WayPoint] = {
+        let step1DescriptionBase = NSLocalizedString("Tap %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+        let step1DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to tap during a guided tour.")
+        let step1: WayPoint = (element: .readerTab, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: Gridicon.iconOfType(.reader)))
+
+        let step2DescriptionBase = NSLocalizedString("Tap %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+        let step2DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to tap during a guided tour.")
+        let step2: WayPoint = (element: .readerBack, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: Gridicon.iconOfType(.chevronLeft)))
+
+        let step3DescriptionBase = NSLocalizedString("Tap %@ to look for sites with similar interests", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+        let step3DescriptionTarget = NSLocalizedString("Search", comment: "The menu item to tap during a guided tour.")
+        let step3: WayPoint = (element: .readerSearch, description: step3DescriptionBase.highlighting(phrase: step3DescriptionTarget, icon: Gridicon.iconOfType(.search)))
+
+        return [step1, step2, step3]
+    }()
 }
 
 private extension String {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -154,6 +154,14 @@ struct QuickStartFollowTour: QuickStartTour {
 
         return [step1, step2, step3]
     }()
+
+    func setupReaderTab() {
+        guard let tabBar = WPTabBarController.sharedInstance() else {
+            return
+        }
+
+        tabBar.resetReaderTab()
+    }
 }
 
 private extension String {

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -144,7 +144,11 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
     [WPStyleGuide configureTableViewCell:cell];
     cell.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
-    cell.accessoryView = nil;
+    if (indexPath == [NSIndexPath indexPathForRow:0 inSection:0] && [[QuickStartTourGuide find] isCurrentElement:QuickStartTourElementConnections]) {
+        cell.accessoryView = [QuickStartSpotlightView new];
+    } else {
+        cell.accessoryView = nil;
+    }
 
     if (indexPath.section == SharingPublicizeServices) {
         [self configurePublicizeCell:cell atIndexPath:indexPath];
@@ -207,6 +211,8 @@ static NSString *const CellIdentifier = @"CellIdentifier";
         PublicizeService *publicizer = self.publicizeServices[indexPath.row];
         controller = [[SharingConnectionsViewController alloc] initWithBlog:self.blog publicizeService:publicizer];
         [WPAppAnalytics track:WPAnalyticsStatSharingOpenedPublicize withBlog:self.blog];
+
+        [[QuickStartTourGuide find] visited:QuickStartTourElementConnections];
     } else {
         controller = [[SharingButtonsViewController alloc] initWithBlog:self.blog];
         [WPAppAnalytics track:WPAnalyticsStatSharingOpenedSharingButtonSettings withBlog:self.blog];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -593,6 +593,7 @@ import WordPressShared
 
         if menuItem.type == .search {
             currentReaderStream = nil
+            QuickStartTourGuide.find()?.visited(.readerSearch)
             return viewControllerForSearch()
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -563,6 +563,10 @@ import WordPressShared
             return
         }
 
+        if menuItem.type == .search {
+            QuickStartTourGuide.find()?.visited(.readerSearch)
+        }
+
         if menuItem.type == .addItem {
             tableView.deselectSelectedRowWithAnimation(true)
             showAddTag()
@@ -593,7 +597,6 @@ import WordPressShared
 
         if menuItem.type == .search {
             currentReaderStream = nil
-            QuickStartTourGuide.find()?.visited(.readerSearch)
             return viewControllerForSearch()
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -613,6 +613,10 @@ import WordPressShared
         WPStyleGuide.configureTableViewCell(cell)
         cell.accessoryView = nil
         cell.accessoryType = (splitViewControllerIsHorizontallyCompact) ? .disclosureIndicator : .none
+        if menuItem.type == .search && QuickStartTourGuide.find()?.isCurrentElement(.readerSearch) ?? false {
+            cell.accessoryView = QuickStartSpotlightView()
+        }
+
         cell.selectionStyle = .default
         cell.textLabel?.text = menuItem.title
         cell.imageView?.image = menuItem.icon

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -47,6 +47,10 @@ extension WPTabBarController {
         QuickStartTourGuide.find()?.visited(.newpost)
     }
 
+    @objc func alertQuickStartThatReaderWasTapped() {
+        QuickStartTourGuide.find()?.visited(.readerTab)
+    }
+
     @objc func stopWatchingQuickTours() {
         NotificationCenter.default.removeObserver(quickStartObserver as Any)
         quickStartObserver = nil

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -5,25 +5,42 @@ private var quickStartObserver: NSObject?
 extension WPTabBarController {
     @objc func startWatchingQuickTours() {
         let observer = NotificationCenter.default.addObserver(forName: .QuickStartTourElementChangedNotification, object: nil, queue: nil) { [weak self] (notification) in
+            spotlightView?.removeFromSuperview()
+            spotlightView = nil
+
             guard let userInfo = notification.userInfo,
                 let element = userInfo[QuickStartTourGuide.notificationElementKey] as? QuickStartTourElement,
-                element == .newpost,
+                [.newpost, .readerTab].contains(element),
                 let tabBar = self?.tabBar else {
-                    spotlightView?.removeFromSuperview()
-                    spotlightView = nil
                     return
             }
 
             let newSpotlight = QuickStartSpotlightView()
             tabBar.addSubview(newSpotlight)
 
-            let x = tabBar.bounds.size.width / 2.0
-
+            let x: CGFloat
+            if element == .newpost {
+                x = tabBar.bounds.size.width / 2.0
+            } else {
+                x = tabBar.bounds.size.width * 0.40 - newSpotlight.frame.size.width
+            }
             newSpotlight.frame = CGRect(x: x, y: spotlightViewOffset, width: newSpotlight.frame.width, height: newSpotlight.frame.height)
             spotlightView = newSpotlight
         }
 
         quickStartObserver = observer as? NSObject
+    }
+
+    private func findTabView(index: Int) -> UIView? {
+        var tabs: [UIView] = []
+        for subview in tabBar.subviews {
+            tabs.append(subview)
+        }
+        tabs.sort {
+            $0.frame.origin.x < $1.frame.origin.x
+        }
+
+        return tabs[index]
     }
 
     @objc func alertQuickStartThatWriteWasTapped() {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -1,0 +1,37 @@
+private var spotlightView: QuickStartSpotlightView?
+private let spotlightViewOffset: CGFloat = -5.0
+private var quickStartObserver: NSObject?
+
+extension WPTabBarController {
+    @objc func startWatchingQuickTours() {
+        let observer = NotificationCenter.default.addObserver(forName: .QuickStartTourElementChangedNotification, object: nil, queue: nil) { [weak self] (notification) in
+            guard let userInfo = notification.userInfo,
+                let element = userInfo[QuickStartTourGuide.notificationElementKey] as? QuickStartTourElement,
+                element == .newpost,
+                let tabBar = self?.tabBar else {
+                    spotlightView?.removeFromSuperview()
+                    spotlightView = nil
+                    return
+            }
+
+            let newSpotlight = QuickStartSpotlightView()
+            tabBar.addSubview(newSpotlight)
+
+            let x = tabBar.bounds.size.width / 2.0
+
+            newSpotlight.frame = CGRect(x: x, y: spotlightViewOffset, width: newSpotlight.frame.width, height: newSpotlight.frame.height)
+            spotlightView = newSpotlight
+        }
+
+        quickStartObserver = observer as? NSObject
+    }
+
+    @objc func alertQuickStartThatWriteWasTapped() {
+        QuickStartTourGuide.find()?.visited(.newpost)
+    }
+
+    @objc func stopWatchingQuickTours() {
+        NotificationCenter.default.removeObserver(quickStartObserver as Any)
+        quickStartObserver = nil
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -41,6 +41,7 @@ typedef NS_ENUM(NSUInteger, WPTabType) {
 
 - (void)showMySitesTab;
 - (void)showReaderTab;
+- (void)resetReaderTab;
 - (void)showPostTab;
 - (void)showPostTabWithCompletion:(void (^)(void))afterDismiss;
 - (void)showPostTabForBlog:(Blog *)blog;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -97,6 +97,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     self = [super init];
     if (self) {
         [self setDelegate:self];
+        self.tourGuide = [[QuickStartTourGuide alloc] init];
 
         [self setRestorationIdentifier:WPTabBarRestorationID];
         [self setRestorationClass:[WPTabBarController class]];
@@ -218,7 +219,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     self.blogListViewController = [[BlogListViewController alloc] init];
     _blogListNavigationController = [[ManyDelegateNavigationController alloc] initWithRootViewController:self.blogListViewController];
     _blogListNavigationController.navigationBar.translucent = NO;
-    self.tourGuide = [[QuickStartTourGuide alloc] init];
     _blogListNavigationController.delegate = self.tourGuide.navigationWatcher;
 
     UIImage *mySitesTabBarImage = [UIImage imageNamed:@"icon-tab-mysites"];
@@ -242,9 +242,11 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (UINavigationController *)readerNavigationController
 {
     if (!_readerNavigationController) {
-        _readerNavigationController = [[UINavigationController alloc] initWithRootViewController:self.readerMenuViewController];
+        _readerNavigationController = [[ManyDelegateNavigationController alloc] initWithRootViewController:self.readerMenuViewController];
 
         _readerNavigationController.navigationBar.translucent = NO;
+        _readerNavigationController.delegate = self.tourGuide.navigationWatcher;
+
         UIImage *readerTabBarImage = [UIImage imageNamed:@"icon-tab-reader"];
         _readerNavigationController.tabBarItem.image = readerTabBarImage;
         _readerNavigationController.tabBarItem.selectedImage = readerTabBarImage;
@@ -829,6 +831,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
             }
             case WPTabReader: {
                 [WPAppAnalytics track:WPAnalyticsStatReaderAccessed];
+                [self alertQuickStartThatReaderWasTapped];
                 break;
             }
             case WPTabMe: {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -165,6 +165,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)dealloc
 {
+    [self stopWatchingQuickTours];
     [[NSNotificationCenter defaultCenter] removeObserver:self];
     [[UIApplication sharedApplication] removeObserver:self forKeyPath:WPApplicationIconBadgeNumberKeyPath];
 }
@@ -512,6 +513,8 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     } else {
         [self showPostTabAnimated:true toMedia:false blog:nil afterDismiss:afterDismiss];
     }
+
+    [self alertQuickStartThatWriteWasTapped];
 }
 
 - (void)showPostTabForBlog:(Blog *)blog
@@ -980,6 +983,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 {
     [super viewDidAppear:animated];
     [self updateNotificationBadgeVisibility];
+    [self startWatchingQuickTours];
 }
 
 - (void)viewDidLayoutSubviews

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -467,6 +467,19 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     self.selectedIndex = WPTabMySites;
 }
 
+- (void)resetReaderTab
+{
+    _readerNavigationController = nil;
+    _readerMenuViewController = nil;
+    _readerSplitViewController = nil;
+
+    [self setViewControllers:@[self.blogListSplitViewController,
+                               self.readerSplitViewController,
+                               self.newPostViewController,
+                               self.meSplitViewController,
+                               self.notificationsSplitViewController]];
+}
+
 #pragma mark - Navigation Coordinators
 
 - (MySitesCoordinator *)mySitesCoordinator

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
@@ -29,6 +29,8 @@ open class ThemeBrowserHeaderView: UICollectionReusableView {
 
     // MARK: - Properties
 
+    private var observer: NSObjectProtocol?
+
     fileprivate var theme: Theme? {
         didSet {
             currentThemeName.text = theme?.name
@@ -77,6 +79,12 @@ open class ThemeBrowserHeaderView: UICollectionReusableView {
 
         applyStyles()
         setTextForLabels()
+
+        startObservingForQuickStart()
+    }
+
+    deinit {
+        stopObservingForQuickStart()
     }
 
     fileprivate func applyStyles() {
@@ -113,6 +121,16 @@ open class ThemeBrowserHeaderView: UICollectionReusableView {
         }
     }
 
+    private func startObservingForQuickStart() {
+        observer = NotificationCenter.default.addObserver(forName: .QuickStartTourElementChangedNotification, object: nil, queue: nil) { [weak self] (notification) in
+            self?.spotlightCustomizeButtonIfTourIsActive()
+        }
+    }
+
+    private func stopObservingForQuickStart() {
+        NotificationCenter.default.removeObserver(observer as Any)
+    }
+
     fileprivate func setTextForLabels() {
         currentThemeLabel.text = NSLocalizedString("Current Theme",
                                                    comment: "Current Theme text that appears in Theme Browser Header")
@@ -140,6 +158,8 @@ open class ThemeBrowserHeaderView: UICollectionReusableView {
 
     @IBAction fileprivate func didTapCustomizeButton(_ sender: UIButton) {
         presenter?.presentCustomizeForTheme(theme)
+
+        quickStartSpotlightView.removeFromSuperview()
     }
 
     @IBAction fileprivate func didTapDetailsButton(_ sender: UIButton) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 		43C9908E21067E22009EFFEB /* QuickStartChecklistViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43C9908D21067E22009EFFEB /* QuickStartChecklistViewController.swift */; };
 		43D54D131DCAA070007F575F /* PostPostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43D54D121DCAA070007F575F /* PostPostViewController.swift */; };
 		43DC0EF12040B23200896C9C /* SignupUsernameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DC0EF02040B23200896C9C /* SignupUsernameViewController.swift */; };
+		43DDFE8C21715ADD008BE72F /* WPTabBarController+QuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43DDFE8B21715ADD008BE72F /* WPTabBarController+QuickStart.swift */; };
 		43FB3F411EBD215C00FC8A62 /* LoginEpilogueBlogCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43FB3F401EBD215C00FC8A62 /* LoginEpilogueBlogCell.swift */; };
 		43FB3F471EC10F1E00FC8A62 /* LoginEpilogueTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43FB3F461EC10F1E00FC8A62 /* LoginEpilogueTableViewController.swift */; };
 		43FF64EF20DAA0840060A69A /* GravatarUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43FF64EE20DAA0840060A69A /* GravatarUploader.swift */; };
@@ -1873,6 +1874,7 @@
 		43C9908D21067E22009EFFEB /* QuickStartChecklistViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartChecklistViewController.swift; sourceTree = "<group>"; };
 		43D54D121DCAA070007F575F /* PostPostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostPostViewController.swift; sourceTree = "<group>"; };
 		43DC0EF02040B23200896C9C /* SignupUsernameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupUsernameViewController.swift; sourceTree = "<group>"; };
+		43DDFE8B21715ADD008BE72F /* WPTabBarController+QuickStart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPTabBarController+QuickStart.swift"; sourceTree = "<group>"; };
 		43FB3F401EBD215C00FC8A62 /* LoginEpilogueBlogCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEpilogueBlogCell.swift; sourceTree = "<group>"; };
 		43FB3F461EC10F1E00FC8A62 /* LoginEpilogueTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEpilogueTableViewController.swift; sourceTree = "<group>"; };
 		43FF64EE20DAA0840060A69A /* GravatarUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GravatarUploader.swift; sourceTree = "<group>"; };
@@ -5165,6 +5167,7 @@
 				3101866A1A373B01008F7DF6 /* WPTabBarController.m */,
 				17A28DC2205001A900EA6D9E /* FilterBar.swift */,
 				D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */,
+				43DDFE8B21715ADD008BE72F /* WPTabBarController+QuickStart.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -8365,6 +8368,7 @@
 				591A428C1A6DC1B0003807A6 /* WPBackgroundDimmerView.m in Sources */,
 				74989B8C2088E3650054290B /* BlogDetailsViewController+Activity.swift in Sources */,
 				B532D4EB199D4357006E4DF6 /* NoteBlockTableViewCell.swift in Sources */,
+				43DDFE8C21715ADD008BE72F /* WPTabBarController+QuickStart.swift in Sources */,
 				74FA4BED1FBFA2350031EAAD /* SharedCoreDataStack.swift in Sources */,
 				E11000991CDB5F1E00E33887 /* KeychainTools.swift in Sources */,
 				D800D87020998A7300E7C7E5 /* SavedForLaterMenuItemCreator.swift in Sources */,


### PR DESCRIPTION
Refs #9447

This adds the three final tours for Quick Start.

### Publish a post 
![tour-post](https://user-images.githubusercontent.com/517257/46978840-cb4ece00-d084-11e8-8fd2-94f1a8033535.gif)

### Share your site
![tour-sharing](https://user-images.githubusercontent.com/517257/46978909-ed485080-d084-11e8-9b61-0d875dd16bf3.gif)

### Follow other sites
![tour-reader](https://user-images.githubusercontent.com/517257/46978948-07822e80-d085-11e8-95d9-46a7d17ca0d6.gif)


To test:
- Setup a site with Quick Start enabled (either create a new site or get my snippet)
- go through the three new tours
  - the followers tour should be resilient to leaving the reader tab in different states _before_ starting the tour. check it out!
- test on ipad, too

Do you mind doing this since you're already familiar with it, @etoledom?


