### PR TITLE
Removing reference to WPNoResultsView. 

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -24,13 +24,13 @@ end
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.6.0'
+#    pod 'WordPressShared', '~> 1.6.0'
 
     ## for development:
     ##pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    ##pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'd664be9e496112b8f2d98f41607db41cbcc6fd0b'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '84d09bcbb0c9c1ba7f39c119e7fce61927f02f43'
 end
 
 def aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -198,7 +198,7 @@ PODS:
     - UIDeviceIdentifier (~> 0.4)
     - WordPressShared (~> 1.4)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.6.0):
+  - WordPressShared (1.6.1-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.1.1)
@@ -252,7 +252,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.4.1)
   - WordPressAuthenticator (~> 1.1.7)
   - WordPressKit (~> 1.7.0-beta)
-  - WordPressShared (~> 1.6.0)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `84d09bcbb0c9c1ba7f39c119e7fce61927f02f43`)
   - WordPressUI (~> 1.1)
   - WPMediaPicker (= 1.3.2)
   - wpxmlrpc (= 0.8.3)
@@ -295,7 +295,6 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -323,6 +322,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
     :tag: v0.1.3
+  WordPressShared:
+    :commit: 84d09bcbb0c9c1ba7f39c119e7fce61927f02f43
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -345,6 +347,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: https://github.com/wordpress-mobile/react-native-aztec.git
     :tag: v0.1.3
+  WordPressShared:
+    :commit: 84d09bcbb0c9c1ba7f39c119e7fce61927f02f43
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -389,13 +394,13 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 617116ef6b454ff11eed2cbdeafc6cf78a54aec2
   WordPressAuthenticator: e8019fa8ab52004d0150d99004172487418543b0
   WordPressKit: 4acadbe3d833ea8e010a04799537c7fde1252e0a
-  WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
+  WordPressShared: c52ecb98864f4474c8c18d3ee20103ac3542f494
   WordPressUI: 3c69543f0170e011226e48910b8c3071e5d400af
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 864cfe2059a3225755d5afd988c7e359e6b9b8bd
+PODFILE CHECKSUM: fbe536e591dff2e9e5f391ecc6f9f98b9799dc69
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -133,7 +133,6 @@
 
 #import <WordPressShared/WPDeviceIdentification.h>
 #import <WordPressShared/WPFontManager.h>
-#import <WordPressShared/WPNoResultsView.h>
 #import <WordPressShared/WPStyleGuide.h>
 #import <WordPressShared/WPTableViewCell.h>
 #import <WordPressShared/WPAnalytics.h>


### PR DESCRIPTION
Fixes # n/a

This simply removes references to the now defunct `WPNoResultsView`. 

To test:
Since `WPNoResultsView` is no longer used, just verify the app runs.

NOTE: I will update the WordPressShared pod version when that PR is merged.

Ref WordPressShared PR: https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/172
