### PR TITLE
Swap position of 'Done' and 'Remove' buttons (PostGeolocationViewController)

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Geolocation/PostGeolocationViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/Geolocation/PostGeolocationViewController.m
@@ -51,8 +51,8 @@ typedef NS_ENUM(NSInteger, SearchResultsSection) {
     self.view.backgroundColor = [WPStyleGuide greyLighten30];
     self.title = NSLocalizedString(@"Location", @"Title for screen to select post location");
     [self.view addSubview:self.geoView];
-    self.navigationItem.leftBarButtonItems = @[self.doneButton];
-    self.navigationItem.rightBarButtonItems = @[self.removeButton];
+    self.navigationItem.leftBarButtonItems = @[self.removeButton];
+    self.navigationItem.rightBarButtonItems = @[self.doneButton];
     [self.view addSubview:self.searchBar];
     [self.view addSubview:self.tableView];
     [self.view addSubview:self.searchBarTop];


### PR DESCRIPTION
Fixes #10767 

This was a trivial fix. Just swapped the placement of the buttons. Functionality unchanged.

To test:
- Create a new post
- Navigate to Post Settings by clicking on the ellipses at the top right
- Select 'Set Location'
- Notice that the 'Done' bar button is now on the right, and the 'Remove' bar button is on the left.

Update release notes:
- Nothing to update