### PR TITLE
Make gutenberg editor title respect to safe area

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergContainerView.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergContainerView.swift
@@ -1,0 +1,53 @@
+import UIKit
+
+class GutenbergContainerView: UIView, NibLoadable {
+
+    @IBOutlet weak var titleTextField: UITextField!
+    @IBOutlet weak var separatorView: UIView!
+    @IBOutlet weak var editorContainerView: UIView!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureTitleTextField()
+        configureSeparatorView()
+    }
+
+    func configureTitleTextField() {
+        titleTextField.borderStyle = .none
+        titleTextField.heightAnchor.constraint(equalToConstant: Size.titleTextFieldHeight).isActive = true
+        titleTextField.font = Fonts.title
+        titleTextField.textColor = Colors.title
+        titleTextField.backgroundColor = Colors.background
+        titleTextField.placeholder = NSLocalizedString("Title", comment: "Placeholder for the post title.")
+        let leftView = UIView()
+        leftView.translatesAutoresizingMaskIntoConstraints = false
+        leftView.heightAnchor.constraint(equalToConstant: Size.titleTextFieldHeight).isActive = true
+        leftView.widthAnchor.constraint(equalToConstant: Size.titleTextFieldLeftPadding).isActive = true
+        leftView.backgroundColor = Colors.background
+        titleTextField.leftView = leftView
+        titleTextField.leftViewMode = .always
+    }
+
+    func configureSeparatorView() {
+        separatorView.backgroundColor = Colors.separator
+    }
+}
+
+private extension GutenbergContainerView {
+
+    enum Colors {
+        static let title = UIColor.darkText
+        static let separator = WPStyleGuide.greyLighten30()
+        static let background = UIColor.white
+    }
+
+    enum Fonts {
+        static let title = WPFontManager.notoBoldFont(ofSize: 24.0)
+    }
+
+    enum Size {
+        static let titleTextFieldHeight: CGFloat = 50.0
+        static let titleTextFieldLeftPadding: CGFloat = 10.0
+        static let titleTextFieldBottomSeparatorHeight: CGFloat = 1.0
+    }
+}

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergContainerView.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergContainerView.swift
@@ -14,18 +14,10 @@ class GutenbergContainerView: UIView, NibLoadable {
 
     func configureTitleTextField() {
         titleTextField.borderStyle = .none
-        titleTextField.heightAnchor.constraint(equalToConstant: Size.titleTextFieldHeight).isActive = true
         titleTextField.font = Fonts.title
         titleTextField.textColor = Colors.title
         titleTextField.backgroundColor = Colors.background
         titleTextField.placeholder = NSLocalizedString("Title", comment: "Placeholder for the post title.")
-        let leftView = UIView()
-        leftView.translatesAutoresizingMaskIntoConstraints = false
-        leftView.heightAnchor.constraint(equalToConstant: Size.titleTextFieldHeight).isActive = true
-        leftView.widthAnchor.constraint(equalToConstant: Size.titleTextFieldLeftPadding).isActive = true
-        leftView.backgroundColor = Colors.background
-        titleTextField.leftView = leftView
-        titleTextField.leftViewMode = .always
     }
 
     func configureSeparatorView() {
@@ -43,11 +35,5 @@ private extension GutenbergContainerView {
 
     enum Fonts {
         static let title = WPFontManager.notoBoldFont(ofSize: 24.0)
-    }
-
-    enum Size {
-        static let titleTextFieldHeight: CGFloat = 50.0
-        static let titleTextFieldLeftPadding: CGFloat = 10.0
-        static let titleTextFieldBottomSeparatorHeight: CGFloat = 1.0
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergContainerView.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergContainerView.xib
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="GutenbergContainerView" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="1Wr-qV-SCb">
+                    <rect key="frame" x="0.0" y="44" width="375" height="51"/>
+                    <subviews>
+                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WOn-ha-b6w">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="50" id="sdB-Jj-uHz"/>
+                            </constraints>
+                            <nil key="textColor"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                            <textInputTraits key="textInputTraits"/>
+                        </textField>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lia-oS-aK0">
+                            <rect key="frame" x="0.0" y="50" width="375" height="1"/>
+                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="1" id="mGx-Rj-2z6"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                </stackView>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gml-eF-Nq3">
+                    <rect key="frame" x="0.0" y="95" width="375" height="717"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                </view>
+            </subviews>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="1Wr-qV-SCb" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="4P9-4e-VN9"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="1Wr-qV-SCb" secondAttribute="trailing" id="QeZ-mG-iJL"/>
+                <constraint firstAttribute="bottom" secondItem="Gml-eF-Nq3" secondAttribute="bottom" id="Qyr-Ok-fpI"/>
+                <constraint firstItem="Gml-eF-Nq3" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Xim-o2-B2m"/>
+                <constraint firstItem="Gml-eF-Nq3" firstAttribute="top" secondItem="1Wr-qV-SCb" secondAttribute="bottom" id="aHN-4N-S1h"/>
+                <constraint firstItem="1Wr-qV-SCb" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="j8g-Ia-1qw"/>
+                <constraint firstAttribute="trailing" secondItem="Gml-eF-Nq3" secondAttribute="trailing" id="mfX-um-DiL"/>
+            </constraints>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <connections>
+                <outlet property="editorContainerView" destination="Gml-eF-Nq3" id="h1X-eY-NjA"/>
+                <outlet property="separatorView" destination="lia-oS-aK0" id="ZXv-GI-yft"/>
+                <outlet property="titleTextField" destination="WOn-ha-b6w" id="Bcn-pZ-hGz"/>
+            </connections>
+            <point key="canvasLocation" x="138.40000000000001" y="152.21674876847291"/>
+        </view>
+    </objects>
+</document>

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergContainerView.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergContainerView.xib
@@ -19,15 +19,27 @@
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="1Wr-qV-SCb">
                     <rect key="frame" x="0.0" y="44" width="375" height="51"/>
                     <subviews>
-                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WOn-ha-b6w">
+                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="olW-iv-ZID">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="50" id="sdB-Jj-uHz"/>
-                            </constraints>
-                            <nil key="textColor"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <textInputTraits key="textInputTraits"/>
-                        </textField>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HGg-Sw-1g3" userLabel="Padding view">
+                                    <rect key="frame" x="0.0" y="0.0" width="12" height="50"/>
+                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="12" id="3j6-aF-isN"/>
+                                    </constraints>
+                                </view>
+                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WOn-ha-b6w">
+                                    <rect key="frame" x="12" y="0.0" width="363" height="50"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="50" id="sdB-Jj-uHz"/>
+                                    </constraints>
+                                    <nil key="textColor"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                    <textInputTraits key="textInputTraits"/>
+                                </textField>
+                            </subviews>
+                        </stackView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lia-oS-aK0">
                             <rect key="frame" x="0.0" y="50" width="375" height="1"/>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -16,32 +16,11 @@ class GutenbergViewController: UIViewController, PostEditor {
 
     // MARK: - UI
 
-    private let titleTextField: UITextField = {
-        let textField = UITextField()
-        textField.borderStyle = .none
-        textField.heightAnchor.constraint(equalToConstant: Size.titleTextFieldHeight).isActive = true
-        textField.font = Fonts.title
-        textField.textColor = Colors.title
-        textField.backgroundColor = Colors.background
-        textField.placeholder = NSLocalizedString("Title", comment: "Placeholder for the post title.")
-        textField.addTarget(self, action: #selector(titleTextFieldDidChange(_:)), for: .editingChanged)
-        let leftView = UIView()
-        leftView.translatesAutoresizingMaskIntoConstraints = false
-        leftView.heightAnchor.constraint(equalToConstant: Size.titleTextFieldHeight).isActive = true
-        leftView.widthAnchor.constraint(equalToConstant: Size.titleTextFieldLeftPadding).isActive = true
-        leftView.backgroundColor = Colors.background
-        textField.leftView = leftView
-        textField.leftViewMode = .always
-        return textField
-    }()
+    private var titleTextField: UITextField {
+        return containerView.titleTextField
+    }
 
-    private let separatorView: UIView = {
-        let view = UIView()
-        view.heightAnchor.constraint(equalToConstant: Size.titleTextFieldBottomSeparatorHeight).isActive = true
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = Colors.separator
-        return view
-    }()
+    private var containerView = GutenbergContainerView.loadFromNib()
 
     // MARK: - Aztec
 
@@ -176,16 +155,18 @@ class GutenbergViewController: UIViewController, PostEditor {
 
     // MARK: - Lifecycle methods
     override func loadView() {
-        let stackView = UIStackView(arrangedSubviews: [titleTextField,
-                                                       separatorView,
-                                                       gutenberg.rootView])
-        stackView.axis = .vertical
-        stackView.backgroundColor = Colors.background
-        view = stackView
+        gutenberg.rootView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.editorContainerView.addSubview(gutenberg.rootView)
+        containerView.editorContainerView.leftAnchor.constraint(equalTo: gutenberg.rootView.leftAnchor).isActive = true
+        containerView.editorContainerView.rightAnchor.constraint(equalTo: gutenberg.rootView.rightAnchor).isActive = true
+        containerView.editorContainerView.topAnchor.constraint(equalTo: gutenberg.rootView.topAnchor).isActive = true
+        containerView.editorContainerView.bottomAnchor.constraint(equalTo: gutenberg.rootView.bottomAnchor).isActive = true
+        view = containerView
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        registerEventListeners()
         createRevisionOfPost()
         configureNavigationBar()
         refreshInterface()
@@ -199,6 +180,10 @@ class GutenbergViewController: UIViewController, PostEditor {
     }
 
     // MARK: - Functions
+
+    private func registerEventListeners() {
+        titleTextField.addTarget(self, action: #selector(titleTextFieldDidChange(_:)), for: .editingChanged)
+    }
 
     private func configureNavigationBar() {
         navigationController?.navigationBar.isTranslucent = false
@@ -373,21 +358,5 @@ private extension GutenbergViewController {
 
     enum Analytics {
         static let editorSource = "gutenberg"
-    }
-
-    enum Colors {
-        static let title = UIColor.darkText
-        static let separator = WPStyleGuide.greyLighten30()
-        static let background = UIColor.white
-    }
-
-    enum Fonts {
-        static let title = WPFontManager.notoBoldFont(ofSize: 24.0)
-    }
-
-    enum Size {
-        static let titleTextFieldHeight: CGFloat = 50.0
-        static let titleTextFieldLeftPadding: CGFloat = 10.0
-        static let titleTextFieldBottomSeparatorHeight: CGFloat = 1.0
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -773,6 +773,8 @@
 		85DA8C4418F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m in Sources */ = {isa = PBXBuildFile; fileRef = 85DA8C4318F3F29A0074C8A4 /* WPAnalyticsTrackerWPCom.m */; };
 		85ED988817DFA00000090D0B /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 85ED988717DFA00000090D0B /* Images.xcassets */; };
 		85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */; };
+		9111C15121CA59A100DA0662 /* GutenbergContainerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9111C15021CA59A100DA0662 /* GutenbergContainerView.xib */; };
+		9111C15321CA59BC00DA0662 /* GutenbergContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9111C15221CA59BB00DA0662 /* GutenbergContainerView.swift */; };
 		91D8364121946EFB008340B2 /* GutenbergMediaPickerHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D8364021946EFB008340B2 /* GutenbergMediaPickerHelper.swift */; };
 		91DCE84421A6A7840062F134 /* PostEditor+BlogPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DCE84321A6A7840062F134 /* PostEditor+BlogPicker.swift */; };
 		91DCE84621A6A7F50062F134 /* PostEditor+MoreOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DCE84521A6A7F50062F134 /* PostEditor+MoreOptions.swift */; };
@@ -2626,6 +2628,8 @@
 		85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PushAuthenticationServiceTests.swift; sourceTree = "<group>"; };
 		8CE5BBD00FF1470AC4B88247 /* Pods_WordPressTodayWidget.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressTodayWidget.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9111C15021CA59A100DA0662 /* GutenbergContainerView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GutenbergContainerView.xib; sourceTree = "<group>"; };
+		9111C15221CA59BB00DA0662 /* GutenbergContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergContainerView.swift; sourceTree = "<group>"; };
 		91D8364021946EFB008340B2 /* GutenbergMediaPickerHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergMediaPickerHelper.swift; sourceTree = "<group>"; };
 		91DCE84321A6A7840062F134 /* PostEditor+BlogPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditor+BlogPicker.swift"; sourceTree = "<group>"; };
 		91DCE84521A6A7F50062F134 /* PostEditor+MoreOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditor+MoreOptions.swift"; sourceTree = "<group>"; };
@@ -5399,6 +5403,8 @@
 				91D8364021946EFB008340B2 /* GutenbergMediaPickerHelper.swift */,
 				7EA30DB421ADA20F0092F894 /* AztecAttachmentDelegate.swift */,
 				7EA30DB321ADA20F0092F894 /* EditorMediaUtility.swift */,
+				9111C15021CA59A100DA0662 /* GutenbergContainerView.xib */,
+				9111C15221CA59BB00DA0662 /* GutenbergContainerView.swift */,
 			);
 			path = Gutenberg;
 			sourceTree = "<group>";
@@ -8488,6 +8494,7 @@
 				401A3D022027DBD80099A127 /* PluginListCell.xib in Resources */,
 				98812973219CF5100075FF33 /* SimpleTotalsCell.xib in Resources */,
 				981C34912183871200FC2683 /* SiteStatsDashboard.storyboard in Resources */,
+				9111C15121CA59A100DA0662 /* GutenbergContainerView.xib in Resources */,
 				435035991EDCAB99004ECF47 /* post.json in Resources */,
 				98812967219CE42A0075FF33 /* StatsTotalRow.xib in Resources */,
 				98B3FA8621C05BF000148DD4 /* ViewMoreRow.xib in Resources */,
@@ -9267,6 +9274,7 @@
 				43AF2F972107D3810069C012 /* QuickStartTourState.swift in Sources */,
 				5D5A6E931B613CA400DAF819 /* ReaderPostCardCell.swift in Sources */,
 				9A38DC6B218899FB006A409B /* DiffContentValue.swift in Sources */,
+				9111C15321CA59BC00DA0662 /* GutenbergContainerView.swift in Sources */,
 				7E4123C020F4097B00DF8486 /* FormattableTextContent.swift in Sources */,
 				E10520581F2B1CC900A948F6 /* WordPress-61-62.xcmappingmodel in Sources */,
 				B5772AC41C9C7A070031F97E /* GravatarService.swift in Sources */,


### PR DESCRIPTION
This PR makes the Gutenberg title respect to safe area, the issue is visible on iPhone X landscape mode.

**Before:**
 
<img width="675" alt="screen shot 2018-12-18 at 19 53 47" src="https://user-images.githubusercontent.com/5032900/50218024-8eac9500-039b-11e9-953a-2dc97363fc6f.png">

**After:**

<img width="692" alt="screen shot 2018-12-19 at 14 18 10" src="https://user-images.githubusercontent.com/5032900/50218035-9a985700-039b-11e9-9c7c-0c4064db53e1.png">

**To test:**

Test 1 - iPhone X - landscape

- Open WPiOS app with one of the iPhone X generation device or simulator, open a gutenberg post
- Switch device orientation to landscape
- Make sure title respects the safe areas leaving enough space from left/right

Test 2 - non iPhone X

- Open WPiOS app with one of iPhone 6/7/8/SE device or simulator, open a gutenberg post
- Switch device orientation to landscape
- There shouldn't be any spaces this time on left/right of the title

Test 3 - Portrait mode

- Switch to Portrait mode and check the title
- There shouldn't be any spaces this time on left/right of the title

Test 4 - Basic title update

- Update a post's title
- Save and close
- Reopen the post
- Verify that you see the updated title

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.