### PR TITLE
NoResults: Stop WPAnimatedBox animation when removing from superview

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -268,7 +268,10 @@ private extension NoResultsViewController {
         }
 
         if let accessorySubview = accessorySubview {
-            accessoryView.subviews.forEach { $0.removeFromSuperview() }
+            accessoryView.subviews.forEach { view in
+                stopAnimatingViewIfNeeded(view)
+                view.removeFromSuperview()
+            }
             accessoryView.addSubview(accessorySubview)
         }
 
@@ -475,10 +478,14 @@ private extension NoResultsViewController {
         animatedBox.animate(afterDelay: 0.1)
     }
 
-    func stopAnimatingIfNeeded() {
-        guard let animatedBox = accessorySubview as? WPAnimatedBox else {
+    func stopAnimatingViewIfNeeded(_ view: UIView?) {
+        guard let animatedBox = view as? WPAnimatedBox else {
             return
         }
         animatedBox.suspendAnimation()
+    }
+
+    func stopAnimatingIfNeeded() {
+        stopAnimatingViewIfNeeded(accessorySubview)
     }
 }


### PR DESCRIPTION
Fixes #10770.

This PR hopefully fixes the high CPU usage that I noted in #10770. It adjusts the usage of `WPAnimatedBox` in `NoResultsViewController` to explicitly stop the animation when removing the animated box from the no results view.

**To test**

* Build and run
* Navigate to the Menus screen for a size. On `develop`, I see 100% CPU even when the screen has loaded. On this branch, I see normal CPU usage.