### PR TITLE
Improve analytics captured in support of rich notifications

### DIFF
--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -472,6 +472,9 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
         let userInfo = response.notification.request.content.userInfo as NSDictionary
         let textInputResponse = response as? UNTextInputNotificationResponse
 
+        // Analytics
+        PushNotificationsManager.shared.trackNotification(with: userInfo)
+
         if handleAction(with: response.actionIdentifier,
                         category: response.notification.request.content.categoryIdentifier,
                         userInfo: userInfo,

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -165,9 +165,6 @@ final public class PushNotificationsManager: NSObject {
             return
         }
 
-        // Analytics
-        trackNotification(with: userInfo)
-
         // Handling!
         let handlers = [ handleSupportNotification,
                          handleAuthenticationNotification,
@@ -179,6 +176,29 @@ final public class PushNotificationsManager: NSObject {
                 break
             }
         }
+    }
+
+    /// Tracks a Notification Event
+    ///
+    /// - Parameter userInfo: The Notification's Payload
+    ///
+    func trackNotification(with userInfo: NSDictionary) {
+        var properties = [String: String]()
+
+        if let noteId = userInfo.number(forKey: Notification.identifierKey) {
+            properties[Tracking.identifierKey] = noteId.stringValue
+        }
+
+        if let type = userInfo.string(forKey: Notification.typeKey) {
+            properties[Tracking.typeKey] = type
+        }
+
+        if let theToken = deviceToken {
+            properties[Tracking.tokenKey] = theToken
+        }
+
+        let event: WPAnalyticsStat = (applicationState == .background) ? .pushNotificationReceived : .pushNotificationAlertPressed
+        WPAnalytics.track(event, withProperties: properties)
     }
 }
 
@@ -314,35 +334,6 @@ extension PushNotificationsManager {
         }
 
         return true
-    }
-}
-
-
-// MARK: - Private Methods
-//
-private extension PushNotificationsManager {
-
-    /// Tracks a Notification Event
-    ///
-    /// - Parameter userInfo: The Notification's Payload
-    ///
-    func trackNotification(with userInfo: NSDictionary) {
-        var properties = [String: String]()
-
-        if let noteId = userInfo.number(forKey: Notification.identifierKey) {
-            properties[Tracking.identifierKey] = noteId.stringValue
-        }
-
-        if let type = userInfo.string(forKey: Notification.typeKey) {
-            properties[Tracking.typeKey] = type
-        }
-
-        if let theToken = deviceToken {
-            properties[Tracking.tokenKey] = theToken
-        }
-
-        let event: WPAnalyticsStat = (applicationState == .background) ? .pushNotificationReceived : .pushNotificationAlertPressed
-        WPAnalytics.track(event, withProperties: properties)
     }
 }
 

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -40,7 +40,9 @@ class NotificationService: UNNotificationServiceExtension {
             let notificationKind = NotificationKind(rawValue: notificationType),
             token != nil else {
 
+            tracks.trackNotificationMalformed()
             contentHandler(request.content)
+
             return
         }
 
@@ -93,6 +95,8 @@ class NotificationService: UNNotificationServiceExtension {
     }
 
     override func serviceExtensionTimeWillExpire() {
+        tracks.trackNotificationTimedOut()
+
         notificationService?.wordPressComRestApi.invalidateAndCancelTasks()
 
         if let contentHandler = contentHandler,

--- a/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
@@ -13,6 +13,8 @@ private enum ServiceExtensionEvents: String {
     case discarded  = "wpios_notification_service_extension_discarded"
     case failed     = "wpios_notification_service_extension_failed"
     case assembled  = "wpios_notification_service_extension_assembled"
+    case malformed  = "wpios_notification_service_extension_malformed_payload"
+    case timedOut   = "wpios_notification_service_extension_timed_out"
 }
 
 // MARK: - Supports tracking notification service extension events.
@@ -55,6 +57,16 @@ extension Tracks {
     /// Tracks the successful retrieval & assembly of a rich notification.
     func trackNotificationAssembled() {
         trackEvent(ServiceExtensionEvents.assembled)
+    }
+
+    /// Tracks the unsuccessful unwrapping of push notification payload data.
+    func trackNotificationMalformed() {
+        trackEvent(ServiceExtensionEvents.malformed)
+    }
+
+    /// Tracks the timeout of service extension processing.
+    func trackNotificationTimedOut() {
+        trackEvent(ServiceExtensionEvents.timedOut)
     }
 
     /// Utility method to capture an event & submit it to Tracks.


### PR DESCRIPTION
### Description
Fixes #10543, which calls for the addition of new analytics events to the notification service extension. 

It also addresses a lingering issue from #6256, where event parity was achieved, but the funnel was still not behaving as expected. Namely, in the case of a quick action, the initial analytics event was not being called.

### Testing
Checkout the branch and confirm that existing tests pass. The new events are associated with error cases, so this may be difficult to validate via manual testing.
