### PR TITLE
Don’t allow string interpolation in localizations

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -73,6 +73,6 @@ custom_rules:
 
   string_interpolation_in_localized_string:
     name: "String Interpolation in Localized String"
-    regex: 'NSLocalizedString\("[^"]+\\\(\S*\)'
+    regex: 'NSLocalizedString\("[^"]*\\\(\S*\)'
     message: "Localized strings must not use interpolated variables. Instead, use `String(format:`"
     severity: error

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -70,3 +70,9 @@ custom_rules:
     regex: 'NSLocalizedString([^,]+,\s+comment:\s*"")'
     message: "Localized strings should include a description giving context for how the string is used."
     severity: warning
+
+  string_interpolation_in_localized_string:
+    name: "String Interpolation in Localized String"
+    regex: 'NSLocalizedString\("[^"]+\\\(\S*\)'
+    message: "Localized strings must not used interpolated variables. Instead, use `String(format:`"
+    severity: error

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -74,5 +74,5 @@ custom_rules:
   string_interpolation_in_localized_string:
     name: "String Interpolation in Localized String"
     regex: 'NSLocalizedString\("[^"]+\\\(\S*\)'
-    message: "Localized strings must not used interpolated variables. Instead, use `String(format:`"
+    message: "Localized strings must not use interpolated variables. Instead, use `String(format:`"
     severity: error


### PR DESCRIPTION
Following up on https://github.com/wordpress-mobile/WordPress-iOS/pull/10511, I'm thinking we should have an automated way to prevent this sort of change from being committed in the future.

**To test:**
Add the following to a file in the project:

```swift
let year = 2018
NSLocalizedString("© \(year) Automattic, Inc.", comment: "About View's Footer Text")
```

Run `swiftlint` in the project root (if you don't have it, `brew swiftlint`). You should see 1 violation. Remove it, and now you should see zero! 