### PR TITLE
Reader Post > no comments: on iPhone, restrict empty state view 

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -155,7 +155,7 @@ import WordPressShared
     ///
     /// - Parameters:
     ///   - title:  Main descriptive text. Required.
-    func configureForNoSearchResults(title: String) {
+    @objc func configureForNoSearchResults(title: String) {
         configure(title: title)
         displayTitleViewOnly = true
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/KeyboardDismissHelper.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/KeyboardDismissHelper.swift
@@ -46,7 +46,14 @@ import UIKit
     ///
     @objc var onDidChangeFrame: (() -> Void)?
 
-
+    /// Indicates whether the keyboard is visible or not
+    ///
+    @objc var isKeyboardVisible = false {
+        didSet {
+            // Reset any current Drag OP on change
+            trackingDragOperation = false
+        }
+    }
 
     /// Reference to the container view
     ///
@@ -63,15 +70,6 @@ import UIKit
     /// State of the dismissable control's frame, at the beginning of a drag OP
     ///
     fileprivate var initialControlPositionY = CGFloat(0)
-
-    /// Indicates whether the keyboard is visible or not
-    ///
-    fileprivate var isKeyboardVisible = false {
-        didSet {
-            // Reset any current Drag OP on change
-            trackingDragOperation = false
-        }
-    }
 
     /// Indicates whether an Interactive Drag OP is being processed
     ///

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -668,7 +668,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     // Landscape: show nothing.
     if (WPDeviceIdentification.isiPhone && self.keyboardManager.isKeyboardVisible) {
         [self.noResultsViewController.view setHidden:true];
-        [self createTitleOnlyNoResultsView];
         [self.noResultsTitleViewController.view setHidden:(UIDevice.currentDevice.orientation != UIDeviceOrientationPortrait)];
         return;
     }
@@ -681,6 +680,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
         return;
     }
 
+    [self createTitleOnlyNoResultsView];
     [self createFullNoResultsView];
 }
 


### PR DESCRIPTION
Fixes #10207 

In Reader > Post > Comments > no comments, when the keyboard is displayed and the reply text view grows, it was overlapping the empty state view.

This fixes two issues:
- iPhone portrait: the expanded reply text view overlapped the empty state text. Attempting to update the existing empty state view to show/hide the image based on state and orientation caused weird animation issues. So I took advantage of the `NoResultsViewController:configureForNoSearchResults` method to only show the title when the keyboard is visible (that method probably needs to be renamed, but I'll do that separately).
- iPhone landscape: the expanded reply text view overlapped the empty state text. Now when the keyboard is visible, the empty state view does not appear at all. 

To test:

- Go to Reader > Followed Sites > Manage.
- Select a site that has a post with no comments.
- Press the comment icon on the post with no comments.

---
iPhone portrait - no keyboard: should still display the full empty state view:

![no_keyboard_portrait](https://user-images.githubusercontent.com/1816888/46984140-03640a00-d0a1-11e8-9d37-4cadf8088f6f.png)

---
iPhone landscape - no keyboard: should still display the title only:

![no_keyboard_landscape](https://user-images.githubusercontent.com/1816888/46984183-373f2f80-d0a1-11e8-927e-748fcb496fc4.png)

---
iPhone portrait - with keyboard: should display the title only. Note this view has the title static near the top of the view.

![keyboard_portrait](https://user-images.githubusercontent.com/1816888/46984220-5e95fc80-d0a1-11e8-9d52-38d0015a1bc5.png)

---
iPhone landscape - with keyboard: should not display the empty state view:

![keyboard_landscape](https://user-images.githubusercontent.com/1816888/46984232-6b1a5500-d0a1-11e8-8c2f-8c277f6daa8b.png)


