### PR TITLE
Update revisions error messaging to remove variables

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
@@ -31,13 +31,6 @@ class RevisionsTableViewController: UITableViewController {
         return tableViewHandler.resultsController.sections?.count ?? 0
     }
 
-    private var postType: String {
-        switch post {
-        case _ as Page: return NSLocalizedString("page", comment: "No Result placeholder when an AbstractPost is a type: Page")
-        default: return NSLocalizedString("post", comment: "No Result placeholder when an AbstractPost is a type: Post ")
-        }
-    }
-
 
     required init(post: AbstractPost, onRevisionLoaded: @escaping RevisionLoadedBlock) {
         self.post = post
@@ -108,7 +101,7 @@ private extension RevisionsTableViewController {
 
     @objc private func refreshRevisions() {
         if sectionCount == 0 {
-            configureAndDisplayNoResults(title: String(format: NoResultsText.loadingTitle, postType),
+            configureAndDisplayNoResults(title: NoResultsText.loadingTitle,
                                          accessoryView: NoResultsViewController.loadingAccessoryView())
         }
 
@@ -267,13 +260,13 @@ extension RevisionsTableViewController: RevisionsView {
             // When the API call failed and there are no revisions saved yet
             //
             configureAndDisplayNoResults(title: NoResultsText.errorTitle,
-                                         subtitle: String(format: NoResultsText.errorSubtitle, postType),
+                                         subtitle: NoResultsText.errorSubtitle,
                                          buttonTitle: NoResultsText.reloadButtonTitle)
         case (true, let count) where count == 0:
             // When the API call successed but there are no revisions loaded
             // This is an edge cas. It shouldn't happen since we open the revisions list only if the post revisions array is not empty.
             configureAndDisplayNoResults(title: NoResultsText.noResultsTitle,
-                                         subtitle: String(format: NoResultsText.noResultsSubtitle, postType))
+                                         subtitle: NoResultsText.noResultsSubtitle)
         default:
             hideNoResults()
         }

--- a/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
@@ -303,10 +303,10 @@ private extension Date {
 
 
 struct NoResultsText {
-    static let loadingTitle = NSLocalizedString("Loading %@ history...", comment: "Displayed while a call is loading the history. The placeholder might be 'post' or 'page'.")
+    static let loadingTitle = NSLocalizedString("Loading history...", comment: "Displayed while a call is loading the history.")
     static let reloadButtonTitle = NSLocalizedString("Try again", comment: "Re-load the history again. It appears if the loading call fails.")
     static let noResultsTitle = NSLocalizedString("No history yet", comment: "Displayed when a call is made to load the revisions but there's no result or an error.")
-    static let noResultsSubtitle = NSLocalizedString("When you make changes to your %@ you'll be able to see the history here", comment: "Displayed when a call is made to load the history but there's no result or an error. The placeholder might be 'post' or 'page'.")
+    static let noResultsSubtitle = NSLocalizedString("When you make changes in the editor you'll be able to see the history here", comment: "Displayed when a call is made to load the history but there's no result or an error.")
     static let errorTitle = NSLocalizedString("Oops", comment: "Title for the view when there's an error loading the history")
-    static let errorSubtitle = NSLocalizedString("There was an error loading the %@ history", comment: "Text displayed when there is a failure loading the history. The placeholder might be 'post' or 'page'.")
+    static let errorSubtitle = NSLocalizedString("There was an error loading the history", comment: "Text displayed when there is a failure loading the history.")
 }


### PR DESCRIPTION
**To test:**
Let's just make sure that the updated strings look ok in context. I assume they will though, because they'd need to grow / shrink for other languages.