### PR TITLE
Change position of comment approve aniamtion

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -311,7 +311,7 @@ private extension NoteBlockActionsTableViewCell {
             return
         }
 
-        contentView.addSubview(overlayImageView)
+        button.addSubview(overlayImageView)
 
         let animation = button.isSelected ? overlayImageView.fadeInWithRotationAnimation : overlayImageView.fadeOutWithRotationAnimation
         animation { _ in
@@ -325,7 +325,7 @@ private extension NoteBlockActionsTableViewCell {
             return
         }
 
-        contentView.addSubview(overlayImageView)
+        button.addSubview(overlayImageView)
 
         let animation = button.isSelected ? overlayImageView.implodeAnimation : overlayImageView.explodeAnimation
         animation { _ in
@@ -340,7 +340,7 @@ private extension NoteBlockActionsTableViewCell {
         }
 
         let overlayImageView = UIImageView(image: targetImage)
-        overlayImageView.frame = contentView.convert(buttonImageView.bounds, from: buttonImageView)
+        overlayImageView.frame = button.convert(buttonImageView.bounds, from: buttonImageView)
 
         return overlayImageView
     }


### PR DESCRIPTION
Fixes #10589

This fixes the positioning of the approve animation so that it is always aligned with the approve button.

![comment-approve-animation](https://user-images.githubusercontent.com/517257/49907729-59002d00-fe2c-11e8-8dbe-70befd446444.gif)

To test:
- Approve a comment
- Ensure the animation is correct now, vs. the GIF in #10589 

Update release notes:
- This is a minor bug fix, I wouldn't expect it to be mentioned in the release notes.