### PR TITLE
Quick Start: cancel tours when user navigates away

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1172,6 +1172,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     CommentsViewController *controller = [[CommentsViewController alloc] initWithStyle:UITableViewStylePlain];
     controller.blog = self.blog;
     [self showDetailViewController:controller sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showPostList
@@ -1179,6 +1181,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatOpenedPosts withBlog:self.blog];
     PostListViewController *controller = [PostListViewController controllerWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showPageList
@@ -1186,6 +1190,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatOpenedPages withBlog:self.blog];
     PageListViewController *controller = [PageListViewController controllerWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showMediaLibrary
@@ -1193,6 +1199,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatOpenedMediaLibrary withBlog:self.blog];
     MediaLibraryViewController *controller = [[MediaLibraryViewController alloc] initWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showPeople
@@ -1200,6 +1208,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatOpenedPeople withBlog:self.blog];
     PeopleViewController *controller = [PeopleViewController controllerWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showPlugins
@@ -1207,6 +1217,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatOpenedPluginDirectory withBlog:self.blog];
     PluginDirectoryViewController *controller = [[PluginDirectoryViewController alloc] initWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showPlans
@@ -1214,6 +1226,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatOpenedPlans withBlog:self.blog];
     PlanListViewController *controller = [[PlanListViewController alloc] initWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showSettings
@@ -1221,6 +1235,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatOpenedSiteSettings withBlog:self.blog];
     SiteSettingsViewController *controller = [[SiteSettingsViewController alloc] initWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showSharing
@@ -1257,6 +1273,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     } else {
         [self showDetailViewController:statsView sender:self];
     }
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showQuickStart
@@ -1271,6 +1289,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     ActivityListViewController *controller = [[ActivityListViewController alloc] initWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showThemes
@@ -1287,6 +1307,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatMenusAccessed withBlog:self.blog];
     MenusViewController *viewController = [MenusViewController controllerWithBlog:self.blog];
     [self showDetailViewController:viewController sender:self];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showViewSite
@@ -1321,6 +1343,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         dashboardUrl = [self.blog adminUrlWithPath:@""];
     }
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:dashboardUrl] options:nil completionHandler:nil];
+
+    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
 - (void)showNotificationPrimerAlert

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -144,9 +144,16 @@ open class QuickStartTourGuide: NSObject {
     }
 
     @objc func visited(_ element: QuickStartTourElement) {
-        guard element == currentElement(),
+        let readerElements: [QuickStartTourElement] = [.readerTab, .readerBack]
+        guard let currentElement = currentElement(),
             let tourState = currentTourState else {
-                return
+            return
+        }
+        guard element == currentElement else {
+            if element == .tabFlipped, !readerElements.contains(currentElement)  {
+                endCurrentTour()
+            }
+            return
         }
 
         dismissCurrentNotice()
@@ -160,7 +167,7 @@ open class QuickStartTourGuide: NSObject {
         }
         currentTourState = nextStep
 
-        if currentElement() == .readerBack && navigationWatcher.shouldSkipReaderBack() {
+        if currentElement == .readerBack && navigationWatcher.shouldSkipReaderBack() {
             visited(.readerBack)
             return
         }
@@ -342,6 +349,7 @@ internal extension NSNotification.Name {
 @objc
 public enum QuickStartTourElement: Int {
     case noSuchElement
+    case tabFlipped
     case viewSite
     case checklist
     case themes

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -144,15 +144,17 @@ open class QuickStartTourGuide: NSObject {
     }
 
     @objc func visited(_ element: QuickStartTourElement) {
-        let readerElements: [QuickStartTourElement] = [.readerTab, .readerBack]
         guard let currentElement = currentElement(),
             let tourState = currentTourState else {
             return
         }
         if element != currentElement {
-            if element == .blogDetailNavigation {
+            let blogDetailEvents: [QuickStartTourElement] = [.blogDetailNavigation, .checklist, .themes, .viewSite, .sharing]
+            let readerElements: [QuickStartTourElement] = [.readerTab, .readerBack]
+
+            if blogDetailEvents.contains(element) {
                 endCurrentTour()
-            } else if element == .tabFlipped, !readerElements.contains(currentElement)  {
+            } else if element == .tabFlipped, !readerElements.contains(currentElement) {
                 endCurrentTour()
             }
             return

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -149,8 +149,10 @@ open class QuickStartTourGuide: NSObject {
             let tourState = currentTourState else {
             return
         }
-        guard element == currentElement else {
-            if element == .tabFlipped, !readerElements.contains(currentElement)  {
+        if element != currentElement {
+            if element == .blogDetailNavigation {
+                endCurrentTour()
+            } else if element == .tabFlipped, !readerElements.contains(currentElement)  {
                 endCurrentTour()
             }
             return
@@ -350,6 +352,8 @@ internal extension NSNotification.Name {
 public enum QuickStartTourElement: Int {
     case noSuchElement
     case tabFlipped
+    case blogDetails
+    case blogDetailNavigation
     case viewSite
     case checklist
     case themes

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -354,7 +354,6 @@ internal extension NSNotification.Name {
 public enum QuickStartTourElement: Int {
     case noSuchElement
     case tabFlipped
-    case blogDetails
     case blogDetailNavigation
     case viewSite
     case checklist

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -32,11 +32,15 @@ extension WPTabBarController {
     }
 
     @objc func alertQuickStartThatWriteWasTapped() {
-        QuickStartTourGuide.find()?.visited(.newpost)
+        tourGuide.visited(.newpost)
     }
 
     @objc func alertQuickStartThatReaderWasTapped() {
-        QuickStartTourGuide.find()?.visited(.readerTab)
+        tourGuide.visited(.readerTab)
+    }
+
+    @objc func alertQuickStartThatOtherTabWasTapped() {
+        tourGuide.visited(.tabFlipped)
     }
 
     @objc func stopWatchingQuickTours() {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -853,6 +853,8 @@ static CGFloat const WPTabBarIconSize = 32.0f;
             }
             default: break;
         }
+
+        [self alertQuickStartThatOtherTabWasTapped];
     } else {
         // If the current view controller is selected already and it's at its root then scroll to the top
         if ([viewController isKindOfClass:[UINavigationController class]]) {


### PR DESCRIPTION
Fixes #10398

If the user goes somewhere outside the given tour, it automatically ends.

![quick start cancel tour](https://user-images.githubusercontent.com/517257/48101130-d9eb5980-e1da-11e8-9713-327e33e9bb16.gif)


To test:
 - start a tour
 - ignore it, go somewhere else in the app
 - ensure the notice is dismissed

