### PR TITLE
Set a default value to the image view

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Revisions/Views/Cell/RevisionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Views/Cell/RevisionsTableViewCell.swift
@@ -37,6 +37,8 @@ class RevisionsTableViewCell: UITableViewCell {
 
     var avatarURL: String? {
         didSet {
+            avatarImageView.image = UIImage(named: "gravatar")
+
             if let avatarURL = avatarURL,
                 let placeholder = UIImage(named: "gravatar") {
                 let url = URL(string: avatarURL)


### PR DESCRIPTION
Refs. #10304 

This PR fix a RevisionCell behaviour. I added a default value to the imageview. Because the gravatar image is assigned only if there is a valid URL, I added a default value in order to avoid wrong data displayed when a cell is reused.

**To test:**
- Open a revisions list and check if the image placeholder is displayed when there's no author

Issue found by @rachelmcr 

