### PR TITLE
Updating Aztec reference to pre-release hash (for release v1.1)

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -46,8 +46,8 @@ def aztec
     ## When using a tagged version, feel free to comment out the WordPress-Aztec-iOS line below.
     ## When using a commit number (during development) you should provide the same commit number for both pods.
     ##
-    ## pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '14846f9550e24993d61d24df76cee84f3363ee91'
-    pod 'WordPress-Editor-iOS', '1.0.2'
+    pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'cc56f1886a6e3f566f6af65b1a663007c2aa82c9'
+#    pod 'WordPress-Editor-iOS', '1.0.2'
 end
 
 def wordpress_ui

--- a/Podfile
+++ b/Podfile
@@ -47,7 +47,6 @@ def aztec
     ## When using a commit number (during development) you should provide the same commit number for both pods.
     ##
     ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'cc56f1886a6e3f566f6af65b1a663007c2aa82c9'
-    ## pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'cc56f1886a6e3f566f6af65b1a663007c2aa82c9'
     pod 'WordPress-Editor-iOS', '1.1'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -47,6 +47,7 @@ def aztec
     ## When using a commit number (during development) you should provide the same commit number for both pods.
     ##
     pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'cc56f1886a6e3f566f6af65b1a663007c2aa82c9'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'cc56f1886a6e3f566f6af65b1a663007c2aa82c9'
 #    pod 'WordPress-Editor-iOS', '1.0.2'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -46,9 +46,9 @@ def aztec
     ## When using a tagged version, feel free to comment out the WordPress-Aztec-iOS line below.
     ## When using a commit number (during development) you should provide the same commit number for both pods.
     ##
-    pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '777ee955bf315e7236ea93390521af75c2b29ba6'
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '777ee955bf315e7236ea93390521af75c2b29ba6'
-#    pod 'WordPress-Editor-iOS', '1.0.2'
+    ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'cc56f1886a6e3f566f6af65b1a663007c2aa82c9'
+    ## pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'cc56f1886a6e3f566f6af65b1a663007c2aa82c9'
+    pod 'WordPress-Editor-iOS', '1.1'
 end
 
 def wordpress_ui

--- a/Podfile
+++ b/Podfile
@@ -46,8 +46,8 @@ def aztec
     ## When using a tagged version, feel free to comment out the WordPress-Aztec-iOS line below.
     ## When using a commit number (during development) you should provide the same commit number for both pods.
     ##
-    pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'cc56f1886a6e3f566f6af65b1a663007c2aa82c9'
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'cc56f1886a6e3f566f6af65b1a663007c2aa82c9'
+    pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '777ee955bf315e7236ea93390521af75c2b29ba6'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => '777ee955bf315e7236ea93390521af75c2b29ba6'
 #    pod 'WordPress-Editor-iOS', '1.0.2'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -169,7 +169,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.4)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Editor-iOS (= 1.0.2)
+  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `cc56f1886a6e3f566f6af65b1a663007c2aa82c9`)
   - WordPressAuthenticator (= 1.1.2-beta.1)
   - WordPressKit (= 1.4.2-beta.3)
   - WordPressShared (= 1.2.0-beta.1)
@@ -207,7 +207,6 @@ SPEC REPOS:
     - SVProgressHUD
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
-    - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
@@ -220,11 +219,17 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPress-Editor-iOS:
+    :commit: cc56f1886a6e3f566f6af65b1a663007c2aa82c9
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPress-Editor-iOS:
+    :commit: cc56f1886a6e3f566f6af65b1a663007c2aa82c9
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -264,6 +269,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: be6aa6c1abed8f0cf987602a046b49e376f4822b
+PODFILE CHECKSUM: 56c9146754b09fef39f37639939617a9bc2ad4c9
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -103,9 +103,9 @@ PODS:
   - Starscream (3.0.4)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.0.2)
-  - WordPress-Editor-iOS (1.0.2):
-    - WordPress-Aztec-iOS (= 1.0.2)
+  - WordPress-Aztec-iOS (1.1)
+  - WordPress-Editor-iOS (1.1):
+    - WordPress-Aztec-iOS (= 1.1)
   - WordPressAuthenticator (1.1.2-beta.1):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
@@ -169,8 +169,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.4)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `777ee955bf315e7236ea93390521af75c2b29ba6`)
-  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `777ee955bf315e7236ea93390521af75c2b29ba6`)
+  - WordPress-Editor-iOS (= 1.1)
   - WordPressAuthenticator (= 1.1.2-beta.1)
   - WordPressKit (= 1.4.2-beta.3)
   - WordPressShared (= 1.2.0-beta.1)
@@ -207,6 +206,8 @@ SPEC REPOS:
     - Starscream
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPress-Aztec-iOS
+    - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
@@ -219,23 +220,11 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  WordPress-Aztec-iOS:
-    :commit: 777ee955bf315e7236ea93390521af75c2b29ba6
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WordPress-Editor-iOS:
-    :commit: 777ee955bf315e7236ea93390521af75c2b29ba6
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  WordPress-Aztec-iOS:
-    :commit: 777ee955bf315e7236ea93390521af75c2b29ba6
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WordPress-Editor-iOS:
-    :commit: 777ee955bf315e7236ea93390521af75c2b29ba6
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -265,8 +254,8 @@ SPEC CHECKSUMS:
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: a736985cc6de6ffceb30a03e380d849b4956ae51
-  WordPress-Editor-iOS: 571e9a168881af4cbe6cc909af603c278a5f0fe3
+  WordPress-Aztec-iOS: 5bb57849aad4583a2e714ba8634eff1db0d03ac3
+  WordPress-Editor-iOS: 5a949802536d73c67ffb4d7705f922ca13a71550
   WordPressAuthenticator: 6e39e1362c9aaa755960c1e7f21be910f697a5b8
   WordPressKit: afbdb50a6bbf3c6a0c0b2c1463bbcc6eca405fcd
   WordPressShared: a1a3923a22456dfe77428dbbe6e95397c4f7000a
