### PR TITLE
Fix/xmlrpc sticky post

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -51,8 +51,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 1.5.0'
-    ##pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '79fb867'
+#    pod 'WordPressKit', '~> 1.5.0'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'b2d5ec226b65634071948dc00290dd88d51f6434'
     ##pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -184,7 +184,7 @@ PODS:
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
     - wpxmlrpc (~> 0.8)
-  - WordPressKit (1.5.0):
+  - WordPressKit (1.5.1.beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -241,7 +241,7 @@ DEPENDENCIES:
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Editor-iOS (= 1.2)
   - WordPressAuthenticator (~> 1.1)
-  - WordPressKit (~> 1.5.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `b2d5ec226b65634071948dc00290dd88d51f6434`)
   - WordPressShared (~> 1.6.0)
   - WordPressUI (~> 1.1)
   - WPMediaPicker (= 1.3.1)
@@ -283,7 +283,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - WPMediaPicker
@@ -305,6 +304,9 @@ EXTERNAL SOURCES:
     :tag: 8.0.8
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
+  WordPressKit:
+    :commit: b2d5ec226b65634071948dc00290dd88d51f6434
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -321,6 +323,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 08916a6d6491132969f33c1867af8a5b1d733758
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
+  WordPressKit:
+    :commit: b2d5ec226b65634071948dc00290dd88d51f6434
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -361,7 +366,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 507f6a08e176c2a9af6ec532a54697466b5a9114
   WordPress-Editor-iOS: 28339c1311dcdfdd9e50aba60dcf4c35184d032f
   WordPressAuthenticator: 83f495cce863d3f65bb440f6dea57161af401729
-  WordPressKit: 46fe8a4fa2ff4195f73a992f0f6f3a1eb2972b70
+  WordPressKit: 035110cec43feb34b3c74396b1c1975959a7e165
   WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
   WordPressUI: d3dbd0258f12560d6607647d3240c62c83e089fe
   WPMediaPicker: ea92f84950843c7baf6a7325caed72ad7852418d
@@ -369,6 +374,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: bf4228825b9949d83d63b9f4273d4ef5cb8bf27d
+PODFILE CHECKSUM: dd6df654e244d786cd729ac3127f6468ac939e19
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -605,7 +605,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
         postPost.postFormat = remotePost.format;
         postPost.tags = [remotePost.tags componentsJoinedByString:@","];
         postPost.postType = remotePost.type;
-        postPost.isStickyPost = remotePost.isStickyPost;
+        postPost.isStickyPost = (remotePost.isStickyPost != nil) ? remotePost.isStickyPost.boolValue : NO;
         [self updatePost:postPost withRemoteCategories:remotePost.categories];
 
         Coordinate *geolocation = nil;
@@ -685,7 +685,13 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
         remotePost.tags = [postPost.tags componentsSeparatedByString:@","];
         remotePost.categories = [self remoteCategoriesForPost:postPost];
         remotePost.metadata = [self remoteMetadataForPost:postPost];
-        remotePost.isStickyPost = postPost.isStickyPost;
+
+        // Because we can't get what's the self-hosted non JetPack site capabilities
+        // only Admin users are allowed to set a post as sticky.
+        // This doesn't affect WPcom sites.
+        //
+        BOOL canMarkPostAsSticky = ([post.blog supports:BlogFeatureWPComRESTAPI] || post.blog.isAdmin);
+        remotePost.isStickyPost = canMarkPostAsSticky ? @(postPost.isStickyPost) : nil;
     }
 
     remotePost.isFeaturedImageChanged = post.isFeaturedImageChanged;

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -395,14 +395,22 @@ FeaturedImageViewControllerDelegate>
 
 - (void)configureSections
 {
-    self.sections = @[@(PostSettingsSectionTaxonomy),
-                      @(PostSettingsSectionMeta),
-                      @(PostSettingsSectionFormat),
-                      @(PostSettingsSectionFeaturedImage),
-                      @(PostSettingsSectionStickyPost),
-                      @(PostSettingsSectionShare),
-                      @(PostSettingsSectionGeolocation),
-                      @(PostSettingsSectionMoreOptions)];
+    NSNumber *stickyPostSection = @(PostSettingsSectionStickyPost);
+    NSMutableArray *sections = [@[ @(PostSettingsSectionTaxonomy),
+                                  @(PostSettingsSectionMeta),
+                                  @(PostSettingsSectionFormat),
+                                  @(PostSettingsSectionFeaturedImage),
+                                  stickyPostSection,
+                                  @(PostSettingsSectionShare),
+                                  @(PostSettingsSectionGeolocation),
+                                  @(PostSettingsSectionMoreOptions) ] mutableCopy];
+    // Remove sticky post section for self-hosted non JetPack site
+    // and non admin user
+    //
+    if (![self.apost.blog supports:BlogFeatureWPComRESTAPI] && !self.apost.blog.isAdmin) {
+        [sections removeObject:stickyPostSection];
+    }
+    self.sections = [sections copy];
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView


### PR DESCRIPTION
Fixes #10370 

This PR fixes the bug when an authors can not publish posts on self hosted sites (non Jetpack).

## The problem
For self-hosted (non Jetpack) sites, a user (author or contributor) wasn't able to publish a post.
The problem was related to the _Mark a post as sticky_ feature due to the `sticky` property always set when a post was created or updated.
The reason is this:
```
if ( ! empty( $request['sticky'] ) && ! current_user_can( $post_type->cap->edit_others_posts ) ) {
   return new WP_Error( 'rest_cannot_assign_sticky', __( 'Sorry, you are not allowed to make posts sticky.' ), array( 'status' => rest_authorization_required_code() ) );
}
```
## Solution
Because for self-hosted (non Jetpack) sites I can't get the capabilities informations, we decided to allow only admin users to mark the post as sticky.
The `isStickyPost` property is automatically set to _nil_ if a user can't set this value and its value can't be encoded.

**To test:**
- **WP.com site**: create a post as admin and author: you should be able to do it
- **WP.com site**: mark a post as sticky (as admin and author user): you should be able to do it
- **Jetpack site**: create a post as admin and author: you should be able to do it
- **Jetpack site**: mark a post as sticky (as admin and author user): you should be able to do it
- **No Jetpack site**: create a post as admin and author: you should be able to do it
- **No Jetpack site**: mark a post as sticky (as admin user): you should be able to do it
- **No Jetpack site**: try to mark a post as sticky (as author user): you shouldn't see the setting option

@rachelmcr 
@elibud 
@charliescheer 

