### PR TITLE
Fix launch screen image

### DIFF
--- a/WordPress/Launch Screen.storyboard
+++ b/WordPress/Launch Screen.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="8191" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8154"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -14,16 +18,15 @@
                         <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-wp" translatesAutoresizingMaskIntoConstraints="NO" id="FfR-yo-4a1">
-                                <rect key="frame" x="275" y="274" width="50" height="52"/>
+                                <rect key="frame" x="162.5" y="267.5" width="50" height="52"/>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" red="0.0" green="0.52941176470588" blue="0.74509803921569" alpha="1" colorSpace="calibratedRGB"/>
+                        <color key="backgroundColor" red="0.0" green="0.52941176470588003" blue="0.74509803921568996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="FfR-yo-4a1" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="T0u-ej-Kyp"/>
                             <constraint firstItem="FfR-yo-4a1" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="a6p-Lx-MaV"/>
                         </constraints>
                     </view>

--- a/WordPress/Launch Screen.storyboard
+++ b/WordPress/Launch Screen.storyboard
@@ -27,6 +27,7 @@
                         </subviews>
                         <color key="backgroundColor" red="0.0" green="0.52941176470588003" blue="0.74509803921568996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="FfR-yo-4a1" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" constant="-40" id="T0u-ej-Kyp"/>
                             <constraint firstItem="FfR-yo-4a1" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="a6p-Lx-MaV"/>
                         </constraints>
                     </view>


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/8231 (maybe)

**To test:**

1. In the simulator, turn on the in-call status bar (cmd + Y).
2. Set a breakpoint in `main.m` at `UIApplicationMain`.
3. Launch the app in the simulator

**Before**: The middle would be cut out of the logo
**After**: The logo looks fine.


**Also to test**
This change affects how the launch screen looks without the double-height status bar.

1. Disable the in-call status bar.
2. Re-launch the app in the simulator.
3. Ensure it _still_ looks good this way, too.

**Example Screenshots**

![simulator screen shot - iphone 7 - 2018-11-30 at 12 01 18](https://user-images.githubusercontent.com/1123407/49309798-a75f1480-f499-11e8-92ca-95b52b4ab961.png)
![simulator screen shot - iphone 7 - 2018-11-30 at 12 01 40](https://user-images.githubusercontent.com/1123407/49309799-a7f7ab00-f499-11e8-82ec-8f06b2953b05.png)