### PR TITLE
Preload metadata of blogs on `viewWillAppear:` in `BlogDetailsViewController`.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1064,6 +1064,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self preloadPosts];
         [self preloadPages];
         [self preloadComments];
+        [self preloadMetadata];
     }
 }
 
@@ -1144,6 +1145,16 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if ([CommentService shouldRefreshCacheFor:self.blog]) {
         [commentService syncCommentsForBlog:self.blog success:nil failure:nil];
     }
+}
+
+- (void)preloadMetadata
+{
+    __weak __typeof(self) weakSelf = self;
+    [self.blogService syncBlogAndAllMetadata:self.blog
+                           completionHandler:^{
+                               [weakSelf configureTableViewData];
+                               [weakSelf reloadTableViewPreservingSelection];
+                           }];
 }
 
 - (void)scrollToElement:(QuickStartTourElement) element


### PR DESCRIPTION
There was a weird edge case when trying to install plugins on site, it goes roughly like this:

* User has opened an app quite some time ago
* They have upgraded to a Business plan in the meantime
* The app wasn't reloaded in a while
* They try to go to "Plugins" section in the app 
* There is no "Plugins" section displayed, because the app doesn't know about that the site was upgraded to business plan.

This sorta fixes it! It now refreshed the site metadata on `viewWillAppear` of `BlogDetailsViewController`, so when a user comes back from some other screen, we'll refresh the active plan and be able to show the section.

To test:

* Open the blog detail views in an app, of a site that doesn't have a Biz plan active
* Add a Biz plan to the site (using SA, or ping me ;P)
* Go to any screen from the blog details screen (i.e. post list)
* Go back
* Verify that the the "Plugins" section is now there