### PR TITLE
Update WPMediaPicker to include parental control updates

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -129,9 +129,9 @@ target 'WordPress' do
     pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
     pod 'Gridicons', '0.16'
     pod 'NSURL+IDN', '0.3'
-    ##pod 'WPMediaPicker', '1.3.1'
+    pod 'WPMediaPicker', '1.3.2'
     ## while PR is in review:
-    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'e546205cd2a992838837b0a4de502507b89b6e63'
+    ## pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'e546205cd2a992838837b0a4de502507b89b6e63'
 
     pod 'WordPressAuthenticator', '~> 1.1.7'
 

--- a/Podfile
+++ b/Podfile
@@ -131,7 +131,7 @@ target 'WordPress' do
     pod 'NSURL+IDN', '0.3'
     ##pod 'WPMediaPicker', '1.3.1'
     ## while PR is in review:
-    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '585017b08a559cd31257202d2109fcfc20fecfa2'
+    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'e546205cd2a992838837b0a4de502507b89b6e63'
 
     pod 'WordPressAuthenticator', '~> 1.1.7'
 

--- a/Podfile
+++ b/Podfile
@@ -129,9 +129,9 @@ target 'WordPress' do
     pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.2.3'
     pod 'Gridicons', '0.16'
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', '1.3.1'
+    ##pod 'WPMediaPicker', '1.3.1'
     ## while PR is in review:
-    ## pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '82f798c0dc18b17a11dfafa37f1fd39eb508b29b'
+    pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => '585017b08a559cd31257202d2109fcfc20fecfa2'
 
     pod 'WordPressAuthenticator', '~> 1.1.7'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -254,7 +254,7 @@ DEPENDENCIES:
   - WordPressKit (~> 1.7.0-beta)
   - WordPressShared (~> 1.6.0)
   - WordPressUI (~> 1.1)
-  - WPMediaPicker (= 1.3.1)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `585017b08a559cd31257202d2109fcfc20fecfa2`)
   - wpxmlrpc (= 0.8.3)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
   - ZendeskSDK (= 2.2.0)
@@ -297,7 +297,6 @@ SPEC REPOS:
     - WordPressKit
     - WordPressShared
     - WordPressUI
-    - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
 
@@ -323,6 +322,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
     :tag: v0.1.3
+  WPMediaPicker:
+    :commit: 585017b08a559cd31257202d2109fcfc20fecfa2
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -345,6 +347,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
     :tag: v0.1.3
+  WPMediaPicker:
+    :commit: 585017b08a559cd31257202d2109fcfc20fecfa2
+    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -391,11 +396,11 @@ SPEC CHECKSUMS:
   WordPressKit: 22fb9ae63faa1ab4c7b3b5eda842aff8c9dc859d
   WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
   WordPressUI: 3c69543f0170e011226e48910b8c3071e5d400af
-  WPMediaPicker: ea92f84950843c7baf6a7325caed72ad7852418d
+  WPMediaPicker: dd85427b142fc928e14aa5e7d0db2a1fa249aba2
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: be30819f48c9520dabcf963a3477de306a4961ee
+PODFILE CHECKSUM: 465b286e1d71f4eceaddb76225f43dd7665dfffd
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -254,7 +254,7 @@ DEPENDENCIES:
   - WordPressKit (~> 1.7.0-beta)
   - WordPressShared (~> 1.6.0)
   - WordPressUI (~> 1.1)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `585017b08a559cd31257202d2109fcfc20fecfa2`)
+  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `e546205cd2a992838837b0a4de502507b89b6e63`)
   - wpxmlrpc (= 0.8.3)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
   - ZendeskSDK (= 2.2.0)
@@ -323,7 +323,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
     :tag: v0.1.3
   WPMediaPicker:
-    :commit: 585017b08a559cd31257202d2109fcfc20fecfa2
+    :commit: e546205cd2a992838837b0a4de502507b89b6e63
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
@@ -348,7 +348,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
     :tag: v0.1.3
   WPMediaPicker:
-    :commit: 585017b08a559cd31257202d2109fcfc20fecfa2
+    :commit: e546205cd2a992838837b0a4de502507b89b6e63
     :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 465b286e1d71f4eceaddb76225f43dd7665dfffd
+PODFILE CHECKSUM: e58285fa830b3f9ff727953d823471d1f8da20a7
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -202,7 +202,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.1.1)
-  - WPMediaPicker (1.3.1)
+  - WPMediaPicker (1.3.2)
   - wpxmlrpc (0.8.3)
   - yoga (0.57.5.React)
   - ZendeskSDK (2.2.0):
@@ -254,7 +254,7 @@ DEPENDENCIES:
   - WordPressKit (~> 1.7.0-beta)
   - WordPressShared (~> 1.6.0)
   - WordPressUI (~> 1.1)
-  - WPMediaPicker (from `https://github.com/wordpress-mobile/MediaPicker-iOS.git`, commit `e546205cd2a992838837b0a4de502507b89b6e63`)
+  - WPMediaPicker (= 1.3.2)
   - wpxmlrpc (= 0.8.3)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
   - ZendeskSDK (= 2.2.0)
@@ -297,6 +297,7 @@ SPEC REPOS:
     - WordPressKit
     - WordPressShared
     - WordPressUI
+    - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
 
@@ -322,9 +323,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
     :tag: v0.1.3
-  WPMediaPicker:
-    :commit: e546205cd2a992838837b0a4de502507b89b6e63
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -347,9 +345,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
     :tag: v0.1.3
