### PR TITLE
Fix translations that are using string interpolation

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
@@ -190,7 +190,8 @@ open class AboutViewController: UITableViewController {
     // MARK: - Private Properties
     fileprivate lazy var footerTitleText: String = {
         let year = Calendar.current.component(.year, from: Date())
-        return NSLocalizedString("© \(year) Automattic, Inc.", comment: "About View's Footer Text")
+        let localizedTitleText = NSLocalizedString("© %@ Automattic, Inc.", comment: "About View's Footer Text. The variable is the current year")
+        return String(format: localizedTitleText, year)
     }()
 
     fileprivate var rows: [[Row]] {

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -164,7 +164,9 @@ private class AccountSettingsController: SettingsController {
             return nil
         }
 
-        return NSLocalizedString("There is a pending change of your email to \(pendingAddress). Please check your inbox for a confirmation link.",
-                                 comment: "Displayed when there's a pending Email Change")
+        let localizedNotice = NSLocalizedString("There is a pending change of your email to %@. Please check your inbox for a confirmation link.",
+            comment: "Displayed when there's a pending Email Change. The variable is the new email address.")
+
+        return String(format: localizedNotice, pendingAddress)
     }
 }


### PR DESCRIPTION
In just a couple of places in the codebase, we're using String interpolation for translation that includes variables, rather than the more standard `String(format:,...)` API. This makes it difficult for translators to identify a variable, vs text that might just be in brackets. This PR removes this method of translation, and makes the format a little more consistent.

For a translator, the difference looks like:

**Old**
`There is a pending change of your email to (pendingAddress).`

**New**
`There is a pending change of your email to %@.`

Context: Slack conversations
https://wordpress.slack.com/archives/C02RQC4LY/p1542666991030900
https://wordpress.slack.com/archives/C02RQC4LY/p1542667503035600
https://wordpress.slack.com/archives/C02RQC4LY/p1542667604036700

One open question, though, is whether it's worth updating these strings at all, as they'd need to be re-translated. While this shouldn't be a _lot_ of work (it should appear next to the old translation in the list), I want to be careful not to waste our translators time.

This PR is here for discussion at this point, and shouldn't be merged until we've considered the point above.