### PR TITLE
Bump Gutenberg ref to release 0.3.4

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -94,8 +94,8 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '3113af15dab02aee780d51c1673d59cf12e96dc4'
-    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '3113af15dab02aee780d51c1673d59cf12e96dc4'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v0.3.4'
+    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v0.3.4'
 
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'

--- a/Podfile
+++ b/Podfile
@@ -94,8 +94,8 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '2bade57ef289ec1ddd1604a5f354381a2a3c78fa'
-    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '2bade57ef289ec1ddd1604a5f354381a2a3c78fa'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '3113af15dab02aee780d51c1673d59cf12e96dc4'
+    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '3113af15dab02aee780d51c1673d59cf12e96dc4'
 
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -226,7 +226,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `3113af15dab02aee780d51c1673d59cf12e96dc4`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v0.3.4`)
   - HockeySDK (= 5.1.4)
   - MGSwipeTableCell (= 1.6.8)
   - MRProgress (= 0.8.3)
@@ -241,7 +241,7 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `3113af15dab02aee780d51c1673d59cf12e96dc4`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v0.3.4`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -302,8 +302,8 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: 3113af15dab02aee780d51c1673d59cf12e96dc4
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :tag: v0.3.4
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   react-native-keyboard-aware-scroll-view:
@@ -314,8 +314,8 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 3113af15dab02aee780d51c1673d59cf12e96dc4
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :tag: v0.3.4
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -327,14 +327,14 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.3-beta.1
   Gutenberg:
-    :commit: 3113af15dab02aee780d51c1673d59cf12e96dc4
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :tag: v0.3.4
   RNSVG:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 3113af15dab02aee780d51c1673d59cf12e96dc4
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+    :tag: v0.3.4
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -389,6 +389,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 622733a9d801f35188b678bc65c9501739938e22
+PODFILE CHECKSUM: b884248bdadc3d4984b8efc4fcb236cd78d26295
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -226,7 +226,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `2bade57ef289ec1ddd1604a5f354381a2a3c78fa`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `3113af15dab02aee780d51c1673d59cf12e96dc4`)
   - HockeySDK (= 5.1.4)
   - MGSwipeTableCell (= 1.6.8)
   - MRProgress (= 0.8.3)
@@ -241,7 +241,7 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `2bade57ef289ec1ddd1604a5f354381a2a3c78fa`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `3113af15dab02aee780d51c1673d59cf12e96dc4`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -302,7 +302,7 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: 2bade57ef289ec1ddd1604a5f354381a2a3c78fa
+    :commit: 3113af15dab02aee780d51c1673d59cf12e96dc4
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
@@ -314,7 +314,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 2bade57ef289ec1ddd1604a5f354381a2a3c78fa
+    :commit: 3113af15dab02aee780d51c1673d59cf12e96dc4
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -327,13 +327,13 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.3-beta.1
   Gutenberg:
-    :commit: 2bade57ef289ec1ddd1604a5f354381a2a3c78fa
+    :commit: 3113af15dab02aee780d51c1673d59cf12e96dc4
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNSVG:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 2bade57ef289ec1ddd1604a5f354381a2a3c78fa
+    :commit: 3113af15dab02aee780d51c1673d59cf12e96dc4
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -389,6 +389,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: f644e7e3a31f7f2e60ed84269d614817c3e6e47f
+PODFILE CHECKSUM: 622733a9d801f35188b678bc65c9501739938e22
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Bump Gutenberg ref to release 0.3.4

To test:

- `rake dependencies`.
- Build and run the project.
- Open an instance of Gutenberg. (Without metro running)
- Check that it behaves correctly.
- Try one or a couple of late fixes.
  - An easy one to test: The keyboard hide button should be docked at the right: https://github.com/wordpress-mobile/gutenberg-mobile/pull/480
  - Another easy to test: https://github.com/wordpress-mobile/gutenberg-mobile/pull/481