### PR TITLE
Transform values from SiteCreator to SiteCreatorOutput

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -130,7 +130,7 @@ final class AssembledSiteView: UIView {
 
         let siteURL = URL(string: urlString)!
         let siteRequest = URLRequest(url: siteURL)
-    
+
         webView.load(siteRequest)
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -11,6 +11,8 @@ final class AssembledSiteView: UIView {
 
     // MARK: Properties
 
+    /// A collection of parameters uses for animation & layout of the view.
+    ///
     private struct Parameters {
         static let iPadWidthPortrait        = CGFloat(512)
         static let iPadWidthLandscape       = CGFloat(704)
@@ -24,16 +26,22 @@ final class AssembledSiteView: UIView {
         static let textFieldHeight          = CGFloat(36)
     }
 
+    /// This value displays in the address bar.
     private let domainName: String
 
+    /// This subview fulfills the role of address bar.
     private let textField: UITextField
 
+    /// At the moment, we are loading the assembled site in a web view. This underscores that.
     private let activityIndicator: UIActivityIndicatorView
 
+    /// The web view that renders our newly assembled site
     private let webView: WKWebView
 
+    /// This interacts with our `WKNavigationDelegate` to influence the policy behavior before & after site loading.
     private var webViewHasLoadedContent: Bool = false
 
+    /// This informs constraints applied to the view. It _may_ be possible to transition this to intrinsicContentSize.
     var preferredSize: CGSize {
         let screenBounds = UIScreen.main.bounds
 
@@ -53,6 +61,7 @@ final class AssembledSiteView: UIView {
         return CGSize(width: preferredWidth, height: preferredHeight)
     }
 
+    /// The URL string for the assembled site - this will be replaced with domainName once the service has been integrated.
     var urlString: String = "" {
         didSet {
             loadSite(urlString: urlString)
@@ -61,6 +70,9 @@ final class AssembledSiteView: UIView {
 
     // MARK: AssembledSiteView
 
+    /// The designated initializer.
+    ///
+    /// - Parameter domainName: the domain associated with the site pending assembly.
     init(domainName: String) {
         self.domainName = domainName
 
@@ -143,9 +155,9 @@ final class AssembledSiteView: UIView {
     }
 
     private func loadSite(urlString: String) {
-        let mockURL = URL(string: urlString)!
-        let mockRequest = URLRequest(url: mockURL)
-        webView.load(mockRequest)
+        let siteURL = URL(string: urlString)!
+        let siteRequest = URLRequest(url: siteURL)
+        webView.load(siteRequest)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -39,6 +39,8 @@ final class AssembledSiteView: UIView {
     private let webView: WKWebView
 
     /// This interacts with our `WKNavigationDelegate` to influence the policy behavior before & after site loading.
+    /// After the site has been loaded, we want to disable user interaction with the rendered site.
+    ///
     private var webViewHasLoadedContent: Bool = false
 
     /// This informs constraints applied to the view. It _may_ be possible to transition this to intrinsicContentSize.
@@ -59,13 +61,6 @@ final class AssembledSiteView: UIView {
         let preferredHeight = screenBounds.height * Parameters.minimumHeightScaleFactor
 
         return CGSize(width: preferredWidth, height: preferredHeight)
-    }
-
-    /// The URL string for the assembled site - this will be replaced with domainName once the service has been integrated.
-    var urlString: String = "" {
-        didSet {
-            loadSite(urlString: urlString)
-        }
     }
 
     // MARK: AssembledSiteView
@@ -124,6 +119,21 @@ final class AssembledSiteView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: Internal behavior
+
+    /// Triggers the new site to load for the first (!) time.
+    ///
+    func loadSite() {
+        // NB: Not all of the values from `MockSiteAddressService` are real sites, so we are use a placeholder for now.
+        // let urlString = "https://" + domainName
+        let urlString = "https://longreads.com"
+
+        let siteURL = URL(string: urlString)!
+        let siteRequest = URLRequest(url: siteURL)
+    
+        webView.load(siteRequest)
+    }
+
     // MARK: Private behavior
 
     private func configure() {
@@ -152,12 +162,6 @@ final class AssembledSiteView: UIView {
         layer.shadowOffset = Parameters.shadowOffset
         layer.shadowOpacity = Parameters.shadowOpacity
         layer.shadowRadius = Parameters.shadowRadius
-    }
-
-    private func loadSite(urlString: String) {
-        let siteURL = URL(string: urlString)!
-        let siteRequest = URLRequest(url: siteURL)
-        webView.load(siteRequest)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
@@ -10,6 +10,8 @@ final class SiteAssemblyContentView: UIView {
 
     // MARK: Properties
 
+    /// A collection of parameters uses for animation & layout of the view.
+    ///
     private struct Parameters {
         static let animationDuration                        = TimeInterval(0.5)
         static let buttonContainerScaleFactor               = CGFloat(2)
@@ -18,40 +20,54 @@ final class SiteAssemblyContentView: UIView {
         static let statusStackViewSpacing                   = CGFloat(16)
     }
 
+    /// This influences the top of the completion label as it animates into place.
     private var completionLabelTopConstraint: NSLayoutConstraint?
 
+    /// This advises the user that the site creation request completed successfully.
     private(set) var completionLabel: UILabel
 
+    /// This advises the user that the site creation request is underway.
     private let statusLabel: UILabel
 
+    /// The loading indicator provides an indeterminate view of progress as the site is being created.
     private let activityIndicator: UIActivityIndicatorView
 
+    /// The stack view manages the appearance of a status label and a loading indicator.
     private(set) var statusStackView: UIStackView
 
+    /// This influences the top of the assembled site, which varies by device & orientation.
     private var assembledSiteTopConstraint: NSLayoutConstraint?
 
+    /// This influences the height of the assembled site, which varies by device & orientation.
     private var assembledSiteHeightConstraint: NSLayoutConstraint?
 
+    /// This influences the width of the assembled site, which varies by device & orientation.
     private var assembledSiteWidthConstraint: NSLayoutConstraint?
 
+    /// This is a representation of the assembled site.
     private(set) var assembledSiteView: AssembledSiteView?
 
+    /// This constraint influences the presentation of the Done button as it animates into view.
     private var buttonContainerBottomConstraint: NSLayoutConstraint?
 
+    /// We adjust the button container view slightly to account for the Home indicator ("unsafe") region on the device.
     private var buttonContainerContainer: UIView?
 
+    /// The button container view is associated with the root view of a `NUXButtonViewController`
     var buttonContainerView: UIView? {
         didSet {
             installButtonContainerView()
         }
     }
 
+    /// The domain name is applied to the appearance of the created site.
     var domainName: String? {
         didSet {
             installAssembledSiteView()
         }
     }
 
+    /// The status of site assembly. As the state advances, the view updates in concert.
     var status: SiteAssemblyStatus = .idle {
         didSet {
             setNeedsLayout()
@@ -60,6 +76,8 @@ final class SiteAssemblyContentView: UIView {
 
     // MARK: SiteAssemblyContentView
 
+    /// The designated initializer.
+    ///
     init() {
         self.completionLabel = {
             let label = UILabel()
@@ -124,6 +142,8 @@ final class SiteAssemblyContentView: UIView {
         configure()
     }
 
+    /// This method is intended to be called by its owning view controller when constraints change.
+    ///
     func adjustConstraints() {
         guard let assembledSitePreferredSize = assembledSiteView?.preferredSize,
             let widthConstraint = assembledSiteWidthConstraint else {
@@ -152,6 +172,7 @@ final class SiteAssemblyContentView: UIView {
         case .failed:
             layoutFailed()
         case .succeeded:
+            // NB: Not all of the values from `MockSiteAddressService` are real sites, so we are using a temporary one.
             assembledSiteView?.urlString = "https://longreads.com"
             layoutSucceeded()
         }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
@@ -172,8 +172,6 @@ final class SiteAssemblyContentView: UIView {
         case .failed:
             layoutFailed()
         case .succeeded:
-            // NB: Not all of the values from `MockSiteAddressService` are real sites, so we are using a temporary one.
-            assembledSiteView?.urlString = "https://longreads.com"
             layoutSucceeded()
         }
     }
@@ -286,6 +284,8 @@ final class SiteAssemblyContentView: UIView {
     }
 
     private func layoutSucceeded() {
+        assembledSiteView?.loadSite()
+
         UIView.animate(withDuration: Parameters.animationDuration, delay: 0, options: .curveEaseOut, animations: { [statusStackView] in
             statusStackView.alpha = 0
             }, completion: { [weak self] completed in

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
@@ -7,8 +7,10 @@ final class SiteAssemblyStep: WizardStep {
 
     // MARK: Properties
 
+    /// The creator collects user input as they advance through the wizard flow.
     private let creator: SiteCreator
 
+    /// The service with which the final assembly interacts to coordinate site creation.
     private let service: SiteAssemblyService
 
     // MARK: WizardStep

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -5,16 +5,23 @@ import WordPressAuthenticator
 
 // MARK: - SiteAssemblyWizardContent
 
+/// This view controller manages the final step in the enhanced site creation sequence - invoking the service &
+/// apprising the user of the outcome.
+///
 final class SiteAssemblyWizardContent: UIViewController {
 
     // MARK: Properties
 
+    /// The creator collects user input as they advance through the wizard flow.
     private let siteCreator: SiteCreator
 
+    /// The service with which the final assembly interacts to coordinate site creation.
     private let service: SiteAssemblyService
 
+    /// The content view serves as the root view of this view controller.
     private let contentView = SiteAssemblyContentView()
 
+    /// We reuse a `NUXButtonViewController` from `WordPressAuthenticator`. Ideally this might be in `WordPressUI`.
     private let buttonViewController = NUXButtonViewController.instance()
 
     // MARK: SiteAssemblyWizardContent

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -61,13 +61,19 @@ final class SiteAssemblyWizardContent: UIViewController {
         navigationController?.isNavigationBarHidden = true
         setNeedsStatusBarAppearanceUpdate()
 
-        if let domainName = siteCreator.address?.domainName {
-            contentView.domainName = domainName
-        }
+        do {
+            let wizardOutput = try siteCreator.build()
 
-        let wizardOutput = siteCreator.build()
-        service.createSite(creatorOutput: wizardOutput) { [contentView] status in
-            contentView.status = status
+            contentView.domainName = wizardOutput.siteURLString
+            service.createSite(creatorOutput: wizardOutput) { [contentView] status in
+                contentView.status = status
+            }
+        } catch is SiteCreatorOutputError {
+            DDLogError("Unable to proceed in Site Creation flow due to an apparent validation error")
+            assertionFailure()
+        } catch {
+            DDLogError("Unable to proceed due to unexpected error")
+            assertionFailure()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
@@ -1,15 +1,64 @@
+
+import Foundation
+
+// MARK: - SiteCreatorOutputError
+
+enum SiteCreatorOutputError: Error {
+    case invalidSegmentIdentifier
+    case invalidVerticalIdentifier
+    case invalidDomain
+    case invalidSiteInformation
+}
+
+// MARK: - SiteCreator
+
 // Tracks data state shared between Site Creation Wizard Steps. I am not too fond of the name, but it kind of works for now.
 final class SiteCreator {
-    var segment: SiteSegment?
-    var vertical: SiteVertical?
-    var information: SiteInformation?
-    var address: DomainSuggestion?
 
+    // MARK: Properties
+
+    var segment: SiteSegment?
+
+    var vertical: SiteVertical?
+
+    var information: SiteInformation?
+
+    var address: DomainSuggestion?
 
     /// Generates the final object that will be posted to the backend
     ///
     /// - Returns: an Encodable object
-    func build() -> SiteCreatorOutput {
-        return SiteCreatorOutput()
+    func build() throws -> SiteCreatorOutput {
+
+        // NB: complete type-switch via #10670
+        guard let _ = segment?.identifier else {
+            throw SiteCreatorOutputError.invalidSegmentIdentifier
+        }
+
+        // NB: complete type-switch via #10670
+        guard let _ = vertical?.identifier else {
+            throw SiteCreatorOutputError.invalidVerticalIdentifier
+        }
+
+        guard let domainSuggestion = address else {
+            throw SiteCreatorOutputError.invalidDomain
+        }
+
+        guard let siteInformation = information else {
+            throw SiteCreatorOutputError.invalidSiteInformation
+        }
+
+        let output = SiteCreatorOutput(
+            segmentIdentifier: 0,                       // NB: complete type-switch via #10670
+            verticalIdentifier: 0,                      // NB: complete type-switch via #10670
+            tagline: siteInformation.tagLine ?? "",     // Tagline input can be skipped
+            isPublic: true,
+            languageIdentifier: WordPressComLanguageDatabase().deviceLanguageIdNumber().stringValue,
+            shouldValidate: true,
+            siteURLString: domainSuggestion.domainName,
+            title: siteInformation.title                // Title input can be skipped
+        )
+
+        return output
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreatorOutput.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreatorOutput.swift
@@ -2,5 +2,35 @@
 import Foundation
 
 /// The final output of the site creation wizard, is an encodable model object that can be submitted to the backend.
+/// This is intended for use in conjunction with `EnhancedSiteCreationService`.
 ///
-struct SiteCreatorOutput {}
+struct SiteCreatorOutput {
+
+    // MARK: Properties (New / Enhanced)
+
+    /// Maps to `site_segment`
+    let segmentIdentifier: Int64
+
+    /// Maps to `site_vertical`
+    let verticalIdentifier: Int64
+
+    /// Maps to `site_tagline`
+    let tagline: String
+
+    // MARK: Legacy properties
+
+    /// Maps to `public`
+    let isPublic: Bool
+
+    /// Maps to `lang_id`
+    let languageIdentifier: String
+
+    /// Maps to `validate`
+    let shouldValidate: Bool
+
+    /// Maps to `blog_name`
+    let siteURLString: String
+
+    /// Maps to `blog_title`
+    let title: String
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreatorOutput.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreatorOutput.swift
@@ -1,3 +1,6 @@
-// The final output of the site creation wizard, is an encodable model object that can be submitted to the backend
-struct SiteCreatorOutput {
-}
+
+import Foundation
+
+/// The final output of the site creation wizard, is an encodable model object that can be submitted to the backend.
+///
+struct SiteCreatorOutput {}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -423,6 +423,7 @@
 		6867C0633E597372235CB5E0 /* Pods_WordPressDraftActionExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F7E3CC306AECBBCB71D2E19C /* Pods_WordPressDraftActionExtension.framework */; };
 		7059CD210F332B6500A0660B /* WPCategoryTree.m in Sources */ = {isa = PBXBuildFile; fileRef = 7059CD200F332B6500A0660B /* WPCategoryTree.m */; };
 		722F5726ACB4A276B0CF3C83 /* Pods_WordPress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */; };
+		730354BA21C867E500CD18C2 /* SiteCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730354B921C867E500CD18C2 /* SiteCreatorTests.swift */; };
 		7305138321C031FC006BD0A1 /* AssembledSiteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7305138221C031FC006BD0A1 /* AssembledSiteView.swift */; };
 		73178C2721BEE09300E37C9A /* SiteSegmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73178C2121BEE09300E37C9A /* SiteSegmentTests.swift */; };
 		73178C2821BEE09300E37C9A /* SiteCreationDataCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73178C2221BEE09300E37C9A /* SiteCreationDataCoordinatorTests.swift */; };
@@ -2267,6 +2268,7 @@
 		7059CD1F0F332B6500A0660B /* WPCategoryTree.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = WPCategoryTree.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		7059CD200F332B6500A0660B /* WPCategoryTree.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = WPCategoryTree.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		712D0A17BC83B9730BD7CCC0 /* Pods-WordPressDraftActionExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressDraftActionExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressDraftActionExtension/Pods-WordPressDraftActionExtension.debug.xcconfig"; sourceTree = "<group>"; };
+		730354B921C867E500CD18C2 /* SiteCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreatorTests.swift; sourceTree = "<group>"; };
 		7305138221C031FC006BD0A1 /* AssembledSiteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssembledSiteView.swift; sourceTree = "<group>"; };
 		73178C2121BEE09300E37C9A /* SiteSegmentTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteSegmentTests.swift; sourceTree = "<group>"; };
 		73178C2221BEE09300E37C9A /* SiteCreationDataCoordinatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteCreationDataCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -4191,7 +4193,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				F14B5F6F208E648200439554 /* config */,
@@ -4968,6 +4970,7 @@
 				73C8F06521BEF76B00DDDF7E /* SiteAssemblyViewTests.swift */,
 				73178C2221BEE09300E37C9A /* SiteCreationDataCoordinatorTests.swift */,
 				73178C2621BEE09300E37C9A /* SiteCreationHeaderDataTests.swift */,
+				730354B921C867E500CD18C2 /* SiteCreatorTests.swift */,
 				73178C2421BEE09300E37C9A /* SiteSegmentsCellTests.swift */,
 				73178C2321BEE09300E37C9A /* SiteSegmentsStepTests.swift */,
 				73178C2121BEE09300E37C9A /* SiteSegmentTests.swift */,
@@ -8316,7 +8319,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -10350,6 +10353,7 @@
 				D800D87620999AE700E7C7E5 /* DiscoverMenuItemCreatorTests.swift in Sources */,
 				E15027651E03E54100B847E3 /* PinghubTests.swift in Sources */,
 				E1B642131EFA5113001DC6D7 /* ModelTestHelper.swift in Sources */,
+				730354BA21C867E500CD18C2 /* SiteCreatorTests.swift in Sources */,
 				B566EC751B83867800278395 /* NSMutableAttributedStringTests.swift in Sources */,
 				E6B9B8AF1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift in Sources */,
 				732A473D218787500015DA74 /* WPRichTextFormatterTests.swift in Sources */,

--- a/WordPress/WordPressTest/SiteCreation/SiteAssemblyServiceTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteAssemblyServiceTests.swift
@@ -3,6 +3,35 @@ import XCTest
 
 class SiteAssemblyServiceTests: XCTestCase {
 
+    private var pendingSiteInput: SiteCreatorOutput?
+
+    override func setUp() {
+        super.setUp()
+
+        let defaultInput = SiteCreator()
+
+        defaultInput.segment = SiteSegment(identifier: Identifier(value: "12345"), // NB: complete type-switch via #10670
+            title: "A title",
+            subtitle: "A subtitle",
+            icon: URL(string: "https://s.w.org/style/images/about/WordPress-logotype-standard.png")!,
+            iconColor: .red)
+
+        defaultInput.vertical = SiteVertical(identifier: Identifier(value: "678910"), // NB: complete type-switch via #10670,
+            title: "A title",
+            isNew: true)
+
+        defaultInput.information = SiteInformation(title: "A title", tagLine: "A tagline")
+
+        let domainSuggestionPayload: [String: AnyObject] = [
+            "domain_name"       : "domainName.com" as AnyObject,
+            "product_id"        : 42 as AnyObject,
+            "supports_privacy"  : true as AnyObject,
+            ]
+        defaultInput.address = try! DomainSuggestion(json: domainSuggestionPayload)
+
+        pendingSiteInput = try! defaultInput.build()
+    }
+
     func testSiteAssemblyService_InitialStatus_IsIdle() {
         let service: SiteAssemblyService = MockSiteAssemblyService()
 
@@ -15,7 +44,8 @@ class SiteAssemblyServiceTests: XCTestCase {
     func testSiteAssemblyService_StatusInflight_IsInProgress() {
         let service: SiteAssemblyService = MockSiteAssemblyService()
 
-        let output = SiteCreatorOutput()
+        XCTAssertNotNil(pendingSiteInput)
+        let output = pendingSiteInput!
         service.createSite(creatorOutput: output, changeHandler: nil)
         let actualStatus = service.currentStatus
 
@@ -29,7 +59,8 @@ class SiteAssemblyServiceTests: XCTestCase {
 
         let service: SiteAssemblyService = MockSiteAssemblyService()
 
-        let output = SiteCreatorOutput()
+        XCTAssertNotNil(pendingSiteInput)
+        let output = pendingSiteInput!
         service.createSite(creatorOutput: output) { status in
             if status == .inProgress {
                 inProgressExpectation.fulfill()

--- a/WordPress/WordPressTest/SiteCreation/SiteAssemblyServiceTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteAssemblyServiceTests.swift
@@ -23,9 +23,9 @@ class SiteAssemblyServiceTests: XCTestCase {
         defaultInput.information = SiteInformation(title: "A title", tagLine: "A tagline")
 
         let domainSuggestionPayload: [String: AnyObject] = [
-            "domain_name"       : "domainName.com" as AnyObject,
-            "product_id"        : 42 as AnyObject,
-            "supports_privacy"  : true as AnyObject,
+            "domain_name": "domainName.com" as AnyObject,
+            "product_id": 42 as AnyObject,
+            "supports_privacy": true as AnyObject,
             ]
         defaultInput.address = try! DomainSuggestion(json: domainSuggestionPayload)
 

--- a/WordPress/WordPressTest/SiteCreation/SiteCreatorTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteCreatorTests.swift
@@ -27,9 +27,9 @@ class SiteCreatorTests: XCTestCase {
         defaultInput.information = SiteInformation(title: "A title", tagLine: "A tagline")
 
         let domainSuggestionPayload: [String: AnyObject] = [
-            "domain_name"       : "domainName.com" as AnyObject,
-            "product_id"        : 42 as AnyObject,
-            "supports_privacy"  : true as AnyObject,
+            "domain_name": "domainName.com" as AnyObject,
+            "product_id": 42 as AnyObject,
+            "supports_privacy": true as AnyObject,
         ]
         defaultInput.address = try! DomainSuggestion(json: domainSuggestionPayload)
 

--- a/WordPress/WordPressTest/SiteCreation/SiteCreatorTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteCreatorTests.swift
@@ -1,0 +1,109 @@
+
+import XCTest
+@testable import WordPress
+@testable import WordPressKit
+
+// MARK: - SiteCreatorTests
+
+class SiteCreatorTests: XCTestCase {
+
+    private var pendingSiteInput: SiteCreator?
+
+    override func setUp() {
+        super.setUp()
+
+        let defaultInput = SiteCreator()
+
+        defaultInput.segment = SiteSegment(identifier: Identifier(value: "12345"), // NB: complete type-switch via #10670
+            title: "A title",
+            subtitle: "A subtitle",
+            icon: URL(string: "https://s.w.org/style/images/about/WordPress-logotype-standard.png")!,
+            iconColor: .red)
+
+        defaultInput.vertical = SiteVertical(identifier: Identifier(value: "678910"), // NB: complete type-switch via #10670,
+            title: "A title",
+            isNew: true)
+
+        defaultInput.information = SiteInformation(title: "A title", tagLine: "A tagline")
+
+        let domainSuggestionPayload: [String: AnyObject] = [
+            "domain_name"       : "domainName.com" as AnyObject,
+            "product_id"        : 42 as AnyObject,
+            "supports_privacy"  : true as AnyObject,
+        ]
+        defaultInput.address = try! DomainSuggestion(json: domainSuggestionPayload)
+
+        pendingSiteInput = defaultInput
+    }
+
+    func testSiteCreator_buildSucceeds_HappyPathInput() {
+        // Given
+        XCTAssertNotNil(pendingSiteInput)
+        let siteInput = pendingSiteInput!
+
+        // When : no changes from default instance
+
+        // Then
+        XCTAssertNoThrow(try siteInput.build())
+    }
+
+    func testSiteCreator_buildFails_MissingSiteSegment() {
+        // Given
+        XCTAssertNotNil(pendingSiteInput)
+        let siteInput = pendingSiteInput!
+
+        // When
+        siteInput.segment = nil
+
+        // Then
+        XCTAssertThrowsError(try siteInput.build())
+    }
+
+    func testSiteCreator_buildFails_MissingSiteVertical() {
+        // Given
+        XCTAssertNotNil(pendingSiteInput)
+        let siteInput = pendingSiteInput!
+
+        // When
+        siteInput.vertical = nil
+
+        // Then
+        XCTAssertThrowsError(try siteInput.build())
+    }
+
+    func testSiteCreator_buildFails_MissingSiteInfo() {
+        // Given
+        XCTAssertNotNil(pendingSiteInput)
+        let siteInput = pendingSiteInput!
+
+        // When
+        siteInput.information = nil
+
+        // Then
+        XCTAssertThrowsError(try siteInput.build())
+    }
+
+    func testSiteCreator_buildSucceeds_MissingSiteInfoTagline() {
+        // Given
+        XCTAssertNotNil(pendingSiteInput)
+        let siteInput = pendingSiteInput!
+
+        // When
+        siteInput.information = SiteInformation(title: "", tagLine: nil)
+
+        // Then
+        XCTAssertNoThrow(try siteInput.build())
+    }
+
+    func testSiteCreator_buildFails_MissingDomainSuggestion() {
+        // Given
+        XCTAssertNotNil(pendingSiteInput)
+        let siteInput = pendingSiteInput!
+
+        // When
+        siteInput.address = nil
+
+        // Then
+        XCTAssertThrowsError(try siteInput.build())
+    }
+}


### PR DESCRIPTION
### Description

Fixes #10328, which calls for the transformation of information collected from user input during the enhanced site creation flow into values suitable for submission to the server. 

I took the opportunity to shore up some of the preliminary inline documentation for the final site assembly step, and created unit tests that articulate our expectations for this behavior.

Noteworthy:

- We have agreed to change the segment & vertical identifiers from `String` to `Int64` (the Android implementation is using `Long`) as part of #10670. I documented applicable references here, but did not implement that change as part of this PR.
- While the _Site Info_ screen can be skipped, the values of the title & tagline attributes are `String` & `String?`, respectively. I implemented this to account for that (i.e., empty values). Separately, we might want to further clarify `SiteInformation`.
- If we determine that the `SiteCreatorOutput` struct can take advantage of Swift's `Codable` support, that work will be performed as part of #10429.

### Testing

- Checkout the branch and verify that both new & existing test pass.
- Run through the enhanced site creation flow and verify that it works with the mock service implementation as before.

### Release notes

_No user-facing changes_
