### PR TITLE
Fastlane: Added check for clean git status to remaining lanes

### DIFF
--- a/Scripts/fastlane/actions/ios_finalize_prechecks.rb
+++ b/Scripts/fastlane/actions/ios_finalize_prechecks.rb
@@ -19,6 +19,9 @@ module Fastlane
           UI.message(message)
         end
 
+        # Check local repo status
+        other_action.ensure_git_status_clean()
+
         version
       end
 

--- a/Scripts/fastlane/actions/ios_update_metadata_source.rb
+++ b/Scripts/fastlane/actions/ios_update_metadata_source.rb
@@ -2,6 +2,9 @@ module Fastlane
   module Actions
     class IosUpdateMetadataSourceAction < Action
       def self.run(params)
+        # Check local repo status
+        other_action.ensure_git_status_clean()
+
         other_action.gp_update_metadata_source(po_file_path: params[:po_file_path],
           source_files: params[:source_files], 
           release_version: params[:release_version])


### PR DESCRIPTION
Some Fastlane lanes (such as `finalize_release`) don't check for a clean git status. This can lead to accidental commits.

This PR adds the `ensure_git_status_clean` check to the two actions that were missing it.

To test:

These lanes still work as expected:
- `bundle exec fastlane finalize_release`
- `bundle exec fastlane update_appstore_strings`

