### PR TITLE
Capture analytics for push notification actions

### DIFF
--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -93,18 +93,28 @@ final class InteractiveNotificationsManager: NSObject {
             return false
         }
 
+        var event: WPAnalyticsStat? = nil
         switch action {
         case .commentApprove:
+            event = .notificationsCommentApproved
             approveCommentWithCommentID(commentID, noteID: noteID, siteID: siteID)
         case .commentLike:
+            event = .notificationsCommentLiked
             likeCommentWithCommentID(commentID, noteID: noteID, siteID: siteID)
         case .commentReply:
             if let responseText = responseText {
+                event = .notificationsCommentRepliedTo
                 replyToCommentWithCommentID(commentID, noteID: noteID, siteID: siteID, content: responseText)
             } else {
                 DDLogError("Tried to reply to a comment notification with no text")
             }
-        default: break
+        default:
+            break
+        }
+
+        if let actionEvent = event {
+            let actionAnalyticsProperties = [ "is_quick_action": true ]
+            WPAppAnalytics.track(actionEvent, withProperties: actionAnalyticsProperties)
         }
 
         return true


### PR DESCRIPTION
Addresses #6256, which observes that analytics are not captured when a user interacts with a push notification via custom actions.

To test:

- Whether through manual push notification delivery or a fabricated payload, at least three push notifications must be initiated to validate that each of the three events noted in the issue..
- To ensure that the appropriate action can be exercised, the `category` for the APNS payload must match [one of the following values](https://github.com/wordpress-mobile/WordPress-iOS/blob/593a6719ea2cc7df7f0541cd63b8003e3845fdb8/WordPress/Classes/Utility/InteractiveNotificationsManager.swift#L259-L262).
- Once each action has been initiated, visit _Tracks Live View_ and confirm that each of the following three events can be found: `wpios_notifications_approved`, `wpios_notifications_comment_liked `, & `wpios_notifications_replied_to`. These events should include a key-value pair in `properties` where `is_quick_action` is set to `true`.

