### PR TITLE
Plans: Make the plans service send authenticated requests.

### DIFF
--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -8,7 +8,14 @@ open class PlanService: LocalCoreDataService {
     @objc public func getWpcomPlans(_ success: @escaping () -> Void,
                           failure: @escaping (Error?) -> Void) {
 
-        let remote = PlanServiceRemote(wordPressComRestApi: WordPressComRestApi())
+        let accountService = AccountService(managedObjectContext: managedObjectContext)
+        var remote: PlanServiceRemote
+        if let api = accountService.defaultWordPressComAccount()?.wordPressComRestApi {
+            remote = PlanServiceRemote(wordPressComRestApi: api)
+        } else {
+            remote = PlanServiceRemote(wordPressComRestApi: WordPressComRestApi())
+        }
+
         remote.getWpcomPlans({ plans in
 
             self.mergeRemoteWpcomPlans(plans.plans, remoteGroups: plans.groups, remoteFeatures: plans.features, onComplete: {

--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -9,7 +9,7 @@ open class PlanService: LocalCoreDataService {
                           failure: @escaping (Error?) -> Void) {
 
         let accountService = AccountService(managedObjectContext: managedObjectContext)
-        var remote: PlanServiceRemote
+        let remote: PlanServiceRemote
         if let api = accountService.defaultWordPressComAccount()?.wordPressComRestApi {
             remote = PlanServiceRemote(wordPressComRestApi: api)
         } else {


### PR DESCRIPTION
REST requests from the Plans service were being made without authentication.  This PR updates the PlansService to make authenticated requests.  This fixes an issue where the Plans endpoint might omit certain plans for unauthenticated requests.

To test:
Confirm the bug by viewing the plans list with an account that has a site subscribed to the blogger plan.
Switch to this branch and view plans again. Confirm that the blogger plan now appears.

![simulator screen shot - iphone 8 - 2019-01-19 at 14 08 31](https://user-images.githubusercontent.com/1435271/51431881-99558680-1bf4-11e9-97a6-5ccf9f3a8d21.png)

@rachelmcr would you mind testing this one since you have a test blog with the blogger plan?
@jklausa could I trouble you for the code review? 
