### PR TITLE
Handle gutenberg request "open media picker"

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -138,6 +138,8 @@ PODS:
   - React/RCTImage (0.57.1):
     - React/Core
     - React/RCTNetwork
+  - React/RCTLinkingIOS (0.57.1):
+    - React/Core
   - React/RCTNetwork (0.57.1):
     - React/Core
   - React/RCTText (0.57.1):
@@ -147,7 +149,15 @@ PODS:
     - React/fishhook
     - React/RCTBlob
   - RNReactNativeGutenbergBridge (0.1.0):
-    - React
+    - React/Core (= 0.57.1)
+    - React/CxxBridge (= 0.57.1)
+    - React/RCTActionSheet (= 0.57.1)
+    - React/RCTAnimation (= 0.57.1)
+    - React/RCTImage (= 0.57.1)
+    - React/RCTLinkingIOS (= 0.57.1)
+    - React/RCTNetwork (= 0.57.1)
+    - React/RCTText (= 0.57.1)
+    - yoga (= 0.57.1.React)
   - RNSVG (6.5.2):
     - React
   - Starscream (3.0.4)
@@ -339,7 +349,7 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   React: 1fe0eb13d90b625d94c3b117c274dcfd2e760e11
-  RNReactNativeGutenbergBridge: 808f8ede2e7f9e56bc8efd35f42e8b64f2e1bdf8
+  RNReactNativeGutenbergBridge: ab5de9ad9b7b056dcbc10bb41b4321f2875ef5e9
   RNSVG: 3c037ade1c42014de732e27e3879bf2b77ea78ea
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6

--- a/WordPress/RN/Gutenberg/GutenbergController.swift
+++ b/WordPress/RN/Gutenberg/GutenbergController.swift
@@ -1,8 +1,10 @@
-
+import CoreServices
 import UIKit
 import React
