### PR TITLE
Reader:  Refactor to scan nested tags.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
@@ -194,11 +194,33 @@ class WPRichTextFormatter {
     ///
     func processAndExtractTags(_ string: String) -> ParsedSource {
         var attachments = [WPTextAttachment]()
+        var processedString = string
 
         guard string.count > 0 else {
-            return (string, attachments)
+            return (processedString, attachments)
         }
 
+        for tag in tags {
+            // process string for each tag processor
+            let (str, attchs) = processString(processedString, forTag: tag)
+            processedString = str
+            attachments.append(contentsOf: attchs)
+        }
+
+        return (processedString, attachments)
+    }
+
+
+    /// Processes the supplied string, scanning for and handling the specified tag.
+    ///
+    /// - Parameters:
+    ///     - string: The string to process.
+    ///     - tag: An HtmlTagProcessor.
+    ///
+    /// - Returns: An instance of ParsedSource containing the modified string and any attachments.
+    ///
+    func processString(_ string: String, forTag tag:HtmlTagProcessor ) -> ParsedSource {
+        var attachments = [WPTextAttachment]()
         var processedString = ""
         let scanner = Scanner(string: string)
         scanner.charactersToBeSkipped = nil
@@ -229,8 +251,7 @@ class WPRichTextFormatter {
             scanner.scanLocation = tagStartLocation
 
             // Process tags of interest.
-            if let tagName = tagName,
-                let tag = processorForTagName(tagName as String) {
+            if tag.tagName == tagName as String? {
 
                 let (string, attachment) = tag.process(scanner)
                 processedString += string
@@ -247,7 +268,6 @@ class WPRichTextFormatter {
                 scanner.scanLocation += 1
             }
         }
-
         return (processedString, attachments)
     }
 


### PR DESCRIPTION
This tweaks the way tags are scanned.  Rather than scanning once and handling tags as they are found this runs a scanner per tag.  This ensures that nested tags are not ignored by scanning ahead to find the closing tag of a container element.

This will improve the way Gutenberg galleries are handled -- images should be correctly sized -- but more work is needed to remove the list bullets and to choose the best image to show.

Fixes #10245 
Refs #10206

To test:
View a post with images nested inside a list and confirm the images are correctly rendered.  You can use p77Llu-b9T-p2 as a test post.  
Confirm no other reader text formatting is disrupted. Browse a variety of posts and look for anything amiss.

Heya @etoledom, would you mind reviewing this one? 