### PR TITLE
Issue/gutenberg show keyboard on load properly

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -96,7 +96,7 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :path => '../gutenberg-mobile'#:git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v0.2.5'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '9b0c02ed883b4f2647814a255447102ccaaa5345'
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'

--- a/Podfile
+++ b/Podfile
@@ -96,7 +96,7 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v0.2.5'
+    pod 'Gutenberg', :path => '../gutenberg-mobile'#:git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v0.2.5'
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'

--- a/Podfile
+++ b/Podfile
@@ -96,7 +96,7 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '9b0c02ed883b4f2647814a255447102ccaaa5345'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v0.2.6'
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.1.4)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.1.4)"
   - Gridicons (0.16)
-  - Gutenberg (0.2.5):
+  - Gutenberg (0.2.6):
     - React/Core (= 0.57.5)
     - React/CxxBridge (= 0.57.5)
     - React/DevSupport (= 0.57.5)
@@ -224,7 +224,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (= 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `9b0c02ed883b4f2647814a255447102ccaaa5345`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v0.2.6`)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -302,8 +302,8 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: 9b0c02ed883b4f2647814a255447102ccaaa5345
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :tag: v0.2.6
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   RNSVG:
@@ -320,8 +320,8 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   Gutenberg:
-    :commit: 9b0c02ed883b4f2647814a255447102ccaaa5345
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :tag: v0.2.6
   RNSVG:
     :git: https://github.com/react-native-community/react-native-svg.git
     :tag: 8.0.8
@@ -348,7 +348,7 @@ SPEC CHECKSUMS:
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
   Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
-  Gutenberg: 311d2103e0b98739eee2fbb0a23648208dee6292
+  Gutenberg: eeb85858abf45acd58383305d93528b8aaa0d6c7
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
   lottie-ios: d699fdee68d7b63e721d949388b015fef1aaa4ac
   MGSwipeTableCell: fb20e983988bde2b8d0df29c2d9e1d8ffd10b74a
@@ -377,6 +377,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 8752741cb209ddcbb528ad1da576470fbe3efc34
+PODFILE CHECKSUM: 95f785b55d89f766ca95361f4fac6a00e9faf327
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -224,7 +224,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (= 0.16)
-  - Gutenberg (from `../gutenberg-mobile`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `9b0c02ed883b4f2647814a255447102ccaaa5345`)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -302,7 +302,8 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :path: "../gutenberg-mobile"
+    :commit: 9b0c02ed883b4f2647814a255447102ccaaa5345
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   RNSVG:
@@ -318,6 +319,9 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
+  Gutenberg:
+    :commit: 9b0c02ed883b4f2647814a255447102ccaaa5345
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNSVG:
     :git: https://github.com/react-native-community/react-native-svg.git
     :tag: 8.0.8
@@ -344,7 +348,7 @@ SPEC CHECKSUMS:
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
   Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
-  Gutenberg: cb1c69f596935f86fdb3c41906b3de66b6b68343
+  Gutenberg: 311d2103e0b98739eee2fbb0a23648208dee6292
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
   lottie-ios: d699fdee68d7b63e721d949388b015fef1aaa4ac
   MGSwipeTableCell: fb20e983988bde2b8d0df29c2d9e1d8ffd10b74a
@@ -373,6 +377,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: aea5ae0c36feb6b1ca4082c5e108ff4ebaa27631
+PODFILE CHECKSUM: 5957a85821e0ec860cf6fc5256d4db3952604a31
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -224,7 +224,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (= 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v0.2.5`)
+  - Gutenberg (from `../gutenberg-mobile`)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -302,8 +302,7 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-    :tag: v0.2.5
+    :path: "../gutenberg-mobile"
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   RNSVG:
@@ -319,9 +318,6 @@ CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
-  Gutenberg:
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-    :tag: v0.2.5
   RNSVG:
     :git: https://github.com/react-native-community/react-native-svg.git
     :tag: 8.0.8
@@ -348,7 +344,7 @@ SPEC CHECKSUMS:
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
   Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
-  Gutenberg: 311d2103e0b98739eee2fbb0a23648208dee6292
+  Gutenberg: cb1c69f596935f86fdb3c41906b3de66b6b68343
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
   lottie-ios: d699fdee68d7b63e721d949388b015fef1aaa4ac
   MGSwipeTableCell: fb20e983988bde2b8d0df29c2d9e1d8ffd10b74a
@@ -377,6 +373,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 7b0237b51ceeaf47137e3579c78caccf5f7a061a
+PODFILE CHECKSUM: aea5ae0c36feb6b1ca4082c5e108ff4ebaa27631
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -148,6 +148,7 @@ class GutenbergViewController: UIViewController, PostEditor {
     private lazy var gutenberg = Gutenberg(dataSource: self)
     private var requestHTMLReason: RequestHTMLReason?
     private(set) var mode: EditMode = .richText
+    private var isFirstGutenbergLayout = true
 
     // MARK: - Initializers
     required init(
@@ -287,10 +288,21 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         }
     }
 
-    func gutenbergDidLoad() {
-        if !post.hasContent() && isViewLoaded {
+    func gutenbergDidLayout() {
+        defer {
+            isFirstGutenbergLayout = false
+        }
+        focusTitleIfNeeded()
+    }
+
+    private func focusTitleIfNeeded() {
+        if shouldFocusTitleAutomatically {
             titleTextField.becomeFirstResponder()
         }
+    }
+
+    private var shouldFocusTitleAutomatically: Bool {
+        return !post.hasContent() && !titleTextField.isFirstResponder && isFirstGutenbergLayout
     }
 }
 


### PR DESCRIPTION
This PR fixes an issue where the gutenberg toolbar might be positioned a bit higher than it should when the keyboard is presented automatically after opening a new post.

This is done by implementing the new `gutenbergDidLayout` method, and presenting the keyboard after the first layout.

Ref: `gutenberg-mobile` PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/396

**Before:**
![toolbar_00](https://user-images.githubusercontent.com/9772967/50161115-88f37880-02e3-11e9-8c04-386d52358584.gif)

**After:**
![toolbar_01](https://user-images.githubusercontent.com/9772967/50161122-8e50c300-02e3-11e9-99d8-0acd207af38b.gif)

To test:
- Checkout the related `gutenberg-mobile` branch: `issue/toolbar-initial-vertical-position`
- Run `yarn start:reset`
- Build and run WPiOS on this branch.
- Open a new post using Gutenberg.
- Check that the toolbar is properly positioned.
