### PR TITLE
Bump Aztec to 1.3.3

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -39,7 +39,7 @@ def aztec
     ##
     ## pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'e2792ee1f7ae21aae9873084faf0a29891785d9b'
     ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'e2792ee1f7ae21aae9873084faf0a29891785d9b'
-    pod 'WordPress-Editor-iOS', '1.3.2'
+    pod 'WordPress-Editor-iOS', '1.3.3'
 end
 
 def wordpress_ui

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -169,9 +169,9 @@ PODS:
   - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (0.5.0)
-  - WordPress-Aztec-iOS (1.3.2)
-  - WordPress-Editor-iOS (1.3.2):
-    - WordPress-Aztec-iOS (= 1.3.2)
+  - WordPress-Aztec-iOS (1.3.3)
+  - WordPress-Editor-iOS (1.3.3):
+    - WordPress-Aztec-iOS (= 1.3.3)
   - WordPressAuthenticator (1.1.6):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
@@ -241,7 +241,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
-  - WordPress-Editor-iOS (= 1.3.2)
+  - WordPress-Editor-iOS (= 1.3.3)
   - WordPressAuthenticator (~> 1.1.6)
   - WordPressKit (~> 1.5.1)
   - WordPressShared (~> 1.6.0)
@@ -362,8 +362,8 @@ SPEC CHECKSUMS:
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPress-Aztec-iOS: 767b66aa6377ea44eb1718d196c3c58609ae2a5d
-  WordPress-Editor-iOS: 72d398ee34a00efe8cd4694b523e21b616a09a4a
+  WordPress-Aztec-iOS: c3da701f78587453a532e3cf0c6ba8489ebdd576
+  WordPress-Editor-iOS: 836b77ff08c18483fbce6a1f96a9a71fb19dc038
   WordPressAuthenticator: 83f495cce863d3f65bb440f6dea57161af401729
   WordPressKit: b0d9838a874a2ea126da17965d939f0422d94581
   WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
@@ -373,6 +373,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: c63c67b507572f521b97095ae5fcf68ae4d3b9ed
+PODFILE CHECKSUM: 363d0a2636ccb5a4e33ac02313bdc0be92344eb5
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Bump Aztec in `release/11.4` so we can do a hotfix release for https://github.com/wordpress-mobile/AztecEditor-iOS/issues/1111

To test:

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
