### PR TITLE
Exclude RNTAztecView from the check against commit hash references 

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -20,4 +20,4 @@ warn("Core Data: Do not edit an existing model in a release branch unless it has
 
 # Podfile: no references to commit hashes
 ### (except for Gutenberg)
-warn("Podfile: reference to a commit hash") if File.readlines('Podfile').any? { |l| l[/^[^#]*:commit/] && !l.include?("Gutenberg") }
+warn("Podfile: reference to a commit hash") if File.readlines('Podfile').any? { |l| l[/^[^#]*:commit/] && !l.include?("Gutenberg") && !l.include?("RNTAztecView")}


### PR DESCRIPTION
This PR excludes `RNTAztecView` from the check against references to commit hashes in the Podfile.

To test:
Verify that no warning is raised by Danger in this PR.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
