### PR TITLE
Fixes a crashing bug in "About WordPress".

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
@@ -190,7 +190,7 @@ open class AboutViewController: UITableViewController {
     // MARK: - Private Properties
     fileprivate lazy var footerTitleText: String = {
         let year = Calendar.current.component(.year, from: Date())
-        let localizedTitleText = NSLocalizedString("© %@ Automattic, Inc.", comment: "About View's Footer Text. The variable is the current year")
+        let localizedTitleText = NSLocalizedString("© %d Automattic, Inc.", comment: "About View's Footer Text. The variable is the current year")
         return String(format: localizedTitleText, year)
     }()
 


### PR DESCRIPTION
### Description:

Fixes a crashing bug in `me > App Settings > About WordPress`.

### Testing:

Just open `me > App Settings > About WordPress` and make sure the app won't crash.

EDIT: I forgot to mention this, but props to @hypest for finding this!