### PR TITLE
Quick Start: add analytics events

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -21,25 +21,12 @@ end
 ## Pods shared between all the targets
 ## ===================================
 ##
-def shared_with_all_pods
+def wordpress_shared
+    ## for production:
     pod 'WordPressShared', '1.2.0-beta.1'
-    pod 'CocoaLumberjack', '3.4.2'
-    pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
-    pod 'NSObject-SafeExpectations', '0.0.3'
-    pod 'UIDeviceIdentifier', '~> 0.4'
-end
 
-def shared_with_networking_pods
-    pod 'AFNetworking', '3.2.1'
-    pod 'Alamofire', '4.7.3'
-    pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', '1.4.2-beta.3'
-end
-
-def shared_test_pods
-    pod 'OHHTTPStubs', '6.1.0'
-    pod 'OHHTTPStubs/Swift', '6.1.0'
-    pod 'OCMock', '~> 3.4'
+    ## for development:
+    ## pod 'WordPressUI', :path => '../WordPress-iOS-Shared'
 end
 
 def aztec
@@ -57,6 +44,27 @@ def wordpress_ui
     ## pod 'WordPressUI', :path => '../WordPressUI-iOS'
     ## while PR is in review:
     ## pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :commit => '5ec2be1533a86335710221ec20df5b4ba78b06e4'
+end
+
+def shared_with_all_pods
+    wordpress_shared
+    pod 'CocoaLumberjack', '3.4.2'
+    pod 'FormatterKit/TimeIntervalFormatter', '1.8.2'
+    pod 'NSObject-SafeExpectations', '0.0.3'
+    pod 'UIDeviceIdentifier', '~> 0.4'
+end
+
+def shared_with_networking_pods
+    pod 'AFNetworking', '3.2.1'
+    pod 'Alamofire', '4.7.3'
+    pod 'wpxmlrpc', '0.8.3'
+    pod 'WordPressKit', '1.4.2-beta.3'
+end
+
+def shared_test_pods
+    pod 'OHHTTPStubs', '6.1.0'
+    pod 'OHHTTPStubs/Swift', '6.1.0'
+    pod 'OCMock', '~> 3.4'
 end
 
 ## WordPress iOS
@@ -158,7 +166,7 @@ target 'WordPressNotificationContentExtension' do
     inherit! :search_paths
 
     pod 'WordPressKit', '1.4.2-beta.3'
-    pod 'WordPressShared', '1.2.0-beta.1'
+    wordpress_shared
     wordpress_ui
 end
 
@@ -174,7 +182,7 @@ target 'WordPressNotificationServiceExtension' do
 
     pod 'Gridicons', '0.16'
     pod 'WordPressKit', '1.4.2-beta.3'
-    pod 'WordPressShared', '1.2.0-beta.1'
+    wordpress_shared
 
     wordpress_ui
 end

--- a/Podfile
+++ b/Podfile
@@ -23,13 +23,13 @@ end
 ##
 def wordpress_shared
     ## for production:
-    ## pod 'WordPressShared', '1.2.0-beta.1'
+    pod 'WordPressShared', '1.2.0-beta.2'
 
     ## for development:
     ## pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '35c81ae4c75bb36455d49c7d4b495d22fb7871e3'
+    ## pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '35c81ae4c75bb36455d49c7d4b495d22fb7871e3'
 end
 
 def aztec
@@ -61,7 +61,7 @@ def shared_with_networking_pods
     pod 'AFNetworking', '3.2.1'
     pod 'Alamofire', '4.7.3'
     pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', '1.4.2-beta.3'
+    pod 'WordPressKit', '1.4.2-beta.4'
 end
 
 def shared_test_pods
@@ -168,7 +168,7 @@ target 'WordPressNotificationContentExtension' do
 
     inherit! :search_paths
 
-    pod 'WordPressKit', '1.4.2-beta.3'
+    pod 'WordPressKit', '1.4.2-beta.4'
     wordpress_shared
     wordpress_ui
 end
@@ -184,7 +184,7 @@ target 'WordPressNotificationServiceExtension' do
     inherit! :search_paths
 
     pod 'Gridicons', '0.16'
-    pod 'WordPressKit', '1.4.2-beta.3'
+    pod 'WordPressKit', '1.4.2-beta.4'
     wordpress_shared
 
     wordpress_ui

