### PR TITLE
Remove all BuddyBuild configuration

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -113,7 +113,6 @@ target 'WordPress' do
     pod 'Reachability',    '3.2'
     pod 'SVProgressHUD', '2.2.5'
     pod 'Crashlytics', '3.12.0'
-    pod 'BuddyBuildSDK', '1.0.17', :configurations => ['Release-Alpha']
     pod 'Gifu', '3.2.0'
     pod 'GiphyCoreSDK', '~> 1.4.0'
     pod 'MGSwipeTableCell', '1.6.8'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,7 +21,6 @@ PODS:
     - Reachability (~> 3.1)
     - UIDeviceIdentifier (~> 1.1.4)
   - boost-for-react-native (1.63.0)
-  - BuddyBuildSDK (1.0.17)
   - CocoaLumberjack (3.4.2):
     - CocoaLumberjack/Default (= 3.4.2)
     - CocoaLumberjack/Extensions (= 3.4.2)
@@ -218,7 +217,6 @@ DEPENDENCIES:
   - AFNetworking (= 3.2.1)
   - Alamofire (= 4.7.3)
   - Automattic-Tracks-iOS (from `https://github.com/Automattic/Automattic-Tracks-iOS.git`, tag `0.3`)
-  - BuddyBuildSDK (= 1.0.17)
   - CocoaLumberjack (= 3.4.2)
   - Crashlytics (= 3.12.0)
   - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
@@ -260,7 +258,6 @@ SPEC REPOS:
     - AFNetworking
     - Alamofire
     - boost-for-react-native
-    - BuddyBuildSDK
     - CocoaLumberjack
     - Crashlytics
     - DoubleConversion
@@ -345,7 +342,6 @@ SPEC CHECKSUMS:
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
   Automattic-Tracks-iOS: ebf4af27bc662682f785a272afe19eba49747fe3
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
-  BuddyBuildSDK: 8ae12ee721098b356a961ea7dce70ae55f93a7d2
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   Crashlytics: 07fb167b1694128c1c9a5a5cc319b0e9c3ca0933
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
@@ -389,6 +385,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 99c1fd718368b9d6beef68b54a9144c74d75537b
+PODFILE CHECKSUM: a7b6da1af34339de4c87ee96755453523161046a
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -125,10 +125,6 @@
 #import <SVProgressHUD/SVProgressHUD.h>
 #import <FormatterKit/FormatterKit-umbrella.h>
 
-#ifdef BUDDYBUILD_ENABLED
-#import <BuddyBuildSDK/BuddyBuildSDK.h>
-#endif
-
 #import <WPMediaPicker/WPMediaPicker.h>
 
 #import <WordPressShared/WPDeviceIdentification.h>

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -8,10 +8,6 @@
 #import <SVProgressHUD/SVProgressHUD.h>
 #import <WordPressUI/WordPressUI.h>
 
-#ifdef BUDDYBUILD_ENABLED
-#import <BuddyBuildSDK/BuddyBuildSDK.h>
-#endif
-
 // Data model
 #import "Blog.h"
 
@@ -102,7 +98,6 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
 
     [[InteractiveNotificationsManager shared] registerForUserNotifications];
     [self showWelcomeScreenIfNeededAnimated:NO];
-    [self setupBuddyBuild];
     [self setupPingHub];
     [self setupShortcutCreator];
     [self setupBackgroundRefresh:application];
@@ -110,27 +105,6 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     [self disableAnimationsForUITests:application];
 
     return YES;
-}
-
-- (void)setupBuddyBuild
-{
-#ifdef BUDDYBUILD_ENABLED
-    [BuddyBuildSDK setScreenshotAllowedCallback:^BOOL{
-        return NO;
-    }];
-    
-    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
-    WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
-    NSString *username = defaultAccount.username;
-    
-    if (username.length > 0) {
-        [BuddyBuildSDK setUserDisplayNameCallback:^() {
-            return @"Johnny Appleseed";
-        }];
-    }
-    
-    [BuddyBuildSDK setup];
-#endif
 }
 
 - (void)setupPingHub

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -11862,7 +11862,6 @@
 					INTERNAL_BUILD,
 					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 					ALPHA_BUILD,
-					BUDDYBUILD_ENABLED,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_THUMB_SUPPORT = NO;
@@ -11920,7 +11919,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_ROOT}/Headers/Public\"",
-					"\"${PODS_ROOT}/Headers/Public/BuddyBuildSDK\"",
 					"\"${PODS_ROOT}/Headers/Public/Crashlytics\"",
 					"\"${PODS_ROOT}/Headers/Public/Fabric\"",
 					"\"${PODS_ROOT}/Headers/Public/HockeySDK\"",
