### PR TITLE
Issues/11.3 revisions analytics

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -24,13 +24,13 @@ end
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.5.0'
+    pod 'WordPressShared', '~> 1.6.0'
 
     ## for development:
     ## pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    ## pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '14a5ebae28fdc09130b091330d84a3a310132cd2'
+#     pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'd9973eac8e72ce944a3d3fbe7061737a8d1b861f'
 end
 
 def aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -127,7 +127,7 @@ PODS:
     - UIDeviceIdentifier (~> 0.4)
     - WordPressShared (~> 1.4)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.5.0):
+  - WordPressShared (1.6.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.1.0)
@@ -172,7 +172,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.2)
   - WordPressAuthenticator (~> 1.1)
   - WordPressKit (~> 1.5.0)
-  - WordPressShared (~> 1.5.0)
+  - WordPressShared (~> 1.6.0)
   - WordPressUI (~> 1.1)
   - WPMediaPicker (= 1.3.1)
   - wpxmlrpc (= 0.8.3)
@@ -258,12 +258,12 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 28339c1311dcdfdd9e50aba60dcf4c35184d032f
   WordPressAuthenticator: 0e60d89e1637212bc841a0cf66fc5ef8cac01e52
   WordPressKit: 46fe8a4fa2ff4195f73a992f0f6f3a1eb2972b70
-  WordPressShared: c5a14738ee94e8306b37e862db1133c665709c21
+  WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
   WordPressUI: d3dbd0258f12560d6607647d3240c62c83e089fe
   WPMediaPicker: ea92f84950843c7baf6a7325caed72ad7852418d
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 794cf0e8a9ddb2d66ebc11851c1496c19d8e5af9
+PODFILE CHECKSUM: c813351c538291df203f8dd251bd2947026d4d0e
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1019,6 +1019,21 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             eventName = @"post_list_button_pressed";
             eventProperties = @{ TracksEventPropertyButtonKey : @"view" };
             break;
+        case WPAnalyticsStatPostRevisionsListViewed:
+            eventName = @"revisions_list_viewed";
+            break;
+        case WPAnalyticsStatPostRevisionsDetailViewed:
+            eventName = @"revisions_detail_viewed";
+            break;
+        case WPAnalyticsStatPostRevisionsDetailCancelled:
+            eventName = @"revisions_detail_cancelled";
+            break;
+        case WPAnalyticsStatPostRevisionsRevisionLoaded:
+            eventName = @"revisions_revision_loaded";
+            break;
+        case WPAnalyticsStatPostRevisionsLoadUndone:
+            eventName = @"revisions_load_undone";
+            break;
         case WPAnalyticsStatPushAuthenticationApproved:
             eventName = @"push_authentication_approved";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -18,9 +18,6 @@ extern NSString * const WPAppAnalyticsKeyCommentID;
 extern NSString * const WPAppAnalyticsKeyLegacyQuickAction;
 extern NSString * const WPAppAnalyticsKeyQuickAction;
 extern NSString * const WPAppAnalyticsKeySource;
