### PR TITLE
Prevent the code freeze lane to update the release notes key

### DIFF
--- a/Scripts/manage-version.sh
+++ b/Scripts/manage-version.sh
@@ -225,14 +225,6 @@ function updateGlotPressKey() {
         showErrorMessage "Can't find $dmFile."
         stopOnError
     fi
-
-    assFile="../WordPress/Resources/AppStoreStrings.po"
-    if [ -f $assFile ]; then
-        sed -i '' "s#.*whats-new\"#msgctxt \"v$newMainVer-whats-new\"#"  $assFile >> $logFile 2>&1 || stopOnError
-    else
-        showErrorMessage "Can't find $assFile."
-        stopOnError
-    fi
 }
 
 # Updates the app version in Fastlane Deliver file


### PR DESCRIPTION
This PR changes the `manage-release.sh` script so that the `whats-new` key in the `AppStoreStrings.po` file is not updated during the code freeze.
This has to be done in order to prevent bad uploads to GlotPress when we merge a `release` branch back into `develop` while still waiting for the final release notes.
The key is then update by the `update_appstore_strings` lane.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
