### PR TITLE
Empty state: Update margins on view

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -19,13 +19,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ae-eX-ae9" userLabel="No Results View">
-                                <rect key="frame" x="38" y="116.5" width="299" height="454"/>
+                                <rect key="frame" x="30" y="116.5" width="315" height="454"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mkl-mm-wtH">
-                                        <rect key="frame" x="0.0" y="0.0" width="299" height="454"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="315" height="454"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-LB-oOz" userLabel="Accessory Stack View">
-                                                <rect key="frame" x="30" y="0.0" width="239" height="234"/>
+                                                <rect key="frame" x="38" y="0.0" width="239" height="234"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="czl-5D-gem" userLabel="Accessory View">
                                                         <rect key="frame" x="69.5" y="0.0" width="100" height="100"/>
@@ -41,7 +41,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Button Stack View">
-                                                <rect key="frame" x="29.5" y="254" width="240.5" height="200"/>
+                                                <rect key="frame" x="37.5" y="254" width="240.5" height="200"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">
                                                         <rect key="frame" x="26.5" y="0.0" width="187.5" height="72"/>
@@ -96,9 +96,9 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="x31-wL-G0k" firstAttribute="trailing" secondItem="0Ae-eX-ae9" secondAttribute="trailing" priority="999" constant="38" id="8y0-se-MDj"/>
+                            <constraint firstItem="x31-wL-G0k" firstAttribute="trailing" secondItem="0Ae-eX-ae9" secondAttribute="trailing" priority="999" constant="30" id="8y0-se-MDj"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="centerX" secondItem="x31-wL-G0k" secondAttribute="centerX" id="Qie-JB-M8x"/>
-                            <constraint firstItem="0Ae-eX-ae9" firstAttribute="leading" secondItem="x31-wL-G0k" secondAttribute="leading" priority="999" constant="38" id="Yvc-NG-l0P"/>
+                            <constraint firstItem="0Ae-eX-ae9" firstAttribute="leading" secondItem="x31-wL-G0k" secondAttribute="leading" priority="999" constant="30" id="Yvc-NG-l0P"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="centerY" secondItem="x31-wL-G0k" secondAttribute="centerY" id="bvr-5b-sAb"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="x31-wL-G0k"/>


### PR DESCRIPTION
Fixes #n/a

This changes the left and right margins on the empty state view (aka No Results view) from 38 to 30. The max width is still 360.

To test:
Go to an empty state view. Verify the view is a bit wider. Can you see it? I bet @SylvesterWilmott can. 😉 

(@SylvesterWilmott let me know if you need more example screenshots.)

![margins_updated](https://user-images.githubusercontent.com/1816888/48868396-a857be00-ed96-11e8-91df-5a467c29d656.png)





