### PR TITLE
Issue/9447 suggestion behaviour

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -36,8 +36,9 @@ extension BlogDetailsViewController {
     }
 
     private func showNoticeOrAlertAsNeeded() {
-        if shouldSuggestQuickStartTour() {
-            suggestAQuickStartTour()
+        if let tourGuide = QuickStartTourGuide.find(),
+            let tourToSuggest = tourGuide.tourToSuggest(for: blog) {
+            tourGuide.suggest(tourToSuggest, for: blog)
         } else {
             showNotificationPrimerAlert()
         }
@@ -49,35 +50,6 @@ extension BlogDetailsViewController {
         }
         let count = blog.completedQuickStartTours?.count ?? 0
         return count > 0
-    }
-
-    private func shouldSuggestQuickStartTour() -> Bool {
-        // there must be at least one completed tour for quick start to be enabled
-        guard let completedCount = blog.completedQuickStartTours?.count, completedCount > 0 else {
-            return false
-        }
-
-        let skippedCount = blog.skippedQuickStartTours?.count ?? 0
-
-        // don't suggest a tour if they've completed them all or skipped the rest
-        guard completedCount + skippedCount < QuickStartTourGuide.checklistTours.count else {
-            return false
-        }
-
-        // don't suggest a tour if they've skipped the max
-        guard skippedCount < Constants.maxSkippedTours else {
-            return false
-        }
-
-        return true
-    }
-
-    private func suggestAQuickStartTour() {
-        guard let tourGuide = QuickStartTourGuide.find() else {
-            return
-        }
-        let tour = QuickStartViewTour()
-        tourGuide.suggest(tour, for: blog)
     }
 
     private func showNotificationPrimerAlert() {
@@ -112,9 +84,5 @@ extension BlogDetailsViewController {
             alert.transitioningDelegate = self
             self?.tabBarController?.present(alert, animated: true, completion: nil)
         }
-    }
-
-    private struct Constants {
-        static let maxSkippedTours = 3
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -546,11 +546,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     NSMutableArray *rows = [NSMutableArray array];
 
     if ([self shouldShowQuickStartChecklist]) {
-        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Quick Start", @"Name of the Quick Start feature that guides users through a few tasks to setup their new website.")
-                                                        image:[Gridicon iconOfType:GridiconTypeListCheckmark]
-                                                     callback:^{
-                                                         [weakSelf showQuickStart];
-                                                     }]];
+        BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Quick Start", @"Name of the Quick Start feature that guides users through a few tasks to setup their new website.")
+                                                              image:[Gridicon iconOfType:GridiconTypeListCheckmark]
+                                                           callback:^{
+                                                               [weakSelf showQuickStart];
+                                                           }];
+        row.quickStartIdentifier = QuickStartTourElementChecklist;
+        [rows addObject:row];
     }
 
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -38,7 +38,11 @@ internal extension QuickStartTourGuide {
             return nil
         }
 
-        // TODO: this is where the checklist tour will be added
+        // the last tour we suggest is the one to look at the checklist
+        if skippedTours.count == Constants.maxSkippedTours - 1 {
+            return QuickStartChecklistTour()
+        }
+
         let allTours = QuickStartTourGuide.checklistTours
 
         let unavailableIDs = unavailableTours.map { $0.tourID }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -23,6 +23,28 @@ internal extension QuickStartTourGuide {
         completed(tourID: createTour.key, for: blog)
     }
 
+    /// Provides a tour to suggest to the user
+    ///
+    /// - Parameter blog: The Blog for which to suggest a tour.
+    /// - Returns: A QuickStartTour to suggest. `nil` if there are no appropriate tours.
+    func tourToSuggest(for blog: Blog) -> QuickStartTour? {
+        let completedTours: [QuickStartTourState] = blog.completedQuickStartTours ?? []
+        let skippedTours: [QuickStartTourState] = blog.skippedQuickStartTours ?? []
+        let unavailableTours = Array(Set(completedTours + skippedTours))
+
+        guard isQuickStartEnabled(for: blog),
+            skippedTours.count < Constants.maxSkippedTours else {
+            return nil
+        }
+
+        // TODO: this is where the checklist tour will be added
+        let allTours = QuickStartTourGuide.checklistTours
+
+        let unavailableIDs = unavailableTours.map { $0.tourID }
+        let remainingTours = allTours.filter { !unavailableIDs.contains($0.key) }
+        return remainingTours.first
+    }
+
     func suggest(_ tour: QuickStartTour, for blog: Blog) {
         // swallow suggestions if already suggesting or a tour is in progress
         guard currentSuggestion == nil, currentTourState == nil else {
@@ -115,6 +137,14 @@ internal extension QuickStartTourGuide {
 }
 
 private extension QuickStartTourGuide {
+    func isQuickStartEnabled(for blog: Blog) -> Bool {
+        // there must be at least one completed tour for quick start to have been enabled
+        guard let completedTours = blog.completedQuickStartTours else {
+                return false
+        }
+
+        return completedTours.count > 0
+    }
 
     func completed(tourID: String, for blog: Blog) {
         blog.completeTour(tourID)
@@ -184,6 +214,10 @@ private extension QuickStartTourGuide {
         presenter.dismissCurrentNotice()
         ActionDispatcher.dispatch(NoticeAction.empty)
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.noSuchElement])
+    }
+
+    private struct Constants {
+        static let maxSkippedTours = 3
     }
 }
 


### PR DESCRIPTION
Refs #9447 

Improves the behaviour of the Quick Start suggestions, which are these:

<img width="563" alt="screen shot 2018-09-28 at 12 22 44 am" src="https://user-images.githubusercontent.com/517257/47130451-98f0cc80-d24e-11e8-97a9-f77c58323c33.png">

### Improvements:
- Suggestions now disappear after 3 seconds
- Suggestions will end after all tours have been either completed or skipped
- After three suggestions have been skipped, no more will be shown
- After two suggestions have been skipped, it will be suggested that they view the Quick Start checklist itself

## To test:
- Create a new site or ask for my snippet to turn quick start on for existing sites
- Wait for a suggestion and skip it, then skip the next (go back and forth between the blog list and details to get new suggestions)
- Ensure the third suggestion is the one to checkout the Quick Start checklist
- Repeat, this time either skipping or completing every tour
- Ensure there are no suggestions offered

## Note:

This PR currently targets branch `issue/9447-write-post-tour`. Once that PR is merged, I will retarget `develop`