### PR TITLE
[Stats Refresh] Hide/show navigation bar when scrolling

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Tqa-zb-Liz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Tqa-zb-Liz">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -34,21 +34,14 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R6d-mo-itW" customClass="FilterTabBar" customModule="WordPress">
-                                <rect key="frame" x="0.0" y="64" width="375" height="46"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="46" id="u03-Cy-Pus"/>
-                                </constraints>
-                            </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J6j-x0-sMS" userLabel="Insights Container View">
-                                <rect key="frame" x="0.0" y="110" width="375" height="557"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <connections>
                                     <segue destination="Hcp-7d-sgU" kind="embed" id="1nS-hf-ioa"/>
                                 </connections>
                             </containerView>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OmR-2E-jXp" userLabel="Stats Container View">
-                                <rect key="frame" x="0.0" y="110" width="375" height="557"/>
+                                <rect key="frame" x="0.0" y="64" width="375" height="603"/>
                                 <connections>
                                     <segue destination="plb-uA-RCD" kind="embed" id="HLi-0c-1Fw"/>
                                 </connections>
@@ -56,17 +49,14 @@
                         </subviews>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="R6d-mo-itW" firstAttribute="trailing" secondItem="Ocg-ig-pQt" secondAttribute="trailing" id="3Vy-SZ-45b"/>
                             <constraint firstItem="OmR-2E-jXp" firstAttribute="leading" secondItem="Ocg-ig-pQt" secondAttribute="leading" id="4PI-hg-39d"/>
                             <constraint firstItem="J6j-x0-sMS" firstAttribute="bottom" secondItem="Ocg-ig-pQt" secondAttribute="bottom" id="5Dc-js-I5s"/>
-                            <constraint firstItem="J6j-x0-sMS" firstAttribute="top" secondItem="R6d-mo-itW" secondAttribute="bottom" id="Cgj-jO-OfC"/>
+                            <constraint firstItem="OmR-2E-jXp" firstAttribute="top" secondItem="Ocg-ig-pQt" secondAttribute="top" id="7bK-ih-Qmv"/>
                             <constraint firstItem="J6j-x0-sMS" firstAttribute="trailing" secondItem="Ocg-ig-pQt" secondAttribute="trailing" id="GXb-KG-d0p"/>
                             <constraint firstItem="OmR-2E-jXp" firstAttribute="bottom" secondItem="Ocg-ig-pQt" secondAttribute="bottom" id="aAd-fu-NMn"/>
                             <constraint firstItem="OmR-2E-jXp" firstAttribute="trailing" secondItem="Ocg-ig-pQt" secondAttribute="trailing" id="doC-hh-j5P"/>
-                            <constraint firstItem="R6d-mo-itW" firstAttribute="top" secondItem="Ocg-ig-pQt" secondAttribute="top" id="gS5-1d-Huj"/>
-                            <constraint firstItem="OmR-2E-jXp" firstAttribute="top" secondItem="R6d-mo-itW" secondAttribute="bottom" id="iEq-zu-8bV"/>
                             <constraint firstItem="J6j-x0-sMS" firstAttribute="leading" secondItem="Ocg-ig-pQt" secondAttribute="leading" id="iem-bg-Jp2"/>
-                            <constraint firstItem="R6d-mo-itW" firstAttribute="leading" secondItem="Ocg-ig-pQt" secondAttribute="leading" id="irM-hU-WLy"/>
+                            <constraint firstItem="J6j-x0-sMS" firstAttribute="top" secondItem="Ocg-ig-pQt" secondAttribute="top" id="rFN-Pq-kKP"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Ocg-ig-pQt"/>
                     </view>
@@ -78,6 +68,11 @@
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ixM-JR-6YX" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R6d-mo-itW" customClass="FilterTabBar" customModule="WordPress">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="46"/>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <viewLayoutGuide key="safeArea" id="C12-Oc-qio"/>
+                </view>
             </objects>
             <point key="canvasLocation" x="240.80000000000001" y="232.53373313343329"/>
         </scene>
@@ -86,7 +81,7 @@
             <objects>
                 <tableViewController id="Hcp-7d-sgU" userLabel="Insights Table View Controller" customClass="SiteStatsInsightsTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="qZC-N3-iSA">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="557"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <connections>
@@ -108,7 +103,7 @@
             <objects>
                 <tableViewController id="plb-uA-RCD" userLabel="Stats Table View Controller" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="zaS-th-YDU">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="557"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <connections>


### PR DESCRIPTION


This change removes the Filter Tab Bar from the master Dashboard view, and adds it to the tableHeaderView of the table being displayed (Insights or DWMY).

NOTE: Since DWMY doesn't exist yet, if one of those filters is selected the Filter Tab Bar isn't displayed as there is no header to add it to.

To test:
- Go to Stats > Insights.
- Verify:
  - The filter tab bar displays.
  - Scrolls with the table, i.e. is not shown when scrolling down, is shown when scrolled to the top.

---
<img width="350" alt="shown" src="https://user-images.githubusercontent.com/1816888/51354295-5c608700-1a70-11e9-8774-a6dd86a7c0d2.png">

---
<img width="350" alt="not_shown" src="https://user-images.githubusercontent.com/1816888/51354297-5f5b7780-1a70-11e9-9eae-78d753f057c0.png">


