### PR TITLE
Reader empty states: adjust empty view for keyboard

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -293,6 +293,12 @@ private extension NoResultsViewController {
     }
 
     func setAccessoryViewsVisibility() {
+
+        if hideImage == true {
+            accessoryStackView.isHidden = true
+            return
+        }
+
         // Always hide the accessory/image stack view when in iPhone landscape.
         accessoryStackView.isHidden = UIDevice.current.orientation.isLandscape && WPDeviceIdentification.isiPhone()
 

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -294,7 +294,7 @@ private extension NoResultsViewController {
 
     func setAccessoryViewsVisibility() {
 
-        if hideImage == true {
+        if hideImage {
             accessoryStackView.isHidden = true
             return
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/KeyboardDismissHelper.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/KeyboardDismissHelper.swift
@@ -46,7 +46,14 @@ import UIKit
     ///
     @objc var onDidChangeFrame: (() -> Void)?
 
-
+    /// Indicates whether the keyboard is visible or not
+    ///
+    @objc var isKeyboardVisible = false {
+        didSet {
+            // Reset any current Drag OP on change
+            trackingDragOperation = false
+        }
+    }
 
     /// Reference to the container view
     ///
@@ -63,15 +70,6 @@ import UIKit
     /// State of the dismissable control's frame, at the beginning of a drag OP
     ///
     fileprivate var initialControlPositionY = CGFloat(0)
-
-    /// Indicates whether the keyboard is visible or not
-    ///
-    fileprivate var isKeyboardVisible = false {
-        didSet {
-            // Reset any current Drag OP on change
-            trackingDragOperation = false
-        }
-    }
 
     /// Indicates whether an Interactive Drag OP is being processed
     ///

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -15,9 +15,10 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
     fileprivate var tableView: UITableView!
     fileprivate var tableViewHandler: WPTableViewHandler!
     fileprivate var tableViewController: UITableViewController!
-
     fileprivate let cellIdentifier = "CellIdentifier"
 
+    private var currentKeyboardHeight: CGFloat = 0
+    private var deviceIsRotating = false
     private let noResultsViewController = NoResultsViewController.controller()
 
     /// Convenience method for instantiating an instance of ReaderFollowedSitesViewController
@@ -73,6 +74,20 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
 
         syncSites()
         configureNoResultsView()
+        startListeningToNotifications()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        stopListeningToNotifications()
+    }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        deviceIsRotating = true
+        coordinator.animate(alongsideTransition: nil, completion: { _ in
+            self.deviceIsRotating = false
+        })
     }
 
 
@@ -127,6 +142,28 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         gestureRecognizer.cancelsTouchesInView = false
         view.addGestureRecognizer(gestureRecognizer)
     }
+
+
+    // MARK: - Keyboard Handling
+
+
+    @objc func keyboardWillShow(_ notification: Foundation.Notification) {
+        guard let userInfo = notification.userInfo as? [String: AnyObject],
+            let keyboardFrame = (userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue
+            else {
+                return
+        }
+
+        currentKeyboardHeight = keyboardFrame.height
+        configureNoResultsView()
+    }
+
+    @objc func keyboardWillHide(_ notification: Foundation.Notification) {
+        currentKeyboardHeight = 0
+        configureNoResultsView()
+    }
+
+
     // MARK: - Instance Methods
 
 
@@ -274,6 +311,12 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
 private extension ReaderFollowedSitesViewController {
 
     func configureNoResultsView() {
+        // During rotation, the keyboard hides and shows.
+        // To prevent view flashing, do nothing until rotation is finished.
+        if deviceIsRotating == true {
+            return
+        }
+
         noResultsViewController.removeFromView()
 
         if let count = tableViewHandler.resultsController.fetchedObjects?.count, count > 0 {
@@ -286,6 +329,16 @@ private extension ReaderFollowedSitesViewController {
             noResultsViewController.configure(title: NoResultsText.noResultsTitle,
                                               buttonTitle: NoResultsText.buttonTitle,
                                               subtitle: NoResultsText.noResultsMessage)
+
+            // Due to limited space when the keyboard is visible,
+            // hide the image on iPhone and iPad landscape.
+            var hideImageView = false
+            if currentKeyboardHeight > 0 {
+                hideImageView = WPDeviceIdentification.isiPhone() ||
+                                (WPDeviceIdentification.isiPad() && UIDevice.current.orientation.isLandscape)
+            }
+
+            noResultsViewController.hideImageView(hideImageView)
         }
 
         showNoResultView()
@@ -295,6 +348,11 @@ private extension ReaderFollowedSitesViewController {
         tableViewController.addChild(noResultsViewController)
         tableView.addSubview(withFadeAnimation: noResultsViewController.view)
         noResultsViewController.view.frame = tableView.frame
+
+        if currentKeyboardHeight > 0 {
+            noResultsViewController.view.frame.size.height -= (currentKeyboardHeight - searchBar.frame.height)
+        }
+
         noResultsViewController.didMove(toParent: tableViewController)
     }
 
@@ -311,6 +369,18 @@ private extension ReaderFollowedSitesViewController {
         static let noResultsMessage = NSLocalizedString("You are not following any sites yet. Why not follow one now?", comment: "A suggestion to the user that they try following a site in their reader.")
         static let buttonTitle = NSLocalizedString("Discover Sites", comment: "Button title. Tapping takes the user to the Discover sites list.")
         static let loadingTitle = NSLocalizedString("Fetching sites...", comment: "A short message to inform the user data for their followed sites is being fetched..")
+    }
+
+    func startListeningToNotifications() {
+        let nc = NotificationCenter.default
+        nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        nc.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
+    }
+
+    func stopListeningToNotifications() {
+        let nc = NotificationCenter.default
+        nc.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+        nc.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -61,6 +61,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         setupTableView()
         setupTableViewHandler()
         configureSearchBar()
+        setupBackgroundTapGestureRecognizer()
         noResultsViewController.delegate = self
 
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
@@ -118,6 +119,14 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
         searchBar.setImage(UIImage(named: "icon-reader-search-plus"), for: .search, state: UIControl.State())
     }
 
+    func setupBackgroundTapGestureRecognizer() {
+        let gestureRecognizer = UITapGestureRecognizer()
+        gestureRecognizer.on(call: { [weak self] (gesture) in
+            self?.view.endEditing(true)
+        })
+        gestureRecognizer.cancelsTouchesInView = false
+        view.addGestureRecognizer(gestureRecognizer)
+    }
     // MARK: - Instance Methods
 
 


### PR DESCRIPTION
Fixes #10207 #10260 

To test:

---
Reader > Post > Comments > no comments (#10207)

- On a site that has followed sites, go to Reader > Followed Sites > Manage.
- Select a site that has a post with no comments.
- Press the comment icon on the post with no comments.

With the keyboard visible (tap in the reply field):
- [ ] iPad landscape: the image is hidden.
- [ ] iPhone portrait: the image is hidden.
- [ ] iPhone landscape: the empty view is not displayed.

---
Reader > Manage > no followed sites (#10260)

- On a site that has not followed sites, go to Reader > Manage Sites.

With the keyboard visible (tap in the URL field):
- [ ] iPhone: the image is hidden.
  - Note: there is still spacing issues in iPhone landscape. Sylvester is looking into the padding, so I'll save this for another day.
- [ ] Tapping the view will now dismiss the keyboard.