+import WPMediaPicker
 
 class GutenbergController: UIViewController, PostEditor {
+
     var onClose: ((Bool, Bool) -> Void)?
 
     var isOpenedDirectlyForPhotoPost: Bool = false
@@ -11,6 +13,8 @@ class GutenbergController: UIViewController, PostEditor {
     let gutenberg: Gutenberg
 
     let navBarManager = PostEditorNavigationBarManager()
+
+    var mediaPickerHelper: GutenbergMediaPickerHelper!
 
     var mainContext: NSManagedObjectContext {
         return ContextManager.sharedInstance().mainContext
@@ -33,6 +37,7 @@ class GutenbergController: UIViewController, PostEditor {
         self.gutenberg = Gutenberg(props: ["initialData": post.content ?? ""])
         super.init(nibName: nil, bundle: nil)
 
+        mediaPickerHelper = GutenbergMediaPickerHelper(context: self, post: post)
         navBarManager.delegate = self
     }
 
@@ -98,6 +103,13 @@ extension GutenbergController {
 }
 
 extension GutenbergController: GutenbergBridgeDelegate {
+
+    func gutenbergDidRequestMediaPicker(callback: @escaping MediaPickerDidPickMediaCallback) {
+        mediaPickerHelper.presentMediaPickerFullScreen(animated: true,
+                                                       dataSourceType: .mediaLibrary,
+                                                       callback: callback)
+    }
+
     func gutenbergDidProvideHTML(_ html: String) {
 
     }

--- a/WordPress/RN/Gutenberg/GutenbergController.swift
+++ b/WordPress/RN/Gutenberg/GutenbergController.swift
@@ -1,4 +1,3 @@
-import CoreServices
 import UIKit
 import React
 import WPMediaPicker

--- a/WordPress/RN/Gutenberg/GutenbergController.swift
+++ b/WordPress/RN/Gutenberg/GutenbergController.swift
@@ -13,7 +13,9 @@ class GutenbergController: UIViewController, PostEditor {
 
     let navBarManager = PostEditorNavigationBarManager()
 
-    var mediaPickerHelper: GutenbergMediaPickerHelper!
+    lazy var mediaPickerHelper: GutenbergMediaPickerHelper = {
+        return GutenbergMediaPickerHelper(context: self, post: post)
+    }()
 
     var mainContext: NSManagedObjectContext {
         return ContextManager.sharedInstance().mainContext
@@ -36,7 +38,6 @@ class GutenbergController: UIViewController, PostEditor {
         self.gutenberg = Gutenberg(props: ["initialData": post.content ?? ""])
         super.init(nibName: nil, bundle: nil)
 
-        mediaPickerHelper = GutenbergMediaPickerHelper(context: self, post: post)
         navBarManager.delegate = self
     }
 

--- a/WordPress/RN/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/RN/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -1,0 +1,99 @@
+import Foundation
+import CoreServices
+import WPMediaPicker
+
+
+class GutenbergMediaPickerHelper: NSObject {
+
+    fileprivate struct Constants {
+        static let mediaPickerInsertText = NSLocalizedString(
+            "Insert %@",
+            comment: "Button title used in media picker to insert media (photos / videos) into a post. Placeholder will be the number of items that will be inserted."
+        )
+    }
+
+    fileprivate let post: AbstractPost
+    fileprivate unowned let context: UIViewController
+
+    /// Media Library Data Source
+    ///
+    fileprivate lazy var mediaLibraryDataSource: MediaLibraryPickerDataSource = {
+        return MediaLibraryPickerDataSource(post: self.post)
+    }()
+
+    /// Device Photo Library Data Source
+    ///
+    fileprivate lazy var devicePhotoLibraryDataSource = WPPHAssetDataSource()
+
+    fileprivate lazy var mediaPickerOptions: WPMediaPickerOptions = {
+        let options = WPMediaPickerOptions()
+        options.showMostRecentFirst = true
+        options.filter = [.all]
+        options.allowCaptureOfMedia = false
+        options.showSearchBar = true
+        options.badgedUTTypes = [String(kUTTypeGIF)]
+        options.allowMultipleSelection = false
+        return options
+    }()
+
+    var didPickMediaCallback: MediaPickerDidPickMediaCallback?
+
+    init(context: UIViewController, post: AbstractPost) {
+        self.context = context
+        self.post = post
+    }
+
+    func presentMediaPickerFullScreen(animated: Bool,
+                                      dataSourceType: MediaPickerDataSourceType = .device,
+                                      callback: @escaping MediaPickerDidPickMediaCallback) {
+
+        didPickMediaCallback = callback
+
+        let picker = WPNavigationMediaPickerViewController()
+
+        switch dataSourceType {
+        case .device:
+            picker.dataSource = devicePhotoLibraryDataSource
+        case .mediaLibrary:
+            picker.startOnGroupSelector = false
+            picker.showGroupSelector = false
+            picker.dataSource = mediaLibraryDataSource
+        }
+
+        picker.selectionActionTitle = Constants.mediaPickerInsertText
+        picker.mediaPicker.options = mediaPickerOptions
+        picker.delegate = self
+        picker.modalPresentationStyle = .currentContext
+        context.present(picker, animated: true)
+    }
+}
+
+extension GutenbergMediaPickerHelper: WPMediaPickerViewControllerDelegate {
+
+    func mediaPickerController(_ picker: WPMediaPickerViewController, didFinishPicking assets: [WPMediaAsset]) {
+
+        guard !assets.isEmpty else {
+            return
+        }
+
+        for asset in assets {
+            switch asset {
+            case let media as Media:
+                invokeMediaPickerCallback(url: media.remoteURL)
+            default:
+                continue
+            }
+        }
+        picker.dismiss(animated: true, completion: nil)
+    }
+
+    func mediaPickerControllerDidCancel(_ picker: WPMediaPickerViewController) {
+        invokeMediaPickerCallback(url: nil)
+        picker.dismiss(animated: true, completion: nil)
+    }
+
+    fileprivate func invokeMediaPickerCallback(url: String?) {
+        didPickMediaCallback?(url)
+        didPickMediaCallback = nil
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -692,6 +692,7 @@
 		85DA8C4418F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m in Sources */ = {isa = PBXBuildFile; fileRef = 85DA8C4318F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m */; };
 		85ED988817DFA00000090D0B /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85ED988717DFA00000090D0B /* Images.xcassets */; };
 		85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */; };
+		91D8364121946EFB008340B2 /* GutenbergMediaPickerHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D8364021946EFB008340B2 /* GutenbergMediaPickerHelper.swift */; };
 		930D5C8B1ED3298F00D9A771 /* WordPressComStatsiOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 930D5C8A1ED3298F00D9A771 /* WordPressComStatsiOS.framework */; };
 		930F09171C7D110E00995926 /* ShareExtensionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930F09161C7D110E00995926 /* ShareExtensionService.swift */; };
 		930F09191C7E1C1E00995926 /* ShareExtensionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 930F09161C7D110E00995926 /* ShareExtensionService.swift */; };
@@ -2370,6 +2371,7 @@
 		85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushAuthenticationServiceTests.swift; sourceTree = "<group>"; };
 		8CE5BBD00FF1470AC4B88247 /* Pods_WordPressTodayWidget.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressTodayWidget.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		91D8364021946EFB008340B2 /* GutenbergMediaPickerHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergMediaPickerHelper.swift; sourceTree = "<group>"; };
 		930284B618EAF7B600CB0BF4 /* LocalCoreDataService.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LocalCoreDataService.h; sourceTree = "<group>"; };
 		93069F54176237A4000C966D /* ActivityLogViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ActivityLogViewController.h; sourceTree = "<group>"; };
 		93069F55176237A4000C966D /* ActivityLogViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ActivityLogViewController.m; sourceTree = "<group>"; };
@@ -4833,6 +4835,7 @@
 			isa = PBXGroup;
 			children = (
 				7E3E9B6F2177C9DC00FD5797 /* GutenbergController.swift */,
+				91D8364021946EFB008340B2 /* GutenbergMediaPickerHelper.swift */,
 				7E3E9B6C2177C7BD00FD5797 /* MediaProvider.swift */,
 			);
 			path = Gutenberg;
