### PR TITLE
Quick Start: Fix notice view container from swallowing all taps

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -271,6 +271,10 @@ private class NoticeContainerView: UIView {
 
         layoutIfNeeded()
     }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        return noticeView.point(inside: convert(point, to: noticeView), with: event)
+    }
 }
 
 private extension UNMutableNotificationContent {


### PR DESCRIPTION
This PR restricts swallowed taps to just those that will be used by the NoticeView itself.

Fixes #10298

To test:
- ensure that "View Site" is now tappable on iPad (see #10298 for an example)
- ensure that notices are still tappable:
  - Quick Start "suggestion" notices
  - Async post notices
- ensure that the above still work on iPhone

