### PR TITLE
Center notice view titles when there is no message

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -122,9 +122,7 @@ class NoticeView: UIView {
 
         contentStackView.addArrangedSubview(labelStackView)
 
-        NSLayoutConstraint.activate([
-            labelStackView.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor)
-            ])
+        labelStackView.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor).isActive = true
 
         titleLabel.font = notice.style.titleLabelFont
         messageLabel.font = notice.style.messageLabelFont
@@ -134,7 +132,9 @@ class NoticeView: UIView {
         messageLabel.textColor = notice.style.messageColor
 
         messageLabel.numberOfLines = 0
-        messageLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: Appearance.minMessageHeight).isActive = true
+        if notice.cancelTitle != nil {
+            messageLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: Appearance.minMessageHeight).isActive = true
+        }
     }
 
     private func configureActionButton() {


### PR DESCRIPTION
The issue can be seen here:

<img width="444" alt="screen shot 2018-11-28 at 11 08 11 am" src="https://user-images.githubusercontent.com/517257/49175880-6e3e6d00-f2fe-11e8-9900-ed49320eb9de.png">

And here it is after the fix:

<img width="430" alt="image" src="https://user-images.githubusercontent.com/517257/49176056-dc832f80-f2fe-11e8-8933-02ed7e51fffc.png">

And to verify that the other notices haven't been negatively affected:

<img width="429" alt="image" src="https://user-images.githubusercontent.com/517257/49176078-e7d65b00-f2fe-11e8-9f59-bd9881f8bc17.png">
<img width="430" alt="image" src="https://user-images.githubusercontent.com/517257/49176085-eb69e200-f2fe-11e8-9bf8-a0aef4d37b38.png">


To test:
- Make a new post
- Ensure the notice of its successful publishing looks correct

@jklausa since you noticed this can you review this fix? THANKS