### PR TITLE
Fix a layout issue when we don’t have image size

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,4 @@
 * Fixed an issue where the message field in "Customize the message" screen was empty.
 * Added clarification text about empty messages to footer of "Customize your message" screen.
 * Adds support for iOS's password autofill when entering a username during login
+* Fixes an issue where there'd be big spaces on top of (or below) some images.

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -298,8 +298,15 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
         let finalSize = efficientImageSize(with: url, proposedSize: proposedSize)
         let image = richTextImage(with: finalSize, url, attachment)
 
+        let isUsingTemporaryLayoutDimensions = finalSize.height == 0
+
         // show that something is loading.
-        attachment.maxSize = CGSize(width: proposedSize.width, height: proposedSize.height)
+        if isUsingTemporaryLayoutDimensions {
+            attachment.maxSize = CGSize(width: finalSize.width, height: finalSize.width / 2)
+        }
+        else {
+            attachment.maxSize = CGSize(width: finalSize.width, height: finalSize.height)
+        }
 
         let contentInformation = ContentInformation(isPrivateOnWPCom: isPrivate, isSelfHostedWithCredentials: false)
         let index = mediaArray.count
@@ -311,6 +318,10 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
             }
 
             richMedia.attachment.maxSize = image.contentSize()
+
+            if isUsingTemporaryLayoutDimensions {
+                self?.layoutAttachmentViews()
+            }
         }, onError: { (indexPath, error) in
             DDLogError("\(String(describing: error))")
         })


### PR DESCRIPTION
Fixes #10834

To test: Try with gifs, comments, and non-animated, fixed-size images. Also, watch the CPU usage – it should peak quickly when loading in a new image or when loading the initial post. This is important because the original PR addressed a crash caused by excessive CPU usage.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
