### PR TITLE
Turn on Quick Start for everyone

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -17,7 +17,7 @@ enum FeatureFlag: Int {
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .quickStart:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .newsCard:
             return true
         case .giphy:


### PR DESCRIPTION
Fixes #9447

This PR turns on Quick Start for everyone.

To test:
- I dunno, make a non-developer build and ensure quick start appears?

