### PR TITLE
Analytics: Fixes an issue with applicationOpenedTime being reset.

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -193,6 +193,15 @@ static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_
  */
 - (void)trackApplicationOpened
 {
+    // UIApplicationDidBecomeActiveNotification will be dispatched if the user
+    // returns from a system overlay (like notification center) or when multi
+    // tasking on the iPad and adjusting the split screen divider. This happens
+    // without previously dispatching UIApplicationDidEnterBackgroundNotification.
+    // We don't want to track application opened in thise cases so check for a
+    // nil applicationOpenedTime first.
+    if (self.applicationOpenedTime != nil) {
+        return;
+    }
     self.applicationOpenedTime = [NSDate date];
     [WPAnalytics track:WPAnalyticsStatApplicationOpened];
 }


### PR DESCRIPTION
This PR addresses an issue with the `applicationOpenedTime` property being reset with a new date due to `UIApplicationDidBecomeActiveNotification` notifications received while multitasking or viewing a system overlay.

For more background see p9OQAC-90-p2.

To test:
- Use an iPad to test all uses cases.
- Set breakpoints in `trackApplicationOpened` and `trackApplicationClosed`.

Scenario 1:
Launch the app and confirm that `trackApplicationOpened` is called and the date is correctly set.
Background the app and confirm that `trackApplicationClosed` is called and the date is unset.

Scenario 2: 
With the app in the foreground, swipe down from the top left or right corners to view Mission Control or Notification Center.  Note that `UIApplicationDidEnterBackgroundNotification` is not dispatched and `trackApplicationClosed` is not called (interestingly `UIApplicationDidBecomeActiveNotification` is for some reason 🤔).  Dismiss the system overlay and confirm that while `trackApplicationOpened` is called the date is not nil and is therefore not reset.

Scenario 3
Swipe up to view the launch bar.  Tap and hold on another app to multitask.  
Observe that `UIApplicationDidBecomeActiveNotification` is dispatched when multitasking starts.  Adjust the split screen and observe that `UIApplicationDidBecomeActiveNotification` is again dispatched. 
In both cases confirm that confirm that while `trackApplicationOpened` is called the date is not nil and is therefore not reset.

@jklausa could I trouble you for a review? 