### PR TITLE
UI fixes for domains.

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.xib
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.xib
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,10 +19,10 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7hQ-Qd-7gD">
-                        <rect key="frame" x="0.0" y="0.0" width="102" height="45.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="129" height="45.5"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JYy-XU-9v8">
-                                <rect key="frame" x="16" y="12" width="83" height="21.5"/>
+                                <rect key="frame" x="16" y="12" width="110" height="21.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -38,7 +37,7 @@
                         </constraints>
                     </view>
                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="aoI-Bw-gsZ" customClass="LoginTextField" customModule="WordPressAuthenticator">
-                        <rect key="frame" x="102" y="0.0" width="256" height="45.5"/>
+                        <rect key="frame" x="129" y="0.0" width="234" height="45.5"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
@@ -47,7 +46,7 @@
                 <constraints>
                     <constraint firstAttribute="bottom" secondItem="aoI-Bw-gsZ" secondAttribute="bottom" id="6sO-Yu-79x"/>
                     <constraint firstItem="aoI-Bw-gsZ" firstAttribute="leading" secondItem="7hQ-Qd-7gD" secondAttribute="trailing" id="7da-If-Hjk"/>
-                    <constraint firstItem="7hQ-Qd-7gD" firstAttribute="width" secondItem="aoI-Bw-gsZ" secondAttribute="width" multiplier="0.45" id="T1g-JA-BoX"/>
+                    <constraint firstItem="7hQ-Qd-7gD" firstAttribute="width" secondItem="aoI-Bw-gsZ" secondAttribute="width" multiplier="0.55" id="T1g-JA-BoX"/>
                     <constraint firstItem="aoI-Bw-gsZ" firstAttribute="top" secondItem="6tg-46-1kN" secondAttribute="top" id="cht-u8-Mxn"/>
                     <constraint firstItem="7hQ-Qd-7gD" firstAttribute="leading" secondItem="6tg-46-1kN" secondAttribute="leading" id="jfM-h3-9Cc"/>
                     <constraint firstAttribute="bottom" secondItem="7hQ-Qd-7gD" secondAttribute="bottom" id="kAm-Mb-ESq"/>

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+HeaderFooter.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+HeaderFooter.swift
@@ -7,14 +7,26 @@ extension RegisterDomainDetailsViewController {
     }
 
     func configureTableFooterView() {
+        var safeAreaInset: CGFloat = 0
+
+        if #available(iOS 11.0, *) {
+            safeAreaInset = tableView.safeAreaInsets.bottom
+        }
+
+
         //Creating a UIView with a custom frame because table tableFooterView doesn't support autolayout
         let footer = UIView(frame: CGRect(x: 0,
                                           y: 0,
                                           width: view.frame.size.width,
-                                          height: Constants.buttonContainerHeight))
+                                          height: Constants.buttonContainerHeight + safeAreaInset))
         footerView.frame = footer.frame
         footer.addSubview(footerView)
-        footer.pinSubviewToAllEdges(footerView)
+        footer.addConstraints([
+            footer.topAnchor.constraint(equalTo: footerView.topAnchor),
+            footer.rightAnchor.constraint(equalTo: footerView.rightAnchor),
+            footer.bottomAnchor.constraint(equalTo: footerView.bottomAnchor),
+            footer.leftAnchor.constraint(equalTo: footerView.leftAnchor),
+            ])
         tableView.tableFooterView = footer
     }
 

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -48,6 +48,7 @@ class RegisterDomainDetailsViewController: NUXTableViewController {
         configureView()
     }
 
