### PR TITLE
Move post epilogue tracking to after post post screen is revealed

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -75,14 +75,11 @@ class PostPostViewController: UIViewController {
         configureForPost()
 
         if revealPost {
+            WPAnalytics.track(.postEpilogueDisplayed)
+
             view.alpha = WPAlphaFull
             animatePostPost()
         }
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        WPAnalytics.track(.postEpilogueDisplayed)
     }
 
     private func setupActionButtons() {


### PR DESCRIPTION
I just noticed that the tracks event `post_epilogue_displayed` was getting sent every time we displayed the editor (because it's the PostPost screen that presents the editor). I've moved the event from `viewDidAppear` to when the post is revealed.

I think I got it right, but @nheagy could you check for me as you know this screen the best?

**To test:**

* Build and run
* Filter the Xcode console to search for `post_epilogue_displayed`
* Open the editor. You shouldn't see the even posted
* Publish a post, and then tap the View button in the successfully published notice that appears
* Check the event is posted
