### PR TITLE
Site People: remove deleted users

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,3 +5,4 @@
 * When creating a new site, on the site type selection page, the 'Start with' label now wraps.
 * Localises the button to edit a comment.
 * Localises the "Done" button on screen presented after publishing a Post.
+* Fixes issue where deleted users where still appearing in the site's People lists.

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -269,7 +269,33 @@ private extension PeopleService {
                 createManagedPerson(remotePerson)
             }
         }
+
+        guard let firstPerson = remotePeople.first else {
+            return
+        }
+
+        let peopleType = type(of: firstPerson)
+        removeDeletedPeople(remotePeople, type: peopleType)
     }
+
+    /// Compares the array of People received from remote against People in Core Data
+    /// to find those that no longer exist and remove them from Core Data.
+    ///
+    func removeDeletedPeople<T: Person>(_ remotePeople: [T], type: T.Type) {
+
+        // Get all People for the type.
+        var allPeopleOfType = loadPeople(siteID, type: type)
+
+        // Remove People that were just loaded.
+        for remotePerson in remotePeople {
+            allPeopleOfType.removeAll(where: {$0.ID == remotePerson.ID })
+        }
+
+        // Remove remaining from Core Data.
+        let idSet = Set(allPeopleOfType.compactMap({ $0.ID }))
+        removeManagedPeopleWithIDs(idSet, type: type)
+    }
+
 
     /// Retrieves the collection of users, persisted in Core Data, associated with the current blog.
     ///

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -214,9 +214,10 @@ struct PeopleService {
     ///
     func removeManagedPeople() {
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: "Person")
-        request.predicate = NSPredicate(format: "siteID = %@", NSNumber(value: siteID as Int))
-        let objects = (try? context.fetch(request) as! [NSManagedObject]) ?? []
-        objects.forEach({ context.delete($0) })
+        request.predicate = NSPredicate(format: "siteID = %@", NSNumber(value: siteID))
+        if let objects = (try? context.fetch(request)) as? [NSManagedObject] {
+            objects.forEach { context.delete($0) }
+        }
     }
 
     /// Validates Invitation Recipients.

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -148,9 +148,9 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         setupView()
         observeNetworkStatus()
+        resetManagedPeople()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -213,6 +213,7 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
 
     @IBAction
     func refresh() {
+        resetManagedPeople()
         refreshPeople()
     }
 
@@ -337,6 +338,14 @@ private extension PeopleViewController {
             self?.shouldLoadMore = shouldLoadMore
             self?.refreshControl?.endRefreshing()
         }
+    }
+
+    func resetManagedPeople() {
+        guard let blog = blog, let service = PeopleService(blog: blog, context: context) else {
+            return
+        }
+
+        service.removeManagedPeople()
     }
 
     func loadMorePeopleIfNeeded() {

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -46,6 +46,11 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
     ///
     private var isLoadingMore = false
 
+    /// Indicates when the People in Core Data have been refreshed.
+    /// Used to display the loading view on initial view and refresh.
+    ///
+    private var isInitialLoad = true
+
     /// Number of records to skip in the next request
     ///
     private var nextRequestOffset = 0
@@ -333,6 +338,8 @@ private extension PeopleViewController {
 
     func refreshPeople() {
         loadPeoplePage() { [weak self] (retrieved, shouldLoadMore) in
+            self?.isInitialLoad = false
+            self?.refreshNoResultsView()
             self?.tableView.reloadData()
             self?.nextRequestOffset = retrieved
             self?.shouldLoadMore = shouldLoadMore
@@ -341,6 +348,8 @@ private extension PeopleViewController {
     }
 
     func resetManagedPeople() {
+        isInitialLoad = true
+
         guard let blog = blog, let service = PeopleService(blog: blog, context: context) else {
             return
         }
@@ -430,24 +439,39 @@ private extension PeopleViewController {
     func refreshNoResultsView() {
         noResultsViewController.removeFromView()
 
+        if isInitialLoad {
+            displayNoResultsView(forLoading: true)
+            return
+        }
+
         guard resultsController.fetchedObjects?.count == 0 else {
             return
         }
 
-        noResultsViewController.configure(title: noResultsTitle())
+        displayNoResultsView()
+    }
+
+    func displayNoResultsView(forLoading: Bool = false) {
+        let accessoryView = forLoading ? NoResultsViewController.loadingAccessoryView() : nil
+        noResultsViewController.configure(title: noResultsTitle(), accessoryView: accessoryView)
 
         addChild(noResultsViewController)
         tableView.addSubview(withFadeAnimation: noResultsViewController.view)
 
-        let headerInset = UIEdgeInsets(top: filterBar.frame.height, left: 0, bottom: 0, right: 0)
-        noResultsViewController.view.frame = tableView.bounds.inset(by: headerInset)
+        // Set the NRV top as the filterBar bottom so the NRV
+        // adjusts correctly when refreshControl is active.
+        let filterBarBottom = filterBar.frame.origin.y + filterBar.frame.size.height
+        noResultsViewController.view.frame.origin.y = filterBarBottom
 
         noResultsViewController.didMove(toParent: self)
     }
 
     func noResultsTitle() -> String {
-        let noPeopleFormat = NSLocalizedString("No %@ yet",
-                                               comment: "Empty state message (People Management). %@ can be 'users' or 'followers'")
+        if isInitialLoad {
+            return NSLocalizedString("Loading People...", comment: "Text displayed while loading site People.")
+        }
+
+        let noPeopleFormat = NSLocalizedString("No %@ yet", comment: "Empty state message (People Management). %@ can be 'users' or 'followers'")
         let noPeople = String(format: noPeopleFormat, filter.title.lowercased())
 
         return connectionAvailable() ? noPeople : noConnectionMessage()


### PR DESCRIPTION
Fixes #5675 

This fixes the issue of deleted users appearing in the People lists.

The issue was People were being added/updated in Core Data but never removed. This change removes all People from Core Data when the view is initially shown, and on pull to refresh. Core Data is repopulated as the People lists are loaded.

To test:
- Via the website (https://wordpress.com/people/team), invite a user.
- As that user, accept the invitation.
  - In the app, verify the user appears in Site > People.
- Via the website, remove that user.
  - In the app, refresh the People list.
  - Verify the user no longer appears.


Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.