### PR TITLE
Make the domain valiation error message properly translatable

### DIFF
--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+LocalizedStrings.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+LocalizedStrings.swift
@@ -2,8 +2,40 @@ import UIKit
 
 enum RegisterDomainDetails {
     enum Localized {
-        static let validationError = NSLocalizedString(
-            "Please enter a valid %@",
+        static let validationErrorFirstName = NSLocalizedString(
+            "Please enter a valid First Name",
+            comment: "Register Domain - Domain contact information validation error message for an input field"
+        )
+        static let validationErrorLastName = NSLocalizedString(
+            "Please enter a valid Last Name",
+            comment: "Register Domain - Domain contact information validation error message for an input field"
+        )
+        static let validationErrorEmail = NSLocalizedString(
+            "Please enter a valid Email",
+            comment: "Register Domain - Domain contact information validation error message for an input field"
+        )
+        static let validationErrorCountry = NSLocalizedString(
+            "Please enter a valid Country",
+            comment: "Register Domain - Domain contact information validation error message for an input field"
+        )
+        static let validationErrorPhone = NSLocalizedString(
+            "Please enter a valid phone number",
+            comment: "Register Domain - Domain contact information validation error message for an input field"
+        )
+        static let validationErrorAddress = NSLocalizedString(
+            "Please enter a valid address",
+            comment: "Register Domain - Domain contact information validation error message for an input field"
+        )
+        static let validationErrorCity = NSLocalizedString(
+            "Please enter a valid City",
+            comment: "Register Domain - Domain contact information validation error message for an input field"
+        )
+        static let validationErrorState = NSLocalizedString(
+            "Please enter a valid State",
+            comment: "Register Domain - Domain contact information validation error message for an input field"
+        )
+        static let validationErrorPostalCode = NSLocalizedString(
+            "Please enter a valid Postal Code",
             comment: "Register Domain - Domain contact information validation error message for an input field"
         )
         static let prefillError = NSLocalizedString(

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowList.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowList.swift
@@ -45,9 +45,32 @@ extension RegisterDomainDetailsViewModel {
     }
 
     static func serverSideRule(with key: String, hasErrorMessage: Bool = true) -> ValidationRule {
+        let errorMessage: String = nil
+        if hasErrorMessage {
+            switch key {
+            case Localized.ContactInformation.firstName:
+                errorMessage = Localized.validationErrorFirstName
+            case Localized.ContactInformation.lastName:
+                errorMessage = Localized.validationErrorLastName
+            case Localized.ContactInformation.email:
+                errorMessage = Localized.validationErrorEmail
+            case Localized.ContactInformation.country:
+                errorMessage = Localized.validationErrorCountry
+            case Localized.ContactInformation.phone:
+                errorMessage = Localized.validationErrorPhone
+            case Localized.Address.addressLine:
+                errorMessage = Localized.validationErrorAddress
+            case Localized.Address.city:
+                errorMessage = Localized.validationErrorCity
+            case Localized.Address.state:
+                errorMessage = Localized.validationErrorState
+            case Localized.Address.postalCode:
+                errorMessage = Localized.validationErrorPostalCode
+            }
+        }
         return ValidationRule(context: .serverSide,
                               validationBlock: nil, //validation is handled on serverside
-            errorMessage: hasErrorMessage ? String(format: Localized.validationError, key.lowercased()) : nil)
+                              errorMessage: errorMessage)
     }
 
     static var contactInformationRows: [RowType] {
@@ -129,7 +152,7 @@ extension RegisterDomainDetailsViewModel {
             value: nil,
             placeholder: Localized.Address.addressPlaceholder,
             editingStyle: .inline,
-            validationRules: optional ? [] : [nonEmptyRule, serverSideRule(with: key)]
+            validationRules: optional ? [] : [nonEmptyRule, serverSideRule(with: Localized.Address.addressLine)]
             ))
     }
 


### PR DESCRIPTION
This fixes an error message that is not properly translatable to many languages introduced in #10384.

The variable contents for `Please enter a valid %@` can be `First Name`, `Country`, `Phone number`. This only works in English because there is practically no gender for nouns. This is not true for example French or German. The above needs to be translated depending on the variable in German to `Bitte gib eine gültige %@ ein`, `Bitte gib ein gültiges %@ ein` or `Bitte gib einen gültigen %@ ein`.

Since the number of error message generated by the above string is quite small, we just need to write them all out.

I cannot compile WordPress iOS on my machine, so I just modified the Swift code to my best knowledge. Happy to get followup commits that fix any syntax error.