### PR TITLE
CircleCI: Fix danger dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,13 +45,14 @@ jobs:
       - checkout
       - restore_cache:
           keys:
+            - wordpress-ios-danger-{{ checksum "Rakefile" }}-{{ checksum "Gemfile.lock" }}
             - wordpress-ios-danger-{{ checksum "Gemfile.lock" }}
             - wordpress-ios-danger-
       - run:
-          name: Dependencies
-          command: rake dependencies
+          name: Dependencies for danger
+          command: rake dependencies:bundle:check dependencies:lint:check
       - save_cache:
-          key: wordpress-ios-danger-{{ checksum "Gemfile.lock" }}
+          key: wordpress-ios-danger-{{ checksum "Rakefile" }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/
       - run:
@@ -60,7 +61,7 @@ jobs:
 
 workflows:
   version: 2
-  build_and_test:
+  wordpress_ios:
     jobs:
       - danger
       - build_and_test


### PR DESCRIPTION
The danger CircleCI workflow is currently running `rake dependencies` which unnecessarily installs all pods. This is causing it to fail since its not set up properly for this. In this I have updated it to only install the gems and swiftlint.

To test:

- The danger CircleCI check on this PR should be green

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