@@ -12055,7 +12053,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_ROOT}/Headers/Public\"",
-					"\"${PODS_ROOT}/Headers/Public/BuddyBuildSDK\"",
 					"\"${PODS_ROOT}/Headers/Public/Crashlytics\"",
 					"\"${PODS_ROOT}/Headers/Public/Fabric\"",
 					"\"${PODS_ROOT}/Headers/Public/GoogleSignIn\"",
@@ -12119,7 +12116,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_ROOT}/Headers/Public\"",
-					"\"${PODS_ROOT}/Headers/Public/BuddyBuildSDK\"",
 					"\"${PODS_ROOT}/Headers/Public/Crashlytics\"",
 					"\"${PODS_ROOT}/Headers/Public/Fabric\"",
 					"\"${PODS_ROOT}/Headers/Public/GoogleSignIn\"",
@@ -12183,7 +12179,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_ROOT}/Headers/Public\"",
-					"\"${PODS_ROOT}/Headers/Public/BuddyBuildSDK\"",
 					"\"${PODS_ROOT}/Headers/Public/Crashlytics\"",
 					"\"${PODS_ROOT}/Headers/Public/Fabric\"",
 					"\"${PODS_ROOT}/Headers/Public/GoogleSignIn\"",
@@ -12247,7 +12242,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_ROOT}/Headers/Public\"",
-					"\"${PODS_ROOT}/Headers/Public/BuddyBuildSDK\"",
 					"\"${PODS_ROOT}/Headers/Public/Crashlytics\"",
 					"\"${PODS_ROOT}/Headers/Public/Fabric\"",
 					"\"${PODS_ROOT}/Headers/Public/GoogleSignIn\"",
@@ -12405,7 +12399,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_ROOT}/Headers/Public\"",
-					"\"${PODS_ROOT}/Headers/Public/BuddyBuildSDK\"",
 					"\"${PODS_ROOT}/Headers/Public/Crashlytics\"",
 					"\"${PODS_ROOT}/Headers/Public/Fabric\"",
 					"\"${PODS_ROOT}/Headers/Public/HockeySDK\"",
@@ -12750,7 +12743,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_ROOT}/Headers/Public\"",
-					"\"${PODS_ROOT}/Headers/Public/BuddyBuildSDK\"",
 					"\"${PODS_ROOT}/Headers/Public/Crashlytics\"",
 					"\"${PODS_ROOT}/Headers/Public/Fabric\"",
 					"\"${PODS_ROOT}/Headers/Public/HockeySDK\"",
@@ -12784,7 +12776,6 @@
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"${PODS_ROOT}/Headers/Public\"",
-					"\"${PODS_ROOT}/Headers/Public/BuddyBuildSDK\"",
 					"\"${PODS_ROOT}/Headers/Public/Crashlytics\"",
 					"\"${PODS_ROOT}/Headers/Public/Fabric\"",
 					"\"${PODS_ROOT}/Headers/Public/HockeySDK\"",

--- a/WordPress/buddybuild_prebuild.sh
+++ b/WordPress/buddybuild_prebuild.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-echo "warning: Detected Prebuild Step"
-mkdir -p ~/.mobile-secrets/iOS/WPiOS/
-cp ${BUDDYBUILD_SECURE_FILES}/wpcom_app_credentials ~/.mobile-secrets/iOS/WPiOS/wpcom_app_credentials
-cp ${BUDDYBUILD_SECURE_FILES}/wpcom_internal_app_credentials ~/.mobile-secrets/iOS/WPiOS/wpcom_internal_app_credentials
-cp ${BUDDYBUILD_SECURE_FILES}/wpcom_alpha_app_credentials ~/.mobile-secrets/iOS/WPiOS/wpcom_alpha_app_credentials
-cp ${BUDDYBUILD_SECURE_FILES}/wpcom_test_credentials ~/.wpcom_test_credentials
-echo "warning: Copied files over"

--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-chruby 2.3.1
-bundle install
-bundle exec danger --fail-on-errors=true

--- a/buddybuild_prebuild.sh
+++ b/buddybuild_prebuild.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-./Scripts/allowSimulatorPhotosAccess.sh


### PR DESCRIPTION
This removes all references to BuddyBuild since it is now disabled in favour of CircleCI.

To test:

- CircleCI should be green.
- There should be no BuddyBuild check on this PR.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
