### PR TITLE
Add analytics event for Custom Domains.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -24,13 +24,13 @@ end
 ##
 def wordpress_shared
     ## for production:
-    ##pod 'WordPressShared', '~> 1.5.0'
+    pod 'WordPressShared', '~> 1.5'
 
     ## for development:
     ##pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'd664be9e496112b8f2d98f41607db41cbcc6fd0b'
+    ##pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'd664be9e496112b8f2d98f41607db41cbcc6fd0b'
 end
 
 def aztec

--- a/Podfile
+++ b/Podfile
@@ -24,13 +24,13 @@ end
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.5.0'
+    ##pod 'WordPressShared', '~> 1.5.0'
 
     ## for development:
-    ## pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
+    ##pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    ## pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '14a5ebae28fdc09130b091330d84a3a310132cd2'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'd664be9e496112b8f2d98f41607db41cbcc6fd0b'
 end
 
 def aztec

--- a/Podfile
+++ b/Podfile
@@ -24,7 +24,7 @@ end
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.5'
+    pod 'WordPressShared', '~> 1.5.1'
 
     ## for development:
     ##pod 'WordPressShared', :path => '../WordPress-iOS-Shared'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -172,7 +172,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.2)
   - WordPressAuthenticator (~> 1.1)
   - WordPressKit (~> 1.5.0)
-  - WordPressShared (~> 1.5.0)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `d664be9e496112b8f2d98f41607db41cbcc6fd0b`)
   - WordPressUI (~> 1.1)
   - WPMediaPicker (= 1.3.1)
   - wpxmlrpc (= 0.8.3)
@@ -210,7 +210,6 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -220,11 +219,17 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPressShared:
+    :commit: d664be9e496112b8f2d98f41607db41cbcc6fd0b
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  WordPressShared:
+    :commit: d664be9e496112b8f2d98f41607db41cbcc6fd0b
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -264,6 +269,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 794cf0e8a9ddb2d66ebc11851c1496c19d8e5af9
+PODFILE CHECKSUM: 203c2bdd5a68ae9a2cc266319b416e2341b6fb6f
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -127,7 +127,7 @@ PODS:
     - UIDeviceIdentifier (~> 0.4)
     - WordPressShared (~> 1.4)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.5.0):
+  - WordPressShared (1.5.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.1.0)
@@ -172,7 +172,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.2)
   - WordPressAuthenticator (~> 1.1)
   - WordPressKit (~> 1.5.0)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `d664be9e496112b8f2d98f41607db41cbcc6fd0b`)
+  - WordPressShared (~> 1.5)
   - WordPressUI (~> 1.1)
   - WPMediaPicker (= 1.3.1)
   - wpxmlrpc (= 0.8.3)
@@ -210,6 +210,7 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -219,17 +220,11 @@ EXTERNAL SOURCES:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  WordPressShared:
-    :commit: d664be9e496112b8f2d98f41607db41cbcc6fd0b
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  WordPressShared:
-    :commit: d664be9e496112b8f2d98f41607db41cbcc6fd0b
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -263,12 +258,12 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 28339c1311dcdfdd9e50aba60dcf4c35184d032f
   WordPressAuthenticator: 0e60d89e1637212bc841a0cf66fc5ef8cac01e52
   WordPressKit: 46fe8a4fa2ff4195f73a992f0f6f3a1eb2972b70
-  WordPressShared: c5a14738ee94e8306b37e862db1133c665709c21
+  WordPressShared: 2a2d74bbe0ee4c31452f8c33aafe255278dc56f6
   WordPressUI: d3dbd0258f12560d6607647d3240c62c83e089fe
   WPMediaPicker: ea92f84950843c7baf6a7325caed72ad7852418d
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 203c2bdd5a68ae9a2cc266319b416e2341b6fb6f
+PODFILE CHECKSUM: 068c73d7d3426ba7fa5186bec36f0c07c31688f4
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -172,7 +172,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.2)
   - WordPressAuthenticator (~> 1.1)
   - WordPressKit (~> 1.5.0)
-  - WordPressShared (~> 1.5)
+  - WordPressShared (~> 1.5.1)
   - WordPressUI (~> 1.1)
   - WPMediaPicker (= 1.3.1)
   - wpxmlrpc (= 0.8.3)
@@ -264,6 +264,6 @@ SPEC CHECKSUMS:
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 068c73d7d3426ba7fa5186bec36f0c07c31688f4
+PODFILE CHECKSUM: 9f31cd9f30d5b80fc282675de522e7498ef5f71c
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -277,6 +277,30 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatAppSettingsVideoOptimizationChanged:
             eventName = @"app_settings_video_optimization_changed";
             break;
