### PR TITLE
Removed superfluous calls to removeObserver via NotificationCenter

### DIFF
--- a/WordPress/Classes/Stores/StoreContainer.swift
+++ b/WordPress/Classes/Stores/StoreContainer.swift
@@ -7,10 +7,6 @@ class StoreContainer {
         NotificationCenter.default.addObserver(self, selector: #selector(applicationWillResignActive), name: UIApplication.willResignActiveNotification, object: nil)
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     @objc fileprivate func applicationWillResignActive() {
         try? plugin.persistState()
     }

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -38,10 +38,6 @@ open class WP3DTouchShortcutCreator: NSObject {
         registerForNotifications()
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     public convenience override init() {
         self.init(shortcutsProvider: UIApplication.shared)
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -62,11 +62,6 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     return (WordPressAppDelegate *)[[UIApplication sharedApplication] delegate];
 }
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 #pragma mark - UIApplicationDelegate
 
 - (BOOL)application:(UIApplication *)application willFinishLaunchingWithOptions:(NSDictionary *)launchOptions

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -46,13 +46,6 @@ static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_
 
 @implementation WPAppAnalytics
 
-#pragma mark - Dealloc
-
-- (void)dealloc
-{
-    [self stopObservingNotifications];
-}
-
 #pragma mark - Init
 
 - (instancetype)init
@@ -126,11 +119,6 @@ static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_
                                              selector:@selector(accountSettingsDidChange:)
                                                  name:NSNotification.AccountSettingsChanged
                                                object:nil];
-}
-
-- (void)stopObservingNotifications
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 #pragma mark - Notifications

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -26,11 +26,6 @@ static ContextManager *_override;
 //
 @implementation ContextManager
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (instancetype)init
 {
     self = [super init];

--- a/WordPress/Classes/Utility/PingHubManager.swift
+++ b/WordPress/Classes/Utility/PingHubManager.swift
@@ -117,7 +117,6 @@ class PingHubManager: NSObject {
     deinit {
         delayedRetry?.cancel()
         reachability.stopNotifier()
-        NotificationCenter.default.removeObserver(self)
     }
 
     fileprivate func stateChanged(old: State, new: State) {

--- a/WordPress/Classes/Utility/WPCrashlytics.m
+++ b/WordPress/Classes/Utility/WPCrashlytics.m
@@ -18,13 +18,6 @@ NSString * const WPCrashlyticsKeyNumberOfBlogs = @"number_of_blogs";
 
 @implementation WPCrashlytics
 
-#pragma mark - Dealloc
-
-- (void)dealloc
-{
-    [self stopObservingNotifications];
-}
-
 #pragma mark - Initialization
 
 - (instancetype)initWithAPIKey:(NSString *)apiKey
@@ -127,13 +120,6 @@ NSString * const WPCrashlyticsKeyNumberOfBlogs = @"number_of_blogs";
                            selector:@selector(handleDefaultAccountChangedNotification:)
                                name:WPAccountDefaultWordPressComAccountChangedNotification
                              object:nil];
-}
-
-- (void)stopObservingNotifications
-{
-    NSNotificationCenter *notificationCenter = [NSNotificationCenter defaultCenter];
-    
-    [notificationCenter removeObserver:self];
 }
 
 - (void)handleDefaultAccountChangedNotification:(NSNotification *)notification

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -82,13 +82,6 @@ class WebKitViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.title))
-        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))
-        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
-        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.isLoading))
-    }
-
     private func startObservingWebView() {
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.title), options: [.new], context: nil)
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: [.new], context: nil)

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -82,6 +82,13 @@ class WebKitViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    deinit {
+        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.title))
+        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.url))
+        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress))
+        webView.removeObserver(self, forKeyPath: #keyPath(WKWebView.isLoading))
+    }
+
     private func startObservingWebView() {
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.title), options: [.new], context: nil)
         webView.addObserver(self, forKeyPath: #keyPath(WKWebView.url), options: [.new], context: nil)

--- a/WordPress/Classes/ViewRelated/Aztec/Helpers/AztecVerificationPromptHelper.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Helpers/AztecVerificationPromptHelper.swift
@@ -35,10 +35,6 @@ class AztecVerificationPromptHelper: NSObject {
                                                object: nil)
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     func needsVerification(before action: PostEditorAction) -> Bool {
         guard action == .publish else {
             return false

--- a/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
@@ -32,6 +32,10 @@ public class MediaProgressCoordinator: NSObject {
 
     private var mediaProgressObserverContext: String = "mediaProgressObserverContext"
 
+    deinit {
+        mediaGlobalProgress?.removeObserver(self, forKeyPath: #keyPath(Progress.fractionCompleted))
+    }
+
     /// Setup the coordinator to track the provided number of tasks
     ///
     /// - Parameter count: the number of tasks that need to be tracked

--- a/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Media/MediaProgressCoordinator.swift
@@ -32,10 +32,6 @@ public class MediaProgressCoordinator: NSObject {
 
     private var mediaProgressObserverContext: String = "mediaProgressObserverContext"
 
-    deinit {
-        mediaGlobalProgress?.removeObserver(self, forKeyPath: #keyPath(Progress.fractionCompleted))
-    }
-
     /// Setup the coordinator to track the provided number of tasks
     ///
     /// - Parameter count: the number of tasks that need to be tracked

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -519,7 +519,6 @@ class AztecPostViewController: UIViewController, PostEditor {
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
         removeObservers(fromPost: post)
         unregisterMediaObserver()
         cancelAllPendingMediaRequests()

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -223,7 +223,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)dealloc
 {
     [self stopObservingQuickStart];
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (id)initWithStyle:(UITableViewStyle)style

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -41,11 +41,6 @@ static NSInteger HideSearchMinSites = 3;
     return [[WPTabBarController sharedInstance] blogListViewController];
 }
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (instancetype)init
 {
     self = [super init];

--- a/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogSelectorViewController.m
@@ -21,11 +21,6 @@
 
 @implementation BlogSelectorViewController
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (instancetype)initWithSelectedBlogObjectID:(NSManagedObjectID *)objectID
                               successHandler:(BlogSelectorSuccessHandler)successHandler
                               dismissHandler:(BlogSelectorDismissHandler)dismissHandler

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -13,12 +13,6 @@ open class DiscussionSettingsViewController: UITableViewController {
         self.blog = blog
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
-
-
     // MARK: - View Lifecycle
     open override func viewDidLoad() {
         super.viewDidLoad()

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -15,10 +15,6 @@ class QuickStartChecklistViewController: UITableViewController {
         startObservingForQuickStart()
     }
 
-    deinit {
-        stopObservingForQuickStart()
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -114,10 +110,6 @@ class QuickStartChecklistViewController: UITableViewController {
     private func reload() {
         dataSource?.loadCompletedTours()
         tableView.reloadData()
-    }
-
-    private func stopObservingForQuickStart() {
-        NotificationCenter.default.removeObserver(observer as Any)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -116,11 +116,6 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
 
 @implementation SiteSettingsViewController
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (instancetype)initWithBlog:(Blog *)blog
 {
     NSParameterAssert([blog isKindOfClass:[Blog class]]);

--- a/WordPress/Classes/ViewRelated/Cells/WPProgressTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Cells/WPProgressTableViewCell.m
@@ -28,11 +28,6 @@ NSProgressUserInfoKey const WPProgressImageThumbnailKey = @"WPProgressImageThumb
     return self;
 }
 
-- (void)dealloc
-{
-    [_progress removeObserver:self forKeyPath:NSStringFromSelector(@selector(fractionCompleted))];
-}
-
 - (void)prepareForReuse
 {
     [super prepareForReuse];

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -53,11 +53,6 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 
 @implementation CommentViewController
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)loadView
 {
     [super loadView];

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -36,7 +36,6 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 - (void)dealloc
 {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
     _syncHelper.delegate = nil;
     _tableViewHandler.delegate = nil;
 }

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentViewController.m
@@ -49,11 +49,6 @@ static UIEdgeInsets EditCommentInsetsPhone = {5, 10, 5, 11};
 
 #pragma mark - Lifecycle
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -47,10 +47,6 @@ private class AccountSettingsController: SettingsController {
         notificationCenter.addObserver(self, selector: #selector(AccountSettingsController.loadSettings), name: NSNotification.Name.AccountSettingsChanged, object: nil)
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     func refreshModel() {
         service.refreshSettings()
     }

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -37,10 +37,6 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/WordPress/Classes/ViewRelated/Me/MyProfileViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MyProfileViewController.swift
@@ -87,10 +87,6 @@ private class MyProfileController: SettingsController {
         notificationCenter.addObserver(self, selector: #selector(MyProfileController.loadSettings), name: NSNotification.Name.AccountSettingsChanged, object: nil)
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     func refreshModel() {
         service.refreshSettings()
     }

--- a/WordPress/Classes/ViewRelated/Media/AnimatedImageCache.swift
+++ b/WordPress/Classes/ViewRelated/Media/AnimatedImageCache.swift
@@ -15,10 +15,6 @@ class AnimatedImageCache {
                                                object: nil)
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     // MARK: Private fields
 
     fileprivate lazy var session: URLSession = {

--- a/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
@@ -94,10 +94,6 @@ public class CachedAnimatedImageView: UIImageView, GIFAnimatable {
                                                object: nil)
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     // MARK: - Public methods
 
     override public func display(_ layer: CALayer) {

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemEditingViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemEditingViewController.m
@@ -64,11 +64,6 @@ typedef NS_ENUM(NSUInteger, MenuItemEditingViewControllerContentLayout) {
     return controller;
 }
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)setupWithItem:(MenuItem *)item blog:(Blog *)blog
 {
     _blog = blog;

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemSourceCell.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemSourceCell.m
@@ -29,11 +29,6 @@ static CGFloat const MenuItemSourceCellHierarchyIdentationWidth = 17.0;
 
 @implementation MenuItemSourceCell
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier
 {
     self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemTypeSelectionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemTypeSelectionView.m
@@ -17,11 +17,6 @@
 
 @implementation MenuItemTypeSelectionView
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (id)init
 {
     self = [super init];

--- a/WordPress/Classes/ViewRelated/Menus/MenusSelectionItemView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusSelectionItemView.m
@@ -18,11 +18,6 @@
 
 @implementation MenusSelectionItemView
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (id)init
 {
     self = [super init];

--- a/WordPress/Classes/ViewRelated/Menus/MenusSelectionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusSelectionView.m
@@ -17,11 +17,6 @@
 
 @implementation MenusSelectionView
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)awakeFromNib
 {
     [super awakeFromNib];

--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -58,11 +58,6 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
     return controller;
 }
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)setupWithBlog:(Blog *)blog
 {
     // using a new child context to keep local changes discardable

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -8,10 +8,6 @@ import WordPressAuthenticator
 @objc
 class WordPressAuthenticationManager: NSObject {
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     /// Support is only available to the WordPress iOS App. Our Authentication Framework doesn't have direct access.
     /// We'll setup a mechanism to relay the Support event back to the Authenticator.
     ///

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -116,8 +116,6 @@ class NotificationDetailsViewController: UIViewController {
 
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
-
         // Failsafe: Manually nuke the tableView dataSource and delegate. Make sure not to force a loadView event!
         guard isViewLoaded else {
             return

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -62,10 +62,6 @@ class NotificationSettingDetailsViewController: UITableViewController {
         self.stream = stream
     }
 
-    deinit {
-        stopListeningToNotifications()
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -94,10 +90,6 @@ class NotificationSettingDetailsViewController: UITableViewController {
     private func startListeningToNotifications() {
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(self, selector: #selector(refreshPushAuthorizationStatus), name: UIApplication.didBecomeActiveNotification, object: nil)
-    }
-
-    private func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 
     private func setupTitle() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
@@ -46,10 +46,6 @@ class NotificationSettingStreamsViewController: UITableViewController {
         setupWithSettings(settings)
     }
 
-    deinit {
-        stopListeningToNotifications()
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -71,10 +67,6 @@ class NotificationSettingStreamsViewController: UITableViewController {
     private func startListeningToNotifications() {
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(self, selector: #selector(refreshPushAuthorizationStatus), name: UIApplication.didBecomeActiveNotification, object: nil)
-    }
-
-    private func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 
     private func setupTableView() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSiteSubscriptionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSiteSubscriptionViewController.swift
@@ -79,10 +79,6 @@ class NotificationSiteSubscriptionViewController: UITableViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        stopListeningToNotifications()
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -194,10 +190,6 @@ class NotificationSiteSubscriptionViewController: UITableViewController {
     private func startListeningToNotifications() {
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(self, selector: #selector(followingSiteStateToggled), name: NSNotification.Name(rawValue: ReaderPostServiceToggleSiteFollowingState), object: nil)
-    }
-
-    private func stopListeningToNotifications() {
-        NotificationCenter.default.removeObserver(self)
     }
 
     @objc func followingSiteStateToggled() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -90,10 +90,6 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
 
     // MARK: - View Lifecycle
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/KeyboardDismissHelper.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/KeyboardDismissHelper.swift
@@ -75,13 +75,6 @@ import UIKit
     ///
     fileprivate var trackingDragOperation = false
 
-
-    /// Deinitializer
-    ///
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     /// Designated initializer
     ///
     /// -   Parameter scrollView: View that contains everything
@@ -132,8 +125,6 @@ import UIKit
     @objc func stopListeningToKeyboardNotifications() {
         NotificationCenter.default.removeObserver(self)
     }
-
-
 
     /// ScrollView willBeginDragging Event
     ///

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewController.swift
@@ -54,10 +54,6 @@ class PluginViewController: UITableViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self, name: UIContentSizeCategory.didChangeNotification, object: nil)
-    }
-
     @objc private func didChangeDynamicType() {
         // (non-trivial) NSAttributedStrings and Dynamic Type don't work super well with each other.
         // We use fairly complex NSAttributedStrings in this view — so we subscribe to the notification

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -113,7 +113,6 @@ FeaturedImageViewControllerDelegate>
 {
     [self.internetReachability stopNotifier];
     
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
     [self removePostPropertiesObserver];
     [self removeMediaObserver];
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -113,11 +113,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
 #pragma mark - LifeCycle Methods
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (instancetype)init
 {
     self = [super init];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -83,12 +83,6 @@ import WordPressShared
 
     // MARK: - Lifecycle Methods
 
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
-
     override init(style: UITableView.Style) {
         super.init(style: style)
         // Need to use `super` to work around a Swift compiler bug

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewModel.swift
@@ -157,10 +157,6 @@ enum ReaderDefaultMenuItemOrder: Int {
     }
 
     // MARK: - Lifecycle Methods
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
 
     init(sectionCreators: [ReaderMenuItemCreator]) {
         self.sectionCreators = sectionCreators

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -82,12 +82,6 @@ import Gridicons
 
     // MARK: Lifecycle methods
 
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
-
     open override func awakeAfter(using aDecoder: NSCoder) -> Any? {
         restorationIdentifier = type(of: self).restorationClassIdentifier
         restorationClass = type(of: self)

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -43,10 +43,6 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     return self;
 }
 
-- (void)dealloc {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)viewDidLoad
 {
     [super viewDidLoad];

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
@@ -149,11 +149,6 @@ CGFloat const STVSeparatorHeight = 1.f;
                                                object:nil];
 }
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 - (void)layoutSubviews
 {
     [super layoutSubviews];

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -30,10 +30,6 @@ class SupportTableViewController: UITableViewController {
         self.init(style: .grouped)
     }
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     // MARK: - View
 
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -167,7 +167,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (void)dealloc
 {
     [self stopWatchingQuickTours];
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
     [[UIApplication sharedApplication] removeObserver:self forKeyPath:WPApplicationIconBadgeNumberKeyPath];
 }
 

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
@@ -83,10 +83,6 @@ open class ThemeBrowserHeaderView: UICollectionReusableView {
         startObservingForQuickStart()
     }
 
-    deinit {
-        stopObservingForQuickStart()
-    }
-
     fileprivate func applyStyles() {
         currentThemeBar.backgroundColor = Styles.currentThemeBackgroundColor
         currentThemeDivider.backgroundColor = Styles.currentThemeDividerColor
@@ -125,10 +121,6 @@ open class ThemeBrowserHeaderView: UICollectionReusableView {
         observer = NotificationCenter.default.addObserver(forName: .QuickStartTourElementChangedNotification, object: nil, queue: nil) { [weak self] (notification) in
             self?.spotlightCustomizeButtonIfTourIsActive()
         }
-    }
-
-    private func stopObservingForQuickStart() {
-        NotificationCenter.default.removeObserver(observer as Any)
     }
 
     fileprivate func setTextForLabels() {

--- a/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
@@ -121,10 +121,6 @@ class ShareExtensionAbstractViewController: UIViewController, ShareSegueHandler 
 
     // MARK: - Lifecycle Methods
 
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 

--- a/WordPress/WordPressTest/Extensions/NotificationCenterObserveOnceTests.swift
+++ b/WordPress/WordPressTest/Extensions/NotificationCenterObserveOnceTests.swift
@@ -10,9 +10,6 @@ class NotificationCenterObserveOnceTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
-        if let observer = observer {
-            notificationCenter.removeObserver(observer)
-        }
         observer = nil
     }
 

--- a/WordPressComStatsiOS/WordPressComStatsiOS/UI/InsightsContributionGraphHeaderView.m
+++ b/WordPressComStatsiOS/WordPressComStatsiOS/UI/InsightsContributionGraphHeaderView.m
@@ -34,9 +34,4 @@ static NSString *const DidTouchPostActivityDateNotification = @"DidTouchPostActi
                     }];
 }
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 @end

--- a/WordPressComStatsiOS/WordPressComStatsiOS/UI/WPStatsContributionGraph.m
+++ b/WordPressComStatsiOS/WordPressComStatsiOS/UI/WPStatsContributionGraph.m
@@ -34,11 +34,6 @@ static NSString *const ClearPostActivityDateNotification = @"ClearPostActivityDa
                 }];
 }
 
-- (void)dealloc
-{
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-}
-
 // Load one-time setup data from the delegate
 - (void)loadDefaults
 {


### PR DESCRIPTION
### Description
Addresses #10402. 

The `removeObserver(_:)` [documentation](https://developer.apple.com/documentation/foundation/notificationcenter/1413994-removeobserver) states the following:
> If your app targets iOS 9.0 and later or macOS 10.11 and later, you don't need to unregister an observer in its `dealloc` method. 

Because our deployment target is iOS 10, this PR deletes these now-superfluous calls.

### Testing
Checkout the branch and verify that existing tests pass. Perform a cursory "smoke test" of the app.