### PR TITLE
Present localised TOS

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,5 +3,4 @@
 * Fixes an issue where the wrong notification detail may be displayed when navigating between notifications.
 * Fixes an issue where the Stats widget would always revert back to the primary site.
 * When creating a new site, on the site type selection page, the 'Start with' label now wraps.
-* Localises the button to edit a comment.
-* Localises the "Done" button on screen presented after publishing a Post.
+* Improvements to localisations.

--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -164,3 +164,19 @@ extension NSURL {
         return url.appendingHideMasterbarParameters() as NSURL?
     }
 }
+
+extension URL {
+    func prependLocaleAsSubdomain() -> URL {
+        guard let localeLanguageCode = Locale.current.languageCode,
+            let host = self.host else {
+            return self
+        }
+
+        var components = URLComponents()
+        components.scheme = self.scheme
+        components.host = "\(localeLanguageCode).".appending(host)
+        components.path = self.path
+
+        return components.url ?? self
+    }
+}

--- a/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AboutViewController.swift
@@ -138,9 +138,14 @@ open class AboutViewController: UITableViewController {
 
     // MARK: - Private Helpers
     fileprivate func displayWebView(_ urlString: String) {
-        guard let url = URL(string: urlString) else {
+        displayWebView(URL(string: urlString))
+    }
+
+    private func displayWebView(_ url: URL?) {
+        guard let url = url else {
             return
         }
+
         let webViewController = WebViewControllerFactory.controller(url: url)
         if presentingViewController != nil {
             navigationController?.pushViewController(webViewController, animated: true)
@@ -205,7 +210,7 @@ open class AboutViewController: UITableViewController {
 
                 Row(title: NSLocalizedString("Terms of Service", comment: "Opens the Terms of Service Web"),
                     details: nil,
-                    handler: { self.displayWebView(WPAutomatticTermsOfServiceURL) }),
+                    handler: { self.displayWebView(URL(string: WPAutomatticTermsOfServiceURL)?.prependLocaleAsSubdomain()) }),
 
                 Row(title: NSLocalizedString("Privacy Policy", comment: "Opens the Privacy Policy Web"),
                     details: nil,


### PR DESCRIPTION
Fixes #9824 

Load the TOS in the system locale. 

@etoledom May I trouble you with a review? 😊 

![screen recording 2019-01-09 at 3 11 38 pm mov](https://user-images.githubusercontent.com/2722505/50883337-b8009400-1422-11e9-845f-24344993d1aa.gif)

As discussed on slack, the solution to localise the TOS seems to be loading the specific language as subdomain:  p1547015680116700-slack-C02ECE3ML

To test:
- Check out the branch
- Run the app on a device (or simulator) with the system set to a language other than English.
- Navigate to Me > App Settings > About WordPress for iOS > tap Terms of Service

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.