### PR TITLE
Issues/10432 fix weird transitions

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -188,6 +188,9 @@ class NoticePresenter: NSObject {
     private func animatePresentation(fromState: AnimationBlock, toState: @escaping AnimationBlock, completion: @escaping AnimationBlock) {
         fromState()
 
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .nanoseconds(1)) {
+
+//        /// This causes the nav transition to be wonky
         UIView.animate(withDuration: Animations.appearanceDuration,
                        delay: 0,
                        usingSpringWithDamping: Animations.appearanceSpringDamping,
@@ -197,6 +200,27 @@ class NoticePresenter: NSObject {
                        completion: { _ in
                         completion()
         })
+        }
+//
+//        /// This leaves the nav transition alone
+//        UIViewPropertyAnimator.runningPropertyAnimator(withDuration: Animations.appearanceDuration,
+//                                                            delay: 0,
+//                                                            options: [],
+//                                                            animations: toState) { _ in
+//                                                                completion()
+//        }
+
+        /// This makes the transition wonky again!
+//        let springTimings = UISpringTimingParameters(dampingRatio: Animations.appearanceSpringDamping,
+//                                                     initialVelocity: CGVector(dx: 0, dy: Animations.appearanceSpringVelocity))
+//        let animator = UIViewPropertyAnimator(duration: Animations.appearanceDuration, dampingRatio: 0, animations: nil)
+//        animator.addCompletion { _ in
+//            completion()
+//        }
+//        animator.addAnimations {
+//            toState()
+//        }
+//        animator.startAnimation()
     }
 
     private enum Animations {

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -188,39 +188,18 @@ class NoticePresenter: NSObject {
     private func animatePresentation(fromState: AnimationBlock, toState: @escaping AnimationBlock, completion: @escaping AnimationBlock) {
         fromState()
 
+        // this delay avoids affecting other transitions like navigation pushes
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .nanoseconds(1)) {
-
-//        /// This causes the nav transition to be wonky
-        UIView.animate(withDuration: Animations.appearanceDuration,
-                       delay: 0,
-                       usingSpringWithDamping: Animations.appearanceSpringDamping,
-                       initialSpringVelocity: Animations.appearanceSpringVelocity,
-                       options: [],
-                       animations: toState,
-                       completion: { _ in
-                        completion()
-        })
+            UIView.animate(withDuration: Animations.appearanceDuration,
+                           delay: 0,
+                           usingSpringWithDamping: Animations.appearanceSpringDamping,
+                           initialSpringVelocity: Animations.appearanceSpringVelocity,
+                           options: [],
+                           animations: toState,
+                           completion: { _ in
+                            completion()
+            })
         }
-//
-//        /// This leaves the nav transition alone
-//        UIViewPropertyAnimator.runningPropertyAnimator(withDuration: Animations.appearanceDuration,
-//                                                            delay: 0,
-//                                                            options: [],
-//                                                            animations: toState) { _ in
-//                                                                completion()
-//        }
-
-        /// This makes the transition wonky again!
-//        let springTimings = UISpringTimingParameters(dampingRatio: Animations.appearanceSpringDamping,
-//                                                     initialVelocity: CGVector(dx: 0, dy: Animations.appearanceSpringVelocity))
-//        let animator = UIViewPropertyAnimator(duration: Animations.appearanceDuration, dampingRatio: 0, animations: nil)
-//        animator.addCompletion { _ in
-//            completion()
-//        }
-//        animator.addAnimations {
-//            toState()
-//        }
-//        animator.startAnimation()
     }
 
     private enum Animations {


### PR DESCRIPTION
Fixes #10432

Quick start transitions are no longer weird:

![quick start normal transition](https://user-images.githubusercontent.com/517257/48219371-336d9880-e341-11e8-9009-e180bf5ecb0a.gif)

### To test:
Transitions get weird when a notice animates while the navigation controller changes.
- Create a new wpcom site, say yes to quick start
- Start the theme quick start tour
- Tap the themes item
- Ensure the transition is normal

## Note:
I hate using delays to fix errors, but I couldn't find another way :( 


