### PR TITLE
Fastlane: ensure secrets are up to date in build preflight

### DIFF
--- a/Scripts/fastlane/actions/ios_build_preflight.rb
+++ b/Scripts/fastlane/actions/ios_build_preflight.rb
@@ -1,7 +1,13 @@
 module Fastlane
   module Actions
     class IosBuildPreflightAction < Action
-      def self.run(params) 
+      def self.run(params)
+        # Ensure mobile secrets are up to date. This will do nothing if not a git repo
+        secrets_git_dir = File.expand_path('~/.mobile-secrets/.git')
+        if File.exist?(secrets_git_dir)
+          Action.sh("git --git-dir \"#{secrets_git_dir}\" pull")
+        end
+
         Action.sh("cd .. && rm -rf ~/Library/Developer/Xcode/DerivedData")
         Action.sh("rake clobber")
         Action.sh("rake dependencies")


### PR DESCRIPTION
This removes the risk that `~/.mobile-secrets` is out of date if using a git repo to track changes in it. If its not a git repo, this does nothing.

@loremattei This is a proposal. If you would prefer the pull to be manual, I'm open to not making this change.

To test:

- `bundle exec fastlane run ios_build_preflight` should now update `~/.mobile-secrets`.

