### PR TITLE
Gutenberg: Added readableContentGuide when running on iPad.

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -155,18 +155,11 @@ class GutenbergViewController: UIViewController, PostEditor {
     }
 
     // MARK: - Lifecycle methods
-    override func loadView() {
-        gutenberg.rootView.translatesAutoresizingMaskIntoConstraints = false
-        containerView.editorContainerView.addSubview(gutenberg.rootView)
-        containerView.editorContainerView.leftAnchor.constraint(equalTo: gutenberg.rootView.leftAnchor).isActive = true
-        containerView.editorContainerView.rightAnchor.constraint(equalTo: gutenberg.rootView.rightAnchor).isActive = true
-        containerView.editorContainerView.topAnchor.constraint(equalTo: gutenberg.rootView.topAnchor).isActive = true
-        containerView.editorContainerView.bottomAnchor.constraint(equalTo: gutenberg.rootView.bottomAnchor).isActive = true
-        view = containerView
-    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupContainerView()
+        setupGutenbergView()
         registerEventListeners()
         createRevisionOfPost()
         configureNavigationBar()
@@ -240,6 +233,35 @@ class GutenbergViewController: UIViewController, PostEditor {
     func savePostEditsAndSwitchToAztec() {
         requestHTMLReason = .switchToAztec
         gutenberg.requestHTML()
+    }
+}
+
+// MARK: - Views setup
+
+extension GutenbergViewController {
+    private func setupGutenbergView() {
+        gutenberg.rootView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.editorContainerView.addSubview(gutenberg.rootView)
+        containerView.editorContainerView.leftAnchor.constraint(equalTo: gutenberg.rootView.leftAnchor).isActive = true
+        containerView.editorContainerView.rightAnchor.constraint(equalTo: gutenberg.rootView.rightAnchor).isActive = true
+        containerView.editorContainerView.topAnchor.constraint(equalTo: gutenberg.rootView.topAnchor).isActive = true
+        containerView.editorContainerView.bottomAnchor.constraint(equalTo: gutenberg.rootView.bottomAnchor).isActive = true
+    }
+
+    private func setupContainerView() {
+        view.backgroundColor = .white
+        view.addSubview(containerView)
+
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        if WPDeviceIdentification.isiPad() {
+            containerView.leftAnchor.constraint(equalTo: view.readableContentGuide.leftAnchor).isActive = true
+            containerView.rightAnchor.constraint(equalTo: view.readableContentGuide.rightAnchor).isActive = true
+        } else {
+            containerView.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
+            containerView.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+        }
+        containerView.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+        containerView.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
     }
 }
 


### PR DESCRIPTION
As the title says, this PR adds readable content guide when Gutenberg is running on iPad.
iPhone layout is not touched.

![readable](https://user-images.githubusercontent.com/9772967/50240230-e3b4cf00-03cc-11e9-98a4-fcd1cd3b040b.png)

To test:

- Run the project on iPad.
- Open a post on Gutenberg.
- Check that the layout follows readable content guide.
- Test the same on iPhone.
- Check that the layout looks as before (no extra margins).