### PR TITLE
Fix crash by removing performBatchUpdates

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -824,24 +824,10 @@ static NSInteger HideSearchMinSites = 3;
 
         self.firstHide = nil;
         self.hideCount = 0;
-    }
-    else {
+    } else {
+        self.tableView.tableHeaderView = nil;
         [self updateViewsForCurrentSiteCount];
         [self updateSearchVisibility];
-
-        __weak __typeof(self) weakSelf = self;
-        if (@available(iOS 11.0, *)) {
-            [UIView setAnimationsEnabled:NO];
-            [self.tableView performBatchUpdates:^{
-                weakSelf.tableView.tableHeaderView = nil;
-            } completion:^(BOOL finished) {
-                [UIView setAnimationsEnabled:YES];
-            }];
-        } else {
-            [self.tableView beginUpdates];
-            self.tableView.tableHeaderView = nil;
-            [self.tableView endUpdates];
-        }
     }
 }
 


### PR DESCRIPTION
Fixes #10528 
Reopens #10435 

This fixes the logout crash. However this undoes the fix in #10435. I now believe that headers/footers cannot be modified inside `performBatchUpdates` blocks (nor `performUpdates`).

To test:
- follow the instructions from #10528 with and without this fix
- ensure the crashes have stopped

@stevebaranski if you have time to review, great. if not, @jtreanor do you have time?
