### PR TITLE
Replace the gutenberg flag with a setting

### DIFF
--- a/WordPress/Classes/Services/EditorSettings.swift
+++ b/WordPress/Classes/Services/EditorSettings.swift
@@ -97,28 +97,32 @@ class EditorSettings: NSObject {
     // In Swift 4, we'll be able to do `instantiateEditor() -> UIViewController & PostEditor`,
     // and then let the caller configure the editor.
     func instantiatePostEditor(post: AbstractPost, configure: (PostEditor, UIViewController) -> Void) -> UIViewController {
-        switch current {
-        case .aztec:
-            let vc = AztecPostViewController(post: post)
+        switch (gutenbergCanHandle(post: post), current) {
+        case (true, .gutenberg):
+            let vc = GutenbergViewController(post: post)
             configure(vc, vc)
             return vc
-        case .gutenberg:
-            let vc = GutenbergViewController(post: post)
+        default:
+            let vc = AztecPostViewController(post: post)
             configure(vc, vc)
             return vc
         }
     }
 
     func instantiatePageEditor(page post: AbstractPost, configure: (PostEditor, UIViewController) -> Void) -> UIViewController {
-        switch current {
-        case .aztec:
-            let vc = AztecPostViewController(post: post)
-            configure(vc, vc)
-            return vc
-        case .gutenberg:
+        switch (gutenbergCanHandle(post: post), current) {
+        case (true, .gutenberg):
             let vc = GutenbergViewController(post: post)
             configure(vc, vc)
             return vc
+        default:
+            let vc = AztecPostViewController(post: post)
+            configure(vc, vc)
+            return vc
         }
+    }
+
+    private func gutenbergCanHandle(post: AbstractPost) -> Bool {
+        return !post.hasRemote() || post.containsGutenbergBlocks()
     }
 }

--- a/WordPress/Classes/Services/EditorSettings.swift
+++ b/WordPress/Classes/Services/EditorSettings.swift
@@ -54,7 +54,11 @@ class EditorSettings: NSObject {
     // MARK: Public accessors
 
     private var current: Editor {
-        return Feature.enabled(.gutenberg) ? .gutenberg : .aztec
+        guard Feature.enabled(.gutenberg),
+            let gutenbergEnabled = database.object(forKey: gutenbergEditorEnabledKey) as? Bool else {
+                return .aztec
+        }
+        return gutenbergEnabled ? .gutenberg : .aztec
     }
 
     @objc func isEnabled(_ editor: Editor) -> Bool {
@@ -74,9 +78,17 @@ class EditorSettings: NSObject {
 
         switch editor {
         case .aztec:
-            database.set(true, forKey: aztecEditorEnabledKey)
+            database.set(false, forKey: gutenbergEditorEnabledKey)
         case .gutenberg:
-            database.set(false, forKey: aztecEditorEnabledKey)
+            database.set(true, forKey: gutenbergEditorEnabledKey)
+        }
+    }
+
+    func toggle() {
+        if isEnabled(.gutenberg) {
+            database.set(false, forKey: gutenbergEditorEnabledKey)
+        } else {
+            database.set(true, forKey: gutenbergEditorEnabledKey)
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -38,7 +38,7 @@ enum FeatureFlag: Int {
         case .bottomSheetDemo:
             return BuildConfiguration.current == .localDeveloper
         case .gutenberg:
-            return BuildConfiguration.current == .localDeveloper && CommandLine.arguments.contains("-gutenberg")
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cPrereleaseTesting]
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -306,7 +306,7 @@ private extension AppSettingsViewController {
         let editorSettings = EditorSettings()
         let enabled = editorSettings.isEnabled(.gutenberg)
         let gutenbergEditor = SwitchRow(
-            title: "(A8C) Gutenberg",
+            title: "(A8C) Enable Gutenberg editor",
             value: enabled,
             onChange: toggleEditor()
         )

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -77,7 +77,8 @@ class AppSettingsViewController: UITableViewController {
 
     func tableViewModel() -> ImmuTable {
 
-        return ImmuTable(sections: [
+        return ImmuTable(optionalSections: [
+            editorTableSection(),
             mediaTableSection(),
             privacyTableSection(),
             otherTableSection()
@@ -196,9 +197,9 @@ class AppSettingsViewController: UITableViewController {
         }
     }
 
-    func enableEditor(_ editor: EditorSettings.Editor) -> ImmuTableAction {
+    func toggleEditor() -> (Bool) -> Void {
         return { [weak self] _ in
-            EditorSettings().enable(editor)
+            EditorSettings().toggle()
             self?.reloadViewModel()
         }
     }
@@ -297,6 +298,25 @@ fileprivate struct ImageSizingRow: ImmuTableRow {
 // MARK: - Table Sections Private Extension
 
 private extension AppSettingsViewController {
+
+    func editorTableSection() -> ImmuTableSection? {
+        guard Feature.enabled(.gutenberg) else {
+            return nil
+        }
+        let editorSettings = EditorSettings()
+        let enabled = editorSettings.isEnabled(.gutenberg)
+        let gutenbergEditor = SwitchRow(
+            title: "(A8C) Gutenberg",
+            value: enabled,
+            onChange: toggleEditor()
+        )
+        // I'm intentionally not localizing strings since this is a temporary workaround for internal versions
+        let headerText = "Gutenberg"
+        let footerTextDisabled = "💣 This is still an experimental version of Gutenberg 🙈"
+        let footerTextEnabled = "💣 This is still an experimental version of Gutenberg 🙊"
+        let footerText = enabled ? footerTextEnabled : footerTextDisabled
+        return ImmuTableSection(headerText: headerText, rows: [gutenbergEditor], footerText: footerText)
+    }
 
     func mediaTableSection() -> ImmuTableSection {
         let mediaHeader = NSLocalizedString("Media", comment: "Title label for the media settings section in the app settings")

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -164,10 +164,6 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-gutenberg"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "-debugJetpackConnectionFlow"
             isEnabled = "NO">
          </CommandLineArgument>


### PR DESCRIPTION
Instead of the command line `-gutenberg` flag, this adds a setting on Debug an Internal builds to enable Gutenberg

![gb-toggle](https://user-images.githubusercontent.com/8739/49091787-d3438580-f260-11e8-92ca-f1feca537125.gif)

Fixes #10554 

To test:

- Create a new post, Aztec should show
- Go to Me > App Settings, and toggle the Gutenberg switch
- Create a new post, Gutenberg should show
- Make sure the toggle and Gutenberg only show up in Debug/Internal builds (I haven't had time to test this myself yet)