### PR TITLE
Add History option for Gutenberg editor

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -95,7 +95,7 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => 'f9b4a3cad1eb089083d5f8220e76e405761b290f'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => 'c54efb2f0893a65ef19db3dbaaca272aafa277aa'
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'

--- a/Podfile
+++ b/Podfile
@@ -95,7 +95,7 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => 'c54efb2f0893a65ef19db3dbaaca272aafa277aa'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => 'b6117ef3a2167f0dd8bab0ad11b59838bfe8899f'
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'

--- a/Podfile
+++ b/Podfile
@@ -95,7 +95,7 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v0.2.2'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => 'f9b4a3cad1eb089083d5f8220e76e405761b290f'
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'

--- a/Podfile
+++ b/Podfile
@@ -95,7 +95,7 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => 'b6117ef3a2167f0dd8bab0ad11b59838bfe8899f'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/'
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -223,7 +223,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (= 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `f9b4a3cad1eb089083d5f8220e76e405761b290f`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `c54efb2f0893a65ef19db3dbaaca272aafa277aa`)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -299,7 +299,7 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: f9b4a3cad1eb089083d5f8220e76e405761b290f
+    :commit: c54efb2f0893a65ef19db3dbaaca272aafa277aa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
@@ -316,7 +316,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   Gutenberg:
-    :commit: f9b4a3cad1eb089083d5f8220e76e405761b290f
+    :commit: c54efb2f0893a65ef19db3dbaaca272aafa277aa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNSVG:
     :git: https://github.com/react-native-community/react-native-svg.git
@@ -372,6 +372,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: c49e257d95aa823dc0902003367503400093765f
+PODFILE CHECKSUM: 9c2e3eac907de3d1a29246638ba20878840e769d
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -223,7 +223,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (= 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `c54efb2f0893a65ef19db3dbaaca272aafa277aa`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -299,7 +299,6 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: c54efb2f0893a65ef19db3dbaaca272aafa277aa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
@@ -316,7 +315,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   Gutenberg:
-    :commit: c54efb2f0893a65ef19db3dbaaca272aafa277aa
+    :commit: 27c2e2852ecd9076a43d0b10ed89694b23bf98b3
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNSVG:
     :git: https://github.com/react-native-community/react-native-svg.git
@@ -372,6 +371,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 9c2e3eac907de3d1a29246638ba20878840e769d
+PODFILE CHECKSUM: 76af47239c34b18d4f89da60c38382c992c024c4
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -223,7 +223,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (= 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v0.2.2`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `f9b4a3cad1eb089083d5f8220e76e405761b290f`)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -299,8 +299,8 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
+    :commit: f9b4a3cad1eb089083d5f8220e76e405761b290f
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-    :tag: v0.2.2
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   RNSVG:
@@ -316,8 +316,8 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   Gutenberg:
+    :commit: f9b4a3cad1eb089083d5f8220e76e405761b290f
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-    :tag: v0.2.2
   RNSVG:
     :git: https://github.com/react-native-community/react-native-svg.git
     :tag: 8.0.8
@@ -372,6 +372,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 73ab8c3558033fdfe62b3d4cb995826560339313
+PODFILE CHECKSUM: c49e257d95aa823dc0902003367503400093765f
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -47,13 +47,11 @@ extension GutenbergViewController {
             self?.displayPreview()
         }
 
-        //TODO: Comment in when bridge is ready
-        /*
         if Feature.enabled(.revisions) && (post.revisions ?? []).count > 0 {
             alert.addDefaultActionWithTitle(MoreSheetAlert.historyTitle) { [weak self] _ in
                 self?.displayHistory()
             }
-        }*/
+        }
 
         alert.addDefaultActionWithTitle(MoreSheetAlert.postSettingsTitle) { [weak self] _ in
             self?.displayPostSettings()

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -99,7 +99,7 @@ class GutenbergViewController: UIViewController, PostEditor {
 
     func setHTML(_ html: String) {
         self.html = html
-        //TODO: Update Gutenberg UI
+        gutenberg.updateHtml(html)
     }
 
     func getHTML() -> String {


### PR DESCRIPTION
Fixes part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/182

This change adds History option to the Gutenberg editor. The behavior is same as Aztec, when an older revision is selected  among the old revision list the editor content is updated with that revision. After that we need to tap Update button if we want to publish the new content, we can still discard the content by tapping Close button and then choosing "Discard".

We'll need to merge the dependent PR first https://github.com/wordpress-mobile/gutenberg-mobile/pull/313

![ezgif com-gif-maker](https://user-images.githubusercontent.com/5032900/49445298-ad7b2b00-f7e2-11e8-9b3b-f86e9a2398e9.gif)

**To test:**

Test 1 - Update content on Visual mode

Tap (...) on right top corner, Select "History" and select one of the previous revisions
Verify that visual editor content updated with the given html
Switch to HTML mode and verify contents match with Visual mode
Tap Close button and verify that "You have unsaved changes" prompt pops up
Proceed with publishing the post
Reopen the same post and verify that you see the lastly published version

Test 2 - Update content on HTML mode

Tap (...) on right top corner, Select "Switch to HTML Mode"
Tap (...) on right top corner, Select "History" and select one of the previous revisions
Verify that HTML editor content updated with the given html
Switch to Visual mode and verify contents match with HTML mode
Tap Close button and verify that "You have unsaved changes" prompt pops up
Proceed with publishing the post
Reopen the same post and verify that you see the lastly published version

Test 3 - Test changed flag upon Updating a restored revision

Tap (...) on right top corner, Select "History" and select one of the previous revisions
Tap "Update" button
Tap Close button
Verify that post is closed without a prompt

