### PR TITLE
Update react-native-svg version to be same as the example app

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -99,7 +99,7 @@ target 'WordPress' do
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'
-    pod 'RNSVG', :git => 'https://github.com/react-native-community/react-native-svg.git', :tag => '6.5.2'
+    pod 'RNSVG', :git => 'https://github.com/react-native-community/react-native-svg.git', :tag => '8.0.8'
     pod 'RNTAztecView', :git => 'https://github.com/wordpress-mobile/react-native-aztec.git'
 
     ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -159,7 +159,7 @@ PODS:
     - React/Core
     - React/fishhook
     - React/RCTBlob
-  - RNSVG (6.5.2):
+  - RNSVG (8.0.8):
     - React
   - RNTAztecView (1.0.0):
     - React
@@ -234,7 +234,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 6.1.0)
   - Reachability (= 3.2)
   - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
-  - RNSVG (from `https://github.com/react-native-community/react-native-svg.git`, tag `6.5.2`)
+  - RNSVG (from `https://github.com/react-native-community/react-native-svg.git`, tag `8.0.8`)
   - RNTAztecView (from `https://github.com/wordpress-mobile/react-native-aztec.git`)
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -302,7 +302,7 @@ EXTERNAL SOURCES:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   RNSVG:
     :git: https://github.com/react-native-community/react-native-svg.git
-    :tag: 6.5.2
+    :tag: 8.0.8
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
   yoga:
@@ -317,7 +317,7 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNSVG:
     :git: https://github.com/react-native-community/react-native-svg.git
-    :tag: 6.5.2
+    :tag: 8.0.8
   RNTAztecView:
     :commit: 08916a6d6491132969f33c1867af8a5b1d733758
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
@@ -353,7 +353,7 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   React: 01aa04500b2957c2767e1dff9fe12e09444a467c
-  RNSVG: 3c037ade1c42014de732e27e3879bf2b77ea78ea
+  RNSVG: 2d4741933313f02e79b12af1b49b2856228b382a
   RNTAztecView: 57bb73dba9d88a27aabda2cefb1b1e0dcad90502
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
@@ -369,6 +369,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 8592a9351bc3c203d93d2bcde99cff7041cab951
+PODFILE CHECKSUM: 0d43a11131106c07426e17f32a1b9b58b266bca8
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Fixes the below crash on the WordPressiOS side whenever a post is opened for edit.

![simulator screen shot - iphone 7 - 2018-11-23 at 18 28 10](https://user-images.githubusercontent.com/5032900/48952057-e9480200-ef51-11e8-88ff-2a07e9f90aff.png)

And toolbar buttons aren't displayed properly:

![simulator screen shot - iphone 7 - 2018-11-23 at 18 28 29](https://user-images.githubusercontent.com/5032900/48952088-05e43a00-ef52-11e8-884a-52709c1afd21.png)

**To test:**

- Checkout the latest master from gutenberg-mobile
- Open the WordPress-iOS app with gutenberg flag on.
- Verify that the above error doesn't occur
- Verify that toolbar buttons are displayed properly

