### PR TITLE
Update pods to final versions for 11.2 code freeze

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,7 +23,7 @@ end
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '1.2.0'
+    pod 'WordPressShared', '1.3.0'
 
     ## for development:
     ## pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
@@ -61,7 +61,7 @@ def shared_with_networking_pods
     pod 'AFNetworking', '3.2.1'
     pod 'Alamofire', '4.7.3'
     pod 'wpxmlrpc', '0.8.3'
-    pod 'WordPressKit', '1.4.3-beta.2'
+    pod 'WordPressKit', '1.4.3'
 end
 
 def shared_test_pods
@@ -106,7 +106,7 @@ target 'WordPress' do
     pod 'WPMediaPicker', '1.3.1'
     ## while PR is in review:
     ## pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '82f798c0dc18b17a11dfafa37f1fd39eb508b29b'
-    pod 'WordPressAuthenticator', '1.1.2'
+    pod 'WordPressAuthenticator', '1.1.4'
 
     aztec
     wordpress_ui
@@ -168,7 +168,7 @@ target 'WordPressNotificationContentExtension' do
 
     inherit! :search_paths
 
-    pod 'WordPressKit', '1.4.3-beta.2'
+    pod 'WordPressKit', '1.4.3'
 
     wordpress_shared
     wordpress_ui
@@ -185,7 +185,7 @@ target 'WordPressNotificationServiceExtension' do
     inherit! :search_paths
 
     pod 'Gridicons', '0.16'
-    pod 'WordPressKit', '1.4.3-beta.2'
+    pod 'WordPressKit', '1.4.3'
 
     wordpress_shared
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -106,7 +106,7 @@ PODS:
   - WordPress-Aztec-iOS (1.1)
   - WordPress-Editor-iOS (1.1):
     - WordPress-Aztec-iOS (= 1.1)
-  - WordPressAuthenticator (1.1.2):
+  - WordPressAuthenticator (1.1.4):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (= 3.4.2)
@@ -116,18 +116,18 @@ PODS:
     - "NSURL+IDN (= 0.3)"
     - SVProgressHUD (= 2.2.5)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressKit (~> 1.4.2)
-    - WordPressShared (~> 1.2.0)
+    - WordPressKit (~> 1.4.3)
+    - WordPressShared (~> 1.3.0)
     - WordPressUI (~> 1.0)
     - wpxmlrpc (~> 0.8)
-  - WordPressKit (1.4.3-beta.2):
+  - WordPressKit (1.4.3):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressShared (~> 1.2.0)
+    - WordPressShared (~> 1.3.0)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.2.0):
+  - WordPressShared (1.3.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.0.8)
@@ -170,9 +170,9 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Editor-iOS (= 1.1)
-  - WordPressAuthenticator (= 1.1.2)
-  - WordPressKit (= 1.4.3-beta.2)
-  - WordPressShared (= 1.2.0)
+  - WordPressAuthenticator (= 1.1.4)
+  - WordPressKit (= 1.4.3)
+  - WordPressShared (= 1.3.0)
   - WordPressUI (= 1.0.8)
   - WPMediaPicker (= 1.3.1)
   - wpxmlrpc (= 0.8.3)
@@ -256,14 +256,14 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-Aztec-iOS: 5bb57849aad4583a2e714ba8634eff1db0d03ac3
   WordPress-Editor-iOS: 5a949802536d73c67ffb4d7705f922ca13a71550
-  WordPressAuthenticator: 0506b827e7050c902dcc07623ff4e5ad89d4cbe1
-  WordPressKit: 7995008e10580636bf6308cf4c3c05e6c4bad0b6
-  WordPressShared: 7ef0253d54989b195e020a74100a8500be0a4315
+  WordPressAuthenticator: 44fd9a0e03a1831846a2470107d1efed8d04ca52
+  WordPressKit: e851c9bdb86544b39cf2a5716b3f59ef66fa6970
+  WordPressShared: 28b4c30f86ac042175580fcba690abddb759d67e
   WordPressUI: e50965adee24b4f10da398f6cdbdd3a822274158
   WPMediaPicker: ea92f84950843c7baf6a7325caed72ad7852418d
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 687ba8e84ee0eeb44f1c716034bf3d2c498bf35c
+PODFILE CHECKSUM: 7f3f709789a4452a80fcf1a568ab74bee08967a5
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Updating WordPress internal pods to the final versions.