### PR TITLE
Fix cropped localized text

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -728,7 +728,7 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
         case SiteSettingsSectionMedia:
             return MediaQuotaCell.height;
         default:
-            return WPTableViewDefaultRowHeight;
+            return UITableViewAutomaticDimension;
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Cells/SwitchTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/SwitchTableViewCell.swift
@@ -25,8 +25,6 @@ open class SwitchTableViewCell: WPTableViewCell {
         }
     }
 
-
-
     // MARK: - Initializers
     public required init(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)!
@@ -64,17 +62,28 @@ open class SwitchTableViewCell: WPTableViewCell {
     fileprivate func setupSubviews() {
         selectionStyle = .none
 
-        contentView.addGestureRecognizer(tapGestureRecognizer)
-        tapGestureRecognizer.addTarget(self, action: #selector(SwitchTableViewCell.rowWasPressed(_:)))
-
-        flipSwitch = UISwitch()
-        flipSwitch.addTarget(self, action: #selector(SwitchTableViewCell.switchDidChange(_:)), for: .valueChanged)
-        accessoryView = flipSwitch
+        setupContentView()
+        setupSwitch()
+        setupTextLabel()
 
         WPStyleGuide.configureTableViewCell(self)
     }
 
+    private func setupContentView() {
+        contentView.addGestureRecognizer(tapGestureRecognizer)
+        tapGestureRecognizer.addTarget(self, action: #selector(SwitchTableViewCell.rowWasPressed(_:)))
+    }
 
+    private func setupSwitch() {
+        flipSwitch = UISwitch()
+        flipSwitch.addTarget(self, action: #selector(SwitchTableViewCell.switchDidChange(_:)), for: .valueChanged)
+        accessoryView = flipSwitch
+    }
+
+    private func setupTextLabel() {
+        textLabel?.numberOfLines = 0
+        textLabel?.adjustsFontForContentSizeCategory = true
+    }
 
     // MARK: - Private Properties
     fileprivate let tapGestureRecognizer = UITapGestureRecognizer()

--- a/WordPress/Classes/ViewRelated/Cells/WPReusableTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/WPReusableTableViewCells.swift
@@ -44,10 +44,17 @@ class WPTableViewCellSubtitle: WPReusableTableViewCell {
 class WPTableViewCellValue1: WPReusableTableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .value1, reuseIdentifier: reuseIdentifier)
+        commonInit()
     }
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        textLabel?.numberOfLines = 0
+        textLabel?.adjustsFontForContentSizeCategory = true
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Cells/WPReusableTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/WPReusableTableViewCells.swift
@@ -19,6 +19,26 @@ class WPReusableTableViewCell: WPTableViewCell {
         selectionStyle = .default
         accessibilityLabel = nil
     }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        commonInit()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    fileprivate func commonInit() {
+        setupLabel(textLabel)
+        setupLabel(detailTextLabel)
+    }
+
+    private func setupLabel(_ label: UILabel?) {
+        label?.numberOfLines = 0
+        label?.adjustsFontForContentSizeCategory = true
+    }
 }
 
 class WPTableViewCellDefault: WPReusableTableViewCell {
@@ -44,17 +64,15 @@ class WPTableViewCellSubtitle: WPReusableTableViewCell {
 class WPTableViewCellValue1: WPReusableTableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .value1, reuseIdentifier: reuseIdentifier)
-        commonInit()
     }
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        commonInit()
     }
 
-    private func commonInit() {
-        textLabel?.numberOfLines = 0
-        textLabel?.adjustsFontForContentSizeCategory = true
+    override func commonInit() {
+        super.commonInit()
+        detailTextLabel?.numberOfLines = 1
     }
 }
 


### PR DESCRIPTION
Fixes #9816

This PR also fixed other similar issues where the labels get trimmed with text in other languages or with a bigger font.

There is still an issue with the right detail label on tables, that they are left without space by the left text label. I believe that issue deserves its own PR, I tried some possible simple solutions but non of those worked.

![text_sizes](https://user-images.githubusercontent.com/9772967/50774334-72619100-1293-11e9-93c5-974ea75d5f86.png)

To test:
- Change your device/simulator to Spanish (or other language with longer words)
- Increase the text size to make the issues more evident. (iOS Settings -> Display -> Text Size)
- Visit the sections shown in the added image.
- Check that the cropped text issue is resolved.
- Turn ON accessibility text sizes and increase it (iOS Settings -> General -> Accessibility -> Larger Text
- Visit again the same screens and check that they look properly.
