### PR TITLE
Add a better message error when replying to comment fails.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -641,8 +641,20 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     };
     
     void (^failureBlock)(NSError *error) = ^void(NSError *error) {
-        
-        NSString *message = NSLocalizedString(@"There has been an unexpected error while sending your reply", nil);
+        NSUInteger lastIndex = content.length == 0 ? 0 : content.length - 1;
+        NSUInteger composedCharacterIndex = NSMaxRange([content rangeOfComposedCharacterSequenceAtIndex:MIN(lastIndex, 140)]);
+        // 140 is a somewhat arbitraily chosen number (old tweet length) — should be enough to let people know what
+        // comment failed to show, but not too long to display.
+
+        NSString *replyExcerpt = [content substringToIndex:composedCharacterIndex];
+
+        NSString *message = [NSString stringWithFormat:NSLocalizedString(@"There has been an unexpected error while sending your reply: \n\"%@\"", nil), replyExcerpt];
+        if (composedCharacterIndex < lastIndex) {
+            NSMutableString *mutString = message.mutableCopy;
+            [mutString insertString:@"…" atIndex:(message.length - 2)];
+
+            message = mutString.copy;
+        }
         
         UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil
                                                                                  message:message

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1076,10 +1076,14 @@ private extension NotificationDetailsViewController {
     }
 
     func displayReplyError(with block: FormattableCommentContent, content: String) {
-        let message     = NSLocalizedString("There has been an unexpected error while sending your reply",
-                                            comment: "Reply Failure Message")
+        var message     = String(format: NSLocalizedString("There has been an unexpected error while sending your reply: \n\"%@\"",
+                                            comment: "Reply Failure Message"), String(content.prefix(140)))
         let cancelTitle = NSLocalizedString("Cancel", comment: "Cancels an Action")
         let retryTitle  = NSLocalizedString("Try Again", comment: "Retries sending a reply")
+
+        if content.count >= 140 {
+            message.insert("…", at: message.index(message.endIndex, offsetBy: -1))
+        }
 
         let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
         alertController.addCancelActionWithTitle(cancelTitle)


### PR DESCRIPTION
Fixes #9299.

This adds an excerpt of the comment to the error message that show up when there's an error posting a comment. The excerpt is capped at 140 chars, which was chosen arbitrarily, but should be enough to give people context on which comment failed to post.

![simulator screen shot - iphone xs max - 2019-01-09 at 05 19 08](https://user-images.githubusercontent.com/1594081/50879719-36861300-13dc-11e9-98bd-5813bf14efdf.png)

To test:
1. Try replying to comment with a long post, under conditions that would cause it to fail (i.e. no network) (to test the flow in Notifications, it's easiest to add `completion(false); return` to `NotificationActionService.swift:61`



Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.