### PR TITLE
Permanently deleted posts with local edits aren now purged.

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -490,7 +490,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     
     if (purge) {
         // Set up predicate for fetching any posts that could be purged for the sync.
-        NSPredicate *predicate  = [NSPredicate predicateWithFormat:@"(remoteStatusNumber = %@) AND (postID != NULL) AND (original = NULL) AND (revision = NULL) AND (blog = %@)", @(AbstractPostRemoteStatusSync), blog];
+        NSPredicate *predicate  = [NSPredicate predicateWithFormat:@"(remoteStatusNumber = %@) AND (postID != NULL) AND (blog = %@)", @(AbstractPostRemoteStatusSync), blog];
         if ([statuses count] > 0) {
             NSPredicate *statusPredicate = [NSPredicate predicateWithFormat:@"status IN %@", statuses];
             predicate = [NSCompoundPredicate andPredicateWithSubpredicates:@[predicate, statusPredicate]];


### PR DESCRIPTION
## Description:

Fixes #8459.

Apparently, posts with local edits, permanently deleted through the web were not being purged correctly.

## Details:

The culprit was found by @oguzkocer [here](
https://github.com/wordpress-mobile/WordPress-iOS/issues/8459#issuecomment-452406462).

It seems that we were only allowing posts without an original or a revision to be removed.  I believe the reason these filters existed was so that posts with local edits are not purged automagically... but it is my belief that if the user is permanently deleting a post, they probably don't care about local revisions in their devices.

Part of the review process is to evaluate if this approach makes sense, and is agreeable (or not!).

## Testing:

To create a post for testing the old issue.

1. Connect your device
2. Publish a post
3. Edit the post
4. Disconnect internet
5. Tap X to close the post, but save changes
6. Wait until the upload fails.
7. Reconnect internet.
8. Trash the post
9. Through the webpage, permanently delete the post
10. Go back to the app and pull down to refresh.

The post should be gone.