### PR TITLE
Stats Refresh: Remove loading progress indicator.

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
@@ -53,20 +53,14 @@
                                     <segue destination="plb-uA-RCD" kind="embed" id="HLi-0c-1Fw"/>
                                 </connections>
                             </containerView>
-                            <progressView hidden="YES" opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="VXq-2d-hqa">
-                                <rect key="frame" x="0.0" y="110" width="375" height="2"/>
-                            </progressView>
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="R6d-mo-itW" firstAttribute="trailing" secondItem="Ocg-ig-pQt" secondAttribute="trailing" id="3Vy-SZ-45b"/>
                             <constraint firstItem="OmR-2E-jXp" firstAttribute="leading" secondItem="Ocg-ig-pQt" secondAttribute="leading" id="4PI-hg-39d"/>
                             <constraint firstItem="J6j-x0-sMS" firstAttribute="bottom" secondItem="Ocg-ig-pQt" secondAttribute="bottom" id="5Dc-js-I5s"/>
-                            <constraint firstAttribute="trailing" secondItem="VXq-2d-hqa" secondAttribute="trailing" id="5pE-GQ-9dX"/>
                             <constraint firstItem="J6j-x0-sMS" firstAttribute="top" secondItem="R6d-mo-itW" secondAttribute="bottom" id="Cgj-jO-OfC"/>
-                            <constraint firstItem="VXq-2d-hqa" firstAttribute="top" secondItem="R6d-mo-itW" secondAttribute="bottom" id="EeE-In-TIf"/>
                             <constraint firstItem="J6j-x0-sMS" firstAttribute="trailing" secondItem="Ocg-ig-pQt" secondAttribute="trailing" id="GXb-KG-d0p"/>
-                            <constraint firstItem="VXq-2d-hqa" firstAttribute="leading" secondItem="IsW-kc-L5Q" secondAttribute="leading" id="Lcx-nR-uDo"/>
                             <constraint firstItem="OmR-2E-jXp" firstAttribute="bottom" secondItem="Ocg-ig-pQt" secondAttribute="bottom" id="aAd-fu-NMn"/>
                             <constraint firstItem="OmR-2E-jXp" firstAttribute="trailing" secondItem="Ocg-ig-pQt" secondAttribute="trailing" id="doC-hh-j5P"/>
                             <constraint firstItem="R6d-mo-itW" firstAttribute="top" secondItem="Ocg-ig-pQt" secondAttribute="top" id="gS5-1d-Huj"/>
@@ -80,7 +74,6 @@
                     <connections>
                         <outlet property="filterTabBar" destination="R6d-mo-itW" id="fNF-ni-3g1"/>
                         <outlet property="insightsContainerView" destination="J6j-x0-sMS" id="Zd2-hc-Bwl"/>
-                        <outlet property="progressView" destination="VXq-2d-hqa" id="wdh-5h-5qQ"/>
                         <outlet property="statsContainerView" destination="OmR-2E-jXp" id="LWw-FC-YvT"/>
                     </connections>
                 </viewController>
@@ -102,6 +95,7 @@
                         </connections>
                     </tableView>
                     <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="zYc-fh-rSf">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </refreshControl>
                 </tableViewController>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -1,12 +1,6 @@
 import UIKit
 import WordPressComStatsiOS
 
-protocol StatsLoadingProgressDelegate {
-    func didBeginLoadingStats(viewController: UIViewController)
-    func statsLoadingProgress(viewController: UIViewController, percentage: Float)
-    func didEndLoadingStats(viewController: UIViewController)
-}
-
 class SiteStatsDashboardViewController: UIViewController {
 
     // MARK: - Properties
@@ -18,7 +12,6 @@ class SiteStatsDashboardViewController: UIViewController {
     @IBOutlet weak var filterTabBar: FilterTabBar!
     @IBOutlet weak var insightsContainerView: UIView!
     @IBOutlet weak var statsContainerView: UIView!
-    @IBOutlet weak var progressView: UIProgressView!
 
     var insightsTableViewController: SiteStatsInsightsTableViewController?
 
@@ -38,7 +31,6 @@ class SiteStatsDashboardViewController: UIViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let insightsTableVC = segue.destination as? SiteStatsInsightsTableViewController {
             insightsTableVC.statsService = initStatsService()
-            insightsTableVC.loadingProgressDelegate = self
             insightsTableViewController = insightsTableVC
         }
     }
@@ -139,48 +131,6 @@ private extension SiteStatsDashboardViewController {
         currentSelectedPeriod = StatsPeriodType(rawValue: filterBar.selectedIndex) ?? StatsPeriodType.insights
 
         // TODO: reload view based on selected tab
-    }
-
-}
-
-// MARK: - StatsLoadingProgressDelegate Support
-
-extension SiteStatsDashboardViewController: StatsLoadingProgressDelegate {
-
-    func didBeginLoadingStats(viewController: UIViewController) {
-
-        guard shouldShowProgressView(viewController: viewController) else {
-            return
-        }
-
-        progressView.isHidden = false
-        progressView.setProgress(Constants.progressViewInitialProgress, animated: true)
-    }
-
-    func statsLoadingProgress(viewController: UIViewController, percentage: Float) {
-
-        guard shouldShowProgressView(viewController: viewController) else {
-            return
-        }
-
-        progressView.setProgress(percentage, animated: true)
-    }
-
-    func didEndLoadingStats(viewController: UIViewController) {
-
-        guard shouldShowProgressView(viewController: viewController) else {
-            return
-        }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(Constants.progressViewHideDelay)) {
-            UIView.animate(withDuration: Constants.progressViewHideDuration, animations: {
-                self.progressView.alpha = 0.0
-            }, completion: { _ in
-                self.progressView.isHidden = true
-                self.progressView.alpha = 1.0
-                self.progressView.progress = 0.0
-            })
-        }
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsInsightsTableViewController.swift
@@ -7,7 +7,6 @@ class SiteStatsInsightsTableViewController: UITableViewController {
 
     var statsService: WPStatsService?
     var latestPostSummary: StatsLatestPostSummary?
-    var loadingProgressDelegate: StatsLoadingProgressDelegate?
 
     // MARK: - View
 
@@ -56,9 +55,6 @@ class SiteStatsInsightsTableViewController: UITableViewController {
 private extension SiteStatsInsightsTableViewController {
 
     @objc func fetchStats() {
-
-        loadingProgressDelegate?.didBeginLoadingStats(viewController: self)
-
         statsService?.retrieveInsightsStats(allTimeStatsCompletionHandler: { (allTimeStats, error) in
 
         }, insightsCompletionHandler: { (mostPopularStats, error) in
@@ -88,10 +84,8 @@ private extension SiteStatsInsightsTableViewController {
         }, streakCompletionHandler: { (statsStreak, error) in
 
         }, progressBlock: { (numberOfFinishedOperations, totalNumberOfOperations) in
-                let percentage = Float(numberOfFinishedOperations) / Float(totalNumberOfOperations)
-                self.loadingProgressDelegate?.statsLoadingProgress(viewController: self, percentage: percentage)
+
         }, andOverallCompletionHandler: {
-            self.loadingProgressDelegate?.didEndLoadingStats(viewController: self)
             self.refreshControl?.endRefreshing()
         })
 


### PR DESCRIPTION
Refs: #10379  #10380 

Since we'll be adding loading views with the referenced issues, the loading progress indicator is no longer needed. Tis nixed!

To test:
- Go to Stats > Insights.
- Verify the progress indicator no longer appears under the filter bar.

