### PR TITLE
CircleCI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,6 @@ jobs:
   build_and_test:
     macos:
       xcode: "10.1.0"
-    environment:
-      DESTINATION: "platform=iOS Simulator,name=iPhone XS,OS=12.1"
     steps:
       - checkout
       - restore_cache:
@@ -33,10 +31,10 @@ jobs:
             - vendor/bundle
       - run:
           name: Build
-          command: xcodebuild build-for-testing -scheme "WordPress" -configuration "Debug" -destination "${DESTINATION}" -workspace "WordPress.xcworkspace" | bundle exec xcpretty
+          command: xcodebuild -scheme "WordPress" -configuration "Debug" -workspace "WordPress.xcworkspace" -sdk iphonesimulator build-for-testing | bundle exec xcpretty
       - run:
           name: Test
-          command: xcodebuild test-without-building -scheme "WordPress" -configuration "Debug" -destination "${DESTINATION}" -workspace "WordPress.xcworkspace" | bundle exec xcpretty -r junit
+          command: xcodebuild -scheme "WordPress" -configuration "Debug" -workspace "WordPress.xcworkspace" -destination 'platform=iOS Simulator,name=iPhone XS,OS=latest' test-without-building | bundle exec xcpretty -r junit
       - store_test_results:
           path: build/reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,11 +33,13 @@ jobs:
             - vendor/bundle
       - run:
           name: Build
-          command: xcodebuild build-for-testing -scheme "WordPress" -configuration "Debug" -destination "${DESTINATION}" -workspace "WordPress.xcworkspace" | bundle exec xcpretty && exit ${PIPESTATUS[0]}
+          command: xcodebuild build-for-testing -scheme "WordPress" -configuration "Debug" -destination "${DESTINATION}" -workspace "WordPress.xcworkspace" | bundle exec xcpretty
       - run:
           name: Test
-          command: xcodebuild test-without-building -scheme "WordPress" -configuration "Debug" -destination "${DESTINATION}" -workspace "WordPress.xcworkspace" | bundle exec xcpretty && exit ${PIPESTATUS[0]}
-      
+          command: xcodebuild test-without-building -scheme "WordPress" -configuration "Debug" -destination "${DESTINATION}" -workspace "WordPress.xcworkspace" | bundle exec xcpretty -r junit
+      - store_test_results:
+          path: build/reports
+
   danger:
     macos:
       xcode: "10.1.0"


### PR DESCRIPTION
This makes a few improvements to the CircleCI config to make it more useful and more reliable:

- Record test results using `xcpretty` so that they will be displayed in the CircleCI UI
- Don't use `-destination` for the build command as it was causing some unpredictable failures.

To test:

- CircleCI checks on this PR should be green.
- Test results should be displayed on the "build_and_test" job.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