@@ -275,6 +264,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: c1debd6bed02ce88cb3f24dc68849867595b13a9
+PODFILE CHECKSUM: f0c3629c9242678545de9556afd6a72c9ce6d39c
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -169,6 +169,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.4)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `cc56f1886a6e3f566f6af65b1a663007c2aa82c9`)
   - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `cc56f1886a6e3f566f6af65b1a663007c2aa82c9`)
   - WordPressAuthenticator (= 1.1.2-beta.1)
   - WordPressKit (= 1.4.2-beta.3)
@@ -206,7 +207,6 @@ SPEC REPOS:
     - Starscream
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPress-Aztec-iOS
     - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
@@ -219,6 +219,9 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPress-Aztec-iOS:
+    :commit: cc56f1886a6e3f566f6af65b1a663007c2aa82c9
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPress-Editor-iOS:
     :commit: cc56f1886a6e3f566f6af65b1a663007c2aa82c9
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
@@ -227,6 +230,9 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPress-Aztec-iOS:
+    :commit: cc56f1886a6e3f566f6af65b1a663007c2aa82c9
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPress-Editor-iOS:
     :commit: cc56f1886a6e3f566f6af65b1a663007c2aa82c9
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
@@ -269,6 +275,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 56c9146754b09fef39f37639939617a9bc2ad4c9
+PODFILE CHECKSUM: 1137ff86f56fad67d4f682af90df30fdaf97e2f6
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -169,8 +169,8 @@ DEPENDENCIES:
   - Starscream (= 3.0.4)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `cc56f1886a6e3f566f6af65b1a663007c2aa82c9`)
-  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `cc56f1886a6e3f566f6af65b1a663007c2aa82c9`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `777ee955bf315e7236ea93390521af75c2b29ba6`)
+  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `777ee955bf315e7236ea93390521af75c2b29ba6`)
   - WordPressAuthenticator (= 1.1.2-beta.1)
   - WordPressKit (= 1.4.2-beta.3)
   - WordPressShared (= 1.2.0-beta.1)
@@ -220,10 +220,10 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPress-Aztec-iOS:
-    :commit: cc56f1886a6e3f566f6af65b1a663007c2aa82c9
+    :commit: 777ee955bf315e7236ea93390521af75c2b29ba6
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPress-Editor-iOS:
-    :commit: cc56f1886a6e3f566f6af65b1a663007c2aa82c9
+    :commit: 777ee955bf315e7236ea93390521af75c2b29ba6
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 CHECKOUT OPTIONS:
@@ -231,10 +231,10 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   WordPress-Aztec-iOS:
-    :commit: cc56f1886a6e3f566f6af65b1a663007c2aa82c9
+    :commit: 777ee955bf315e7236ea93390521af75c2b29ba6
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPress-Editor-iOS:
-    :commit: cc56f1886a6e3f566f6af65b1a663007c2aa82c9
+    :commit: 777ee955bf315e7236ea93390521af75c2b29ba6
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 SPEC CHECKSUMS:
@@ -275,6 +275,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 1137ff86f56fad67d4f682af90df30fdaf97e2f6
+PODFILE CHECKSUM: c1debd6bed02ce88cb3f24dc68849867595b13a9
 
 COCOAPODS: 1.5.3

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3837,7 +3837,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
+		29B97314FDCFA39411CA2CEA = {
 			isa = PBXGroup;
 			children = (
 				F14B5F6F208E648200439554 /* config */,
@@ -7467,7 +7467,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
+			mainGroup = 29B97314FDCFA39411CA2CEA;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -10531,7 +10531,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = $HOME/.mobile-secrets/iOS/WPiOS/wpcom_alpha_app_credentials;
+				WPCOM_CONFIG = "$HOME/.mobile-secrets/iOS/WPiOS/wpcom_alpha_app_credentials";
 			};
 			name = "Release-Alpha";
 		};
@@ -11013,7 +11013,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = $HOME/.mobile-secrets/iOS/WPiOS/wpcom_internal_app_credentials;
+				WPCOM_CONFIG = "$HOME/.mobile-secrets/iOS/WPiOS/wpcom_internal_app_credentials";
 			};
 			name = "Release-Internal";
 		};
@@ -11362,7 +11362,7 @@
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SWIFT_VERSION = 3.0;
-				WPCOM_CONFIG = $HOME/.mobile-secrets/iOS/WPiOS/wpcom_app_credentials;
+				WPCOM_CONFIG = "$HOME/.mobile-secrets/iOS/WPiOS/wpcom_app_credentials";
 			};
 			name = Debug;
 		};
@@ -11415,7 +11415,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
-				WPCOM_CONFIG = $HOME/.mobile-secrets/iOS/WPiOS/wpcom_app_credentials;
+				WPCOM_CONFIG = "$HOME/.mobile-secrets/iOS/WPiOS/wpcom_app_credentials";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
This PR updates the Aztec reference to the last commit on `develop`.

To test:
- Overal functionality of Aztec Editor.
- Pasting from Notes App.
- Pasting from Google Docs

