### PR TITLE
Introduced feature flag for enhanced site creation

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -8,6 +8,7 @@ enum FeatureFlag: Int {
     case newsCard
     case giphy
     case automatedTransfer
+    case enhancedSiteCreation
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -24,6 +25,8 @@ enum FeatureFlag: Int {
             return BuildConfiguration.current == .localDeveloper
         case .automatedTransfer:
             return true
+        case .enhancedSiteCreation:
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -897,7 +897,12 @@ static NSInteger HideSearchMinSites = 3;
 - (void)showAddNewWordPressController
 {
     [self setEditing:NO animated:NO];
-    
+
+    // to be integrated via [#10322](https://github.com/wordpress-mobile/WordPress-iOS/issues/10312)
+    if ([Feature enabled:FeatureFlagEnhancedSiteCreation] == YES) {
+        DDLogDebug(@"The feature flag for enhanced site creation is ENABLED.");
+    }
+
     UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"SiteCreation" bundle:nil];
     SiteCreationCategoryTableViewController *controller = [storyboard instantiateViewControllerWithIdentifier:@"siteCategory"];
     SiteCreationNavigationController *navController = [[SiteCreationNavigationController alloc]

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5055,15 +5055,15 @@
 				82301B8E1E787420009C9C4E /* AppRatingUtilityTests.swift */,
 				17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */,
 				E180BD4B1FB462FF00D0D781 /* CookieJarTests.swift */,
+				E1AB5A391E0C464700574B4E /* DelayTests.swift */,
 				E1EBC3721C118ED200F638E0 /* ImmuTableTest.swift */,
 				93A379EB19FFBF7900415023 /* KeychainTest.m */,
+				1759F1711FE017F20003EC81 /* QueueTests.swift */,
+				1797373620EBAA4100377B4E /* RouteMatcherTests.swift */,
+				E1928B2D1F8369F100E076C8 /* WebViewAuthenticatorTests.swift */,
 				5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */,
 				E1E4CE0C177439D100430844 /* WPAvatarSourceTest.m */,
 				5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */,
-				E1AB5A391E0C464700574B4E /* DelayTests.swift */,
-				E1928B2D1F8369F100E076C8 /* WebViewAuthenticatorTests.swift */,
-				1759F1711FE017F20003EC81 /* QueueTests.swift */,
-				1797373620EBAA4100377B4E /* RouteMatcherTests.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -6556,13 +6556,12 @@
 		E1239B7B176A2E0F00D37220 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				172D7823212D937F00D513F7 /* Giphy */,
 				7E442FC520F677A300DEACA5 /* ActivityLog */,
-				D88A6490208D79F1008AE9BC /* Stock Photos */,
 				FF7691661EE06CF500713F4B /* Aztec */,
 				B5AEEC7F1ACAD099008BF2A4 /* Categories */,
 				B5AEEC731ACACF3B008BF2A4 /* Core Data */,
 				E1C9AA541C1041E600732665 /* Extensions */,
+				172D7823212D937F00D513F7 /* Giphy */,
 				FF7C89A11E3A1029000472A8 /* MediaPicker */,
 				5D7A577D1AFBFD7C0097C028 /* Models */,
 				85F8E1991B017A8E000859BB /* Networking */,
@@ -6570,6 +6569,7 @@
 				59ECF8791CB705EB00E68F25 /* Posts */,
 				E6B9B8AB1B94EA710001B92F /* Reader */,
 				B5AEEC7E1ACAD088008BF2A4 /* Services */,
+				D88A6490208D79F1008AE9BC /* Stock Photos */,
 				BEA0E4821BD8353B000AEE81 /* System */,
 				59B48B601B99E0B0008EBB84 /* TestUtilities */,
 				852416D01A12ED2D0030700C /* Utility */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -385,6 +385,7 @@
 		7059CD210F332B6500A0660B /* WPCategoryTree.m in Sources */ = {isa = PBXBuildFile; fileRef = 7059CD200F332B6500A0660B /* WPCategoryTree.m */; };
 		722F5726ACB4A276B0CF3C83 /* Pods_WordPress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */; };
 		7326718B210F75D2001FA866 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 7326718D210F75D2001FA866 /* Localizable.strings */; };
+		732B99172180D3A600C4EBDB /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 732B99162180D3A600C4EBDB /* FeatureFlagTests.swift */; };
 		7335AC5821220AB40012EF2D /* FormattableContentGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123AD20F4097900DF8486 /* FormattableContentGroup.swift */; };
 		7335AC5921220AC40012EF2D /* FormattableContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123B220F4097A00DF8486 /* FormattableContent.swift */; };
 		7335AC5A21220AD10012EF2D /* FormattableContentRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4123B420F4097A00DF8486 /* FormattableContentRange.swift */; };
