### PR TITLE
Resolved verticals selection issue when navigating through site creation

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsStep.swift
@@ -6,7 +6,7 @@ final class VerticalsStep: WizardStep {
     private let verticalsService: SiteVerticalsService
 
     private(set) lazy var content: UIViewController = {
-        return VerticalsWizardContent(segment: self.creator.segment, promptService: promptService, verticalsService: self.verticalsService, selection: self.didSelect)
+        return VerticalsWizardContent(creator: self.creator, promptService: promptService, verticalsService: self.verticalsService, selection: self.didSelect)
     }()
 
     var delegate: WizardDelegate?

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
@@ -22,8 +22,8 @@ final class VerticalsWizardContent: UIViewController {
         static let separatorInset = UIEdgeInsets(top: 0, left: 16.0, bottom: 0, right: 0)
     }
 
-    /// The segment selected by the user in a preceding step
-    private let segment: SiteSegment?
+    /// The creator collects user input as they advance through the wizard flow.
+    private let siteCreator: SiteCreator
 
     /// The service which retrieves localized prompt verbiage specific to the chosen segment
     private let promptService: SiteVerticalsPromptService
@@ -62,13 +62,13 @@ final class VerticalsWizardContent: UIViewController {
     /// The designated initializer.
     ///
     /// - Parameters:
-    ///   - segment:            the segment selected by the user in a preceding step
+    ///   - creator:            accumulates user input as a user navigates through the site creation flow
     ///   - promptService:      the service which retrieves localized prompt verbiage specific to the chosen segment
     ///   - verticalsService:   the service which conducts searches for know verticals
     ///   - selection:          the action to perform once a Vertical is selected by the user
     ///
-    init(segment: SiteSegment?, promptService: SiteVerticalsPromptService, verticalsService: SiteVerticalsService, selection: @escaping (SiteVertical) -> Void) {
-        self.segment = segment
+    init(creator: SiteCreator, promptService: SiteVerticalsPromptService, verticalsService: SiteVerticalsService, selection: @escaping (SiteVertical) -> Void) {
+        self.siteCreator = creator
         self.promptService = promptService
         self.verticalsService = verticalsService
         self.selection = selection
@@ -134,7 +134,7 @@ final class VerticalsWizardContent: UIViewController {
         }
 
         // This should never apply, but we have a Segment?
-        guard let promptRequest = segment?.identifier else {
+        guard let promptRequest = siteCreator.segment?.identifier else {
             let defaultPrompt = VerticalsWizardContent.defaultPrompt
             setupTableHeaderWithPrompt(defaultPrompt)
 


### PR DESCRIPTION
### Description

Fixes #10801, which observed that selecting a segment in the first step of the flow, then navigating back and selecting a different step didn't properly update.

This PR modifies the `VerticalsWizardContent` initializer to accept the outer reference type rather than an inner value type. This change is consistent with the signature of both `WebAddressWizardContent` & `SiteAssemblyWizardContent`.

To test:
 - Checkout the branch and confirm that existing tests pass.
 - Review the code change and make sure everything looks good.
 - Replicate the steps noted in the defect, selecting **Blogger** (the first segment) the first time and **Professional** the second time.
 - Verify that the prompt on the second step (_Verticals_) properly updates. That is to say, the title text should now read: _What type of business do you have?_.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
