### PR TITLE
Plans: Don't unwrap optional during assignment.

### DIFF
--- a/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
@@ -33,14 +33,14 @@ class PlanComparisonViewController: PagedViewController {
     init(sitePricedPlans: SitePricedPlans, initialPlan: Plan, service: PlanService<StoreKitStore>) {
         self.siteID = sitePricedPlans.siteID
         self.pricedPlans = sitePricedPlans.availablePlans
-        self.activePlan = sitePricedPlans.activePlan!
+        self.activePlan = sitePricedPlans.activePlan
         self.initialPlan = initialPlan
         self.service = service
 
         let viewControllers: [PlanDetailViewController] = pricedPlans.map({ (plan, price) in
             let controller = PlanDetailViewController.controllerWithPlan(plan,
                                                                          siteID: sitePricedPlans.siteID,
-                                                                         activePlan: sitePricedPlans.activePlan!,
+                                                                         activePlan: sitePricedPlans.activePlan,
                                                                          price: price)
 
             return controller


### PR DESCRIPTION
Fixes #10331 

This PR fixes the crash reported in #10331 by not unwrapping the optional when its nil.  Not sure how this one slipped past us -- I'd have sworn we also tested the detail pages when patching the original issue. 

To test:
Apply the patch and test the plans feature, list + detail screens, with multiple blogs on different plans.  At least one of the blogs should be on a plan other than the four default plans passed by the `v1.2/sites/site/plans` endpoint.  Ping me and I'll invite you to a test blog if you like.

@stevebaranski could I trouble you with this one? 