### PR TITLE
Fix crash on launch when app is offline.

### DIFF
--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -48,7 +48,7 @@ struct PlanService<S: InAppPurchaseStore> {
                                                       forSite: siteID,
                                                       hasDomainCredit: plans.activePlan.hasDomainCredit ?? false)
             },
-            failure: failure)
+            failure: { _ in })
         }
     }
 


### PR DESCRIPTION
This fixes a crash on launch that was happening when the app was offline (or had network connectivity problems, w/e).

It was caused by the fact that the `failure` block of 
```swift 
func plansWithPricesForBlog(_ siteID: Int, success: @escaping (SitePricedPlans) -> Void, failure: @escaping (Error) -> Void) {
```
(in `PlanService.swift`)

could have been called multiple times. Re-entrant completion blocks, are bad, actually! We were using `DispatchGroup` elsewhere in the app to synchronize mutlitple callbacks and this was causing us to call `dispatch_group_leave()` on an already-empty group, leading to crash.

This gets rid of the `failure` block being called for the `1.3` endpoint.

To test: 
1. Build latest develop, open the app when offline. Observe crash.
2. Build this PR, open the app and verify it doesn't crash anymore.


@nheagy I _believe_ I've seen you mention something yesterday on Slack about observing this crash — would you be so kind to look at this?