@@ -2063,6 +2064,7 @@
 		712D0A17BC83B9730BD7CCC0 /* Pods-WordPressDraftActionExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressDraftActionExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressDraftActionExtension/Pods-WordPressDraftActionExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		7326718E210F75F0001FA866 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		7326718F210F7601001FA866 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
+		732B99162180D3A600C4EBDB /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		732D4E1D2126253900BF7F11 /* WordPressNotificationContentExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = WordPressNotificationContentExtension.entitlements; sourceTree = "<group>"; };
 		732D4E1E212625A100BF7F11 /* WordPressNotificationContentExtension-Alpha.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = "WordPressNotificationContentExtension-Alpha.entitlements"; sourceTree = "<group>"; };
 		732D4E1F212625A100BF7F11 /* WordPressNotificationContentExtension-Internal.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = "WordPressNotificationContentExtension-Internal.entitlements"; sourceTree = "<group>"; };
@@ -5056,6 +5058,7 @@
 				17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */,
 				E180BD4B1FB462FF00D0D781 /* CookieJarTests.swift */,
 				E1AB5A391E0C464700574B4E /* DelayTests.swift */,
+				732B99162180D3A600C4EBDB /* FeatureFlagTests.swift */,
 				E1EBC3721C118ED200F638E0 /* ImmuTableTest.swift */,
 				93A379EB19FFBF7900415023 /* KeychainTest.m */,
 				1759F1711FE017F20003EC81 /* QueueTests.swift */,
@@ -9324,6 +9327,7 @@
 				F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */,
 				E180BD4E1FB4681E00D0D781 /* MockCookieJar.swift in Sources */,
 				D81C2F6A20F8B449002AE1F1 /* NotificationActionParserTest.swift in Sources */,
+				732B99172180D3A600C4EBDB /* FeatureFlagTests.swift in Sources */,
 				E1E4CE0D177439D100430844 /* WPAvatarSourceTest.m in Sources */,
 				D88A64A2208D8F05008AE9BC /* StockPhotosMediaTests.swift in Sources */,
 				B55F1AA21C107CE200FD04D4 /* BlogSettingsDiscussionTests.swift in Sources */,

--- a/WordPress/WordPressTest/FeatureFlagTests.swift
+++ b/WordPress/WordPressTest/FeatureFlagTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import WordPress
 
-class FeatureFlagTests: XCTestCase {
+final class FeatureFlagTests: XCTestCase {
 
     func testFeatureFlag_EnhancedSiteCreation_Enabled_ForLocalDeveloperBuildConfiguration() {
         BuildConfiguration.localDeveloper.test {

--- a/WordPress/WordPressTest/FeatureFlagTests.swift
+++ b/WordPress/WordPressTest/FeatureFlagTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import WordPress
+
+class FeatureFlagTests: XCTestCase {
+
+    func testFeatureFlag_EnhancedSiteCreation_Enabled_ForLocalDeveloperBuildConfiguration() {
+        BuildConfiguration.localDeveloper.test {
+            let actualValue = FeatureFlag.enhancedSiteCreation.enabled
+            XCTAssertTrue(actualValue, "Enhanced site creation should be enabled for .localDeveloper BuildConfiguration")
+        }
+    }
+
+    func testFeatureFlag_EnhancedSiteCreation_Disabled_ForBranchTestBuildConfiguration() {
+        BuildConfiguration.a8cBranchTest.test {
+            let actualValue = FeatureFlag.enhancedSiteCreation.enabled
+            XCTAssertFalse(actualValue, "Enhanced site creation should be disabled for .a8cBranchTest BuildConfiguration")
+        }
+    }
+
+    func testFeatureFlag_EnhancedSiteCreation_Disabled_ForPrereleaseTestingBuildConfiguration() {
+        BuildConfiguration.a8cPrereleaseTesting.test {
+            let actualValue = FeatureFlag.enhancedSiteCreation.enabled
+            XCTAssertFalse(actualValue, "Enhanced site creation should be disabled for .a8cPrereleaseTesting BuildConfiguration")
+        }
+    }
+
+    func testFeatureFlag_EnhancedSiteCreation_Disabled_ForAppStoreBuildConfiguration() {
+        BuildConfiguration.appStore.test {
+            let actualValue = FeatureFlag.enhancedSiteCreation.enabled
+            XCTAssertFalse(actualValue, "Enhanced site creation should be disabled for .appStore BuildConfiguration")
+        }
+    }
+}


### PR DESCRIPTION
Fixes #10312.

### Testing

- Checkout the branch and confirm that existing tests pass.
- New `FeatureFlagTests` should also pass.

Additionally, exercise the following _manual_ steps:

1. Launch the app in `Debug` build configuration.
1. Ensure that the user has signed in to WordPress.
1. From the _My Sites_ tab, tap the **+** in the right bar button item and select "Create WordPress.com site".
1. Visually confirm that the existing Site Creation flow remains intact.

To validate that the feature flag is recognized, consider setting a breakpoint [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/1925c6372518bc6617192d470eb25f698421b930/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m#L902), and observing that the `if` block is entered.