### PR TITLE
Properly Placed Pages: fix indentation bug for private pages

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -414,10 +414,11 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         cell.accessoryType = .none
 
         let page = pageAtIndexPath(indexPath)
+        let filterType = filterSettings.currentPostListFilter().filterType
 
         if cell.reuseIdentifier == Constant.Identifiers.pageCellIdentifier {
             cell.indentationWidth = _tableViewHandler.isSearching ? 0.0 : Constant.Size.pageListTableViewCellLeading
-            cell.indentationLevel = page.status != .publish ? 0 : page.hierarchyIndex
+            cell.indentationLevel = filterType != .published ? 0 : page.hierarchyIndex
             cell.onAction = { [weak self] cell, button, page in
                 self?.handleMenuAction(fromCell: cell, fromButton: button, forPage: page)
             }


### PR DESCRIPTION
Fixes #10837 

![ppp-indentation](https://user-images.githubusercontent.com/912252/51313431-cfa4d180-1a4d-11e9-8bf4-18d2b431904b.jpg)

This PR fixes the indentation for published pages with a status different from _publish_.
The indentation should work only if the current post **filter type** is _ published_ and _NOT_ if the **page status** is _publish_.

**To test:**
- Select or create a page and set its status to Private
- Set its parent page: you shouldn't see any indentation

@aerych because you reviewed all the PPP PRs, do you mind to have a quick look to this one as well?

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
