### PR TITLE
Use the ~/.mobile-secrets credentials for screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ WordPress/Derived Sources/
 # coverage.py
 */CoverageData/*
 WordPress/Images.xcassets/AppIcon-Internal.appiconset
+WordPress/WordPressScreenshotGeneration/ScreenshotCredentials.swift
 
 # Bundler
 /vendor/bundle/

--- a/Scripts/BuildPhases/CopyScreenshotCredentials.sh
+++ b/Scripts/BuildPhases/CopyScreenshotCredentials.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Log everything in this script to the Xcode build console
+set -e
+
+CREDENTIALS_FILE=~/.mobile-secrets/iOS/WPiOS/ScreenshotCredentials.swift
+DESTINATION=$SOURCE_ROOT/WordPressScreenshotGeneration/ScreenshotCredentials.swift
+TEMPLATE=$SOURCE_ROOT/WordPressScreenshotGeneration/ScreenshotCredentials-Template.swift
+
+echo $CREDENTIALS_FILE
+echo $DESTINATION
+
+# If the file exists in mobile secrets, just copy it over. Otherwise, use a template.
+if [ -f $CREDENTIALS_FILE ]; then
+    echo "USING PRODUCTION"
+    cp $CREDENTIALS_FILE $DESTINATION
+else
+    echo "USING TEMPLATE"
+    cp $TEMPLATE $DESTINATION
+fi
+
+# Update the file-last-updated time to prevent build issues
+touch $DESTINATION

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -8965,6 +8965,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"~/.mobile-secrets/iOS/WPiOS/ScreenshotCredentials.swift",
 			);
 			name = "Copy Screenshot Credentials";
 			outputFileListPaths = (

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1555,6 +1555,7 @@
 		F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B43771F849F580089B817 /* PostAttachmentTests.swift */; };
 		F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
 		F1D690171F82914200200E30 /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
+		F9463A7321C05EE90081F11E /* ScreenshotCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9463A7221C05EE90081F11E /* ScreenshotCredentials.swift */; };
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
@@ -3609,6 +3610,7 @@
 		F373612EEEEF10E500093FF3 /* Pods-WordPress.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressShareExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F7E3CC306AECBBCB71D2E19C /* Pods_WordPressDraftActionExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressDraftActionExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F9463A7221C05EE90081F11E /* ScreenshotCredentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScreenshotCredentials.swift; sourceTree = "<group>"; };
 		FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Themes.swift"; sourceTree = "<group>"; };
 		FA2D12891BCED0AD006F2A15 /* WordPress 40.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 40.xcdatamodel"; sourceTree = "<group>"; };
 		FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementService.swift; sourceTree = "<group>"; };
@@ -5559,6 +5561,7 @@
 				8511CFC31C60884300B7CEED /* WordPressScreenshotGeneration-Bridging-Header.h */,
 				8511CFC61C60894200B7CEED /* WordPressScreenshotGeneration.swift */,
 				1AA2EFDA2101D75C00734283 /* XCTest+Extensions.swift */,
+				F9463A7221C05EE90081F11E /* ScreenshotCredentials.swift */,
 			);
 			path = WordPressScreenshotGeneration;
 			sourceTree = "<group>";
