### PR TITLE
[Site Creation] Implement verticals selection 

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
@@ -214,4 +214,9 @@ extension VerticalsWizardContent: UITableViewDataSource, UITableViewDelegate {
             cell.addBottomBorder(withColor: WPStyleGuide.greyLighten20())
         }
     }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let vertical = data[indexPath.row]
+        didSelect(vertical)
+    }
 }


### PR DESCRIPTION
Fixes #10689 

As part of the process to style the Verticals screen we lost the functionality of the table view delegate, and therefore it is not possible to navigate to the next step

To test:
- Checkout the branch
- Navigate to Enhanced Site Creation
- Select a Segment > Select a Vertical > Notice the wizard transitions to the Site Info screen

Update release notes:
There are no user facing changes