### PR TITLE
Danger: no check for commit hashes for Gutenberg

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -20,4 +20,4 @@ warn("Core Data: Do not edit an existing model in a release branch unless it has
 
 # Podfile: no references to commit hashes
 ### (except for Gutenberg)
-warn("Podfile: reference to a commit hash") if `grep -e "^[^#]*:commit" Podfile | grep -v Gutenberg`.length > 1
+warn("Podfile: reference to a commit hash") if File.readlines('Podfile').any? { |l| l[/^[^#]*:commit/] && !l.include?("Gutenberg") }

--- a/Dangerfile
+++ b/Dangerfile
@@ -19,4 +19,5 @@ has_modified_model = git.modified_files.include? "WordPress/Classes/WordPress.xc
 warn("Core Data: Do not edit an existing model in a release branch unless it hasn't been released to testers yet. Instead create a new model version and merge back to develop soon.") if has_modified_model
 
 # Podfile: no references to commit hashes
-warn("Podfile: reference to a commit hash") if `grep -e "^[^#]*:commit" Podfile`.length > 1
+### (except for Gutenberg)
+warn("Podfile: reference to a commit hash") if `grep -e "^[^#]*:commit" Podfile | grep -v Gutenberg`.length > 1


### PR DESCRIPTION
This PR prevents Danger from checking that the Gutenberg pod is referenced by commit hash, as a temporary solution while we figure out the release process for the Gutenberg related stuff.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
