### PR TITLE
Stats Refresh: add initial Insights 'Latest Post Summary' view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.swift
@@ -44,15 +44,19 @@ private extension LatestPostSummaryCell {
         headerLabel.font = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
 
         viewsLabel.textColor = WPStyleGuide.darkGrey()
+        viewsLabel.text = CellStrings.views
         viewsDataLabel.textColor = WPStyleGuide.darkGrey()
 
         likesLabel.textColor = viewsLabel.textColor
+        likesLabel.text = CellStrings.likes
         likesDataLabel.textColor = viewsDataLabel.textColor
 
         commentsLabel.textColor = viewsLabel.textColor
+        commentsLabel.text = CellStrings.comments
         commentsDataLabel.textColor = viewsDataLabel.textColor
 
         viewMoreLabel.textColor = WPStyleGuide.wordPressBlue()
+        viewMoreLabel.text = CellStrings.viewMore
     }
 
     func attributedSummary() -> NSAttributedString {
@@ -60,7 +64,7 @@ private extension LatestPostSummaryCell {
         let postTitle = "Testing testing testing"
         let time = "666 months"
 
-        let unformattedString = String(format: CellStrings.cardSummary, time, postTitle)
+        let unformattedString = String(format: CellStrings.summary, time, postTitle)
 
         // Add formatting to entire string.
         let attributedString = NSMutableAttributedString(string: unformattedString, attributes: [
@@ -83,7 +87,11 @@ private extension LatestPostSummaryCell {
 
     struct CellStrings {
         static let header = NSLocalizedString("Latest Post Summary", comment: "Insights latest post summary section header")
-        static let cardSummary = NSLocalizedString("It's been %@ since %@ was published. Here's how the post performed so far.", comment: "Latest post summary text including placeholder for time and the post title.")
+        static let summary = NSLocalizedString("It's been %@ since %@ was published. Here's how the post performed so far.", comment: "Latest post summary text including placeholder for time and the post title.")
+        static let views = NSLocalizedString("Views", comment: "Label for post views count.")
+        static let likes = NSLocalizedString("Likes", comment: "Label for post likes count.")
+        static let comments = NSLocalizedString("Comments", comment: "Label for post comments count.")
+        static let viewMore = NSLocalizedString("View more", comment: "Label for viewing more post information.")
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.swift
@@ -15,6 +15,8 @@ class LatestPostSummaryCell: UITableViewCell {
     @IBOutlet weak var commentsLabel: UILabel!
     @IBOutlet weak var commentsDataLabel: UILabel!
 
+    @IBOutlet weak var viewMoreLabel: UILabel!
+
     // MARK: - View
 
     override func awakeFromNib() {
@@ -49,6 +51,8 @@ private extension LatestPostSummaryCell {
 
         commentsLabel.textColor = viewsLabel.textColor
         commentsDataLabel.textColor = viewsDataLabel.textColor
+
+        viewMoreLabel.textColor = WPStyleGuide.wordPressBlue()
     }
 
     func attributedSummary() -> NSAttributedString {

--- a/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.swift
@@ -8,6 +8,13 @@ class LatestPostSummaryCell: UITableViewCell {
     @IBOutlet weak var headerLabel: UILabel!
     @IBOutlet weak var summaryLabel: UILabel!
 
+    @IBOutlet weak var viewsLabel: UILabel!
+    @IBOutlet weak var viewsDataLabel: UILabel!
+    @IBOutlet weak var likesLabel: UILabel!
+    @IBOutlet weak var likesDataLabel: UILabel!
+    @IBOutlet weak var commentsLabel: UILabel!
+    @IBOutlet weak var commentsDataLabel: UILabel!
+
     // MARK: - View
 
     override func awakeFromNib() {
@@ -33,6 +40,15 @@ private extension LatestPostSummaryCell {
         headerLabel.text = CellStrings.header
         headerLabel.textColor = WPStyleGuide.darkGrey()
         headerLabel.font = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
+
+        viewsLabel.textColor = WPStyleGuide.darkGrey()
+        viewsDataLabel.textColor = WPStyleGuide.darkGrey()
+
+        likesLabel.textColor = viewsLabel.textColor
+        likesDataLabel.textColor = viewsDataLabel.textColor
+
+        commentsLabel.textColor = viewsLabel.textColor
+        commentsDataLabel.textColor = viewsDataLabel.textColor
     }
 
     func attributedSummary() -> NSAttributedString {

--- a/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.swift
@@ -1,0 +1,69 @@
+import UIKit
+
+class LatestPostSummaryCell: UITableViewCell {
+
+    // MARK: - Properties
+
+    @IBOutlet weak var borderedView: UIView!
+    @IBOutlet weak var headerLabel: UILabel!
+    @IBOutlet weak var summaryLabel: UILabel!
+
+    // MARK: - View
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        applyStyles()
+    }
+
+    func configure() {
+        summaryLabel.attributedText = attributedSummary()
+    }
+
+}
+
+// MARK: - Private Extension
+
+private extension LatestPostSummaryCell {
+
+    func applyStyles() {
+        contentView.backgroundColor = WPStyleGuide.greyLighten30()
+        borderedView.layer.borderColor = WPStyleGuide.greyLighten20().cgColor
+        borderedView.layer.borderWidth = 0.5
+
+        headerLabel.text = CellStrings.header
+        headerLabel.textColor = WPStyleGuide.darkGrey()
+        headerLabel.font = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
+    }
+
+    func attributedSummary() -> NSAttributedString {
+
+        let postTitle = "Testing testing testing"
+        let time = "666 months"
+
+        let unformattedString = String(format: CellStrings.cardSummary, time, postTitle)
+
+        // Add formatting to entire string.
+        let attributedString = NSMutableAttributedString(string: unformattedString, attributes: [
+            .foregroundColor: WPStyleGuide.darkGrey(),
+            .font: WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
+            ])
+
+        guard let postTitleRange = unformattedString.nsRange(of: postTitle) else {
+            return attributedString
+        }
+
+        // Add formatting to post title
+        attributedString.addAttributes(        [
+            .foregroundColor: WPStyleGuide.wordPressBlue(),
+            .font: WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+            ], range: postTitleRange)
+
+        return attributedString
+    }
+
+    struct CellStrings {
+        static let header = NSLocalizedString("Latest Post Summary", comment: "Insights latest post summary section header")
+        static let cardSummary = NSLocalizedString("It's been %@ since %@ was published. Here's how the post performed so far.", comment: "Latest post summary text including placeholder for time and the post title.")
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressComStatsiOS
 
 class LatestPostSummaryCell: UITableViewCell {
 
@@ -24,8 +25,15 @@ class LatestPostSummaryCell: UITableViewCell {
         applyStyles()
     }
 
-    func configure() {
-        summaryLabel.attributedText = attributedSummary()
+    func configure(withData summaryData: StatsLatestPostSummary?) {
+        guard let summaryData = summaryData else {
+            return
+        }
+
+        summaryLabel.attributedText = attributedSummary(postTitle: summaryData.postTitle, postAge: summaryData.postAge)
+        viewsDataLabel.text = summaryData.views
+        likesDataLabel.text = summaryData.likes
+        commentsDataLabel.text = summaryData.comments
     }
 
 }
@@ -59,12 +67,9 @@ private extension LatestPostSummaryCell {
         viewMoreLabel.text = CellStrings.viewMore
     }
 
-    func attributedSummary() -> NSAttributedString {
+    func attributedSummary(postTitle: String, postAge: String) -> NSAttributedString {
 
-        let postTitle = "Testing testing testing"
-        let time = "666 months"
-
-        let unformattedString = String(format: CellStrings.summary, time, postTitle)
+        let unformattedString = String(format: CellStrings.summary, postAge, postTitle)
 
         // Add formatting to entire string.
         let attributedString = NSMutableAttributedString(string: unformattedString, attributes: [

--- a/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.xib
@@ -22,25 +22,84 @@
                     <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WbC-hI-HqV" userLabel="Bordered View">
                         <rect key="frame" x="0.0" y="8" width="320" height="538.5"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Latest Post Summary" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iwt-UQ-iMD" userLabel="Header Label">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Latest Post Summary" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iwt-UQ-iMD" userLabel="Header Label">
                                 <rect key="frame" x="16" y="12" width="288" height="20.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="It's been 999 months since Your Post was published. Here's how the post performed so far." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MnQ-57-h8x" userLabel="Summary Label">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It's been 999 months since Your Post was published. Here's how the post performed so far." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MnQ-57-h8x" userLabel="Summary Label">
                                 <rect key="frame" x="16" y="54.5" width="288" height="58"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="irr-i0-AM0" userLabel="Data Stack View">
+                                <rect key="frame" x="24" y="143.5" width="272" height="383"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="wux-rC-UyT" userLabel="Views Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="80" height="383"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L5K-Wp-mW9" userLabel="Views Label">
+                                                <rect key="frame" x="22" y="0.0" width="36" height="347.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Efd-SW-O9K" userLabel="Views Data">
+                                                <rect key="frame" x="34" y="351.5" width="12" height="31.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="5Lu-bf-dhz" userLabel="Likes Stack View">
+                                        <rect key="frame" x="96" y="0.0" width="80" height="383"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Likes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-AB-ffn" userLabel="Likes Label">
+                                                <rect key="frame" x="24.5" y="0.0" width="31.5" height="347.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eSJ-ds-3G4" userLabel="Likes Data">
+                                                <rect key="frame" x="34" y="351.5" width="12" height="31.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="INN-7n-UXp" userLabel="Comments Stack View">
+                                        <rect key="frame" x="192" y="0.0" width="80" height="383"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jLy-hA-LxG" userLabel="Comments Label">
+                                                <rect key="frame" x="7.5" y="0.0" width="65.5" height="347.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ke4-L3-2a5" userLabel="Comments Data">
+                                                <rect key="frame" x="34" y="351.5" width="12" height="31.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstAttribute="bottom" secondItem="irr-i0-AM0" secondAttribute="bottom" constant="12" id="275-Eg-vZP"/>
                             <constraint firstItem="MnQ-57-h8x" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="16" id="3gL-ef-8Z6"/>
+                            <constraint firstAttribute="trailing" secondItem="irr-i0-AM0" secondAttribute="trailing" constant="24" id="JoX-qU-Cdu"/>
                             <constraint firstItem="MnQ-57-h8x" firstAttribute="top" secondItem="Iwt-UQ-iMD" secondAttribute="bottom" constant="22" id="Tjy-69-Fns"/>
+                            <constraint firstItem="irr-i0-AM0" firstAttribute="top" secondItem="MnQ-57-h8x" secondAttribute="bottom" constant="31" id="Wbc-9E-iYy"/>
+                            <constraint firstItem="irr-i0-AM0" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="24" id="cec-En-J8O"/>
                             <constraint firstItem="Iwt-UQ-iMD" firstAttribute="top" secondItem="WbC-hI-HqV" secondAttribute="top" constant="12" id="fz0-eF-o55"/>
-                            <constraint firstAttribute="bottom" secondItem="MnQ-57-h8x" secondAttribute="bottom" constant="12" id="tNL-h6-oeg"/>
                             <constraint firstAttribute="trailing" secondItem="Iwt-UQ-iMD" secondAttribute="trailing" constant="16" id="vdz-eU-As7"/>
                             <constraint firstAttribute="trailing" secondItem="MnQ-57-h8x" secondAttribute="trailing" constant="16" id="y9b-gW-KIB"/>
                             <constraint firstItem="Iwt-UQ-iMD" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="16" id="yMP-2P-LWA"/>
@@ -58,8 +117,14 @@
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="borderedView" destination="WbC-hI-HqV" id="Lnp-5X-VVN"/>
+                <outlet property="commentsDataLabel" destination="Ke4-L3-2a5" id="Mi7-wx-efz"/>
+                <outlet property="commentsLabel" destination="jLy-hA-LxG" id="jxu-pA-4Xa"/>
                 <outlet property="headerLabel" destination="Iwt-UQ-iMD" id="5zZ-8W-Of7"/>
+                <outlet property="likesDataLabel" destination="eSJ-ds-3G4" id="g1g-h2-qD5"/>
+                <outlet property="likesLabel" destination="UBX-AB-ffn" id="kcJ-sh-Lsa"/>
                 <outlet property="summaryLabel" destination="MnQ-57-h8x" id="0Qb-wb-77F"/>
+                <outlet property="viewsDataLabel" destination="Efd-SW-O9K" id="CL6-zS-XtJ"/>
+                <outlet property="viewsLabel" destination="L5K-Wp-mW9" id="gpt-1m-oBt"/>
             </connections>
             <point key="canvasLocation" x="52.799999999999997" y="24.7376311844078"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.xib
@@ -107,14 +107,17 @@
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="dj8-5c-J6O" userLabel="View More Stack View">
                                 <rect key="frame" x="16" y="305.5" width="343" height="26"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="View more" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xet-wC-hmj" userLabel="View More Label">
-                                        <rect key="frame" x="0.0" y="3" width="335" height="20.5"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View more" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xet-wC-hmj" userLabel="View More Label">
+                                        <rect key="frame" x="0.0" y="3" width="333" height="20.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="disclosure-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="NUJ-mV-eYK" userLabel="View More Disclosure Image">
-                                        <rect key="frame" x="335" y="6.5" width="8" height="13"/>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="disclosure-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="NUJ-mV-eYK" userLabel="View More Disclosure Image">
+                                        <rect key="frame" x="333" y="6.5" width="10" height="13"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="10" id="AYx-EH-X3W"/>
+                                        </constraints>
                                     </imageView>
                                 </subviews>
                             </stackView>

--- a/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.xib
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="latestPostSummaryCell" rowHeight="555" id="KGk-i7-Jjw" customClass="LatestPostSummaryCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="555"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="554.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WbC-hI-HqV" userLabel="Bordered View">
+                        <rect key="frame" x="0.0" y="8" width="320" height="538.5"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Latest Post Summary" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iwt-UQ-iMD" userLabel="Header Label">
+                                <rect key="frame" x="16" y="12" width="288" height="20.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="It's been 999 months since Your Post was published. Here's how the post performed so far." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MnQ-57-h8x" userLabel="Summary Label">
+                                <rect key="frame" x="16" y="54.5" width="288" height="58"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="MnQ-57-h8x" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="16" id="3gL-ef-8Z6"/>
+                            <constraint firstItem="MnQ-57-h8x" firstAttribute="top" secondItem="Iwt-UQ-iMD" secondAttribute="bottom" constant="22" id="Tjy-69-Fns"/>
+                            <constraint firstItem="Iwt-UQ-iMD" firstAttribute="top" secondItem="WbC-hI-HqV" secondAttribute="top" constant="12" id="fz0-eF-o55"/>
+                            <constraint firstAttribute="bottom" secondItem="MnQ-57-h8x" secondAttribute="bottom" constant="12" id="tNL-h6-oeg"/>
+                            <constraint firstAttribute="trailing" secondItem="Iwt-UQ-iMD" secondAttribute="trailing" constant="16" id="vdz-eU-As7"/>
+                            <constraint firstAttribute="trailing" secondItem="MnQ-57-h8x" secondAttribute="trailing" constant="16" id="y9b-gW-KIB"/>
+                            <constraint firstItem="Iwt-UQ-iMD" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="16" id="yMP-2P-LWA"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                <constraints>
+                    <constraint firstItem="WbC-hI-HqV" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="BcG-y3-7d3"/>
+                    <constraint firstAttribute="trailing" secondItem="WbC-hI-HqV" secondAttribute="trailing" id="GUc-Ln-WUC"/>
+                    <constraint firstItem="WbC-hI-HqV" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="8" id="KbD-hj-p3v"/>
+                    <constraint firstAttribute="bottom" secondItem="WbC-hI-HqV" secondAttribute="bottom" constant="8" id="iKd-Ny-sBY"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="borderedView" destination="WbC-hI-HqV" id="Lnp-5X-VVN"/>
+                <outlet property="headerLabel" destination="Iwt-UQ-iMD" id="5zZ-8W-Of7"/>
+                <outlet property="summaryLabel" destination="MnQ-57-h8x" id="0Qb-wb-77F"/>
+            </connections>
+            <point key="canvasLocation" x="52.799999999999997" y="24.7376311844078"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/LatestPostSummaryCell.xib
@@ -12,42 +12,42 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="latestPostSummaryCell" rowHeight="555" id="KGk-i7-Jjw" customClass="LatestPostSummaryCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="555"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="latestPostSummaryCell" rowHeight="555" id="KGk-i7-Jjw" customClass="LatestPostSummaryCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="360"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="554.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="359.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WbC-hI-HqV" userLabel="Bordered View">
-                        <rect key="frame" x="0.0" y="8" width="320" height="538.5"/>
+                        <rect key="frame" x="0.0" y="8" width="375" height="343.5"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Latest Post Summary" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iwt-UQ-iMD" userLabel="Header Label">
-                                <rect key="frame" x="16" y="12" width="288" height="20.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Latest Post Summary" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Iwt-UQ-iMD" userLabel="Header Label">
+                                <rect key="frame" x="16" y="12" width="343" height="20.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It's been 999 months since Your Post was published. Here's how the post performed so far." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MnQ-57-h8x" userLabel="Summary Label">
-                                <rect key="frame" x="16" y="54.5" width="288" height="58"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It's been 999 months since Your Post was published. Here's how the post performed so far." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MnQ-57-h8x" userLabel="Summary Label">
+                                <rect key="frame" x="16" y="54.5" width="343" height="38"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="irr-i0-AM0" userLabel="Data Stack View">
-                                <rect key="frame" x="24" y="143.5" width="272" height="383"/>
+                                <rect key="frame" x="24" y="123.5" width="327" height="55"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="wux-rC-UyT" userLabel="Views Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="80" height="383"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="98.5" height="55"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L5K-Wp-mW9" userLabel="Views Label">
-                                                <rect key="frame" x="22" y="0.0" width="36" height="347.5"/>
+                                                <rect key="frame" x="31" y="0.0" width="36" height="19.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Efd-SW-O9K" userLabel="Views Data">
-                                                <rect key="frame" x="34" y="351.5" width="12" height="31.5"/>
+                                                <rect key="frame" x="43" y="23.5" width="12" height="31.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -55,16 +55,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="5Lu-bf-dhz" userLabel="Likes Stack View">
-                                        <rect key="frame" x="96" y="0.0" width="80" height="383"/>
+                                        <rect key="frame" x="114.5" y="0.0" width="98" height="55"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Likes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-AB-ffn" userLabel="Likes Label">
-                                                <rect key="frame" x="24.5" y="0.0" width="31.5" height="347.5"/>
+                                                <rect key="frame" x="33.5" y="0.0" width="31.5" height="19.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eSJ-ds-3G4" userLabel="Likes Data">
-                                                <rect key="frame" x="34" y="351.5" width="12" height="31.5"/>
+                                                <rect key="frame" x="43" y="23.5" width="12" height="31.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -72,16 +72,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="INN-7n-UXp" userLabel="Comments Stack View">
-                                        <rect key="frame" x="192" y="0.0" width="80" height="383"/>
+                                        <rect key="frame" x="228.5" y="0.0" width="98.5" height="55"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jLy-hA-LxG" userLabel="Comments Label">
-                                                <rect key="frame" x="7.5" y="0.0" width="65.5" height="347.5"/>
+                                                <rect key="frame" x="16.5" y="0.0" width="65.5" height="19.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ke4-L3-2a5" userLabel="Comments Data">
-                                                <rect key="frame" x="34" y="351.5" width="12" height="31.5"/>
+                                                <rect key="frame" x="43.5" y="23.5" width="12" height="31.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -90,19 +90,54 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="dVi-l5-zbj" userLabel="Chart Stack View">
+                                <rect key="frame" x="19" y="193.5" width="337" height="100"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Imagine some pretty bars here" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xXG-ir-S4b" userLabel="Temporary Label">
+                                        <rect key="frame" x="0.0" y="0.0" width="337" height="100"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="100" id="dWM-sE-VnA"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="dj8-5c-J6O" userLabel="View More Stack View">
+                                <rect key="frame" x="16" y="305.5" width="343" height="26"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="View more" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xet-wC-hmj" userLabel="View More Label">
+                                        <rect key="frame" x="0.0" y="3" width="335" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="disclosure-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="NUJ-mV-eYK" userLabel="View More Disclosure Image">
+                                        <rect key="frame" x="335" y="6.5" width="8" height="13"/>
+                                    </imageView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="bottom" secondItem="irr-i0-AM0" secondAttribute="bottom" constant="12" id="275-Eg-vZP"/>
                             <constraint firstItem="MnQ-57-h8x" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="16" id="3gL-ef-8Z6"/>
+                            <constraint firstItem="dj8-5c-J6O" firstAttribute="top" secondItem="dVi-l5-zbj" secondAttribute="bottom" constant="12" id="7X5-oE-LcA"/>
+                            <constraint firstAttribute="trailing" secondItem="dj8-5c-J6O" secondAttribute="trailing" constant="16" id="EOV-sp-Kz4"/>
+                            <constraint firstAttribute="bottom" secondItem="dVi-l5-zbj" secondAttribute="bottom" constant="50" id="JED-w1-FAI"/>
                             <constraint firstAttribute="trailing" secondItem="irr-i0-AM0" secondAttribute="trailing" constant="24" id="JoX-qU-Cdu"/>
                             <constraint firstItem="MnQ-57-h8x" firstAttribute="top" secondItem="Iwt-UQ-iMD" secondAttribute="bottom" constant="22" id="Tjy-69-Fns"/>
                             <constraint firstItem="irr-i0-AM0" firstAttribute="top" secondItem="MnQ-57-h8x" secondAttribute="bottom" constant="31" id="Wbc-9E-iYy"/>
                             <constraint firstItem="irr-i0-AM0" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="24" id="cec-En-J8O"/>
+                            <constraint firstItem="dVi-l5-zbj" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="19" id="eBb-KR-aXA"/>
                             <constraint firstItem="Iwt-UQ-iMD" firstAttribute="top" secondItem="WbC-hI-HqV" secondAttribute="top" constant="12" id="fz0-eF-o55"/>
+                            <constraint firstItem="dj8-5c-J6O" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="16" id="gvG-pJ-4xk"/>
+                            <constraint firstAttribute="bottom" secondItem="dj8-5c-J6O" secondAttribute="bottom" constant="12" id="lUk-KG-w76"/>
+                            <constraint firstAttribute="trailing" secondItem="dVi-l5-zbj" secondAttribute="trailing" constant="19" id="r9E-0J-Rvm"/>
                             <constraint firstAttribute="trailing" secondItem="Iwt-UQ-iMD" secondAttribute="trailing" constant="16" id="vdz-eU-As7"/>
                             <constraint firstAttribute="trailing" secondItem="MnQ-57-h8x" secondAttribute="trailing" constant="16" id="y9b-gW-KIB"/>
                             <constraint firstItem="Iwt-UQ-iMD" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="16" id="yMP-2P-LWA"/>
+                            <constraint firstItem="dVi-l5-zbj" firstAttribute="top" secondItem="irr-i0-AM0" secondAttribute="bottom" constant="15" id="yj8-Q1-oT6"/>
                         </constraints>
                     </view>
                 </subviews>
@@ -123,10 +158,14 @@
                 <outlet property="likesDataLabel" destination="eSJ-ds-3G4" id="g1g-h2-qD5"/>
                 <outlet property="likesLabel" destination="UBX-AB-ffn" id="kcJ-sh-Lsa"/>
                 <outlet property="summaryLabel" destination="MnQ-57-h8x" id="0Qb-wb-77F"/>
+                <outlet property="viewMoreLabel" destination="Xet-wC-hmj" id="nyD-ll-qT4"/>
                 <outlet property="viewsDataLabel" destination="Efd-SW-O9K" id="CL6-zS-XtJ"/>
                 <outlet property="viewsLabel" destination="L5K-Wp-mW9" id="gpt-1m-oBt"/>
             </connections>
-            <point key="canvasLocation" x="52.799999999999997" y="24.7376311844078"/>
+            <point key="canvasLocation" x="52.799999999999997" y="24.287856071964018"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <image name="disclosure-chevron" width="8" height="13"/>
+    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
@@ -96,16 +96,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="557"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="hdf-Gg-9hU">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hdf-Gg-9hU" id="SxM-39-d7c">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
                         <connections>
                             <outlet property="dataSource" destination="Hcp-7d-sgU" id="iKJ-SM-Oyo"/>
                             <outlet property="delegate" destination="Hcp-7d-sgU" id="1zr-d2-Cjw"/>
@@ -124,16 +114,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="557"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" id="Crf-1R-0io">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Crf-1R-0io" id="1Bz-8C-Fiv">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                </tableViewCellContentView>
-                            </tableViewCell>
-                        </prototypes>
                         <connections>
                             <outlet property="dataSource" destination="plb-uA-RCD" id="ArZ-Zu-Uyu"/>
                             <outlet property="delegate" destination="plb-uA-RCD" id="2Qq-uI-Ae3"/>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
@@ -101,6 +101,9 @@
                             <outlet property="delegate" destination="Hcp-7d-sgU" id="1zr-d2-Cjw"/>
                         </connections>
                     </tableView>
+                    <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="zYc-fh-rSf">
+                        <autoresizingMask key="autoresizingMask"/>
+                    </refreshControl>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="LmM-2F-Flv" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
@@ -91,8 +91,8 @@
         <!--Insights Table View Controller-->
         <scene sceneID="pUd-Yh-VXv">
             <objects>
-                <tableViewController id="Hcp-7d-sgU" userLabel="Insights Table View Controller" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="qZC-N3-iSA">
+                <tableViewController id="Hcp-7d-sgU" userLabel="Insights Table View Controller" customClass="SiteStatsInsightsTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="qZC-N3-iSA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="557"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -101,7 +101,7 @@
                                 <rect key="frame" x="0.0" y="28" width="375" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hdf-Gg-9hU" id="SxM-39-d7c">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressComStatsiOS
 
 protocol StatsLoadingProgressDelegate {
     func didBeginLoadingStats(viewController: UIViewController)
@@ -36,6 +37,7 @@ class SiteStatsDashboardViewController: UIViewController {
 
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let insightsTableVC = segue.destination as? SiteStatsInsightsTableViewController {
+            insightsTableVC.statsService = initStatsService()
             insightsTableViewController = insightsTableVC
         }
     }
@@ -89,6 +91,7 @@ private extension SiteStatsDashboardViewController {
         static let progressViewInitialProgress = Float(0.03)
         static let progressViewHideDelay = 1
         static let progressViewHideDuration = 0.25
+        static let cacheExpirationInterval = Double(300)
     }
 
     enum StatsPeriodType: Int {
@@ -141,6 +144,19 @@ private extension SiteStatsDashboardViewController {
         return shouldShow
     }
 
+    func initStatsService() -> WPStatsService? {
+
+        guard let siteID = siteID,
+            let siteTimeZone = siteTimeZone,
+            let oauth2Token = oauth2Token else {
+            return nil
+        }
+
+        return WPStatsService.init(siteId: siteID,
+                                   siteTimeZone: siteTimeZone,
+                                   oauth2Token: oauth2Token,
+                                   andCacheExpirationInterval: Constants.cacheExpirationInterval)
+    }
 }
 
 // MARK: - FilterTabBar Support

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -15,9 +15,11 @@ class SiteStatsDashboardViewController: UIViewController {
     @IBOutlet weak var statsContainerView: UIView!
     @IBOutlet weak var progressView: UIProgressView!
 
+    var insightsTableViewController: SiteStatsInsightsTableViewController?
+
     // TODO: replace UITableViewController with real controller names that
-    // correspond to Insights and Stats.
-    var insightsTableViewController: UITableViewController?
+    // corresponds to Stats.
+
     var statsTableViewController: UITableViewController?
 
     // MARK: - View
@@ -26,6 +28,12 @@ class SiteStatsDashboardViewController: UIViewController {
         super.viewDidLoad()
         setupFilterBar()
         getSelectedPeriodFromUserDefaults()
+    }
+
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if let insightsTableVC = segue.destination as? SiteStatsInsightsTableViewController {
+            insightsTableViewController = insightsTableVC
+        }
     }
 
     // MARK: - StatsLoadingProgressDelegate methods

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -10,6 +10,10 @@ class SiteStatsDashboardViewController: UIViewController {
 
     // MARK: - Properties
 
+    @objc var siteID: NSNumber?
+    @objc var siteTimeZone: TimeZone?
+    @objc var oauth2Token: String?
+
     @IBOutlet weak var filterTabBar: FilterTabBar!
     @IBOutlet weak var insightsContainerView: UIView!
     @IBOutlet weak var statsContainerView: UIView!

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -38,45 +38,8 @@ class SiteStatsDashboardViewController: UIViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let insightsTableVC = segue.destination as? SiteStatsInsightsTableViewController {
             insightsTableVC.statsService = initStatsService()
+            insightsTableVC.loadingProgressDelegate = self
             insightsTableViewController = insightsTableVC
-        }
-    }
-
-    // MARK: - StatsLoadingProgressDelegate methods
-
-    func didBeginLoadingStats(viewController: UIViewController) {
-
-        guard shouldShowProgressView(viewController: viewController) else {
-            return
-        }
-
-        progressView.isHidden = false
-        progressView.setProgress(Constants.progressViewInitialProgress, animated: true)
-    }
-
-    func statsLoadingProgress(viewController: UIViewController, percentage: Float) {
-
-        guard shouldShowProgressView(viewController: viewController) else {
-            return
-        }
-
-        progressView.setProgress(percentage, animated: true)
-    }
-
-    func didEndLoadingStats(viewController: UIViewController) {
-
-        guard shouldShowProgressView(viewController: viewController) else {
-            return
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(Constants.progressViewHideDelay)) {
-            UIView.animate(withDuration: Constants.progressViewHideDuration, animations: {
-                self.progressView.alpha = 0.0
-            }, completion: { _ in
-                self.progressView.isHidden = true
-                self.progressView.alpha = 1.0
-                self.progressView.progress = 0.0
-            })
         }
     }
 
@@ -90,7 +53,7 @@ private extension SiteStatsDashboardViewController {
         static let userDefaultsKey = "LastSelectedStatsPeriodType"
         static let progressViewInitialProgress = Float(0.03)
         static let progressViewHideDelay = 1
-        static let progressViewHideDuration = 0.25
+        static let progressViewHideDuration = 0.15
         static let cacheExpirationInterval = Double(300)
     }
 
@@ -176,6 +139,48 @@ private extension SiteStatsDashboardViewController {
         currentSelectedPeriod = StatsPeriodType(rawValue: filterBar.selectedIndex) ?? StatsPeriodType.insights
 
         // TODO: reload view based on selected tab
+    }
+
+}
+
+// MARK: - StatsLoadingProgressDelegate Support
+
+extension SiteStatsDashboardViewController: StatsLoadingProgressDelegate {
+
+    func didBeginLoadingStats(viewController: UIViewController) {
+
+        guard shouldShowProgressView(viewController: viewController) else {
+            return
+        }
+
+        progressView.isHidden = false
+        progressView.setProgress(Constants.progressViewInitialProgress, animated: true)
+    }
+
+    func statsLoadingProgress(viewController: UIViewController, percentage: Float) {
+
+        guard shouldShowProgressView(viewController: viewController) else {
+            return
+        }
+
+        progressView.setProgress(percentage, animated: true)
+    }
+
+    func didEndLoadingStats(viewController: UIViewController) {
+
+        guard shouldShowProgressView(viewController: viewController) else {
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(Constants.progressViewHideDelay)) {
+            UIView.animate(withDuration: Constants.progressViewHideDuration, animations: {
+                self.progressView.alpha = 0.0
+            }, completion: { _ in
+                self.progressView.isHidden = true
+                self.progressView.alpha = 1.0
+                self.progressView.progress = 0.0
+            })
+        }
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
@@ -16,6 +16,7 @@ class SiteStatsInsightsTableViewController: UITableViewController {
 
         tableView.backgroundColor = WPStyleGuide.greyLighten30()
         setUpLatestPostSummaryCell()
+        refreshControl?.addTarget(self, action: #selector(fetchStats), for: .valueChanged)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -54,7 +55,7 @@ class SiteStatsInsightsTableViewController: UITableViewController {
 
 private extension SiteStatsInsightsTableViewController {
 
-    func fetchStats() {
+    @objc func fetchStats() {
 
         loadingProgressDelegate?.didBeginLoadingStats(viewController: self)
 
@@ -91,6 +92,7 @@ private extension SiteStatsInsightsTableViewController {
                 self.loadingProgressDelegate?.statsLoadingProgress(viewController: self, percentage: percentage)
         }, andOverallCompletionHandler: {
             self.loadingProgressDelegate?.didEndLoadingStats(viewController: self)
+            self.refreshControl?.endRefreshing()
         })
 
     }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
@@ -5,6 +5,7 @@ class SiteStatsInsightsTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.backgroundColor = WPStyleGuide.greyLighten30()
+        setUpLatestPostSummaryCell()
     }
 
     // MARK: - Table view data source
@@ -28,3 +29,18 @@ class SiteStatsInsightsTableViewController: UITableViewController {
 
 }
 
+private extension SiteStatsInsightsTableViewController {
+
+    func setUpLatestPostSummaryCell() {
+        let nib = UINib(nibName: NibNames.latestPostSummary, bundle: nil)
+        tableView.register(nib, forCellReuseIdentifier: ReuseIdentifiers.latestPostSummary)
+    }
+
+    struct NibNames {
+        static let latestPostSummary = "LatestPostSummaryCell"
+    }
+
+    struct ReuseIdentifiers {
+        static let latestPostSummary = "latestPostSummaryCell"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
@@ -1,9 +1,17 @@
 import UIKit
+import WordPressComStatsiOS
 
 class SiteStatsInsightsTableViewController: UITableViewController {
 
+    // MARK: - Properties
+
+    var statsService: WPStatsService?
+
+    // MARK: - View
+
     override func viewDidLoad() {
         super.viewDidLoad()
+
         tableView.backgroundColor = WPStyleGuide.greyLighten30()
         setUpLatestPostSummaryCell()
     }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
@@ -1,0 +1,30 @@
+import UIKit
+
+class SiteStatsInsightsTableViewController: UITableViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.backgroundColor = WPStyleGuide.greyLighten30()
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell()
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+}
+

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
@@ -7,6 +7,7 @@ class SiteStatsInsightsTableViewController: UITableViewController {
 
     var statsService: WPStatsService?
     var latestPostSummary: StatsLatestPostSummary?
+    var loadingProgressDelegate: StatsLoadingProgressDelegate?
 
     // MARK: - View
 
@@ -55,7 +56,7 @@ private extension SiteStatsInsightsTableViewController {
 
     func fetchStats() {
 
-        // TODO: update progress view
+        loadingProgressDelegate?.didBeginLoadingStats(viewController: self)
 
         statsService?.retrieveInsightsStats(allTimeStatsCompletionHandler: { (allTimeStats, error) in
 
@@ -86,9 +87,10 @@ private extension SiteStatsInsightsTableViewController {
         }, streakCompletionHandler: { (statsStreak, error) in
 
         }, progressBlock: { (numberOfFinishedOperations, totalNumberOfOperations) in
-            // TODO: update progress view
+                let percentage = Float(numberOfFinishedOperations) / Float(totalNumberOfOperations)
+                self.loadingProgressDelegate?.statsLoadingProgress(viewController: self, percentage: percentage)
         }, andOverallCompletionHandler: {
-            // TODO: update progress view
+            self.loadingProgressDelegate?.didEndLoadingStats(viewController: self)
         })
 
     }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
@@ -19,7 +19,8 @@ class SiteStatsInsightsTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = UITableViewCell()
+        let cell = tableView.dequeueReusableCell(withIdentifier: ReuseIdentifiers.latestPostSummary, for: indexPath) as! LatestPostSummaryCell
+        cell.configure()
         return cell
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
@@ -6,6 +6,7 @@ class SiteStatsInsightsTableViewController: UITableViewController {
     // MARK: - Properties
 
     var statsService: WPStatsService?
+    var latestPostSummary: StatsLatestPostSummary?
 
     // MARK: - View
 
@@ -16,7 +17,12 @@ class SiteStatsInsightsTableViewController: UITableViewController {
         setUpLatestPostSummaryCell()
     }
 
-    // MARK: - Table view data source
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        fetchStats()
+    }
+
+    // MARK: - Table Methods
 
     override func numberOfSections(in tableView: UITableView) -> Int {
         return 1
@@ -27,9 +33,14 @@ class SiteStatsInsightsTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: ReuseIdentifiers.latestPostSummary, for: indexPath) as! LatestPostSummaryCell
-        cell.configure()
-        return cell
+
+        if latestPostSummary != nil {
+            let cell = tableView.dequeueReusableCell(withIdentifier: ReuseIdentifiers.latestPostSummary, for: indexPath) as! LatestPostSummaryCell
+            cell.configure(withData: latestPostSummary)
+            return cell
+        }
+
+        return UITableViewCell()
     }
 
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -37,6 +48,54 @@ class SiteStatsInsightsTableViewController: UITableViewController {
     }
 
 }
+
+// MARK: - Data Fetching
+
+private extension SiteStatsInsightsTableViewController {
+
+    func fetchStats() {
+
+        // TODO: update progress view
+
+        statsService?.retrieveInsightsStats(allTimeStatsCompletionHandler: { (allTimeStats, error) in
+
+        }, insightsCompletionHandler: { (mostPopularStats, error) in
+
+        }, todaySummaryCompletionHandler: { (todaySummary, error) in
+
+        }, latestPostSummaryCompletionHandler: { (latestPostSummary, error) in
+            if error != nil {
+                DDLogDebug("Error fetching latest post summary: \(String(describing: error?.localizedDescription))")
+                self.latestPostSummary = nil
+            } else {
+                self.latestPostSummary = latestPostSummary
+                self.tableView.reloadData()
+            }
+        }, commentsAuthorCompletionHandler: { (commentsAuthors, error) in
+
+        }, commentsPostsCompletionHandler: { (commentsPosts, error) in
+
+        }, tagsCategoriesCompletionHandler: { (tagsCategories, error) in
+
+        }, followersDotComCompletionHandler: { (followersDotCom, error) in
+
+        }, followersEmailCompletionHandler: { (followersEmail, error) in
+
+        }, publicizeCompletionHandler: { (publicize, error) in
+
+        }, streakCompletionHandler: { (statsStreak, error) in
+
+        }, progressBlock: { (numberOfFinishedOperations, totalNumberOfOperations) in
+            // TODO: update progress view
+        }, andOverallCompletionHandler: {
+            // TODO: update progress view
+        })
+
+    }
+}
+
+
+// MARK: - Cell Support
 
 private extension SiteStatsInsightsTableViewController {
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -25,6 +25,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 @property (nonatomic, assign) BOOL offline;
 @property (nonatomic, strong) UINavigationController *statsNavVC;
 @property (nonatomic, strong) WPStatsViewController *statsVC;
+@property (nonatomic, strong) SiteStatsDashboardViewController *siteStatsDashboardVC;
 @property (nonatomic, weak) NoResultsViewController *noResultsViewController;
 @property (nonatomic, strong) UIActivityIndicatorView *loadingIndicator;
 
@@ -54,9 +55,8 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     self.navigationItem.title = NSLocalizedString(@"Stats", @"Stats window title");
     
     if ([Feature enabled:FeatureFlagStatsRefresh]) {
-        NSBundle *statsBundle = [NSBundle bundleForClass:[SiteStatsDashboardViewController class]];
-        self.statsNavVC = [[UIStoryboard storyboardWithName:@"SiteStatsDashboard" bundle:statsBundle] instantiateInitialViewController];
-        self.statsVC = self.statsNavVC.viewControllers.firstObject;
+        self.statsNavVC = [[UIStoryboard storyboardWithName:@"SiteStatsDashboard" bundle:nil] instantiateInitialViewController];
+        self.siteStatsDashboardVC = self.statsNavVC.viewControllers.firstObject;
     } else {
         NSBundle *statsBundle = [NSBundle bundleForClass:[WPStatsViewController class]];
         self.statsNavVC = [[UIStoryboard storyboardWithName:@"SiteStats" bundle:statsBundle] instantiateInitialViewController];
@@ -94,7 +94,11 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 - (void)addStatsViewControllerToView
 {
-    if (![Feature enabled:FeatureFlagStatsRefresh]) {
+    if ([Feature enabled:FeatureFlagStatsRefresh]) {
+        [self addChildViewController:self.siteStatsDashboardVC];
+        [self.view addSubview:self.siteStatsDashboardVC.view];
+        [self.siteStatsDashboardVC didMoveToParentViewController:self];
+    } else {
         if (self.presentingViewController == nil) {
             UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Today", @"") style:UIBarButtonItemStylePlain target:self action:@selector(makeSiteTodayWidgetSite:)];
             self.navigationItem.rightBarButtonItem = settingsButton;
@@ -104,10 +108,6 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
         [self.view addSubview:self.statsVC.view];
         self.statsVC.view.translatesAutoresizingMaskIntoConstraints = NO;
         [self.view pinSubviewToAllEdges:self.statsVC.view];
-        [self.statsVC didMoveToParentViewController:self];
-    } else {
-        [self addChildViewController:self.statsVC];
-        [self.view addSubview:self.statsVC.view];
         [self.statsVC didMoveToParentViewController:self];
     }
 }
@@ -126,14 +126,19 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
     
-    if (![Feature enabled:FeatureFlagStatsRefresh]) {
+    if ([Feature enabled:FeatureFlagStatsRefresh]) {
+        self.siteStatsDashboardVC.siteTimeZone = [blogService timeZoneForBlog:self.blog];
+    } else {
         self.statsVC.siteTimeZone = [blogService timeZoneForBlog:self.blog];
     }
     
     // WordPress.com + Jetpack REST
     if (self.blog.account) {
         
-        if (![Feature enabled:FeatureFlagStatsRefresh]) {
+        if ([Feature enabled:FeatureFlagStatsRefresh]) {
+            self.siteStatsDashboardVC.oauth2Token = self.blog.account.authToken;
+            self.siteStatsDashboardVC.siteID = self.blog.dotComID;
+        } else {
             self.statsVC.oauth2Token = self.blog.account.authToken;
             self.statsVC.siteID = self.blog.dotComID;
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -752,6 +752,8 @@
 		93F2E5421E9E5A350050D489 /* QuickLook.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93F2E5411E9E5A350050D489 /* QuickLook.framework */; };
 		93F2E5441E9E5A570050D489 /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93F2E5431E9E5A570050D489 /* CoreSpotlight.framework */; };
 		93FA59DD18D88C1C001446BC /* PostCategoryService.m in Sources */ = {isa = PBXBuildFile; fileRef = 93FA59DC18D88C1C001446BC /* PostCategoryService.m */; };
+		980026CF2187B97200A0C30A /* LatestPostSummaryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980026CD2187B97200A0C30A /* LatestPostSummaryCell.swift */; };
+		980026D02187B97200A0C30A /* LatestPostSummaryCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 980026CE2187B97200A0C30A /* LatestPostSummaryCell.xib */; };
 		98077B5A2075561800109F95 /* SupportTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98077B592075561800109F95 /* SupportTableViewController.swift */; };
 		9808655A203D075E00D58786 /* EpilogueUserInfoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98086559203D075D00D58786 /* EpilogueUserInfoCell.xib */; };
 		9808655C203D079B00D58786 /* EpilogueUserInfoCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9808655B203D079A00D58786 /* EpilogueUserInfoCell.swift */; };
@@ -781,6 +783,7 @@
 		986FF29F214198D9005B28EC /* String+Ranges.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FFCF91F034F1A0070812C /* String+Ranges.swift */; };
 		986FF2A0214198D9005B28EC /* String+Ranges.swift in Sources */ = {isa = PBXBuildFile; fileRef = B55FFCF91F034F1A0070812C /* String+Ranges.swift */; };
 		9872CB30203B8A730066A293 /* SignupEpilogueTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9872CB2F203B8A730066A293 /* SignupEpilogueTableViewController.swift */; };
+		988056032183CCE50083B643 /* SiteStatsInsightsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988056022183CCE50083B643 /* SiteStatsInsightsTableViewController.swift */; };
 		98921EF721372E12004949AA /* MediaCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98921EF621372E12004949AA /* MediaCoordinator.swift */; };
 		98921EF921372E30004949AA /* LocalNewsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98921EF821372E30004949AA /* LocalNewsService.swift */; };
 		98921EFB21372E57004949AA /* NewsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98921EFA21372E57004949AA /* NewsService.swift */; };
@@ -2485,6 +2488,8 @@
 		93FA0F0218E451A80007903B /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		93FA59DB18D88C1C001446BC /* PostCategoryService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = PostCategoryService.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		93FA59DC18D88C1C001446BC /* PostCategoryService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = PostCategoryService.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
+		980026CD2187B97200A0C30A /* LatestPostSummaryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatestPostSummaryCell.swift; sourceTree = "<group>"; };
+		980026CE2187B97200A0C30A /* LatestPostSummaryCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LatestPostSummaryCell.xib; sourceTree = "<group>"; };
 		98077B592075561800109F95 /* SupportTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportTableViewController.swift; sourceTree = "<group>"; };
 		98086559203D075D00D58786 /* EpilogueUserInfoCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = EpilogueUserInfoCell.xib; sourceTree = "<group>"; };
 		9808655B203D079A00D58786 /* EpilogueUserInfoCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EpilogueUserInfoCell.swift; sourceTree = "<group>"; };
@@ -2506,6 +2511,7 @@
 		98656BD72037A1770079DE67 /* SignupEpilogueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupEpilogueViewController.swift; sourceTree = "<group>"; };
 		986CC4D120E1B2F6004F300E /* CustomLogFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomLogFormatter.swift; sourceTree = "<group>"; };
 		9872CB2F203B8A730066A293 /* SignupEpilogueTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupEpilogueTableViewController.swift; sourceTree = "<group>"; };
+		988056022183CCE50083B643 /* SiteStatsInsightsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStatsInsightsTableViewController.swift; sourceTree = "<group>"; };
 		98921EF621372E12004949AA /* MediaCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaCoordinator.swift; sourceTree = "<group>"; };
 		98921EF821372E30004949AA /* LocalNewsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalNewsService.swift; sourceTree = "<group>"; };
 		98921EFA21372E57004949AA /* NewsService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsService.swift; sourceTree = "<group>"; };
@@ -4148,6 +4154,9 @@
 				7470840E1E269669002CA726 /* JetpackLoginViewController.xib */,
 				981C348F2183871100FC2683 /* SiteStatsDashboard.storyboard */,
 				981C3493218388CA00FC2683 /* SiteStatsDashboardViewController.swift */,
+				988056022183CCE50083B643 /* SiteStatsInsightsTableViewController.swift */,
+				980026CD2187B97200A0C30A /* LatestPostSummaryCell.swift */,
+				980026CE2187B97200A0C30A /* LatestPostSummaryCell.xib */,
 			);
 			path = Stats;
 			sourceTree = "<group>";
@@ -7694,6 +7703,7 @@
 				401A3D022027DBD80099A127 /* PluginListCell.xib in Resources */,
 				981C34912183871200FC2683 /* SiteStatsDashboard.storyboard in Resources */,
 				435035991EDCAB99004ECF47 /* post.json in Resources */,
+				980026D02187B97200A0C30A /* LatestPostSummaryCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8405,6 +8415,7 @@
 				1715179420F4B5CD002C4A38 /* MySitesCoordinator.swift in Sources */,
 				08D978561CD2AF7D0054F19A /* MenuItem+ViewDesign.m in Sources */,
 				B52C4C7F199D74AE009FD823 /* NoteTableViewCell.swift in Sources */,
+				988056032183CCE50083B643 /* SiteStatsInsightsTableViewController.swift in Sources */,
 				315FC2C51A2CB29300E7CDA2 /* MeHeaderView.m in Sources */,
 				E1222B631F877FD700D23173 /* WebProgressView.swift in Sources */,
 				E185042F1EE6ABD9005C234C /* Restorer.swift in Sources */,
@@ -8540,6 +8551,7 @@
 				B541276B1C0F7D610015CA80 /* SettingsMultiTextViewController.m in Sources */,
 				B5AC00681BE3C4E100F8E7C3 /* DiscussionSettingsViewController.swift in Sources */,
 				D816C1F620E0896F00C4D82F /* TrashComment.swift in Sources */,
+				980026CF2187B97200A0C30A /* LatestPostSummaryCell.swift in Sources */,
 				08AAD69F1CBEA47D002B2418 /* MenusService.m in Sources */,
 				9A22D9C0214A6BCA00BAEAF2 /* PageListTableViewHandler.swift in Sources */,
 				74729CA62056FE6000D1394D /* SearchableItemConvertable.swift in Sources */,


### PR DESCRIPTION
Fixes #10366 

This adds a `SiteStatsInsightsTableViewController` that displays the initial `Latest Post Summary` view (`LatestPostSummaryCell` class and xib).
- It shows the initial view as designed in Zeplin.
- Displays a temporary label where the chart will eventually be.
- The progress view is updated as the data is loading.
- Refresh control to reload the data.

NOTES:
- There are follow-up tasks to complete this feature. Please let me know if something's missing and there isn't an issue to cover it.
  - https://github.com/wordpress-mobile/WordPress-iOS/issues/10372 - alternate views
  - https://github.com/wordpress-mobile/WordPress-iOS/issues/10373 - tappable text areas
  - https://github.com/wordpress-mobile/WordPress-iOS/issues/10374 - dynamic rows
  - https://github.com/wordpress-mobile/WordPress-iOS/issues/10375 - abbreviate totals
  - https://github.com/wordpress-mobile/WordPress-iOS/issues/10379 - show loading view

To test:

Go to Stats > Insights.
- [ ] Verify the `Latest Post Summary` is displayed with data for: post age, post title, Views, Likes, Comments.
- [ ] Verify the progress bar is updated as the data loads.
- [ ] Verify the refresh control refreshes.

![latest_post_summary](https://user-images.githubusercontent.com/1816888/47823225-d82e1b80-dd2c-11e8-95f4-35ba0374e7cd.png)



