### PR TITLE
Notification Details: Refresh router on Note change

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,3 @@
 * Updates the Plans to be more descriptive.
+* Fixes an issue where the wrong notification detail may be displayed when navigating between notifications.
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -89,6 +89,7 @@ class NotificationDetailsViewController: UIViewController {
                 return
             }
 
+            router = makeRouter()
             refreshInterface()
             markAsReadIfNeeded()
         }
@@ -99,7 +100,7 @@ class NotificationDetailsViewController: UIViewController {
     }()
 
     lazy var router: NotificationContentRouter = {
-        return NotificationContentRouter(activity: note, coordinator: coordinator)
+        return makeRouter()
     }()
 
     /// Whenever the user performs a destructive action, the Deletion Request Callback will be called,
@@ -173,6 +174,10 @@ class NotificationDetailsViewController: UIViewController {
         super.viewDidLayoutSubviews()
 
         refreshNavigationBar()
+    }
+
+    private func makeRouter() -> NotificationContentRouter {
+        return NotificationContentRouter(activity: note, coordinator: coordinator)
     }
 
     fileprivate func markAsReadIfNeeded() {


### PR DESCRIPTION
Fixes #10758.

Please see the original issue for full details / reproduction steps. This PR fixes the issue by ensuring the notifications router is updated whenever the view controller's notification changes. Previously, the router wasn't getting updated so it was still navigating to detail for the original notification.

**To test**

* Follow the steps in the original issue. Essentially:
* Go to Notifications and navigate to a comment notification
* Use the arrows to navigate to another notification
* Tap the header, and ensure you're taken to the right detail screen

@etoledom Would you mind reviewing this one, as you wrote the router originally?

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.