### PR TITLE
Removed superfluous calls to synchronize via UserDefaults

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -50,7 +50,6 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         defaultAccount.displayName = [defaultAccount.displayName stringByDecodingXMLCharacters];
     } else {
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:DefaultDotcomAccountUUIDDefaultsKey];
-        [[NSUserDefaults standardUserDefaults] synchronize];
     }
     
     return defaultAccount;
@@ -73,7 +72,6 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     }
 
     [[NSUserDefaults standardUserDefaults] setObject:account.uuid forKey:DefaultDotcomAccountUUIDDefaultsKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
 
     NSManagedObjectID *accountID = account.objectID;
     void (^notifyAccountChange)(void) = ^{
@@ -133,7 +131,6 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 
     // Remove defaults
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:DefaultDotcomAccountUUIDDefaultsKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
     
     [WPAnalytics refreshMetadata];
     [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:nil];

--- a/WordPress/Classes/Services/ShareExtensionService.swift
+++ b/WordPress/Classes/Services/ShareExtensionService.swift
@@ -48,7 +48,6 @@ open class ShareExtensionService: NSObject {
 
         userDefaults.set(defaultSiteID, forKey: WPShareExtensionUserDefaultsPrimarySiteID)
         userDefaults.set(defaultSiteName, forKey: WPShareExtensionUserDefaultsPrimarySiteName)
-        userDefaults.synchronize()
     }
 
     /// Sets the Last Used Site that should be pre-selected in the Share Extension.
@@ -64,7 +63,6 @@ open class ShareExtensionService: NSObject {
 
         userDefaults.set(lastUsedSiteID, forKey: WPShareExtensionUserDefaultsLastUsedSiteID)
         userDefaults.set(lastUsedSiteName, forKey: WPShareExtensionUserDefaultsLastUsedSiteName)
-        userDefaults.synchronize()
     }
 
     /// Sets the Maximum Media Size.
@@ -77,7 +75,6 @@ open class ShareExtensionService: NSObject {
         }
 
         userDefaults.set(maximumMediaDimension, forKey: WPShareExtensionMaximumMediaDimensionKey)
-        userDefaults.synchronize()
     }
 
 
@@ -91,7 +88,6 @@ open class ShareExtensionService: NSObject {
         }
 
         userDefaults.set(recentSites, forKey: WPShareExtensionRecentSitesKey)
-        userDefaults.synchronize()
     }
 
     /// Nukes all of the Share Extension Configuration
@@ -120,7 +116,6 @@ open class ShareExtensionService: NSObject {
             userDefaults.removeObject(forKey: WPShareExtensionUserDefaultsLastUsedSiteName)
             userDefaults.removeObject(forKey: WPShareExtensionMaximumMediaDimensionKey)
             userDefaults.removeObject(forKey: WPShareExtensionRecentSitesKey)
-            userDefaults.synchronize()
         }
     }
 

--- a/WordPress/Classes/Services/TodayExtensionService.m
+++ b/WordPress/Classes/Services/TodayExtensionService.m
@@ -19,7 +19,6 @@
     [sharedDefaults setObject:timeZone.name forKey:WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey];
     [sharedDefaults setObject:siteID forKey:WPStatsTodayWidgetUserDefaultsSiteIdKey];
     [sharedDefaults setObject:blogName forKey:WPStatsTodayWidgetUserDefaultsSiteNameKey];
