### PR TITLE
[Stats Refresh] Add initial Stats Period view

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -276,6 +276,20 @@ private extension StatsInsightsStore {
         return !isFetching
     }
 
+    func setAllAsFetching() {
+        state.fetchingLatestPostSummary = true
+        state.fetchingAllTimeStats = true
+        state.fetchingMostPopularStats = true
+        state.fetchingDotComFollowers = true
+        state.fetchingEmailFollowers = true
+        state.fetchingPublicize = true
+        state.fetchingTodaysStats = true
+        state.fetchingPostingActivity = true
+        state.fetchingCommentsAuthors = true
+        state.fetchingCommentsPosts = true
+        state.fetchingTagsAndCategories = true
+    }
+
 }
 
 // MARK: - Public Accessors
@@ -404,17 +418,4 @@ extension StatsInsightsStore {
             state.fetchingTagsAndCategories
     }
 
-    func setAllAsFetching() {
-        state.fetchingLatestPostSummary = true
-        state.fetchingAllTimeStats = true
-        state.fetchingMostPopularStats = true
-        state.fetchingDotComFollowers = true
-        state.fetchingEmailFollowers = true
-        state.fetchingPublicize = true
-        state.fetchingTodaysStats = true
-        state.fetchingPostingActivity = true
-        state.fetchingCommentsAuthors = true
-        state.fetchingCommentsPosts = true
-        state.fetchingTagsAndCategories = true
-    }
 }

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -1,0 +1,82 @@
+import Foundation
+import WordPressFlux
+import WordPressComStatsiOS
+
+enum PeriodAction: Action {
+
+}
+
+enum PeriodQuery {
+    case periods
+}
+
+struct PeriodStoreState {
+
+}
+
+class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
+
+    init() {
+        super.init(initialState: PeriodStoreState())
+    }
+
+    override func onDispatch(_ action: Action) {
+
+        guard let periodAction = action as? PeriodAction else {
+            return
+        }
+
+        switch periodAction {
+        default:
+            break
+        }
+    }
+
+    override func queriesChanged() {
+        super.queriesChanged()
+        processQueries()
+    }
+
+}
+
+// MARK: - Private Methods
+
+private extension StatsPeriodStore {
+
+    func processQueries() {
+
+        guard !activeQueries.isEmpty && shouldFetch() else {
+            return
+        }
+
+        fetchPeriodData()
+    }
+
+    func fetchPeriodData() {
+
+    }
+
+    func refreshPeriodData() {
+        guard shouldFetch() else {
+            DDLogInfo("Stats Period refresh triggered while one was in progress.")
+            return
+        }
+
+        fetchPeriodData()
+    }
+
+    func shouldFetch() -> Bool {
+        return !isFetching
+    }
+
+}
+
+// MARK: - Public Accessors
+
+extension StatsPeriodStore {
+
+    var isFetching: Bool {
+        return true
+    }
+
+}

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -3,7 +3,7 @@ import WordPressFlux
 import WordPressComStatsiOS
 
 enum PeriodAction: Action {
-
+    case refreshPeriodData()
 }
 
 enum PeriodQuery {
@@ -75,8 +75,12 @@ private extension StatsPeriodStore {
 
 extension StatsPeriodStore {
 
+    func getPostsAndPages() -> [StatsItem]? {
+        return [StatsItem]()
+    }
+
     var isFetching: Bool {
-        return true
+        return false
     }
 
 }

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -11,7 +11,8 @@ enum PeriodQuery {
 }
 
 struct PeriodStoreState {
-
+    var pagesAndPosts: [StatsItem]?
+    var fetchingPagesAndPosts = false
 }
 
 class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
@@ -27,8 +28,8 @@ class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
         }
 
         switch periodAction {
-        default:
-            break
+        case .refreshPeriodData:
+            refreshPeriodData()
         }
     }
 
