### PR TITLE
Indicate the secrets directory this project uses

### DIFF
--- a/.configure
+++ b/.configure
@@ -3,5 +3,8 @@
   "pinned_hash": "b553ca03b595acac33f06f308100ab4ef78355e7",
   "files_to_copy": [
 
+  ],
+  "file_dependencies": [
+    "iOS/WPiOS/"
   ]
 }


### PR DESCRIPTION
A small fix to make `configure_validate` less noisy during builds. Relies on https://github.com/wordpress-mobile/release-toolkit/pull/12