### PR TITLE
Change the feature flag of custom domains to relase it to everyone.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -21,7 +21,7 @@ enum FeatureFlag: Int {
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .automatedTransfersCustomDomain:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .quickStart:
             return true
         case .newsCard:


### PR DESCRIPTION
What it says in the title.

To test:
Look at the code, verify that it looks correct

To test if you‘re an overachiever:
Build a „Release“ build of the app
Have a Biz site with a free domain credit (and no custom domain associated)
Go to Plugins on that site
Verify that the popup prompting you to set a custom domain shows up