### PR TITLE
[Stats Refresh] Add Period > Posts and Pages card

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -70,7 +70,6 @@ private extension StatsPeriodStore {
         }
 
         runPeriodsQuery()
-
     }
 
     func runPeriodsQuery() {

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/UITableViewCell+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/UITableViewCell+Stats.swift
@@ -19,6 +19,7 @@ extension UITableViewCell {
 
         guard numberOfDataRows > 0 else {
             let row = StatsNoDataRow.loadFromNib()
+            row.configure(forType: statType)
             rowsStackView.addArrangedSubview(row)
             return
         }

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/UITableViewCell+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/UITableViewCell+Stats.swift
@@ -1,9 +1,17 @@
 import Foundation
 
+/// Convenience enum to easily indicate what type of rows are being added.
+///
+enum StatType: Int {
+    case insights
+    case period
+}
+
 extension UITableViewCell {
 
     func addRows(_ dataRows: [StatsTotalRowData],
                  toStackView rowsStackView: UIStackView,
+                 forType statType: StatType,
                  limitRowsDisplayed: Bool = true,
                  rowDelegate: StatsTotalRowDelegate? = nil) {
 

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -3,7 +3,7 @@ import Foundation
 
 /// Helper class for getting/modifying Stats data for display purposes.
 ///
-class StatsDataHelper: NSObject {
+class StatsDataHelper {
 
     class func dataBarPercentForRow(_ row: StatsItem, relativeToRow maxValueRow: StatsItem?) -> Float? {
 

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+
+/// Helper class for getting/modifying Stats data for display purposes.
+///
+class StatsDataHelper: NSObject {
+
+    class func dataBarPercentForRow(_ row: StatsItem, relativeToRow maxValueRow: StatsItem?) -> Float? {
+
+        // Get value from maxValueRow
+        guard let maxValueRow = maxValueRow,
+            let maxValueString = maxValueRow.value,
+            let rowsMaxValue = maxValueString.statFloatValue() else {
+                return nil
+        }
+
+        // Get value from row
+        guard let rowValueString = row.value,
+            let rowValue = rowValueString.statFloatValue() else {
+                return nil
+        }
+
+        // Return percent
+        return rowValue / rowsMaxValue
+    }
+
+}
+
+/// These methods format stat Strings for display and usage.
+/// Once the backend is updated to provide number values, this extension
+/// and all it's usage should no longer be necessary.
+///
+
+extension String {
+
+    /// Strips commas from formatting stat Strings and returns the Float value.
+    ///
+    func statFloatValue() -> Float? {
+        return Float(replacingOccurrences(of: ",", with: "", options: NSString.CompareOptions.literal, range: nil))
+    }
+
+    /// If the String can be converted to a Float, return the abbreviated format for it.
+    /// Otherwise return the original String.
+    ///
+    func displayString() -> String {
+        if let floatValue = statFloatValue() {
+            return floatValue.abbreviatedString()
+        }
+
+        return self
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Annual Site Stats/AnnualSiteStatsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Annual Site Stats/AnnualSiteStatsCell.swift
@@ -71,14 +71,14 @@ private extension AnnualSiteStatsCell {
             let totalsDataRows = totalsDataRows,
             let averagesDataRows = averagesDataRows else {
                 dataStackView.isHidden = true
-                addRows([], toStackView: totalPostsStackView, limitRowsDisplayed: false)
+                addRows([], toStackView: totalPostsStackView, forType: .insights, limitRowsDisplayed: false)
                 return
         }
 
         dataStackView.isHidden = false
-        addRows([totalPostsRow], toStackView: totalPostsStackView, limitRowsDisplayed: false)
-        addRows(totalsDataRows, toStackView: totalsStackView, limitRowsDisplayed: false)
-        addRows(averagesDataRows, toStackView: averagesStackView, limitRowsDisplayed: false)
+        addRows([totalPostsRow], toStackView: totalPostsStackView, forType: .insights, limitRowsDisplayed: false)
+        addRows(totalsDataRows, toStackView: totalsStackView, forType: .insights, limitRowsDisplayed: false)
+        addRows(averagesDataRows, toStackView: averagesStackView, forType: .insights, limitRowsDisplayed: false)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.swift
@@ -33,7 +33,7 @@ class SimpleTotalsCell: UITableViewCell, NibLoadable {
         dataSubtitleLabel.text = dataSubtitle
 
         setSubtitleVisibility()
-        addRows(dataRows, toStackView: rowsStackView, limitRowsDisplayed: false)
+        addRows(dataRows, toStackView: rowsStackView, forType: .insights, limitRowsDisplayed: false)
         applyStyles()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -100,7 +100,7 @@ private extension SiteStatsInsightsTableViewController {
                 SimpleTotalsStatsSubtitlesRow.self,
                 PostingActivityRow.self,
                 TabbedTotalsStatsRow.self,
-                TopTotalsStatsRow.self,
+                TopTotalsInsightStatsRow.self,
                 AnnualSiteStatsRow.self]
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -305,7 +305,7 @@ private extension SiteStatsInsightsViewModel {
         var dataRows = [StatsTotalRowData]()
 
         publicize?.forEach { item in
-            let dataBarPercent = dataBarPercentForRow(item, relativeToRow: publicize?.first)
+            let dataBarPercent = StatsDataHelper.dataBarPercentForRow(item, relativeToRow: publicize?.first)
             dataRows.append(StatsTotalRowData.init(name: item.label,
                                                    data: item.value.displayString(),
                                                    dataBarPercent: dataBarPercent,
@@ -389,7 +389,7 @@ private extension SiteStatsInsightsViewModel {
                 }
             }()
 
-            let dataBarPercent = dataBarPercentForRow(item, relativeToRow: tagsAndCategories?.first)
+            let dataBarPercent = StatsDataHelper.dataBarPercentForRow(item, relativeToRow: tagsAndCategories?.first)
 
             let row = StatsTotalRowData.init(name: item.label,
                                              data: item.value.displayString(),
@@ -521,7 +521,7 @@ private extension SiteStatsInsightsViewModel {
         var rows = [StatsTotalRowData]()
 
         rowData?.forEach { row in
-            let dataBarPercent = showDataBar ? dataBarPercentForRow(row, relativeToRow: rowData?.first) : nil
+            let dataBarPercent = showDataBar ? StatsDataHelper.dataBarPercentForRow(row, relativeToRow: rowData?.first) : nil
 
             let disclosureURL: URL? = {
                 if showDisclosure, let action = row.actions.first as? StatsItemAction {
@@ -543,51 +543,6 @@ private extension SiteStatsInsightsViewModel {
                             dataSubtitle: dataSubtitle,
                             totalCount: totalCount,
                             dataRows: rows)
-    }
-
-    func dataBarPercentForRow(_ row: StatsItem, relativeToRow maxValueRow: StatsItem?) -> Float? {
-
-        // Get value from maxValueRow
-        guard let maxValueRow = maxValueRow,
-            let maxValueString = maxValueRow.value,
-            let rowsMaxValue = maxValueString.statFloatValue() else {
-                return nil
-        }
-
-        // Get value from row
-        guard let rowValueString = row.value,
-            let rowValue = rowValueString.statFloatValue() else {
-                return nil
-        }
-
-        // Return percent
-        return rowValue / rowsMaxValue
-    }
-
-}
-
-/// These methods format stat Strings for display and usage.
-/// Once the backend is updated to provide number values, this extension
-/// and all it's usage should no longer be necessary.
-///
-
-private extension String {
-
-    /// Strips commas from formatting stat Strings and returns the Float value.
-    ///
-    func statFloatValue() -> Float? {
-        return Float(replacingOccurrences(of: ",", with: "", options: NSString.CompareOptions.literal, range: nil))
-    }
-
-    /// If the String can be converted to a Float, return the abbreviated format for it.
-    /// Otherwise return the original String.
-    ///
-    func displayString() -> String {
-            if let floatValue = statFloatValue() {
-                return floatValue.abbreviatedString()
-            }
-
-            return self
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -57,7 +57,7 @@ class SiteStatsInsightsViewModel: Observable {
                                                                dataRows: createMostPopularStatsRows()))
             case .tagsAndCategories:
                 tableRows.append(CellHeaderRow(title: InsightsHeaders.tagsAndCategories))
-                tableRows.append(TopTotalsStatsRow(itemSubtitle: TagsAndCategories.itemSubtitle,
+                tableRows.append(TopTotalsInsightStatsRow(itemSubtitle: TagsAndCategories.itemSubtitle,
                                                    dataSubtitle: TagsAndCategories.dataSubtitle,
                                                    dataRows: createTagsAndCategoriesRows(),
                                                    siteStatsInsightsDelegate: siteStatsInsightsDelegate))

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -49,7 +49,7 @@ class TabbedTotalsCell: UITableViewCell, NibLoadable {
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
         self.showTotalCount = showTotalCount
         setupFilterBar()
-        addRows(tabsData[filterTabBar.selectedIndex].dataRows, toStackView: rowsStackView, rowDelegate: self)
+        addRows(tabsData[filterTabBar.selectedIndex].dataRows, toStackView: rowsStackView, forType: .insights, rowDelegate: self)
         configureSubtitles()
         applyStyles()
     }
@@ -79,7 +79,7 @@ private extension TabbedTotalsCell {
 
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
         removeRowsFromStackView(rowsStackView)
-        addRows(tabsData[filterTabBar.selectedIndex].dataRows, toStackView: rowsStackView, rowDelegate: self)
+        addRows(tabsData[filterTabBar.selectedIndex].dataRows, toStackView: rowsStackView, forType: .insights, rowDelegate: self)
         configureSubtitles()
         siteStatsInsightsDelegate?.tabbedTotalsCellUpdated?()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -1,21 +1,14 @@
 import UIKit
 import WordPressFlux
 
-enum PeriodDisplayed: Int {
-    case days = 1
-    case weeks
-    case months
-    case years
-}
-
 class SiteStatsPeriodTableViewController: UITableViewController {
 
     // MARK: - Properties
 
-    var periodDisplayed: PeriodDisplayed? = .days {
+    var selectedPeriod: StatsPeriodUnit? = .day {
         didSet {
-            DDLogInfo("Stats Period selected: \(String(describing: periodDisplayed))")
-            guard periodDisplayed != nil else {
+            DDLogInfo("selectedPeriod selected: \(String(describing: selectedPeriod))")
+            guard selectedPeriod != nil else {
                 return
             }
             refreshData()

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -44,7 +44,7 @@ class SiteStatsPeriodTableViewController: UITableViewController {
         super.viewDidLoad()
 
         WPStyleGuide.Stats.configureTable(tableView)
-        refreshControl?.addTarget(self, action: #selector(refreshData), for: .valueChanged)
+        refreshControl?.addTarget(self, action: #selector(userInitiatedRefresh), for: .valueChanged)
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
     }
 
@@ -93,13 +93,19 @@ private extension SiteStatsPeriodTableViewController {
         refreshControl?.endRefreshing()
     }
 
-    @objc func refreshData() {
+    @objc func userInitiatedRefresh() {
+        refreshControl?.beginRefreshing()
+        refreshData()
+    }
+
+    func refreshData() {
+
         guard let selectedDate = selectedDate,
             let selectedPeriod = selectedPeriod else {
+                refreshControl?.endRefreshing()
                 return
         }
 
-        refreshControl?.beginRefreshing()
         viewModel?.refreshPeriodData(withDate: selectedDate, forPeriod: selectedPeriod)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -5,12 +5,10 @@ class SiteStatsPeriodTableViewController: UITableViewController {
 
     // MARK: - Properties
 
-    var selectedPeriod: StatsPeriodUnit? = .day {
+    var selectedDate: Date = Date()
+    var selectedPeriod: StatsPeriodUnit = .day {
         didSet {
             DDLogInfo("selectedPeriod selected: \(String(describing: selectedPeriod))")
-            guard selectedPeriod != nil else {
-                return
-            }
             refreshData()
         }
     }
@@ -44,7 +42,7 @@ private extension SiteStatsPeriodTableViewController {
     // MARK: - View Model
 
     func initViewModel() {
-        viewModel = SiteStatsPeriodViewModel(store: store)
+        viewModel = SiteStatsPeriodViewModel(store: store, selectedDate: selectedDate, selectedPeriod: selectedPeriod)
 
         changeReceipt = viewModel?.onChange { [weak self] in
             guard let store = self?.store,
@@ -73,7 +71,7 @@ private extension SiteStatsPeriodTableViewController {
 
     @objc func refreshData() {
         refreshControl?.beginRefreshing()
-        viewModel?.refreshPeriodData()
+        viewModel?.refreshPeriodData(withDate: selectedDate, forPeriod: selectedPeriod)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -1,6 +1,12 @@
 import UIKit
 import WordPressFlux
 
+
+@objc protocol SiteStatsPeriodDelegate {
+    @objc optional func displayWebViewWithURL(_ url: URL)
+}
+
+
 class SiteStatsPeriodTableViewController: UITableViewController {
 
     // MARK: - Properties
@@ -72,6 +78,19 @@ private extension SiteStatsPeriodTableViewController {
     @objc func refreshData() {
         refreshControl?.beginRefreshing()
         viewModel?.refreshPeriodData(withDate: selectedDate, forPeriod: selectedPeriod)
+    }
+
+}
+
+
+// MARK: - SiteStatsPeriodDelegate Methods
+
+extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
+
+    func displayWebViewWithURL(_ url: URL) {
+        let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
+        let navController = UINavigationController.init(rootViewController: webViewController)
+        present(navController, animated: true, completion: nil)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -48,7 +48,10 @@ private extension SiteStatsPeriodTableViewController {
     // MARK: - View Model
 
     func initViewModel() {
-        viewModel = SiteStatsPeriodViewModel(store: store, selectedDate: selectedDate, selectedPeriod: selectedPeriod)
+        viewModel = SiteStatsPeriodViewModel(store: store,
+                                             selectedDate: selectedDate,
+                                             selectedPeriod: selectedPeriod,
+                                             periodDelegate: self)
 
         changeReceipt = viewModel?.onChange { [weak self] in
             guard let store = self?.store,
@@ -61,7 +64,7 @@ private extension SiteStatsPeriodTableViewController {
     }
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
-        return [CellHeaderRow.self, TopTotalsStatsRow.self]
+        return [CellHeaderRow.self, TopTotalsPeriodStatsRow.self]
     }
 
     // MARK: - Table Refreshing

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -14,7 +14,7 @@ class SiteStatsPeriodTableViewController: UITableViewController {
     var selectedDate: Date = Date()
     var selectedPeriod: StatsPeriodUnit = .day {
         didSet {
-            DDLogInfo("selectedPeriod selected: \(String(describing: selectedPeriod))")
+            DDLogInfo("selectedPeriod: \(String(describing: selectedPeriod.rawValue))")
             refreshData()
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -53,19 +53,14 @@ private extension SiteStatsPeriodTableViewController {
     func initViewModel() {
         viewModel = SiteStatsPeriodViewModel(store: store)
 
-        // TODO: remove this when code below is utilized.
-        refreshTableView()
+        changeReceipt = viewModel?.onChange { [weak self] in
+            guard let store = self?.store,
+                !store.isFetching else {
+                    return
+            }
 
-        // TODO: uncomment this when the Store actually does something.
-
-//        changeReceipt = viewModel?.onChange { [weak self] in
-//            guard let store = self?.store,
-//                !store.isFetching else {
-//                    return
-//            }
-//
-//            self?.refreshTableView()
-//        }
+            self?.refreshTableView()
+        }
     }
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
@@ -80,13 +75,11 @@ private extension SiteStatsPeriodTableViewController {
         }
 
         tableHandler.viewModel = viewModel.tableViewModel()
-//        refreshControl?.endRefreshing()
+        refreshControl?.endRefreshing()
     }
 
     @objc func refreshData() {
-//        refreshControl?.beginRefreshing()
-
-        // TODO: use PeriodDisplayed when fetching data
+        refreshControl?.beginRefreshing()
         viewModel?.refreshPeriodData()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -11,11 +11,21 @@ class SiteStatsPeriodTableViewController: UITableViewController {
 
     // MARK: - Properties
 
-    var selectedDate: Date = Date()
-    var selectedPeriod: StatsPeriodUnit = .day {
+    var selectedDate: Date?
+    var selectedPeriod: StatsPeriodUnit? {
         didSet {
-            DDLogInfo("selectedPeriod: \(String(describing: selectedPeriod.rawValue))")
-            refreshData()
+
+            guard selectedPeriod != nil else {
+                return
+            }
+
+            // If this is the first time setting the Period, need to initialize the view model.
+            // Otherwise, just refresh the data.
+            if oldValue == nil {
+                initViewModel()
+            } else {
+                refreshData()
+            }
         }
     }
 
@@ -36,7 +46,6 @@ class SiteStatsPeriodTableViewController: UITableViewController {
         WPStyleGuide.Stats.configureTable(tableView)
         refreshControl?.addTarget(self, action: #selector(refreshData), for: .valueChanged)
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
-        initViewModel()
     }
 
 }
@@ -48,6 +57,12 @@ private extension SiteStatsPeriodTableViewController {
     // MARK: - View Model
 
     func initViewModel() {
+
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return
+        }
+
         viewModel = SiteStatsPeriodViewModel(store: store,
                                              selectedDate: selectedDate,
                                              selectedPeriod: selectedPeriod,
@@ -79,12 +94,16 @@ private extension SiteStatsPeriodTableViewController {
     }
 
     @objc func refreshData() {
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return
+        }
+
         refreshControl?.beginRefreshing()
         viewModel?.refreshPeriodData(withDate: selectedDate, forPeriod: selectedPeriod)
     }
 
 }
-
 
 // MARK: - SiteStatsPeriodDelegate Methods
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -17,9 +17,11 @@ class SiteStatsPeriodViewModel: Observable {
 
     // MARK: - Constructor
 
-    init(store: StatsPeriodStore = StoreContainer.shared.statsPeriod) {
+    init(store: StatsPeriodStore = StoreContainer.shared.statsPeriod,
+         selectedDate: Date,
+         selectedPeriod: StatsPeriodUnit) {
         self.store = store
-        periodReceipt = store.query(.periods)
+        periodReceipt = store.query(.periods(date: selectedDate, period: selectedPeriod))
 
         changeReceipt = store.onChange { [weak self] in
             self?.emitChange()
@@ -42,8 +44,8 @@ class SiteStatsPeriodViewModel: Observable {
 
     // MARK: - Refresh Data
 
-    func refreshPeriodData() {
-        ActionDispatcher.dispatch(PeriodAction.refreshPeriodData())
+    func refreshPeriodData(withDate date: Date, forPeriod period: StatsPeriodUnit) {
+        ActionDispatcher.dispatch(PeriodAction.refreshPeriodData(date: date, period: period))
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -10,6 +10,7 @@ class SiteStatsPeriodViewModel: Observable {
 
     let changeDispatcher = Dispatcher<Void>()
 
+    private let periodDelegate: SiteStatsPeriodDelegate
     private let store: StatsPeriodStore
     private let periodReceipt: Receipt
     private var changeReceipt: Receipt?
@@ -19,7 +20,9 @@ class SiteStatsPeriodViewModel: Observable {
 
     init(store: StatsPeriodStore = StoreContainer.shared.statsPeriod,
          selectedDate: Date,
-         selectedPeriod: StatsPeriodUnit) {
+         selectedPeriod: StatsPeriodUnit,
+         periodDelegate: SiteStatsPeriodDelegate) {
+        self.periodDelegate = periodDelegate
         self.store = store
         periodReceipt = store.query(.periods(date: selectedDate, period: selectedPeriod))
 
@@ -53,7 +56,7 @@ class SiteStatsPeriodViewModel: Observable {
 
 private extension SiteStatsPeriodViewModel {
 
-    // Period Stats strings
+    // MARK: - Period Stats strings
 
     struct PeriodHeaders {
         static let postsAndPages = NSLocalizedString("Posts and Pages", comment: "Period Stats 'Posts and Pages' header")
@@ -64,16 +67,16 @@ private extension SiteStatsPeriodViewModel {
         static let dataSubtitle = NSLocalizedString("Views", comment: "Posts and Pages label for number of views")
     }
 
-    // Create Period Rows
+    // MARK: - Create Table Rows
 
     func postsAndPagesTableRows() -> [ImmuTableRow] {
 
         var tableRows = [ImmuTableRow]()
         tableRows.append(CellHeaderRow(title: PeriodHeaders.postsAndPages))
-        tableRows.append(TopTotalsStatsRow(itemSubtitle: PostsAndPages.itemSubtitle,
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: PostsAndPages.itemSubtitle,
                                            dataSubtitle: PostsAndPages.dataSubtitle,
                                            dataRows: postsAndPagesDataRows(),
-                                           siteStatsInsightsDelegate: nil))
+                                           siteStatsPeriodDelegate: periodDelegate))
 
         return tableRows
     }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -87,8 +87,8 @@ private extension SiteStatsPeriodViewModel {
 
         postsAndPages?.forEach { item in
 
-            // TODO: use Page or Post icon
-            let icon = Style.imageForGridiconType(.folder)
+            // TODO: when the backend provides the item type, set the icon to either pages or posts depending that.
+            let icon = Style.imageForGridiconType(.posts)
 
             let dataBarPercent = StatsDataHelper.dataBarPercentForRow(item, relativeToRow: postsAndPages?.first)
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -93,8 +93,11 @@ private extension SiteStatsPeriodViewModel {
             // TODO: use Page or Post icon
             let icon = Style.imageForGridiconType(.folder)
 
+            let dataBarPercent = StatsDataHelper.dataBarPercentForRow(item, relativeToRow: postsAndPages?.first)
+
             let row = StatsTotalRowData.init(name: item.label,
                                              data: item.value.displayString(),
+                                             dataBarPercent: dataBarPercent,
                                              icon: icon,
                                              showDisclosure: true,
                                              disclosureURL: disclosureURL)

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -87,14 +87,6 @@ private extension SiteStatsPeriodViewModel {
 
         postsAndPages?.forEach { item in
 
-            let disclosureURL: URL? = {
-                if let actions = item.actions,
-                    let action = actions.first as? StatsItemAction {
-                    return action.url
-                }
-                return nil
-            }()
-
             // TODO: use Page or Post icon
             let icon = Style.imageForGridiconType(.folder)
 
@@ -104,8 +96,7 @@ private extension SiteStatsPeriodViewModel {
                                              data: item.value.displayString(),
                                              dataBarPercent: dataBarPercent,
                                              icon: icon,
-                                             showDisclosure: true,
-                                             disclosureURL: disclosureURL)
+                                             showDisclosure: true)
 
             dataRows.append(row)
         }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -77,19 +77,27 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func postsAndPagesDataRows() -> [StatsTotalRowData] {
-
+        let postsAndPages = store.getTopPostsAndPages()
         var dataRows = [StatsTotalRowData]()
 
-        // TODO: replace with real Pages and Posts data from the Store
-        // let postsAndPages = store.getPostsAndPages()
+        postsAndPages?.forEach { item in
 
-        let icon = Style.imageForGridiconType(.folder)
+            let disclosureURL: URL? = {
+                if let actions = item.actions,
+                    let action = actions.first as? StatsItemAction {
+                    return action.url
+                }
+                return nil
+            }()
 
-        for count in 1...10 {
-            let row = StatsTotalRowData.init(name: "Row \(count)" ,
-                                             data: "666",
+            // TODO: use Page or Post icon
+            let icon = Style.imageForGridiconType(.folder)
+
+            let row = StatsTotalRowData.init(name: item.label,
+                                             data: item.value.displayString(),
                                              icon: icon,
-                                             showDisclosure: true)
+                                             showDisclosure: true,
+                                             disclosureURL: disclosureURL)
 
             dataRows.append(row)
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsNoDataRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsNoDataRow.swift
@@ -5,12 +5,15 @@ class StatsNoDataRow: UIView, NibLoadable {
     // MARK: - Properties
 
     @IBOutlet weak var noDataLabel: UILabel!
-    private let dataLabel = NSLocalizedString("No data yet", comment: "Text displayed when a stats section has no data.")
+    private let insightsNoDataLabel = NSLocalizedString("No data yet",
+                                                        comment: "Text displayed when an Insights stat section has no data.")
+    private let periodNoDataLabel = NSLocalizedString("No data for this period",
+                                                      comment: "Text displayed when Period stat section has no data.")
 
     // MARK: - Configure
 
-    override func awakeFromNib() {
-        noDataLabel.text = dataLabel
+    func configure(forType statType: StatType) {
+        noDataLabel.text = statType == .insights ? insightsNoDataLabel : periodNoDataLabel
         WPStyleGuide.Stats.configureLabelAsNoData(noDataLabel)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -40,7 +40,9 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
         self.siteStatsPeriodDelegate = siteStatsPeriodDelegate
 
         setSubtitleVisibility()
-        addRows(dataRows, toStackView: rowsStackView, rowDelegate: self)
+
+        let statType: StatType = (siteStatsPeriodDelegate != nil) ? .period : .insights
+        addRows(dataRows, toStackView: rowsStackView, forType: statType, rowDelegate: self)
         applyStyles()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -23,6 +23,7 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
     private let subtitlesBottomMargin: CGFloat = 7.0
     private var dataRows = [StatsTotalRowData]()
     private var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+    private var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
     private typealias Style = WPStyleGuide.Stats
 
     // MARK: - Configure
@@ -30,11 +31,13 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
     func configure(itemSubtitle: String,
                    dataSubtitle: String,
                    dataRows: [StatsTotalRowData],
-                   siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
+                   siteStatsInsightsDelegate: SiteStatsInsightsDelegate?,
+                   siteStatsPeriodDelegate: SiteStatsPeriodDelegate?) {
         itemSubtitleLabel.text = itemSubtitle
         dataSubtitleLabel.text = dataSubtitle
         self.dataRows = dataRows
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
+        self.siteStatsPeriodDelegate = siteStatsPeriodDelegate
 
         setSubtitleVisibility()
         addRows(dataRows, toStackView: rowsStackView, rowDelegate: self)
@@ -74,6 +77,7 @@ extension TopTotalsCell: StatsTotalRowDelegate {
 
     func displayWebViewWithURL(_ url: URL) {
         siteStatsInsightsDelegate?.displayWebViewWithURL?(url)
+        siteStatsPeriodDelegate?.displayWebViewWithURL?(url)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -94,7 +94,10 @@ private extension SiteStatsDashboardViewController {
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
         currentSelectedPeriod = StatsPeriodType(rawValue: filterBar.selectedIndex) ?? StatsPeriodType.insights
 
-        periodTableViewController?.selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1)
+        // TODO: when implemented, pass user selected date to VC.
+        periodTableViewController?.selectedDate = Date()
+        let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
+        periodTableViewController?.selectedPeriod = selectedPeriod
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -94,10 +94,12 @@ private extension SiteStatsDashboardViewController {
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
         currentSelectedPeriod = StatsPeriodType(rawValue: filterBar.selectedIndex) ?? StatsPeriodType.insights
 
-        // TODO: when implemented, pass user selected date to VC.
-        periodTableViewController?.selectedDate = Date()
-        let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
-        periodTableViewController?.selectedPeriod = selectedPeriod
+        if currentSelectedPeriod != .insights {
+            // TODO: when implemented, pass user selected date to VC.
+            periodTableViewController?.selectedDate = Date()
+            let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
+            periodTableViewController?.selectedPeriod = selectedPeriod
+        }
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -93,7 +93,8 @@ private extension SiteStatsDashboardViewController {
 
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
         currentSelectedPeriod = StatsPeriodType(rawValue: filterBar.selectedIndex) ?? StatsPeriodType.insights
-        periodTableViewController?.periodDisplayed = PeriodDisplayed.init(rawValue: currentSelectedPeriod.rawValue)
+
+        periodTableViewController?.selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -70,6 +70,7 @@ private extension SiteStatsDashboardViewController {
         set {
             filterTabBar?.setSelectedIndex(newValue.rawValue)
             setContainerViewVisibility()
+            updatePeriodView()
             saveSelectedPeriodToUserDefaults()
         }
     }
@@ -93,13 +94,6 @@ private extension SiteStatsDashboardViewController {
 
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
         currentSelectedPeriod = StatsPeriodType(rawValue: filterBar.selectedIndex) ?? StatsPeriodType.insights
-
-        if currentSelectedPeriod != .insights {
-            // TODO: when implemented, pass user selected date to VC.
-            periodTableViewController?.selectedDate = Date()
-            let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
-            periodTableViewController?.selectedPeriod = selectedPeriod
-        }
     }
 
 }
@@ -114,5 +108,17 @@ private extension SiteStatsDashboardViewController {
 
     func getSelectedPeriodFromUserDefaults() {
         currentSelectedPeriod = StatsPeriodType(rawValue: UserDefaults.standard.integer(forKey: Constants.userDefaultsKey)) ?? .insights
+    }
+
+    func updatePeriodView() {
+
+        guard currentSelectedPeriod != .insights else {
+            return
+        }
+
+        // TODO: when implemented, pass user selected date to VC.
+        periodTableViewController?.selectedDate = Date()
+        let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
+        periodTableViewController?.selectedPeriod = selectedPeriod
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -119,7 +119,7 @@ struct TabbedTotalsStatsRow: ImmuTableRow {
     }
 }
 
-struct TopTotalsStatsRow: ImmuTableRow {
+struct TopTotalsInsightStatsRow: ImmuTableRow {
 
     typealias CellType = TopTotalsCell
 
@@ -130,7 +130,7 @@ struct TopTotalsStatsRow: ImmuTableRow {
     let itemSubtitle: String
     let dataSubtitle: String
     let dataRows: [StatsTotalRowData]
-    let siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+    let siteStatsInsightsDelegate: SiteStatsInsightsDelegate
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -142,7 +142,36 @@ struct TopTotalsStatsRow: ImmuTableRow {
         cell.configure(itemSubtitle: itemSubtitle,
                        dataSubtitle: dataSubtitle,
                        dataRows: dataRows,
-                       siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+                       siteStatsInsightsDelegate: siteStatsInsightsDelegate,
+                       siteStatsPeriodDelegate: nil)
+    }
+}
+
+struct TopTotalsPeriodStatsRow: ImmuTableRow {
+
+    typealias CellType = TopTotalsCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let itemSubtitle: String
+    let dataSubtitle: String
+    let dataRows: [StatsTotalRowData]
+    let siteStatsPeriodDelegate: SiteStatsPeriodDelegate
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(itemSubtitle: itemSubtitle,
+                       dataSubtitle: dataSubtitle,
+                       dataRows: dataRows,
+                       siteStatsInsightsDelegate: nil,
+                       siteStatsPeriodDelegate: siteStatsPeriodDelegate)
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -922,6 +922,7 @@
 		98B33C88202283860071E1E2 /* NoResults.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 98B33C87202283860071E1E2 /* NoResults.storyboard */; };
 		98B3FA8421C05BDC00148DD4 /* ViewMoreRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B3FA8321C05BDC00148DD4 /* ViewMoreRow.swift */; };
 		98B3FA8621C05BF000148DD4 /* ViewMoreRow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98B3FA8521C05BF000148DD4 /* ViewMoreRow.xib */; };
+		98B52AE121F7AF4A006FF6B4 /* StatsDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */; };
 		98BDFF6B20D0732900C72C58 /* SupportTableViewController+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BDFF6A20D0732900C72C58 /* SupportTableViewController+Activity.swift */; };
 		98D60B9B1FFEE39500145190 /* SiteCreationThemeSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D60B9A1FFEE39500145190 /* SiteCreationThemeSelectionViewController.swift */; };
 		98D60B9E1FFEE3D800145190 /* SiteCreationThemeSelectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D60B9C1FFEE3D800145190 /* SiteCreationThemeSelectionCell.swift */; };
@@ -2826,6 +2827,7 @@
 		98B33C87202283860071E1E2 /* NoResults.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = NoResults.storyboard; sourceTree = "<group>"; };
 		98B3FA8321C05BDC00148DD4 /* ViewMoreRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMoreRow.swift; sourceTree = "<group>"; };
 		98B3FA8521C05BF000148DD4 /* ViewMoreRow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ViewMoreRow.xib; sourceTree = "<group>"; };
+		98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsDataHelper.swift; sourceTree = "<group>"; };
 		98BDFF6A20D0732900C72C58 /* SupportTableViewController+Activity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SupportTableViewController+Activity.swift"; sourceTree = "<group>"; };
 		98D60B9A1FFEE39500145190 /* SiteCreationThemeSelectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteCreationThemeSelectionViewController.swift; sourceTree = "<group>"; };
 		98D60B9C1FFEE3D800145190 /* SiteCreationThemeSelectionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteCreationThemeSelectionCell.swift; sourceTree = "<group>"; };
@@ -6188,6 +6190,7 @@
 			isa = PBXGroup;
 			children = (
 				9874767221963D320080967F /* SiteStatsInformation.swift */,
+				98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -9577,6 +9580,7 @@
 				B5AC00681BE3C4E100F8E7C3 /* DiscussionSettingsViewController.swift in Sources */,
 				D816C1F620E0896F00C4D82F /* TrashComment.swift in Sources */,
 				08AAD69F1CBEA47D002B2418 /* MenusService.m in Sources */,
+				98B52AE121F7AF4A006FF6B4 /* StatsDataHelper.swift in Sources */,
 				9A22D9C0214A6BCA00BAEAF2 /* PageListTableViewHandler.swift in Sources */,
 				74729CA62056FE6000D1394D /* SearchableItemConvertable.swift in Sources */,
 				5D000DDE1AC076C000A7BAF9 /* PostCardActionBar.m in Sources */,


### PR DESCRIPTION
Fixes #10875 

This adds the Period Posts and Pages card.
- Displays top 6 results.
- If there are more than 6, `View more` is added.
- Each row contains:
  - Icon
  - Data bar
  - Disclosure icon
- Selecting different filters (DWMY) updates the data.
- If there is no data, `No data for this period` is displayed.

NOTES:
- `View more` will show a temporary alert.
- Selecting a row will show a temporary alert.
- Since the backend does not distinguish between Posts or Pages, for now every row will use the Post icon. (cc @SylvesterWilmott ) (related issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/10886)
- @jklausa  - I added a `SiteStatsPeriodDelegate`. I thought I was going to need it for this card, but I was  mistaken. However, I will need it for other cards, so went ahead and left it. Sorry for the bit of extra code to review, but it'll be worth it! 😄 

To test:

---
On a site with Posts and/or Pages, go to Stats > Days, Weeks, Months, or Years.
- en.blog and Hogwarts are good ones.
- Verify the view is:
<img width="350" alt="pandp" src="https://user-images.githubusercontent.com/1816888/51641304-0a61aa80-1f23-11e9-9c68-334f7975a764.png">

---
On a site with _no_ Posts or Pages, go to Stats > Days, Weeks, Months, or Years.
- Verify the view is:
<img width="350" alt="nopandp" src="https://user-images.githubusercontent.com/1816888/51641405-472da180-1f23-11e9-8ebe-5f8841159a54.png">



