### PR TITLE
Make `Me` header view height adjust to text size

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/MeHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Me/MeHeaderView.m
@@ -142,7 +142,6 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
 - (UIStackView *)newStackView
 {
     UIStackView *stackView = [UIStackView new];
-    stackView = [UIStackView new];
     stackView.translatesAutoresizingMaskIntoConstraints = NO;
     stackView.axis = UILayoutConstraintAxisVertical;
     stackView.alignment = UIStackViewAlignmentCenter;

--- a/WordPress/Classes/ViewRelated/Me/MeHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Me/MeHeaderView.m
@@ -19,6 +19,7 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
 @property (nonatomic, strong) UILabel *usernameLabel;
 @property (nonatomic, strong) UIActivityIndicatorView *activityIndicator;
 @property (nonatomic, strong) UIView *gravatarDropTarget;
+@property (nonatomic, strong) UIStackView *stackView;
 
 @end
 
@@ -35,19 +36,17 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
     self = [super initWithFrame:frame];
     if (self) {
         _gravatarImageView = [self newImageViewForGravatar];
-        [self addSubview:_gravatarImageView];
-        
+        _displayNameLabel = [self newLabelForDisplayName];
+        _usernameLabel = [self newLabelForUsername];
+
+        _stackView = [self newStackView];
+        [self addSubview:_stackView];
+
         _gravatarDropTarget = [self newDropTargetForGravatar];
         [self addSubview:_gravatarDropTarget];
 
         _activityIndicator = [self newSpinner];
         [_gravatarImageView addSubview:_activityIndicator];
-        
-        _displayNameLabel = [self newLabelForDisplayName];
-        [self addSubview:_displayNameLabel];
-
-        _usernameLabel = [self newLabelForUsername];
-        [self addSubview:_usernameLabel];
 
         [self configureConstraints];
     }
@@ -121,52 +120,37 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
 
 - (void)configureConstraints
 {
-    NSDictionary *views = NSDictionaryOfVariableBindings(_gravatarImageView, _displayNameLabel, _usernameLabel);
-    NSDictionary *metrics = @{@"gravatarSize": @(MeHeaderViewGravatarSize),
-                              @"labelHeight":@(MeHeaderViewLabelHeight),
-                              @"verticalSpacing":@(MeHeaderViewVerticalSpacing),
-                              @"verticalMargin":@(MeHeaderViewVerticalMargin)};
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-verticalMargin-[_gravatarImageView(gravatarSize)]-verticalSpacing-[_displayNameLabel(labelHeight)][_usernameLabel(labelHeight)]-verticalMargin-|"
-                                                                 options:0
-                                                                 metrics:metrics
-                                                                   views:views]];
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"[_gravatarImageView(gravatarSize)]"
-                                                                 options:0
-                                                                 metrics:metrics
-                                                                   views:views]];
+    UIView *spaceView = [UIView new];
+    [self.stackView addArrangedSubview:self.gravatarImageView];
+    [self.stackView addArrangedSubview:spaceView];
+    [self.stackView addArrangedSubview:self.displayNameLabel];
+    [self.stackView addArrangedSubview:self.usernameLabel];
 
-    [self addConstraint:[NSLayoutConstraint constraintWithItem:self.gravatarImageView
-                                                     attribute:NSLayoutAttributeCenterX
-                                                     relatedBy:NSLayoutRelationEqual
-                                                        toItem:self
-                                                     attribute:NSLayoutAttributeCenterX
-                                                    multiplier:1
-                                                      constant:0]];
-    
+    [NSLayoutConstraint activateConstraints:@[
+                                              [self.gravatarImageView.heightAnchor constraintEqualToConstant:MeHeaderViewGravatarSize],
+                                              [self.gravatarImageView.widthAnchor constraintEqualToConstant:MeHeaderViewGravatarSize],
+                                              [spaceView.heightAnchor constraintEqualToConstant:MeHeaderViewVerticalSpacing],
+                                              [self.stackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
+                                              [self.stackView.centerXAnchor constraintEqualToAnchor:self.centerXAnchor],
+                                              ]];
+
     [self.gravatarDropTarget pinSubviewToAllEdgeMargins:self.gravatarImageView];
-
-    [self addConstraint:[NSLayoutConstraint constraintWithItem:self.displayNameLabel
-                                                     attribute:NSLayoutAttributeCenterX
-                                                     relatedBy:NSLayoutRelationEqual
-                                                        toItem:self
-                                                     attribute:NSLayoutAttributeCenterX
-                                                    multiplier:1
-                                                      constant:0]];
-
-    [self addConstraint:[NSLayoutConstraint constraintWithItem:self.usernameLabel
-                                                    attribute:NSLayoutAttributeCenterX
-                                                    relatedBy:NSLayoutRelationEqual
-                                                       toItem:self
-                                                    attribute:NSLayoutAttributeCenterX
-                                                   multiplier:1
-                                                      constant:0]];
-    
     [self.gravatarImageView pinSubviewAtCenter:_activityIndicator];
     
     [super setNeedsUpdateConstraints];
 }
 
 #pragma mark - Subview factories
