### PR TITLE
History / Revisions: Set the revisions array only if it exists

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -586,7 +586,10 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     post.mt_excerpt = remotePost.excerpt;
     post.wp_slug = remotePost.slug;
     post.suggested_slug = remotePost.suggestedSlug;
-    post.revisions = [remotePost.revisions copy];
+    
+    if ([remotePost.revisions wp_isValidObject]) {
+        post.revisions = [remotePost.revisions copy];
+    }
 
     if (remotePost.postID != previousPostID) {
         [self updateCommentsForPost:post];


### PR DESCRIPTION
Fixes #10522 

This PR fixes a bug when a draft post is restored. This happen because the post local service uses the same method to map the remote post into the abstract post from different responses, and
`post.revisions = [remotePost.revisions copy];` should happen only if `remotePost.revisions` exists because in some response it might be nil and might override a previous value.

**To test:**
- Create a draft -> then save several revisions -> trash the draft -> restore it. You should see the history button from the menu.


