### PR TITLE
Post Editor media search: Check for search query before showing no results view

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3727,7 +3727,7 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
     func mediaPickerController(_ picker: WPMediaPickerViewController, didUpdateSearchWithAssetCount assetCount: Int) {
         noResultsView.removeFromView()
 
-        if mediaLibraryDataSource.searchQuery?.count ?? 0 > 0 {
+        if (mediaLibraryDataSource.searchQuery?.count ?? 0) > 0 {
             noResultsView.configureForNoSearchResult()
         }
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3726,7 +3726,10 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, didUpdateSearchWithAssetCount assetCount: Int) {
         noResultsView.removeFromView()
-        noResultsView.configureForNoSearchResult()
+
+        if mediaLibraryDataSource.searchQuery?.count ?? 0 > 0 {
+            noResultsView.configureForNoSearchResult()
+        }
     }
 
     func mediaPickerControllerWillBeginLoadingData(_ picker: WPMediaPickerViewController) {


### PR DESCRIPTION
Fixes #10306 

The problem was the `No media matching your search` view was trying to display after a search was previously performed.

This adds a check to ensure `searchQuery` has a value before displaying the no results view.

To test:
- Edit a post.
- Press `+`, and select the WP Media Library. 
- Enter an invalid search term (to get the `No media matching your search` message).
- `Cancel` the search via the _nav bar_.
- Go back to the WP Media Library and insert an image.
- Go back to the WP Media Library again. (This is when the crash was occurring.)
- Verify it doesn't crash.
- Insert images to your ❤️ s delight.

