### PR TITLE
rake dependencies: Check if Podfile matches Podfile.lock

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,8 @@ XCODE_CONFIGURATION="Debug"
 require 'fileutils'
 require 'tmpdir'
 require 'rake/clean'
+require 'yaml'
+require 'digest'
 PROJECT_DIR = File.expand_path(File.dirname(__FILE__))
 
 task default: %w[test]
@@ -54,7 +56,7 @@ namespace :dependencies do
   namespace :pod do
     task :check do
       sh "bundle exec pod check --silent", verbose: false do |ok, res|
-        next if ok
+        next if ok && podfile_locked?
         dependency_failed("CocoaPods")
         Rake::Task["dependencies:pod:install"].invoke
       end
@@ -254,6 +256,13 @@ end
 def pod(args)
   args = %w[bundle exec pod] + args
   sh(*args)
+end
+
+def podfile_locked?
+  podfile_checksum = Digest::SHA1.file("Podfile")
+  lockfile_checksum = YAML.load(File.read("Podfile.lock"))["PODFILE CHECKSUM"]
+
+  podfile_checksum == lockfile_checksum
 end
 
 def swiftlint_path

--- a/Rakefile
+++ b/Rakefile
@@ -55,7 +55,7 @@ namespace :dependencies do
 
   namespace :pod do
     task :check do
-      sh "bundle exec pod check --silent", verbose: false do |ok, res|
+      sh "bundle exec pod check &> /dev/null", verbose: false do |ok, res|
         next if ok && podfile_locked?
         dependency_failed("CocoaPods")
         Rake::Task["dependencies:pod:install"].invoke


### PR DESCRIPTION
Currently, if you run `rake dependencies` after making changes to the `Podfile`, nothing happens. This is because `bundle exec pod check` only checks if `Podfile.lock` and `Pods/Manifest.lock` match.

This PR updates `rake dependencies` to also check if the checksum in `Podfile.lock` matches the `Podfile` (Thanks @koke for the idea!).

The downside is that `rake dependencies` isn't as fast if you have no changes. I think its a trade off worth making.

I'll open a PR for https://github.com/square/cocoapods-check to see if they will accept a change so we don't need to do this.

To test:

- Make any change to `Podfile`
- Run `rake dependencies`

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