--- a/Podfile
+++ b/Podfile
@@ -23,10 +23,13 @@ end
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '1.2.0-beta.1'
+    ## pod 'WordPressShared', '1.2.0-beta.1'
 
     ## for development:
-    ## pod 'WordPressUI', :path => '../WordPress-iOS-Shared'
+    ## pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
+
+    ## while PR is in review:
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '35c81ae4c75bb36455d49c7d4b495d22fb7871e3'
 end
 
 def aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -172,7 +172,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.0.2)
   - WordPressAuthenticator (= 1.1.2-beta.1)
   - WordPressKit (= 1.4.2-beta.3)
-  - WordPressShared (= 1.2.0-beta.1)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `35c81ae4c75bb36455d49c7d4b495d22fb7871e3`)
   - WordPressUI (= 1.0.8)
   - WPMediaPicker (= 1.3.1)
   - wpxmlrpc (= 0.8.3)
@@ -210,7 +210,6 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -220,11 +219,17 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPressShared:
+    :commit: 35c81ae4c75bb36455d49c7d4b495d22fb7871e3
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPressShared:
+    :commit: 35c81ae4c75bb36455d49c7d4b495d22fb7871e3
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -264,6 +269,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: be6aa6c1abed8f0cf987602a046b49e376f4822b
+PODFILE CHECKSUM: 749c67c69310cc98467aad48022d885f40d1ff3f
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -120,14 +120,14 @@ PODS:
     - WordPressShared (~> 1.2.0-beta.1)
     - WordPressUI (~> 1.0)
     - wpxmlrpc (~> 0.8)
-  - WordPressKit (1.4.2-beta.3):
+  - WordPressKit (1.4.2-beta.4):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressShared (= 1.2.0-beta.1)
+    - WordPressShared (~> 1.2.0-beta.1)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.2.0-beta.1):
+  - WordPressShared (1.2.0-beta.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.0.8)
@@ -171,8 +171,8 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Editor-iOS (= 1.0.2)
   - WordPressAuthenticator (= 1.1.2-beta.1)
-  - WordPressKit (= 1.4.2-beta.3)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `35c81ae4c75bb36455d49c7d4b495d22fb7871e3`)
+  - WordPressKit (= 1.4.2-beta.4)
+  - WordPressShared (= 1.2.0-beta.2)
   - WordPressUI (= 1.0.8)
   - WPMediaPicker (= 1.3.1)
   - wpxmlrpc (= 0.8.3)
@@ -210,6 +210,7 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -219,17 +220,11 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  WordPressShared:
-    :commit: 35c81ae4c75bb36455d49c7d4b495d22fb7871e3
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  WordPressShared:
-    :commit: 35c81ae4c75bb36455d49c7d4b495d22fb7871e3
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -262,13 +257,13 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: a736985cc6de6ffceb30a03e380d849b4956ae51
   WordPress-Editor-iOS: 571e9a168881af4cbe6cc909af603c278a5f0fe3
   WordPressAuthenticator: 6e39e1362c9aaa755960c1e7f21be910f697a5b8
-  WordPressKit: afbdb50a6bbf3c6a0c0b2c1463bbcc6eca405fcd
-  WordPressShared: a1a3923a22456dfe77428dbbe6e95397c4f7000a
+  WordPressKit: 1fddb7a77f64564489b4fae78acbd42ca61a4f31
+  WordPressShared: 247848fd87f5af867a32c703a5cef1f36c6b32f8
   WordPressUI: e50965adee24b4f10da398f6cdbdd3a822274158
   WPMediaPicker: ea92f84950843c7baf6a7325caed72ad7852418d
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 749c67c69310cc98467aad48022d885f40d1ff3f
+PODFILE CHECKSUM: e76d5488e6d432a2563ebd3d8772e7e3db1e04d9
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1045,6 +1045,36 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatPushNotificationOSAlertDenied:
             eventName = @"notifications_os_alert_denied";
             break;
