### PR TITLE
Reader - Comments header view dynamic text type.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -20,7 +20,6 @@
 // crash in certain circumstances when the tableView lays out its visible cells,
 // and those cells contain WPRichTextEmbeds. -- Aerych, 2016.11.30
 static CGFloat const EstimatedCommentRowHeight = 300.0;
-static CGFloat const PostHeaderHeight = 54.0;
 static NSInteger const MaxCommentDepth = 4.0;
 static CGFloat const CommentIndentationWidth = 40.0;
 
@@ -262,7 +261,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     __typeof(self) __weak weakSelf = self;
     
     // Wrapper view
-    UIView *headerWrapper = [[UIView alloc] initWithFrame:CGRectMake(0.0, 0.0, CGRectGetWidth(self.view.bounds), PostHeaderHeight)];
+    UIView *headerWrapper = [UIView new];
     headerWrapper.translatesAutoresizingMaskIntoConstraints = NO;
     headerWrapper.preservesSuperviewLayoutMargins = YES;
     headerWrapper.backgroundColor = [UIColor whiteColor];
@@ -408,19 +407,15 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
         @"suggestionsview"  : self.suggestionsTableView,
         @"replyTextView"    : self.replyTextView
     };
-    
-    NSDictionary *metrics = @{
-        @"headerHeight"     : @(PostHeaderHeight)
-    };
-    
+
     // PostHeader Constraints
     [[self.postHeaderWrapper.leftAnchor constraintEqualToAnchor:self.tableView.leftAnchor] setActive:YES];
     [[self.postHeaderWrapper.rightAnchor constraintEqualToAnchor:self.tableView.rightAnchor] setActive:YES];
 
     // TableView Contraints
-    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[postHeader(headerHeight)][tableView][replyTextView]"
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[postHeader][tableView][replyTextView]"
                                                                       options:0
-                                                                      metrics:metrics
+                                                                      metrics:nil
                                                                         views:views]];
 
     [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|[tableView]|"

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -162,11 +162,6 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 
 #pragma mark - Public Methods
 
-- (CGSize)intrinsicContentSize
-{
-    return CGSizeMake(PostHeaderViewAvatarSize, PostHeaderViewAvatarSize);
-}
-
 - (void)setShowsDisclosureIndicator:(BOOL)showsDisclosure
 {
     _showsDisclosureIndicator = showsDisclosure;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -100,12 +100,11 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 
     UILabel *label = [[UILabel alloc] init];
     label.translatesAutoresizingMaskIntoConstraints = NO;
-    label.numberOfLines = 1;
     label.backgroundColor = [UIColor whiteColor];
     label.opaque = YES;
     label.textColor = [WPStyleGuide allTAllShadeGrey];
     label.font = [WPStyleGuide subtitleFont];
-    label.adjustsFontSizeToFitWidth = NO;
+    label.adjustsFontForContentSizeCategory = YES;
 
     [self.labelsStackView addArrangedSubview:label];
     self.subtitleLabel = label;
@@ -117,12 +116,11 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 
     UILabel *label = [[UILabel alloc] init];
     label.translatesAutoresizingMaskIntoConstraints = NO;
-    label.numberOfLines = 1;
     label.backgroundColor = [UIColor whiteColor];
     label.opaque = YES;
     label.textColor = [WPStyleGuide littleEddieGrey];
     label.font = [WPStyleGuide subtitleFont];
-    label.adjustsFontSizeToFitWidth = NO;
+    label.adjustsFontForContentSizeCategory = YES;
 
     [self.labelsStackView addArrangedSubview:label];
     self.titleLabel = label;
@@ -152,10 +150,8 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
 
 - (void)setupTapGesture
 {
-    UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(handleViewTapped:)];
-    tapGesture.numberOfTouchesRequired = 1;
-    tapGesture.numberOfTapsRequired = 1;
-
+    UITapGestureRecognizer *tapGesture = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                                 action:@selector(handleViewTapped:)];
     [self addGestureRecognizer:tapGesture];
     self.tapRecognizer = tapGesture;
 }


### PR DESCRIPTION
This PR removes unnecessary height constraints added to `ReaderPostHeaderView`, making it able grow together with the text size. In the same way, this PR makes changes to the `ReaderPostHeaderView` class to handle dynamic type changes.

![comments_header_dynamic_type](https://user-images.githubusercontent.com/9772967/50896737-47e61400-140a-11e9-9050-f498483f720f.png)

**To test:**

- Activate `Larger accessibility text sizes`.
 - iOS settings -> General -> Accessibility -> Larger Text -> Turn the switch ON -> Increase de slider to more than half.
- Go to the WPiOS app.
- Go to `Reader` -> `Followed Sites`
- Look for a post with comments and press the comments button to open them.
- Check that the header is correctly displayed, as shown in the screenshot.

**Font size change:**
- Sitting on the `Post comments` screen, go to the iOS settings again and change the system text size.
- Go back to WPiOS.
- Check that the post comments header text size changed accordingly.

The comment cells might not update automatically, that is not considered on this PR.
