### PR TITLE
Gutenberg: Adding new request HTML reason `switchBlog`

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -12,6 +12,7 @@ class GutenbergViewController: UIViewController, PostEditor {
         case close
         case more
         case switchToAztec
+        case switchBlog
     }
 
     // MARK: - UI
@@ -217,6 +218,11 @@ class GutenbergViewController: UIViewController, PostEditor {
         mode.toggle()
     }
 
+    func requestHTML(for reason: RequestHTMLReason) {
+        requestHTMLReason = reason
+        gutenberg.requestHTML()
+    }
+
     // MARK: - Event handlers
 
     @objc func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
@@ -231,8 +237,7 @@ class GutenbergViewController: UIViewController, PostEditor {
     // MARK: - Switch to Aztec
 
     func savePostEditsAndSwitchToAztec() {
-        requestHTMLReason = .switchToAztec
-        gutenberg.requestHTML()
+        requestHTML(for: .switchToAztec)
     }
 }
 
@@ -292,6 +297,8 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
                 displayMoreSheet()
             case .switchToAztec:
                 switchToAztec(self)
+            case .switchBlog:
+                blogPickerWasPressed()
             }
         }
     }
@@ -363,22 +370,19 @@ extension GutenbergViewController: PostEditorNavigationBarManagerDelegate {
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, closeWasPressed sender: UIButton) {
-        requestHTMLReason = .close
-        gutenberg.requestHTML()
+        requestHTML(for: .close)
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, moreWasPressed sender: UIButton) {
-        requestHTMLReason = .more
-        gutenberg.requestHTML()
+        requestHTML(for: .more)
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, blogPickerWasPressed sender: UIButton) {
-        blogPickerWasPressed()
+        requestHTML(for: .switchBlog)
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, publishButtonWasPressed sender: UIButton) {
-        requestHTMLReason = .publish
-        gutenberg.requestHTML()
+        requestHTML(for: .publish)
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, displayCancelMediaUploads sender: UIButton) {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+BlogPicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+BlogPicker.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 extension PostEditor where Self: UIViewController {
 


### PR DESCRIPTION
Used to update HTML content before switching to another blog.

This PR solves an issue where the content was lost after switching to another Blog using the blog picker.

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/442

Now:
![blog_change](https://user-images.githubusercontent.com/9772967/50398350-7c599f00-077f-11e9-9604-389127526ec5.gif)


To test:
- Open the Gutenberg post editor with a new post (mid button in the bottom tab bar.
- Write some content.
- Switch to another blog using the blog picker (as shown in the GIF)
- Check that all the content is still there.
- Save/Publish the post.
- Check that the post is saved in the corresponding blog.


