### PR TITLE
CircleCI: Check that Podfile and Podfile.lock match

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,17 @@ jobs:
           name: Bundle install
           command: bundle install --path=vendor/bundle
       - run:
+          name: Check Podfile matches Podfile.lock
+          command: |
+            function helpful_error () {
+              echo "Podfile and Podfile.lock do not match. Please run 'bundle exec pod install' and try again."
+            }
+            trap helpful_error ERR
+
+            # This verifies that the PODFILE CHECKSUM in Podfile.lock matches Podfile
+            PODFILE_SHA1=$(ruby -e "require 'yaml';puts YAML.load_file('Podfile.lock')['PODFILE CHECKSUM']")
+            echo "$PODFILE_SHA1 *Podfile" | shasum -c
+      - run:
           name: CocoaPods Check
           command: (bundle exec pod check && touch .skip_pod_install) || echo "Pods will be updated"
       - run:


### PR DESCRIPTION
I noticed that CircleCI runs to completion even if `Podfile` and `Podfile.lock` don't match. This is a simple change to enforce.

In the near future we can move these config steps to somewhere they can be shared across all repos (probably using [Orbs](https://circleci.com/orbs/)).

To test:

- See that [this](https://circleci.com/gh/wordpress-mobile/WordPress-iOS/4086) build which did not have matching Podfile/Podfile.lock files failed.
- CI is green for this PR.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
