### PR TITLE
[Stats Refresh] Update card header

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -41,8 +41,8 @@ extension WPStyleGuide {
         }
 
         static func configureLabelAsHeader(_ label: UILabel) {
-            label.textColor = defaultTextColor
-            label.font = headerFont
+            label.textColor = headerTextColor
+            label.text = label.text?.localizedUppercase
         }
 
         static func configureLabelAsSummary(_ label: UILabel) {
@@ -100,13 +100,13 @@ extension WPStyleGuide {
         // MARK: - Style Values
 
         static let defaultTextColor = WPStyleGuide.darkGrey()
+        static let headerTextColor = WPStyleGuide.greyDarken20()
         static let secondaryTextColor = WPStyleGuide.grey()
         static let itemDetailTextColor = WPStyleGuide.greyDarken10()
         static let actionTextColor = WPStyleGuide.wordPressBlue()
         static let summaryTextColor = WPStyleGuide.darkGrey()
         static let substringHighlightTextColor = WPStyleGuide.wordPressBlue()
 
-        static let headerFont = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
         static let subTitleFont = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .medium)
         static let summaryFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         static let substringHighlightFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -31,11 +31,6 @@ extension WPStyleGuide {
             cell.contentView.backgroundColor = cellBackgroundColor
         }
 
-        static func configureBorderForView(_ borderedView: UIView) {
-            borderedView.layer.borderColor = cellBorderColor
-            borderedView.layer.borderWidth = cellBorderWidth
-        }
-
         static func configureViewAsSeperator(_ seperatorView: UIView) {
             seperatorView.backgroundColor = seperatorColor
         }
@@ -112,9 +107,7 @@ extension WPStyleGuide {
         static let substringHighlightFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
 
         static let tableBackgroundColor = WPStyleGuide.greyLighten30()
-        static let cellBackgroundColor = WPStyleGuide.greyLighten30()
-        static let cellBorderColor = WPStyleGuide.greyLighten20().cgColor
-        static let cellBorderWidth = CGFloat(0.5)
+        static let cellBackgroundColor = UIColor.white
         static let seperatorColor = WPStyleGuide.greyLighten20()
 
         static let filterTintColor = WPStyleGuide.wordPressBlue()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/LatestPostSummaryCell.swift
@@ -2,12 +2,11 @@ import UIKit
 import WordPressComStatsiOS
 import Gridicons
 
-class LatestPostSummaryCell: UITableViewCell {
+class LatestPostSummaryCell: UITableViewCell, NibLoadable {
 
     // MARK: - Properties
 
     @IBOutlet weak var borderedView: UIView!
-    @IBOutlet weak var headerStackView: UIStackView!
     @IBOutlet weak var summaryLabel: UILabel!
 
     @IBOutlet weak var contentStackViewTopConstraint: NSLayoutConstraint!
@@ -40,7 +39,6 @@ class LatestPostSummaryCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        addHeader()
         applyStyles()
     }
 
@@ -74,12 +72,6 @@ class LatestPostSummaryCell: UITableViewCell {
 // MARK: - Private Extension
 
 private extension LatestPostSummaryCell {
-
-    func addHeader() {
-        let header = StatsCellHeader.loadFromNib()
-        header.headerLabel.text = CellStrings.header
-        headerStackView.addArrangedSubview(header)
-    }
 
     func applyStyles() {
 
@@ -173,7 +165,6 @@ private extension LatestPostSummaryCell {
     }
 
     struct CellStrings {
-        static let header = NSLocalizedString("Latest Post Summary", comment: "Insights latest post summary header")
         static let summaryPostInfo = NSLocalizedString("It's been %@ since %@ was published. ", comment: "Latest post summary text including placeholder for time and the post title.")
         static let summaryPerformance = NSLocalizedString("Here's how the post performed so far.", comment: "Appended to latest post summary text when the post has data.")
         static let summaryNoData = NSLocalizedString("Get the ball rolling and increase your post views by sharing your post.", comment: "Appended to latest post summary text when the post does not have data.")

--- a/WordPress/Classes/ViewRelated/Stats/Insights/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/LatestPostSummaryCell.swift
@@ -6,10 +6,9 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
 
     // MARK: - Properties
 
-    @IBOutlet weak var borderedView: UIView!
     @IBOutlet weak var summaryLabel: UILabel!
-
     @IBOutlet weak var contentStackViewTopConstraint: NSLayoutConstraint!
+
     @IBOutlet weak var summariesStackView: UIStackView!
     @IBOutlet weak var chartStackView: UIStackView!
     @IBOutlet weak var actionStackView: UIStackView!
@@ -24,6 +23,9 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var actionLabel: UILabel!
     @IBOutlet weak var actionImageView: UIImageView!
     @IBOutlet weak var disclosureImageView: UIImageView!
+
+    @IBOutlet weak var topSeparatorLine: UIView!
+    @IBOutlet weak var bottomSeparatorLine: UIView!
 
     private var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     private typealias Style = WPStyleGuide.Stats
@@ -76,9 +78,10 @@ private extension LatestPostSummaryCell {
     func applyStyles() {
 
         Style.configureCell(self)
-        Style.configureBorderForView(borderedView)
 
         Style.configureLabelAsSummary(summaryLabel)
+        Style.configureViewAsSeperator(topSeparatorLine)
+        Style.configureViewAsSeperator(bottomSeparatorLine)
 
         viewsLabel.text = CellStrings.views
         viewsLabel.textColor = Style.defaultTextColor
@@ -160,8 +163,8 @@ private extension LatestPostSummaryCell {
     }
 
     struct ContentStackViewTopConstraint {
-        static let dataShown = CGFloat(20)
-        static let dataHidden = CGFloat(10)
+        static let dataShown = CGFloat(37)
+        static let dataHidden = CGFloat(16)
     }
 
     struct CellStrings {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/LatestPostSummaryCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/LatestPostSummaryCell.xib
@@ -12,166 +12,174 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="634" id="KGk-i7-Jjw" customClass="LatestPostSummaryCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="384"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="580" id="KGk-i7-Jjw" customClass="LatestPostSummaryCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="330"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="383.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="329.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WbC-hI-HqV" userLabel="Bordered View">
-                        <rect key="frame" x="0.0" y="16" width="375" height="367.5"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It's been 999 months since Your Post was published. Here's how the post performed so far." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MnQ-57-h8x" userLabel="Summary Label">
+                        <rect key="frame" x="16" y="16" width="343" height="38"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yj9-fI-q4P" userLabel="Summary Button">
+                        <rect key="frame" x="16" y="16" width="343" height="38"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <connections>
+                            <action selector="didTapSummaryButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="pk5-ep-izU"/>
+                        </connections>
+                    </button>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="bEY-vj-O3h" userLabel="Content Stack View">
+                        <rect key="frame" x="16" y="91" width="343" height="238.5"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It's been 999 months since Your Post was published. Here's how the post performed so far." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MnQ-57-h8x" userLabel="Summary Label">
-                                <rect key="frame" x="16" y="20" width="343" height="38"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yj9-fI-q4P" userLabel="Summary Button">
-                                <rect key="frame" x="16" y="20" width="343" height="38"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <connections>
-                                    <action selector="didTapSummaryButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="pk5-ep-izU"/>
-                                </connections>
-                            </button>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="bEY-vj-O3h" userLabel="Content Stack View">
-                                <rect key="frame" x="16" y="78" width="343" height="289.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="irr-i0-AM0" userLabel="Summaries Stack View">
+                                <rect key="frame" x="0.0" y="0.0" width="343" height="64.5"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="irr-i0-AM0" userLabel="Summaries Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="343" height="115.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="wux-rC-UyT" userLabel="Views Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="103.5" height="64.5"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="wux-rC-UyT" userLabel="Views Stack View">
-                                                <rect key="frame" x="0.0" y="0.0" width="103.5" height="115.5"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L5K-Wp-mW9" userLabel="Views Label">
-                                                        <rect key="frame" x="34" y="0.0" width="36" height="80"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Efd-SW-O9K" userLabel="Views Data">
-                                                        <rect key="frame" x="46" y="84" width="12" height="31.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="5Lu-bf-dhz" userLabel="Likes Stack View">
-                                                <rect key="frame" x="119.5" y="0.0" width="104" height="115.5"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Likes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-AB-ffn" userLabel="Likes Label">
-                                                        <rect key="frame" x="36.5" y="0.0" width="31.5" height="80"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eSJ-ds-3G4" userLabel="Likes Data">
-                                                        <rect key="frame" x="46" y="84" width="12" height="31.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="INN-7n-UXp" userLabel="Comments Stack View">
-                                                <rect key="frame" x="239.5" y="0.0" width="103.5" height="115.5"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jLy-hA-LxG" userLabel="Comments Label">
-                                                        <rect key="frame" x="19" y="0.0" width="65.5" height="80"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ke4-L3-2a5" userLabel="Comments Data">
-                                                        <rect key="frame" x="45.5" y="84" width="12" height="31.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="dVi-l5-zbj" userLabel="Chart Stack View">
-                                        <rect key="frame" x="0.0" y="130.5" width="343" height="100"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Imagine some pretty bars here" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xXG-ir-S4b" userLabel="Temporary Label">
-                                                <rect key="frame" x="0.0" y="0.0" width="343" height="100"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="100" id="dWM-sE-VnA"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L5K-Wp-mW9" userLabel="Views Label">
+                                                <rect key="frame" x="34" y="0.0" width="36" height="29"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Efd-SW-O9K" userLabel="Views Data">
+                                                <rect key="frame" x="46" y="33" width="12" height="31.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="dj8-5c-J6O" userLabel="Action Stack View">
-                                        <rect key="frame" x="0.0" y="245.5" width="343" height="44"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="5Lu-bf-dhz" userLabel="Likes Stack View">
+                                        <rect key="frame" x="119.5" y="0.0" width="104" height="64.5"/>
                                         <subviews>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OZB-d7-5Vo" userLabel="Action Icon Image">
-                                                <rect key="frame" x="0.0" y="10" width="24" height="24"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="24" id="Ltv-y1-Dw5"/>
-                                                    <constraint firstAttribute="height" constant="24" id="cek-yN-0vF"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View more" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xet-wC-hmj" userLabel="Action Label">
-                                                <rect key="frame" x="40" y="12" width="279" height="20.5"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Likes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-AB-ffn" userLabel="Likes Label">
+                                                <rect key="frame" x="36.5" y="0.0" width="31.5" height="29"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="disclosure-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="NUJ-mV-eYK" userLabel="Disclosure Image">
-                                                <rect key="frame" x="335" y="15.5" width="8" height="13"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="8" id="AYx-EH-X3W"/>
-                                                    <constraint firstAttribute="height" constant="13" id="AZH-gy-7Ym"/>
-                                                </constraints>
-                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eSJ-ds-3G4" userLabel="Likes Data">
+                                                <rect key="frame" x="46" y="33" width="12" height="31.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                         </subviews>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="LDT-2j-RkH"/>
-                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="INN-7n-UXp" userLabel="Comments Stack View">
+                                        <rect key="frame" x="239.5" y="0.0" width="103.5" height="64.5"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jLy-hA-LxG" userLabel="Comments Label">
+                                                <rect key="frame" x="19" y="0.0" width="65.5" height="29"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ke4-L3-2a5" userLabel="Comments Data">
+                                                <rect key="frame" x="45.5" y="33" width="12" height="31.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3OP-qA-To0" userLabel="Action Button">
-                                <rect key="frame" x="16" y="323.5" width="343" height="44"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <connections>
-                                    <action selector="didTapActionButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="crC-F5-hoa"/>
-                                </connections>
-                            </button>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="dVi-l5-zbj" userLabel="Chart Stack View">
+                                <rect key="frame" x="0.0" y="79.5" width="343" height="100"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Imagine some pretty bars here" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xXG-ir-S4b" userLabel="Temporary Label">
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="100"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="100" id="dWM-sE-VnA"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="dj8-5c-J6O" userLabel="Action Stack View">
+                                <rect key="frame" x="0.0" y="194.5" width="343" height="44"/>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OZB-d7-5Vo" userLabel="Action Icon Image">
+                                        <rect key="frame" x="0.0" y="10" width="24" height="24"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="24" id="Ltv-y1-Dw5"/>
+                                            <constraint firstAttribute="height" constant="24" id="cek-yN-0vF"/>
+                                        </constraints>
+                                    </imageView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View more" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xet-wC-hmj" userLabel="Action Label">
+                                        <rect key="frame" x="40" y="12" width="279" height="20.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="disclosure-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="NUJ-mV-eYK" userLabel="Disclosure Image">
+                                        <rect key="frame" x="335" y="15.5" width="8" height="13"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="8" id="AYx-EH-X3W"/>
+                                            <constraint firstAttribute="height" constant="13" id="AZH-gy-7Ym"/>
+                                        </constraints>
+                                    </imageView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="LDT-2j-RkH"/>
+                                </constraints>
+                            </stackView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </stackView>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3OP-qA-To0" userLabel="Action Button">
+                        <rect key="frame" x="16" y="285.5" width="343" height="44"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <connections>
+                            <action selector="didTapActionButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="crC-F5-hoa"/>
+                        </connections>
+                    </button>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JSW-bj-szW" userLabel="Top Seperator Line">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="0.5"/>
+                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="MnQ-57-h8x" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="16" id="3gL-ef-8Z6"/>
-                            <constraint firstItem="yj9-fI-q4P" firstAttribute="bottom" secondItem="MnQ-57-h8x" secondAttribute="bottom" id="Buj-Hh-Tjr"/>
-                            <constraint firstItem="3OP-qA-To0" firstAttribute="leading" secondItem="dj8-5c-J6O" secondAttribute="leading" id="ILI-Wv-vrp"/>
-                            <constraint firstItem="yj9-fI-q4P" firstAttribute="leading" secondItem="MnQ-57-h8x" secondAttribute="leading" id="JFj-Gd-fox"/>
-                            <constraint firstItem="bEY-vj-O3h" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="16" id="JbI-2b-BUP"/>
-                            <constraint firstItem="3OP-qA-To0" firstAttribute="top" secondItem="dj8-5c-J6O" secondAttribute="top" id="NTI-EP-AKn"/>
-                            <constraint firstAttribute="trailing" secondItem="bEY-vj-O3h" secondAttribute="trailing" constant="16" id="Rwn-hz-bqU"/>
-                            <constraint firstItem="yj9-fI-q4P" firstAttribute="top" secondItem="MnQ-57-h8x" secondAttribute="top" id="SqG-yS-FAT"/>
-                            <constraint firstItem="MnQ-57-h8x" firstAttribute="top" secondItem="WbC-hI-HqV" secondAttribute="top" constant="20" id="Sxc-xt-ZHX"/>
-                            <constraint firstItem="3OP-qA-To0" firstAttribute="bottom" secondItem="dj8-5c-J6O" secondAttribute="bottom" id="VIY-K9-gmi"/>
-                            <constraint firstItem="3OP-qA-To0" firstAttribute="trailing" secondItem="dj8-5c-J6O" secondAttribute="trailing" id="Y3c-ST-ZYJ"/>
-                            <constraint firstItem="bEY-vj-O3h" firstAttribute="top" secondItem="MnQ-57-h8x" secondAttribute="bottom" constant="20" id="ciO-yG-Ee8"/>
-                            <constraint firstItem="yj9-fI-q4P" firstAttribute="trailing" secondItem="MnQ-57-h8x" secondAttribute="trailing" id="cxs-pZ-Taw"/>
-                            <constraint firstAttribute="bottom" secondItem="bEY-vj-O3h" secondAttribute="bottom" id="mZl-4q-eUX"/>
-                            <constraint firstAttribute="trailing" secondItem="MnQ-57-h8x" secondAttribute="trailing" constant="16" id="y9b-gW-KIB"/>
+                            <constraint firstAttribute="height" constant="0.5" id="ZL5-Xb-acP"/>
+                        </constraints>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ogd-ft-cmW" userLabel="Bottom Seperator Line">
+                        <rect key="frame" x="0.0" y="329" width="375" height="0.5"/>
+                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.5" id="DlC-nH-qYA"/>
                         </constraints>
                     </view>
                 </subviews>
-                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
-                    <constraint firstItem="WbC-hI-HqV" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="BcG-y3-7d3"/>
-                    <constraint firstAttribute="trailing" secondItem="WbC-hI-HqV" secondAttribute="trailing" id="GUc-Ln-WUC"/>
-                    <constraint firstItem="WbC-hI-HqV" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="KbD-hj-p3v"/>
-                    <constraint firstAttribute="bottom" secondItem="WbC-hI-HqV" secondAttribute="bottom" id="iKd-Ny-sBY"/>
+                    <constraint firstAttribute="bottom" secondItem="bEY-vj-O3h" secondAttribute="bottom" id="1Xk-xj-7sr"/>
+                    <constraint firstItem="yj9-fI-q4P" firstAttribute="trailing" secondItem="MnQ-57-h8x" secondAttribute="trailing" id="6m6-uF-zFb"/>
+                    <constraint firstItem="bEY-vj-O3h" firstAttribute="top" secondItem="MnQ-57-h8x" secondAttribute="bottom" constant="37" id="9Vd-ny-SGg"/>
+                    <constraint firstAttribute="trailing" secondItem="MnQ-57-h8x" secondAttribute="trailing" constant="16" id="EoB-PV-pQf"/>
+                    <constraint firstItem="3OP-qA-To0" firstAttribute="bottom" secondItem="dj8-5c-J6O" secondAttribute="bottom" id="G6C-Pl-MJz"/>
+                    <constraint firstItem="JSW-bj-szW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="GSo-Tf-T4G"/>
+                    <constraint firstItem="3OP-qA-To0" firstAttribute="trailing" secondItem="dj8-5c-J6O" secondAttribute="trailing" id="HVd-qt-bfv"/>
+                    <constraint firstItem="3OP-qA-To0" firstAttribute="top" secondItem="dj8-5c-J6O" secondAttribute="top" id="HmM-nj-qBP"/>
+                    <constraint firstItem="MnQ-57-h8x" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="I5y-dW-v1A"/>
+                    <constraint firstItem="bEY-vj-O3h" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="I7j-LS-Nx7"/>
+                    <constraint firstItem="yj9-fI-q4P" firstAttribute="bottom" secondItem="MnQ-57-h8x" secondAttribute="bottom" id="L8m-Ex-6C4"/>
+                    <constraint firstAttribute="trailing" secondItem="bEY-vj-O3h" secondAttribute="trailing" constant="16" id="PL4-wc-ElT"/>
+                    <constraint firstItem="3OP-qA-To0" firstAttribute="leading" secondItem="dj8-5c-J6O" secondAttribute="leading" id="TzG-h9-5jU"/>
+                    <constraint firstItem="JSW-bj-szW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="Ugq-GK-MgF"/>
+                    <constraint firstItem="yj9-fI-q4P" firstAttribute="leading" secondItem="MnQ-57-h8x" secondAttribute="leading" id="XBq-Q5-JzZ"/>
+                    <constraint firstItem="yj9-fI-q4P" firstAttribute="top" secondItem="MnQ-57-h8x" secondAttribute="top" id="ZnV-2L-TM5"/>
+                    <constraint firstAttribute="trailing" secondItem="ogd-ft-cmW" secondAttribute="trailing" id="pYN-iK-2gB"/>
+                    <constraint firstItem="ogd-ft-cmW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="qnq-J6-gS6"/>
+                    <constraint firstAttribute="trailing" secondItem="JSW-bj-szW" secondAttribute="trailing" id="xA0-12-IkS"/>
+                    <constraint firstAttribute="bottom" secondItem="ogd-ft-cmW" secondAttribute="bottom" id="xJm-Yz-tr9"/>
+                    <constraint firstItem="MnQ-57-h8x" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="yOb-7C-mxM"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -179,20 +187,21 @@
                 <outlet property="actionImageView" destination="OZB-d7-5Vo" id="ZYF-8v-WcS"/>
                 <outlet property="actionLabel" destination="Xet-wC-hmj" id="amV-hg-OIZ"/>
                 <outlet property="actionStackView" destination="dj8-5c-J6O" id="gkV-Yq-6bI"/>
-                <outlet property="borderedView" destination="WbC-hI-HqV" id="Lnp-5X-VVN"/>
+                <outlet property="bottomSeparatorLine" destination="ogd-ft-cmW" id="lTW-ff-ahD"/>
                 <outlet property="chartStackView" destination="dVi-l5-zbj" id="kyV-EI-lLg"/>
                 <outlet property="commentsDataLabel" destination="Ke4-L3-2a5" id="Mi7-wx-efz"/>
                 <outlet property="commentsLabel" destination="jLy-hA-LxG" id="jxu-pA-4Xa"/>
-                <outlet property="contentStackViewTopConstraint" destination="ciO-yG-Ee8" id="pIG-eC-6u8"/>
+                <outlet property="contentStackViewTopConstraint" destination="9Vd-ny-SGg" id="60x-Z3-6cn"/>
                 <outlet property="disclosureImageView" destination="NUJ-mV-eYK" id="Feu-jf-QlE"/>
                 <outlet property="likesDataLabel" destination="eSJ-ds-3G4" id="g1g-h2-qD5"/>
                 <outlet property="likesLabel" destination="UBX-AB-ffn" id="kcJ-sh-Lsa"/>
                 <outlet property="summariesStackView" destination="irr-i0-AM0" id="uUi-Wo-PAU"/>
                 <outlet property="summaryLabel" destination="MnQ-57-h8x" id="0Qb-wb-77F"/>
+                <outlet property="topSeparatorLine" destination="JSW-bj-szW" id="KgK-Mb-YQM"/>
                 <outlet property="viewsDataLabel" destination="Efd-SW-O9K" id="CL6-zS-XtJ"/>
                 <outlet property="viewsLabel" destination="L5K-Wp-mW9" id="gpt-1m-oBt"/>
             </connections>
-            <point key="canvasLocation" x="5.5999999999999996" y="278.86056971514245"/>
+            <point key="canvasLocation" x="-44" y="109.74512743628186"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Stats/Insights/LatestPostSummaryCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/LatestPostSummaryCell.xib
@@ -22,39 +22,36 @@
                     <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WbC-hI-HqV" userLabel="Bordered View">
                         <rect key="frame" x="0.0" y="16" width="375" height="367.5"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4Mg-WZ-Xz7">
-                                <rect key="frame" x="16" y="12" width="343" height="52"/>
-                            </stackView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It's been 999 months since Your Post was published. Here's how the post performed so far." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MnQ-57-h8x" userLabel="Summary Label">
-                                <rect key="frame" x="16" y="84" width="343" height="38"/>
+                                <rect key="frame" x="16" y="20" width="343" height="38"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yj9-fI-q4P" userLabel="Summary Button">
-                                <rect key="frame" x="16" y="84" width="343" height="38"/>
+                                <rect key="frame" x="16" y="20" width="343" height="38"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <connections>
                                     <action selector="didTapSummaryButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="pk5-ep-izU"/>
                                 </connections>
                             </button>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="bEY-vj-O3h" userLabel="Content Stack View">
-                                <rect key="frame" x="16" y="142" width="343" height="225.5"/>
+                                <rect key="frame" x="16" y="78" width="343" height="289.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="irr-i0-AM0" userLabel="Summaries Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="343" height="51.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="115.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="wux-rC-UyT" userLabel="Views Stack View">
-                                                <rect key="frame" x="0.0" y="0.0" width="103.5" height="51.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="103.5" height="115.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L5K-Wp-mW9" userLabel="Views Label">
-                                                        <rect key="frame" x="34" y="0.0" width="36" height="16"/>
+                                                        <rect key="frame" x="34" y="0.0" width="36" height="80"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Efd-SW-O9K" userLabel="Views Data">
-                                                        <rect key="frame" x="46" y="20" width="12" height="31.5"/>
+                                                        <rect key="frame" x="46" y="84" width="12" height="31.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -62,16 +59,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="5Lu-bf-dhz" userLabel="Likes Stack View">
-                                                <rect key="frame" x="119.5" y="0.0" width="104" height="51.5"/>
+                                                <rect key="frame" x="119.5" y="0.0" width="104" height="115.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Likes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-AB-ffn" userLabel="Likes Label">
-                                                        <rect key="frame" x="36.5" y="0.0" width="31.5" height="16"/>
+                                                        <rect key="frame" x="36.5" y="0.0" width="31.5" height="80"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eSJ-ds-3G4" userLabel="Likes Data">
-                                                        <rect key="frame" x="46" y="20" width="12" height="31.5"/>
+                                                        <rect key="frame" x="46" y="84" width="12" height="31.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -79,16 +76,16 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="INN-7n-UXp" userLabel="Comments Stack View">
-                                                <rect key="frame" x="239.5" y="0.0" width="103.5" height="51.5"/>
+                                                <rect key="frame" x="239.5" y="0.0" width="103.5" height="115.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jLy-hA-LxG" userLabel="Comments Label">
-                                                        <rect key="frame" x="19" y="0.0" width="65.5" height="16"/>
+                                                        <rect key="frame" x="19" y="0.0" width="65.5" height="80"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ke4-L3-2a5" userLabel="Comments Data">
-                                                        <rect key="frame" x="45.5" y="20" width="12" height="31.5"/>
+                                                        <rect key="frame" x="45.5" y="84" width="12" height="31.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -98,7 +95,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="dVi-l5-zbj" userLabel="Chart Stack View">
-                                        <rect key="frame" x="0.0" y="66.5" width="343" height="100"/>
+                                        <rect key="frame" x="0.0" y="130.5" width="343" height="100"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Imagine some pretty bars here" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xXG-ir-S4b" userLabel="Temporary Label">
                                                 <rect key="frame" x="0.0" y="0.0" width="343" height="100"/>
@@ -112,7 +109,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="dj8-5c-J6O" userLabel="Action Stack View">
-                                        <rect key="frame" x="0.0" y="181.5" width="343" height="44"/>
+                                        <rect key="frame" x="0.0" y="245.5" width="343" height="44"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OZB-d7-5Vo" userLabel="Action Icon Image">
                                                 <rect key="frame" x="0.0" y="10" width="24" height="24"/>
@@ -152,21 +149,18 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="MnQ-57-h8x" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="16" id="3gL-ef-8Z6"/>
-                            <constraint firstItem="MnQ-57-h8x" firstAttribute="top" secondItem="4Mg-WZ-Xz7" secondAttribute="bottom" constant="20" id="BZq-1p-CqS"/>
                             <constraint firstItem="yj9-fI-q4P" firstAttribute="bottom" secondItem="MnQ-57-h8x" secondAttribute="bottom" id="Buj-Hh-Tjr"/>
-                            <constraint firstItem="4Mg-WZ-Xz7" firstAttribute="top" secondItem="WbC-hI-HqV" secondAttribute="top" constant="12" id="EE5-Hu-Hov"/>
                             <constraint firstItem="3OP-qA-To0" firstAttribute="leading" secondItem="dj8-5c-J6O" secondAttribute="leading" id="ILI-Wv-vrp"/>
                             <constraint firstItem="yj9-fI-q4P" firstAttribute="leading" secondItem="MnQ-57-h8x" secondAttribute="leading" id="JFj-Gd-fox"/>
                             <constraint firstItem="bEY-vj-O3h" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="16" id="JbI-2b-BUP"/>
                             <constraint firstItem="3OP-qA-To0" firstAttribute="top" secondItem="dj8-5c-J6O" secondAttribute="top" id="NTI-EP-AKn"/>
                             <constraint firstAttribute="trailing" secondItem="bEY-vj-O3h" secondAttribute="trailing" constant="16" id="Rwn-hz-bqU"/>
                             <constraint firstItem="yj9-fI-q4P" firstAttribute="top" secondItem="MnQ-57-h8x" secondAttribute="top" id="SqG-yS-FAT"/>
+                            <constraint firstItem="MnQ-57-h8x" firstAttribute="top" secondItem="WbC-hI-HqV" secondAttribute="top" constant="20" id="Sxc-xt-ZHX"/>
                             <constraint firstItem="3OP-qA-To0" firstAttribute="bottom" secondItem="dj8-5c-J6O" secondAttribute="bottom" id="VIY-K9-gmi"/>
                             <constraint firstItem="3OP-qA-To0" firstAttribute="trailing" secondItem="dj8-5c-J6O" secondAttribute="trailing" id="Y3c-ST-ZYJ"/>
                             <constraint firstItem="bEY-vj-O3h" firstAttribute="top" secondItem="MnQ-57-h8x" secondAttribute="bottom" constant="20" id="ciO-yG-Ee8"/>
                             <constraint firstItem="yj9-fI-q4P" firstAttribute="trailing" secondItem="MnQ-57-h8x" secondAttribute="trailing" id="cxs-pZ-Taw"/>
-                            <constraint firstAttribute="trailing" secondItem="4Mg-WZ-Xz7" secondAttribute="trailing" constant="16" id="hbv-ZK-xBj"/>
-                            <constraint firstItem="4Mg-WZ-Xz7" firstAttribute="leading" secondItem="WbC-hI-HqV" secondAttribute="leading" constant="16" id="jDS-FC-5TM"/>
                             <constraint firstAttribute="bottom" secondItem="bEY-vj-O3h" secondAttribute="bottom" id="mZl-4q-eUX"/>
                             <constraint firstAttribute="trailing" secondItem="MnQ-57-h8x" secondAttribute="trailing" constant="16" id="y9b-gW-KIB"/>
                         </constraints>
@@ -191,7 +185,6 @@
                 <outlet property="commentsLabel" destination="jLy-hA-LxG" id="jxu-pA-4Xa"/>
                 <outlet property="contentStackViewTopConstraint" destination="ciO-yG-Ee8" id="pIG-eC-6u8"/>
                 <outlet property="disclosureImageView" destination="NUJ-mV-eYK" id="Feu-jf-QlE"/>
-                <outlet property="headerStackView" destination="4Mg-WZ-Xz7" id="3Si-KK-QRS"/>
                 <outlet property="likesDataLabel" destination="eSJ-ds-3G4" id="g1g-h2-qD5"/>
                 <outlet property="likesLabel" destination="UBX-AB-ffn" id="kcJ-sh-Lsa"/>
                 <outlet property="summariesStackView" destination="irr-i0-AM0" id="uUi-Wo-PAU"/>

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.swift
@@ -1,32 +1,27 @@
 import UIKit
 
-class SimpleTotalsCell: UITableViewCell {
+class SimpleTotalsCell: UITableViewCell, NibLoadable {
 
     // MARK: - Properties
 
     @IBOutlet weak var borderedView: UIView!
-    @IBOutlet weak var headerStackView: UIStackView!
     @IBOutlet weak var subtitleStackView: UIStackView!
     @IBOutlet weak var rowsStackView: UIStackView!
     @IBOutlet weak var itemSubtitleLabel: UILabel!
     @IBOutlet weak var dataSubtitleLabel: UILabel!
 
     private var dataRows = [StatsTotalRowData]()
-    private let headerView = StatsCellHeader.loadFromNib()
     private typealias Style = WPStyleGuide.Stats
 
     // MARK: - Configure
 
-    func configure(withTitle title: String,
-                   dataRows: [StatsTotalRowData],
-                   showSubtitles: Bool = false,
+    func configure(dataRows: [StatsTotalRowData],
                    itemSubtitle: String? = nil,
                    dataSubtitle: String? = nil) {
         self.dataRows = dataRows
         itemSubtitleLabel.text = itemSubtitle
         dataSubtitleLabel.text = dataSubtitle
-        subtitleStackView.isHidden = !showSubtitles
-        addHeader(title)
+        subtitleStackView.isHidden = (itemSubtitle != nil || dataSubtitle != nil)
         addRows()
         applyStyles()
     }
@@ -34,11 +29,6 @@ class SimpleTotalsCell: UITableViewCell {
 }
 
 private extension SimpleTotalsCell {
-
-    func addHeader(_ title: String) {
-        headerView.headerLabel.text = title
-        headerStackView.insertArrangedSubview(headerView, at: 0)
-    }
 
     func addRows() {
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.swift
@@ -48,6 +48,8 @@ private extension SimpleTotalsCell {
 
     func addRows() {
 
+        removeExistingRows()
+
         if dataRows.count == 0 {
             let row = StatsNoDataRow.loadFromNib()
             rowsStackView.addArrangedSubview(row)
@@ -58,6 +60,13 @@ private extension SimpleTotalsCell {
             let row = StatsTotalRow.loadFromNib()
             row.configure(rowData: dataRow)
             rowsStackView.addArrangedSubview(row)
+        }
+    }
+
+    func removeExistingRows() {
+        rowsStackView.arrangedSubviews.forEach {
+            rowsStackView.removeArrangedSubview($0)
+            $0.removeFromSuperview()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.swift
@@ -4,11 +4,14 @@ class SimpleTotalsCell: UITableViewCell, NibLoadable {
 
     // MARK: - Properties
 
-    @IBOutlet weak var borderedView: UIView!
     @IBOutlet weak var subtitleStackView: UIStackView!
     @IBOutlet weak var rowsStackView: UIStackView!
     @IBOutlet weak var itemSubtitleLabel: UILabel!
     @IBOutlet weak var dataSubtitleLabel: UILabel!
+    @IBOutlet weak var rowsStackViewTopConstraint: NSLayoutConstraint!
+    @IBOutlet weak var subtitlesStackViewTopConstraint: NSLayoutConstraint!
+    @IBOutlet weak var topSeparatorLine: UIView!
+    @IBOutlet weak var bottomSeparatorLine: UIView!
 
     private var dataRows = [StatsTotalRowData]()
     private typealias Style = WPStyleGuide.Stats
@@ -21,7 +24,8 @@ class SimpleTotalsCell: UITableViewCell, NibLoadable {
         self.dataRows = dataRows
         itemSubtitleLabel.text = itemSubtitle
         dataSubtitleLabel.text = dataSubtitle
-        subtitleStackView.isHidden = (itemSubtitle != nil || dataSubtitle != nil)
+
+        setSubtitleVisibility()
         addRows()
         applyStyles()
     }
@@ -29,6 +33,18 @@ class SimpleTotalsCell: UITableViewCell, NibLoadable {
 }
 
 private extension SimpleTotalsCell {
+
+    func setSubtitleVisibility() {
+        let showSubtitles = (itemSubtitleLabel.text != nil || dataSubtitleLabel.text != nil)
+        subtitleStackView.isHidden = !showSubtitles
+
+        if showSubtitles {
+            let subtitleBottom = subtitleStackView.frame.origin.y + subtitleStackView.frame.size.height
+            // The top and bottom subtitle margins are the same, so whatever the top constraint
+            // is, add that to the bottom margin.
+            rowsStackViewTopConstraint.constant = subtitleBottom + subtitlesStackViewTopConstraint.constant
+        }
+    }
 
     func addRows() {
 
@@ -47,9 +63,10 @@ private extension SimpleTotalsCell {
 
     func applyStyles() {
         Style.configureCell(self)
-        Style.configureBorderForView(borderedView)
         Style.configureLabelAsSubtitle(itemSubtitleLabel)
         Style.configureLabelAsSubtitle(dataSubtitleLabel)
+        Style.configureViewAsSeperator(topSeparatorLine)
+        Style.configureViewAsSeperator(bottomSeparatorLine)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.xib
@@ -22,26 +22,21 @@
                     <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mBj-LN-gvU" userLabel="Bordered View">
                         <rect key="frame" x="0.0" y="16" width="323" height="183.5"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="oZA-Fe-ylr" userLabel="Header Stack View">
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Tyj-5B-MLc" userLabel="Subtitles Stack View">
                                 <rect key="frame" x="16" y="12" width="291" height="16"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Tyj-5B-MLc" userLabel="Subtitles Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="291" height="16"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbE-CG-voj">
-                                                <rect key="frame" x="0.0" y="0.0" width="145.5" height="16"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DfF-g0-7Iu">
-                                                <rect key="frame" x="145.5" y="0.0" width="145.5" height="16"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbE-CG-voj">
+                                        <rect key="frame" x="0.0" y="0.0" width="145.5" height="16"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DfF-g0-7Iu">
+                                        <rect key="frame" x="145.5" y="0.0" width="145.5" height="16"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="w2N-OJ-hIR">
@@ -50,13 +45,13 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="oZA-Fe-ylr" secondAttribute="trailing" constant="16" id="9B0-RJ-aFe"/>
-                            <constraint firstItem="w2N-OJ-hIR" firstAttribute="top" secondItem="oZA-Fe-ylr" secondAttribute="bottom" constant="7" id="AxK-rk-BHk"/>
-                            <constraint firstItem="oZA-Fe-ylr" firstAttribute="top" secondItem="mBj-LN-gvU" secondAttribute="top" constant="12" id="FT1-IE-P80"/>
-                            <constraint firstItem="oZA-Fe-ylr" firstAttribute="leading" secondItem="mBj-LN-gvU" secondAttribute="leading" constant="16" id="N4Z-O5-FDK"/>
+                            <constraint firstItem="w2N-OJ-hIR" firstAttribute="top" secondItem="Tyj-5B-MLc" secondAttribute="bottom" constant="7" id="IQ4-Ks-QAH"/>
+                            <constraint firstAttribute="trailing" secondItem="Tyj-5B-MLc" secondAttribute="trailing" constant="16" id="QRL-8f-ltS"/>
                             <constraint firstAttribute="trailing" secondItem="w2N-OJ-hIR" secondAttribute="trailing" id="TCC-lS-dSk"/>
                             <constraint firstAttribute="bottom" secondItem="w2N-OJ-hIR" secondAttribute="bottom" id="VfP-Iz-DQY"/>
                             <constraint firstItem="w2N-OJ-hIR" firstAttribute="leading" secondItem="mBj-LN-gvU" secondAttribute="leading" id="fNr-Y8-Cps"/>
+                            <constraint firstItem="Tyj-5B-MLc" firstAttribute="leading" secondItem="mBj-LN-gvU" secondAttribute="leading" constant="16" id="l3X-uZ-kGW"/>
+                            <constraint firstItem="Tyj-5B-MLc" firstAttribute="top" secondItem="mBj-LN-gvU" secondAttribute="top" constant="12" id="ssD-pV-bsd"/>
                         </constraints>
                     </view>
                 </subviews>
@@ -72,7 +67,6 @@
             <connections>
                 <outlet property="borderedView" destination="mBj-LN-gvU" id="hTf-I2-0tx"/>
                 <outlet property="dataSubtitleLabel" destination="DfF-g0-7Iu" id="JdZ-nM-kKj"/>
-                <outlet property="headerStackView" destination="oZA-Fe-ylr" id="waQ-VU-bFw"/>
                 <outlet property="itemSubtitleLabel" destination="vbE-CG-voj" id="eZl-wI-KfG"/>
                 <outlet property="rowsStackView" destination="w2N-OJ-hIR" id="5DU-xj-fcC"/>
                 <outlet property="subtitleStackView" destination="Tyj-5B-MLc" id="mua-cf-sfq"/>

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.xib
@@ -19,57 +19,67 @@
                 <rect key="frame" x="0.0" y="0.0" width="323" height="199.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mBj-LN-gvU" userLabel="Bordered View">
-                        <rect key="frame" x="0.0" y="16" width="323" height="183.5"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Tyj-5B-MLc" userLabel="Subtitles Stack View">
+                        <rect key="frame" x="16" y="7" width="291" height="16"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Tyj-5B-MLc" userLabel="Subtitles Stack View">
-                                <rect key="frame" x="16" y="12" width="291" height="16"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbE-CG-voj">
-                                        <rect key="frame" x="0.0" y="0.0" width="145.5" height="16"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DfF-g0-7Iu">
-                                        <rect key="frame" x="145.5" y="0.0" width="145.5" height="16"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                            </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="w2N-OJ-hIR">
-                                <rect key="frame" x="0.0" y="35" width="323" height="148.5"/>
-                            </stackView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbE-CG-voj">
+                                <rect key="frame" x="0.0" y="0.0" width="145.5" height="16"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DfF-g0-7Iu">
+                                <rect key="frame" x="145.5" y="0.0" width="145.5" height="16"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </stackView>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="w2N-OJ-hIR">
+                        <rect key="frame" x="0.0" y="0.0" width="323" height="199.5"/>
+                    </stackView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cBd-Ut-Uch" userLabel="Top Seperator Line">
+                        <rect key="frame" x="0.0" y="0.0" width="323" height="0.5"/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="w2N-OJ-hIR" firstAttribute="top" secondItem="Tyj-5B-MLc" secondAttribute="bottom" constant="7" id="IQ4-Ks-QAH"/>
-                            <constraint firstAttribute="trailing" secondItem="Tyj-5B-MLc" secondAttribute="trailing" constant="16" id="QRL-8f-ltS"/>
-                            <constraint firstAttribute="trailing" secondItem="w2N-OJ-hIR" secondAttribute="trailing" id="TCC-lS-dSk"/>
-                            <constraint firstAttribute="bottom" secondItem="w2N-OJ-hIR" secondAttribute="bottom" id="VfP-Iz-DQY"/>
-                            <constraint firstItem="w2N-OJ-hIR" firstAttribute="leading" secondItem="mBj-LN-gvU" secondAttribute="leading" id="fNr-Y8-Cps"/>
-                            <constraint firstItem="Tyj-5B-MLc" firstAttribute="leading" secondItem="mBj-LN-gvU" secondAttribute="leading" constant="16" id="l3X-uZ-kGW"/>
-                            <constraint firstItem="Tyj-5B-MLc" firstAttribute="top" secondItem="mBj-LN-gvU" secondAttribute="top" constant="12" id="ssD-pV-bsd"/>
+                            <constraint firstAttribute="height" constant="0.5" id="l1A-zV-rug"/>
+                        </constraints>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9px-XX-eCP" userLabel="Bottom Seperator Line">
+                        <rect key="frame" x="0.0" y="199" width="323" height="0.5"/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.5" id="BI8-lO-5aD"/>
                         </constraints>
                     </view>
                 </subviews>
-                <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
-                    <constraint firstItem="mBj-LN-gvU" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="8Uo-ru-3nN"/>
-                    <constraint firstItem="mBj-LN-gvU" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="G5D-FT-ACx"/>
-                    <constraint firstAttribute="bottom" secondItem="mBj-LN-gvU" secondAttribute="bottom" id="ah5-4x-W5N"/>
-                    <constraint firstAttribute="trailing" secondItem="mBj-LN-gvU" secondAttribute="trailing" id="zwg-H5-YQb"/>
+                    <constraint firstItem="Tyj-5B-MLc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="04p-Eh-3C7"/>
+                    <constraint firstItem="cBd-Ut-Uch" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="3tF-WR-xtY"/>
+                    <constraint firstItem="Tyj-5B-MLc" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="7" id="3w8-O5-egA"/>
+                    <constraint firstAttribute="bottom" secondItem="w2N-OJ-hIR" secondAttribute="bottom" id="42h-SA-4TJ"/>
+                    <constraint firstItem="w2N-OJ-hIR" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="HgO-4i-Tfs"/>
+                    <constraint firstAttribute="trailing" secondItem="w2N-OJ-hIR" secondAttribute="trailing" id="J0K-LT-LLo"/>
+                    <constraint firstItem="cBd-Ut-Uch" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="MkM-w2-NRz"/>
+                    <constraint firstAttribute="trailing" secondItem="9px-XX-eCP" secondAttribute="trailing" id="WsP-Kk-luU"/>
+                    <constraint firstAttribute="trailing" secondItem="Tyj-5B-MLc" secondAttribute="trailing" constant="16" id="XOL-9m-28D"/>
+                    <constraint firstAttribute="trailing" secondItem="cBd-Ut-Uch" secondAttribute="trailing" id="bwo-8W-tHL"/>
+                    <constraint firstAttribute="bottom" secondItem="9px-XX-eCP" secondAttribute="bottom" id="e26-py-r2V"/>
+                    <constraint firstItem="w2N-OJ-hIR" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="olb-Fp-tx9"/>
+                    <constraint firstItem="9px-XX-eCP" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="qfo-Hn-1HP"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
-                <outlet property="borderedView" destination="mBj-LN-gvU" id="hTf-I2-0tx"/>
+                <outlet property="bottomSeparatorLine" destination="9px-XX-eCP" id="jWU-xt-Cru"/>
                 <outlet property="dataSubtitleLabel" destination="DfF-g0-7Iu" id="JdZ-nM-kKj"/>
                 <outlet property="itemSubtitleLabel" destination="vbE-CG-voj" id="eZl-wI-KfG"/>
                 <outlet property="rowsStackView" destination="w2N-OJ-hIR" id="5DU-xj-fcC"/>
+                <outlet property="rowsStackViewTopConstraint" destination="olb-Fp-tx9" id="Xed-rK-meE"/>
                 <outlet property="subtitleStackView" destination="Tyj-5B-MLc" id="mua-cf-sfq"/>
+                <outlet property="subtitlesStackViewTopConstraint" destination="3w8-O5-egA" id="mIe-Qk-rxL"/>
+                <outlet property="topSeparatorLine" destination="cBd-Ut-Uch" id="C1i-Zd-yPU"/>
             </connections>
             <point key="canvasLocation" x="55.200000000000003" y="17.991004497751124"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -62,7 +62,7 @@ class SiteStatsInsightsTableViewController: UITableViewController {
 
         WPStyleGuide.Stats.configureTable(tableView)
         refreshControl?.addTarget(self, action: #selector(refreshData), for: .valueChanged)
-        ImmuTable.registerRows([LatestPostSummaryRow.self, AllTimeStatsRow.self], tableView: tableView)
+        ImmuTable.registerRows([LatestPostSummaryRow.self, AllTimeStatsRow.self, CellHeaderRow.self], tableView: tableView)
         loadInsightsFromUserDefaults()
         initViewModel()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -41,10 +41,12 @@ class SiteStatsInsightsViewModel: Observable {
         insightsToShow.forEach { insightType in
             switch insightType {
             case .latestPostSummary:
+                tableRows.append(CellHeaderRow(title: StatsHeaders.latestPostSummary))
                 tableRows.append(LatestPostSummaryRow(summaryData: store.getLatestPostSummary(),
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
             case .allTimeStats:
-                tableRows.append(AllTimeStatsRow(title: AllTimeStats.headerTitle, dataRows: createAllTimeStatsRows()))
+                tableRows.append(CellHeaderRow(title: StatsHeaders.allTimeStats))
+                tableRows.append(AllTimeStatsRow(dataRows: createAllTimeStatsRows()))
             case .followersTotals:
                 DDLogDebug("Show \(insightType) here.")
             case .mostPopularDayAndHour:
@@ -84,8 +86,12 @@ class SiteStatsInsightsViewModel: Observable {
 
 private extension SiteStatsInsightsViewModel {
 
+    struct StatsHeaders {
+        static let latestPostSummary = NSLocalizedString("Latest Post Summary", comment: "Insights latest post summary header")
+        static let allTimeStats = NSLocalizedString("All Time Stats", comment: "Insights 'All Time Stats' header")
+    }
+
     struct AllTimeStats {
-        static let headerTitle = NSLocalizedString("All Time Stats", comment: "Insights 'All Time Stats' header")
         static let postsTitle = NSLocalizedString("Posts", comment: "All Time Stats 'Posts' label")
         static let postsIcon = Style.imageForGridiconType(.posts)
         static let viewsTitle = NSLocalizedString("Views", comment: "All Time Stats 'Views' label")

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -41,11 +41,11 @@ class SiteStatsInsightsViewModel: Observable {
         insightsToShow.forEach { insightType in
             switch insightType {
             case .latestPostSummary:
-                tableRows.append(CellHeaderRow(title: StatsHeaders.latestPostSummary))
+                tableRows.append(CellHeaderRow(title: InsightsHeaders.latestPostSummary))
                 tableRows.append(LatestPostSummaryRow(summaryData: store.getLatestPostSummary(),
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
             case .allTimeStats:
-                tableRows.append(CellHeaderRow(title: StatsHeaders.allTimeStats))
+                tableRows.append(CellHeaderRow(title: InsightsHeaders.allTimeStats))
                 tableRows.append(AllTimeStatsRow(dataRows: createAllTimeStatsRows()))
             case .followersTotals:
                 DDLogDebug("Show \(insightType) here.")
@@ -86,7 +86,7 @@ class SiteStatsInsightsViewModel: Observable {
 
 private extension SiteStatsInsightsViewModel {
 
-    struct StatsHeaders {
+    struct InsightsHeaders {
         static let latestPostSummary = NSLocalizedString("Latest Post Summary", comment: "Insights latest post summary header")
         static let allTimeStats = NSLocalizedString("All Time Stats", comment: "Insights 'All Time Stats' header")
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -1,21 +1,15 @@
 import UIKit
 import Gridicons
 
-class StatsCellHeader: UIView, NibLoadable {
+class StatsCellHeader: UITableViewCell, NibLoadable {
 
     @IBOutlet weak var headerLabel: UILabel!
     @IBOutlet weak var manageInsightButton: UIButton!
 
     private typealias Style = WPStyleGuide.Stats
 
-    var showManageInsightButton = false {
-        didSet {
-            manageInsightButton.isHidden = !showManageInsightButton
-        }
-    }
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
+    func configure(withTitle title: String) {
+        headerLabel.text = title
         applyStyles()
     }
 
@@ -31,7 +25,9 @@ private extension StatsCellHeader {
     }
 
     func configureManageInsightButton() {
-        manageInsightButton.isHidden = !showManageInsightButton
+        // TODO: remove this when Manage Insights implemented
+        manageInsightButton.isHidden = true
+
         manageInsightButton.tintColor = Style.ImageTintColor.grey.styleGuideColor
         manageInsightButton.setImage(Style.imageForGridiconType(.ellipsis), for: .normal)
         manageInsightButton.accessibilityLabel = NSLocalizedString("Manage Insight", comment: "Action button to display manage insight options.")

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.xib
@@ -6,63 +6,53 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
-        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="StatsCellHeader" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="40"/>
-            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4Yw-KF-i1G">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="40"/>
-                    <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="CkM-4y-ChA">
-                            <rect key="frame" x="0.0" y="0.0" width="375" height="40"/>
-                            <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Cell Header Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KlA-v8-RRf">
-                                    <rect key="frame" x="0.0" y="0.0" width="351" height="40"/>
-                                    <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8jd-aL-8Rx">
-                                    <rect key="frame" x="351" y="0.0" width="24" height="40"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="24" id="auP-tV-2Rs"/>
-                                    </constraints>
-                                    <connections>
-                                        <action selector="manageInsightButtonPressed:" destination="iN0-l3-epB" eventType="touchUpInside" id="lTr-Kv-cN6"/>
-                                    </connections>
-                                </button>
-                            </subviews>
-                        </stackView>
-                    </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstAttribute="trailing" secondItem="CkM-4y-ChA" secondAttribute="trailing" id="GTQ-5O-ofh"/>
-                        <constraint firstAttribute="bottom" secondItem="CkM-4y-ChA" secondAttribute="bottom" id="N4y-yO-3wF"/>
-                        <constraint firstItem="CkM-4y-ChA" firstAttribute="leading" secondItem="4Yw-KF-i1G" secondAttribute="leading" id="bok-cC-vPW"/>
-                        <constraint firstItem="CkM-4y-ChA" firstAttribute="top" secondItem="4Yw-KF-i1G" secondAttribute="top" id="zDq-I0-aFX"/>
-                    </constraints>
-                </view>
-            </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-            <constraints>
-                <constraint firstItem="4Yw-KF-i1G" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="Bzv-fm-Wta"/>
-                <constraint firstItem="4Yw-KF-i1G" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="gcJ-8m-dME"/>
-                <constraint firstItem="4Yw-KF-i1G" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="n6k-WC-JX4"/>
-                <constraint firstItem="4Yw-KF-i1G" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="pfb-lv-KcW"/>
-            </constraints>
-            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="82" id="3fP-pA-Ovw" customClass="StatsCellHeader" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="82"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3fP-pA-Ovw" id="fMA-Y8-HGb">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="81.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="B45-HF-Mto">
+                        <rect key="frame" x="16" y="29" width="343" height="30"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CELL HEADER LABEL" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fZv-YC-hoV">
+                                <rect key="frame" x="0.0" y="0.0" width="319" height="30"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pmt-5q-3Mg">
+                                <rect key="frame" x="319" y="0.0" width="24" height="30"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="24" id="71g-sj-afi"/>
+                                    <constraint firstAttribute="width" constant="24" id="kMN-0Q-A6x"/>
+                                </constraints>
+                                <connections>
+                                    <action selector="manageInsightButtonPressed:" destination="3fP-pA-Ovw" eventType="touchUpInside" id="3ln-6E-gCK"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="B45-HF-Mto" firstAttribute="leading" secondItem="fMA-Y8-HGb" secondAttribute="leading" constant="16" id="Bum-ye-yWk"/>
+                    <constraint firstAttribute="trailing" secondItem="B45-HF-Mto" secondAttribute="trailing" constant="16" id="OPB-sC-KWU"/>
+                    <constraint firstItem="B45-HF-Mto" firstAttribute="top" secondItem="fMA-Y8-HGb" secondAttribute="top" constant="29" id="RWL-Fv-z9B"/>
+                    <constraint firstAttribute="bottom" secondItem="B45-HF-Mto" secondAttribute="bottom" constant="9" id="zBu-as-SLm"/>
+                </constraints>
+            </tableViewCellContentView>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <connections>
-                <outlet property="headerLabel" destination="KlA-v8-RRf" id="YQW-B3-0cr"/>
-                <outlet property="manageInsightButton" destination="8jd-aL-8Rx" id="5Mm-gp-F21"/>
+                <outlet property="headerLabel" destination="fZv-YC-hoV" id="iNM-se-RIs"/>
+                <outlet property="manageInsightButton" destination="Pmt-5q-3Mg" id="y2o-B3-h7B"/>
             </connections>
-            <point key="canvasLocation" x="138.40000000000001" y="-271.664167916042"/>
-        </view>
+            <point key="canvasLocation" x="336.80000000000001" y="-462.36881559220393"/>
+        </tableViewCell>
     </objects>
 </document>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.xib
@@ -11,24 +11,24 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="82" id="3fP-pA-Ovw" customClass="StatsCellHeader" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="82"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="57" id="3fP-pA-Ovw" customClass="StatsCellHeader" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="57"/>
             <autoresizingMask key="autoresizingMask"/>
-            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3fP-pA-Ovw" id="fMA-Y8-HGb">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="81.5"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3fP-pA-Ovw" id="fMA-Y8-HGb">
+                <rect key="frame" x="0.0" y="0.0" width="375" height="56.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="B45-HF-Mto">
-                        <rect key="frame" x="16" y="29" width="343" height="30"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="B45-HF-Mto">
+                        <rect key="frame" x="16" y="20" width="343" height="36"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CELL HEADER LABEL" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fZv-YC-hoV">
-                                <rect key="frame" x="0.0" y="0.0" width="319" height="30"/>
+                                <rect key="frame" x="0.0" y="10" width="319" height="16"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Pmt-5q-3Mg">
-                                <rect key="frame" x="319" y="0.0" width="24" height="30"/>
+                                <rect key="frame" x="319" y="6" width="24" height="24"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="24" id="71g-sj-afi"/>
                                     <constraint firstAttribute="width" constant="24" id="kMN-0Q-A6x"/>
@@ -38,13 +38,16 @@
                                 </connections>
                             </button>
                         </subviews>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="36" id="zcu-iF-hUF"/>
+                        </constraints>
                     </stackView>
                 </subviews>
                 <constraints>
                     <constraint firstItem="B45-HF-Mto" firstAttribute="leading" secondItem="fMA-Y8-HGb" secondAttribute="leading" constant="16" id="Bum-ye-yWk"/>
                     <constraint firstAttribute="trailing" secondItem="B45-HF-Mto" secondAttribute="trailing" constant="16" id="OPB-sC-KWU"/>
-                    <constraint firstItem="B45-HF-Mto" firstAttribute="top" secondItem="fMA-Y8-HGb" secondAttribute="top" constant="29" id="RWL-Fv-z9B"/>
-                    <constraint firstAttribute="bottom" secondItem="B45-HF-Mto" secondAttribute="bottom" constant="9" id="zBu-as-SLm"/>
+                    <constraint firstItem="B45-HF-Mto" firstAttribute="top" secondItem="fMA-Y8-HGb" secondAttribute="top" constant="20" id="RWL-Fv-z9B"/>
+                    <constraint firstAttribute="bottom" secondItem="B45-HF-Mto" secondAttribute="bottom" id="zBu-as-SLm"/>
                 </constraints>
             </tableViewCellContentView>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -52,7 +55,7 @@
                 <outlet property="headerLabel" destination="fZv-YC-hoV" id="iNM-se-RIs"/>
                 <outlet property="manageInsightButton" destination="Pmt-5q-3Mg" id="y2o-B3-h7B"/>
             </connections>
-            <point key="canvasLocation" x="336.80000000000001" y="-462.36881559220393"/>
+            <point key="canvasLocation" x="336.80000000000001" y="-442.12893553223392"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -8,8 +8,7 @@ struct LatestPostSummaryRow: ImmuTableRow {
     typealias CellType = LatestPostSummaryCell
 
     static let cell: ImmuTableCell = {
-        let nib = UINib(nibName: "LatestPostSummaryCell", bundle: Bundle(for: CellType.self))
-        return ImmuTableCell.nib(nib, CellType.self)
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
     }()
 
     let summaryData: StatsLatestPostSummary?
@@ -32,11 +31,9 @@ struct AllTimeStatsRow: ImmuTableRow {
     typealias CellType = SimpleTotalsCell
 
     static let cell: ImmuTableCell = {
-        let nib = UINib(nibName: "SimpleTotalsCell", bundle: Bundle(for: CellType.self))
-        return ImmuTableCell.nib(nib, CellType.self)
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
     }()
 
-    let title: String
     let dataRows: [StatsTotalRowData]
     let action: ImmuTableAction? = nil
 
@@ -46,6 +43,27 @@ struct AllTimeStatsRow: ImmuTableRow {
             return
         }
 
-        cell.configure(withTitle: title, dataRows: dataRows)
+        cell.configure(dataRows: dataRows)
+    }
+}
+
+struct CellHeaderRow: ImmuTableRow {
+
+    typealias CellType = StatsCellHeader
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let title: String
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(withTitle: title)
     }
 }


### PR DESCRIPTION
Fixes #10498 

This actually encompasses these changes:
1) Updates the card header to the new design.
2) Removes the full border on the cards, and now has only a top and bottom.
3) Updates margins for the Latest Post Summary text.
4) Fixes an issue where All Time Stats rows were being duplicated on pull to refresh.

The new card header should match this Zeplin design zpl://screen?pid=5a86dd8dfaff0fa0290982db&sid=5bf2a8d9e6b0427eb9a22108 (Full Stats Refresh > Heading Bar Changes).

To test:

---
On a site with Latest Post Summary data, Go to Stats > Insights. Verify the view is:

![with_lps](https://user-images.githubusercontent.com/1816888/48814222-2d8b9600-ecf7-11e8-827b-0032040ec307.png)

---
On a site with _no_ Latest Post Summary data, Go to Stats > Insights. Verify the view is:

![no_lps](https://user-images.githubusercontent.com/1816888/48814247-50b64580-ecf7-11e8-9960-8b94bcf87bd8.png)

---
On a site with _no_ All Time Stats data, Go to Stats > Insights. Verify the view is:

![no_ats](https://user-images.githubusercontent.com/1816888/48814672-e1d9ec00-ecf8-11e8-8627-ef836dbe1638.png)


