### PR TITLE
Removed superfluous nil completion handlers

### DIFF
--- a/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
@@ -16,7 +16,7 @@ import WordPressFlux
         while leafViewController.presentedViewController != nil && !leafViewController.presentedViewController!.isBeingDismissed {
             leafViewController = leafViewController.presentedViewController!
         }
-        leafViewController.present(self, animated: true, completion: nil)
+        leafViewController.present(self, animated: true)
     }
 }
 

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
@@ -56,6 +56,6 @@ open class WP3DTouchShortcutHandler: NSObject {
     }
 
     fileprivate func clearCurrentViewController() {
-        WordPressAppDelegate.sharedInstance().window!.rootViewController?.dismiss(animated: false, completion: nil)
+        WordPressAppDelegate.sharedInstance().window!.rootViewController?.dismiss(animated: false)
     }
 }

--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -91,14 +91,14 @@ struct DefaultContentCoordinator: ContentCoordinator {
 
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
         let navController = UINavigationController(rootViewController: webViewController)
-        controller?.present(navController, animated: true, completion: nil)
+        controller?.present(navController, animated: true)
     }
 
     func displayFullscreenImage(_ image: UIImage) {
         let imageViewController = WPImageViewController(image: image)
         imageViewController.modalTransitionStyle = .crossDissolve
         imageViewController.modalPresentationStyle = .fullScreen
-        controller?.present(imageViewController, animated: true, completion: nil)
+        controller?.present(imageViewController, animated: true)
     }
 
     func displayPlugin(withSlug pluginSlug: String, on siteSlug: String) throws {

--- a/WordPress/Classes/Utility/ImmuTableViewController.swift
+++ b/WordPress/Classes/Utility/ImmuTableViewController.swift
@@ -21,7 +21,7 @@ extension ImmuTablePresenter where Self: UIViewController {
         return {
             [unowned self] in
             let controller = controllerGenerator($0)
-            self.present(controller, animated: true, completion: nil)
+            self.present(controller, animated: true)
         }
     }
 }

