### PR TITLE
Update Gutenberg version as 0.2.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -95,7 +95,7 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v0.2.0'
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -320,7 +320,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/react-native-community/react-native-svg.git
     :tag: 8.0.8
   RNTAztecView:
-    :commit: 08916a6d6491132969f33c1867af8a5b1d733758
+    :commit: 1e0ed52336ef099c72e5bb0a2a878508a85ad021
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.1.4)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.1.4)"
   - Gridicons (0.16)
-  - Gutenberg (0.1.3):
+  - Gutenberg (0.2.0):
     - React/Core (= 0.57.5)
     - React/CxxBridge (= 0.57.5)
     - React/DevSupport (= 0.57.5)
@@ -221,7 +221,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (= 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v0.2.0`)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -298,6 +298,7 @@ EXTERNAL SOURCES:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :tag: v0.2.0
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   RNSVG:
@@ -313,8 +314,8 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   Gutenberg:
-    :commit: 7ac7875094b52bb13eacb8d36005aeba36ed0cf8
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :tag: v0.2.0
   RNSVG:
     :git: https://github.com/react-native-community/react-native-svg.git
     :tag: 8.0.8
@@ -341,7 +342,7 @@ SPEC CHECKSUMS:
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
   Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
-  Gutenberg: c650fdbab730350e00d0cde3475a83041ba6aebe
+  Gutenberg: ad2285ae4b6fe6707c50ecd7bf884d8ff6acfc59
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
   lottie-ios: d699fdee68d7b63e721d949388b015fef1aaa4ac
   MGSwipeTableCell: fb20e983988bde2b8d0df29c2d9e1d8ffd10b74a
@@ -369,6 +370,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: bf4228825b9949d83d63b9f4273d4ef5cb8bf27d
+PODFILE CHECKSUM: 2c7aed60e263a24173a39a73558e9a9a98908283
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/10569

To test:

Remove what's underneath pods folder and run "rake dependencies"
Stop metro if it is running
Then make sure gutenberg editor is running ok


