### PR TITLE
Open Gutenberg on empty posts.

### DIFF
--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -44,7 +44,9 @@ class GutenbergSettings {
     /// - Returns: true if the post must be edited with Gutenberg.
     ///
     func mustUseGutenberg(for post: AbstractPost) -> Bool {
+        let postIsEmpty = post.content?.isEmpty ?? true
+
         return isGutenbergEnabled()
-            && (!post.hasRemote() || post.containsGutenbergBlocks())
+            && (!post.hasRemote() || post.containsGutenbergBlocks() || postIsEmpty)
     }
 }


### PR DESCRIPTION
This PR is a follow up of https://github.com/wordpress-mobile/WordPress-Android/pull/8777 to launch Gutenberg when the user opens an empty post, given that Gutenberg is enabled.

To test:
- Publish a post with just a title and no content.
- Open that post.
- Check that it launches Gutenberg.
- Test opening normal Gutenberg and Aztec posts.
- Test switching between the two.

