### PR TITLE
Fix new Notice presentation causing rotation errors

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -33,7 +33,6 @@ class NoticePresenter: NSObject {
         // however, since the alerts aren't permanently on screen, this isn't
         // often a problem.
         window.windowLevel = .alert
-        window.isHidden = false
 
         super.init()
 
@@ -107,6 +106,8 @@ class NoticePresenter: NSObject {
         if let feedbackType = notice.feedbackType {
             generator.notificationOccurred(feedbackType)
         }
+
+        window.isHidden = false
 
         animatePresentation(fromState: fromState, toState: toState, completion: {
             // Quick Start notices don't get automatically dismissed

--- a/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
@@ -23,6 +23,7 @@ class UntouchableViewController: UIViewController {
     required init() {
         super.init(nibName: nil, bundle: nil)
     }
+
     override func loadView() {
         super.loadView()
         view = UntouchableView()
@@ -51,6 +52,17 @@ class UntouchableViewController: UIViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        get {
+            guard let mainWindow = UIApplication.shared.delegate?.window,
+                let rootController = mainWindow?.rootViewController else {
+                    return .all
+            }
+
+            return rootController.topmostPresentedViewController.supportedInterfaceOrientations
+        }
     }
 
     enum Constants {


### PR DESCRIPTION
Fixes #10667

![rotation-fixes](https://user-images.githubusercontent.com/517257/50069040-21bbb400-017d-11e9-98c4-2eaa88ccbf6b.gif)

To test:
- Follow the rotation description/videos in #10667 

Update release notes:
- Fixes a bug that users haven't been exposed to yet, no notes needed.
