### PR TITLE
Fix a crash caused by improper int format handling

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
@@ -190,7 +190,7 @@ open class AboutViewController: UITableViewController {
     // MARK: - Private Properties
     fileprivate lazy var footerTitleText: String = {
         let year = Calendar.current.component(.year, from: Date())
-        let localizedTitleText = NSLocalizedString("© %@ Automattic, Inc.", comment: "About View's Footer Text. The variable is the current year")
+        let localizedTitleText = NSLocalizedString("© %ld Automattic, Inc.", comment: "About View's Footer Text. The variable is the current year")
         return String(format: localizedTitleText, year)
     }()
 


### PR DESCRIPTION
Fixes http://crashes.to/s/9fd5185922a

**To test:**

_Before_: Go to Me > App Settings > About WordPress for iOS. App will crash.
_After_: It will not.