@@ -54,6 +55,8 @@ private extension StatsPeriodStore {
 
     func fetchPeriodData() {
 
+        // TODO: get some data
+
     }
 
     func refreshPeriodData() {
@@ -76,11 +79,11 @@ private extension StatsPeriodStore {
 extension StatsPeriodStore {
 
     func getPostsAndPages() -> [StatsItem]? {
-        return [StatsItem]()
+        return state.pagesAndPosts
     }
 
     var isFetching: Bool {
-        return false
+        return state.fetchingPagesAndPosts
     }
 
 }

--- a/WordPress/Classes/Stores/StoreContainer.swift
+++ b/WordPress/Classes/Stores/StoreContainer.swift
@@ -16,5 +16,6 @@ class StoreContainer {
     let timezone = TimeZoneStore()
     let activity = ActivityStore()
     let statsInsights = StatsInsightsStore()
+    let statsPeriod = StatsPeriodStore()
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -1,0 +1,48 @@
+import UIKit
+
+class SiteStatsPeriodTableViewController: UITableViewController {
+
+    // MARK: - Properties
+
+
+    // MARK: - View
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tableView.backgroundColor = WPStyleGuide.greyLighten30()
+        setupSimpleTotalsCell()
+        // refreshControl?.addTarget(self, action: #selector(refreshData), for: .valueChanged)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+    }
+
+    // MARK: - Table view data source
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: SimpleTotalsCell.defaultReuseID, for: indexPath) as! SimpleTotalsCell
+
+        cell.configure(dataRows: [])
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func setupSimpleTotalsCell() {
+        let nib = UINib(nibName: SimpleTotalsCell.defaultNibName, bundle: nil)
+        tableView.register(nib, forCellReuseIdentifier: SimpleTotalsCell.defaultReuseID)
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -31,6 +31,8 @@ class SiteStatsPeriodTableViewController: UITableViewController {
 
 private extension SiteStatsPeriodTableViewController {
 
+    // MARK: - View Model
+
     func initViewModel() {
         viewModel = SiteStatsPeriodViewModel(store: store)
         refreshTableView()

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -14,6 +14,7 @@ class SiteStatsPeriodTableViewController: UITableViewController {
 
     var periodDisplayed: PeriodDisplayed? = .days {
         didSet {
+            DDLogInfo("Stats Period selected: \(String(describing: periodDisplayed))")
             guard periodDisplayed != nil else {
                 return
             }
@@ -79,11 +80,11 @@ private extension SiteStatsPeriodTableViewController {
         }
 
         tableHandler.viewModel = viewModel.tableViewModel()
-        refreshControl?.endRefreshing()
+//        refreshControl?.endRefreshing()
     }
 
     @objc func refreshData() {
-        refreshControl?.beginRefreshing()
+//        refreshControl?.beginRefreshing()
 
         // TODO: use PeriodDisplayed when fetching data
         viewModel?.refreshPeriodData()

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -1,9 +1,25 @@
 import UIKit
 import WordPressFlux
 
+enum PeriodDisplayed: Int {
+    case days = 1
+    case weeks
+    case months
+    case years
+}
+
 class SiteStatsPeriodTableViewController: UITableViewController {
 
     // MARK: - Properties
+
+    var periodDisplayed: PeriodDisplayed? = .days {
+        didSet {
+            guard periodDisplayed != nil else {
+                return
+            }
+            refreshData()
+        }
+    }
 
     private let store = StoreContainer.shared.statsPeriod
     private var changeReceipt: Receipt?
@@ -35,7 +51,11 @@ private extension SiteStatsPeriodTableViewController {
 
     func initViewModel() {
         viewModel = SiteStatsPeriodViewModel(store: store)
+
+        // TODO: remove this when code below is utilized.
         refreshTableView()
+
+        // TODO: uncomment this when the Store actually does something.
 
 //        changeReceipt = viewModel?.onChange { [weak self] in
 //            guard let store = self?.store,
@@ -64,6 +84,8 @@ private extension SiteStatsPeriodTableViewController {
 
     @objc func refreshData() {
         refreshControl?.beginRefreshing()
+
+        // TODO: use PeriodDisplayed when fetching data
         viewModel?.refreshPeriodData()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -1,0 +1,20 @@
+import Foundation
+import WordPressFlux
+
+/// The view model used by Period Stats.
+///
+
+class SiteStatsPeriodViewModel: Observable {
+
+    // MARK: - Properties
+
+    let changeDispatcher = Dispatcher<Void>()
+
+
+    // MARK: - Constructor
+
+    init() {
+    }
+
+
+}

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -10,10 +10,72 @@ class SiteStatsPeriodViewModel: Observable {
 
     let changeDispatcher = Dispatcher<Void>()
 
+    private let store: StatsPeriodStore
+    private let periodReceipt: Receipt
+    private var changeReceipt: Receipt?
+    private typealias Style = WPStyleGuide.Stats
 
     // MARK: - Constructor
 
-    init() {
+    init(store: StatsPeriodStore = StoreContainer.shared.statsPeriod) {
+        self.store = store
+        periodReceipt = store.query(.periods)
+
+        changeReceipt = store.onChange { [weak self] in
+            self?.emitChange()
+        }
+    }
+
+    // MARK: - Table Model
+
+    func tableViewModel() -> ImmuTable {
+
+        var tableRows = [ImmuTableRow]()
+
+        // Posts and Pages
+        tableRows.append(CellHeaderRow(title: PeriodHeaders.postsAndPages))
+        tableRows.append(TopTotalsStatsRow(itemSubtitle: PostsAndPages.itemSubtitle,
+                                           dataSubtitle: PostsAndPages.dataSubtitle,
+                                           dataRows: createPostsAndPagesRows(),
+                                           siteStatsInsightsDelegate: nil))
+
+        return ImmuTable(sections: [
+            ImmuTableSection(
+                rows: tableRows)
+            ])
+    }
+
+    // MARK: - Refresh Data
+
+    func refreshPeriodData() {
+        ActionDispatcher.dispatch(PeriodAction.refreshPeriodData())
+    }
+}
+
+// MARK: - Private Extension
+
+private extension SiteStatsPeriodViewModel {
+
+    // Period Stats strings
+
+    struct PeriodHeaders {
+        static let postsAndPages = NSLocalizedString("Posts and Pages", comment: "Period Stats 'Posts and Pages' header")
+    }
+
+    struct PostsAndPages {
+        static let itemSubtitle = NSLocalizedString("Title", comment: "Posts and Pages label for post/page title")
+        static let dataSubtitle = NSLocalizedString("Views", comment: "Posts and Pages label for number of views")
+    }
+
+    // Create Period Rows
+
+    func createPostsAndPagesRows() -> [StatsTotalRowData] {
+        let postsAndPages = store.getPostsAndPages()
+        var dataRows = [StatsTotalRowData]()
+
+
+
+        return dataRows
     }
 
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -70,13 +70,24 @@ private extension SiteStatsPeriodViewModel {
     // Create Period Rows
 
     func createPostsAndPagesRows() -> [StatsTotalRowData] {
-        let postsAndPages = store.getPostsAndPages()
+
         var dataRows = [StatsTotalRowData]()
 
+        // TODO: replace with real Pages and Posts data from the Store
+        // let postsAndPages = store.getPostsAndPages()
 
+        let icon = Style.imageForGridiconType(.folder)
+
+        for count in 1...10 {
+            let row = StatsTotalRowData.init(name: "Row \(count)" ,
+                                             data: "666",
+                                             icon: icon,
+                                             showDisclosure: true)
+
+            dataRows.append(row)
+        }
 
         return dataRows
     }
-
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -32,12 +32,7 @@ class SiteStatsPeriodViewModel: Observable {
 
         var tableRows = [ImmuTableRow]()
 
-        // Posts and Pages
-        tableRows.append(CellHeaderRow(title: PeriodHeaders.postsAndPages))
-        tableRows.append(TopTotalsStatsRow(itemSubtitle: PostsAndPages.itemSubtitle,
-                                           dataSubtitle: PostsAndPages.dataSubtitle,
-                                           dataRows: createPostsAndPagesRows(),
-                                           siteStatsInsightsDelegate: nil))
+        tableRows.append(contentsOf: postsAndPagesTableRows())
 
         return ImmuTable(sections: [
             ImmuTableSection(
@@ -69,7 +64,19 @@ private extension SiteStatsPeriodViewModel {
 
     // Create Period Rows
 
-    func createPostsAndPagesRows() -> [StatsTotalRowData] {
+    func postsAndPagesTableRows() -> [ImmuTableRow] {
+
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(title: PeriodHeaders.postsAndPages))
+        tableRows.append(TopTotalsStatsRow(itemSubtitle: PostsAndPages.itemSubtitle,
+                                           dataSubtitle: PostsAndPages.dataSubtitle,
+                                           dataRows: postsAndPagesDataRows(),
+                                           siteStatsInsightsDelegate: nil))
+
+        return tableRows
+    }
+
+    func postsAndPagesDataRows() -> [StatsTotalRowData] {
 
         var dataRows = [StatsTotalRowData]()
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -30,7 +30,7 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
     func configure(itemSubtitle: String,
                    dataSubtitle: String,
                    dataRows: [StatsTotalRowData],
-                   siteStatsInsightsDelegate: SiteStatsInsightsDelegate) {
+                   siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
         itemSubtitleLabel.text = itemSubtitle
         dataSubtitleLabel.text = dataSubtitle
         self.dataRows = dataRows

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Tqa-zb-Liz">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Tqa-zb-Liz">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -106,8 +106,8 @@
         <!--Stats Table View Controller-->
         <scene sceneID="VVg-67-Gst">
             <objects>
-                <tableViewController id="plb-uA-RCD" userLabel="Stats Table View Controller" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="zaS-th-YDU">
+                <tableViewController id="plb-uA-RCD" userLabel="Stats Table View Controller" customClass="SiteStatsPeriodTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="zaS-th-YDU">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="557"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -116,6 +116,9 @@
                             <outlet property="delegate" destination="plb-uA-RCD" id="2Qq-uI-Ae3"/>
                         </connections>
                     </tableView>
+                    <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="8ir-7a-bdo">
+                        <autoresizingMask key="autoresizingMask"/>
+                    </refreshControl>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lv3-Hh-4h3" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -8,12 +8,8 @@ class SiteStatsDashboardViewController: UIViewController {
     @IBOutlet weak var insightsContainerView: UIView!
     @IBOutlet weak var statsContainerView: UIView!
 
-    var insightsTableViewController: SiteStatsInsightsTableViewController?
-
-    // TODO: replace UITableViewController with real controller names that
-    // corresponds to Stats.
-
-    var statsTableViewController: UITableViewController?
+    private var insightsTableViewController: SiteStatsInsightsTableViewController?
+    private var periodTableViewController: SiteStatsPeriodTableViewController?
 
     // MARK: - View
 
@@ -26,6 +22,10 @@ class SiteStatsDashboardViewController: UIViewController {
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let insightsTableVC = segue.destination as? SiteStatsInsightsTableViewController {
             insightsTableViewController = insightsTableVC
+        }
+
+        if let periodTableVC = segue.destination as? SiteStatsPeriodTableViewController {
+            periodTableViewController = periodTableVC
         }
     }
 
@@ -77,19 +77,6 @@ private extension SiteStatsDashboardViewController {
     func setContainerViewVisibility() {
         statsContainerView.isHidden = currentSelectedPeriod == .insights
         insightsContainerView.isHidden = !statsContainerView.isHidden
-    }
-
-    func shouldShowProgressView(viewController: UIViewController) -> Bool {
-
-        var shouldShow = false
-
-        if viewController == insightsTableViewController {
-            shouldShow = !insightsContainerView.isHidden
-        } else if viewController == statsTableViewController {
-            shouldShow = !statsContainerView.isHidden
-        }
-
-        return shouldShow
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -44,10 +44,10 @@ private extension SiteStatsDashboardViewController {
 
     enum StatsPeriodType: Int {
         case insights = 0
-        case days = 1
-        case weeks = 2
-        case months = 3
-        case years = 4
+        case days
+        case weeks
+        case months
+        case years
 
         static let allPeriods = [StatsPeriodType.insights, .days, .weeks, .months, .years]
 
@@ -93,8 +93,7 @@ private extension SiteStatsDashboardViewController {
 
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
         currentSelectedPeriod = StatsPeriodType(rawValue: filterBar.selectedIndex) ?? StatsPeriodType.insights
-
-        // TODO: reload view based on selected tab
+        periodTableViewController?.periodDisplayed = PeriodDisplayed.init(rawValue: currentSelectedPeriod.rawValue)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -130,7 +130,7 @@ struct TopTotalsStatsRow: ImmuTableRow {
     let itemSubtitle: String
     let dataSubtitle: String
     let dataRows: [StatsTotalRowData]
-    let siteStatsInsightsDelegate: SiteStatsInsightsDelegate
+    let siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -876,6 +876,8 @@
 		9848DF8321B8BB6900B99DA4 /* PostingActivityLegend.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9848DF8221B8BB6900B99DA4 /* PostingActivityLegend.xib */; };
 		984B020E200D59B900179E75 /* SiteCreationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984B020D200D59B900179E75 /* SiteCreationService.swift */; };
 		984B138E21F65F870004B6A2 /* SiteStatsPeriodTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984B138D21F65F860004B6A2 /* SiteStatsPeriodTableViewController.swift */; };
+		984B139221F66AC60004B6A2 /* SiteStatsPeriodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984B139121F66AC50004B6A2 /* SiteStatsPeriodViewModel.swift */; };
+		984B139421F66B2D0004B6A2 /* StatsPeriodStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984B139321F66B2D0004B6A2 /* StatsPeriodStore.swift */; };
 		984B4EF320742FCC00F87888 /* ZendeskUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984B4EF220742FCC00F87888 /* ZendeskUtils.swift */; };
 		984F86FB21DEDB070070E0E3 /* TopTotalsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984F86FA21DEDB060070E0E3 /* TopTotalsCell.swift */; };
 		98563DDD21BF30C40006F5E9 /* TabbedTotalsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98563DDB21BF30C40006F5E9 /* TabbedTotalsCell.swift */; };
@@ -2784,6 +2786,8 @@
 		9848DF8221B8BB6900B99DA4 /* PostingActivityLegend.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PostingActivityLegend.xib; sourceTree = "<group>"; };
 		984B020D200D59B900179E75 /* SiteCreationService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteCreationService.swift; sourceTree = "<group>"; };
 		984B138D21F65F860004B6A2 /* SiteStatsPeriodTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsPeriodTableViewController.swift; sourceTree = "<group>"; };
+		984B139121F66AC50004B6A2 /* SiteStatsPeriodViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsPeriodViewModel.swift; sourceTree = "<group>"; };
+		984B139321F66B2D0004B6A2 /* StatsPeriodStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsPeriodStore.swift; sourceTree = "<group>"; };
 		984B4EF220742FCC00F87888 /* ZendeskUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZendeskUtils.swift; sourceTree = "<group>"; };
 		984F86FA21DEDB060070E0E3 /* TopTotalsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTotalsCell.swift; sourceTree = "<group>"; };
 		98563DDB21BF30C40006F5E9 /* TabbedTotalsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedTotalsCell.swift; sourceTree = "<group>"; };
@@ -6128,6 +6132,7 @@
 			isa = PBXGroup;
 			children = (
 				984B138D21F65F860004B6A2 /* SiteStatsPeriodTableViewController.swift */,
+				984B139121F66AC50004B6A2 /* SiteStatsPeriodViewModel.swift */,
 			);
 			path = "Period Stats";
 			sourceTree = "<group>";
@@ -7796,6 +7801,7 @@
 				E1CA0A6B1FA73053004C4BBE /* PluginStore.swift */,
 				40ADB15420686870009A9161 /* PluginStore+Persistence.swift */,
 				98AE3DF4219A1788003C0E24 /* StatsInsightsStore.swift */,
+				984B139321F66B2D0004B6A2 /* StatsPeriodStore.swift */,
 				E1CB6DA2200F376400945457 /* TimeZoneStore.swift */,
 			);
 			path = Stores;
@@ -9670,6 +9676,7 @@
 				439F4F3A219B715300F8D0C7 /* RevisionsNavigationController.swift in Sources */,
 				D818FFDE219177DA000E5FEE /* SiteSegmentsDelegate.swift in Sources */,
 				17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */,
+				984B139221F66AC60004B6A2 /* SiteStatsPeriodViewModel.swift in Sources */,
 				98A437AE20069098004A8A57 /* DomainSuggestionsTableViewController.swift in Sources */,
 				5D1D04761B7A50B100CDE646 /* ReaderStreamViewController.swift in Sources */,
 				B57B92BD1B73B08100DFF00B /* SeparatorsView.swift in Sources */,
@@ -10012,6 +10019,7 @@
 				08216FD11CDBF96000304BA7 /* MenuItemSourceResultsViewController.m in Sources */,
 				4349B0AC218A45270034118A /* RevisionsTableViewController.swift in Sources */,
 				E1209FA41BB4978B00D69778 /* PeopleService.swift in Sources */,
+				984B139421F66B2D0004B6A2 /* StatsPeriodStore.swift in Sources */,
 				735752C7218A7C7700E75EF6 /* LocationResultsTableViewController.swift in Sources */,
 				E13A8C9B1C3E6EF2005BB1C1 /* ImmuTable+WordPress.swift in Sources */,
 				D8CB56232181A95D00554EAE /* SiteSegment.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -875,6 +875,7 @@
 		9848DF8121B8BB5700B99DA4 /* PostingActivityLegend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9848DF8021B8BB5600B99DA4 /* PostingActivityLegend.swift */; };
 		9848DF8321B8BB6900B99DA4 /* PostingActivityLegend.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9848DF8221B8BB6900B99DA4 /* PostingActivityLegend.xib */; };
 		984B020E200D59B900179E75 /* SiteCreationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984B020D200D59B900179E75 /* SiteCreationService.swift */; };
+		984B138E21F65F870004B6A2 /* SiteStatsPeriodTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984B138D21F65F860004B6A2 /* SiteStatsPeriodTableViewController.swift */; };
 		984B4EF320742FCC00F87888 /* ZendeskUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984B4EF220742FCC00F87888 /* ZendeskUtils.swift */; };
 		984F86FB21DEDB070070E0E3 /* TopTotalsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984F86FA21DEDB060070E0E3 /* TopTotalsCell.swift */; };
 		98563DDD21BF30C40006F5E9 /* TabbedTotalsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98563DDB21BF30C40006F5E9 /* TabbedTotalsCell.swift */; };
@@ -2782,6 +2783,7 @@
 		9848DF8021B8BB5600B99DA4 /* PostingActivityLegend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostingActivityLegend.swift; sourceTree = "<group>"; };
 		9848DF8221B8BB6900B99DA4 /* PostingActivityLegend.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PostingActivityLegend.xib; sourceTree = "<group>"; };
 		984B020D200D59B900179E75 /* SiteCreationService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteCreationService.swift; sourceTree = "<group>"; };
+		984B138D21F65F860004B6A2 /* SiteStatsPeriodTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsPeriodTableViewController.swift; sourceTree = "<group>"; };
 		984B4EF220742FCC00F87888 /* ZendeskUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZendeskUtils.swift; sourceTree = "<group>"; };
 		984F86FA21DEDB060070E0E3 /* TopTotalsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTotalsCell.swift; sourceTree = "<group>"; };
 		98563DDB21BF30C40006F5E9 /* TabbedTotalsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedTotalsCell.swift; sourceTree = "<group>"; };
@@ -4509,6 +4511,7 @@
 				98747670219638990080967F /* Extensions */,
 				98747674219644E40080967F /* Helpers */,
 				98747671219638BF0080967F /* Insights */,
+				984B138C21F65F680004B6A2 /* Period Stats */,
 				98F89D47219E008600190EE6 /* Shared Views */,
 				7470840D1E269669002CA726 /* JetpackLoginViewController.swift */,
 				7470840E1E269669002CA726 /* JetpackLoginViewController.xib */,
@@ -6119,6 +6122,14 @@
 				4308ACFC210107F90059EA64 /* SiteCreationDomainSuggestionsTableViewController.swift */,
 			);
 			name = "Site Creation";
+			sourceTree = "<group>";
+		};
+		984B138C21F65F680004B6A2 /* Period Stats */ = {
+			isa = PBXGroup;
+			children = (
+				984B138D21F65F860004B6A2 /* SiteStatsPeriodTableViewController.swift */,
+			);
+			path = "Period Stats";
 			sourceTree = "<group>";
 		};
 		984B4EF120742FB900F87888 /* Zendesk */ = {
@@ -9400,6 +9411,7 @@
 				E1222B631F877FD700D23173 /* WebProgressView.swift in Sources */,
 				E185042F1EE6ABD9005C234C /* Restorer.swift in Sources */,
 				D800D86A20997E0C00E7C7E5 /* LikedMenuItemCreator.swift in Sources */,
+				984B138E21F65F870004B6A2 /* SiteStatsPeriodTableViewController.swift in Sources */,
 				98AD07651FFFF96B00485ACA /* SiteCreationSiteDetailsViewController.swift in Sources */,
 				5DFA7EC71AF814E40072023B /* PageListTableViewCell.m in Sources */,
 				5D62BAD718AA88210044E5F7 /* PageSettingsViewController.m in Sources */,


### PR DESCRIPTION
Fixes #n/a

This adds an initial view for Stats Period views (Days, Weeks, Months, Years).
- New `SiteStatsPeriodTableViewController`
- New `SiteStatsPeriodViewModel`
- New `StatsPeriodStore`
- A stub `Posts and Pages` card is displayed with fake data just to show something. It will be complete with a future task.

To test:
Go to Stats > Days, Weeks, Months, or Years.
- Since the data is fake, selecting period filters doesn't do anything yet. But there is a temporary log message indicating the change:
```
Stats Period selected: Optional(WordPress.PeriodDisplayed.weeks)
Stats Period selected: Optional(WordPress.PeriodDisplayed.months)
Stats Period selected: Optional(WordPress.PeriodDisplayed.years)
```

- Verify the view is:

<img width="350" alt="initial_card" src="https://user-images.githubusercontent.com/1816888/51505457-bc726880-1da3-11e9-856d-be80f69ed1b5.png">