-    [sharedDefaults synchronize];
     
     NSError *error;
     [SFHFKeychainUtils storeUsername:WPStatsTodayWidgetKeychainTokenKey
@@ -40,7 +39,6 @@
     [sharedDefaults removeObjectForKey:WPStatsTodayWidgetUserDefaultsSiteTimeZoneKey];
     [sharedDefaults removeObjectForKey:WPStatsTodayWidgetUserDefaultsSiteIdKey];
     [sharedDefaults removeObjectForKey:WPStatsTodayWidgetUserDefaultsSiteNameKey];
-    [sharedDefaults synchronize];
     
     [SFHFKeychainUtils deleteItemForUsername:WPStatsTodayWidgetKeychainTokenKey
                               andServiceName:WPStatsTodayWidgetKeychainServiceName

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -259,7 +259,6 @@ extension WordPressAppDelegate {
             UserDefaults.standard.set(origExtraDebug, forKey: "orig_extra_debug")
             UserDefaults.standard.set(true, forKey: "extra_debug")
             WordPressAppDelegate.setLogLevel(.verbose)
-            UserDefaults.standard.synchronize()
         } else {
             guard let origExtraDebug = UserDefaults.standard.string(forKey: "orig_extra_debug") else {
                 return
@@ -270,7 +269,6 @@ extension WordPressAppDelegate {
             // Restore the original setting and remove orig_extra_debug
             UserDefaults.standard.set(origExtraDebugValue, forKey: "extra_debug")
             UserDefaults.standard.removeObject(forKey: "orig_extra_debug")
-            UserDefaults.standard.synchronize()
 
             if origExtraDebugValue {
                 WordPressAppDelegate.setLogLevel(.verbose)

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -164,7 +164,6 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         if (anonymousID == nil) {
             anonymousID = [[NSUUID UUID] UUIDString];
             [[NSUserDefaults standardUserDefaults] setObject:anonymousID forKey:TracksUserDefaultsAnonymousUserIDKey];
-            [[NSUserDefaults standardUserDefaults] synchronize];
         }
         
         _anonymousID = anonymousID;
@@ -179,12 +178,10 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
 
     if (anonymousID == nil) {
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:TracksUserDefaultsAnonymousUserIDKey];
-        [[NSUserDefaults standardUserDefaults] synchronize];
         return;
     }
 
     [[NSUserDefaults standardUserDefaults] setObject:anonymousID forKey:TracksUserDefaultsAnonymousUserIDKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 - (NSString *)loggedInID
@@ -205,12 +202,10 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
 
     if (loggedInID == nil) {
         [[NSUserDefaults standardUserDefaults] removeObjectForKey:TracksUserDefaultsLoggedInUserIDKey];
-        [[NSUserDefaults standardUserDefaults] synchronize];
         return;
     }
 
     [[NSUserDefaults standardUserDefaults] setObject:loggedInID forKey:TracksUserDefaultsLoggedInUserIDKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 + (TracksEventPair *)eventPairForStat:(WPAnalyticsStat)stat

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -174,7 +174,6 @@ static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_
     }
 
     [[NSUserDefaults standardUserDefaults] setInteger:sessionCount forKey:WPAppAnalyticsKeySessionCount];
-    [[NSUserDefaults standardUserDefaults] synchronize];
 
     return sessionCount;
 }
@@ -346,8 +345,6 @@ static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_
     if (trackingUsage != [WPAppAnalytics isTrackingUsage]) {
         [[NSUserDefaults standardUserDefaults] setBool:trackingUsage
                                                 forKey:WPAppAnalyticsDefaultsKeyUsageTracking_deprecated];
-        [[NSUserDefaults standardUserDefaults] synchronize];
-
     }
 }
 

--- a/WordPress/Classes/Utility/Migrations/10-11/BlogToAccount.m
+++ b/WordPress/Classes/Utility/Migrations/10-11/BlogToAccount.m
@@ -56,7 +56,6 @@
 
     NSURL *accountURL = [[account objectID] URIRepresentation];
     [[NSUserDefaults standardUserDefaults] setURL:accountURL forKey:WPComDefaultAccountUrlKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
 
     return YES;
 }

--- a/WordPress/Classes/Utility/Migrations/20-21/AccountToAccount20to21.swift
+++ b/WordPress/Classes/Utility/Migrations/20-21/AccountToAccount20to21.swift
@@ -20,7 +20,6 @@ class AccountToAccount20to21: NSEntityMigrationPolicy {
 
             let userDefaults = UserDefaults.standard
             userDefaults.setValue(username, forKey: defaultDotcomUsernameKey)
-            userDefaults.synchronize()
 
             DDLogWarn(">> Migration process matched [\(username)] as the default WordPress.com account")
         } else {
@@ -50,7 +49,6 @@ class AccountToAccount20to21: NSEntityMigrationPolicy {
 
         // Cleanup!
         userDefaults.removeObject(forKey: defaultDotcomUsernameKey)
-        userDefaults.synchronize()
     }
 
 
@@ -92,6 +90,5 @@ class AccountToAccount20to21: NSEntityMigrationPolicy {
 
         let defaults = UserDefaults.standard
         defaults.set(accountURL, forKey: defaultDotcomKey)
-        defaults.synchronize()
     }
 }

--- a/WordPress/Classes/Utility/Migrations/AccountToAccount22to23.swift
+++ b/WordPress/Classes/Utility/Migrations/AccountToAccount22to23.swift
@@ -33,7 +33,6 @@ class AccountToAccount22to23: NSEntityMigrationPolicy {
         if isDotCom! == true {
             let userDefaults = UserDefaults.standard
             userDefaults.setValue(username!, forKey: defaultDotcomUsernameKey)
-            userDefaults.synchronize()
 
             DDLogWarn(">> Migration process matched [\(username!)] as the default WordPress.com account")
         } else {
@@ -84,7 +83,6 @@ class AccountToAccount22to23: NSEntityMigrationPolicy {
 
         userDefaults.removeObject(forKey: defaultDotcomKey)
         userDefaults.removeObject(forKey: defaultDotcomUsernameKey)
-        userDefaults.synchronize()
 
         // At last: Execute the Default Account Fix (if needed)
         fixDefaultAccountIfNeeded(context)
@@ -146,7 +144,6 @@ class AccountToAccount22to23: NSEntityMigrationPolicy {
 
         let defaults = UserDefaults.standard
         defaults.set(uuid, forKey: defaultDotcomUUIDKey)
-        defaults.synchronize()
     }
 
 

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -23,7 +23,6 @@ final public class PushNotificationsManager: NSObject {
         }
         set {
             UserDefaults.standard.set(newValue, forKey: Device.tokenKey)
-            UserDefaults.standard.synchronize()
         }
     }
 
@@ -36,7 +35,6 @@ final public class PushNotificationsManager: NSObject {
         }
         set {
             UserDefaults.standard.set(newValue, forKey: Device.idKey)
-            UserDefaults.standard.synchronize()
         }
     }
 

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -515,7 +515,6 @@ private extension ZendeskUtils {
         userProfile[Constants.profileNameKey] = ZendeskUtils.sharedInstance.userName
         DDLogDebug("Zendesk - saving profile to User Defaults: \(userProfile)")
         UserDefaults.standard.set(userProfile, forKey: Constants.zendeskProfileUDKey)
-        UserDefaults.standard.synchronize()
     }
 
     static func getUserProfile() -> Bool {
@@ -530,7 +529,6 @@ private extension ZendeskUtils {
 
     static func saveUnreadCount() {
         UserDefaults.standard.set(unreadNotificationsCount, forKey: Constants.userDefaultsZendeskUnreadNotifications)
-        UserDefaults.standard.synchronize()
     }
 
     // MARK: - Data Helpers

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1441,7 +1441,6 @@ private extension NotificationsViewController {
         }
         set {
             userDefaults.setValue(newValue, forKey: Settings.lastSeenTime)
-            userDefaults.synchronize()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -226,7 +226,6 @@ private extension SupportTableViewController {
     func extraDebugToggled() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
             self.userDefaults.set(newValue, forKey: UserDefaultsKeys.extraDebug)
-            self.userDefaults.synchronize()
             WPLogger.configureLoggerLevelWithExtraDebug()
         }
     }


### PR DESCRIPTION
### Description
Addresses #10402. 

Our deployment target is set to iOS 10, so this PR removes `available` checks against iOS 10. Only one was found within our app. 

The `synchronize` method in `NSUserDefaults.h` was updated in iOS 10 with the following:
```
/*!
 -synchronize is deprecated and will be marked with the NS_DEPRECATED macro in a future release.
 
 -synchronize blocks the calling thread until all in-progress set operations have completed. This is no longer necessary. Replacements for previous uses of -synchronize depend on what the intent of calling synchronize was. If you synchronized...
 - ...before reading in order to fetch updated values: remove the synchronize call
 - ...after writing in order to notify another program to read: the other program can use KVO to observe the default without needing to notify
 - ...before exiting in a non-app (command line tool, agent, or daemon) process: call CFPreferencesAppSynchronize(kCFPreferencesCurrentApplication)
 - ...for any other reason: remove the synchronize call
 */
```

This was made more explicit in [current documentation](https://developer.apple.com/documentation/foundation/userdefaults/1414005-synchronize), which states that:
> this method is unnecessary and shouldn't be used.

This is [corroborated](https://twitter.com/Catfish_Man/status/1041754743645732864) by a developer on the Apple Foundation team.

### Testing
Checkout the branch and verify that existing tests pass. Perform a cursory "smoke test" of the app.