--- a/WordPress/Classes/Utility/Spotlight/SearchManager.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchManager.swift
@@ -433,7 +433,7 @@ fileprivate extension SearchManager {
         openListView(for: post)
         let editor = EditPostViewController.init(post: post)
         editor.modalPresentationStyle = .fullScreen
-        WPTabBarController.sharedInstance().present(editor, animated: true, completion: nil)
+        WPTabBarController.sharedInstance().present(editor, animated: true)
     }
 
     func openEditor(for page: Page) {
@@ -442,14 +442,14 @@ fileprivate extension SearchManager {
         let editorSettings = EditorSettings()
         let postViewController = editorSettings.instantiatePageEditor(page: page) { (editor, vc) in
             editor.onClose = { changesSaved, _ in
-                vc.dismiss(animated: true, completion: nil)
+                vc.dismiss(animated: true)
             }
         }
 
         let navController = UINavigationController(rootViewController: postViewController)
         navController.restorationIdentifier = Restorer.Identifier.navigationController.rawValue
         navController.modalPresentationStyle = .fullScreen
-        WPTabBarController.sharedInstance().present(navController, animated: true, completion: nil)
+        WPTabBarController.sharedInstance().present(navController, animated: true)
     }
 
     func openPreview(for apost: AbstractPost) {
@@ -461,7 +461,7 @@ fileprivate extension SearchManager {
         controller.onClose = {
             navWrapper.dismiss(animated: true) {}
         }
-        WPTabBarController.sharedInstance().present(navWrapper, animated: true, completion: nil)
+        WPTabBarController.sharedInstance().present(navWrapper, animated: true)
         openListView(for: apost)
     }
 
@@ -475,7 +475,7 @@ fileprivate extension SearchManager {
                 // Do nothing — post is already loaded or PostPreviewViewController isn't visible
                 return
         }
-        navController.dismiss(animated: true, completion: nil)
+        navController.dismiss(animated: true)
     }
 
     /// If there is any PostPreviewViewController window open, close it.
@@ -485,6 +485,6 @@ fileprivate extension SearchManager {
             let _ = navController.topViewController as? PostPreviewViewController else {
                 return
         }
-        navController.dismiss(animated: true, completion: nil)
+        navController.dismiss(animated: true)
     }
 }

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -124,7 +124,7 @@ class WebKitViewController: UIViewController {
 
     @objc func loadWebViewRequest() {
         if ReachabilityUtils.alertIsShowing() {
-            self.dismiss(animated: false, completion: nil)
+            self.dismiss(animated: false)
         }
 
         guard let authenticator = authenticator,
@@ -294,7 +294,7 @@ class WebKitViewController: UIViewController {
     // MARK: User Actions
 
     @objc func close() {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 
     @objc func share() {
@@ -311,7 +311,7 @@ class WebKitViewController: UIViewController {
                 WPActivityDefaults.trackActivityType(type)
             }
         }
-        present(activityViewController, animated: true, completion: nil)
+        present(activityViewController, animated: true)
 
     }
 
@@ -393,13 +393,13 @@ extension WebKitViewController: WKUIDelegate {
             let url = navigationAction.request.url {
             let controller = WebKitViewController(url: url, parent: self)
             let navController = UINavigationController(rootViewController: controller)
-            present(navController, animated: true, completion: nil)
+            present(navController, animated: true)
         }
         return nil
     }
 
     func webViewDidClose(_ webView: WKWebView) {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -744,7 +744,7 @@ private extension ZendeskUtils {
         }
 
         // Show alert
-        presentInController?.present(alertController, animated: true, completion: nil)
+        presentInController?.present(alertController, animated: true)
     }
 
     @objc static func emailTextFieldDidChange(_ textField: UITextField) {

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -215,7 +215,7 @@ extension ActivityListViewController: ActivityRewindPresenter {
                                                       handler: { action in
                                                         self.restoreSiteToRewindID(rewindID)
                                                       })
-        self.present(alertController, animated: true, completion: nil)
+        self.present(alertController, animated: true)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Aztec/Helpers/AztecVerificationPromptHelper.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/Helpers/AztecVerificationPromptHelper.swift
@@ -83,7 +83,7 @@ class AztecVerificationPromptHelper: NSObject {
                                                         return
                                             }
 
-                                            displayedAlert.dismiss(animated: true, completion: nil)
+                                            displayedAlert.dismiss(animated: true)
                                             self?.completionBlock?(!updatedAccount.needsEmailVerification)
             }, failure: nil)
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -225,13 +225,13 @@ class AztecAttachmentViewController: UITableViewController {
 
     @objc func handleCancelButtonTapped(sender: UIBarButtonItem) {
         onCancel?()
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 
     @objc func handleDoneButtonTapped(sender: UIBarButtonItem) {
         let checkedAlt = alt == "" ? nil : alt
         onUpdate?(alignment, size, linkURL, checkedAlt, caption)
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 
     private func pushSettingsController(for row: EditableTextRow,

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1203,7 +1203,7 @@ extension AztecPostViewController {
         }
 
         alertController.popoverPresentationController?.barButtonItem = closeBarButtonItem
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     private func publishPost(
@@ -1280,7 +1280,7 @@ extension AztecPostViewController {
             let controller = FancyAlertViewController.makeAsyncPostingAlertController(action: action, isPage: isPage, onConfirm: publishBlock)
             controller.modalPresentationStyle = .custom
             controller.transitioningDelegate = self
-            self.present(controller, animated: true, completion: nil)
+            self.present(controller, animated: true)
         }
 
         if action.isAsync {
@@ -1297,7 +1297,7 @@ extension AztecPostViewController {
     func displayMediaIsUploadingAlert() {
         let alertController = UIAlertController(title: MediaUploadingAlert.title, message: MediaUploadingAlert.message, preferredStyle: .alert)
         alertController.addDefaultActionWithTitle(MediaUploadingAlert.acceptTitle)
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     @IBAction func closeWasPressed() {
@@ -1354,7 +1354,7 @@ private extension AztecPostViewController {
 
         // Setup Handlers
         let successHandler: BlogSelectorSuccessHandler = { selectedObjectID in
-            self.dismiss(animated: true, completion: nil)
+            self.dismiss(animated: true)
 
             guard let blog = self.mainContext.object(with: selectedObjectID) as? Blog else {
                 return
@@ -1364,7 +1364,7 @@ private extension AztecPostViewController {
         }
 
         let dismissHandler: BlogSelectorDismissHandler = {
-            self.dismiss(animated: true, completion: nil)
+            self.dismiss(animated: true)
         }
 
         // Setup Picker
@@ -1384,7 +1384,7 @@ private extension AztecPostViewController {
         navigationController.configurePopoverPresentationStyle(from: sourceView)
 
         // Done!
-        present(navigationController, animated: true, completion: nil)
+        present(navigationController, animated: true)
     }
 
     /// Presents an alert controller, allowing the user to insert a link to either:
@@ -1522,7 +1522,7 @@ private extension AztecPostViewController {
 
         alert.addCancelActionWithTitle(SwitchSiteAlert.cancelTitle)
 
-        present(alert, animated: true, completion: nil)
+        present(alert, animated: true)
     }
 
     func displayPostSettings() {
@@ -1555,7 +1555,7 @@ private extension AztecPostViewController {
         }
 
         alertController.addCancelActionWithTitle(FailedMediaRemovalAlert.cancelTitle)
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     @IBAction func displayCancelMediaUploads() {
@@ -1564,7 +1564,7 @@ private extension AztecPostViewController {
             self.mediaCoordinator.cancelUploadOfAllMedia(for: self.post)
         }
         alertController.addCancelActionWithTitle(MediaUploadingCancelAlert.cancelTitle)
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
         return
     }
 
@@ -1585,7 +1585,7 @@ private extension AztecPostViewController {
         alertController.addDefaultActionWithTitle(publishTitle) { _ in
             publishAction()
         }
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 }
 
@@ -2398,7 +2398,7 @@ extension AztecPostViewController {
     private func dismissOptionsViewController() {
         switch UIDevice.current.userInterfaceIdiom {
         case .pad:
-            dismiss(animated: true, completion: nil)
+            dismiss(animated: true)
         default:
             optionsViewController?.removeFromParent()
             changeRichTextInputView(to: nil)
@@ -2624,11 +2624,11 @@ private extension AztecPostViewController {
             self?.richTextView.edit(attachment) { htmlAttachment in
                 htmlAttachment.rawHTML = html
             }
-            self?.dismiss(animated: true, completion: nil)
+            self?.dismiss(animated: true)
         }
 
         targetVC.onDidCancel = { [weak self] in
-            self?.dismiss(animated: true, completion: nil)
+            self?.dismiss(animated: true)
         }
 
         let navigationController = UINavigationController(rootViewController: targetVC)
@@ -2643,7 +2643,7 @@ private extension AztecPostViewController {
         presentationController?.sourceView = view
         presentationController?.delegate = self
 
-        present(viewController, animated: true, completion: nil)
+        present(viewController, animated: true)
     }
 }
 
@@ -2742,7 +2742,7 @@ private extension AztecPostViewController {
         if let onClose = onClose {
             onClose(didSave, shouldShowPostEpilogue)
         } else if isModal() {
-            presentingViewController?.dismiss(animated: true, completion: nil)
+            presentingViewController?.dismiss(animated: true)
         } else {
             _ = navigationController?.popViewController(animated: true)
         }
@@ -3486,7 +3486,7 @@ extension AztecPostViewController {
 
         let navController = UINavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .formSheet
-        present(navController, animated: true, completion: nil)
+        present(navController, animated: true)
 
         WPAppAnalytics.track(.editorEditedImage, withProperties: [WPAppAnalyticsKeyEditorSource: Analytics.editorSource], with: post)
     }
@@ -3529,13 +3529,13 @@ extension AztecPostViewController {
         controller.showsPlaybackControls = true
         controller.player = player
         player.play()
-        present(controller, animated: true, completion: nil)
+        present(controller, animated: true)
     }
 
     func displayUnableToPlayVideoAlert() {
         let alertController = UIAlertController(title: MediaUnableToPlayVideoAlert.title, message: MediaUnableToPlayVideoAlert.message, preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .`default`, handler: nil))
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
         return
     }
 
@@ -3791,7 +3791,7 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
         if picker != mediaPickerInputViewController?.mediaPicker {
             unregisterChangeObserver()
             mediaLibraryDataSource.searchCancelled()
-            dismiss(animated: true, completion: nil)
+            dismiss(animated: true)
         }
     }
 
@@ -3799,7 +3799,7 @@ extension AztecPostViewController: WPMediaPickerViewControllerDelegate {
         if picker != mediaPickerInputViewController?.mediaPicker {
             unregisterChangeObserver()
             mediaLibraryDataSource.searchCancelled()
-            dismiss(animated: true, completion: nil)
+            dismiss(animated: true)
             mediaSelectionMethod = .fullScreenPicker
         } else {
             mediaSelectionMethod = .inlinePicker

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -77,12 +77,12 @@ extension BlogDetailsViewController {
 
             let alert = FancyAlertViewController.makeNotificationPrimerAlertController { (controller) in
                 InteractiveNotificationsManager.shared.requestAuthorization {
-                    controller.dismiss(animated: true, completion: nil)
+                    controller.dismiss(animated: true)
                 }
             }
             alert.modalPresentationStyle = .custom
             alert.transitioningDelegate = self
-            self?.tabBarController?.present(alert, animated: true, completion: nil)
+            self?.tabBarController?.present(alert, animated: true)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController+SiteCreation.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController+SiteCreation.swift
@@ -3,6 +3,6 @@ extension BlogListViewController {
     func enhancedSiteCreation() {
         let wizardLauncher = SiteCreationWizardLauncher()
         let wizard = wizardLauncher.ui
-        present(wizard, animated: true, completion: nil)
+        present(wizard, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/DateAndTimeFormatSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DateAndTimeFormatSettingsViewController.swift
@@ -206,7 +206,7 @@ open class DateAndTimeFormatSettingsViewController: UITableViewController {
             navigationController?.pushViewController(webViewController, animated: true)
         } else {
             let navController = UINavigationController(rootViewController: webViewController)
-            present(navController, animated: true, completion: nil)
+            present(navController, animated: true)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/JetpackConnectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackConnectionViewController.swift
@@ -84,7 +84,7 @@ open class JetpackConnectionViewController: UITableViewController {
                                                           handler: { action in
                                                               self.disconnectJetpack()
                                                           })
-            self.present(alertController, animated: true, completion: nil)
+            self.present(alertController, animated: true)
         }
     }
 
@@ -115,7 +115,7 @@ open class JetpackConnectionViewController: UITableViewController {
 
     @objc func dismiss() {
         if isModal() {
-            dismiss(animated: true, completion: nil)
+            dismiss(animated: true)
         } else {
             navigationController?.popViewController(animated: true)
         }

--- a/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackSecuritySettingsViewController.swift
@@ -298,7 +298,7 @@ open class JetpackSecuritySettingsViewController: UITableViewController {
             navigationController?.pushViewController(webViewController, animated: true)
         } else {
             let navController = UINavigationController(rootViewController: webViewController)
-            present(navController, animated: true, completion: nil)
+            present(navController, animated: true)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAccountViewController.swift
@@ -331,6 +331,6 @@ extension SharingAccountViewController: NoResultsViewControllerDelegate {
         if let url = URL(string: "https://en.support.wordpress.com/publicize/#facebook-pages") {
             UIApplication.shared.open(url)
         }
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -162,7 +162,7 @@ open class DeleteSiteViewController: UITableViewController {
 
     @IBAction func deleteSite(_ sender: Any) {
         tableView.deselectSelectedRowWithAnimation(true)
-        present(confirmDeleteController(), animated: true, completion: nil)
+        present(confirmDeleteController(), animated: true)
     }
 
     @IBAction func contactSupport(_ sender: Any) {

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SettingsTitleSubtitleController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SettingsTitleSubtitleController.swift
@@ -226,7 +226,7 @@ final class SettingsTitleSubtitleController: UITableViewController {
             }
         }
         alertController.popoverPresentationController?.barButtonItem = navigationItem.rightBarButtonItem
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     private func executeAction() {

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteSettingsViewController+SiteManagement.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteSettingsViewController+SiteManagement.swift
@@ -13,7 +13,7 @@ public extension SiteSettingsViewController {
         tableView.deselectSelectedRowWithAnimation(true)
 
         WPAppAnalytics.track(.siteSettingsExportSiteAccessed, with: self.blog)
-        present(confirmExportController(), animated: true, completion: nil)
+        present(confirmExportController(), animated: true)
     }
 
     /// Creates confirmation alert for Export Content
@@ -92,7 +92,7 @@ public extension SiteSettingsViewController {
                     strongSelf.navigationController?.pushViewController(DeleteSiteViewController.controller(strongSelf.blog), animated: true)
                 } else {
                     WPAppAnalytics.track(.siteSettingsDeleteSitePurchasesShown, with: strongSelf.blog)
-                    strongSelf.present(strongSelf.warnPurchasesController(), animated: true, completion: nil)
+                    strongSelf.present(strongSelf.warnPurchasesController(), animated: true)
                 }
             },
             failure: { error in

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteTagsViewController.swift
@@ -348,7 +348,7 @@ extension SiteTagsViewController {
         let acceptTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alertController.addDefaultActionWithTitle(acceptTitle)
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     private func tagWasUpdated(tag: PostTag, updatedTag: SettingsTitleSubtitleController.Content) -> Bool {

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/StartOverViewController.swift
@@ -126,7 +126,7 @@ open class StartOverViewController: UITableViewController, MFMailComposeViewCont
         mailComposeController.setToRecipients([mailRecipient])
         mailComposeController.setSubject(mailSubject)
         mailComposeController.setMessageBody(mailBody, isHTML: false)
-        present(mailComposeController, animated: true, completion: nil)
+        present(mailComposeController, animated: true)
     }
 
     @objc func showGoogleMailComposerForURL(_ url: URL ) {
@@ -149,7 +149,7 @@ open class StartOverViewController: UITableViewController, MFMailComposeViewCont
     // MARK: - MFMailComposeViewControllerDelegate Method
 
     public func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
-        controller.dismiss(animated: true, completion: nil)
+        controller.dismiss(animated: true)
         if let _ = error {
             showAlertToSendEmail()
         }

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController+Swift.swift
@@ -129,7 +129,7 @@ extension SiteSettingsViewController {
             navigationController?.pushViewController(webViewController, animated: true)
         } else {
             let navController = UINavigationController(rootViewController: webViewController)
-            present(navController, animated: true, completion: nil)
+            present(navController, animated: true)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
@@ -78,7 +78,7 @@ open class AboutViewController: UITableViewController {
 
     // MARK: - Button Helpers
     @IBAction func dismissWasPressed(_ sender: AnyObject) {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 
 
@@ -146,7 +146,7 @@ open class AboutViewController: UITableViewController {
             navigationController?.pushViewController(webViewController, animated: true)
         } else {
             let navController = UINavigationController(rootViewController: webViewController)
-            present(navController, animated: true, completion: nil)
+            present(navController, animated: true)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/GravatarPickerViewController.swift
@@ -120,7 +120,7 @@ class GravatarPickerViewController: UIViewController, WPMediaPickerViewControlle
         let imageCropViewController = ImageCropViewController(image: rawGravatar)
         imageCropViewController.onCompletion = { [weak self] image, _ in
             self?.onCompletion?(image)
-            self?.dismiss(animated: true, completion: nil)
+            self?.dismiss(animated: true)
         }
 
         return imageCropViewController

--- a/WordPress/Classes/ViewRelated/Me/GravatarUploader.swift
+++ b/WordPress/Classes/ViewRelated/Me/GravatarUploader.swift
@@ -18,10 +18,10 @@ extension GravatarUploader {
                 self?.uploadGravatarImage(updatedGravatarImage)
             }
 
-            sourceVC.dismiss(animated: true, completion: nil)
+            sourceVC.dismiss(animated: true)
         }
         pickerViewController.modalPresentationStyle = .formSheet
-        sourceVC.present(pickerViewController, animated: true, completion: nil)
+        sourceVC.present(pickerViewController, animated: true)
     }
 
     func uploadGravatarImage(_ newGravatar: UIImage) {

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -380,7 +380,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
             self.logOut()
         }
 
-        present(alert, animated: true, completion: nil)
+        present(alert, animated: true)
     }
 
     private var logOutAlertTitle: String {
@@ -422,17 +422,17 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
             imageCropViewController.shouldShowCancelButton = true
 
             imageCropViewController.onCancel = { [weak self] in
-                self?.dismiss(animated: true, completion: nil)
+                self?.dismiss(animated: true)
                 self?.updateGravatarStatus(.idle)
             }
             imageCropViewController.onCompletion = { [weak self] image, _ in
-                self?.dismiss(animated: true, completion: nil)
+                self?.dismiss(animated: true)
                 self?.uploadGravatarImage(image)
             }
 
             let navController = UINavigationController(rootViewController: imageCropViewController)
             navController.modalPresentationStyle = .formSheet
-            self?.present(navController, animated: true, completion: nil)
+            self?.present(navController, animated: true)
         }
         return headerView
     }()

--- a/WordPress/Classes/ViewRelated/Me/MyProfileViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MyProfileViewController.swift
@@ -154,10 +154,10 @@ private class MyProfileController: SettingsController {
             if let updatedGravatarImage = image {
                 self?.uploadGravatarImage(updatedGravatarImage, presenter: viewController)
             }
-            viewController.dismiss(animated: true, completion: nil)
+            viewController.dismiss(animated: true)
         }
         pickerViewController.modalPresentationStyle = .formSheet
-        viewController.present(pickerViewController, animated: true, completion: nil)
+        viewController.present(pickerViewController, animated: true)
     }
 
     // MARK: - Helpers

--- a/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/PrivacySettingsViewController.swift
@@ -136,7 +136,7 @@ class PrivacySettingsViewController: UITableViewController {
         }
         let webViewController = WebViewControllerFactory.controller(url: url)
         let navigation = UINavigationController(rootViewController: webViewController)
-        present(navigation, animated: true, completion: nil)
+        present(navigation, animated: true)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -191,7 +191,7 @@ class MediaItemViewController: UITableViewController {
         controller.modalTransitionStyle = .crossDissolve
         controller.modalPresentationStyle = .fullScreen
 
-        self.present(controller, animated: true, completion: nil)
+        self.present(controller, animated: true)
     }
 
     private func presentVideoViewControllerForMedia() {
@@ -250,11 +250,11 @@ class MediaItemViewController: UITableViewController {
                         WPAppAnalytics.track(.mediaLibrarySharedItemLink, with: self?.media.blog)
                     }
                 }
-                present(activityController, animated: true, completion: nil)
+                present(activityController, animated: true)
         } else {
             let alertController = UIAlertController(title: nil, message: NSLocalizedString("Unable to get URL for media item.", comment: "Error message displayed when we were unable to copy the URL for an item in the user's media library."), preferredStyle: .alert)
             alertController.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: "Verb. User action to dismiss error alert when failing to share media."))
-            present(alertController, animated: true, completion: nil)
+            present(alertController, animated: true)
         }
     }
 
@@ -271,7 +271,7 @@ class MediaItemViewController: UITableViewController {
             self.deleteMediaItem()
         })
 
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     private func deleteMediaItem() {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -50,7 +50,7 @@ final class MediaLibraryMediaPickingCoordinator {
         menuAlert.popoverPresentationController?.sourceRect = fromView.bounds
         menuAlert.popoverPresentationController?.barButtonItem = buttonItem
 
-        origin.present(menuAlert, animated: true, completion: nil)
+        origin.present(menuAlert, animated: true)
     }
 
     private func cameraAction(origin: UIViewController, blog: Blog) -> UIAlertAction {
@@ -114,7 +114,7 @@ final class MediaLibraryMediaPickingCoordinator {
             docPicker.allowsMultipleSelection = true
         }
         WPStyleGuide.configureDocumentPickerNavBarAppearance()
-        origin.present(docPicker, animated: true, completion: nil)
+        origin.present(docPicker, animated: true)
     }
 
     private func showMediaPicker(origin: UIViewController, blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPicker.swift
@@ -20,6 +20,6 @@ final class MediaLibraryPicker: NSObject {
         picker.dataSource = dataSource
         picker.delegate = delegate
 
-        origin.present(picker, animated: true, completion: nil)
+        origin.present(picker, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -284,7 +284,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             self.deleteSelectedItems()
         })
 
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     private func deleteSelectedItems() {
@@ -341,7 +341,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
 
         alertController.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: "Verb. Button title. Tapping dismisses a prmopt."))
 
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     override var isEditing: Bool {
@@ -434,7 +434,7 @@ extension MediaLibraryViewController: UIDocumentPickerDelegate {
     }
 
     func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 }
 
@@ -463,7 +463,7 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
         guard picker != self else { return }
         pickerDataSource.searchCancelled()
 
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
 
         guard ReachabilityUtils.isInternetReachable() else {
             ReachabilityUtils.showAlertNoInternetConnection()
@@ -482,7 +482,7 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
     func mediaPickerControllerDidCancel(_ picker: WPMediaPickerViewController) {
         pickerDataSource.searchCancelled()
 
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, willShowOverlayView overlayView: UIView, forCellFor asset: WPMediaAsset) {

--- a/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaNoticeNavigationCoordinator.swift
@@ -16,7 +16,7 @@ class MediaNoticeNavigationCoordinator {
         let editor = EditPostViewController(blog: blog)
         editor.modalPresentationStyle = .fullScreen
         editor.insertedMedia = media
-        WPTabBarController.sharedInstance().present(editor, animated: false, completion: nil)
+        WPTabBarController.sharedInstance().present(editor, animated: false)
         WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": source], with: blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
@@ -33,7 +33,7 @@ final class AztecMediaPickingCoordinator {
         alertController.popoverPresentationController?.sourceRect = CGRect(origin: fromView.frame.origin, size: CGSize(width: 1, height: 1))
         alertController.popoverPresentationController?.permittedArrowDirections = .any
 
-        origin.present(alertController, animated: true, completion: nil)
+        origin.present(alertController, animated: true)
     }
 
     private func freePhotoAction(origin: UIViewController, blog: Blog) -> UIAlertAction {
@@ -74,6 +74,6 @@ final class AztecMediaPickingCoordinator {
             docPicker.allowsMultipleSelection = true
         }
         WPStyleGuide.configureDocumentPickerNavBarAppearance()
-        origin.present(docPicker, animated: true, completion: nil)
+        origin.present(docPicker, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -160,7 +160,7 @@ extension LoginEpilogueViewController {
 
     @IBAction func dismissEpilogue() {
         onDismiss?()
-        navigationController?.dismiss(animated: true, completion: nil)
+        navigationController?.dismiss(animated: true)
     }
 
     @IBAction func handleConnectAnotherButton() {

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -162,7 +162,7 @@ private extension SignupEpilogueViewController {
             }
             self.refreshAccountDetails() {
                 SVProgressHUD.dismiss()
-                self.navigationController?.dismiss(animated: true, completion: nil)
+                self.navigationController?.dismiss(animated: true)
             }
         }
         changesMade = true
@@ -241,7 +241,7 @@ private extension SignupEpilogueViewController {
         let context = ContextManager.sharedInstance().mainContext
         let service = AccountService(managedObjectContext: context)
         guard let account = service.defaultWordPressComAccount() else {
-            self.navigationController?.dismiss(animated: true, completion: nil)
+            self.navigationController?.dismiss(animated: true)
             return
         }
         service.updateUserDetails(for: account, success: { () in

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationCategoryTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationCategoryTableViewController.swift
@@ -52,7 +52,7 @@ class SiteCreationCategoryTableViewController: NUXTableViewController {
     // MARK: - Cancel Button Action
 
     @objc func handleCancelButtonTapped(sender: UIBarButtonItem) {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 
     // MARK: - Table Model

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationCreateSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationCreateSiteViewController.swift
@@ -335,7 +335,7 @@ extension SiteCreationCreateSiteViewController: NoResultsViewControllerDelegate 
     }
 
     func dismissButtonPressed() {
-        navigationController?.dismiss(animated: true, completion: nil)
+        navigationController?.dismiss(animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationDomainsViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationDomainsViewController.swift
@@ -75,7 +75,7 @@ class SiteCreationDomainsViewController: NUXViewController {
 
             // Since the Button View uses auto layout, need to call this so the animation works properly.
             self.view.layoutIfNeeded()
-        }, completion: nil)
+        })
     }
 
     // MARK: - Navigation

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationEpilogueViewController.swift
@@ -55,7 +55,7 @@ extension SiteCreationEpilogueViewController: NUXButtonViewControllerDelegate {
         WPTabBarController.sharedInstance().showPostTab { [weak self] in
             self?.showQuickStartAlert()
         }
-        navigationController?.dismiss(animated: true, completion: nil)
+        navigationController?.dismiss(animated: true)
     }
 
     // 'Configure' button
@@ -81,7 +81,7 @@ extension SiteCreationEpilogueViewController: NUXButtonViewControllerDelegate {
         let fancyAlert = FancyAlertViewController.makeQuickStartAlertController(blog: siteToShow)
         fancyAlert.modalPresentationStyle = .custom
         fancyAlert.transitioningDelegate = tabBar
-        tabBar.present(fancyAlert, animated: true, completion: nil)
+        tabBar.present(fancyAlert, animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationSitePreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationSitePreviewViewController.swift
@@ -78,7 +78,7 @@ class SiteCreationSitePreviewViewController: UIViewController {
             self.siteView.alpha = 1
             UIView.animate(withDuration: WPAnimationDurationDefault, animations: {
                 self.congratulationsView.alpha = 0
-            }, completion: nil)
+            })
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -66,7 +66,7 @@ extension WordPressAuthenticationManager {
         }
 
         let controller = signinForWPComFixingAuthToken()
-        presenter.present(controller, animated: true, completion: nil)
+        presenter.present(controller, animated: true)
     }
 }
 
@@ -127,7 +127,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         let navController = UINavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .formSheet
 
-        sourceViewController.present(navController, animated: true, completion: nil)
+        sourceViewController.present(navController, animated: true)
     }
 
     /// Presents Support new request, with the specified ViewController as a source.

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -168,7 +168,7 @@ class NotificationDetailsViewController: UIViewController {
         super.viewWillTransition(to: size, with: coordinator)
         coordinator.animate(alongsideTransition: { context in
             self.refreshInterfaceIfNeeded()
-        }, completion: nil)
+        })
     }
 
     override func viewDidLayoutSubviews() {
@@ -911,7 +911,7 @@ private extension NotificationDetailsViewController {
             //
             UIView.animate(withDuration: ContentMedia.duration, delay: ContentMedia.delay, options: ContentMedia.options, animations: { [weak self] in
                 self?.tableView.reloadRows(at: [indexPath], with: .fade)
-                }, completion: nil)
+                })
         }
 
         mediaDownloader.downloadMedia(urls: urls, maximumWidth: maxMediaEmbedWidth, completion: completion)
@@ -1117,7 +1117,7 @@ private extension NotificationDetailsViewController {
         navController.modalTransitionStyle = .coverVertical
         navController.navigationBar.isTranslucent = false
 
-        present(navController, animated: true, completion: nil)
+        present(navController, animated: true)
     }
 
     func displayCommentUpdateErrorWithBlock(_ block: FormattableCommentContent, content: String) {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
@@ -202,7 +202,7 @@ class NotificationSettingStreamsViewController: UITableViewController {
                                         comment: "Displayed when Push Notifications are disabled (iOS 7)")
         let button = NSLocalizedString("Dismiss", comment: "Dismiss the AlertView")
 
-        let alert = AlertView(title: title, message: message, button: button, completion: nil)
+        let alert = AlertView(title: title, message: message, button: button)
         alert.show()
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -166,7 +166,7 @@ open class NotificationSettingsViewController: UIViewController {
             self.reloadSettings()
         }
 
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1217,7 +1217,7 @@ internal extension NotificationsViewController {
         UIView.animate(withDuration: WPAnimationDurationDefault, delay: InlinePrompt.animationDelay, options: .curveEaseIn, animations: {
             self.inlinePromptView.alpha = WPAlphaFull
             self.setupTableHeaderView()
-        }, completion: nil)
+        })
 
         WPAnalytics.track(.appReviewsSawPrompt)
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -479,7 +479,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
                     self?.updateFilter(index: filterIndex)
                 }
                 self?._tableViewHandler.isSearching = false
-                vc.dismiss(animated: true, completion: nil)
+                vc.dismiss(animated: true)
             }
         }
         let navController = UINavigationController(rootViewController: postViewController)
@@ -678,7 +678,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         WPAnalytics.track(.postListOpenedCellMenu, withProperties: propertiesForAnalytics())
 
         alertController.modalPresentationStyle = .popover
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
 
         if let presentationController = alertController.popoverPresentationController {
             presentationController.permittedArrowDirections = .any
@@ -714,7 +714,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let parentPageNavigationController = ParentPageSettingsViewController.navigationController(with: pages, selectedPage: selectedPage) {
             self._tableViewHandler.isSearching = false
         }
-        present(parentPageNavigationController, animated: true, completion: nil)
+        present(parentPageNavigationController, animated: true)
     }
 
     fileprivate func pageForObjectID(_ objectID: NSManagedObjectID) -> Page? {

--- a/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
@@ -219,7 +219,7 @@ class ParentPageSettingsViewController: UIViewController {
 
     private func dismiss() {
         onClose?()
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 
 

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -233,7 +233,7 @@ class InvitePersonViewController: UITableViewController {
 extension InvitePersonViewController {
 
     @IBAction func cancelWasPressed() {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 
     @IBAction func sendWasPressed() {
@@ -347,7 +347,7 @@ private extension InvitePersonViewController {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
 
         alert.addDefaultActionWithTitle(okTitle)
-        present(alert, animated: true, completion: nil)
+        present(alert, animated: true)
     }
 
     var sendActionEnabled: Bool {

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -404,7 +404,7 @@ open class PeopleViewController: UITableViewController, NSFetchedResultsControll
             }
 
             self?.filter = filter
-            self?.dismiss(animated: true, completion: nil)
+            self?.dismiss(animated: true)
         }
 
         controller.tableView.isScrollEnabled = false
@@ -412,7 +412,7 @@ open class PeopleViewController: UITableViewController, NSFetchedResultsControll
         ForcePopoverPresenter.configurePresentationControllerForViewController(controller,
                                                                                                            presentingFromView: titleButton)
 
-        present(controller, animated: true, completion: nil)
+        present(controller, animated: true)
     }
 
     fileprivate func filtersAvailableForBlog(_ blog: Blog) -> [Filter] {

--- a/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanComparisonViewController.swift
@@ -11,7 +11,7 @@ class PlanComparisonViewController: PagedViewController {
     }()
 
     @IBAction func closeTapped() {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -210,7 +210,7 @@ class PlanDetailViewController: UIViewController {
             purchaseButton?.isSelected = false
 
             let postPurchaseViewController = PlanPostPurchaseViewController(plan: viewModel.plan)
-            present(postPurchaseViewController, animated: true, completion: nil)
+            present(postPurchaseViewController, animated: true)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
@@ -36,7 +36,7 @@ enum PlanListViewModel {
                 let url = URL(string: WPAutomatticTermsOfServiceURL)!
                 let webViewController = WebViewControllerFactory.controller(url: url)
                 let navController = UINavigationController(rootViewController: webViewController)
-                presenter?.present(navController, animated: true, completion: nil)
+                presenter?.present(navController, animated: true)
             }
 
             return (footerTitle, {})

--- a/WordPress/Classes/ViewRelated/Plans/PlanPostPurchaseViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanPostPurchaseViewController.swift
@@ -60,7 +60,7 @@ class PlanPostPurchaseViewController: UIViewController {
         // If the view is changing size (e.g. on rotation, or multitasking), scroll to the correct page boundary based on the new size
         coordinator.animate(alongsideTransition: { context in
             self.scrollView.setContentOffset(CGPoint(x: CGFloat(self.currentScrollViewPage()) * size.width, y: 0), animated: true)
-            }, completion: nil)
+            })
     }
 
     fileprivate func addPageControl() {
@@ -154,7 +154,7 @@ class PlanPostPurchaseViewController: UIViewController {
     }
 
     @objc func closeTapped() {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 }
 
@@ -324,7 +324,7 @@ class PlanPostPurchasePageViewController: UIViewController {
             let service = BlogService(managedObjectContext: ContextManager.sharedInstance().mainContext)
             WPTabBarController.sharedInstance().switchMySitesTabToCustomizeView(for: service.primaryBlog())
 
-            WPTabBarController.sharedInstance().dismiss(animated: true, completion: nil)
+            WPTabBarController.sharedInstance().dismiss(animated: true)
         case .VideoPress:
             WPTabBarController.sharedInstance().dismiss(animated: true) {
                 WPTabBarController.sharedInstance().showPostTab()
@@ -333,7 +333,7 @@ class PlanPostPurchasePageViewController: UIViewController {
             let service = BlogService(managedObjectContext: ContextManager.sharedInstance().mainContext)
             WPTabBarController.sharedInstance().switchMySitesTabToThemesView(for: service.primaryBlog())
 
-            WPTabBarController.sharedInstance().dismiss(animated: true, completion: nil)
+            WPTabBarController.sharedInstance().dismiss(animated: true)
         default: break
         }
     }

--- a/WordPress/Classes/ViewRelated/Plans/PlansLoadingIndicatorView.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlansLoadingIndicatorView.swift
@@ -183,8 +183,7 @@ class PlansLoadingIndicatorView: UIView {
             options: .curveEaseOut,
             animations: { [unowned freeView] in
                 freeView.transform = CGAffineTransform.identity
-            },
-            completion: nil)
+            })
 
         UIView.animate(
             withDuration: Config.Duration.premium * Config.Duration.durationScale,
@@ -194,8 +193,7 @@ class PlansLoadingIndicatorView: UIView {
             options: .curveEaseOut,
             animations: { [unowned premiumView] in
                 premiumView.transform = CGAffineTransform.identity
-            },
-            completion: nil)
+            })
 
         UIView.animate(
             withDuration: Config.Duration.business * Config.Duration.durationScale,
@@ -205,7 +203,6 @@ class PlansLoadingIndicatorView: UIView {
             options: .curveEaseOut,
             animations: { [unowned businessView] in
                 businessView.transform = CGAffineTransform.identity
-            },
-            completion: nil)
+            })
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -803,7 +803,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         navController.modalPresentationStyle = .formSheet
 
         WPError.showAlert(withTitle: NSLocalizedString("Unable to Connect", comment: "An error message."), message: message, withSupportButton: true) { _ in
-            self.present(navController, animated: true, completion: nil)
+            self.present(navController, animated: true)
         }
     }
 
@@ -905,7 +905,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
             self.updateFilterWithPostStatus(.publish)
         }
 
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     @objc func schedulePost(_ apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/GutenbergAlertPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/GutenbergAlertPresenter.swift
@@ -94,7 +94,7 @@ import Foundation
             let navController = UINavigationController(rootViewController: webViewController)
             navController.modalPresentationStyle = .fullScreen
 
-            controller.present(navController, animated: true, completion: nil)
+            controller.present(navController, animated: true)
         }
 
         let doNotShowAgainSwitchConfig = FancyAlertViewController.Config.SwitchConfig(
@@ -125,7 +125,7 @@ import Foundation
         alert.modalPresentationStyle = .custom
         alert.transitioningDelegate = self
 
-        viewController.present(alert, animated: true, completion: nil)
+        viewController.present(alert, animated: true)
     }
 
     // MARK: - Variable Strings

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -208,7 +208,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             if self.isViewLoaded {
                 self.tableView.reloadData()
             }
-            }, completion: nil)
+            })
     }
 
     // MARK: - Sync Methods
@@ -235,7 +235,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
                                                             self?.updateAuthorFilter()
                                                             self?.refreshAndReload()
                                                             self?.syncItemsWithUserInteraction(false)
-                                                            self?.dismiss(animated: true, completion: nil)
+                                                            self?.dismiss(animated: true)
         }
 
         ForcePopoverPresenter.configurePresentationControllerForViewController(filterController, presentingFromView: sender)
@@ -428,7 +428,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             }
         }
         editor.modalPresentationStyle = .fullScreen
-        present(editor, animated: false, completion: nil)
+        present(editor, animated: false)
         WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: apost)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeNavigationCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeNavigationCoordinator.swift
@@ -29,7 +29,7 @@ class PostNoticeNavigationCoordinator {
 
         let navigationController = UINavigationController(rootViewController: controller)
         navigationController.modalPresentationStyle = .formSheet
-        presenter.present(navigationController, animated: true, completion: nil)
+        presenter.present(navigationController, animated: true)
     }
 
     private static func presentPostEpilogue(for post: Post) {
@@ -42,7 +42,7 @@ class PostNoticeNavigationCoordinator {
         editor.openWithPostPost = true
         editor.onClose = { _ in
         }
-        presenter.present(editor, animated: true, completion: nil)
+        presenter.present(editor, animated: true)
     }
 
     static func retryPostUpload(with userInfo: NSDictionary) {

--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -127,27 +127,27 @@ class PostPostViewController: UIViewController {
 
             UIView.animate(withDuration: animationDuration, delay: 0, options: .curveEaseOut, animations: {
                 self.shadeView.alpha = WPAlphaZero
-                }, completion: nil)
+                })
 
             UIView.animate(withDuration: animationDuration * 0.66, delay: 0, options: .curveEaseOut, animations: {
                 self.postInfoView.alpha = WPAlphaFull
-                }, completion: nil)
+                })
 
             UIView.animate(withDuration: 0.2, delay: animationDuration * 0.5, options: .curveEaseOut, animations: {
                 self.shareButton.alpha = WPAlphaFull
                 self.shareButtonWidth.constant = 0
                 self.actionsStackView.layoutIfNeeded()
-                }, completion: nil)
+                })
             UIView.animate(withDuration: 0.2, delay: animationDuration * 0.6, options: .curveEaseOut, animations: {
                 self.editButton.alpha = WPAlphaFull
                 self.editButtonWidth.constant = 0
                 self.actionsStackView.layoutIfNeeded()
-                }, completion: nil)
+                })
             UIView.animate(withDuration: 0.2, delay: animationDuration * 0.7, options: .curveEaseOut, animations: {
                 self.viewButton.alpha = WPAlphaFull
                 self.viewButtonWidth.constant = 0
                 self.actionsStackView.layoutIfNeeded()
-                }, completion: nil)
+                })
         }) { (context) in }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
@@ -100,7 +100,7 @@ extension PostSettingsViewController {
             alertController.popoverPresentationController?.sourceRect = CGRect(origin: CGPoint(x: anchorView.bounds.midX, y: anchorView.bounds.midY), size: CGSize(width: 1, height: 1))
             alertController.popoverPresentationController?.permittedArrowDirections = .any
         }
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     struct FeaturedImageActionSheet {

--- a/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSharingController.swift
@@ -30,13 +30,13 @@ import SVProgressHUD
             link: link)
 
         if !UIDevice.isPad() {
-            viewController.present(controller, animated: true, completion: nil)
+            viewController.present(controller, animated: true)
             return
         }
 
         // Silly iPad popover rules.
         controller.modalPresentationStyle = .popover
-        viewController.present(controller, animated: true, completion: nil)
+        viewController.present(controller, animated: true)
         if let presentationController = controller.popoverPresentationController {
             presentationController.permittedArrowDirections = .any
             presentationController.barButtonItem = anchorBarButtonItem
@@ -50,13 +50,13 @@ import SVProgressHUD
             link: link)
 
         if !UIDevice.isPad() {
-            viewController.present(controller, animated: true, completion: nil)
+            viewController.present(controller, animated: true)
             return
         }
 
         // Silly iPad popover rules.
         controller.modalPresentationStyle = .popover
-        viewController.present(controller, animated: true, completion: nil)
+        viewController.present(controller, animated: true)
         if let presentationController = controller.popoverPresentationController {
             presentationController.permittedArrowDirections = .any
             presentationController.sourceView = anchorView
@@ -98,14 +98,15 @@ import SVProgressHUD
         let controller = shareController("", summary: "", link: url.absoluteString)
 
         if !UIDevice.isPad() {
-            viewController.present(controller, animated: true, completion: nil)
+            viewController.present(controller, animated: true)
             return
         }
 
         // Silly iPad popover rules.
         controller.modalPresentationStyle = .popover
 
-        viewController.present(controller, animated: true, completion: nil)
+        viewController.present(controller, animated: true)
+
         if let presentationController = controller.popoverPresentationController {
             presentationController.permittedArrowDirections = .any
             presentationController.sourceView = view

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -69,8 +69,7 @@ open class ReaderCrossPostCell: UITableViewCell {
         UIView.animate(withDuration: 0.25,
             delay: 0,
             options: UIView.AnimationOptions(),
-            animations: updateBorder,
-            completion: nil)
+            animations: updateBorder)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -892,7 +892,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         configuration.addsWPComReferrer = true
         let controller = WebViewControllerFactory.controller(configuration: configuration)
         let navController = UINavigationController(rootViewController: controller)
-        present(navController, animated: true, completion: nil)
+        present(navController, animated: true)
     }
 
     @objc func presentFullScreenGif(with animatedGifData: Data?) {
@@ -903,7 +903,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
         controller.modalTransitionStyle = .crossDissolve
         controller.modalPresentationStyle = .fullScreen
-        present(controller, animated: true, completion: nil)
+        present(controller, animated: true)
     }
 
     @objc func presentFullScreenImage(with image: UIImage?, linkURL: URL? = nil) {
@@ -919,7 +919,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
         controller.modalTransitionStyle = .crossDissolve
         controller.modalPresentationStyle = .fullScreen
-        present(controller, animated: true, completion: nil)
+        present(controller, animated: true)
     }
 
     @objc func previewSite() {
@@ -945,7 +945,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
                 options: [.beginFromCurrentState, .allowUserInteraction],
                 animations: {
                     self.view.layoutIfNeeded()
-                }, completion: nil)
+                })
 
         } else {
             // Shows the navbar and footer view
@@ -964,9 +964,8 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
                                 self.textView.setContentOffset(CGPoint(x: 0, y: y), animated: false)
                             }
 
-            }, completion: nil)
+            })
         }
-
     }
 
 
