### PR TITLE
[Gutenberg]: Show "Publish now" button on drafts.

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -265,7 +265,6 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
     func gutenbergDidProvideHTML(_ html: String, changed: Bool) {
         if changed {
             self.html = html
-            editorContentWasUpdated()
         }
 
         editorContentWasUpdated()

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -268,6 +268,8 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             editorContentWasUpdated()
         }
 
+        editorContentWasUpdated()
+
         if let reason = requestHTMLReason {
             requestHTMLReason = nil // clear the reason
             switch reason {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/375

This PR updates postEditorStateContext when `GutenbergViewController` gets html data from the Gutenberg module.
This helps the state context to make better desitions on wether show the secondary publish button or not.

![publish_now](https://user-images.githubusercontent.com/9772967/50071349-25315880-01da-11e9-85ea-03504f18cde3.jpg)

To test:

- Create an empty post.
- Add title and some content.
- Press `...` (more) button.
- Select `Save to draft).
- Press `...` (more) button again.
- Check that the `Publish Now` button is there.
- Check that `Publish Now` works as it should.