### PR TITLE
Post featured image search: Check for a search string before displaying no results view.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteIconPickerPresenter.swift
@@ -183,7 +183,10 @@ extension SiteIconPickerPresenter: WPMediaPickerViewControllerDelegate {
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, didUpdateSearchWithAssetCount assetCount: Int) {
         noResultsView.removeFromView()
-        noResultsView.configureForNoSearchResult()
+
+        if (mediaLibraryDataSource.searchQuery?.count ?? 0) > 0 {
+            noResultsView.configureForNoSearchResult()
+        }
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, shouldShow asset: WPMediaAsset) -> Bool {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1494,7 +1494,10 @@ FeaturedImageViewControllerDelegate>
 - (void)mediaPickerController:(WPMediaPickerViewController *)picker didUpdateSearchWithAssetCount:(NSInteger)assetCount
 {
     [self.noResultsView removeFromView];
-    [self.noResultsView configureForNoSearchResult];
+  
+    if (self.mediaDataSource.searchQuery.wordCount > 0) {
+        [self.noResultsView configureForNoSearchResult];
+    }
 }
 
 - (void)mediaPickerController:(WPMediaPickerViewController *)picker didFinishPickingAssets:(NSArray *)assets


### PR DESCRIPTION
Fixes #10546 

To test:

- Edit a post or a page.
- Go to Post Settings > Set Featured Image > WordPress Media.
- Enter an invalid search term.
- **`Cancel`** on the search bar _**(this is important)**_.
- Return to Post Settings.
- Select Set Featured Image > WordPress Media again. Verify it does not crash.

NOTE:
Although I couldn't get `SiteIconPickerPresenter` to crash, I added the same check there too just to be safe.
