### PR TITLE
Gutenberg: refresh `mediaPickerHelper` after post has changed.

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -93,6 +93,7 @@ class GutenbergViewController: UIViewController, PostEditor {
         didSet {
             postEditorStateContext = PostEditorStateContext(post: post, delegate: self)
             attachmentDelegate = AztecAttachmentDelegate(post: post)
+            mediaPickerHelper = GutenbergMediaPickerHelper(context: self, post: post)
             refreshInterface()
         }
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/443

This PR fixes an issue where the MediaLibrar wasn't updated to the new blog, after switching blog with the blog picker.

Testing this, you might notice an issue that after changing the blog, the post content is deleted. This is solved here: #10724 

Now:
![media_switch_blog](https://user-images.githubusercontent.com/9772967/50398982-9649b080-0784-11e9-9f65-8d3004ef96c9.gif)


To test:
1. Open the Gutenberg editor.
2. Add an empty Image block.
3. Open the media library from that block.
4. Check that the images correspond to your current blog.
5. Switch to another blog using the blog switch button. (As shown in the GIF).
6. Repeat 2, 3 and 4.