### PR TITLE
Improve gutenberg editor change detection

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1212,15 +1212,6 @@ extension AztecPostViewController: PostEditorStateContextDelegate {
         }
     }
 
-    private var editorHasChanges: Bool {
-        return post.hasUnsavedChanges()
-    }
-
-    internal func editorContentWasUpdated() {
-        postEditorStateContext.updated(hasContent: editorHasContent)
-        postEditorStateContext.updated(hasChanges: editorHasChanges)
-    }
-
     internal func context(_ context: PostEditorStateContext, didChangeAction: PostEditorAction) {
         reloadPublishButton()
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -22,6 +22,7 @@ class GutenbergViewController: UIViewController, PostEditor {
         textField.textColor = Colors.title
         textField.backgroundColor = Colors.background
         textField.placeholder = NSLocalizedString("Title", comment: "Placeholder for the post title.")
+        textField.addTarget(self, action: #selector(titleTextFieldDidChange(_:)), for: .editingChanged)
         let leftView = UIView()
         leftView.translatesAutoresizingMaskIntoConstraints = false
         leftView.heightAnchor.constraint(equalToConstant: Size.titleTextFieldHeight).isActive = true
@@ -216,13 +217,20 @@ class GutenbergViewController: UIViewController, PostEditor {
         return html //TODO: return media attachment stripped version in future
     }
 
+    func toggleEditingMode() {
+        gutenberg.toggleHTMLMode()
+        mode.toggle()
+    }
+
+    // MARK: - Event handlers
+
     @objc func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
         return presentationController(forPresented: presented, presenting: presenting)
     }
 
-    func toggleEditingMode() {
-        gutenberg.toggleHTMLMode()
-        mode.toggle()
+    @objc func titleTextFieldDidChange(_ textField: UITextField) {
+        mapUIContentToPostAndSave()
+        editorContentWasUpdated()
     }
 }
 
@@ -237,12 +245,10 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
     }
 
     func gutenbergDidProvideHTML(_ html: String, changed: Bool) {
-        self.html = html
-        postEditorStateContext.updated(hasContent: editorHasContent)
-
-        // TODO: currently we don't need to set this because Update button is always active
-        // but in the future we might need this
-        // postEditorStateContext.updated(hasChanges: changed)
+        if changed {
+            self.html = html
+            editorContentWasUpdated()
+        }
 
         if let reason = requestHTMLReason {
             requestHTMLReason = nil // clear the reason

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -98,6 +98,15 @@ extension PostEditor {
         return post.hasContent()
     }
 
+    var editorHasChanges: Bool {
+        return post.hasUnsavedChanges()
+    }
+
+    func editorContentWasUpdated() {
+        postEditorStateContext.updated(hasContent: editorHasContent)
+        postEditorStateContext.updated(hasChanges: editorHasChanges)
+    }
+
     var mainContext: NSManagedObjectContext {
         return ContextManager.sharedInstance().mainContext
     }


### PR DESCRIPTION
Following problems are solved:

1. Currently even if we change the title and tap close button it doesn't display the "You have unsaved changes" prompt

2. Sometimes(I can't reproduce this on my business site but it happens on free site) if you have Image blocks in your post and you tap close button without changing anything the "You have unsaved changes" prompt is displayed unnecessarily. Root cause of this is as follows: gutenberg side passes _style=""_ attribute to the parent app in the image block but this attribute is discarded on the back end service during saving the block, so the gutenberg version and the database version of the post actually never syncs and it appears to be always like there's a change. To avoid this unnecessary prompt we are using the changed flag that is sent us from RN side. Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/10496

**To test:**

Test 1:

- Open a post
- Change its title
- Tap close
- Verify that "You have unsaved changes" prompt is displayed
- Publish the post
- Verify that it is published with new title

Test 2:

- Open a post that includes image block with a url set
- Do not change anything in the post and tap close
- Verify that "You have unsaved changes" prompt is NOT displayed
