### PR TITLE
Fix ios_update_metadata_source action 

### DIFF
--- a/Scripts/fastlane/actions/ios_update_metadata_source.rb
+++ b/Scripts/fastlane/actions/ios_update_metadata_source.rb
@@ -14,8 +14,12 @@ module Fastlane
           Action.sh("git add #{file}")
         end
 
-        Action.sh("git commit -m \"Update metadata strings\"")
-        Action.sh("git push")
+        repo_status = Actions.sh("git status --porcelain")
+        repo_clean = repo_status.empty?
+        if (!repo_clean) then
+          Action.sh("git commit -m \"Update metadata strings\"")
+          Action.sh("git push")
+        end
       end
 
       #####################################################


### PR DESCRIPTION
This PR fixes a small issue with the ios_update_metadata_source fastlane action where the action fails if there is no change in the source files.
The lane fails because it tries to run a `git commit` when there's nothing to commit.

To test:
1. Run `bundle exec fastlane update_appstore_strings version:11.6` and verify that no file changes and that the lane runs without errors.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
