### PR TITLE
Enable Gutenberg depending on feature flag

### DIFF
--- a/WordPress/Classes/Services/EditorSettings.swift
+++ b/WordPress/Classes/Services/EditorSettings.swift
@@ -54,7 +54,7 @@ class EditorSettings: NSObject {
     // MARK: Public accessors
 
     private var current: Editor {
-        return .gutenberg
+        return Feature.enabled(.gutenberg) ? .gutenberg : .aztec
     }
 
     @objc func isEnabled(_ editor: Editor) -> Bool {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -12,6 +12,7 @@ enum FeatureFlag: Int {
     case revisions
     case statsRefresh
     case bottomSheetDemo
+    case gutenberg
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -36,6 +37,8 @@ enum FeatureFlag: Int {
             return BuildConfiguration.current == .localDeveloper
         case .bottomSheetDemo:
             return BuildConfiguration.current == .localDeveloper
+        case .gutenberg:
+            return BuildConfiguration.current == .localDeveloper && CommandLine.arguments.contains("-gutenberg")
         }
     }
 }

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -161,6 +161,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-gutenberg"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-debugJetpackConnectionFlow"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -53,6 +53,9 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "EditorSettingsTests/testGutenbergEnabledByDefaultButNotForcedAgain()">
+               </Test>
+               <Test
                   Identifier = "RemoteTestCase">
                </Test>
             </SkippedTests>


### PR DESCRIPTION
Only show Gutenberg as the editor if the -gutenberg argument is passed on launch.

To do this, you can edit the WordPress scheme, go to the Arguments tab in Run, and check the `-gutenberg` box or not.

<img width="896" alt="screen shot 2018-11-20 at 16 27 58" src="https://user-images.githubusercontent.com/8739/48783705-5739c280-ece1-11e8-93cf-fff2c45b5c8c.png">

It's not the ideal workflow, but this will do until we have https://github.com/wordpress-mobile/gutenberg-mobile/issues/222 in place