### PR TITLE
Show Gutenberg title after it appears

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -171,7 +171,6 @@ class GutenbergViewController: UIViewController, PostEditor {
         createRevisionOfPost()
         configureNavigationBar()
         refreshInterface()
-        titleTextField.becomeFirstResponder()
 
         gutenberg.delegate = self
     }
@@ -179,6 +178,11 @@ class GutenbergViewController: UIViewController, PostEditor {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         verificationPromptHelper?.updateVerificationStatus()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        titleTextField.becomeFirstResponder()
     }
 
     // MARK: - Functions

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -180,11 +180,6 @@ class GutenbergViewController: UIViewController, PostEditor {
         verificationPromptHelper?.updateVerificationStatus()
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        titleTextField.becomeFirstResponder()
-    }
-
     // MARK: - Functions
 
     private func configureNavigationBar() {


### PR DESCRIPTION
This fixes an issue where the toolbar wouldn't be immediately visible when creating a new post. This sets the focus on the title bar after the editor has appeared, so the gutenberg view gets laid out correctly.


To test:

- Create a new Gutenberg post
- The focus should be in the title field
- The toolbar should be visible