### PR TITLE
Corrected keyboard offset behavior on both Verticals & Domains screens in Site Creation

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TableViewOffsetCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TableViewOffsetCoordinator.swift
@@ -1,0 +1,117 @@
+
+import UIKit
+
+/// In Site Creation, both Verticals & Domains coordinate table view header appearance, keyboard behavior, & offsets.
+/// This class manages that shared behavior.
+///
+final class TableViewOffsetCoordinator {
+
+    // MARK: Properties
+    private struct Constants {
+        static let headerAnimationDuration  = Double(0.25)  // matches current system keyboard transition duration
+        static let topMargin                = CGFloat(36)
+    }
+
+    /// The table view to coordinate
+    private weak var tableView: UITableView?
+
+    /// The value of the bottom constraint constant is set in response to the keyboard appearance
+    private var keyboardContentOffset = CGFloat(0)
+
+    /// To avoid wasted animations, we track whether or not we have already adjusted the table view
+    private var tableViewHasBeenAdjusted = false
+
+    // MARK: TableViewOffsetCoordinator
+
+    /// Initializes a table view offset coordinator with the specified table view.
+    ///
+    /// - Parameter tableView: the table view to manage
+    ///
+    init(coordinated tableView: UITableView) {
+        self.tableView = tableView
+    }
+
+    // MARK: Internal behavior
+
+    /// This method hides the table view header and adjusts the content offset so that the input text field is visible.
+    ///
+    func adjustTableOffsetIfNeeded() {
+        guard let tableView = tableView, keyboardContentOffset > 0, tableViewHasBeenAdjusted == false else {
+            return
+        }
+
+        let topInset: CGFloat
+        if WPDeviceIdentification.isiPhone(), let header = tableView.tableHeaderView as? TitleSubtitleTextfieldHeader {
+            let textfieldFrame = header.textField.frame
+            topInset = textfieldFrame.origin.y - Constants.topMargin
+        } else {
+            topInset = 0
+        }
+
+        let bottomInset: CGFloat
+        if WPDeviceIdentification.isiPad() && UIDevice.current.orientation.isPortrait {
+            bottomInset = 0
+        } else {
+            bottomInset = keyboardContentOffset
+        }
+
+        let targetInsets = UIEdgeInsets(top: -topInset, left: 0, bottom: bottomInset, right: 0)
+
+        UIView.animate(withDuration: Constants.headerAnimationDuration, delay: 0, options: .beginFromCurrentState, animations: { [weak self] in
+            guard let self = self, let tableView = self.tableView else {
+                return
+            }
+
+            tableView.contentInset = targetInsets
+            tableView.scrollIndicatorInsets = targetInsets
+            if WPDeviceIdentification.isiPhone(), let header = tableView.tableHeaderView as? TitleSubtitleTextfieldHeader {
+                header.titleSubtitle.alpha = 0.0
+            }
+        }, completion: { [weak self] _ in
+            self?.tableViewHasBeenAdjusted = true
+        })
+    }
+
+    /// This method resets the table view header and the content offset to the default state.
+    ///
+    func resetTableOffsetIfNeeded() {
+        guard WPDeviceIdentification.isiPhone(), tableViewHasBeenAdjusted == true else {
+            return
+        }
+
+        UIView.animate(withDuration: Constants.headerAnimationDuration, delay: 0, options: .beginFromCurrentState, animations: { [weak self] in
+            guard let self = self, let tableView = self.tableView else {
+                return
+            }
+
+            tableView.contentInset = .zero
+            tableView.scrollIndicatorInsets = .zero
+            if WPDeviceIdentification.isiPhone(), let header = tableView.tableHeaderView as? TitleSubtitleTextfieldHeader {
+                header.titleSubtitle.alpha = 1.0
+            }
+        }, completion: { [weak self] _ in
+            self?.tableViewHasBeenAdjusted = false
+        })
+    }
+
+    @objc
+    func keyboardWillShow(_ notification: Foundation.Notification) {
+        guard let payload = KeyboardInfo(notification) else {
+            return
+        }
+
+        let keyboardScreenFrame = payload.frameEnd
+        keyboardContentOffset = keyboardScreenFrame.height
+    }
+
+    func startListeningToKeyboardNotifications() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(keyboardWillShow),
+                                               name: UIResponder.keyboardWillShowNotification,
+                                               object: nil)
+    }
+
+    func stopListeningToKeyboardNotifications() {
+        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -24,11 +24,6 @@ final class WebAddressWizardContent: UIViewController {
     /// Serves as both the data source & delegate of the table view
     private(set) var tableViewProvider: TableViewProvider?
 
-    /// We manipulate the bottom constraint in response to the keyboard.
-    private lazy var bottomConstraint: NSLayoutConstraint = {
-        return self.table.bottomAnchor.constraint(equalTo: self.view.prevailingLayoutGuide.bottomAnchor)
-    }()
-
     /// The throttle meters requests to the remote service
     private let throttle = Scheduler(seconds: 0.5)
 
@@ -52,7 +47,7 @@ final class WebAddressWizardContent: UIViewController {
     private let noResultsLabel: UILabel
 
     /// The value of the bottom constraint constant is set in response to the keyboard appearance
-    private var bottomConstraintConstant = CGFloat(0)
+    private var keyboardContentOffset = CGFloat(0)
 
     /// To avoid wasted animations, we track whether or not we have already adjusted the table view
     private var tableViewHasBeenAdjusted = false
@@ -316,10 +311,10 @@ final class WebAddressWizardContent: UIViewController {
 
         NSLayoutConstraint.activate([
             table.topAnchor.constraint(equalTo: view.prevailingLayoutGuide.topAnchor),
-            bottomConstraint,
+            table.bottomAnchor.constraint(equalTo: view.prevailingLayoutGuide.bottomAnchor),
             table.leadingAnchor.constraint(equalTo: view.prevailingLayoutGuide.leadingAnchor),
             table.trailingAnchor.constraint(equalTo: view.prevailingLayoutGuide.trailingAnchor),
-            ])
+        ])
     }
 
     private func setupTableDataProvider(_ data: [DomainSuggestion] = []) {
@@ -364,41 +359,44 @@ extension WebAddressWizardContent: UITextFieldDelegate {
     }
 }
 
-
 // MARK: - Keyboard management
 
 private extension WebAddressWizardContent {
     struct Constants {
-        static let bottomMargin             = CGFloat(0)
         static let headerAnimationDuration  = Double(0.25)  // matches current system keyboard transition duration
         static let topMargin                = CGFloat(36)
     }
 
     func adjustTableOffsetIfNeeded(_ animationDuration: Double = Constants.headerAnimationDuration) {
-        guard WPDeviceIdentification.isiPhone(), bottomConstraintConstant > 0, tableViewHasBeenAdjusted == false else {
+        guard keyboardContentOffset > 0, tableViewHasBeenAdjusted == false else {
             return
         }
 
-        bottomConstraint.constant = bottomConstraintConstant
-        view.setNeedsUpdateConstraints()
-
-        let targetInsets: UIEdgeInsets
-        if let header = table.tableHeaderView as? TitleSubtitleTextfieldHeader {
+        let topInset: CGFloat
+        if WPDeviceIdentification.isiPhone(), let header = table.tableHeaderView as? TitleSubtitleTextfieldHeader {
             let textfieldFrame = header.textField.frame
-            targetInsets = UIEdgeInsets(top: (-1 * textfieldFrame.origin.y) + Constants.topMargin, left: 0.0, bottom: bottomConstraintConstant, right: 0.0)
+            topInset = textfieldFrame.origin.y - Constants.topMargin
         } else {
-            targetInsets = .zero
+            topInset = 0
         }
+
+        let bottomInset: CGFloat
+        if WPDeviceIdentification.isiPad() && UIDevice.current.orientation.isPortrait {
+            bottomInset = 0
+        } else {
+            bottomInset = keyboardContentOffset
+        }
+
+        let targetInsets = UIEdgeInsets(top: -topInset, left: 0, bottom: bottomInset, right: 0)
 
         UIView.animate(withDuration: animationDuration, delay: 0, options: .beginFromCurrentState, animations: { [weak self] in
             guard let self = self else {
                 return
             }
 
-            self.view.layoutIfNeeded()
             self.table.contentInset = targetInsets
             self.table.scrollIndicatorInsets = targetInsets
-            if let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader {
+            if WPDeviceIdentification.isiPhone(), let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader {
                 header.titleSubtitle.alpha = 0.0
             }
             }, completion: { [weak self] _ in
@@ -415,12 +413,8 @@ private extension WebAddressWizardContent {
         let keyboardScreenFrame = payload.frameEnd
         let convertedKeyboardFrame = view.convert(keyboardScreenFrame, from: nil)
 
-        var adjustedKeyboardHeight = convertedKeyboardFrame.height
-        if #available(iOS 11.0, *) {
-            let bottomInset = view.safeAreaInsets.bottom
-            adjustedKeyboardHeight -= bottomInset
-        }
-        bottomConstraintConstant = adjustedKeyboardHeight
+        let adjustedKeyboardHeight = convertedKeyboardFrame.height
+        keyboardContentOffset = adjustedKeyboardHeight
     }
 
     func resetTableOffsetIfNeeded(_ animationDuration: Double = Constants.headerAnimationDuration) {
@@ -433,12 +427,9 @@ private extension WebAddressWizardContent {
                 return
             }
 
-            self.view.layoutIfNeeded()
-            self.noResultsLabel.isHidden = true
             self.table.contentInset = .zero
             self.table.scrollIndicatorInsets = .zero
-            self.bottomConstraint.constant = Constants.bottomMargin
-            if let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader {
+            if WPDeviceIdentification.isiPhone(), let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader {
                 header.titleSubtitle.alpha = 1.0
             }
             }, completion: { [weak self] _ in

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -24,6 +24,9 @@ final class WebAddressWizardContent: UIViewController {
     /// Serves as both the data source & delegate of the table view
     private(set) var tableViewProvider: TableViewProvider?
 
+    /// Manages header visibility, keyboard management, and table view offset
+    private(set) var tableViewOffsetCoordinator: TableViewOffsetCoordinator?
+
     /// The throttle meters requests to the remote service
     private let throttle = Scheduler(seconds: 0.5)
 
@@ -45,12 +48,6 @@ final class WebAddressWizardContent: UIViewController {
 
     /// This message advises the user that
     private let noResultsLabel: UILabel
-
-    /// The value of the bottom constraint constant is set in response to the keyboard appearance
-    private var keyboardContentOffset = CGFloat(0)
-
-    /// To avoid wasted animations, we track whether or not we have already adjusted the table view
-    private var tableViewHasBeenAdjusted = false
 
     // MARK: WebAddressWizardContent
 
@@ -92,6 +89,8 @@ final class WebAddressWizardContent: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        self.tableViewOffsetCoordinator = TableViewOffsetCoordinator(coordinated: table)
+
         applyTitle()
         setupBackground()
         setupTable()
@@ -100,7 +99,7 @@ final class WebAddressWizardContent: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         observeNetworkStatus()
-        startListeningToKeyboardNotifications()
+        tableViewOffsetCoordinator?.startListeningToKeyboardNotifications()
         prepareViewIfNeeded()
     }
 
@@ -117,7 +116,7 @@ final class WebAddressWizardContent: UIViewController {
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
 
-        stopListeningToKeyboardNotifications()
+        tableViewOffsetCoordinator?.stopListeningToKeyboardNotifications()
         clearContent()
     }
 
@@ -135,7 +134,7 @@ final class WebAddressWizardContent: UIViewController {
             return
         }
         validDataProvider.data = []
-        resetTableOffsetIfNeeded()
+        tableViewOffsetCoordinator?.resetTableOffsetIfNeeded()
     }
 
     private func fetchAddresses(_ searchTerm: String) {
@@ -226,7 +225,7 @@ final class WebAddressWizardContent: UIViewController {
             return
         }
 
-        adjustTableOffsetIfNeeded()
+        tableViewOffsetCoordinator?.adjustTableOffsetIfNeeded()
         performSearchIfNeeded(query: inputText)
     }
 
@@ -338,7 +337,7 @@ final class WebAddressWizardContent: UIViewController {
         }
 
         performSearchIfNeeded(query: searchTerm)
-        adjustTableOffsetIfNeeded()
+        tableViewOffsetCoordinator?.adjustTableOffsetIfNeeded()
     }
 }
 
@@ -354,97 +353,7 @@ extension WebAddressWizardContent: NetworkStatusDelegate {
 
 extension WebAddressWizardContent: UITextFieldDelegate {
     func textFieldShouldClear(_ textField: UITextField) -> Bool {
-        resetTableOffsetIfNeeded()
+        tableViewOffsetCoordinator?.resetTableOffsetIfNeeded()
         return true
-    }
-}
-
-// MARK: - Keyboard management
-
-private extension WebAddressWizardContent {
-    struct Constants {
-        static let headerAnimationDuration  = Double(0.25)  // matches current system keyboard transition duration
-        static let topMargin                = CGFloat(36)
-    }
-
-    func adjustTableOffsetIfNeeded(_ animationDuration: Double = Constants.headerAnimationDuration) {
-        guard keyboardContentOffset > 0, tableViewHasBeenAdjusted == false else {
-            return
-        }
-
-        let topInset: CGFloat
-        if WPDeviceIdentification.isiPhone(), let header = table.tableHeaderView as? TitleSubtitleTextfieldHeader {
-            let textfieldFrame = header.textField.frame
-            topInset = textfieldFrame.origin.y - Constants.topMargin
-        } else {
-            topInset = 0
-        }
-
-        let bottomInset: CGFloat
-        if WPDeviceIdentification.isiPad() && UIDevice.current.orientation.isPortrait {
-            bottomInset = 0
-        } else {
-            bottomInset = keyboardContentOffset
-        }
-
-        let targetInsets = UIEdgeInsets(top: -topInset, left: 0, bottom: bottomInset, right: 0)
-
-        UIView.animate(withDuration: animationDuration, delay: 0, options: .beginFromCurrentState, animations: { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            self.table.contentInset = targetInsets
-            self.table.scrollIndicatorInsets = targetInsets
-            if WPDeviceIdentification.isiPhone(), let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader {
-                header.titleSubtitle.alpha = 0.0
-            }
-            }, completion: { [weak self] _ in
-                self?.tableViewHasBeenAdjusted = true
-        })
-    }
-
-    @objc
-    func keyboardWillShow(_ notification: Foundation.Notification) {
-        guard let payload = KeyboardInfo(notification) else {
-            return
-        }
-
-        let keyboardScreenFrame = payload.frameEnd
-        let convertedKeyboardFrame = view.convert(keyboardScreenFrame, from: nil)
-
-        let adjustedKeyboardHeight = convertedKeyboardFrame.height
-        keyboardContentOffset = adjustedKeyboardHeight
-    }
-
-    func resetTableOffsetIfNeeded(_ animationDuration: Double = Constants.headerAnimationDuration) {
-        guard WPDeviceIdentification.isiPhone(), tableViewHasBeenAdjusted == true else {
-            return
-        }
-
-        UIView.animate(withDuration: animationDuration, delay: 0, options: .beginFromCurrentState, animations: { [weak self] in
-            guard let self = self else {
-                return
-            }
-
-            self.table.contentInset = .zero
-            self.table.scrollIndicatorInsets = .zero
-            if WPDeviceIdentification.isiPhone(), let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader {
-                header.titleSubtitle.alpha = 1.0
-            }
-            }, completion: { [weak self] _ in
-                self?.tableViewHasBeenAdjusted = false
-        })
-    }
-
-    func startListeningToKeyboardNotifications() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(keyboardWillShow),
-                                               name: UIResponder.keyboardWillShowNotification,
-                                               object: nil)
-    }
-
-    func stopListeningToKeyboardNotifications() {
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -511,6 +511,7 @@
 		73C8F06421BEEF3400DDDF7E /* SiteAssemblyService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73178C2E21BEE1F500E37C9A /* SiteAssemblyService.swift */; };
 		73C8F06621BEF76B00DDDF7E /* SiteAssemblyViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73C8F06521BEF76B00DDDF7E /* SiteAssemblyViewTests.swift */; };
 		73C8F06821BF1A5E00DDDF7E /* SiteAssemblyContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73C8F06721BF1A5E00DDDF7E /* SiteAssemblyContentView.swift */; };
+		73CE3E0E21F7F9D3007C9C85 /* TableViewOffsetCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CE3E0D21F7F9D3007C9C85 /* TableViewOffsetCoordinator.swift */; };
 		73D5AC63212622B200ADDDD2 /* NotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D5AC5C212622B200ADDDD2 /* NotificationViewController.swift */; };
 		73D5AC64212622B200ADDDD2 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 73D5AC5E212622B200ADDDD2 /* Localizable.strings */; };
 		73E32389212CD8B5001B735C /* NSAttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54866C91A0D7042004AC79D /* NSAttributedString+Helpers.swift */; };
@@ -2363,6 +2364,7 @@
 		73C8F06121BEEEDE00DDDF7E /* SiteAssemblyWizardContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteAssemblyWizardContent.swift; sourceTree = "<group>"; };
 		73C8F06521BEF76B00DDDF7E /* SiteAssemblyViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteAssemblyViewTests.swift; sourceTree = "<group>"; };
 		73C8F06721BF1A5E00DDDF7E /* SiteAssemblyContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteAssemblyContentView.swift; sourceTree = "<group>"; };
+		73CE3E0D21F7F9D3007C9C85 /* TableViewOffsetCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewOffsetCoordinator.swift; sourceTree = "<group>"; };
 		73D5AC5C212622B200ADDDD2 /* NotificationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationViewController.swift; sourceTree = "<group>"; };
 		73D5AC5F212622B200ADDDD2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		73D5AC60212622B200ADDDD2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -5178,6 +5180,7 @@
 				738B9A4921B85CF20005062B /* ModelSettableCell.swift */,
 				738B9A4D21B85CF20005062B /* SiteCreationHeaderData.swift */,
 				738B9A4A21B85CF20005062B /* TableDataCoordinator.swift */,
+				73CE3E0D21F7F9D3007C9C85 /* TableViewOffsetCoordinator.swift */,
 				738B9A4B21B85CF20005062B /* TitleSubtitleHeader.swift */,
 				738B9A4821B85CF20005062B /* TitleSubtitleTextfieldHeader.swift */,
 				738B9A5D21B8632E0005062B /* UITableView+Header.swift */,
@@ -9539,6 +9542,7 @@
 				E6D2E1651B8AAD7E0000ED14 /* ReaderSiteStreamHeader.swift in Sources */,
 				F126FE0020A33BDB0010EB6E /* VideoUploadProcessor.swift in Sources */,
 				E166FA1B1BB0656B00374B5B /* PeopleCellViewModel.swift in Sources */,
+				73CE3E0E21F7F9D3007C9C85 /* TableViewOffsetCoordinator.swift in Sources */,
 				436D56292117312700CEAA33 /* RegisterDomainDetailsViewController.swift in Sources */,
 				83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */,
 				91DCE84421A6A7840062F134 /* PostEditor+BlogPicker.swift in Sources */,


### PR DESCRIPTION
### Description

Fixes #10821 & #10822 

To test:
 - Checkout the branch and confirm that existing tests pass.
 - Review the changed code for correctness.
 - Exercise the _Enhanced Site Creation_ flow on devices with limited screen real estate and confirm that you can now scroll to view & select all content on both the _Verticals_ & _Domains_ screens. It may be helpful to refer to prior PRs for : [Domains](https://github.com/wordpress-mobile/WordPress-iOS/pull/10786) & [Verticals](https://github.com/wordpress-mobile/WordPress-iOS/pull/10784).
 - Confirm that no regressions are observed with regard to error states.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

### Screenshots

The following static screenshots show that it is now possible to scroll the visible table view content from beneath the keyboard. The original behaviors regarding header visibility, keyboard appearance, and text field offset are preserved as well.

![Verticals : iPad Landscape](https://user-images.githubusercontent.com/221062/51578460-7f28dc00-1e72-11e9-8b56-2f9280049b6f.png)

![Domains : iPhone SE](https://user-images.githubusercontent.com/221062/51578465-83ed9000-1e72-11e9-989b-4e7fefa0ada7.png)