### PR TITLE
Localize title of the button to edit comments

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,2 @@
-* Updates the Plans to be more descriptive.
+* Localises the button to edit a comment.
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -209,6 +209,7 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
         btnApprove.setTitleColor(textSelectedColor, for: .highlighted)
         btnApprove.setTitleColor(textSelectedColor, for: .selected)
 
+        btnEdit.setTitle(EditComment.title, for: UIControl.State())
         btnEdit.setTitleColor(textNormalColor, for: UIControl.State())
         btnEdit.accessibilityLabel = EditComment.title
         btnEdit.accessibilityHint = EditComment.hint


### PR DESCRIPTION
Fixes #10247 

Before and after (notice the Edit button)
![before-after](https://user-images.githubusercontent.com/2722505/50752223-51477300-1288-11e9-84f3-1d30d301c3e4.jpg)

To test:
- Checkout the branch
- Either build and run on a localised device or edit the WordPress scheme select Run configuration and in Options change the Application Language from System Language to any other language
- Navigate to Notifications > select a comment

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

@frosty do you mind taking a look? It is literally a one liner