+        case WPAnalyticsStatQuickStartAllToursCompleted:
+            eventName = @"quick_start_all_tasks_completed";
+            break;
+        case WPAnalyticsStatQuickStartChecklistItemTapped:
+            eventName = @"quick_start_list_item_tapped";
+            break;
+        case WPAnalyticsStatQuickStartChecklistSkippedAll:
+            eventName = @"quick_start_list_all_tasks_skipped";
+            break;
+        case WPAnalyticsStatQuickStartChecklistViewed:
+            eventName = @"quick_start_list_viewed";
+            break;
+        case WPAnalyticsStatQuickStartCongratulationsViewed:
+            eventName = @"quick_start_list_completed_viewed";
+            break;
+        case WPAnalyticsStatQuickStartRequestAlertButtonTapped:
+            eventName = @"quick_start_request_dialog_button_tapped";
+            break;
+        case WPAnalyticsStatQuickStartRequestAlertViewed:
+            eventName = @"quick_start_request_dialog_viewed";
+            break;
+        case WPAnalyticsStatQuickStartSuggestionButtonTapped:
+            eventName = @"quick_start_dialog_button_tapped";
+            break;
+        case WPAnalyticsStatQuickStartSuggestionViewed:
+            eventName = @"quick_start_dialog_viewed";
+            break;
+        case WPAnalyticsStatQuickStartTourCompleted:
+            eventName = @"quick_start_task_completed";
+            break;
         case WPAnalyticsStatReaderAccessed:
             eventName = @"reader_accessed";
             break;

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -13,6 +13,8 @@ class QuickStartChecklistViewController: UITableViewController {
         self.blog = blog
 
         startObservingForQuickStart()
+
+        WPAnalytics.track(.quickStartChecklistViewed)
     }
 
     deinit {
@@ -72,6 +74,7 @@ class QuickStartChecklistViewController: UITableViewController {
                     self?.reload()
                     self?.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
                 }
+                WPAnalytics.track(.quickStartChecklistSkippedAll)
                 return nil
             }
         }
@@ -89,6 +92,8 @@ class QuickStartChecklistViewController: UITableViewController {
         tourGuide.start(tour: tour, for: blog)
 
         self.navigationController?.popViewController(animated: true)
+
+        WPAnalytics.track(.quickStartChecklistItemTapped, withProperties: ["task_name": tour.analyticsKey])
     }
 
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -167,7 +172,12 @@ private class QuickStartChecklistDataSource: NSObject, UITableViewDataSource {
 
         switch section {
         case .congratulations:
-            return shouldShowCongratulations() ? 1 : 0
+            if shouldShowCongratulations() {
+                WPAnalytics.track(.quickStartCongratulationsViewed)
+                return 1
+            } else {
+                return 0
+            }
         case .checklistItems:
             return QuickStartTourGuide.checklistTours.count
         case .skipAll:

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -172,7 +172,6 @@ private class QuickStartChecklistDataSource: NSObject, UITableViewDataSource {
         switch section {
         case .congratulations:
             if shouldShowCongratulations() {
-                WPAnalytics.track(.quickStartCongratulationsViewed)
                 return 1
             } else {
                 return 0

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -74,7 +74,6 @@ class QuickStartChecklistViewController: UITableViewController {
                     self?.reload()
                     self?.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: true)
                 }
-                WPAnalytics.track(.quickStartChecklistSkippedAll)
                 return nil
             }
         }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -13,8 +13,6 @@ class QuickStartChecklistViewController: UITableViewController {
         self.blog = blog
 
         startObservingForQuickStart()
-
-        WPAnalytics.track(.quickStartChecklistViewed)
     }
 
     deinit {
@@ -54,6 +52,8 @@ class QuickStartChecklistViewController: UITableViewController {
                 QuickStartTourGuide.find()?.complete(tour: QuickStartCongratulationsTour(), for: blog)
             }
         }
+
+        WPAnalytics.track(.quickStartChecklistViewed)
     }
 
     override func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -242,7 +242,7 @@ private extension QuickStartTourGuide {
             WPAnalytics.track(.quickStartCongratulationsViewed)
             return
         }
-        
+
         WPAnalytics.track(.quickStartTourCompleted, withProperties: ["task_name": tour.analyticsKey])
 
         if allToursCompleted(for: blog) {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -237,6 +237,11 @@ private extension QuickStartTourGuide {
         blog.completeTour(tour.key)
 
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.tourCompleted])
+
+        guard !(tour is QuickStartCongratulationsTour) else {
+            return
+        }
+        
         WPAnalytics.track(.quickStartTourCompleted, withProperties: ["task_name": tour.analyticsKey])
 
         if allToursCompleted(for: blog) {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -188,6 +188,8 @@ open class QuickStartTourGuide: NSObject {
             }
 
             whenSkipped()
+
+            WPAnalytics.track(.quickStartChecklistSkippedAll)
         }
         alertController.preferredAction = skipAction
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -237,7 +237,13 @@ private extension QuickStartTourGuide {
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.tourCompleted])
         WPAnalytics.track(.quickStartTourCompleted, withProperties: ["task_name": tour.analyticsKey])
 
