### PR TITLE
Gutenberg: Fetching RNAztecView from gutenberg-mobile

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -96,14 +96,15 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '625bce184de38f81af9f43be8a314f10e4dca35a'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :branch => 'issue/rnaztecview-podspec'
+    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :branch => 'issue/rnaztecview-podspec'
+
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'
     gutenberg_pod 'react-native-safe-area'
     gutenberg_pod 'react-native-keyboard-aware-scroll-view', 'develop'
     pod 'RNSVG', :git => 'https://github.com/wordpress-mobile/react-native-svg.git', :tag => '8.0.9-gb.0'
-    pod 'RNTAztecView', :git => 'https://github.com/wordpress-mobile/gutenberg-mobile/', :branch => 'issue/rnaztecview-podspec'
 
     ## Third party libraries
     ## =====================

--- a/Podfile
+++ b/Podfile
@@ -103,7 +103,7 @@ target 'WordPress' do
     gutenberg_pod 'react-native-safe-area'
     gutenberg_pod 'react-native-keyboard-aware-scroll-view', 'develop'
     pod 'RNSVG', :git => 'https://github.com/wordpress-mobile/react-native-svg.git', :tag => '8.0.9-gb.0'
-    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :branch => 'issue/rnaztecview-podspec'
+    pod 'RNTAztecView', :git => 'https://github.com/wordpress-mobile/gutenberg-mobile/', :branch => 'issue/rnaztecview-podspec'
 
     ## Third party libraries
     ## =====================

--- a/Podfile
+++ b/Podfile
@@ -96,8 +96,8 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :branch => 'issue/rnaztecview-podspec'
-    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :branch => 'issue/rnaztecview-podspec'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '2bade57ef289ec1ddd1604a5f354381a2a3c78fa'
+    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '2bade57ef289ec1ddd1604a5f354381a2a3c78fa'
 
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'

--- a/Podfile
+++ b/Podfile
@@ -101,7 +101,7 @@ target 'WordPress' do
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'
     gutenberg_pod 'react-native-safe-area'
-    gutenberg_pod 'RNTAztecView', 'develop'
+    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :branch => 'issue/rnaztecview-podspec'
     pod 'RNSVG', :git => 'https://github.com/wordpress-mobile/react-native-svg.git', :tag => '8.0.9-gb.0'
     pod 'react-native-keyboard-aware-scroll-view', :git => 'https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git', :tag => 'gb-v0.8.2'
 

--- a/Podfile
+++ b/Podfile
@@ -79,8 +79,8 @@ def shared_test_pods
     pod 'OCMock', '~> 3.4'
 end
 
-def gutenberg_pod(name)
-    gutenberg_branch='master'
+def gutenberg_pod(name, branch=nil)
+    gutenberg_branch=branch || 'master'
     pod name, :podspec => "https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/#{gutenberg_branch}/react-native-gutenberg-bridge/third-party-podspecs/#{name}.podspec.json"
 end
 
@@ -101,8 +101,8 @@ target 'WordPress' do
     gutenberg_pod 'yoga'
     gutenberg_pod 'Folly'
     gutenberg_pod 'react-native-safe-area'
+    gutenberg_pod 'RNTAztecView', 'develop'
     pod 'RNSVG', :git => 'https://github.com/wordpress-mobile/react-native-svg.git', :tag => '8.0.9-gb.0'
-    pod 'RNTAztecView', :git => 'https://github.com/wordpress-mobile/react-native-aztec.git', :tag => 'v0.1.3'
     pod 'react-native-keyboard-aware-scroll-view', :git => 'https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git', :tag => 'gb-v0.8.2'
 
     ## Third party libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -167,7 +167,7 @@ PODS:
     - React/RCTBlob
   - RNSVG (8.0.9):
     - React
-  - RNTAztecView (0.1.5):
+  - RNTAztecView (0.3.3):
     - React
     - WordPress-Aztec-iOS
   - SimulatorStatusMagic (2.3.2)
@@ -244,7 +244,7 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git`, tag `gb-v0.8.2`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/RNTAztecView.podspec.json`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, branch `issue/rnaztecview-podspec`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -320,7 +320,8 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/RNTAztecView.podspec.json
+    :branch: issue/rnaztecview-podspec
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -344,8 +345,8 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 46ca3f35d62919febcf7feecc6fbae23095d28bc
-    :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
+    :commit: 4e5e39570ad6237fe0c22a2aac0e88a1fd75b9d2
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -384,7 +385,7 @@ SPEC CHECKSUMS:
   react-native-keyboard-aware-scroll-view: 26f978f88bbc46507a7609c608358ccef4bd9503
   react-native-safe-area: 7dc92953fce43bf36ab5ecae2fb4ffa2bda9a203
   RNSVG: 6d5813dd9c6a8e041e142abf1372faf012ce5759
