### PR TITLE
Issues/10860 create second list

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -4,7 +4,6 @@
 enum FeatureFlag: Int {
     case exampleFeature
     case jetpackDisconnect
-    case quickStart
     case newsCard
     case giphy
     case automatedTransfersCustomDomain
@@ -23,8 +22,6 @@ enum FeatureFlag: Int {
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .automatedTransfersCustomDomain:
-            return true
-        case .quickStart:
             return true
         case .newsCard:
             return true

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -13,6 +13,7 @@ enum FeatureFlag: Int {
     case statsRefresh
     case bottomSheetDemo
     case gutenberg
+    case quickStartV2
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -39,6 +40,8 @@ enum FeatureFlag: Int {
             return BuildConfiguration.current == .localDeveloper
         case .gutenberg:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cPrereleaseTesting]
+        case .quickStartV2:
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -48,6 +48,28 @@ extension BlogDetailsViewController {
         return QuickStartTourGuide.shouldShowChecklist(for: blog)
     }
 
+    @objc func showQuickStartV1() {
+        let tours = QuickStartTourGuide.checklistTours
+        showQuickStart(list: tours)
+    }
+
+    @objc func showQuickStartCustomize() {
+        let tours = QuickStartTourGuide.customizeListTours
+        showQuickStart(list: tours)
+    }
+
+    @objc func showQuickStartGrow() {
+        let tours = QuickStartTourGuide.growListTours
+        showQuickStart(list: tours)
+    }
+
+    private func showQuickStart(list: [QuickStartTour]) {
+        let checklist = QuickStartChecklistViewController(blog: blog, list: list)
+        navigationController?.showDetailViewController(checklist, sender: self)
+
+        QuickStartTourGuide.find()?.visited(.checklist)
+    }
+
     private func showNotificationPrimerAlert() {
         guard noPresentedViewControllers else {
             return

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -45,10 +45,6 @@ extension BlogDetailsViewController {
     }
 
     @objc func shouldShowQuickStartChecklist() -> Bool {
-        guard Feature.enabled(.quickStart) else {
-            return false
-        }
-
         return QuickStartTourGuide.shouldShowChecklist(for: blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -547,7 +547,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     NSMutableArray *rows = [NSMutableArray array];
 
     if ([self shouldShowQuickStartChecklist]) {
-        BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Quick Start", @"Name of the Quick Start feature that guides users through a few tasks to setup their new website.")
+        BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Customize Your Site", @"Name of the Quick Start list that guides users through a few tasks to customize their new website.")
                                                          identifier:BlogDetailsPlanCellIdentifier
                                                               image:[Gridicon iconOfType:GridiconTypeListCheckmark]
                                                            callback:^{
@@ -557,6 +557,19 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
         row.detail = [[QuickStartTourGuide find] detailStringFor:self.blog];
         [rows addObject:row];
+
+        if ([feature enabled:FeatureFlagQuickStartV2]) {
+            BlogDetailsRow *row2 = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Grow Your Audience", @"Name of the Quick Start feature that guides users through a few tasks to grow the audience of their new website.")
+                                                             identifier:BlogDetailsPlanCellIdentifier
+                                                                  image:[Gridicon iconOfType:GridiconTypeListCheckmark]
+                                                               callback:^{
+                                                                   [weakSelf showQuickStart];
+                                                               }];
+            row2.quickStartIdentifier = QuickStartTourElementChecklist;
+
+            row2.detail = [[QuickStartTourGuide find] detailStringFor:self.blog];
+            [rows addObject:row2];
+        }
     }
 
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1323,30 +1323,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
-- (void)showQuickStart
-{
-    QuickStartChecklistViewController *checklist = [[QuickStartChecklistViewController alloc] initWithBlog:self.blog];
-    [self.navigationController showDetailViewController:checklist sender:self];
-
-    [[QuickStartTourGuide find] visited:QuickStartTourElementChecklist];
-}
-
-- (void)showQuickStartCustomize
-{
-    QuickStartChecklistViewController *checklist = [[QuickStartChecklistViewController alloc] initWithBlog:self.blog];
-    [self.navigationController showDetailViewController:checklist sender:self];
-
-    [[QuickStartTourGuide find] visited:QuickStartTourElementChecklist];
-}
-
-- (void)showQuickStartGrow
-{
-    QuickStartChecklistViewController *checklist = [[QuickStartChecklistViewController alloc] initWithBlog:self.blog];
-    [self.navigationController showDetailViewController:checklist sender:self];
-
-    [[QuickStartTourGuide find] visited:QuickStartTourElementChecklist];
-}
-
 - (void)showActivity
 {
     ActivityListViewController *controller = [[ActivityListViewController alloc] initWithBlog:self.blog];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -333,7 +333,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             [self.tableView selectRowAtIndexPath:indexPath
                                         animated:NO
                                   scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
-            [self showQuickStart];
+            [self showQuickStartV1];
             break;
         case BlogDetailsSubsectionStats:
             self.restorableSelectedIndexPath = indexPath;
@@ -553,7 +553,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                      identifier:BlogDetailsPlanCellIdentifier
                                                           image:[Gridicon iconOfType:GridiconTypeListCheckmark]
                                                        callback:^{
-                                                           [weakSelf showQuickStart];
+                                                           [weakSelf showQuickStartCustomize];
                                                        }];
     row.quickStartIdentifier = QuickStartTourElementChecklist;
 
@@ -564,7 +564,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                       identifier:BlogDetailsPlanCellIdentifier
                                                            image:[Gridicon iconOfType:GridiconTypeListCheckmark]
                                                         callback:^{
-                                                            [weakSelf showQuickStart];
+                                                            [weakSelf showQuickStartGrow];
                                                         }];
     row2.quickStartIdentifier = QuickStartTourElementChecklist;
 
@@ -585,7 +585,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                          identifier:BlogDetailsPlanCellIdentifier
                                                               image:[Gridicon iconOfType:GridiconTypeListCheckmark]
                                                            callback:^{
-                                                               [weakSelf showQuickStart];
+                                                               [weakSelf showQuickStartV1];
                                                            }];
         row.quickStartIdentifier = QuickStartTourElementChecklist;
 
@@ -1463,7 +1463,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             NSUInteger generalSectionCountAfter = self.tableSections[0].rows.count;
             if (generalSectionCountBefore != generalSectionCountAfter) {
                 // quick start was just enabled
-                [self showQuickStart];
+                if ([Feature enabled:FeatureFlagQuickStartV2]) {
+                    [self showQuickStartCustomize];
+                } else {
+                    [self showQuickStartV1];
+                }
             }
         }
         [self reloadTableViewPreservingSelection];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -558,7 +558,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         row.detail = [[QuickStartTourGuide find] detailStringFor:self.blog];
         [rows addObject:row];
 
-        if ([feature enabled:FeatureFlagQuickStartV2]) {
+        if ([Feature enabled:FeatureFlagQuickStartV2]) {
             BlogDetailsRow *row2 = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Grow Your Audience", @"Name of the Quick Start feature that guides users through a few tasks to grow the audience of their new website.")
                                                              identifier:BlogDetailsPlanCellIdentifier
                                                                   image:[Gridicon iconOfType:GridiconTypeListCheckmark]

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -5,12 +5,17 @@ class QuickStartChecklistViewController: UITableViewController {
         }
     }
     private var blog: Blog?
+    private var list: [QuickStartTour] = []
     private var observer: NSObjectProtocol?
 
-    @objc
-    convenience init(blog: Blog) {
+    @objc convenience init(blog: Blog) {
+        self.init(blog: blog, list: QuickStartTourGuide.checklistTours)
+    }
+
+    convenience init(blog: Blog, list: [QuickStartTour]) {
         self.init()
         self.blog = blog
+        self.list = list
 
         startObservingForQuickStart()
     }
@@ -37,7 +42,7 @@ class QuickStartChecklistViewController: UITableViewController {
         guard let blog = blog else {
             return
         }
-        dataSource = QuickStartChecklistDataSource(blog: blog)
+        dataSource = QuickStartChecklistDataSource(blog: blog, tours: list)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -140,7 +145,7 @@ private class QuickStartChecklistDataSource: NSObject, UITableViewDataSource {
     // managing tours
 
     func tour(at indexPath: IndexPath) -> QuickStartTour {
-        return QuickStartTourGuide.checklistTours[indexPath.row]
+        return tours[indexPath.row]
     }
 
     func isCompleted(tour: QuickStartTour) -> Bool {
@@ -148,8 +153,9 @@ private class QuickStartChecklistDataSource: NSObject, UITableViewDataSource {
     }
 
     func shouldShowCongratulations() -> Bool {
+        // TODO: fix this count implementation to be compatible with v2
         let completedToursCount = QuickStartTourGuide.countChecklistCompleted(for: blog)
-        return completedToursCount >= QuickStartTourGuide.checklistTours.count
+        return completedToursCount >= tours.count
     }
 
     // UITableViewDataSource
@@ -171,7 +177,7 @@ private class QuickStartChecklistDataSource: NSObject, UITableViewDataSource {
                 return 0
             }
         case .checklistItems:
-            return QuickStartTourGuide.checklistTours.count
+            return tours.count
         case .skipAll:
             return shouldShowCongratulations() ? 0 : 1
         }
@@ -186,7 +192,7 @@ private class QuickStartChecklistDataSource: NSObject, UITableViewDataSource {
                 }
             case .checklistItems:
                 if let cell = tableView.dequeueReusableCell(withIdentifier: QuickStartChecklistCell.reuseIdentifier) as? QuickStartChecklistCell {
-                    let tour = QuickStartTourGuide.checklistTours[indexPath.row]
+                    let tour = tours[indexPath.row]
                     cell.tour = tour
                     cell.completed = isCompleted(tour: tour)
                     return cell

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -115,10 +115,12 @@ class QuickStartChecklistViewController: UITableViewController {
 
 private class QuickStartChecklistDataSource: NSObject, UITableViewDataSource {
     private var blog: Blog
+    private var tours: [QuickStartTour]
     private var completedTours = Set<String>()
 
-    init(blog: Blog) {
+    init(blog: Blog, tours: [QuickStartTour]) {
         self.blog = blog
+        self.tours = tours
 
         super.init()
         loadCompletedTours()

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -232,6 +232,23 @@ open class QuickStartTourGuide: NSObject {
         QuickStartPublishTour(),
         QuickStartFollowTour()
     ]
+
+    static let customizeListTours: [QuickStartTour] = [
+        QuickStartCreateTour(),
+        // upload site icon
+        QuickStartThemeTour(),
+        QuickStartCustomizeTour(),
+        // create new page
+        QuickStartViewTour()
+    ]
+
+    static let growListTours: [QuickStartTour] = [
+        // enable post sharing
+        QuickStartPublishTour(),
+        QuickStartFollowTour(),
+        // check your stats
+        // explore plans
+    ]
 }
 
 private extension QuickStartTourGuide {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -235,19 +235,19 @@ open class QuickStartTourGuide: NSObject {
 
     static let customizeListTours: [QuickStartTour] = [
         QuickStartCreateTour(),
-        // upload site icon
+        QuickStartSiteIconTour(),
         QuickStartThemeTour(),
         QuickStartCustomizeTour(),
-        // create new page
+        QuickStartNewPageTour(),
         QuickStartViewTour()
     ]
 
     static let growListTours: [QuickStartTour] = [
-        // enable post sharing
+        QuickStartPostSharingTour(),
         QuickStartPublishTour(),
         QuickStartFollowTour(),
-        // check your stats
-        // explore plans
+        QuickStartCheckStatsTour(),
+        QuickStartExplorePlansTour()
     ]
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -171,6 +171,66 @@ struct QuickStartFollowTour: QuickStartTour {
     }
 }
 
+struct QuickStartSiteIconTour: QuickStartTour {
+    let key = "quick-start-site-icon-tour"
+    let analyticsKey = "site_icon"
+    let title = NSLocalizedString("Upload a site icon", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("Your visitors will see your icon in their browser. Add a custom icon for a polished, pro look.", comment: "Description of a Quick Start Tour")
+    let icon = Gridicon.iconOfType(.globe)
+    let suggestionNoText = Strings.notNow
+    let suggestionYesText = Strings.yesShowMe
+
+    var waypoints: [WayPoint] = []
+}
+
+struct QuickStartNewPageTour: QuickStartTour {
+    let key = "quick-start-new-page-tour"
+    let analyticsKey = "new_page"
+    let title = NSLocalizedString("Create a new page", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("Add a page for key content — an “About” page is a great start.", comment: "Description of a Quick Start Tour")
+    let icon = Gridicon.iconOfType(.pages)
+    let suggestionNoText = Strings.notNow
+    let suggestionYesText = Strings.yesShowMe
+
+    var waypoints: [WayPoint] = []
+}
+
+struct QuickStartPostSharingTour: QuickStartTour {
+    let key = "quick-start-post-sharing-tour"
+    let analyticsKey = "post_sharing"
+    let title = NSLocalizedString("Enable post sharing", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("Automatically share new posts to your social media accounts.", comment: "Description of a Quick Start Tour")
+    let icon = Gridicon.iconOfType(.share)
+    let suggestionNoText = Strings.notNow
+    let suggestionYesText = Strings.yesShowMe
+
+    var waypoints: [WayPoint] = []
+}
+
+struct QuickStartCheckStatsTour: QuickStartTour {
+    let key = "quick-start-check-stats-tour"
+    let analyticsKey = "check_stats"
+    let title = NSLocalizedString("Check your site stats", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("Keep up to date on your site’s performance.", comment: "Description of a Quick Start Tour")
+    let icon = Gridicon.iconOfType(.statsAlt)
+    let suggestionNoText = Strings.notNow
+    let suggestionYesText = Strings.yesShowMe
+
+    var waypoints: [WayPoint] = []
+}
+
+struct QuickStartExplorePlansTour: QuickStartTour {
+    let key = "quick-start-explore-plans-tour"
+    let analyticsKey = "explore_plans"
+    let title = NSLocalizedString("Explore plans", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("Learn about the marketing and SEO tools in our paid plans.", comment: "Description of a Quick Start Tour")
+    let icon = Gridicon.iconOfType(.plans)
+    let suggestionNoText = Strings.notNow
+    let suggestionYesText = Strings.yesShowMe
+
+    var waypoints: [WayPoint] = []
+}
+
 private let congratsTitle = NSLocalizedString("Congrats on finishing Quick Start  🎉", comment: "Title of a Quick Start Tour")
 private let congratsDescription = NSLocalizedString("doesn’t it feel good to cross things off a list?", comment: "subhead shown to users when they complete all Quick Start items")
 struct QuickStartCongratulationsTour: QuickStartTour {


### PR DESCRIPTION
Refs #10860

This replaces the single, existing Quick Start checklist with the two checklists for V2, hidden behind a feature flag. The tours are now shown in the list, but aren't functional. Also, this is basically functionality, the final UI will come in the future PR.

![screen recording 2019-01-21 at 4 05 20 pm](https://user-images.githubusercontent.com/517257/51504754-84652880-1d97-11e9-9139-803e44e8689d.gif)

To test:
- Create a new site and turn on quick start (or put `return true` in `shouldShowQuickStartChecklist()`)
- Ensure the new checklists appear

Update release notes:
- These changes probably won't be visible to users until `11.8`