### PR TITLE
Gutenberg build for production.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -71,26 +71,13 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'React', path: 'Gutenberg/node_modules/react-native', subspecs: [
-    'Core',
-    'jschelpers',
-    'cxxreact',
-    'CxxBridge',
-    'DevSupport',
-    'RCTText',
-    'RCTImage',
-    'RCTNetwork',
-    'RCTActionSheet',
-    'RCTAnimation',
-    'RCTWebSocket',
-    ]
-
-    pod 'yoga', path: 'Gutenberg/node_modules/react-native/ReactCommon/yoga'
-    pod 'DoubleConversion', :podspec => 'Gutenberg/node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
+    pod 'React', :podspec => 'Podspecs/React.podspec.json'
+    pod 'yoga', :podspec => 'Podspecs/yoga.podspec.json'
     pod 'Folly', :podspec => 'Gutenberg/node_modules/react-native/third-party-podspecs/Folly.podspec'
-    pod 'glog', :podspec => 'Gutenberg/node_modules/react-native/third-party-podspecs/glog.podspec'
-    pod 'RNSVG', :podspec => 'Gutenberg/node_modules/react-native-svg/RNSVG.podspec'
+
     pod 'RNReactNativeGutenbergBridge', :path => 'Gutenberg/react-native-gutenberg-bridge/'
+
+    pod 'RNSVG', :podspec => 'Gutenberg/node_modules/react-native-svg/RNSVG.podspec'
     pod 'RNTAztecView', :path => 'Gutenberg/react-native-aztec/'
 
     ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -30,7 +30,7 @@ PODS:
     - CocoaLumberjack/Default
   - Crashlytics (3.10.8):
     - Fabric (~> 1.7.12)
-  - DoubleConversion (1.1.6)
+  - DoubleConversion (1.1.5)
   - Fabric (1.7.13)
   - Folly (2016.10.31.00):
     - boost-for-react-native
@@ -41,7 +41,7 @@ PODS:
     - FormatterKit/Resources
   - Gifu (3.1.0)
   - GiphyCoreSDK (1.4.0)
-  - glog (0.3.5)
+  - glog (0.3.4)
   - GoogleSignInRepacked (4.1.2):
     - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
     - "GoogleToolboxForMac/NSString+URLArguments (~> 2.1)"
@@ -120,10 +120,6 @@ PODS:
     - Folly (= 2016.10.31.00)
     - React/jschelpers
     - React/jsinspector
-  - React/DevSupport (0.57.1):
-    - React/Core
-    - React/RCTWebSocket
-  - React/fishhook (0.57.1)
   - React/jschelpers (0.57.1):
     - Folly (= 2016.10.31.00)
     - React/PrivateDatabase
@@ -133,21 +129,25 @@ PODS:
     - React/Core
   - React/RCTAnimation (0.57.1):
     - React/Core
-  - React/RCTBlob (0.57.1):
-    - React/Core
   - React/RCTImage (0.57.1):
     - React/Core
     - React/RCTNetwork
+  - React/RCTLinkingIOS (0.57.1):
+    - React/Core
   - React/RCTNetwork (0.57.1):
     - React/Core
   - React/RCTText (0.57.1):
     - React/Core
-  - React/RCTWebSocket (0.57.1):
-    - React/Core
-    - React/fishhook
-    - React/RCTBlob
   - RNReactNativeGutenbergBridge (0.1.0):
-    - React
+    - React/Core (= 0.57.1)
+    - React/CxxBridge (= 0.57.1)
+    - React/RCTActionSheet (= 0.57.1)
+    - React/RCTAnimation (= 0.57.1)
+    - React/RCTImage (= 0.57.1)
+    - React/RCTLinkingIOS (= 0.57.1)
+    - React/RCTNetwork (= 0.57.1)
+    - React/RCTText (= 0.57.1)
+    - yoga (= 0.57.1.React)
   - RNSVG (6.5.2):
     - React
   - RNTAztecView (0.0.2):
@@ -205,12 +205,10 @@ DEPENDENCIES:
   - BuddyBuildSDK (= 1.0.17)
   - CocoaLumberjack (= 3.4.2)
   - Crashlytics (= 3.10.8)
