### PR TITLE
Update Gutenberg to 0.3

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -96,12 +96,12 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v0.2.6'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v0.3.0'
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'
-    pod 'RNSVG', :git => 'https://github.com/react-native-community/react-native-svg.git', :tag => '8.0.8'
-    pod 'RNTAztecView', :git => 'https://github.com/wordpress-mobile/react-native-aztec.git', :commit => '6e98ff2e09924dbba773e539be67396da5438eba'
+    pod 'RNSVG', :git => 'https://github.com/wordpress-mobile/react-native-svg.git', :tag => '8.0.9-gb.0'
+    pod 'RNTAztecView', :git => 'https://github.com/wordpress-mobile/react-native-aztec.git', :tag => 'v0.1.3'
 
     ## Third party libraries
     ## =====================

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -54,7 +54,7 @@ PODS:
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.1.4)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.1.4)"
   - Gridicons (0.16)
-  - Gutenberg (0.2.6):
+  - Gutenberg (0.3.0):
     - React/Core (= 0.57.5)
     - React/CxxBridge (= 0.57.5)
     - React/DevSupport (= 0.57.5)
@@ -161,9 +161,9 @@ PODS:
     - React/Core
     - React/fishhook
     - React/RCTBlob
-  - RNSVG (8.0.8):
+  - RNSVG (8.0.9):
     - React
-  - RNTAztecView (1.0.0):
+  - RNTAztecView (0.1.3):
     - React
     - WordPress-Aztec-iOS
   - SimulatorStatusMagic (2.3.2)
@@ -224,7 +224,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (= 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v0.2.6`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v0.3.0`)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -237,8 +237,8 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 6.1.0)
   - Reachability (= 3.2)
   - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
-  - RNSVG (from `https://github.com/react-native-community/react-native-svg.git`, tag `8.0.8`)
-  - RNTAztecView (from `https://github.com/wordpress-mobile/react-native-aztec.git`, commit `6e98ff2e09924dbba773e539be67396da5438eba`)
+  - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
+  - RNTAztecView (from `https://github.com/wordpress-mobile/react-native-aztec.git`, tag `v0.1.3`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -303,15 +303,15 @@ EXTERNAL SOURCES:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-    :tag: v0.2.6
+    :tag: v0.3.0
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   RNSVG:
-    :git: https://github.com/react-native-community/react-native-svg.git
-    :tag: 8.0.8
+    :git: https://github.com/wordpress-mobile/react-native-svg.git
+    :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 6e98ff2e09924dbba773e539be67396da5438eba
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
+    :tag: v0.1.3
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -321,13 +321,13 @@ CHECKOUT OPTIONS:
     :tag: 0.2.3
   Gutenberg:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-    :tag: v0.2.6
+    :tag: v0.3.0
   RNSVG:
-    :git: https://github.com/react-native-community/react-native-svg.git
-    :tag: 8.0.8
+    :git: https://github.com/wordpress-mobile/react-native-svg.git
+    :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 6e98ff2e09924dbba773e539be67396da5438eba
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
+    :tag: v0.1.3
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -348,7 +348,7 @@ SPEC CHECKSUMS:
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
   GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
   Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
-  Gutenberg: eeb85858abf45acd58383305d93528b8aaa0d6c7
+  Gutenberg: b82640792b5240689e97bb4009a95324d9bbbd2e
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
   lottie-ios: d699fdee68d7b63e721d949388b015fef1aaa4ac
   MGSwipeTableCell: fb20e983988bde2b8d0df29c2d9e1d8ffd10b74a
@@ -360,8 +360,8 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
   React: 01aa04500b2957c2767e1dff9fe12e09444a467c
-  RNSVG: 2d4741933313f02e79b12af1b49b2856228b382a
-  RNTAztecView: 57bb73dba9d88a27aabda2cefb1b1e0dcad90502
+  RNSVG: 6d5813dd9c6a8e041e142abf1372faf012ce5759
+  RNTAztecView: 266ca6b864df41b55e942f23c4283a449a078af6
   SimulatorStatusMagic: 0c0e711acef6e70dd8a0710962347635a9cdef24
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
@@ -377,6 +377,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 5f68d2d10da0b8536c766d23ccf5e97dbe62c6aa
+PODFILE CHECKSUM: 2ac23c2189b2a609a231b8c62ac54968f20dd066
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
I've been testing this through #10701 and releasing several builds for others to test, but doing a newer PR with cleaner history

To test:

- Run and make sure Gutenberg loads
- A good hint that it has the latest version is to look for the border at the side of focused blocks

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`. Internal only