### PR TITLE
[Stats Refresh] Insights Comments > Posts & Pages: show in web view 

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -431,11 +431,19 @@ private extension SiteStatsInsightsViewModel {
         rowData?.forEach { row in
             let dataBarPercent = showDataBar ? dataBarPercentForRow(row, relativeToRow: rowData?.first) : nil
 
+            let disclosureURL: URL? = {
+                if showDisclosure, let action = row.actions.first as? StatsItemAction {
+                    return action.url
+                }
+                return nil
+            }()
+
             rows.append(StatsTotalRowData.init(name: row.label,
                                                data: row.value,
                                                dataBarPercent: dataBarPercent,
                                                userIconURL: row.iconURL,
-                                               showDisclosure: showDisclosure))
+                                               showDisclosure: showDisclosure,
+                                               disclosureURL: disclosureURL))
         }
 
         return TabData.init(tabTitle: tabTitle,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -127,7 +127,7 @@ private extension TabbedTotalsCell {
         for index in 0..<numberOfRowsToAdd {
             let dataRow = dataRows[index]
             let row = StatsTotalRow.loadFromNib()
-            row.configure(rowData: dataRow)
+            row.configure(rowData: dataRow, delegate: self)
 
             // Don't show the separator line on the last row.
             if index == (numberOfRowsToAdd - 1) {
@@ -153,6 +153,16 @@ private extension TabbedTotalsCell {
             rowsStackView.removeArrangedSubview($0)
             $0.removeFromSuperview()
         }
+    }
+
+}
+
+// MARK: - StatsTotalRowDelegate
+
+extension TabbedTotalsCell: StatsTotalRowDelegate {
+
+    func displayWebViewWithURL(_ url: URL) {
+        siteStatsInsightsDelegate?.displayWebViewWithURL?(url)
     }
 
 }


### PR DESCRIPTION
Ref #10687

To test:
- Go to Stats > Insights > Comments.
- Select `Posts and Pages`.
- Tap on a row.
- Verify the post/page is displayed in a web view.

![webview](https://user-images.githubusercontent.com/1816888/50664353-04069100-0f6a-11e9-9ebe-409e34b98018.gif)



