### PR TITLE
History/Revisions: Add last analytics event

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,3 +2,4 @@
 * History / Revisions: Added swipe action to the revisions browser
 * Added a notice and undo button when loading a revision from a post's history.
 * Feeds are filtered and removed from followed sites list in setting.
+* History / Revisions: Added last Analytics event for the undo action.

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -37,6 +37,8 @@ extension PostEditor where Self: UIViewController {
                         return
                     }
                     self?.post = clone
+
+                    WPAnalytics.track(.postRevisionsLoadUndone)
                 }
             }
             ActionDispatcher.dispatch(NoticeAction.post(notice))


### PR DESCRIPTION
Refs. #10304 

This PR adds the last Analytics event for History/Revisions: _revisions_load_undone_.

**To test:**
- Select a Revision from the revisions list.
- Load the selected Revision
- When the Notice View appears click the _Undo_ button
- You should see the event `revisions_load_undone` tracked

Update release notes:

- [x] I have added an item to `RELEASE-NOTES.txt`.
