### PR TITLE
Add new top-level Tracks event for custom notification actions

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,7 @@ end
 ## ===================================
 ##
 def shared_with_all_pods
-    pod 'WordPressShared', '1.1.1-beta.5'
+    pod 'WordPressShared', '1.2.0-beta.1'
     pod 'CocoaLumberjack', '3.4.2'
     pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
     pod 'NSObject-SafeExpectations', '0.0.3'
@@ -33,7 +33,7 @@ def shared_with_networking_pods
     pod 'AFNetworking', '3.2.1'
     pod 'Alamofire', '4.7.3'
     pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', '1.4.2-beta.2'
+    pod 'WordPressKit', '1.4.2-beta.3'
 end
 
 def shared_test_pods
@@ -95,7 +95,7 @@ target 'WordPress' do
     pod 'WPMediaPicker', '1.3.1'
     ## while PR is in review:
     ## pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '82f798c0dc18b17a11dfafa37f1fd39eb508b29b'
-    pod 'WordPressAuthenticator', '1.1.1'
+    pod 'WordPressAuthenticator', '1.1.2-beta.1'
 
     aztec
     wordpress_ui
@@ -157,8 +157,8 @@ target 'WordPressNotificationContentExtension' do
 
     inherit! :search_paths
 
-    pod 'WordPressKit', '1.4.2-beta.2'
-    pod 'WordPressShared', '1.1.1-beta.5'
+    pod 'WordPressKit', '1.4.2-beta.3'
+    pod 'WordPressShared', '1.2.0-beta.1'
     wordpress_ui
 end
 
@@ -173,8 +173,8 @@ target 'WordPressNotificationServiceExtension' do
     inherit! :search_paths
 
     pod 'Gridicons', '0.16'
-    pod 'WordPressKit', '1.4.2-beta.2'
-    pod 'WordPressShared', '1.1.1-beta.5'
+    pod 'WordPressKit', '1.4.2-beta.3'
+    pod 'WordPressShared', '1.2.0-beta.1'
 
     wordpress_ui
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -106,7 +106,7 @@ PODS:
   - WordPress-Aztec-iOS (1.0.2)
   - WordPress-Editor-iOS (1.0.2):
     - WordPress-Aztec-iOS (= 1.0.2)
-  - WordPressAuthenticator (1.1.1):
+  - WordPressAuthenticator (1.1.2-beta.1):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (= 3.4.2)
@@ -116,18 +116,18 @@ PODS:
     - "NSURL+IDN (= 0.3)"
     - SVProgressHUD (= 2.2.5)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressKit (~> 1.4.1-beta.2)
-    - WordPressShared (~> 1.1.1-beta.4)
+    - WordPressKit (~> 1.4.2-beta.3)
+    - WordPressShared (~> 1.2.0-beta.1)
     - WordPressUI (~> 1.0)
     - wpxmlrpc (~> 0.8)
-  - WordPressKit (1.4.2-beta.2):
+  - WordPressKit (1.4.2-beta.3):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressShared (~> 1.1.1-beta.4)
+    - WordPressShared (= 1.2.0-beta.1)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.1.1-beta.5):
+  - WordPressShared (1.2.0-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.0.8)
@@ -170,9 +170,9 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Editor-iOS (= 1.0.2)
-  - WordPressAuthenticator (= 1.1.1)
-  - WordPressKit (= 1.4.2-beta.2)
-  - WordPressShared (= 1.1.1-beta.5)
+  - WordPressAuthenticator (= 1.1.2-beta.1)
+  - WordPressKit (= 1.4.2-beta.3)
+  - WordPressShared (= 1.2.0-beta.1)
   - WordPressUI (= 1.0.8)
   - WPMediaPicker (= 1.3.1)
   - wpxmlrpc (= 0.8.3)
@@ -256,14 +256,14 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-Aztec-iOS: a736985cc6de6ffceb30a03e380d849b4956ae51
   WordPress-Editor-iOS: 571e9a168881af4cbe6cc909af603c278a5f0fe3
-  WordPressAuthenticator: 6e9cdd8f492ec771f9cb352e62a94059166f15c1
-  WordPressKit: a60ac809261ca23ac35e1c39e0249d9e05ab3ec0
-  WordPressShared: 66c7de16e1f0266d5eb4359803eb371b1c2ec4de
+  WordPressAuthenticator: 6e39e1362c9aaa755960c1e7f21be910f697a5b8
+  WordPressKit: afbdb50a6bbf3c6a0c0b2c1463bbcc6eca405fcd
+  WordPressShared: a1a3923a22456dfe77428dbbe6e95397c4f7000a
   WordPressUI: e50965adee24b4f10da398f6cdbdd3a822274158
   WPMediaPicker: ea92f84950843c7baf6a7325caed72ad7852418d
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 174e262272d8b663ba85a0744568dc3d43c1dc74
+PODFILE CHECKSUM: be6aa6c1abed8f0cf987602a046b49e376f4822b
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1015,6 +1015,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatPushNotificationReceived:
             eventName = @"push_notification_received";
             break;
+        case WPAnalyticsStatPushNotificationQuickActionCompleted:
+            eventName = @"quick_action_touched";
+            break;
         case WPAnalyticsStatPushNotificationPrimerSeen:
             eventName = @"notifications_primer_seen";
             break;


### PR DESCRIPTION
### Description
Resolves #6256, which calls for the addition of a new top-level event to track a user's interaction with custom push notification actions.

### Testing

- Checkout the branch and confirm that it builds. Please note that it may be necessary to run `pod install --repo-update`
- Confirm that existing tests pass.
- At least three push notification stimuli must be initiated to validate this change: one for each currently supported custom notification action : approve, like & reply. See _below_ for guidance on doing this manually, either via the web or via fabricated APNS payloads.
- After exercising these events in the preceding step, visit _Tracks Live View_ and confirm that an event named `wpios_quick_action_touched` can be found for each occurrence. Each of those should include a unique property with the key : `quick_action` & value set to either `approve`, `like`, or `reply-to`.

#### Manually push fabricated APNS payload(s)
@mariozorz has furnished some excellent instructions in the corresponding [Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/8450).

#### Manually push fabricated APNS payload(s)
Please contact me offline if you need assistance with Pusher or obtaining the necessary APNS configuration. the key takeaway with this approach is that the `category` for the APNS payload must match [one of the following values](https://github.com/wordpress-mobile/WordPress-iOS/blob/593a6719ea2cc7df7f0541cd63b8003e3845fdb8/WordPress/Classes/Utility/InteractiveNotificationsManager.swift#L259-L262).

