### PR TITLE
Disable iPhone Landscape support in Enhanced Site Creation flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -864,6 +864,16 @@ static NSInteger HideSearchMinSites = 3;
                                                                           [self showAddNewWordPressController];
                                                                       }];
         [addSiteAlertController addAction:addNewWordPressAction];
+
+        if ([Feature enabled: FeatureFlagEnhancedSiteCreation]) {
+            UIAlertAction *enhancedSiteAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Enhanced site creation", @"Enhanced site creation")
+                                                                         style:UIAlertActionStyleDefault
+                                                                       handler:^(UIAlertAction *action) {
+                                                                           [self enhancedSiteCreation];
+                                                                       }];
+
+            [addSiteAlertController addAction:enhancedSiteAction];
+        }
     }
 
     UIAlertAction *addSiteAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Add self-hosted site", @"Add self-hosted site button")
@@ -872,16 +882,6 @@ static NSInteger HideSearchMinSites = 3;
                                                               [self showLoginControllerForAddingSelfHostedSite];
                                                           }];
     [addSiteAlertController addAction:addSiteAction];
-
-    if ([Feature enabled: FeatureFlagEnhancedSiteCreation]) {
-        UIAlertAction *enhancedSiteAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Enhanced site creation", @"Enhanced site creation")
-                                                                     style:UIAlertActionStyleDefault
-                                                                   handler:^(UIAlertAction *action) {
-                                                                       [self enhancedSiteCreation];
-                                                                   }];
-
-        [addSiteAlertController addAction:enhancedSiteAction];
-    }
 
     if ([Feature enabled:FeatureFlagBottomSheetDemo] == YES) {
         NSString *title = NSLocalizedString(@"Demo bottom sheet", @"Demo bottom sheet");

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/WizardNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/WizardNavigation.swift
@@ -1,5 +1,19 @@
 import UIKit
 
+// MARK: - EnhancedSiteCreationNavigationController
+
+private final class EnhancedSiteCreationNavigationController: UINavigationController {
+    override var shouldAutorotate: Bool {
+        return WPDeviceIdentification.isiPad() ? true : false
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return WPDeviceIdentification.isiPad() ? .all : .portrait
+    }
+}
+
+// MARK: - WizardNavigation
+
 final class WizardNavigation {
     private let steps: [WizardStep]
     private let pointer = WizardNavigationPointer()
@@ -9,7 +23,7 @@ final class WizardNavigation {
             return nil
         }
 
-        let returnValue = UINavigationController(rootViewController: root)
+        let returnValue = EnhancedSiteCreationNavigationController(rootViewController: root)
         returnValue.delegate = self.pointer
         return returnValue
     }()


### PR DESCRIPTION
### Description
Fixes #10657. I also noted that the new site creation flow could be initiated without a WPCOM account, so I remedied that.

_There are no changes impacting release notes._

### Testing 

- Checkout the branch and verify that test pass. 
- Launch the "Enhanced Site Creation" flow on iPhone and verify that content remains in Portrait orientation. 
- Repeat the preceding step on iPad and verify that rotation still works.