### PR TITLE
Move credential files to the dedicated repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ After you created an application you will have an associated a client ID and a c
 
 In order to use these details, you'll need to create a credential file in your build machine. Start by copying the sample credentials file to your home folder by doing this:
 
-` cp ./WordPress/Credentials/wpcom_app_credentials.txt ~/.wpcom_app_credentials `
+` mkdir -p ~/.mobile-secrets/iOS/WPiOS/ `
+
+` cp ./WordPress/Credentials/wpcom_app_credentials.txt ~/.mobile-secrets/iOS/WPiOS/wpcom_app_credentials `
 
 Then edit the `~/.wpcom_app_credentials` file and change the `WPCOM_APP_ID` and `WPCOM_APP_SECRET` fields to the values you got for your app.
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -10527,7 +10527,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = $HOME/.wpcom_alpha_app_credentials;
+				WPCOM_CONFIG = $HOME/.mobile-secrets/iOS/WPiOS/wpcom_alpha_app_credentials;
 			};
 			name = "Release-Alpha";
 		};
@@ -11009,7 +11009,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = $HOME/.wpcom_internal_app_credentials;
+				WPCOM_CONFIG = $HOME/.mobile-secrets/iOS/WPiOS/wpcom_internal_app_credentials;
 			};
 			name = "Release-Internal";
 		};
@@ -11358,7 +11358,7 @@
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 3.0;
-				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
+				WPCOM_CONFIG = $HOME/.mobile-secrets/iOS/WPiOS/wpcom_app_credentials;
 			};
 			name = Debug;
 		};
@@ -11411,7 +11411,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = $HOME/.wpcom_app_credentials;
+				WPCOM_CONFIG = $HOME/.mobile-secrets/iOS/WPiOS/wpcom_app_credentials;
 			};
 			name = Release;
 		};

--- a/WordPress/buddybuild_prebuild.sh
+++ b/WordPress/buddybuild_prebuild.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 echo "warning: Detected Prebuild Step"
-cp ${BUDDYBUILD_SECURE_FILES}/wpcom_app_credentials ~/.wpcom_app_credentials
-cp ${BUDDYBUILD_SECURE_FILES}/wpcom_internal_app_credentials ~/.wpcom_internal_app_credentials
-cp ${BUDDYBUILD_SECURE_FILES}/wpcom_alpha_app_credentials ~/.wpcom_alpha_app_credentials
+mkdir -p ~/.mobile-secrets/iOS/WPiOS/
+cp ${BUDDYBUILD_SECURE_FILES}/wpcom_app_credentials ~/.mobile-secrets/iOS/WPiOS/wpcom_app_credentials
+cp ${BUDDYBUILD_SECURE_FILES}/wpcom_internal_app_credentials ~/.mobile-secrets/iOS/WPiOS/wpcom_internal_app_credentials
+cp ${BUDDYBUILD_SECURE_FILES}/wpcom_alpha_app_credentials ~/.mobile-secrets/iOS/WPiOS/wpcom_alpha_app_credentials
 cp ${BUDDYBUILD_SECURE_FILES}/wpcom_test_credentials ~/.wpcom_test_credentials
 echo "warning: Copied files over"


### PR DESCRIPTION
This PR changes the expected path for the credential files. The new path let the build system to pick the files from the dedicated repository.

To Test:
1. Verify that the `ApiCredentials.m` into the `Derived Sources` folder contains the correct data after a build;
2. In theory, the previous point should be enough, but  verify that the app can access the relevant services (WP, Google Login, Crashlytics, Hockey, Zendesk) or at least a few of them won't hurt :-) 

@aerych can I bother you with this review?

