### PR TITLE
Silence xib warnings

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/MediaSizeSliderCell.xib
+++ b/WordPress/Classes/ViewRelated/Cells/MediaSizeSliderCell.xib
@@ -24,7 +24,7 @@
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IZE-tn-T3b">
                                 <rect key="frame" x="0.0" y="0.0" width="288" height="0.0"/>
                                 <accessibility key="accessibilityConfiguration" identifier=""/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -42,7 +42,7 @@
                                 <accessibility key="accessibilityConfiguration">
                                     <bool key="isElement" value="NO"/>
                                 </accessibility>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -93,7 +93,7 @@
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Site description" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uvZ-h9-MUU">
                                     <rect key="frame" x="16" y="0.0" width="288" height="19.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                     <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>


### PR DESCRIPTION
This PR silence some warnings related to dynamic types in a couple of xib files.

The warning says that system fonts does not support dynamic types, so I opted for changing it for the corresponding dynamic type font style of the same point size.

Ref: https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/typography/

This effectively silence the warning keeping the automatic font sizing and font style intact.

To test:

- Clean project and build folder.
- Build the project.
- Check that there are no warnings related to xib files.
- Check that the modified elements display correctly:
 - Reader site header: (more info) https://github.com/wordpress-mobile/WordPress-iOS/pull/10780
 - Media settings slider: (more info) https://github.com/wordpress-mobile/WordPress-iOS/pull/10768