@@ -1143,7 +1142,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         }
         controller.modalTransitionStyle = .crossDissolve
         controller.modalPresentationStyle = .fullScreen
-        present(controller, animated: true, completion: nil)
+        present(controller, animated: true)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -417,14 +417,14 @@ import WordPressShared
         let navController = UINavigationController(rootViewController: controller)
         navController.modalPresentationStyle = .formSheet
 
-        present(navController, animated: true, completion: nil)
+        present(navController, animated: true)
     }
 
 
     /// Dismisses a presented view controller.
     ///
     @objc func dismissModal() {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 
     func deselectSelectedRow(animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -538,8 +538,7 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         UIView.animate(withDuration: 0.25,
             delay: 0,
             options: UIView.AnimationOptions(),
-            animations: updateBorder,
-            completion: nil)
+            animations: updateBorder)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostMenu.swift
@@ -78,7 +78,7 @@ open class ReaderPostMenu {
 
         if UIDevice.isPad() {
             alertController.modalPresentationStyle = .popover
-            viewController.present(alertController, animated: true, completion: nil)
+            viewController.present(alertController, animated: true)
             if let presentationController = alertController.popoverPresentationController {
                 presentationController.permittedArrowDirections = .any
                 presentationController.sourceView = anchorView
@@ -86,7 +86,7 @@ open class ReaderPostMenu {
             }
 
         } else {
-            viewController.present(alertController, animated: true, completion: nil)
+            viewController.present(alertController, animated: true)
         }
     }
 
@@ -193,6 +193,6 @@ open class ReaderPostMenu {
         configuration.addsWPComReferrer = true
         let controller = WebViewControllerFactory.controller(configuration: configuration)
         let navController = UINavigationController(rootViewController: controller)
-        viewController.present(navController, animated: true, completion: nil)
+        viewController.present(navController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
@@ -88,7 +88,7 @@ class ReaderSearchSuggestionsViewController: UIViewController {
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
         coordinator.animate(alongsideTransition: { (_) in
             self.updateHeightConstraint()
-            }, completion: nil)
+            })
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowAttributionAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowAttributionAction.swift
@@ -24,6 +24,6 @@ final class ReaderShowAttributionAction {
         configuration.addsWPComReferrer = true
         let controller = WebViewControllerFactory.controller(configuration: configuration)
         let navController = UINavigationController(rootViewController: controller)
-        origin.present(navController, animated: true, completion: nil)
+        origin.present(navController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -56,7 +56,7 @@ final class ReaderShowMenuAction {
 
         if WPDeviceIdentification.isiPad() {
             alertController.modalPresentationStyle = .popover
-            vc.present(alertController, animated: true, completion: nil)
+            vc.present(alertController, animated: true)
             if let presentationController = alertController.popoverPresentationController {
                 presentationController.permittedArrowDirections = .any
                 presentationController.sourceView = anchor
@@ -64,7 +64,7 @@ final class ReaderShowMenuAction {
             }
 
         } else {
-            vc.present(alertController, animated: true, completion: nil)
+            vc.present(alertController, animated: true)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1189,7 +1189,7 @@ extension ReaderStreamViewController: NewsManagerDelegate {
         configuration.addsWPComReferrer = true
         let controller = WebViewControllerFactory.controller(configuration: configuration)
         let navController = UINavigationController(rootViewController: controller)
-        present(navController, animated: true, completion: nil)
+        present(navController, animated: true)
     }
 
     private func presentReaderDetailViewControllerWithURL(_ url: URL) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderVisitSiteAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderVisitSiteAction.swift
@@ -15,6 +15,6 @@ final class ReaderVisitSiteAction {
         }
         let controller = WebViewControllerFactory.controller(configuration: configuration)
         let navController = UINavigationController(rootViewController: controller)
-        origin.present(navController, animated: true, completion: nil)
+        origin.present(navController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/JetpackLoginViewController.swift
@@ -162,7 +162,7 @@ class JetpackLoginViewController: UIViewController {
         let controller = JetpackConnectionWebViewController(blog: blog)
         controller.delegate = self
         let navController = UINavigationController(rootViewController: controller)
-        present(navController, animated: true, completion: nil)
+        present(navController, animated: true)
     }
 
     fileprivate func signIn() {

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -63,16 +63,16 @@ class SupportTableViewController: UITableViewController {
 
         let tabBarController = WPTabBarController.sharedInstance()
         if let presentedVC = tabBarController?.presentedViewController {
-            presentedVC.present(navigationController, animated: true, completion: nil)
+            presentedVC.present(navigationController, animated: true)
         } else {
-            tabBarController?.present(navigationController, animated: true, completion: nil)
+            tabBarController?.present(navigationController, animated: true)
         }
     }
 
     // MARK: - Button Actions
 
     @IBAction func dismissPressed(_ sender: AnyObject) {
-        dismiss(animated: true, completion: nil)
+        dismiss(animated: true)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+Async.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+Async.swift
@@ -50,7 +50,7 @@ extension FancyAlertViewController {
         }
 
         let dismissButton = ButtonConfig(GeneralStrings.keepEditingTitle) { controller, _ in
-            controller.dismiss(animated: true, completion: nil)
+            controller.dismiss(animated: true)
         }
 
         let moreHelpButton = ButtonConfig(GeneralStrings.moreHelpTitle) { controller, _ in
@@ -60,7 +60,7 @@ extension FancyAlertViewController {
 
             let safariViewController = SFSafariViewController(url: url)
             safariViewController.modalPresentationStyle = .pageSheet
-            controller.present(safariViewController, animated: true, completion: nil)
+            controller.present(safariViewController, animated: true)
         }
 
         let image = UIImage(named: "wp-illustration-easy-async")

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+NotificationPrimer.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+NotificationPrimer.swift
@@ -26,7 +26,7 @@ extension FancyAlertViewController {
             defer {
                 WPAnalytics.track(.pushNotificationPrimerNoTapped, withProperties: [Analytics.locationKey: Analytics.alertKey])
             }
-            controller.dismiss(animated: true, completion: nil)
+            controller.dismiss(animated: true)
         }
 
         let image = UIImage(named: "wp-illustration-stay-in-the-loop")

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+SavedPosts.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+SavedPosts.swift
@@ -16,13 +16,13 @@ extension FancyAlertViewController {
             controller.modalPresentationStyle = .custom
             controller.transitioningDelegate = origin
 
-            origin.present(controller, animated: true, completion: nil)
+            origin.present(controller, animated: true)
         }
     }
 
     static func makeReaderSavedPostsAlertController() -> FancyAlertViewController {
         let dismissButton = ButtonConfig(Strings.okTitle) { controller, _ in
-            controller.dismiss(animated: true, completion: nil)
+            controller.dismiss(animated: true)
         }
 
         let image = UIImage(named: "wp-illustration-mobile-save-for-later")

--- a/WordPress/Classes/ViewRelated/System/FancyAlerts+VerificationPrompt.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlerts+VerificationPrompt.swift
@@ -39,7 +39,7 @@ extension FancyAlertViewController {
 
         let defaultButton = FancyAlertViewController.Config.ButtonConfig(Strings.ok) { controller, _ in
             completion?()
-            controller.dismiss(animated: true, completion: nil)
+            controller.dismiss(animated: true)
         }
 
         let config = FancyAlertViewController.Config(titleText: Strings.titleText,
@@ -57,7 +57,7 @@ extension FancyAlertViewController {
 
     private static func successfullySentVerificationEmailConfig() -> FancyAlertViewController.Config {
         let okButton = FancyAlertViewController.Config.ButtonConfig(Strings.ok) { controller, _ in
-            controller.dismiss(animated: true, completion: nil)
+            controller.dismiss(animated: true)
         }
 
         return FancyAlertViewController.Config(titleText: Strings.titleText,
@@ -73,7 +73,7 @@ extension FancyAlertViewController {
 
     private static func failureSendingVerificationEmailConfig(with error: VerificationFailureError) -> FancyAlertViewController.Config {
         let okButton = FancyAlertViewController.Config.ButtonConfig(Strings.ok) { controller, _ in
-            controller.dismiss(animated: true, completion: nil)
+            controller.dismiss(animated: true)
         }
 
         let bodyText: String

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -300,7 +300,7 @@ class FilterTabBar: UIControl {
                            options: .curveEaseInOut,
                            animations: {
                 self.layoutIfNeeded()
-            }, completion: nil)
+            })
         }
     }
 

--- a/WordPress/Classes/ViewRelated/System/PagedViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/PagedViewController.swift
@@ -41,7 +41,7 @@ class PagedViewController: UIViewController {
         // If the view is changing size (e.g. on rotation, or multitasking), scroll to the correct page boundary based on the new size
         coordinator.animate(alongsideTransition: { context in
             self.scrollView.setContentOffset(CGPoint(x: CGFloat(self.currentIndex) * size.width, y: 0), animated: false)
-            }, completion: nil)
+        })
     }
 
     override var shouldAutorotate: Bool {

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -150,7 +150,7 @@ class WPSplitViewController: UISplitViewController {
         coordinator.animate(alongsideTransition: { context in
             self.updateSplitViewForPrimaryColumnWidth()
             self.updateDimmingViewFrame()
-        }, completion: nil)
+        })
 
         // Calling `setOverrideTraitCollection` prompts `overrideTraitCollectionForChildViewController` to be called.
         if let _ = overriddenTraitCollectionForDetailViewController,

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -702,7 +702,7 @@ public protocol ThemePresenter: class {
 
         collectionView.performBatchUpdates({
             hidden ? hide() : show()
-        }, completion: nil)
+        })
     }
 
     // MARK: - UISearchResultsUpdating
@@ -868,10 +868,10 @@ public protocol ThemePresenter: class {
 
         if searchController != nil && searchController.isActive {
             searchController.dismiss(animated: true, completion: {
-                self.present(navigation, animated: true, completion: nil)
+                self.present(navigation, animated: true)
             })
         } else {
-            present(navigation, animated: true, completion: nil)
+            present(navigation, animated: true)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Views/AlertView/AlertView.swift
+++ b/WordPress/Classes/ViewRelated/Views/AlertView/AlertView.swift
@@ -16,7 +16,7 @@ open class AlertView: NSObject {
     ///     - message: Message string to be displayed. Note: Bold is supported, **markdown flavor**.
     ///     - completion: A closure to be executed right after the button is pressed.
     ///
-    @objc public init(title: String, message: String, button: String, completion: Completion?) {
+    @objc public init(title: String, message: String, button: String, completion: Completion? = nil) {
         super.init()
 
         Bundle.main.loadNibNamed(AlertView.classNameWithoutNamespaces(), owner: self, options: nil)

--- a/WordPress/WordPressDraftActionExtension/MainDraftActionViewController.swift
+++ b/WordPress/WordPressDraftActionExtension/MainDraftActionViewController.swift
@@ -53,7 +53,7 @@ private extension MainDraftActionViewController {
         let shareNavController = MainDraftNavigationController(rootViewController: modularController)
         shareNavController.transitioningDelegate = extensionTransitioningManager
         shareNavController.modalPresentationStyle = .custom
-        present(shareNavController, animated: !shareNavController.shouldFillContentContainer, completion: nil)
+        present(shareNavController, animated: !shareNavController.shouldFillContentContainer)
     }
 
     func trackExtensionLaunch() {

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -53,7 +53,7 @@ private extension MainShareViewController {
         shareNavController.transitioningDelegate = extensionTransitioningManager
         shareNavController.modalPresentationStyle = .custom
 
-        present(shareNavController, animated: true, completion: nil)
+        present(shareNavController, animated: true)
     }
 
     func trackExtensionLaunch() {

--- a/WordPress/WordPressShareExtension/ShareCategoriesPickerViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareCategoriesPickerViewController.swift
@@ -162,7 +162,7 @@ class ShareCategoriesPickerViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.flashRowAtIndexPath(indexPath, scrollPosition: .none, flashLength: Constants.flashAnimationLength, completion: nil)
+        tableView.flashRowAtIndexPath(indexPath, scrollPosition: .none, flashLength: Constants.flashAnimationLength)
         selectedCategoryTableRowAt(indexPath)
     }
 }

--- a/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
@@ -153,7 +153,7 @@ extension ShareExtensionAbstractViewController {
         }
 
         alertController.addAction(alertAction)
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     func saveImageToSharedContainer(_ image: UIImage) -> URL? {

--- a/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
@@ -752,7 +752,7 @@ extension ShareExtensionEditorViewController {
             self?.richTextView.becomeFirstResponder()
         }
 
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     @objc func alertTextFieldDidChange(_ textField: UITextField) {
@@ -896,7 +896,7 @@ extension ShareExtensionEditorViewController {
     private func dismissOptionsViewController() {
         switch UIDevice.current.userInterfaceIdiom {
         case .pad:
-            dismiss(animated: true, completion: nil)
+            dismiss(animated: true)
         default:
             optionsViewController?.removeFromParent()
             changeRichTextInputView(to: nil)

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -469,12 +469,12 @@ fileprivate extension ShareModularViewController {
         switch ModulesSection(rawValue: indexPath.section)! {
         case .categories:
             if shareData.categoryCountForSelectedSite > 1 {
-                modulesTableView.flashRowAtIndexPath(indexPath, scrollPosition: .none, flashLength: Constants.flashAnimationLength, completion: nil)
+                modulesTableView.flashRowAtIndexPath(indexPath, scrollPosition: .none, flashLength: Constants.flashAnimationLength)
                 showCategoriesPicker()
             }
             return
         case .tags:
-            modulesTableView.flashRowAtIndexPath(indexPath, scrollPosition: .none, flashLength: Constants.flashAnimationLength, completion: nil)
+            modulesTableView.flashRowAtIndexPath(indexPath, scrollPosition: .none, flashLength: Constants.flashAnimationLength)
             showTagsPicker()
             return
         case .summary:
@@ -553,7 +553,7 @@ fileprivate extension ShareModularViewController {
     }
 
     func selectedSitesTableRowAt(_ indexPath: IndexPath) {
-        sitesTableView.flashRowAtIndexPath(indexPath, scrollPosition: .none, flashLength: Constants.flashAnimationLength, completion: nil)
+        sitesTableView.flashRowAtIndexPath(indexPath, scrollPosition: .none, flashLength: Constants.flashAnimationLength)
 
         guard let cell = sitesTableView.cellForRow(at: indexPath),
             let site = siteForRowAtIndexPath(indexPath),
@@ -858,7 +858,7 @@ fileprivate extension ShareModularViewController {
         }
         alertController.addAction(dismissAction)
 
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 
     func showPermissionsAlert() {
@@ -873,7 +873,7 @@ fileprivate extension ShareModularViewController {
         }
         alertController.addAction(dismissAction)
 
-        present(alertController, animated: true, completion: nil)
+        present(alertController, animated: true)
     }
 }
 

--- a/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
+++ b/WordPress/WordPressShareExtension/ShareNoticeNavigationCoordinator.swift
@@ -19,7 +19,7 @@ class ShareNoticeNavigationCoordinator {
 
         let editor = EditPostViewController.init(post: post)
         editor.modalPresentationStyle = .fullScreen
-        WPTabBarController.sharedInstance().present(editor, animated: false, completion: nil)
+        WPTabBarController.sharedInstance().present(editor, animated: false)
     }
 
     static func navigateToPostList(with userInfo: NSDictionary) {

--- a/WordPress/WordPressShareExtension/UITableView+Extensions.swift
+++ b/WordPress/WordPressShareExtension/UITableView+Extensions.swift
@@ -18,7 +18,7 @@ extension UITableView {
     @objc func flashRowAtIndexPath(_ indexPath: IndexPath,
                                    scrollPosition: UITableView.ScrollPosition = .middle,
                                    flashLength: TimeInterval,
-                                   completion: (() -> Void)?) {
+                                   completion: (() -> Void)? = nil) {
         selectRow(at: indexPath, animated: true, scrollPosition: scrollPosition)
 
         let time = DispatchTime.now() + Double(Int64(flashLength * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)


### PR DESCRIPTION
### Description
Addresses #10402. 

Swift [documentation](https://swift.org/documentation/api-design-guidelines/#parameter-names) advises us of the following:

> Take advantage of defaulted parameters when it simplifies common uses. Any parameter with a single commonly-used value is a candidate for a default.

This PR takes the suggestion to heart, with an emphasis on removing superfluous completion handlers found throughout the app. The most common call sites impacted are presentation & dismissal methods in [`UIViewController`](https://developer.apple.com/documentation/uikit/uiviewcontroller).

### Testing
Checkout the branch and verify that existing tests pass. Perform a cursory "smoke test" of the app.