### PR TITLE
Bump WordPressKit and WordPressAuthenticator to release versions

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -52,7 +52,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 1.5.2-beta.1'
+    pod 'WordPressKit', '~> 1.5.2'
     ##pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'b2d5ec226b65634071948dc00290dd88d51f6434'
     ##pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
@@ -131,7 +131,7 @@ target 'WordPress' do
     ## while PR is in review:
     ## pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '82f798c0dc18b17a11dfafa37f1fd39eb508b29b'
 
-    pod 'WordPressAuthenticator', '~> 1.1.7-beta.1'
+    pod 'WordPressAuthenticator', '~> 1.1.7'
 
     aztec
     wordpress_ui

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -45,14 +45,14 @@ PODS:
   - GoogleSignInRepacked (4.1.2):
     - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
     - "GoogleToolboxForMac/NSString+URLArguments (~> 2.1)"
-  - GoogleToolboxForMac/DebugUtils (2.1.4):
-    - GoogleToolboxForMac/Defines (= 2.1.4)
-  - GoogleToolboxForMac/Defines (2.1.4)
-  - "GoogleToolboxForMac/NSDictionary+URLArguments (2.1.4)":
-    - GoogleToolboxForMac/DebugUtils (= 2.1.4)
-    - GoogleToolboxForMac/Defines (= 2.1.4)
-    - "GoogleToolboxForMac/NSString+URLArguments (= 2.1.4)"
-  - "GoogleToolboxForMac/NSString+URLArguments (2.1.4)"
+  - GoogleToolboxForMac/DebugUtils (2.2.0):
+    - GoogleToolboxForMac/Defines (= 2.2.0)
+  - GoogleToolboxForMac/Defines (2.2.0)
+  - "GoogleToolboxForMac/NSDictionary+URLArguments (2.2.0)":
+    - GoogleToolboxForMac/DebugUtils (= 2.2.0)
+    - GoogleToolboxForMac/Defines (= 2.2.0)
+    - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.0)"
+  - "GoogleToolboxForMac/NSString+URLArguments (2.2.0)"
   - Gridicons (0.16)
   - Gutenberg (0.3.0):
     - React/Core (= 0.57.5)
@@ -173,7 +173,7 @@ PODS:
   - WordPress-Aztec-iOS (1.4.1)
   - WordPress-Editor-iOS (1.4.1):
     - WordPress-Aztec-iOS (= 1.4.1)
-  - WordPressAuthenticator (1.1.7-beta.1):
+  - WordPressAuthenticator (1.1.7):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (= 3.4.2)
@@ -187,7 +187,7 @@ PODS:
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
     - wpxmlrpc (~> 0.8)
-  - WordPressKit (1.5.2-beta.1):
+  - WordPressKit (1.5.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -244,8 +244,8 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - UIDeviceIdentifier (~> 0.4)
   - WordPress-Editor-iOS (= 1.4.1)
-  - WordPressAuthenticator (~> 1.1.7-beta.1)
-  - WordPressKit (~> 1.5.2-beta.1)
+  - WordPressAuthenticator (~> 1.1.7)
+  - WordPressKit (~> 1.5.2)
   - WordPressShared (~> 1.6.0)
   - WordPressUI (~> 1.1)
   - WPMediaPicker (= 1.3.1)
@@ -346,7 +346,7 @@ SPEC CHECKSUMS:
   GiphyCoreSDK: 1fe401c5fc65f182e7aa8b7fb2c9005f2a523374
   glog: 1de0bb937dccdc981596d3b5825ebfb765017ded
   GoogleSignInRepacked: d357702618c555f38923576924661325eb1ef22b
-  GoogleToolboxForMac: 91c824d21e85b31c2aae9bb011c5027c9b4e738f
+  GoogleToolboxForMac: ff31605b7d66400dcec09bed5861689aebadda4d
   Gridicons: 8cc5cb666d5ad8b8f1771d3c7a93d27ae25b7c2e
   Gutenberg: b82640792b5240689e97bb4009a95324d9bbbd2e
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
@@ -368,8 +368,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
   WordPress-Aztec-iOS: 383ea61afd3f96ef4d0c7e3f1ab8e7a362f5cd67
   WordPress-Editor-iOS: 617116ef6b454ff11eed2cbdeafc6cf78a54aec2
-  WordPressAuthenticator: ef9169f1d8c7ee06c731c39c6acc9c015228b0bf
-  WordPressKit: 0c205c556e30a375f40d4c21be59c566da28d558
+  WordPressAuthenticator: e8019fa8ab52004d0150d99004172487418543b0
+  WordPressKit: 758c7b5a7ff7419bb3de2626858c04d560c98225
   WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
   WordPressUI: 3c69543f0170e011226e48910b8c3071e5d400af
   WPMediaPicker: ea92f84950843c7baf6a7325caed72ad7852418d
@@ -377,6 +377,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 2ac23c2189b2a609a231b8c62ac54968f20dd066
+PODFILE CHECKSUM: e07ffc78a6aa41b06a874817a684c531e8156ff8
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Bumping these pods to non beta versions for the 11.5 release.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