+
+- (UIStackView *)newStackView
+{
+    UIStackView *stackView = [UIStackView new];
+    stackView = [UIStackView new];
+    stackView.translatesAutoresizingMaskIntoConstraints = NO;
+    stackView.axis = UILayoutConstraintAxisVertical;
+    stackView.alignment = UIStackViewAlignmentCenter;
+    return stackView;
+}
 
 - (UILabel *)newLabelForDisplayName
 {

--- a/WordPress/Classes/ViewRelated/Me/MeHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Me/MeHeaderView.m
@@ -27,8 +27,7 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
 
 - (instancetype)init
 {
-    CGRect frame = CGRectMake(0, 0, 0, MeHeaderViewHeight);
-    return [self initWithFrame:frame];
+    return [self initWithFrame:CGRectZero];
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -54,11 +53,6 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
 }
 
 #pragma mark - Public Methods
-
-- (CGSize)intrinsicContentSize
-{
-    return CGSizeMake(UIViewNoIntrinsicMetric, MeHeaderViewHeight);
-}
 
 - (void)setDisplayName:(NSString *)displayName
 {
@@ -126,13 +120,16 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
     [self.stackView addArrangedSubview:self.displayNameLabel];
     [self.stackView addArrangedSubview:self.usernameLabel];
 
-    [NSLayoutConstraint activateConstraints:@[
-                                              [self.gravatarImageView.heightAnchor constraintEqualToConstant:MeHeaderViewGravatarSize],
-                                              [self.gravatarImageView.widthAnchor constraintEqualToConstant:MeHeaderViewGravatarSize],
-                                              [spaceView.heightAnchor constraintEqualToConstant:MeHeaderViewVerticalSpacing],
-                                              [self.stackView.centerYAnchor constraintEqualToAnchor:self.centerYAnchor],
-                                              [self.stackView.centerXAnchor constraintEqualToAnchor:self.centerXAnchor],
-                                              ]];
+    NSArray *constraints = @[
+                             [self.gravatarImageView.heightAnchor constraintEqualToConstant:MeHeaderViewGravatarSize],
+                             [self.gravatarImageView.widthAnchor constraintEqualToConstant:MeHeaderViewGravatarSize],
+                             [spaceView.heightAnchor constraintEqualToConstant:MeHeaderViewVerticalSpacing],
+                             [self.stackView.topAnchor constraintEqualToAnchor:self.topAnchor constant:MeHeaderViewVerticalSpacing],
+                             [self.bottomAnchor constraintEqualToAnchor:self.stackView.bottomAnchor constant:MeHeaderViewVerticalSpacing],
+                             [self.stackView.centerXAnchor constraintEqualToAnchor:self.centerXAnchor],
+                             ];
+
+    [NSLayoutConstraint activateConstraints:constraints];
 
     [self.gravatarDropTarget pinSubviewToAllEdgeMargins:self.gravatarImageView];
     [self.gravatarImageView pinSubviewAtCenter:_activityIndicator];

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -101,6 +101,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         // My guess is the table view adjusts the height of the first section
         // based on if there's a header or not.
         tableView.tableHeaderView = account.map { headerViewForAccount($0) }
+        tableView.layoutHeaderView()
 
         // After we've reloaded the view model we should maintain the current
         // table row selection, or if the split view we're in is not compact

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -106,7 +106,6 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         // My guess is the table view adjusts the height of the first section
         // based on if there's a header or not.
         tableView.tableHeaderView = account.map { headerViewForAccount($0) }
-        tableView.layoutHeaderView()
 
         // After we've reloaded the view model we should maintain the current
         // table row selection, or if the split view we're in is not compact

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -58,6 +58,11 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        tableView.layoutHeaderView()
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 


### PR DESCRIPTION
This PR makes `MeHeaderView` height flexible, adjusting to different font sizes.

Before, even though the font size was adjusting, the header height was constant. This was problematic for larger font sizes, specially with `Larger accessibility text sizes` active.

![header_text](https://user-images.githubusercontent.com/9772967/50832564-ead95800-134e-11e9-97b2-ce5379911777.png)

To test:

- Activate `Larger accessibility text sizes`.
 - iOS settings -> General -> Accessibility -> Larger Text -> Turn the switch ON -> Increase de slider to more than half.
- Go to the WPiOS app.
- Go to the `Me` tab section.
- Check that the table header is correctly displayed, as shown in the screenshot.