### PR TITLE
Ensure `magick` and `gs` are on the build machine

### DIFF
--- a/Scripts/fastlane/actions/ios_build_preflight.rb
+++ b/Scripts/fastlane/actions/ios_build_preflight.rb
@@ -7,7 +7,25 @@ module Fastlane
         other_action.configure_validate
 
         Action.sh("cd .. && rm -rf ~/Library/Developer/Xcode/DerivedData")
-        
+
+        # Verify that ImageMagick exists on this machine and can be called from the command-line.
+        # Internal Builds use it to generate the App Icon as part of the build process
+        begin
+            Action.sh("which magick")
+        rescue
+            UI.user_error!("Couldn't find ImageMagick. Please install it by running `brew install imagemagick`")
+            raise
+        end
+
+        # Verify that Ghostscript exists on this machine and can be called from the command-line.
+        # Internal Builds use it to generate the App Icon as part of the build process
+        begin
+            Action.sh("which gs")
+        rescue
+            UI.user_error!("Couldn't find Ghostscript. Please install it by running `brew install ghostscript`")
+            raise
+        end
+
         # Check gems and pods are up to date. This will exit if it fails
         begin
           Action.sh("bundle check")


### PR DESCRIPTION
They’re used late in the build process, but if you do the entire build and don’t have them installed, you have to do it all over again.

That’s no fun.

This will save some frustration on new build machines (or CI!)

**To test:**

Try removing ImageMagick and Ghostscript from your machine with:
`brew remove imagemagick ghostscript`

Then run `bundle exec fastlane build_and_upload_release`.

You'll get a warning about ImageMagick. Follow the directions in the prompt, and try running again.

Next you'll get a warning about Ghostscript, follow the directions again.

Run it a third time, and you'll pass the checks and be off to build the full app.

