### PR TITLE
Workaround proposal to fix crash building with Xcode 10.1

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1604,7 +1604,7 @@ extension AztecPostViewController: PostEditorStateContextDelegate {
                 postEditorStateContext.updated(postStatus: status)
                 editorContentWasUpdated()
             }
-        case #keyPath(AbstractPost.dateCreated):
+        case #keyPath(AbstractPost.date_created_gmt):
             let dateCreated = post.dateCreated ?? Date()
             postEditorStateContext.updated(publishDate: dateCreated)
             editorContentWasUpdated()
@@ -1641,13 +1641,13 @@ extension AztecPostViewController: PostEditorStateContextDelegate {
 
     internal func addObservers(toPost: AbstractPost) {
         toPost.addObserver(self, forKeyPath: AbstractPost.statusKeyPath, options: [], context: nil)
-        toPost.addObserver(self, forKeyPath: #keyPath(AbstractPost.dateCreated), options: [], context: nil)
+        toPost.addObserver(self, forKeyPath: #keyPath(AbstractPost.date_created_gmt), options: [], context: nil)
         toPost.addObserver(self, forKeyPath: #keyPath(AbstractPost.content), options: [], context: nil)
     }
 
     internal func removeObservers(fromPost: AbstractPost) {
         fromPost.removeObserver(self, forKeyPath: AbstractPost.statusKeyPath)
-        fromPost.removeObserver(self, forKeyPath: #keyPath(AbstractPost.dateCreated))
+        fromPost.removeObserver(self, forKeyPath: #keyPath(AbstractPost.date_created_gmt))
         fromPost.removeObserver(self, forKeyPath: #keyPath(AbstractPost.content))
     }
 }


### PR DESCRIPTION
Fixes #10389 .

Since this have been working from 2017, and now after the Xcode update it started crashing, we could assume that there's a bug introduced on this new Xcode version.

### Search:

The crash happens at `swift_objc_classCopyFixupHandler`. It seems to be a private API and I couldn't find anything about it, or crashes related to it. (Even though it says it comes from `libswiftCore.dylib` 🤔 )

Searching about Xcode 10.1 KVO related issues didn't help either.
Xcode 10.1 [release notes](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_1_release_notes/) didn't show relevant information.

Bottom line, I couldn't find information that could help.

### Experimenting:

Since this seems to be related to `swift_objc` interoperability, one of my first tests was to see if it crashes when there's no swift code related. `AbstractPost` is already Objc, so I created a small Objc class to be the observer. It also crashed in the same way. 🤔 🤔 

What about `AbstractPost.dateCreated`?

It's a computed var (objc getter-setter):
```objc
- (NSDate *)dateCreated
{
    return self.date_created_gmt;
}

- (void)setDateCreated:(NSDate *)localDate
{
    self.date_created_gmt = localDate;
    /// ...
}
```

Clearly `dateCreated` depends on `date_created_gmt`, but I'm not sure how KVO is working here. 
🤔 🤔 🤔 

I saw that `keyPathsForValuesAffectingDateCreated` wasn't implemented so I made a simple implementation returning `date_created_gmt` but it also does nothing. I haven't used KVO in some years already so I might be missing important things.

### Workaround

Finally I decided to try observing `date_created_gmt` directly. It doesn't crash anymore and preliminary tests show that it performs in the same way.

If there are more things we could try or if there are resources that I didn't find, I'll be happy to try/check out and modify this PR accordingly.

Thank you!

### To test:
**Reproduce the crash:**
1. Checkout `release/11.2` (or develop) 
2. Build and run with Xcode 10.1 on a iPhone XS or XS max running iOS 12.1. This configuration is proven to experiment this issue.
3. Open one of your posts from the site's post list.
4. Check that it crash.

**Test fix:**
1. Check out this branch.
2. repeat 2 and 3 from **Reproduce the crash:**.
3. Check that the crash is fixed.
4. Edit your post changing the creation date.
5. Check that [this line](https://github.com/wordpress-mobile/WordPress-iOS/blob/9954975fc06ed6d5e7da8293b7240a5346de9790/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift#L1609) is called.