### PR TITLE
 Modified Verticals header to properly reset appearance

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
@@ -339,7 +339,9 @@ private extension VerticalsWizardContent {
 
     @objc
     func keyboardWillHide(_ notification: Foundation.Notification) {
-        guard let payload = KeyboardInfo(notification) else { return }
+        guard WPDeviceIdentification.isiPhone(), let payload = KeyboardInfo(notification) else {
+            return
+        }
         let animationDuration = payload.animationDuration
 
         UIView.animate(withDuration: animationDuration,
@@ -360,7 +362,9 @@ private extension VerticalsWizardContent {
 
     @objc
     func keyboardWillShow(_ notification: Foundation.Notification) {
-        guard let payload = KeyboardInfo(notification) else { return }
+        guard WPDeviceIdentification.isiPhone(), let payload = KeyboardInfo(notification) else {
+            return
+        }
         let keyboardScreenFrame = payload.frameEnd
 
         let convertedKeyboardFrame = view.convert(keyboardScreenFrame, from: nil)


### PR DESCRIPTION
### Description
Fixes both #10791 & #10812.

This branch builds off work for both #10815 & #10816. It required extracting the existing table offset animations, changing the stimulus that triggered those animations, and properly accounting for reentrant behavior (i.e., navigating forward & back multiple times). Moreover, these changes are limited to iPhone.

To test:
 - Checkout the branch and confirm that existing tests pass.
 - Review the code changes and make sure everything looks good.
 - On **iPhone**, start the Site Creation flow and search/select a few different verticals. Try deleting text manually and clearing the text field with the clear button and observe behavior. Select a vertical & come back (header is initially visible). Navigate even further back, select a different segment: search text should be reset.
 - On **iPad**, verify that the header changes in the preceding step do _not_ occur.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

#### Caveats
 - This branch includes content from both `issue/10801-site-creation-wizard-nav-bug` & `issue/10688-iPad-dont-hide-site-creation-headers`. The net addition is `
0cd5051`.
 - Due to the behavior of the software keyboard on the iOS Simulator, this is most reliably validated on-device.
 - This does not yet address account for #10811.

![10791d](https://user-images.githubusercontent.com/221062/51144752-d7266980-1806-11e9-87ba-1c87074b7716.gif)