### PR TITLE
Privacy: Add explanation to Remove Location from Media feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,0 +1,1 @@
+#10407 - App Settings Privacy: Added explanation for the Remove Location from Media feature.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,1 +1,1 @@
-#10407 - App Settings Privacy: Added explanation for the Remove Location from Media feature.
+* App Settings Privacy: Added explanation for the 'Remove Location from Media' feature.

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -389,7 +389,6 @@ private extension AppSettingsViewController {
             accessibilityIdentifier: "spotlightClearCacheButton")
 
         var tableRows: [ImmuTableRow] = [
-            mediaRemoveLocation,
             privacySettings,
             spotlightClearCacheRow
         ]
@@ -403,9 +402,14 @@ private extension AppSettingsViewController {
             tableRows.append(siriClearCacheRow)
         }
 
+        tableRows.append(mediaRemoveLocation)
+        let removeLocationFooterText = NSLocalizedString("Removes metadata about the location photos were taken before uploading them to your site.", comment: "Explanatory text for removing the location from uploaded RELEASE-NOTES.txtmedia.")
+
         return ImmuTableSection(
             headerText: privacyHeader,
-            rows: tableRows)
+            rows: tableRows,
+            footerText: removeLocationFooterText
+        )
     }
 
     func otherTableSection() -> ImmuTableSection {

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -403,7 +403,7 @@ private extension AppSettingsViewController {
         }
 
         tableRows.append(mediaRemoveLocation)
-        let removeLocationFooterText = NSLocalizedString("Removes metadata about the location photos were taken before uploading them to your site.", comment: "Explanatory text for removing the location from uploaded RELEASE-NOTES.txtmedia.")
+        let removeLocationFooterText = NSLocalizedString("Removes metadata about the location photos were taken before uploading them to your site.", comment: "Explanatory text for removing the location from uploaded media.")
 
         return ImmuTableSection(
             headerText: privacyHeader,

--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -403,7 +403,7 @@ private extension AppSettingsViewController {
         }
 
         tableRows.append(mediaRemoveLocation)
-        let removeLocationFooterText = NSLocalizedString("Removes metadata about the location photos were taken before uploading them to your site.", comment: "Explanatory text for removing the location from uploaded media.")
+        let removeLocationFooterText = NSLocalizedString("Removes location metadata from photos before uploading them to your site.", comment: "Explanatory text for removing the location from uploaded media.")
 
         return ImmuTableSection(
             headerText: privacyHeader,


### PR DESCRIPTION
Fixes #10407 

To test:
- Go to Me > App Settings > Privacy section.
- Verify `Remove Location from Media` is at the bottom of the section.
- Verify the footer text is:
`Removes location metadata from photos before uploading them to your site.`

<img width="459" alt="remove_location" src="https://user-images.githubusercontent.com/1816888/49667804-6b87fa00-fa19-11e8-8e71-312b58e52e3a.png">


