### PR TITLE
Modified text headers to remain visible on iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
@@ -339,7 +339,9 @@ private extension VerticalsWizardContent {
 
     @objc
     func keyboardWillHide(_ notification: Foundation.Notification) {
-        guard let payload = KeyboardInfo(notification) else { return }
+        guard WPDeviceIdentification.isiPhone(), let payload = KeyboardInfo(notification) else {
+            return
+        }
         let animationDuration = payload.animationDuration
 
         UIView.animate(withDuration: animationDuration,
@@ -360,7 +362,9 @@ private extension VerticalsWizardContent {
 
     @objc
     func keyboardWillShow(_ notification: Foundation.Notification) {
-        guard let payload = KeyboardInfo(notification) else { return }
+        guard WPDeviceIdentification.isiPhone(), let payload = KeyboardInfo(notification) else {
+            return
+        }
         let keyboardScreenFrame = payload.frameEnd
 
         let convertedKeyboardFrame = view.convert(keyboardScreenFrame, from: nil)


### PR DESCRIPTION
### Description
Fixes #10688.

To test:
 - Checkout the branch and confirm that existing tests pass.
 - Review the code changes and make sure everything looks good.
 - Navigate to Step 2 of the enhanced site creation flow (_Verticals_) on both iPhone & iPad. Confirm that the title header remains visible when the text field has been selected.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

#### Caveats
 - Due to the behavior of the software keyboard on the iOS Simulator, this is most reliably validated on-device.
 - This does not yet address the reappearance of the text field when returning to this screen (#10791); nor does it correct the conditions when the headers should be hidden/revealed (#10812). Furthermore, this change is focused on _Verticals_. Once the preceding changes are complete, a more generalized solution will be ported to the Domains screen (#10811).

### Screenshots

_iPhone :_

![10688_iphone](https://user-images.githubusercontent.com/221062/51129122-75520980-17de-11e9-95c7-7157ceb37ef8.png)

_iPad : Portrait (Blogger) :_

![10688_ipad_portrait](https://user-images.githubusercontent.com/221062/51129127-784cfa00-17de-11e9-84c6-93d54ffb38ef.png)

_iPad : Landsape (Professional) :_

<img width="1112" alt="10688_ipad_landscape" src="https://user-images.githubusercontent.com/221062/51129131-7aaf5400-17de-11e9-94e2-7e2620688344.png">