### PR TITLE
Attempted fix crash: "NSInternalInconsistencyException negative sizes are not supported in the flow layout"

### DIFF
--- a/WordPress/Classes/Extensions/Math.swift
+++ b/WordPress/Classes/Extensions/Math.swift
@@ -50,3 +50,9 @@ extension CGSize {
         return clamp(min: CGFloat(minValue), max: CGFloat(maxValue))
     }
 }
+
+extension CGFloat {
+    func zeroIfNaN() -> CGFloat {
+        return self.isNaN ? 0.0 : self
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -156,7 +156,7 @@ extension WPStyleGuide {
 
         static func cellSizeForFrameWidth(_ width: CGFloat) -> CGSize {
             let cellWidth = cellWidthForFrameWidth(width)
-            return CGSize(width: cellWidth, height: cellHeight)
+            return CGSize(width: cellWidth.zeroIfNaN(), height: cellHeight.zeroIfNaN())
         }
 
         static func cellWidthForFrameWidth(_ width: CGFloat) -> CGFloat {

--- a/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
+++ b/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
@@ -108,7 +108,7 @@ extension WPStyleGuide {
         public static func cellSizeForFrameWidth(_ width: CGFloat) -> CGSize {
             let cellWidth = cellWidthForFrameWidth(width)
             let cellHeight = cellHeightForCellWidth(cellWidth)
-            return CGSize(width: cellWidth, height: cellHeight)
+            return CGSize(width: cellWidth.zeroIfNaN(), height: cellHeight.zeroIfNaN())
         }
         public static func imageWidthForFrameWidth(_ width: CGFloat) -> CGFloat {
             let cellWidth = cellWidthForFrameWidth(width)


### PR DESCRIPTION
Fixes #10354 (maybe)

Searching around for the crash on Fabric:
"Fatal Exception: NSInternalInconsistencyException negative sizes are not supported in the flow layout"
brought up a few similar crashes that were due to invalid values returned in the  collection view delegate method: sizeForItemAtIndex.

To test:
I was able to reproduce the crash by returning a hard coded negative value for one of these functions, but was not able to reproduce otherwise.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
