### PR TITLE
Localise Done button in view presented after publishing a new post

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,2 @@
-* Updates the Plans to be more descriptive.
+* Localises the "Done" button on screen presented after publishing a Post.
 

--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -62,6 +62,7 @@ class PostPostViewController: UIViewController {
         let clearImage = UIImage(color: UIColor.clear, havingSize: CGSize(width: 1, height: 1))
         navBar.shadowImage = clearImage
         navBar.setBackgroundImage(clearImage, for: .default)
+        navBar.topItem?.rightBarButtonItem?.title = NSLocalizedString("Done", comment: "Label on button to dismiss view presented after publishing a post")
 
         view.alpha = WPAlphaZero
 


### PR DESCRIPTION
Fixes #10444 

Before > After
![before-after-done](https://user-images.githubusercontent.com/2722505/50753654-8904e980-128d-11e9-90d0-ae869a924fe5.jpg)

To test:
- Checkout the branch
- Either build and run on a localised device or edit the WordPress scheme select Run configuration and in Options change the Application Language from System Language to any other language
- Compose and publish a post. In the Notice presented after the Post is published, tap "View". Notice the Done button in the view presented

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.