### PR TITLE
Add RELEASE-NOTES.txt file to encourage adding release notes iteratively

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,4 +2,6 @@ Fixes #
 
 To test:
 
+Update release notes:
 
+- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

--- a/Scripts/fastlane/helpers/ios_git_helper.rb
+++ b/Scripts/fastlane/helpers/ios_git_helper.rb
@@ -31,6 +31,9 @@ module Fastlane
         Action.sh("git add fastlane/Deliverfile")
         Action.sh("git add fastlane/download_metadata.swift")
         Action.sh("git add ../WordPress/Resources/AppStoreStrings.po")
+        Action.sh("cp ../RELEASE-NOTES.txt ../WordPress/Resources/release_notes.txt ")
+        Action.sh("echo > ../RELEASE-NOTES.txt")
+        Action.sh("git add ../RELEASE-NOTES.txt ../WordPress/Resources/release_notes.txt")
         Action.sh("git commit -m \"Bump version number\"")
         Action.sh("git push")
       end


### PR DESCRIPTION
As discussed, it would be great to start adding release notes throughout the development cycle. I had initially implemented a complex version of this that parsed a `ReleaseNotes.md` file, but I think this simpler approach is better start.

The change is this:
- A file, `RELEASE-NOTES.txt`, is in the root of the repo. ~It should be emptied on `develop` after every code freeze (when the release branch is made). This will be uploaded to the AppStore with fastlane when it is time to release.~ **Updated:** Changes should be added to it through the cycle. It will be cleared and copied to `WordPress/Resources/release_notes.txt` on code freeze so it can be uploaded to the AppStore.
- I have also added a reminder to the Pull Request template (see below) to help us remember to add release notes when needed.

What do you think of this approach? Is there a better way to do this?

If this is merged, I will update the release documentation to reflect this and make the same change for other repos.

To test:

- Run `bundle exec fastlane update_appstore_strings version:11.2`. It still works correctly.
- Run `bundle exec fastlane code_freeze` should copy and clear release notes.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.