### PR TITLE
Login Epilogue: Don’t show empty ‘My Sites’ section

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,3 @@
 * Updates the Plans to be more descriptive.
+* On the login epilogue, don't show 'My Sites' if the account doesn't have any sites. 
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -50,7 +50,18 @@ class LoginEpilogueTableViewController: UITableViewController {
 extension LoginEpilogueTableViewController {
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        return blogDataSource.numberOfSections(in: tableView) + 1
+
+        // If a section is empty, don't show it.
+        let numberOfSections = blogDataSource.numberOfSections(in: tableView)
+        var adjustedNumberOfSections = numberOfSections
+
+        for section in 0..<numberOfSections {
+            if blogDataSource.tableView(tableView, numberOfRowsInSection: section) == 0 {
+                adjustedNumberOfSections -= 1
+            }
+        }
+
+        return adjustedNumberOfSections + 1
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {


### PR DESCRIPTION
Fixes #9708

To test:
- Login with an account that has no sites.
  - Verify the 'My Sites' section is not displayed.
- Login with an account that has sites.
  - Verify the 'My Sites' section is displayed.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
---
<img width="350" alt="iphone_nosites" src="https://user-images.githubusercontent.com/1816888/50794440-5dcbcb80-1288-11e9-9174-24c7dee4eb94.png">

---
<img width="500" alt="ipad_nosites" src="https://user-images.githubusercontent.com/1816888/50794452-67553380-1288-11e9-88d1-19560da55d79.png">

