### PR TITLE
Don't run swiftlint on danger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,20 +39,20 @@ jobs:
           path: build/reports
 
   danger:
-    macos:
-      xcode: "10.1.0"
+    docker:
+      - image: dantoml/danger:latest
     steps:
       - checkout
       - restore_cache:
           keys:
-            - wordpress-ios-danger-{{ checksum "Rakefile" }}-{{ checksum "Gemfile.lock" }}
-            - wordpress-ios-danger-{{ checksum "Gemfile.lock" }}
-            - wordpress-ios-danger-
+            - wordpress-ios-danger-gems-v1-{{ checksum "Rakefile" }}-{{ checksum "Gemfile.lock" }}
+            - wordpress-ios-danger-gems-v1-{{ checksum "Rakefile" }}
+            - wordpress-ios-danger-gems-v1-
       - run:
-          name: Dependencies for danger
-          command: rake dependencies:bundle:check dependencies:lint:check
+          name: Bundle install
+          command: bundle install --path=vendor/bundle
       - save_cache:
-          key: wordpress-ios-danger-{{ checksum "Rakefile" }}-{{ checksum "Gemfile.lock" }}
+          key: wordpress-ios-danger-gems-v1-{{ checksum "Rakefile" }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/
       - run:

--- a/Dangerfile
+++ b/Dangerfile
@@ -18,9 +18,5 @@ has_modified_model = git.modified_files.include? "WordPress/Classes/WordPress.xc
 
 warn("Core Data: Do not edit an existing model in a release branch unless it hasn't been released to testers yet. Instead create a new model version and merge back to develop soon.") if has_modified_model
 
-# SwiftLint, requires https://github.com/ashfurrow/danger-swiftlint
-swiftlint.verbose = true
-swiftlint.lint_files
-
 # Podfile: no references to commit hashes
 warn("Podfile: reference to a commit hash") if `grep -e "^[^#]*:commit" Podfile`.length > 1

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source 'https://rubygems.org' do
   gem 'cocoapods-check'
   gem 'xcpretty-travis-formatter'
   gem 'danger'
-  gem 'danger-swiftlint'
   gem 'octokit', "~> 4.0"
   gem 'fastlane', "2.103.1"
   gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,10 +81,6 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
-    danger-swiftlint (0.17.4)
-      danger
-      rake (> 10)
-      thor (~> 0.19)
     declarative (0.0.10)
     declarative-option (0.1.0)
     diffy (3.3.0)
@@ -217,7 +213,6 @@ GEM
     terminal-notifier (1.8.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thor (0.20.0)
     thread_safe (0.3.6)
     tty-cursor (0.6.0)
     tty-screen (0.6.5)
@@ -250,7 +245,6 @@ DEPENDENCIES
   cocoapods-check!
   cocoapods-repo-update (~> 0.0.3)!
   danger!
-  danger-swiftlint!
   dotenv!
   fastlane (= 2.103.1)!
   fastlane-plugin-wpmreleasetoolkit!


### PR DESCRIPTION
A few months back Hound was having issues running `swiftlint` so we added rules for it to Danger with `danger-swiftlint`. Since everything has been stable again for some time, this PR removes the duplicated work from Danger.

A nice extra benefit of this is that we can run Danger on a linux image in CircleCI. This frees up our macOS queue for iOS builds.

To test:

- See that Hound is working correctly. You can see a filing PR here: https://github.com/wordpress-mobile/WordPress-iOS/pull/10788
- Both Hound and Danger pass for this PR.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
