### PR TITLE
Capture more analytics info for push notification actions

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -14,6 +14,9 @@ extern NSString * const WPAppAnalyticsKeyFeedItemID;
 extern NSString * const WPAppAnalyticsKeyIsJetpack;
 extern NSString * const WPAppAnalyticsKeySessionCount;
 extern NSString * const WPAppAnalyticsKeyEditorSource;
+extern NSString * const WPAppAnalyticsKeyCommentID;
+extern NSString * const WPAppAnalyticsKeyLegacyQuickAction;
+extern NSString * const WPAppAnalyticsKeyQuickAction;
 
 /**
  *  @class      WPAppAnalytics

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -11,18 +11,22 @@
 #import "AbstractPost.h"
 #import "WordPress-Swift.h"
 
-NSString * const WPAppAnalyticsDefaultsUserOptedOut = @"tracks_opt_out";
-NSString * const WPAppAnalyticsDefaultsKeyUsageTracking_deprecated = @"usage_tracking_enabled";
-NSString * const WPAppAnalyticsKeyBlogID = @"blog_id";
-NSString * const WPAppAnalyticsKeyPostID = @"post_id";
-NSString * const WPAppAnalyticsKeyFeedID = @"feed_id";
-NSString * const WPAppAnalyticsKeyFeedItemID = @"feed_item_id";
-NSString * const WPAppAnalyticsKeyIsJetpack = @"is_jetpack";
-NSString * const WPAppAnalyticsKeySessionCount = @"session_count";
-NSString * const WPAppAnalyticsKeyEditorSource = @"editor_source";
-NSString * const WPAppAnalyticsKeyHasGutenbergBlocks = @"has_gutenberg_blocks";
-static NSString * const WPAppAnalyticsKeyLastVisibleScreen = @"last_visible_screen";
-static NSString * const WPAppAnalyticsKeyTimeInApp = @"time_in_app";
+NSString * const WPAppAnalyticsDefaultsUserOptedOut                 = @"tracks_opt_out";
+NSString * const WPAppAnalyticsDefaultsKeyUsageTracking_deprecated  = @"usage_tracking_enabled";
+NSString * const WPAppAnalyticsKeyBlogID                            = @"blog_id";
+NSString * const WPAppAnalyticsKeyPostID                            = @"post_id";
+NSString * const WPAppAnalyticsKeyFeedID                            = @"feed_id";
+NSString * const WPAppAnalyticsKeyFeedItemID                        = @"feed_item_id";
+NSString * const WPAppAnalyticsKeyIsJetpack                         = @"is_jetpack";
+NSString * const WPAppAnalyticsKeySessionCount                      = @"session_count";
+NSString * const WPAppAnalyticsKeyEditorSource                      = @"editor_source";
+NSString * const WPAppAnalyticsKeyCommentID                         = @"comment_id";
+NSString * const WPAppAnalyticsKeyLegacyQuickAction                 = @"is_quick_action";
+NSString * const WPAppAnalyticsKeyQuickAction                       = @"quick_action";
+
+NSString * const WPAppAnalyticsKeyHasGutenbergBlocks                = @"has_gutenberg_blocks";
+static NSString * const WPAppAnalyticsKeyLastVisibleScreen          = @"last_visible_screen";
+static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_app";
 
 @interface WPAppAnalytics ()
 

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -82,6 +82,7 @@ final class InteractiveNotificationsManager: NSObject {
             let noteID = userInfo.object(forKey: "note_id") as? NSNumber,
             let siteID = userInfo.object(forKey: "blog_id") as? NSNumber,
             let commentID = userInfo.object(forKey: "comment_id") as? NSNumber else {
+
             return false
         }
 
@@ -114,10 +115,14 @@ final class InteractiveNotificationsManager: NSObject {
         }
 
         if let actionEvent = legacyAnalyticsEvent {
-            let modernEventProperties = [ "quick_action": action.quickActionName ]
+            let modernEventProperties: [String: Any] = [
+                WPAppAnalyticsKeyQuickAction: action.quickActionName,
+                WPAppAnalyticsKeyBlogID: siteID,
+                WPAppAnalyticsKeyCommentID: commentID
+            ]
             WPAppAnalytics.track(.pushNotificationQuickActionCompleted, withProperties: modernEventProperties)
 
-            let legacyEventProperties = [ "is_quick_action": true ]
+            let legacyEventProperties = [ WPAppAnalyticsKeyLegacyQuickAction: true ]
             WPAppAnalytics.track(actionEvent, withProperties: legacyEventProperties)
         }
 


### PR DESCRIPTION
### Description
Resolves a new facet of #6256. After [the last PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/10280), a request was made via `p4qSXL-2RE-p2` to ensure that `blogid` was included in the event properties.

The [Android PR](https://github.com/wordpress-mobile/WordPress-Android/pull/8454) took the liberty to explicitly include the following attributes: `blog_id`, `is_jetpack`, `post_id`, comment_id`. 

_This_ PR explicitly sets both the blog ID & comment ID, as that information is readily available in the APNS payload. Unfortunately, however, `post_id` is not. In my testing, `is_jetpack` is included in the Tracks data implicitly.

### Testing
- Checkout the branch and verify that existing tests pass.
- Follow the same testing steps as in the [prior PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/10280)
- In _Tracks Live View_, the newly added attributes can be found. `blogid` appears to be promoted in the properties, but `comment_id` can be found under the `eventprops` node.

<img width="755" alt="10287a" src="https://user-images.githubusercontent.com/221062/47232059-875d1100-d383-11e8-8c49-1f1b87b322cd.png">
