### PR TITLE
ImageLoader: Fix crashing when attempting to handle error

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,3 +8,4 @@
 * When creating a new site, on the site type selection page, the 'Start with' label now wraps.
 * Improvements to localisations.
 * Fixes an issue where stale images may appear when navigating between notifications.
+* Fixes a crash caused by image uploading error handling.

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -233,10 +233,16 @@ import MobileCoreServices
         guard let error = error, (error as NSError).code != NSURLErrorCancelled else {
             return
         }
-        DispatchQueue.main.async {
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
             if self.imageView.shouldShowLoadingIndicator {
                 self.loadingIndicator.state = .error
             }
+
             self.errorHandler?(error)
         }
     }


### PR DESCRIPTION
Fixes #10211 

To test:

I'm actually not sure what steps trigger the crash. But, from the crash logs, it appears to be caused by a strong reference. So I've added a weak self reference in `callErrorHandler`. 🤞 this fixes it!

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
