### PR TITLE
Update README to remove 'pod install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ We use a few tools to help with development. To install or update the required d
 #### CocoaPods
 
 WordPress for iOS uses [CocoaPods](http://cocoapods.org/) to manage third party libraries.  
-Trying to build the project by itself (WordPress.xcproj) after launching will result in an error, as the resources managed by CocoaPods are not included. To install and configure the third party libraries just run the following in the command line:
-
-`pod install`
+Third party libraries and resources managed by CocoaPods will be installed by the `rake dependencies` command above.
 
 #### SwiftLint
 


### PR DESCRIPTION
The README currently incorrectly suggests running `pod install` to install dependencies. This updates it to clarify that pods are installed by `rake dependencies`.

To test:

- Check the README 😄 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
