### PR TITLE
Turning on giphy for everyone

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -24,7 +24,7 @@ enum FeatureFlag: Int {
         case .newsCard:
             return true
         case .giphy:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .automatedTransfer:
             return true
         case .enhancedSiteCreation:


### PR DESCRIPTION
Fixes #10092 

To test: Make sure the giphy option shows up in the more options section for media