-  WPMediaPicker:
-    :commit: e546205cd2a992838837b0a4de502507b89b6e63
-    :git: https://github.com/wordpress-mobile/MediaPicker-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -396,11 +391,11 @@ SPEC CHECKSUMS:
   WordPressKit: 22fb9ae63faa1ab4c7b3b5eda842aff8c9dc859d
   WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
   WordPressUI: 3c69543f0170e011226e48910b8c3071e5d400af
-  WPMediaPicker: dd85427b142fc928e14aa5e7d0db2a1fa249aba2
+  WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: e58285fa830b3f9ff727953d823471d1f8da20a7
+PODFILE CHECKSUM: 1f64c18d9f1b2849f6a4c9a94b34da664ebc3b39
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Categories/Media+WPMediaAsset.m
+++ b/WordPress/Classes/Categories/Media+WPMediaAsset.m
@@ -87,7 +87,7 @@
 
 - (NSError *)errorWithMessage:(NSString *)errorMessage {
     return [NSError errorWithDomain:WPMediaPickerErrorDomain
-                               code:WPMediaErrorCodeVideoURLNotAvailable
+                               code:WPMediaPickerErrorCodeVideoURLNotAvailable
                            userInfo:@{NSLocalizedDescriptionKey:errorMessage}];
 }
 

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -197,7 +197,8 @@
         }];
     } else {
         [self.currentDataSource loadDataWithOptions:options success:successBlock failure:^(NSError *error) {
-            if ([error.domain isEqualToString:WPMediaPickerErrorDomain] && error.code == WPMediaErrorCodePermissionsFailed) {
+            if ([error.domain isEqualToString:WPMediaPickerErrorDomain] &&
+                (error.code == WPMediaPickerErrorCodePermissionDenied || error.code == WPMediaPickerErrorCodeRestricted)) {
                 if (self.currentDataSource == self.deviceLibraryDataSource) {                
                     self.currentDataSource = self.mediaLibraryDataSource;
                     [self loadDataWithOptions:options success:successBlock failure:failureBlock];

--- a/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
+++ b/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
@@ -53,7 +53,7 @@ class MediaLibraryPickerDataSourceTests: XCTestCase {
                 return
             }
             XCTAssertTrue(error.domain == WPMediaPickerErrorDomain, "Should return a WPMediaPickerError")
-            XCTAssertTrue(error.code == WPMediaPickerErrorCode.errorCodeVideoURLNotAvailable.rawValue, "Should return a errorCodeVideoURLNotAvailable")
+            XCTAssertTrue(error.code == WPMediaPickerErrorCode.videoURLNotAvailable.rawValue, "Should return a videoURLNotAvailable")
         })
         self.waitForExpectations(timeout: 5, handler: nil)
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/10228

We start showing a different error message in case of a parental control.

![img_0055](https://user-images.githubusercontent.com/5032900/50914953-d11c3b80-1448-11e9-9e1d-0496f65f712b.PNG)

Media Picker changes are in [this PR](https://github.com/wordpress-mobile/MediaPicker-iOS/pull/313).

**To test**

1. Enable parental controls in your device, follow below steps to do this:
- for iOS 12 go to Settings > Screen Time > Turn on Screen Time
- If screen time is already turned on then turn it off and again turn it on because we need to select "This is my child's iPhone" option 
![img_0048](https://user-images.githubusercontent.com/5032900/50910802-982b9900-143f-11e9-8b1f-21f08b514962.PNG)
- Skip Downtime and App limits configuration by selecting "Not Now"
- Tap "Continue" on Content & Privacy
![img_0049](https://user-images.githubusercontent.com/5032900/50910958-eb055080-143f-11e9-85b1-4c1feb8a4ad9.PNG)
- Set a parent passcode, better make this different than the touch id passcode, this is the passcode to change the parental controls.
![img_0050](https://user-images.githubusercontent.com/5032900/50911066-256eed80-1440-11e9-8459-ff447722e579.PNG)
- Choose Content & Privacy Restrictions
![img_0051](https://user-images.githubusercontent.com/5032900/50911183-60712100-1440-11e9-9b60-5283e7233fda.PNG)

- Enter the passcode you just created
- Enable switch near Content & Privacy Resctictions 
- Choose Photos under PRIVACY section
![img_dbea3b535b33-1](https://user-images.githubusercontent.com/5032900/50911338-b9d95000-1440-11e9-90c1-fb499a03cc5f.jpeg)
- Choose "Don't allow changes" and disable switch for WordPress

Now you can leave settings

**2. WordPress app - Verify parental control error message**

- Kill and reopen the app, otherwise new permission settings won't become active.

(if that doesn't work:
 Clean Build Folder from XCode, **DELETE** the WordPress app and reinstall it)

- Login to the WordPress app
- Open a blog post via Aztec editor
- Tap (+) to add an image from the Photo library
- You should see the below error:

![img_0055](https://user-images.githubusercontent.com/5032900/50914964-d7121c80-1448-11e9-8425-eee94603a4ce.PNG)


**3. WordPress app - Verify old error message that indicates we need Media Library access**

- Go to Content & Privacy Resctictions settings and disable switch
- Kill and reopen the app
- Open a blog post via Aztec editor
- Tap (+) to add an image from the Photo library
- Don't allow for media library access
- You should see the below error:

![img_0054](https://user-images.githubusercontent.com/5032900/50912295-e1c9b300-1442-11e9-8179-cf395d0ccb6a.PNG)

- Tapping "Open Settings" should take you to WordPress app settings

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`. None that is critical