-  - DoubleConversion (from `Gutenberg/node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - Folly (from `Gutenberg/node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - Gifu (= 3.1.0)
   - GiphyCoreSDK (~> 1.4.0)
-  - glog (from `Gutenberg/node_modules/react-native/third-party-podspecs/glog.podspec`)
   - Gridicons (= 0.16)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
@@ -223,17 +221,7 @@ DEPENDENCIES:
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - Reachability (= 3.2)
-  - React/Core (from `Gutenberg/node_modules/react-native`)
-  - React/CxxBridge (from `Gutenberg/node_modules/react-native`)
-  - React/cxxreact (from `Gutenberg/node_modules/react-native`)
-  - React/DevSupport (from `Gutenberg/node_modules/react-native`)
-  - React/jschelpers (from `Gutenberg/node_modules/react-native`)
-  - React/RCTActionSheet (from `Gutenberg/node_modules/react-native`)
-  - React/RCTAnimation (from `Gutenberg/node_modules/react-native`)
-  - React/RCTImage (from `Gutenberg/node_modules/react-native`)
-  - React/RCTNetwork (from `Gutenberg/node_modules/react-native`)
-  - React/RCTText (from `Gutenberg/node_modules/react-native`)
-  - React/RCTWebSocket (from `Gutenberg/node_modules/react-native`)
+  - React (from `Podspecs/React.podspec.json`)
   - RNReactNativeGutenbergBridge (from `Gutenberg/react-native-gutenberg-bridge/`)
   - RNSVG (from `Gutenberg/node_modules/react-native-svg/RNSVG.podspec`)
   - RNTAztecView (from `Gutenberg/react-native-aztec/`)
@@ -247,7 +235,7 @@ DEPENDENCIES:
   - WordPressUI (= 1.0.8)
   - WPMediaPicker (= 1.3.1)
   - wpxmlrpc (= 0.8.3)
-  - yoga (from `Gutenberg/node_modules/react-native/ReactCommon/yoga`)
+  - yoga (from `Podspecs/yoga.podspec.json`)
   - ZendeskSDK (= 2.2.0)
 
 SPEC REPOS:
@@ -259,10 +247,12 @@ SPEC REPOS:
     - BuddyBuildSDK
     - CocoaLumberjack
     - Crashlytics
+    - DoubleConversion
     - Fabric
     - FormatterKit
     - Gifu
     - GiphyCoreSDK
+    - glog
     - GoogleSignInRepacked
     - GoogleToolboxForMac
     - Gridicons
@@ -293,14 +283,10 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  DoubleConversion:
-    :podspec: Gutenberg/node_modules/react-native/third-party-podspecs/DoubleConversion.podspec
   Folly:
     :podspec: Gutenberg/node_modules/react-native/third-party-podspecs/Folly.podspec
-  glog:
-    :podspec: Gutenberg/node_modules/react-native/third-party-podspecs/glog.podspec
   React:
-    :path: Gutenberg/node_modules/react-native
+    :podspec: Podspecs/React.podspec.json
   RNReactNativeGutenbergBridge:
     :path: Gutenberg/react-native-gutenberg-bridge/
   RNSVG:
@@ -308,7 +294,7 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :path: Gutenberg/react-native-aztec/
   yoga:
-    :path: Gutenberg/node_modules/react-native/ReactCommon/yoga
+    :podspec: Podspecs/yoga.podspec.json
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
@@ -324,13 +310,13 @@ SPEC CHECKSUMS:
   BuddyBuildSDK: 8ae12ee721098b356a961ea7dce70ae55f93a7d2
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   Crashlytics: 058dc1ba579f6c100bc60a6878703779bff383c4
-  DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
+  DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   Fabric: 25d0963b691fc97be566392243ff0ecef5a68338
   Folly: c89ac2d5c6ab169cd7397ef27485c44f35f742c7
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   Gifu: fd1e9e3a15ac5d90bae0a510e4ed9f94b485ab03
   GiphyCoreSDK: 1fe401c5fc65f182e7aa8b7fb2c9005f2a523374
-  glog: e8acf0ebbf99759d3ff18c86c292a5898282dcde
+  glog: 1de0bb937dccdc981596d3b5825ebfb765017ded
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
   Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
@@ -344,9 +330,9 @@ SPEC CHECKSUMS:
   OCMock: ebe9ee1dca7fbed0ff9193ac0b3e2d8862ea56f6
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
-  React: 1fe0eb13d90b625d94c3b117c274dcfd2e760e11
-  RNReactNativeGutenbergBridge: 808f8ede2e7f9e56bc8efd35f42e8b64f2e1bdf8
-  RNSVG: 3c037ade1c42014de732e27e3879bf2b77ea78ea
+  React: b4e0982b0ed6a7de90e96cf6fe5cf036aeadd1ec
+  RNReactNativeGutenbergBridge: ab5de9ad9b7b056dcbc10bb41b4321f2875ef5e9
+  RNSVG: ef9440cbb099244d050620297ff1358da8d037d1
   RNTAztecView: e7134bf19a4ad5cedf4093477c0f0da8ddcfdb9d
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
@@ -359,9 +345,9 @@ SPEC CHECKSUMS:
   WordPressUI: e50965adee24b4f10da398f6cdbdd3a822274158
   WPMediaPicker: ea92f84950843c7baf6a7325caed72ad7852418d
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
-  yoga: b1ce48b6cf950b98deae82838f5173ea7cf89e85
+  yoga: 833ba47f05b90adf77b2941ee6eef250a90cc39c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: ac6de63e2d9b3255987fb704d93016f466954b8b
+PODFILE CHECKSUM: e032ecb0eba5f3516b11ce8397b4e0ddb0160c75
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -120,6 +120,10 @@ PODS:
     - Folly (= 2016.10.31.00)
     - React/jschelpers
     - React/jsinspector
+  - React/DevSupport (0.57.1):
+    - React/Core
+    - React/RCTWebSocket
+  - React/fishhook (0.57.1)
   - React/jschelpers (0.57.1):
     - Folly (= 2016.10.31.00)
     - React/PrivateDatabase
@@ -128,6 +132,8 @@ PODS:
   - React/RCTActionSheet (0.57.1):
     - React/Core
   - React/RCTAnimation (0.57.1):
+    - React/Core
+  - React/RCTBlob (0.57.1):
     - React/Core
   - React/RCTImage (0.57.1):
     - React/Core
@@ -138,9 +144,14 @@ PODS:
     - React/Core
   - React/RCTText (0.57.1):
     - React/Core
+  - React/RCTWebSocket (0.57.1):
+    - React/Core
+    - React/fishhook
+    - React/RCTBlob
   - RNReactNativeGutenbergBridge (0.1.0):
     - React/Core (= 0.57.1)
     - React/CxxBridge (= 0.57.1)
+    - React/DevSupport (= 0.57.1)
     - React/RCTActionSheet (= 0.57.1)
     - React/RCTAnimation (= 0.57.1)
     - React/RCTImage (= 0.57.1)
@@ -331,8 +342,8 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   React: b4e0982b0ed6a7de90e96cf6fe5cf036aeadd1ec
-  RNReactNativeGutenbergBridge: ab5de9ad9b7b056dcbc10bb41b4321f2875ef5e9
-  RNSVG: ef9440cbb099244d050620297ff1358da8d037d1
+  RNReactNativeGutenbergBridge: 665447f21909219f6acdc2c429e5a3f9a592c4d3
+  RNSVG: 3c037ade1c42014de732e27e3879bf2b77ea78ea
   RNTAztecView: e7134bf19a4ad5cedf4093477c0f0da8ddcfdb9d
   Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6

--- a/Podspecs/React.podspec.json
+++ b/Podspecs/React.podspec.json
@@ -1,0 +1,528 @@
+{
+  "name": "React",
+  "version": "0.57.1",
+  "summary": "A framework for building native apps using React",
+  "description": "React Native apps are built using the React JS\nframework, and render directly to native UIKit\nelements using a fully asynchronous architecture.\nThere is no browser and no HTML. We have picked what\nwe think is the best set of features from these and\nother technologies to build what we hope to become\nthe best product development framework available,\nwith an emphasis on iteration speed, developer\ndelight, continuity of technology, and absolutely\nbeautiful and fast products with no compromises in\nquality or capability.",
+  "homepage": "http://facebook.github.io/react-native/",
+  "license": "MIT",
+  "authors": "Facebook",
+  "source": {
+    "git": "https://github.com/facebook/react-native.git",
+    "tag": "v0.57.1"
+  },
+  "default_subspecs": "Core",
+  "requires_arc": true,
+  "platforms": {
+    "ios": "9.0",
+    "tvos": "9.2"
+  },
+  "pod_target_xcconfig": {
+    "CLANG_CXX_LANGUAGE_STANDARD": "c++14"
+  },
+  "preserve_paths": [
+    "package.json",
+    "LICENSE",
+    "LICENSE-docs"
+  ],
+  "cocoapods_version": ">= 1.2.0",
+  "subspecs": [
+    {
+      "name": "Core",
+      "dependencies": {
+        "yoga": [
+          "0.57.1.React"
+        ]
+      },
+      "source_files": "React/**/*.{c,h,m,mm,S,cpp}",
+      "exclude_files": [
+        "**/__tests__/*",
+        "IntegrationTests/*",
+        "React/DevSupport/*",
+        "React/Inspector/*",
+        "ReactCommon/yoga/*",
+        "React/Cxx*/*",
+        "React/Fabric/**/*"
+      ],
+      "ios": {
+        "exclude_files": "React/**/RCTTV*.*"
+      },
+      "tvos": {
+        "exclude_files": [
+          "React/Modules/RCTClipboard*",
+          "React/Views/RCTDatePicker*",
+          "React/Views/RCTPicker*",
+          "React/Views/RCTRefreshControl*",
+          "React/Views/RCTSlider*",
+          "React/Views/RCTSwitch*",
+          "React/Views/RCTWebView*"
+        ]
+      },
+      "header_dir": "React",
+      "frameworks": "JavaScriptCore",
+      "libraries": "stdc++",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\""
+      }
+    },
+    {
+      "name": "CxxBridge",
+      "dependencies": {
+        "Folly": [
+          "2016.10.31.00"
+        ],
+        "React/Core": [
+
+        ],
+        "React/cxxreact": [
+
+        ]
+      },
+      "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+      "private_header_files": "React/Cxx*/*.h",
+      "source_files": "React/Cxx*/*.{h,m,mm}"
+    },
+    {
+      "name": "DevSupport",
+      "dependencies": {
+        "React/Core": [
+
+        ],
+        "React/RCTWebSocket": [
+
+        ]
+      },
+      "source_files": [
+        "React/DevSupport/*",
+        "React/Inspector/*"
+      ]
+    },
+    {
+      "name": "RCTFabric",
+      "dependencies": {
+        "Folly": [
+          "2016.10.31.00"
+        ],
+        "React/Core": [
+
+        ],
+        "React/fabric": [
+
+        ]
+      },
+      "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+      "source_files": "React/Fabric/**/*.{c,h,m,mm,S,cpp}",
+      "exclude_files": "**/tests/*",
+      "header_dir": "React",
+      "frameworks": "JavaScriptCore",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\""
+      }
+    },
+    {
+      "name": "tvOS",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "React/**/RCTTV*.{h,m}"
+    },
+    {
+      "name": "jschelpers",
+      "dependencies": {
+        "Folly": [
+          "2016.10.31.00"
+        ],
+        "React/PrivateDatabase": [
+
+        ]
+      },
+      "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+      "source_files": "ReactCommon/jschelpers/*.{cpp,h}",
+      "private_header_files": "ReactCommon/jschelpers/*.h",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\""
+      },
+      "frameworks": "JavaScriptCore"
+    },
+    {
+      "name": "jsinspector",
+      "source_files": "ReactCommon/jsinspector/*.{cpp,h}",
+      "private_header_files": "ReactCommon/jsinspector/*.h",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\""
+      }
+    },
+    {
+      "name": "PrivateDatabase",
+      "source_files": "ReactCommon/privatedata/*.{cpp,h}",
+      "private_header_files": "ReactCommon/privatedata/*.h",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\""
+      }
+    },
+    {
+      "name": "cxxreact",
+      "dependencies": {
+        "React/jschelpers": [
+
+        ],
+        "React/jsinspector": [
+
+        ],
+        "boost-for-react-native": [
+          "1.63.0"
+        ],
+        "Folly": [
+          "2016.10.31.00"
+        ]
+      },
+      "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+      "source_files": "ReactCommon/cxxreact/*.{cpp,h}",
+      "exclude_files": "ReactCommon/cxxreact/SampleCxxModule.*",
+      "private_header_files": "ReactCommon/cxxreact/*.h",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/boost-for-react-native\" \"$(PODS_ROOT)/DoubleConversion\" \"$(PODS_ROOT)/Folly\""
+      }
+    },
+    {
+      "name": "fabric",
+      "subspecs": [
+        {
+          "name": "activityindicator",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/activityindicator/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/activityindicator",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "attributedstring",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/attributedstring/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/attributedstring",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "core",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/core/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/core",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "debug",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/debug/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/debug",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "graphics",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/graphics/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/graphics",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "scrollview",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/scrollview/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/scrollview",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "text",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/text/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/text",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "textlayoutmanager",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/textlayoutmanager/**/*.{cpp,h,mm}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/textlayoutmanager",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "uimanager",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/uimanager/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/uimanager",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        },
+        {
+          "name": "view",
+          "dependencies": {
+            "Folly": [
+              "2016.10.31.00"
+            ],
+            "yoga": [
+
+            ]
+          },
+          "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+          "source_files": "ReactCommon/fabric/view/**/*.{cpp,h}",
+          "exclude_files": "**/tests/*",
+          "header_dir": "fabric/view",
+          "pod_target_xcconfig": {
+            "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+          }
+        }
+      ]
+    },
+    {
+      "name": "RCTFabricSample",
+      "dependencies": {
+        "Folly": [
+          "2016.10.31.00"
+        ]
+      },
+      "compiler_flags": "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
+      "source_files": "ReactCommon/fabric/sample/**/*.{cpp,h}",
+      "exclude_files": "**/tests/*",
+      "header_dir": "fabric/sample",
+      "pod_target_xcconfig": {
+        "HEADER_SEARCH_PATHS": "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_ROOT)/Folly\""
+      }
+    },
+    {
+      "name": "ART",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/ART/**/*.{h,m}"
+    },
+    {
+      "name": "RCTActionSheet",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/ActionSheetIOS/*.{h,m}"
+    },
+    {
+      "name": "RCTAnimation",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/NativeAnimation/{Drivers/*,Nodes/*,*}.{h,m}",
+      "header_dir": "RCTAnimation"
+    },
+    {
+      "name": "RCTBlob",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/Blob/*.{h,m,mm}",
+      "preserve_paths": "Libraries/Blob/*.js"
+    },
+    {
+      "name": "RCTCameraRoll",
+      "dependencies": {
+        "React/Core": [
+
+        ],
+        "React/RCTImage": [
+
+        ]
+      },
+      "source_files": "Libraries/CameraRoll/*.{h,m}"
+    },
+    {
+      "name": "RCTGeolocation",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/Geolocation/*.{h,m}"
+    },
+    {
+      "name": "RCTImage",
+      "dependencies": {
+        "React/Core": [
+
+        ],
+        "React/RCTNetwork": [
+
+        ]
+      },
+      "source_files": "Libraries/Image/*.{h,m}"
+    },
+    {
+      "name": "RCTNetwork",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/Network/*.{h,m,mm}"
+    },
+    {
+      "name": "RCTPushNotification",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/PushNotificationIOS/*.{h,m}"
+    },
+    {
+      "name": "RCTSettings",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/Settings/*.{h,m}"
+    },
+    {
+      "name": "RCTText",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/Text/**/*.{h,m}"
+    },
+    {
+      "name": "RCTVibration",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/Vibration/*.{h,m}"
+    },
+    {
+      "name": "RCTWebSocket",
+      "dependencies": {
+        "React/Core": [
+
+        ],
+        "React/RCTBlob": [
+
+        ],
+        "React/fishhook": [
+
+        ]
+      },
+      "source_files": "Libraries/WebSocket/*.{h,m}"
+    },
+    {
+      "name": "fishhook",
+      "header_dir": "fishhook",
+      "source_files": "Libraries/fishhook/*.{h,c}"
+    },
+    {
+      "name": "RCTLinkingIOS",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/LinkingIOS/*.{h,m}"
+    },
+    {
+      "name": "RCTTest",
+      "dependencies": {
+        "React/Core": [
+
+        ]
+      },
+      "source_files": "Libraries/RCTTest/**/*.{h,m}",
+      "frameworks": "XCTest"
+    },
+    {
+      "name": "_ignore_me_subspec_for_linting_",
+      "dependencies": {
+        "React/Core": [
+
+        ],
+        "React/CxxBridge": [
+
+        ]
+      }
+    }
+  ]
+}

