### PR TITLE
History / Revisions: Assign the revisions array to the local post

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -586,6 +586,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     post.mt_excerpt = remotePost.excerpt;
     post.wp_slug = remotePost.slug;
     post.suggested_slug = remotePost.suggestedSlug;
+    post.revisions = [remotePost.revisions copy];
 
     if (remotePost.postID != previousPostID) {
         [self updateCommentsForPost:post];


### PR DESCRIPTION
Refs #10304

This small PR map the *revisions* array from the *RemotePost* to the local *AbstractPost* within the local service. If the post doesn't have a revisions history, then it will be nil.

**To test:**
No action has been added here, so at the moment you can test if the blog list page works as before.
Select a blog, then select *Blog Posts*, and see if the list works correctly.


