### PR TITLE
Fix an issue where images height is set to screen height.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -277,7 +277,7 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
             width = textContainer.size.width
         }
 
-        let height: CGFloat = attachment.height > 0 ? attachment.height : maxDisplaySize.height
+        let height: CGFloat = attachment.height > 0 ? attachment.height : width / 2.0
 
         return CGSize(width: width, height: height)
     }

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextImage.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextImage.swift
@@ -96,7 +96,7 @@ open class WPRichTextImage: UIControl, WPRichTextMediaAttachment {
         guard size.height > 0, size.width > 0 else {
             return CGSize(width: 1.0, height: 1.0)
         }
-        return imageView.intrinsicContentSize
+        return size
     }
 
     func clean() {


### PR DESCRIPTION
Fixes #10848 
See discussion on: https://github.com/wordpress-mobile/WordPress-iOS/issues/10834

Possibly caused by changes made in this PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/1035

ImageLoader has been passed a preferred size since this commit: https://github.com/wordpress-mobile/WordPress-iOS/commit/603a262ef27e0c59479da4cb2898bd9c5479e798
according to the inline comments in LoadImage function: "The preferred size of the image to load. You can pass height 0 to set width and preserve aspect ratio."

And in this commit: https://github.com/wordpress-mobile/WordPress-iOS/commit/e11629c7dcc5eeea3a2f663492895b008c136a5d
The returned height for when the size is 0 is the maxDisplayedSize which is the screen height, but the height at this point was being set to finalSize.width / 2.0 so it didn't get to be set to the screen height
unless finalSize was 0.

I'm not sure why we need to return the maxDisplaySize.height for an attachment so I updated it to return width / 2.0 in case it's 0.



To test:
Notifications-> Load a Post-> Tap on the comments bubble
and possibly also in Reader-> Tap on the comments bubble

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.