@@ -8420,6 +8423,7 @@
 				D80BC7A02074722000614A59 /* CameraCaptureCoordinator.swift in Sources */,
 				74729CAE205722E300D1394D /* AbstractPost+Searchable.swift in Sources */,
 				2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */,
+				91D8364121946EFB008340B2 /* GutenbergMediaPickerHelper.swift in Sources */,
 				F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */,
 				591A428C1A6DC1B0003807A6 /* WPBackgroundDimmerView.m in Sources */,
 				74989B8C2088E3650054290B /* BlogDetailsViewController+Activity.swift in Sources */,

--- a/WordPress/WordPressTest/EditorSettingsTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsTests.swift
@@ -10,19 +10,19 @@ class EditorSettingsTests: XCTestCase {
         super.tearDown()
     }
 
-    func testAztecEnabledByDefaultButNotForcedAgain() {
+    func testGutenbergEnabledByDefaultButNotForcedAgain() {
         let testClosure: () -> () = { () in
             let database = EphemeralKeyValueDatabase()
 
             // This simulates the first launch
             let editorSettings = EditorSettings(database: database)
 
-            XCTAssertTrue(editorSettings.isEnabled(.aztec))
+            XCTAssertTrue(editorSettings.isEnabled(.gutenberg))
 
             // This simulates a second launch
             let secondEditorSettings = EditorSettings(database: database)
 
-            XCTAssertTrue(secondEditorSettings.isEnabled(.aztec))
+            XCTAssertTrue(secondEditorSettings.isEnabled(.gutenberg))
         }
 
         BuildConfiguration.localDeveloper.test(testClosure)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/192

This has child PRs so we need to merge them first:
https://github.com/wordpress-mobile/gutenberg-mobile/pull/229 (merged)
https://github.com/WordPress/gutenberg/pull/11635 (merged)
https://github.com/WordPress/gutenberg/pull/11660 (merged)

To test:

- Clone the WordPress-iOs project, checkout branch try/gutenberg-mediapicker.
- git submodule init --update (clone this project as submodule of WPiOS)
- cd Gutenberg -> This project (and not gutenberg-web)
- All the normal steps to make gutenberg-mobile work. (yarn install... yarn start etc...)
- Go to the WPiOS root folder and pod install.
- Build and run the project on XCode.

Test 1:
- Open a post, add an image block
- Tap Media library and select an image
- Verify that the image block is updated as the selected image

Test 2: 
- Open a post, add an image block
- Tap Media library and tap "Cancel"
- Verify that picker is closed
- Tap Media library and select image
- Verify that the image block is updated as the selected image

Test 3:
Please refer to [child PR](https://github.com/WordPress/gutenberg/pull/11660) to find specific test cases related to toolbar.

Test 4:(Testing example app)
There's an example app under: WordPress-iOS/Gutenberg/ios/gutenberg.xcodeproj it should also work ok after this PR. It should be run by "yarn ios"

Open RCTAztecViewManager.m
Update it as 
#import "RNTAztecView-Swift.h"
//#import "WordPress-Swift.h"

- stop metro if that was already running
- cd to WordPress-iOS/Gutenberg
- run yarn start:reset, yarn ios
- Example app opens, tap Media Library on it
- Verify that image block is updated with a landscape image