-        // TODO: put the competion code here
+        if allToursCompleted(for: blog) {
+            WPAnalytics.track(.quickStartAllToursCompleted)
+        }
+    }
+
+    func allToursCompleted(for blog: Blog) -> Bool {
+        return countChecklistCompleted(for: blog) >= QuickStartTourGuide.checklistTours.count
     }
 
     func showCurrentStep() {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -239,6 +239,7 @@ private extension QuickStartTourGuide {
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.tourCompleted])
 
         guard !(tour is QuickStartCongratulationsTour) else {
+            WPAnalytics.track(.quickStartCongratulationsViewed)
             return
         }
         

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -124,7 +124,7 @@ open class QuickStartTourGuide: NSObject {
     }
 
     func complete(tour: QuickStartTour, for blog: Blog) {
-        completed(tourID: tour.key, for: blog)
+        completed(tour: tour, for: blog)
     }
 
     // we have this because poor stupid ObjC doesn't know what the heck an optional is

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -175,6 +175,7 @@ private let congratsTitle = NSLocalizedString("Congrats on finishing Quick Start
 private let congratsDescription = NSLocalizedString("doesn’t it feel good to cross things off a list?", comment: "subhead shown to users when they complete all Quick Start items")
 struct QuickStartCongratulationsTour: QuickStartTour {
     let key = "quick-start-congratulations-tour"
+    let analyticsKey = "congratulations"
     let title = congratsTitle
     let description = congratsDescription
     let icon = Gridicon.iconOfType(.plus)

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -5,6 +5,7 @@ protocol QuickStartTour {
 
     var key: String { get }
     var title: String { get }
+    var analyticsKey: String { get }
     var description: String { get }
     var icon: UIImage { get }
     var suggestionNoText: String { get }
@@ -19,6 +20,7 @@ private struct Strings {
 
 struct QuickStartChecklistTour: QuickStartTour {
     let key = "quick-start-checklist-tour"
+    let analyticsKey = "view_list"
     let title = NSLocalizedString("Continue with site setup", comment: "Title of a Quick Start Tour")
     let description = NSLocalizedString("Time to finish setting up your site! Our checklist walks you through the next steps.", comment: "Description of a Quick Start Tour")
     let icon = Gridicon.iconOfType(.external)
@@ -34,6 +36,7 @@ struct QuickStartChecklistTour: QuickStartTour {
 
 struct QuickStartCreateTour: QuickStartTour {
     let key = "quick-start-create-tour"
+    let analyticsKey = "create_site"
     let title = NSLocalizedString("Create your site", comment: "Title of a Quick Start Tour")
     let description = NSLocalizedString("Get your site up and running", comment: "Description of a Quick Start Tour")
     let icon = Gridicon.iconOfType(.plus)
@@ -45,6 +48,7 @@ struct QuickStartCreateTour: QuickStartTour {
 
 struct QuickStartViewTour: QuickStartTour {
     let key = "quick-start-view-tour"
+    let analyticsKey = "view_site"
     let title = NSLocalizedString("View your site", comment: "Title of a Quick Start Tour")
     let description = NSLocalizedString("Preview your new site to see what your visitors will see.", comment: "Description of a Quick Start Tour")
     let icon = Gridicon.iconOfType(.external)
@@ -60,6 +64,7 @@ struct QuickStartViewTour: QuickStartTour {
 
 struct QuickStartThemeTour: QuickStartTour {
     let key = "quick-start-theme-tour"
+    let analyticsKey = "browse_themes"
     let title = NSLocalizedString("Choose a theme", comment: "Title of a Quick Start Tour")
     let description = NSLocalizedString("Browse all our themes to find your perfect fit.", comment: "Description of a Quick Start Tour")
     let icon = Gridicon.iconOfType(.themes)
@@ -75,6 +80,7 @@ struct QuickStartThemeTour: QuickStartTour {
 
 struct QuickStartCustomizeTour: QuickStartTour {
     let key = "quick-start-customize-tour"
+    let analyticsKey = "customize_site"
     let title = NSLocalizedString("Customize your site", comment: "Title of a Quick Start Tour")
     let description = NSLocalizedString("Change colors, fonts, and images for a perfectly personalized site.", comment: "Description of a Quick Start Tour")
     let icon = Gridicon.iconOfType(.customize)
@@ -96,6 +102,7 @@ struct QuickStartCustomizeTour: QuickStartTour {
 
 struct QuickStartShareTour: QuickStartTour {
     let key = "quick-start-share-tour"
+    let analyticsKey = "share_site"
     let title = NSLocalizedString("Share your site", comment: "Title of a Quick Start Tour")
     let description = NSLocalizedString("Connect to your social media accounts -- your site will automatically share new posts.", comment: "Description of a Quick Start Tour")
     let icon = Gridicon.iconOfType(.share)
@@ -117,6 +124,7 @@ struct QuickStartShareTour: QuickStartTour {
 
 struct QuickStartPublishTour: QuickStartTour {
     let key = "quick-start-publish-tour"
+    let analyticsKey = "publish_post"
     let title = NSLocalizedString("Publish a post", comment: "Title of a Quick Start Tour")
     let description = NSLocalizedString("It's time! Draft and publish your very first post.", comment: "Description of a Quick Start Tour")
     let icon = Gridicon.iconOfType(.create)
@@ -131,6 +139,7 @@ struct QuickStartPublishTour: QuickStartTour {
 
 struct QuickStartFollowTour: QuickStartTour {
     let key = "quick-start-follow-tour"
+    let analyticsKey = "follow_site"
     let title = NSLocalizedString("Follow other sites", comment: "Title of a Quick Start Tour")
     let description = NSLocalizedString("Find sites that speak to you, and follow them to get updates when they publish.", comment: "Description of a Quick Start Tour")
     let icon = Gridicon.iconOfType(.readerFollow)

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationEpilogueViewController.swift
@@ -82,8 +82,6 @@ extension SiteCreationEpilogueViewController: NUXButtonViewControllerDelegate {
         fancyAlert.modalPresentationStyle = .custom
         fancyAlert.transitioningDelegate = tabBar
         tabBar.present(fancyAlert, animated: true, completion: nil)
-
-        WPAnalytics.track(.quickStartRequestAlertViewed)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationEpilogueViewController.swift
@@ -82,6 +82,8 @@ extension SiteCreationEpilogueViewController: NUXButtonViewControllerDelegate {
         fancyAlert.modalPresentationStyle = .custom
         fancyAlert.transitioningDelegate = tabBar
         tabBar.present(fancyAlert, animated: true, completion: nil)
+
+        WPAnalytics.track(.quickStartRequestAlertViewed)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
@@ -17,6 +17,7 @@ extension FancyAlertViewController {
     /// - Parameter approveAction: block to call when approve is tapped
     /// - Returns: FancyAlertViewController of the primer
     @objc static func makeQuickStartAlertController(blog: Blog) -> FancyAlertViewController {
+        WPAnalytics.track(.quickStartRequestAlertViewed)
 
         let allowButton = ButtonConfig(Strings.allowButtonText) { controller, _ in
             controller.dismiss(animated: true)

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
@@ -26,15 +26,21 @@ extension FancyAlertViewController {
             }
 
             tourGuide.setup(for: blog)
+
+            WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "positive"])
         }
 
         let notNowButton = ButtonConfig(Strings.notNowText) { controller, _ in
             controller.dismiss(animated: true)
+
+            WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "neutral"])
         }
 
         let neverButton = ButtonConfig(Strings.neverText) { controller, _ in
             UserDefaults.standard.quickStartWasDismissedPermanently = true
             controller.dismiss(animated: true)
+
+            WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "negative"])
         }
 
         let image = UIImage(named: "wp-illustration-checklist")


### PR DESCRIPTION
Refs #9447

This adds the analytics events for Quick Start.

<img width="836" alt="image" src="https://user-images.githubusercontent.com/517257/47236038-ba0d0680-d38f-11e8-9ca5-bbf05646b59e.png">


### To test:
Run through various quick start tasks and check that the events are being logged. I can provide a references to the events that android is using.

Thanks @aerych!

### Note:
This is targetting the previous QS branch until that one is merged 👍 