--- a/Podspecs/yoga.podspec.json
+++ b/Podspecs/yoga.podspec.json
@@ -1,0 +1,32 @@
+{
+  "name": "yoga",
+  "version": "0.57.1.React",
+  "license": {
+    "type": "MIT"
+  },
+  "homepage": "https://facebook.github.io/yoga/",
+  "documentation_url": "https://facebook.github.io/yoga/docs/api/c/",
+  "summary": "Yoga is a cross-platform layout engine which implements Flexbox.",
+  "description": "Yoga is a cross-platform layout engine enabling maximum collaboration within your team by implementing an API many designers are familiar with, and opening it up to developers across different platforms.",
+  "authors": "Facebook",
+  "source": {
+    "git": "https://github.com/facebook/react-native.git",
+    "tag": "v0.57.1"
+  },
+  "module_name": "yoga",
+  "requires_arc": false,
+  "compiler_flags": [
+    "-fno-omit-frame-pointer",
+    "-fexceptions",
+    "-Wall",
+    "-Werror",
+    "-std=c++1y",
+    "-fPIC"
+  ],
+  "platforms": {
+    "ios": "9.0",
+    "tvos": "9.2"
+  },
+  "source_files": "ReactCommon/yoga/yoga/*.{cpp,h}",
+  "public_header_files": "ReactCommon/yoga/yoga/{Yoga,YGEnums,YGMacros}.h"
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3839,7 +3839,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				7E3E9B5F2177A44400FD5797 /* RN */,
@@ -7150,6 +7150,7 @@
 				37399571B0D91BBEAE911024 /* [CP] Embed Pods Frameworks */,
 				920B9A6DAD47189622A86A9C /* [CP] Copy Pods Resources */,
 				9879533A2135D77500743763 /* Zendesk Strip Frameworks */,
+				7E539760219A372B006C74CE /* Bundle Gutenberg for production */,
 			);
 			buildRules = (
 			);
