### PR TITLE
Fix slow reader loading with many images

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -299,7 +299,7 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
         let image = richTextImage(with: finalSize, url, attachment)
 
         // show that something is loading.
-        attachment.maxSize = CGSize(width: finalSize.width, height: finalSize.width / 2.0)
+        attachment.maxSize = CGSize(width: finalSize.width, height: finalSize.height)
 
         let contentInformation = ContentInformation(isPrivateOnWPCom: isPrivate, isSelfHostedWithCredentials: false)
         let index = mediaArray.count
@@ -311,7 +311,6 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
             }
 
             richMedia.attachment.maxSize = image.contentSize()
-            self?.layoutAttachmentViews()
         }, onError: { (indexPath, error) in
             DDLogError("\(String(describing: error))")
         })

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -299,7 +299,7 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
         let image = richTextImage(with: finalSize, url, attachment)
 
         // show that something is loading.
-        attachment.maxSize = CGSize(width: finalSize.width, height: finalSize.height)
+        attachment.maxSize = CGSize(width: proposedSize.width, height: proposedSize.height)
 
         let contentInformation = ContentInformation(isPrivateOnWPCom: isPrivate, isSelfHostedWithCredentials: false)
         let index = mediaArray.count


### PR DESCRIPTION
Fixes #6040 (partially) and #3027 (possibly)

When laying out attachment views, the layoutAttachmentViewForAttachment method would be called for each attachment. The resulted in nice, clean code, but it called layoutManager.ensureLayout for every layout attachment, which forces synchronous re-layout for each attachment. When there are many images in a post, this would take several seconds of main thread work to do the layout.

Batching the layout work for attachments and only calling ensureLayout once removes a lot of layout work for the device. This should resolve the "slow to load" and "crashing on old devices" issues in many cases. However, it doesn't resolve the memory issues.

To test:

Add mcraeblog.com to reader.
Choose the post called "Silo Art".
Before
The tile would be outlined, indicating it had been tapped, but the app would appear to be frozen. On new devices, it would take ~3-4 seconds to load the post. On older devices, it would crash.

screen shot 2018-10-23 at 3 25 20 pm

CPU Profiler showing the issue

After
The post loads as expected.

screen shot 2018-10-23 at 3 25 29 pm

CPU isn't working quite as hard

Also
While fixing this bug, I uncovered another – images would load, then "pop" to the right size. Because the performance issue often masked the popping issue, they're both in this PR.

Additionally, I've tested this with all the sites in my reader, but I'd like have a few more people do some testing to ensure we're not breaking any reader posts with this.