-extern NSString * const WPAppAnalyticsValueList;
-extern NSString * const WPAppAnalyticsValueSwipe;
-extern NSString * const WPAppAnalyticsValueChevron;
 
 /**
  *  @class      WPAppAnalytics

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -17,6 +17,10 @@ extern NSString * const WPAppAnalyticsKeyEditorSource;
 extern NSString * const WPAppAnalyticsKeyCommentID;
 extern NSString * const WPAppAnalyticsKeyLegacyQuickAction;
 extern NSString * const WPAppAnalyticsKeyQuickAction;
+extern NSString * const WPAppAnalyticsKeySource;
+extern NSString * const WPAppAnalyticsValueList;
+extern NSString * const WPAppAnalyticsValueSwipe;
+extern NSString * const WPAppAnalyticsValueChevron;
 
 /**
  *  @class      WPAppAnalytics

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -25,9 +25,6 @@ NSString * const WPAppAnalyticsKeyLegacyQuickAction                 = @"is_quick
 NSString * const WPAppAnalyticsKeyQuickAction                       = @"quick_action";
 
 NSString * const WPAppAnalyticsKeySource                            = @"source";
-NSString * const WPAppAnalyticsValueList                            = @"list";
-NSString * const WPAppAnalyticsValueSwipe                           = @"swipe";
-NSString * const WPAppAnalyticsValueChevron                         = @"chevron";
 
 NSString * const WPAppAnalyticsKeyHasGutenbergBlocks                = @"has_gutenberg_blocks";
 static NSString * const WPAppAnalyticsKeyLastVisibleScreen          = @"last_visible_screen";

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -24,6 +24,11 @@ NSString * const WPAppAnalyticsKeyCommentID                         = @"comment_
 NSString * const WPAppAnalyticsKeyLegacyQuickAction                 = @"is_quick_action";
 NSString * const WPAppAnalyticsKeyQuickAction                       = @"quick_action";
 
+NSString * const WPAppAnalyticsKeySource                            = @"source";
+NSString * const WPAppAnalyticsValueList                            = @"list";
+NSString * const WPAppAnalyticsValueSwipe                           = @"swipe";
+NSString * const WPAppAnalyticsValueChevron                         = @"chevron";
+
 NSString * const WPAppAnalyticsKeyHasGutenbergBlocks                = @"has_gutenberg_blocks";
 static NSString * const WPAppAnalyticsKeyLastVisibleScreen          = @"last_visible_screen";
 static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_app";

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/RevisionDiffsBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/RevisionDiffsBrowserViewController.swift
@@ -40,6 +40,7 @@ class RevisionDiffsBrowserViewController: UIViewController {
     private lazy var doneBarButtonItem: UIBarButtonItem = {
         let doneItem = UIBarButtonItem(barButtonSystemItem: .done, target: nil, action: nil)
         doneItem.on() { [weak self] _ in
+            WPAnalytics.track(.postRevisionsDetailCancelled)
             self?.dismiss(animated: true)
         }
         doneItem.title = NSLocalizedString("Done", comment: "Label on button to dismiss revisions view")
@@ -61,6 +62,7 @@ class RevisionDiffsBrowserViewController: UIViewController {
         setupNavbarItems()
         setNextPreviousButtons()
         showRevision()
+        trackRevisionsDetailViewed(with: .list)
     }
 
     private func showRevision() {
@@ -109,11 +111,13 @@ class RevisionDiffsBrowserViewController: UIViewController {
     private func showNext() {
         revisionState?.increaseIndex()
         showRevision()
+        trackRevisionsDetailViewed(with: .chevron)
     }
 
     private func showPrevious() {
         revisionState?.decreaseIndex()
         showRevision()
+        trackRevisionsDetailViewed(with: .chevron)
     }
 
     private func loadRevision() {
@@ -137,5 +141,19 @@ class RevisionDiffsBrowserViewController: UIViewController {
         default:
             break
         }
+    }
+}
+
+
+private extension RevisionDiffsBrowserViewController {
+    enum ShowRevisionSource: String {
+        case list
+        case chevron
+        case swipe
+    }
+
+    func trackRevisionsDetailViewed(with source: ShowRevisionSource) {
+        WPAnalytics.track(.postRevisionsDetailViewed,
+                          withProperties: [WPAppAnalyticsKeySource: source.rawValue])
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
@@ -5,6 +5,7 @@ class RevisionsTableViewController: UITableViewController {
 
     private var post: AbstractPost?
     private var manager: ShowRevisionsListManger?
+    private var viewDidAppear: Bool = false
 
     private lazy var noResultsViewController: NoResultsViewController = {
         let noResultsViewController = NoResultsViewController.controller()
@@ -51,6 +52,14 @@ class RevisionsTableViewController: UITableViewController {
         tableViewHandler.refreshTableView()
         tableViewFooter.isHidden = sectionCount == 0
         refreshRevisions()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        if !viewDidAppear {
+            viewDidAppear.toggle()
+            WPAnalytics.track(.postRevisionsListViewed)
+        }
     }
 }
 
@@ -144,6 +153,7 @@ private extension RevisionsTableViewController {
         let service = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext)
         service.getPostWithID(revision.revisionId, for: blog, success: { post in
             SVProgressHUD.dismiss()
+            WPAnalytics.track(.postRevisionsRevisionLoaded)
             self.onRevisionLoaded(post)
             self.navigationController?.popViewController(animated: true)
         }, failure: { error in


### PR DESCRIPTION
Refs. #10304 
Refs. #10309 

This PR implements _WPShared 1.6.0_ and it adds the new analytics events (Revisions related).
These are the events:
- **WPAnalyticsStatPostRevisionsListViewed** -> `revisions_list_viewed`
- **WPAnalyticsStatPostRevisionsDetailViewed** -> `revisions_detail_viewed`
  - param `source`: `list` & `chevron`
- **WPAnalyticsStatPostRevisionsDetailCancelled** -> `revisions_detail_cancelled`
- **WPAnalyticsStatPostRevisionsRevisionLoaded** -> `revisions_revision_loaded`

**To test:**
- Open a revisions list and check the events on the console:
  - `revisions_list_viewed`: tracked when a revisions list is opened from the Post Editor
  - `revisions_detail_viewed`: tracked when a revisions is selected (source -> list) or when a chevron is pressed (source -> chevron)
  - `revisions_detail_cancelled`: tracked when the _done_ button is pressed and the detail is dismissed
  - `revisions_revision_loaded`: tracked when the _load_ button is pressed and the post revision is loaded successfully