-  RNTAztecView: 0fb1947d32de7dc4beb021cd1d7883940eb27d2c
+  RNTAztecView: 7897dffc4fbc4a6d9f4321f1835c0e6a1f4d0f64
   SimulatorStatusMagic: 0c0e711acef6e70dd8a0710962347635a9cdef24
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
@@ -400,6 +401,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 370830544cff3b5b7e33a896591d1b7dcbf5aae2
+PODFILE CHECKSUM: 5a59cf99e7520be4bcc71fef3ec1d23f79bfe291
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -244,7 +244,7 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, branch `issue/rnaztecview-podspec`)
+  - RNTAztecView (from `https://github.com/wordpress-mobile/gutenberg-mobile/`, branch `issue/rnaztecview-podspec`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -320,7 +320,7 @@ EXTERNAL SOURCES:
     :tag: 8.0.9-gb.0
   RNTAztecView:
     :branch: issue/rnaztecview-podspec
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :git: https://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -339,7 +339,7 @@ CHECKOUT OPTIONS:
     :tag: 8.0.9-gb.0
   RNTAztecView:
     :commit: 9a127f1838a3edeed23f4858c802bb234d1036fb
-    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :git: https://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -394,6 +394,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: ea3d0f4a110f387a9052889b6929f46d234ca79c
+PODFILE CHECKSUM: 712f53ee2620f6775feb517c77ae110339d2304a
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -228,7 +228,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (= 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `625bce184de38f81af9f43be8a314f10e4dca35a`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, branch `issue/rnaztecview-podspec`)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -244,7 +244,7 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `https://github.com/wordpress-mobile/gutenberg-mobile/`, branch `issue/rnaztecview-podspec`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, branch `issue/rnaztecview-podspec`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -307,7 +307,7 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: 625bce184de38f81af9f43be8a314f10e4dca35a
+    :branch: issue/rnaztecview-podspec
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
@@ -320,7 +320,7 @@ EXTERNAL SOURCES:
     :tag: 8.0.9-gb.0
   RNTAztecView:
     :branch: issue/rnaztecview-podspec
-    :git: https://github.com/wordpress-mobile/gutenberg-mobile/
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -332,14 +332,14 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   Gutenberg:
-    :commit: 625bce184de38f81af9f43be8a314f10e4dca35a
+    :commit: 9a127f1838a3edeed23f4858c802bb234d1036fb
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNSVG:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
     :commit: 9a127f1838a3edeed23f4858c802bb234d1036fb
-    :git: https://github.com/wordpress-mobile/gutenberg-mobile/
+    :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -394,6 +394,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 712f53ee2620f6775feb517c77ae110339d2304a
+PODFILE CHECKSUM: 789008bcd8eac451cde6ba56efeec3e6f46aaf05
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -167,7 +167,7 @@ PODS:
     - React/RCTBlob
   - RNSVG (8.0.9):
     - React
-  - RNTAztecView (0.1.3):
+  - RNTAztecView (0.1.5):
     - React
     - WordPress-Aztec-iOS
   - SimulatorStatusMagic (2.3.2)
@@ -244,7 +244,7 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git`, tag `gb-v0.8.2`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `https://github.com/wordpress-mobile/react-native-aztec.git`, tag `v0.1.3`)
+  - RNTAztecView (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/RNTAztecView.podspec.json`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -320,8 +320,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :git: https://github.com/wordpress-mobile/react-native-aztec.git
-    :tag: v0.1.3
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/RNTAztecView.podspec.json
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -345,8 +344,8 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :git: https://github.com/wordpress-mobile/react-native-aztec.git
-    :tag: v0.1.3
+    :commit: 46ca3f35d62919febcf7feecc6fbae23095d28bc
+    :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -385,7 +384,7 @@ SPEC CHECKSUMS:
   react-native-keyboard-aware-scroll-view: 26f978f88bbc46507a7609c608358ccef4bd9503
   react-native-safe-area: 7dc92953fce43bf36ab5ecae2fb4ffa2bda9a203
   RNSVG: 6d5813dd9c6a8e041e142abf1372faf012ce5759
-  RNTAztecView: 266ca6b864df41b55e942f23c4283a449a078af6
+  RNTAztecView: 0fb1947d32de7dc4beb021cd1d7883940eb27d2c
   SimulatorStatusMagic: 0c0e711acef6e70dd8a0710962347635a9cdef24
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
@@ -401,6 +400,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 8398a4bb5d00ba9e3a05fb2d547af7b7a6ed6af6
+PODFILE CHECKSUM: 370830544cff3b5b7e33a896591d1b7dcbf5aae2
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -228,7 +228,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (= 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, branch `issue/rnaztecview-podspec`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `2bade57ef289ec1ddd1604a5f354381a2a3c78fa`)
   - HockeySDK (= 5.1.4)
   - lottie-ios (= 2.5.0)
   - MGSwipeTableCell (= 1.6.7)
@@ -244,7 +244,7 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, branch `issue/rnaztecview-podspec`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `2bade57ef289ec1ddd1604a5f354381a2a3c78fa`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -307,7 +307,7 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :branch: issue/rnaztecview-podspec
+    :commit: 2bade57ef289ec1ddd1604a5f354381a2a3c78fa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
@@ -319,7 +319,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :branch: issue/rnaztecview-podspec
+    :commit: 2bade57ef289ec1ddd1604a5f354381a2a3c78fa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -332,13 +332,13 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.2.3
   Gutenberg:
-    :commit: 9a127f1838a3edeed23f4858c802bb234d1036fb
+    :commit: 2bade57ef289ec1ddd1604a5f354381a2a3c78fa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNSVG:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 9a127f1838a3edeed23f4858c802bb234d1036fb
+    :commit: 2bade57ef289ec1ddd1604a5f354381a2a3c78fa
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -394,6 +394,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 789008bcd8eac451cde6ba56efeec3e6f46aaf05
+PODFILE CHECKSUM: dd7ddd3db0f987b5b5bebc0d2ad9cf09ed29b165
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
This PR updates the Podfile to load the RNAztecView from the `gutenberg-mobile` repo.

To test:

- Run `rake dependencies`
- Build and run the project. (might need to clean build folder or build with legacy build system)
- Check that it build without errors.
- Open the Gutenberg editor and check that it displays without errors.