### PR TITLE
Enable concurrent simulators for screenshot generation

### DIFF
--- a/Scripts/fastlane/Snapfile
+++ b/Scripts/fastlane/Snapfile
@@ -34,7 +34,7 @@ skip_helper_version_check true
 reinstall_app true
 erase_simulator true
 localize_simulator true
-concurrent_simulators false
+concurrent_simulators true
 clear_previous_screenshots true
 
 # By default, the latest version should be used automatically. If you want to change it, do it here


### PR DESCRIPTION
This re-enables concurrent simulators when generating screenshots. This was disabled because our previously flaky tests were less reliable with it. Now that the tests are much more robust, we can turn this back on 😄 

Between this and https://github.com/wordpress-mobile/WordPress-iOS/pull/10755, a full screenshot run for all locales and devices now takes less than an hour on my machine. This should make working with screenshots a bit easier.

To test:

- `cd Scripts && bundle exec fastlane screenshots`

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