@@ -7968,6 +7971,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8511CFC21C607A7000B7CEED /* Build configuration list for PBXNativeTarget "WordPressScreenshotGeneration" */;
 			buildPhases = (
+				F9463A7121C05BAF0081F11E /* Copy Screenshot Credentials */,
 				2DF08408C90B90D744C56E02 /* [CP] Check Pods Manifest.lock */,
 				8511CFB21C607A7000B7CEED /* Sources */,
 				8511CFB31C607A7000B7CEED /* Frameworks */,
@@ -8954,6 +8958,25 @@
 			shellPath = /bin/sh;
 			shellScript = "[ -f ~/.wpcom_app_credentials ] && source ~/.wpcom_app_credentials\n \nif [[ \"Debug\" == \"${CONFIGURATION}\" ]]; then\n  echo \"Skipping Fabric\";\n  exit 0;\nfi\n \nif [ \"x$FABRIC_SCRIPT_KEY\" != \"x\" ]; then\n  \"${PODS_ROOT}/Fabric/run\" $FABRIC_SCRIPT_KEY\nelse\n  echo \"warning: Fabric API Key not found\"\nfi\n";
 			showEnvVarsInLog = 0;
+		};
+		F9463A7121C05BAF0081F11E /* Copy Screenshot Credentials */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Screenshot Credentials";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/WordPressScreenshotGeneration/ScreenshotCredentials.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/bin/sh\nsh ../Scripts/BuildPhases/CopyScreenshotCredentials.sh\n";
 		};
 		FFA8E2301F94E3EF0002170F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -10069,6 +10092,7 @@
 			files = (
 				8511CFC71C60894200B7CEED /* WordPressScreenshotGeneration.swift in Sources */,
 				8511CFC51C60884400B7CEED /* SnapshotHelper.swift in Sources */,
+				F9463A7321C05EE90081F11E /* ScreenshotCredentials.swift in Sources */,
 				1AA2EFDB2101D75C00734283 /* XCTest+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2560,7 +2560,6 @@
 		83FEFC7411FF6C5A0078B462 /* SiteSettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SiteSettingsViewController.m; sourceTree = "<group>"; };
 		8511CFB61C607A7000B7CEED /* WordPressScreenshotGeneration.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WordPressScreenshotGeneration.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8511CFBA1C607A7000B7CEED /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		8511CFC31C60884300B7CEED /* WordPressScreenshotGeneration-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WordPressScreenshotGeneration-Bridging-Header.h"; sourceTree = "<group>"; };
 		8511CFC41C60884400B7CEED /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
 		8511CFC61C60894200B7CEED /* WordPressScreenshotGeneration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressScreenshotGeneration.swift; sourceTree = "<group>"; };
 		8527B15717CE98C5001CBA2E /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
@@ -5558,7 +5557,6 @@
 			children = (
 				8511CFBA1C607A7000B7CEED /* Info.plist */,
 				8511CFC41C60884400B7CEED /* SnapshotHelper.swift */,
-				8511CFC31C60884300B7CEED /* WordPressScreenshotGeneration-Bridging-Header.h */,
 				8511CFC61C60894200B7CEED /* WordPressScreenshotGeneration.swift */,
 				1AA2EFDA2101D75C00734283 /* XCTest+Extensions.swift */,
 				F9463A7221C05EE90081F11E /* ScreenshotCredentials.swift */,

--- a/WordPress/WordPressScreenshotGeneration/ScreenshotCredentials-Template.swift
+++ b/WordPress/WordPressScreenshotGeneration/ScreenshotCredentials-Template.swift
@@ -1,0 +1,7 @@
+// Use the same login here that you did when you created an App
+// in the WordPress.com Application Manager. If you're not sure how to do that,
+// you can read more here: https://github.com/wordpress-mobile/WordPress-iOS#setup-credentials
+struct ScreenshotCredentials {
+    static let username: String = <# Your Wordpress.com Email #>
+    static let password: String = <# Your Wordpress.com Password #>
+}

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -48,12 +48,6 @@ class WordPressScreenshotGeneration: XCTestCase {
         loginButton.tap()
         app.buttons["Self Hosted Login Button"].tap()
 
-        // Use the same login here that you did when you created an App
-        // in the WordPress.com Application Manager. If you're not sure how to do that,
-        // you can read more here: https://github.com/wordpress-mobile/WordPress-iOS#setup-credentials
-        let username: String = <# Your Wordpress.com Email #>
-        let password: String = <# Your Wordpress.com Password #>
-
         // We have to login by site address, due to security issues with the
         // shared testing account which prevent us from signing in by email address.
         let selfHostedUsernameField = app.textFields["usernameField"]
@@ -67,9 +61,9 @@ class WordPressScreenshotGeneration: XCTestCase {
 
         waitForElementToExist(element: passwordField)
         usernameField.tap()
-        usernameField.typeText(username)
+        usernameField.typeText(ScreenshotCredentials.username)
         passwordField.tap()
-        passwordField.typeText(password)
+        passwordField.typeText(ScreenshotCredentials.password)
 
         app.buttons["submitButton"].tap()
 


### PR DESCRIPTION
Add support for using a credential store for screenshot secrets.

**To Test**

Check out the branch, and try running the screenshot generation target. It'll transparently duplicate the template, and will give a build warning, because there's no credentials specified.

Then, delete the newly-created `WordPress/WordPressScreenshotGeneration/ScreenshotCredentials.swift` file, then create a file at `~/.mobile-secrets/iOS/WPiOS/ScreenshotCredentials.swift` based on the template.  Populate it with real values, then run the screenshot generation target again.