### PR TITLE
[Site creation]. Remove custom disclosure indicator from segments cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
@@ -58,7 +58,6 @@ final class SiteSegmentsCell: UITableViewCell, ModelSettableCell {
     }
 
     private func styleAccessoryView() {
-        let accessoryImage = Gridicon.iconOfType(.chevronRight).imageWithTintColor(WPStyleGuide.greyLighten20())
-        accessoryView = UIImageView(image: accessoryImage)
+        accessoryType = .disclosureIndicator
     }
 }


### PR DESCRIPTION
Fixes #10659 

As mentioned during the review of PR #10644 , the disclosure indicators in the Segment cell should be the default.

Before and after:
![disclosure](https://user-images.githubusercontent.com/2722505/51103329-43ac6300-181d-11e9-897d-c48162c3e65a.jpg)

To test:
- Checkout the branch. Make sure it builds and the tests pass.
- Navigate to Enhanced Site Creation. Notice the disclosure indicators in the segments cell.

Update release notes:
- There are no changes worth being mentioned in the release notes

cc @SylvesterWilmott 