### PR TITLE
Track Giphy analytics events

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -388,6 +388,10 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatDeepLinkFailed:
             eventName = @"deep_link_failed";
             break;
+        case WPAnalyticsStatEditorAddedPhotoViaGiphy:
+            eventName = @"editor_photo_added";
+            eventProperties = @{ @"via" : @"giphy" };
+            break;
         case WPAnalyticsStatEditorAddedPhotoViaLocalLibrary:
             eventName = @"editor_photo_added";
             eventProperties = @{ @"via" : @"local_library" };
@@ -567,6 +571,15 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatEditorUploadMediaRetried:
             eventName = @"editor_upload_media_retried";
             break;
+        case WPAnalyticsStatGiphyAccessed:
+            eventName = @"giphy_accessed";
+            break;
+        case WPAnalyticsStatGiphySearched:
+            eventName = @"giphy_searched";
+            break;
+        case WPAnalyticsStatGiphyUploaded:
+            eventName = @"giphy_uploaded";
+            break;
         case WPAnalyticsStatGravatarCropped:
             eventName = @"me_gravatar_cropped";
             break;
@@ -696,9 +709,16 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatMediaLibrarySharedItemLink:
             eventName = @"media_library_shared_item_link";
             break;
+        case WPAnalyticsStatMediaLibraryAddedPhoto:
+            eventName = @"media_library_photo_added";
+            break;
         case WPAnalyticsStatMediaLibraryAddedPhotoViaDeviceLibrary:
             eventName = @"media_library_photo_added";
             eventProperties = @{ @"via" : @"device_library" };
+            break;
+        case WPAnalyticsStatMediaLibraryAddedPhotoViaGiphy:
+            eventName = @"media_library_photo_added";
+            eventProperties = @{ @"via" : @"giphy" };
             break;
         case WPAnalyticsStatMediaLibraryAddedPhotoViaOtherApps:
             eventName = @"media_library_photo_added";
@@ -711,6 +731,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatMediaLibraryAddedPhotoViaCamera:
             eventName = @"media_library_photo_added";
             eventProperties = @{ @"via" : @"camera" };
+            break;
+        case WPAnalyticsStatMediaLibraryAddedVideo:
+            eventName = @"media_library_video_added";
             break;
         case WPAnalyticsStatMediaLibraryAddedVideoViaDeviceLibrary:
             eventName = @"media_library_video_added";
@@ -1631,17 +1654,10 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             break;
 
         // to be implemented
-        case WPAnalyticsStatMediaLibraryAddedPhoto:
-        case WPAnalyticsStatMediaLibraryAddedVideo:
         case WPAnalyticsStatDefaultAccountChanged:
         case WPAnalyticsStatNoStat:
         case WPAnalyticsStatPerformedCoreDataMigrationFixFor45:
         case WPAnalyticsStatMaxValue:
-        case WPAnalyticsStatEditorAddedPhotoViaGiphy:
-        case WPAnalyticsStatGiphyAccessed:
-        case WPAnalyticsStatGiphySearched:
-        case WPAnalyticsStatGiphyUploaded:
-        case WPAnalyticsStatMediaLibraryAddedPhotoViaGiphy:
             return nil;
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
@@ -111,6 +111,8 @@ enum MediaUploadOrigin {
         switch (self, mediaType) {
         case (.mediaLibrary(let source), .image) where source == .deviceLibrary:
             return .mediaLibraryAddedPhotoViaDeviceLibrary
+        case (.mediaLibrary(let source), .image) where source == .giphy:
+            return .mediaLibraryAddedPhotoViaGiphy
         case (.mediaLibrary(let source), .image) where source == .otherApps:
             return .mediaLibraryAddedPhotoViaOtherApps
         case (.mediaLibrary(let source), .image) where source == .stockPhotos:
@@ -123,6 +125,8 @@ enum MediaUploadOrigin {
             return .mediaLibraryAddedVideoViaOtherApps
         case (.mediaLibrary(let source), .video) where source == .camera:
             return .mediaLibraryAddedVideoViaCamera
+        case (.editor(let source), .image) where source == .giphy :
+            return .editorAddedPhotoViaGiphy
         case (.editor(let source), .image) where source == .deviceLibrary:
             return .editorAddedPhotoViaLocalLibrary
         case (.editor(let source), .image) where source == .wpMediaLibrary:

--- a/WordPress/Classes/ViewRelated/Media/Giphy/GiphyDataLoader.swift
+++ b/WordPress/Classes/ViewRelated/Media/Giphy/GiphyDataLoader.swift
@@ -27,7 +27,7 @@ final class GiphyDataLoader {
         let isFirstPage = request?.pageable?.pageIndex == GiphyPageable.defaultPageIndex
         state = .loading
         DispatchQueue.main.async { [weak self] in
-            // TODO: Add Analytics
+            WPAnalytics.track(.giphySearched)
             self?.service.search(params: params) { resultsPage in
                 self?.state = .idle
                 self?.request = GiphySearchParams(text: self?.request?.text, pageable: resultsPage.nextPageable())

--- a/WordPress/Classes/ViewRelated/Media/Giphy/GiphyPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/Giphy/GiphyPicker.swift
@@ -54,6 +54,7 @@ final class GiphyPicker: NSObject {
         }
 
         observeDataSource()
+        trackAccess()
     }
 
     private func observeDataSource() {
@@ -136,5 +137,12 @@ extension GiphyPicker: WPMediaPickerViewControllerDelegate {
                 view.resignFirstResponder()
             }
         }
+    }
+}
+
+// MARK: - Tracks
+extension GiphyPicker {
+    fileprivate func trackAccess() {
+        WPAnalytics.track(.giphyAccessed)
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -677,7 +677,9 @@ extension MediaLibraryViewController: GiphyPickerDelegate {
 
         let mediaCoordinator = MediaCoordinator.shared
         assets.forEach { giphyMedia in
-            mediaCoordinator.addMedia(from: giphyMedia, to: blog)
+            let info = MediaAnalyticsInfo(origin: .mediaLibrary(.giphy), selectionMethod: .fullScreenPicker)
+            mediaCoordinator.addMedia(from: giphyMedia, to: blog, analyticsInfo: info)
+            WPAnalytics.track(.giphyUploaded)
         }
     }
 }


### PR DESCRIPTION
Implements #10091.

We previously added some Giphy analytics events to our analytics tracker, but never actually used them. This PR completes that work.

**To test**

* Complete the following actions and check in the Xcode console that the relevant events are triggered:
* In the Media Library, tap + and choose Giphy
  - [x] Event: `giphy_accessed`
* Perform a search in the Giphy picker
  - [x] Event: `giphy_searched`
* Choose an item from the search results and upload it
  - [x] Event: `giphy_uploaded`
  - [x] Event: `media_library_photo_added`, with `via` property of `giphy`
* In the Editor, chose `...` in the formatting toolbar, and select Giphy
  - [x] Event: `giphy_accessed`
* Perform a search, select a result, and insert it into the post
  - [x] Event: `editor_photo_added`, with `via` property of `giphy`