### PR TITLE
Allow Fastlane lanes to be run with 'bundle exec'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -69,6 +69,12 @@ namespace :dependencies do
         pod %w[install]
       end
     end
+
+    task :clean do
+      fold("clean.cocoapds") do
+        FileUtils.rm_rf('Pods')
+      end
+    end
     CLOBBER << "Pods"
   end
 

--- a/Scripts/fastlane/actions/ios_build_preflight.rb
+++ b/Scripts/fastlane/actions/ios_build_preflight.rb
@@ -3,8 +3,16 @@ module Fastlane
     class IosBuildPreflightAction < Action
       def self.run(params) 
         Action.sh("cd .. && rm -rf ~/Library/Developer/Xcode/DerivedData")
-        Action.sh("rake clobber")
-        Action.sh("rake dependencies")
+        
+        # Check gems and pods are up to date. This will exit if it fails
+        begin
+          Action.sh("bundle check")
+        rescue 
+          UI.user_error!("You should run 'rake dependencies' to make sure gems are up to date")
+          raise
+        end
+
+        Action.sh("rake dependencies:pod:clean")
         other_action.cocoapods()
       end
 


### PR DESCRIPTION
`IosBuildPreflightAction` which is triggered from several lanes currently calls `rake clobber` and `rake dependencies`. This causes crashes if `fastlane` was invoked with `bundle exec` because Fastlane is trying to replace its own binary.

I have made some small changes to it:

- Instead of clobbering gems, the action checks if they are up to date and errors out if not.
- Pods are cleared and reinstalled, but not gems.

The downside of this is that we are not as confident that gems are 100% fresh. However, not running with `bundle exec` is worse because it just uses whatever gems happen to be installed systemwide.

To test:

- Run `bundle exec fastlane run ios_build_preflight` to verify the action works correctly.
