### PR TITLE
Remove feed from followed sites list in setting

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,4 +1,4 @@
 * App Settings Privacy: Added explanation for the 'Remove Location from Media' feature.
 * History / Revisions: Added swipe action to the revisions browser
 * Added a notice and undo button when loading a revision from a post's history.
-* Added the possibility to store and check if a reader site is a feed.
+* Feeds are filtered and removed from followed sites list in setting.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,3 @@
 * App Settings Privacy: Added explanation for the 'Remove Location from Media' feature.
 * History / Revisions: Added swipe action to the revisions browser
+* Added the possibility to store and check if a reader site is a feed.

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -86,7 +86,7 @@ open class NotificationSettingsViewController: UIViewController {
         })
 
         dispatchGroup.notify(queue: .main) { [weak self] in
-            self?.followedSites = siteService.allSiteTopics() ?? []
+            self?.followedSites = (siteService.allSiteTopics() ?? []).filter { !$0.isFeed }
             self?.setupSections()
             self?.activityIndicatorView.stopAnimating()
             self?.tableView.reloadData()
@@ -182,7 +182,7 @@ open class NotificationSettingsViewController: UIViewController {
         case .blog where requiresBlogsPagination:
             return displayBlogMoreWasAccepted ? rowCountForBlogSection + 1 : loadMoreRowCount
         case .followedSites:
-            return displayFollowedMoreWasAccepted ? rowCountForFollowedSite + 1 : loadMoreRowCount
+            return displayFollowedMoreWasAccepted ? rowCountForFollowedSite + 1 : min(loadMoreRowCount, rowCountForFollowedSite)
         default:
             return groupedSettings[section]?.count ?? 0
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -86,7 +86,7 @@ open class NotificationSettingsViewController: UIViewController {
         })
 
         dispatchGroup.notify(queue: .main) { [weak self] in
-            self?.followedSites = (siteService.allSiteTopics() ?? []).filter { !$0.isFeed }
+            self?.followedSites = (siteService.allSiteTopics() ?? []).filter { !$0.isExternal }
             self?.setupSections()
             self?.activityIndicatorView.stopAnimating()
             self?.tableView.reloadData()


### PR DESCRIPTION
Fixes #10639 

This PR removes feeds from the followed sites list in setting.
In the _NotificationSettingsViewController_ I filtered the followed sites removing the feeds. I also fixed a bug on displaying the right number of rows if the array count is less than the threshold.

**To test:**
- Go to the _Reader_ > _Followed Sites_ > _Manage_
- Enter **nytimes.com** in the textfield and press _Done_ and wait till the notice appears saying the site has been added.
- Go to _Me_ > _Notifications Settings_. _The New York Times_ site shouldn't appear on the Followed sites list.

Update release notes:

- [x] I have added an item to `RELEASE-NOTES.txt`.

ccing @theck13