+
     private func configureView() {
         title = NSLocalizedString("Register domain",
                                   comment: "Title for the Register domain screen")
@@ -60,7 +61,30 @@ class RegisterDomainDetailsViewController: NUXTableViewController {
         }
 
         viewModel.prefill()
+
+        changeBottomSafeAreaInset()
         setupEditingEndingTapGestureRecognizer()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        configureTableFooterView()
+        changeBottomSafeAreaInset()
+
+    }
+
+    private func changeBottomSafeAreaInset() {
+        guard #available(iOS 11.0, *) else {
+            return
+        }
+
+        // Footer in this case is the submit button. We want the background to extend under the home "buttom".
+        // The bar at the bottom of the screen. Whatever that thing's called? Home indicator? That thing.
+        // Hence this bit of dark magic.
+        let safeAreaInsets = tableView.safeAreaInsets.bottom
+
+        var newInsets = tableView.contentInset
+        newInsets.bottom = -safeAreaInsets
+        tableView.contentInset = newInsets
     }
 
     private func configureTableView() {

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/Views/RegisterDomainDetailsFooterView.xib
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/Views/RegisterDomainDetailsFooterView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -23,13 +23,16 @@
                     </constraints>
                 </imageView>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="aWW-fc-OkB" customClass="NUXButton" customModule="WordPressAuthenticator">
-                    <rect key="frame" x="20" y="16" width="335" height="110"/>
+                    <rect key="frame" x="20" y="16" width="335" height="50"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="50" id="ujS-fE-lvl"/>
+                    </constraints>
                     <state key="normal" title="Button"/>
                 </button>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstItem="WWz-Oe-Kaz" firstAttribute="bottom" secondItem="aWW-fc-OkB" secondAttribute="bottom" constant="16" id="5N8-7U-xow"/>
+                <constraint firstItem="WWz-Oe-Kaz" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="aWW-fc-OkB" secondAttribute="bottom" constant="16" id="5N8-7U-xow"/>
                 <constraint firstItem="XTo-NK-MSn" firstAttribute="top" secondItem="WWz-Oe-Kaz" secondAttribute="top" constant="-10" id="BTF-Va-qsg"/>
                 <constraint firstItem="WWz-Oe-Kaz" firstAttribute="trailing" secondItem="aWW-fc-OkB" secondAttribute="trailing" constant="20" id="NCI-OG-04F"/>
                 <constraint firstItem="WWz-Oe-Kaz" firstAttribute="trailing" secondItem="XTo-NK-MSn" secondAttribute="trailing" id="QsD-jY-ATt"/>

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueSectionHeaderFooter.xib
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueSectionHeaderFooter.xib
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,12 +28,13 @@
             </subviews>
             <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
             <constraints>
-                <constraint firstItem="h2s-FQ-khG" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" id="3Uz-6C-ppc"/>
-                <constraint firstAttribute="bottom" secondItem="h2s-FQ-khG" secondAttribute="bottom" constant="7" id="3bI-dr-T8V"/>
-                <constraint firstAttribute="trailing" secondItem="h2s-FQ-khG" secondAttribute="trailing" constant="20" id="mUk-yi-bRz"/>
-                <constraint firstItem="h2s-FQ-khG" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="20" id="siM-Nd-UFb"/>
+                <constraint firstItem="h2s-FQ-khG" firstAttribute="leading" secondItem="21a-RX-ZhF" secondAttribute="leading" constant="20" id="3Uz-6C-ppc"/>
+                <constraint firstItem="21a-RX-ZhF" firstAttribute="bottom" secondItem="h2s-FQ-khG" secondAttribute="bottom" constant="7" id="3bI-dr-T8V"/>
+                <constraint firstItem="21a-RX-ZhF" firstAttribute="trailing" secondItem="h2s-FQ-khG" secondAttribute="trailing" constant="20" id="mUk-yi-bRz"/>
+                <constraint firstItem="h2s-FQ-khG" firstAttribute="top" secondItem="21a-RX-ZhF" secondAttribute="top" constant="20" id="siM-Nd-UFb"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="21a-RX-ZhF"/>
             <connections>
                 <outlet property="titleLabel" destination="h2s-FQ-khG" id="xfc-xS-vwy"/>
                 <outlet property="topConstraint" destination="siM-Nd-UFb" id="u2G-qu-xyE"/>


### PR DESCRIPTION
I'm gonna try to squeeze this in for 11.3 still ;P

This fixes some UI issues for domains.

Namely:

1. The address labels now are now wider and fit in one line:
![simulator screen shot - iphone xs - 2018-11-21 at 06 39 07](https://user-images.githubusercontent.com/1594081/48821168-7c1d4c80-ed58-11e8-85ad-eaf0daa50a27.png)

2. Rotation to landscape doesn't break the submit button anymore 

![simulator screen shot - iphone xs - 2018-11-21 at 06 39 48](https://user-images.githubusercontent.com/1594081/48821215-a0792900-ed58-11e8-9af5-c25ec3fe869c.png)

3. Bonus points: the button now extends it's background below the safe area insets!
![simulator screen shot - iphone xs - 2018-11-21 at 06 39 45](https://user-images.githubusercontent.com/1594081/48821219-a7a03700-ed58-11e8-9a04-cd6ff658a366.png)

I also looked into making it follow readable width on iPads — but I don't think we do it anywhere else in the app, and it honestly didn't feel very good. I'm up for revisiting this more broadly in the app, but didn't seem right here.

I'll have one more coming with Analytics and after that it should be wrap for realsies!