@@ -7486,7 +7487,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -7921,6 +7922,24 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		7E539760219A372B006C74CE /* Bundle Gutenberg for production */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle Gutenberg for production";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export NODE_BINARY=node\n../Gutenberg/node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 		825F0EBF1F7EBF7C00321528 /* App Icons: Add Version For Internal Releases */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3841,7 +3841,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
+		29B97314FDCFA39411CA2CEA = {
 			isa = PBXGroup;
 			children = (
 				7E3E9B5F2177A44400FD5797 /* RN */,
@@ -7490,7 +7490,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
+			mainGroup = 29B97314FDCFA39411CA2CEA;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";


### PR DESCRIPTION
This PR implement the changes from https://github.com/wordpress-mobile/gutenberg-mobile/pull/231

We also add the default ReactNative script to build a release app.
This works automagically bundling the Gutenberg app in WPiOS when building for Release, so Metro is not needed. 
(cc @hypest )

**To test CocoaPods:**
- Checkout this branch.
- Clean build folder/derived data/Pods folder.
- Run `pod install`.
- ☝️should succeed.
- Run metro (`cd Gutenberg && yarn install && yarn start`)
- Run the iOS App.
- Check that Gutenberg load from the Metro server. (With the green top loading bar)
- Check that `cmd + R` and `cmd + D` work as expected.

**Test Release build:**
- Be sure that Metro is **not** running.
- Edit the WordPress scheme in Xcode:
  - In the `Run` section -> Build Configuration: Release.
- Run WPiOS (in the simulator is fine).
- Open Gutenberg instance.
- Check that Gutenberg loads and it doesn't show the top loading bar.
- Check that `cmd + R` and `cmd + D` **does not** work.