### PR TITLE
Bump cocoapods-repo-update to 0.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org' do
   gem 'rake'
   gem 'cocoapods', '1.5.3'
-  gem 'cocoapods-repo-update', '~> 0.0.2'
+  gem 'cocoapods-repo-update', '~> 0.0.3'
   gem 'xcpretty-travis-formatter'
   gem 'danger'
   gem 'danger-swiftlint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
     cocoapods-downloader (1.2.1)
     cocoapods-plugins (1.0.0)
       nap
-    cocoapods-repo-update (0.0.2)
+    cocoapods-repo-update (0.0.3)
       cocoapods (~> 1.0, >= 1.3.0)
     cocoapods-search (1.0.0)
     cocoapods-stats (1.0.0)
@@ -239,7 +239,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.5.3)!
-  cocoapods-repo-update (~> 0.0.2)!
+  cocoapods-repo-update (~> 0.0.3)!
   danger!
   danger-swiftlint!
   dotenv!


### PR DESCRIPTION
The CocoaPods plugin I introduced the other day has so far been working smoothly 😅 

However, @jklausa brought a case to my attention where CocoaPods could fail with a different error so the plugin didn't know that specs should be updated. This is a BuddyBuild log showing the error: https://dashboard.buddybuild.com/public/apps/57a120bbe0f5520100e11c19/build/5bee1e28a51a800001f4e852#logs.

Note how it fails with `CocoaPods could not find compatible versions for pod "WordPressKit"` rather than the error we usually see (something like `CocoaPods could not find compatible versions for pod "WordPressKit"`).

I have added support for this type of error in `0.0.3` of `cocoapods-repo-update`. Here's the diff in the plugin: https://github.com/wordpress-mobile/cocoapods-repo-update/compare/0.0.2...0.0.3

To test:

 - `bundle exec pod install` should still work as expected.
