### PR TITLE
Notifications: Adjust no results view with inline prompt

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -379,6 +379,7 @@ private extension NotificationsViewController {
         var headerFrame = tableHeaderView.frame
         headerFrame.size.height = requiredSize.height
         tableHeaderView.frame = headerFrame
+        adjustNoResultsViewSize()
 
         tableHeaderView.layoutIfNeeded()
 
@@ -1128,15 +1129,18 @@ private extension NotificationsViewController {
         addChild(noResultsViewController)
         tableView.insertSubview(noResultsViewController.view, belowSubview: tableHeaderView)
         noResultsViewController.view.frame = tableView.frame
-
-        // Adjust the NRV to accommodate for the segmented control/refresh control.
-        if traitCollection.verticalSizeClass == .regular {
-            noResultsViewController.view.frame.origin.y -= self.tableHeaderView.frame.height
-        } else {
-            noResultsViewController.view.frame.origin.y -= self.tableHeaderView.frame.height/2
-        }
-
+        adjustNoResultsViewSize()
         noResultsViewController.didMove(toParent: self)
+    }
+
+    func adjustNoResultsViewSize() {
+        noResultsViewController.view.frame.origin.y = tableHeaderView.frame.size.height
+
+        if inlinePromptView.alpha == WPAlphaFull {
+            noResultsViewController.view.frame.size.height -= tableHeaderView.frame.size.height
+        } else {
+            noResultsViewController.view.frame.size.height = tableView.frame.size.height - tableHeaderView.frame.size.height
+        }
     }
 
     func updateSplitViewAppearanceForNoResultsView() {


### PR DESCRIPTION
Fixes #10403 

To test:

---

NOTE: hack suggestion: in `NotificationsViewController:setupInlinePrompt`, always call `setupNotificationPrompt` or `setupAppRatings` to get the inline prompt to show.

- On a site that you have not allowed notifications, go to Notifications.
- Select a filter that has no notifications.
- Verify the no results view is below the inline prompt.

![with_prompt](https://user-images.githubusercontent.com/1816888/48033610-36864000-e119-11e8-9b69-2fdcf3a3f59f.png)

- Dismiss the inline prompt.
- Verify the no results view adjusts accordingly, i.e. is re-centered in the view.

![prompt_dismissed](https://user-images.githubusercontent.com/1816888/48033616-3be38a80-e119-11e8-9125-7acc401d4edf.png)

