### PR TITLE
[Stats Refresh] All Time Stats: format large numbers

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -106,27 +106,38 @@ private extension SiteStatsInsightsViewModel {
         let allTimeStats = store.getAllTimeStats()
         var dataRows = [StatsTotalRowData]()
 
-        if let numberOfPostsValue = allTimeStats?.numberOfPostsValue.intValue, numberOfPostsValue > 0 {
+        // For these tests, we need the string version to display since it comes formatted (ex: numberOfPosts).
+        // And we need the actual number value to test > 0 (ex: numberOfPostsValue).
+
+        if let numberOfPosts = allTimeStats?.numberOfPosts,
+            let numberOfPostsValue = allTimeStats?.numberOfPostsValue.intValue,
+            numberOfPostsValue > 0 {
             dataRows.append(StatsTotalRowData.init(name: AllTimeStats.postsTitle,
-                                                   data: String(numberOfPostsValue),
+                                                   data: numberOfPosts,
                                                    icon: AllTimeStats.postsIcon))
         }
 
-        if let numberOfViewsValue = allTimeStats?.numberOfViewsValue.intValue, numberOfViewsValue > 0 {
+        if let numberOfViews = allTimeStats?.numberOfViews,
+            let numberOfViewsValue = allTimeStats?.numberOfViewsValue.intValue,
+            numberOfViewsValue > 0 {
             dataRows.append(StatsTotalRowData.init(name: AllTimeStats.viewsTitle,
-                                                   data: String(numberOfViewsValue),
+                                                   data: numberOfViews,
                                                    icon: AllTimeStats.viewsIcon))
         }
 
-        if let numberOfVisitorsValue = allTimeStats?.numberOfVisitorsValue.intValue, numberOfVisitorsValue > 0 {
+        if let numberOfVisitors = allTimeStats?.numberOfVisitors,
+            let numberOfVisitorsValue = allTimeStats?.numberOfVisitorsValue.intValue,
+            numberOfVisitorsValue > 0 {
             dataRows.append(StatsTotalRowData.init(name: AllTimeStats.visitorsTitle,
-                                                   data: String(numberOfVisitorsValue),
+                                                   data: numberOfVisitors,
                                                    icon: AllTimeStats.visitorsIcon))
         }
 
-        if let bestNumberOfViewsValue = allTimeStats?.bestNumberOfViewsValue.intValue, bestNumberOfViewsValue > 0 {
+        if let bestNumberOfViews = allTimeStats?.bestNumberOfViews,
+            let bestNumberOfViewsValue = allTimeStats?.bestNumberOfViewsValue.intValue,
+            bestNumberOfViewsValue > 0 {
             dataRows.append(StatsTotalRowData.init(name: AllTimeStats.bestViewsEverTitle,
-                                                   data: String(bestNumberOfViewsValue),
+                                                   data: bestNumberOfViews,
                                                    icon: AllTimeStats.bestViewsIcon,
                                                    nameDetail: allTimeStats?.bestViewsOn,
                                                    showSeparator: false))

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.xib
@@ -11,7 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="57" id="3fP-pA-Ovw" customClass="StatsCellHeader" customModule="WordPress" customModuleProvider="target">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="57" id="3fP-pA-Ovw" customClass="StatsCellHeader" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="375" height="57"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="3fP-pA-Ovw" id="fMA-Y8-HGb">


### PR DESCRIPTION
Fixes #10501 

Well this was easier than expected. Turns out I'd used the wrong values to display. The string versions of the values are pre-formatted with commas. So I've simply replaced the number values with the string values. 🎉 !

Also, as a minor bonus, I disabled the selection on the cell header. So now if you select it, it won't turn an ugly brown color.

To test:
- On a site with a bunch of posts, views, visitors, and/or best views ever, go to Stats > Insights.
  - Tip: the Automattic Field Guide has some high number.
- Verify the numbers have commas:

<img width="400" alt="numbers" src="https://user-images.githubusercontent.com/1816888/48870281-71d17180-ed9d-11e8-9740-8e84bbe0ba14.png">
