### PR TITLE
[Stats Refresh] Tabbed cards - update filter bar colors

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -112,13 +112,13 @@ extension WPStyleGuide {
         }
 
         static func configureFilterTabBar(_ filterTabBar: FilterTabBar, forTabbedCard: Bool = false) {
-            filterTabBar.tabSizingStyle = .equalWidths
             filterTabBar.dividerColor =  filterDividerColor
             filterTabBar.deselectedTabColor = filterDeselectedColor
             filterTabBar.tintColor = defaultFilterTintColor
 
             // For FilterTabBar on TabbedTotalsCell
             if forTabbedCard {
+                filterTabBar.tabSizingStyle = .equalWidths
                 filterTabBar.tintColor = tabbedCardFilterTintColor
                 filterTabBar.selectedTitleColor = defaultTextColor
             }

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -111,11 +111,17 @@ extension WPStyleGuide {
             return UIImage(named: "gravatar")
         }
 
-        static func configureFilterTabBar(_ filterTabBar: FilterTabBar) {
-            filterTabBar.tintColor = filterTintColor
-            filterTabBar.deselectedTabColor = filterDeselectedColor
-            filterTabBar.dividerColor = filterDividerColor
+        static func configureFilterTabBar(_ filterTabBar: FilterTabBar, forTabbedCard: Bool = false) {
             filterTabBar.tabSizingStyle = .equalWidths
+            filterTabBar.dividerColor =  filterDividerColor
+            filterTabBar.deselectedTabColor = filterDeselectedColor
+            filterTabBar.tintColor = defaultFilterTintColor
+
+            // For FilterTabBar on TabbedTotalsCell
+            if forTabbedCard {
+                filterTabBar.tintColor = tabbedCardFilterTintColor
+                filterTabBar.selectedTitleColor = defaultTextColor
+            }
         }
 
         // MARK: - Style Values
@@ -136,7 +142,8 @@ extension WPStyleGuide {
         static let cellBackgroundColor = UIColor.white
         static let seperatorColor = WPStyleGuide.greyLighten20()
 
-        static let filterTintColor = WPStyleGuide.wordPressBlue()
+        static let defaultFilterTintColor = WPStyleGuide.wordPressBlue()
+        static let tabbedCardFilterTintColor = WPStyleGuide.greyLighten20()
         static let filterDeselectedColor = WPStyleGuide.greyDarken10()
         static let filterDividerColor = WPStyleGuide.greyLighten20()
 

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -120,7 +120,7 @@ extension WPStyleGuide {
             if forTabbedCard {
                 filterTabBar.tabSizingStyle = .equalWidths
                 filterTabBar.tintColor = tabbedCardFilterTintColor
-                filterTabBar.selectedTitleColor = defaultTextColor
+                filterTabBar.selectedTitleColor = tabbedCardFilterSelectedTitleColor
             }
         }
 
@@ -144,6 +144,7 @@ extension WPStyleGuide {
 
         static let defaultFilterTintColor = WPStyleGuide.wordPressBlue()
         static let tabbedCardFilterTintColor = WPStyleGuide.greyLighten20()
+        static let tabbedCardFilterSelectedTitleColor = WPStyleGuide.darkGrey()
         static let filterDeselectedColor = WPStyleGuide.greyDarken10()
         static let filterDividerColor = WPStyleGuide.greyLighten20()
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -65,7 +65,7 @@ class TabbedTotalsCell: UITableViewCell, NibLoadable {
 private extension TabbedTotalsCell {
 
     func setupFilterBar() {
-        WPStyleGuide.Stats.configureFilterTabBar(filterTabBar)
+        WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forTabbedCard: true)
         filterTabBar.items = tabsData.map { $0.tabTitle }
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
         toggleFilterTabBar()

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -46,18 +46,34 @@ class FilterTabBar: UIControl {
 
     // MARK: - Appearance
 
-    /// Tint color will be applied to titles of selected tabs, and the floating
-    /// selection indicator.
+    /// Tint color will be applied to the floating selection indicator.
+    /// If selectedTitleColor is not provided, tint color will also be applied to
+    /// titles of selected tabs.
     ///
     override var tintColor: UIColor! {
         didSet {
             tabs.forEach({
                 $0.tintColor = tintColor
-                $0.setTitleColor(tintColor, for: .selected)
-                $0.setTitleColor(tintColor, for: .highlighted)
+                $0.setTitleColor(titleColorForSelected, for: .selected)
+                $0.setTitleColor(titleColorForSelected, for: .highlighted)
             })
             selectionIndicator.backgroundColor = tintColor
         }
+    }
+
+    /// Selected Title Color will be applied to titles of selected tabs.
+    ///
+    var selectedTitleColor: UIColor? {
+        didSet {
+            tabs.forEach({
+                $0.setTitleColor(selectedTitleColor, for: .selected)
+                $0.setTitleColor(selectedTitleColor, for: .highlighted)
+            })
+        }
+    }
+
+    private var titleColorForSelected: UIColor {
+        return selectedTitleColor ?? tintColor
     }
 
     var deselectedTabColor: UIColor = .lightGray {
@@ -198,7 +214,7 @@ class FilterTabBar: UIControl {
     private func makeTab(_ title: String) -> UIButton {
         let tab = TabBarButton(type: .custom)
         tab.setTitle(title, for: .normal)
-        tab.setTitleColor(tintColor, for: .selected)
+        tab.setTitleColor(titleColorForSelected, for: .selected)
         tab.setTitleColor(deselectedTabColor, for: .normal)
         tab.tintColor = tintColor
 

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -124,6 +124,8 @@ class FilterTabBar: UIControl {
     enum TabSizingStyle {
         /// The tabs will fill the space available to the filter bar,
         /// with all tabs having equal widths. Tabs will not scroll.
+        /// Because of different language widths, ideally this should only be
+        /// used for 3 tabs or less.
         case equalWidths
         /// The tabs will have differing widths which fit their content size.
         /// If the tabs are too large to fit in the area available, the

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -389,7 +389,7 @@ private class TabBarButton: UIButton {
         super.traitCollectionDidChange(previousTraitCollection)
 
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote, symbolicTraits: .traitBold, maximumPointSize: TabFont.maxSize)
+            titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline, symbolicTraits: .traitBold, maximumPointSize: TabFont.maxSize)
         }
     }
 }


### PR DESCRIPTION
Fixes #10703 

To test:

---
- Go to Stats > Insights.
- On the Comments and Followers cards, verify the selected tab colors are:
  - Text color is dark grey
  - Indicator color is light grey.

<img width="400" alt="tab_card_filter" src="https://user-images.githubusercontent.com/1816888/50619049-1de59c80-0eb4-11e9-92b4-8b0d79295962.png">

---
- Verify other instances of `FilterTabBar` colors have not changed, i.e. the selected tab's text and indicator colors should match. (ex: Stats, Notifications, Site Pages)

<img width="462" alt="default" src="https://user-images.githubusercontent.com/1816888/50618987-a7489f00-0eb3-11e9-8317-1c78cbde8b65.png">
