### PR TITLE
Replace BuddyBuild status badge with CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WordPress for iOS #
 
-[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=57a120bbe0f5520100e11c19&branch=develop&build=latest)](https://dashboard.buddybuild.com/apps/57a120bbe0f5520100e11c19/build/latest)
+[![CircleCI](https://circleci.com/gh/wordpress-mobile/WordPress-iOS.svg?style=svg)](https://circleci.com/gh/wordpress-mobile/WordPress-iOS)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 
 ## Build Instructions


### PR DESCRIPTION
Replaces the BuddyBuild status badge in the README with CircleCI ahead of the upcoming switchover.

To test:

- [View the file](https://github.com/wordpress-mobile/WordPress-iOS/blob/9678259edb7bfb23740c3183a94e1ae83cd3cec5/README.md). It works!

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
