### PR TITLE
[Site creation] Add an isNew property to SiteVertical

### DIFF
--- a/WordPress/Classes/Models/SiteVertical.swift
+++ b/WordPress/Classes/Models/SiteVertical.swift
@@ -3,6 +3,7 @@
 struct SiteVertical {
     let identifier: Identifier
     let title: String
+    let isNew: Bool
 }
 
 extension SiteVertical: Equatable {
@@ -14,12 +15,15 @@ extension SiteVertical: Equatable {
 extension SiteVertical: Decodable {
     enum CodingKeys: String, CodingKey {
         case id
-        case title = "site-vertical-title"
+        case title = "site_vertical_title"
+        case isNew = "is_new_user_vertical"
     }
 
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         identifier = try Identifier(value: values.decode(String.self, forKey: .id))
         title = try values.decode(String.self, forKey: .title)
+        let isNewString = try values.decode(String.self, forKey: .isNew)
+        isNew = isNewString.lowercased() == "true" ? true : false
     }
 }

--- a/WordPress/Classes/Services/SiteVerticalsService.swift
+++ b/WordPress/Classes/Services/SiteVerticalsService.swift
@@ -15,8 +15,8 @@ final class MockSiteVerticalsService: SiteVerticalsService {
     }
 
     private func mockVerticals() -> [SiteVertical] {
-        return [ SiteVertical(identifier: Identifier(value: "SV 1"), title: "Vertical 1"),
-                 SiteVertical(identifier: Identifier(value: "SV 2"), title: "Vertical 2"),
-                 SiteVertical(identifier: Identifier(value: "SV 3"), title: "Vertical 3") ]
+        return [ SiteVertical(identifier: Identifier(value: "SV 1"), title: "Vertical 1", isNew: false),
+                 SiteVertical(identifier: Identifier(value: "SV 2"), title: "Vertical 2", isNew: true),
+                 SiteVertical(identifier: Identifier(value: "SV 3"), title: "Vertical 3", isNew: false) ]
     }
 }

--- a/WordPress/WordPressTest/SiteVerticalTests.swift
+++ b/WordPress/WordPressTest/SiteVerticalTests.swift
@@ -6,6 +6,7 @@ final class SiteVerticalTests: XCTestCase {
     private struct MockValues {
         static let identifier = Identifier(value: "101")
         static let title = "Landscaper"
+        static let isNew = true
     }
 
     private var subject: SiteVertical?
@@ -32,8 +33,12 @@ final class SiteVerticalTests: XCTestCase {
         XCTAssertEqual(subject?.title, MockValues.title)
     }
 
+    func testIsNewIsNotMutated() {
+        XCTAssertEqual(subject?.isNew, MockValues.isNew)
+    }
+
     func testSiteVerticalsWithSameIdAreEqual() {
-        let secondVertical = SiteVertical(identifier: MockValues.identifier, title: "Cascadia")
+        let secondVertical = SiteVertical(identifier: MockValues.identifier, title: "Cascadia", isNew: true)
 
         XCTAssertEqual(subject, secondVertical)
     }

--- a/WordPress/WordPressTest/Test Data/site-vertical.json
+++ b/WordPress/WordPressTest/Test Data/site-vertical.json
@@ -1,5 +1,6 @@
 {
-    "site-vertical-title": "Landscaper",
-    "id": "101"
+    "site_vertical_title": "Landscaper",
+    "id": "101",
+    "is_new_user_vertical": "true"
 }
 


### PR DESCRIPTION
Fixes #10581 

Add an extra property to the `SiteVertical` model object, called `isNew` as mentioned here: p9wMUP-dz-p2

To test:
- Check out the branch
- Build the project
- Run the tests. In particular, `SiteVerticalTests` should all pass
