### PR TITLE
History / Revisions: Fix footer date formatter

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
@@ -23,7 +23,7 @@ class RevisionsTableViewController: UITableViewController {
         let footerView = RevisionsTableViewFooter(frame: CGRect(origin: .zero,
                                                                 size: CGSize(width: tableView.frame.width,
                                                                              height: Sizes.sectionFooterHeight)))
-        footerView.setFooterText(post?.dateCreated?.mediumStringWithTime())
+        footerView.setFooterText(post?.dateCreated?.shortDateString())
         return footerView
     }()
 
@@ -295,6 +295,17 @@ private extension Date {
         formatter.timeStyle = .short
         return formatter
     }()
+
+    private static let shortDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
+    func shortDateString() -> String {
+        return Date.shortDateFormatter.string(from: self)
+    }
 
     func shortTimeString() -> String {
         return Date.shortTimeFormatter.string(from: self)

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Views/Footer/RevisionsTableViewFooter.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Views/Footer/RevisionsTableViewFooter.swift
@@ -21,7 +21,7 @@ class RevisionsTableViewFooter: UIView {
             return
         }
 
-        let text = NSLocalizedString("Post Created on %@", comment: "The footer text appears within the footer displaying when the post has been created.")
+        let text = NSLocalizedString("Post created on %@", comment: "The footer text appears within the footer displaying when the post has been created.")
         footerLabel.text = String.localizedStringWithFormat(text, stringDate)
     }
 }


### PR DESCRIPTION
Fixes #10517 

This PR fixes the date formatter used by the revisions list footer.

![simulator screen shot - iphone x - 2018-11-22 at 10 22 39](https://user-images.githubusercontent.com/912252/48896869-929ed300-ee40-11e8-876d-e5302c66259d.png)

**To test:**
- Open a Revisions list and check the date formatter style. It shouldn't contain the time but only a short date as style.


