### PR TITLE
Prevented stale images from appearing in notifications

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,3 +5,4 @@
 * When creating a new site, on the site type selection page, the 'Start with' label now wraps.
 * Localises the button to edit a comment.
 * Localises the "Done" button on screen presented after publishing a Post.
+* Fixes an issue where stale images may appear when navigating between notifications.

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockImageTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockImageTableViewCell.swift
@@ -30,9 +30,17 @@ class NoteBlockImageTableViewCell: NoteBlockTableViewCell {
     }
 
     // MARK: - View Methods
+
     override func awakeFromNib() {
         super.awakeFromNib()
         selectionStyle = .none
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        blockImageView.image = nil
+        imageURL = nil
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
### Description
Fixes #9778. The `NotificationDetailsViewController` is reused when a user navigates via the arrows. For images, a cell of type `NoteBlockImageTableViewCell` presents images.

This PR implements a `prepareForReuse()` method. It's worth noting that in addition to `nil`-ing out the image view, we also nil out the `imageURL` to prevent early exit from the `downloadImage(_:)` method.

### Testing

- Checkout the branch and confirm that existing tests pass.
- While logged in, select the _Notifications_ tab and navigate between notifications with images. Ideally, you will no longer see "stale" images (i.e., images from old notifications) during said transition.

### Documentation

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

### Evidence

![9778_pr](https://user-images.githubusercontent.com/221062/50866037-414d9300-135d-11e9-97b2-dbcc2dc85d39.gif)