### PR TITLE
Improve screenshot performance and reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ Scripts/fastlane/Preview.html
 Scripts/fastlane/report.xml
 Scripts/fastlane/README.md
 Scripts/Preview.html
+Scripts/fastlane/test_output/

--- a/Scripts/fastlane/ScreenshotFastfile
+++ b/Scripts/fastlane/ScreenshotFastfile
@@ -7,6 +7,34 @@ platform :ios do
 # Screenshot Lanes
 ########################################################################
   #####################################################################################
+  # screenshots
+  # -----------------------------------------------------------------------------------
+  # This lane generates the localised screenshots.
+  # It is the same as running bundle exec fastlane snapshot, but ensures that the app
+  # is only built once.
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane screenshots 
+  #
+  # Example:
+  # bundle exec fastlane screenshots
+  #####################################################################################
+  desc "Generate localised screenshots"
+  lane :screenshots do
+    fastlane_directory = File.expand_path File.dirname(__FILE__)
+    scan(
+      workspace: File.join(fastlane_directory, "../../WordPress.xcworkspace"),
+      scheme: "WordPressScreenshotGeneration",
+      build_for_testing: true,
+      derived_data_path: File.join(fastlane_directory, "DerivedData"),
+    )
+    capture_ios_screenshots(
+      test_without_building: true,
+      derived_data_path: File.join(fastlane_directory, "DerivedData"),
+    )
+  end
+
+  #####################################################################################
   # create_promo_screenshots
   # -----------------------------------------------------------------------------------
   # This lane generates the promo screenshots. 

--- a/Scripts/fastlane/Snapfile
+++ b/Scripts/fastlane/Snapfile
@@ -1,6 +1,13 @@
 # Uncomment the lines below you want to change by removing the # in the beginning
 # Verify script has credentials
 
+fastlane_directory = File.expand_path File.dirname(__FILE__)
+# __FILE__ can return different results when this file is required or used directly
+# This allows it to work in all cases
+if File.basename(fastlane_directory) != "fastlane"
+  fastlane_directory = File.join fastlane_directory, "fastlane"
+end
+
 # A list of devices you want to take the screenshots from
 devices([
   "iPhone XS Max",
@@ -11,14 +18,18 @@ devices([
 languages("da de-DE en-AU en-CA en-GB en-US es-ES fr-FR id it ja ko no nl-NL pt-BR pt-PT ru sv th tr zh-Hans zh-Hant".split(" "))
 
 # Where should the resulting screenshots be stored?
-output_directory "./screenshots"
+output_directory File.join fastlane_directory, "screenshots"
 
 scheme "WordPressScreenshotGeneration"
 
 # clear_previous_screenshots true # remove the '#'' to clear all previously generated screenshots before creating new ones
 
 # Where is your project (or workspace)? Provide the full path here
-workspace File.expand_path File.dirname(__FILE__) + "../../WordPress.xcworkspace"
+workspace File.join fastlane_directory, "../../WordPress.xcworkspace"
+
+# Since Fastlane searches recursively from the current directory for the helper (Scripts/ or fastlane/),
+# this check will always fail for us
+skip_helper_version_check true
 
 reinstall_app true
 erase_simulator true


### PR DESCRIPTION
This makes a number of small improvements to the current screenshot automation:

- Introduce a `screenshots` lane that only builds the app once (currently it is built for every device/locale combination).
- Skip searching for the fastlane snapshot helper. This always fails because fastlane assumes it is being run from the project root. We could fix this by moving `fastlane/` to the root of the repo, but thats a big change.
- Make paths in `Snapfile` more reliable. They didn't always resolve correctly.
- ~~Update `SnapshotHelper.swift`~~ Hound didn't like the whitespace in this. Leaving it out since there were no other changes.

This all means that we should now run screenshots with `bundle exec fastlane screenshots`. Since it no longer spends minutes building the app for each test, it now runs in at least half the time as before. The whoile suite should run in < 2 hours now. It also has the extra plus of matching how we run them on Android.

To test:

- `cd Scripts/ && bundle exec fastlane screenshots`

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
