### PR TITLE
Reader: don't set refresh control to zero frame

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -364,7 +364,6 @@ import WordPressFlux
 
     fileprivate func configureRefreshControl() {
         refreshControl.addTarget(self, action: #selector(ReaderStreamViewController.handleRefresh(_:)), for: .valueChanged)
-        tableViewController.refreshControl = UIRefreshControl(frame: .zero)
     }
 
     fileprivate func add(_ childController: UIViewController, asChildOf controller: UIViewController) {


### PR DESCRIPTION
Fixes #10356

This PR removes the code setting the reader stream's refresh control to a zero frame. I'm not too sure why we were doing this. There doesn't appear to be any visual consequence of removing this. @etoledom I wonder if you'd noticed anything?

To test:
Confirm the issue by attempting to pull to refresh. (The latest beta is affected.)
Apply this branch and repeat the test. Confirm that pull to refresh functions as expected.
Look sharp at the reader stream for any visual artifacts from this change.

@etoledom could I trouble you for a review?