### PR TITLE
Show keyboard when a new post is loaded

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -96,7 +96,7 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v0.2.3'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '6500eafba6dec234f71117fcb4229b0b363e3ac0'
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'

--- a/Podfile
+++ b/Podfile
@@ -96,7 +96,7 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '6500eafba6dec234f71117fcb4229b0b363e3ac0'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v0.2.4'
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.1.4)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.1.4)"
   - Gridicons (0.16)
-  - Gutenberg (0.2.3):
+  - Gutenberg (0.2.4):
     - React/Core (= 0.57.5)
     - React/CxxBridge (= 0.57.5)
     - React/DevSupport (= 0.57.5)
@@ -224,7 +224,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (= 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `6500eafba6dec234f71117fcb4229b0b363e3ac0`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v0.2.4`)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -302,8 +302,8 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: 6500eafba6dec234f71117fcb4229b0b363e3ac0
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :tag: v0.2.4
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   RNSVG:
@@ -320,8 +320,8 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   Gutenberg:
-    :commit: 6500eafba6dec234f71117fcb4229b0b363e3ac0
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :tag: v0.2.4
   RNSVG:
     :git: https://github.com/react-native-community/react-native-svg.git
     :tag: 8.0.8
@@ -348,7 +348,7 @@ SPEC CHECKSUMS:
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
   Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
-  Gutenberg: f8fb45a9e4ea41231d42a76e615d1d19f9f9aead
+  Gutenberg: 3138a04e7a29a8d24d0d4605e803e8110f30f8c4
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
   lottie-ios: d699fdee68d7b63e721d949388b015fef1aaa4ac
   MGSwipeTableCell: fb20e983988bde2b8d0df29c2d9e1d8ffd10b74a
@@ -377,6 +377,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: d65fdcef1b7f9eed0c6badda7feae53b4ae11a1c
+PODFILE CHECKSUM: a54bbf11940d467cf893047f684c9bac9ff5ccad
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -224,7 +224,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (= 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v0.2.3`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `6500eafba6dec234f71117fcb4229b0b363e3ac0`)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -302,8 +302,8 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
+    :commit: 6500eafba6dec234f71117fcb4229b0b363e3ac0
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-    :tag: v0.2.3
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   RNSVG:
@@ -320,9 +320,8 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   Gutenberg:
-    :commit: 771db65fc0bcf6cc40b208c444dd591e9977240f
+    :commit: 6500eafba6dec234f71117fcb4229b0b363e3ac0
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-    :tag: v0.2.3
   RNSVG:
     :git: https://github.com/react-native-community/react-native-svg.git
     :tag: 8.0.8
@@ -378,6 +377,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: ccdeb0d83abb1498f66898b2ad2d92213f085efb
+PODFILE CHECKSUM: d65fdcef1b7f9eed0c6badda7feae53b4ae11a1c
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -282,6 +282,12 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             }
         }
     }
+
+    func gutenbergDidLoad() {
+        if !post.hasContent() && isViewLoaded {
+            titleTextField.becomeFirstResponder()
+        }
+    }
 }
 
 // MARK: - GutenbergBridgeDataSource


### PR DESCRIPTION
This PR implements the changes made in https://github.com/wordpress-mobile/gutenberg-mobile/pull/373 .

Using the new delegate method, we show the keyboard when we start a new post.

To test:
- Clean build folder.
- `pod install`
- Start a new post using Gutenberg. (no metro running)
- Check that the keyboard appears with the toolbar.
- Run metro (from master or from the [related PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/373))
- Start a new post using Gutenberg.
- Check that the keyboard appears with the toolbar.

cc @koke 