### PR TITLE
[Site creation] Hide title and subtitle in headers when selecting the search textfield

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/TitleSubtitleTextfieldHeader.swift
@@ -2,6 +2,13 @@ import UIKit
 import Gridicons
 
 final class TitleSubtitleTextfieldHeader: UIView {
+    private struct Animation {
+        static let duration: TimeInterval = 0.40
+        static let delay: TimeInterval = 0.0
+        static let damping: CGFloat = 0.9
+        static let spring: CGFloat = 1.0
+    }
+
     private lazy var titleSubtitle: TitleSubtitleHeader = {
         let returnValue = TitleSubtitleHeader(frame: .zero)
         returnValue.translatesAutoresizingMaskIntoConstraints = false
@@ -14,6 +21,8 @@ final class TitleSubtitleTextfieldHeader: UIView {
         returnValue.translatesAutoresizingMaskIntoConstraints = false
         returnValue.leftViewMode = .always
         returnValue.backgroundColor = .white
+
+        returnValue.delegate = self
 
         let loupeIcon = Gridicon.iconOfType(.search)
         let imageView = UIImageView(image: loupeIcon)
@@ -65,5 +74,36 @@ final class TitleSubtitleTextfieldHeader: UIView {
 
     func setSubtitle(_ text: String) {
         titleSubtitle.setSubtitle(text)
+    }
+
+    func hideTitleSubtitle() {
+        updateTitleSubtitle(visibility: true)
+    }
+
+    func showTitleSubtitle() {
+        updateTitleSubtitle(visibility: false)
+    }
+
+    private func updateTitleSubtitle(visibility: Bool) {
+        //stackView.arrangedSubviews.first?.isHidden = visibility
+
+        UIView.animate(withDuration: Animation.duration,
+                       delay: Animation.delay,
+                       usingSpringWithDamping: Animation.damping,
+                       initialSpringVelocity: Animation.spring,
+                       options: [],
+                       animations: { [weak self] in
+                            self?.stackView.arrangedSubviews.first?.isHidden = visibility
+        }, completion: nil)
+    }
+}
+
+extension TitleSubtitleTextfieldHeader: UITextFieldDelegate {
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        hideTitleSubtitle()
+    }
+
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        showTitleSubtitle()
     }
 }


### PR DESCRIPTION
Implements #10485 

I am not completely sure this is the behaviour we might want, but this is how this PR implements it:

![hide_headers mov](https://user-images.githubusercontent.com/2722505/48751709-cfdc5700-ecc0-11e8-9eb7-6a49eacc9116.gif)

To test:
- Check out the branch
- Navigate to My Sites > + > Site creation 
- Type in any of the search fields, the title and subtitle should collapse