+        case WPAnalyticsStatAutomatedTransferCustomDomainDialogShown:
+            eventName = @"automated_transfer_custom_domain_dialog_shown";
+            break;
+        case WPAnalyticsStatAutomatedTransferCustomDomainDialogCancelled:
+            eventName = @"automated_transfer_custom_domain_dialog_cancelled";
+            break;
+        case WPAnalyticsStatAutomatedTransferCustomDomainSuggestionQueried:
+            eventName = @"automated_transfer_custom_domain_suggestion_queried";
+            break;
+        case WPAnalyticsStatAutomatedTransferCustomDomainSuggestionSelected:
+            eventName = @"automated_transfer_custom_domain_suggestion_selected";
+            break;
+        case WPAnalyticsStatAutomatedTransferCustomDomainContactInfoValidated:
+            eventName = @"automated_transfer_custom_domain_contact_information_validated";
+            break;
+        case WPAnalyticsStatAutomatedTransferCustomDomainContactInfoValidationFailed:
+            eventName = @"automated_transfer_custom_domain_contact_information_validation_failed";
+            break;
+        case WPAnalyticsStatAutomatedTransferCustomDomainPurchased:
+            eventName = @"automated_transfer_custom_domain_purchased";
+            break;
+        case WPAnalyticsStatAutomatedTransferCustomDomainPurchaseFailed:
+            eventName = @"automated_transfer_custom_domain_purchase_failed";
+            break;
         case WPAnalyticsStatAutomatedTransferDialogShown:
             eventName = @"automated_transfer_confirm_dialog_shown";
             break;

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel.swift
@@ -188,6 +188,10 @@ class RegisterDomainDetailsViewModel {
                 self?.isLoading = false
                 return
             }
+
+
+            WPAnalytics.track(.automatedTransferCustomDomainContactInfoValidated)
+
             // This is a bit of a callback hell, but our services aren't super mobile friendly.
             // We'll manage.
 
@@ -196,6 +200,7 @@ class RegisterDomainDetailsViewModel {
                                                                        domainSuggestion: strongSelf.domain,
                                                                        privacyProtectionEnabled: privacyEnabled,
                                                                        success: { cart in
+
 
                     // And now that we have a cart — time to redeem it.
                     strongSelf.registerDomainDetailsService.redeemCartUsingCredits(cart: cart,
@@ -209,6 +214,8 @@ class RegisterDomainDetailsViewModel {
 
                                 // We've succeeded! The domain is purchased and set to the primary one — time to drop out of this flow
                                 // and return control to the Plugins, which will present the AT flow. (The VC handles that after getting the `.registerSucceeded` message.)
+                                WPAnalytics.track(.automatedTransferCustomDomainPurchased)
+
                                 strongSelf.isLoading = false
                                 strongSelf.onChange?(.registerSucceeded(domain: strongSelf.domain.domainName))
                             },
@@ -224,14 +231,14 @@ class RegisterDomainDetailsViewModel {
 
                         // Failure during the purchase step. Not much we can do from the mobile in any case,
                         // so let's just show a generic error message.
-
+                        WPAnalytics.track(.automatedTransferCustomDomainPurchaseFailed)
                         strongSelf.isLoading = false
                         strongSelf.onChange?(.prefillError(message: Localized.redemptionError))
                     })
             }) { (error) in
 
                 // Same as above. If adding items to cart fails, not much we can do to recover :(
-
+                WPAnalytics.track(.automatedTransferCustomDomainPurchaseFailed)
                 strongSelf.isLoading = false
                 strongSelf.onChange?(.prefillError(message: Localized.redemptionError))
             }
@@ -481,6 +488,7 @@ extension RegisterDomainDetailsViewModel {
                     strongSelf.clearValidationErrors()
                     successCompletion()
                 } else {
+                    WPAnalytics.track(.automatedTransferCustomDomainContactInfoValidationFailed)
                     strongSelf.updateValidationErrors(with: response.messages)
                 }
                 strongSelf.onChange?(.remoteValidationFinished)

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -89,11 +89,13 @@ class RegisterDomainSuggestionsViewController: NUXViewController, DomainSuggesti
 
 extension RegisterDomainSuggestionsViewController: DomainSuggestionsTableViewControllerDelegate {
     func domainSelected(_ domain: DomainSuggestion) {
+        WPAnalytics.track(.automatedTransferCustomDomainSuggestionSelected)
         self.domain = domain
         showButtonView(show: true, withAnimation: true)
     }
 
     func newSearchStarted() {
+        WPAnalytics.track(.automatedTransferCustomDomainSuggestionQueried)
         showButtonView(show: false, withAnimation: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -185,6 +185,7 @@ class PluginViewModel: Observable {
 
                     if FeatureFlag.automatedTransfersCustomDomain.enabled && !hasCustomDomain && hasDomainCredits {
                         let alert = self.confirmRegisterDomainAlert(for: directoryEntry)
+                        WPAnalytics.track(.automatedTransferCustomDomainDialogShown)
                         self.present?(alert)
                     } else {
 
@@ -462,7 +463,9 @@ class PluginViewModel: Observable {
 
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
 
-        alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Cancel registering a domain"))
+        alertController.addCancelActionWithTitle(NSLocalizedString("Cancel", comment: "Cancel registering a domain")) { _ in
+            WPAnalytics.track(.automatedTransferCustomDomainDialogCancelled)
+        }
 
         let registerDomainAction = alertController.addDefaultActionWithTitle(registerDomainActionTitle) { [weak self] (action) in
             self?.presentDomainRegistration(for: directoryEntry)


### PR DESCRIPTION
Adds basic analytics for Custom Domains.

`-Shared` counterpart PR is: https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/168

To test:

Look at the code, and like, trust me that it works ;P
Optionally, just go trough the whole flow and verify that appropriate events are printed to the console.