### PR TITLE
Removed obsolete available check

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1237,7 +1237,6 @@ extension ReaderDetailViewController: WPRichContentViewDelegate {
         return false
     }
 
-    @available(iOS 10, *)
     public func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
         if interaction == .presentActions {
             // show


### PR DESCRIPTION
### Description
Addresses #10402. 

Our deployment target is set to iOS 10, so this PR removes `available` checks against iOS 10. Only one was found within our app. 

### Testing
Verify that the branch builds and tests pass.