### PR TITLE
Quick Start V2: Bug on Checklist rotation

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.xib
@@ -12,73 +12,91 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" customClass="QuickStartChecklistHeader" customModule="WordPress">
+        <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" customClass="QuickStartChecklistHeader" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QaU-FW-PcA" userLabel="Top Stroke">
-                    <rect key="frame" x="-8" y="0.0" width="391" height="0.5"/>
-                    <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294119999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rkz-KZ-Ayy" userLabel="Content View">
+                    <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QaU-FW-PcA" userLabel="Top Stroke">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="0.5"/>
+                            <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294119999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="0.33000000000000002" id="R8g-s7-4QD"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hgL-Ff-jIb" userLabel="Bottom Stroke">
+                            <rect key="frame" x="0.0" y="43.5" width="375" height="0.5"/>
+                            <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294119999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="0.33000000000000002" id="TaS-fP-pXw"/>
+                            </constraints>
+                        </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xiK-ca-ccq">
+                            <rect key="frame" x="16" y="12.5" width="303" height="19"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="2ag-iN-nJf">
+                            <rect key="frame" x="335" y="10" width="24" height="24"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="24" id="T9J-7Q-gOT"/>
+                                <constraint firstAttribute="width" constant="24" id="trJ-6b-F4Y"/>
+                            </constraints>
+                        </imageView>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yus-75-Z9J">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                            <connections>
+                                <action selector="headerDidTouch:" destination="iN0-l3-epB" eventType="touchUpInside" id="g6s-7J-Fwg"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="0.33000000000000002" id="R8g-s7-4QD"/>
+                        <constraint firstItem="xiK-ca-ccq" firstAttribute="leading" secondItem="rkz-KZ-Ayy" secondAttribute="leading" constant="16" id="96L-CX-bjS"/>
+                        <constraint firstAttribute="bottom" secondItem="Yus-75-Z9J" secondAttribute="bottom" id="FvG-Uj-huH"/>
+                        <constraint firstItem="2ag-iN-nJf" firstAttribute="top" secondItem="rkz-KZ-Ayy" secondAttribute="top" constant="10" id="K8N-yy-qzD"/>
+                        <constraint firstItem="QaU-FW-PcA" firstAttribute="top" secondItem="rkz-KZ-Ayy" secondAttribute="top" id="KE0-Mv-gQE"/>
+                        <constraint firstItem="Yus-75-Z9J" firstAttribute="leading" secondItem="rkz-KZ-Ayy" secondAttribute="leading" id="Rx0-3q-tA8"/>
+                        <constraint firstAttribute="trailing" secondItem="2ag-iN-nJf" secondAttribute="trailing" constant="16" id="TIG-45-jVS"/>
+                        <constraint firstItem="Yus-75-Z9J" firstAttribute="top" secondItem="rkz-KZ-Ayy" secondAttribute="top" id="X3c-u2-Ek8"/>
+                        <constraint firstItem="hgL-Ff-jIb" firstAttribute="leading" secondItem="rkz-KZ-Ayy" secondAttribute="leading" id="ax6-VY-Phy"/>
+                        <constraint firstAttribute="trailing" secondItem="hgL-Ff-jIb" secondAttribute="trailing" id="dIb-vm-arH"/>
+                        <constraint firstAttribute="bottom" secondItem="hgL-Ff-jIb" secondAttribute="bottom" id="ela-vm-u3P"/>
+                        <constraint firstItem="QaU-FW-PcA" firstAttribute="leading" secondItem="rkz-KZ-Ayy" secondAttribute="leading" id="hdF-lS-dwe"/>
+                        <constraint firstItem="2ag-iN-nJf" firstAttribute="leading" secondItem="xiK-ca-ccq" secondAttribute="trailing" constant="16" id="lJ6-qk-wDP"/>
+                        <constraint firstItem="hgL-Ff-jIb" firstAttribute="top" secondItem="xiK-ca-ccq" secondAttribute="bottom" constant="12" id="m1h-Vt-iic"/>
+                        <constraint firstAttribute="bottom" secondItem="2ag-iN-nJf" secondAttribute="bottom" constant="10" id="nNG-B9-9qB"/>
+                        <constraint firstAttribute="trailing" secondItem="QaU-FW-PcA" secondAttribute="trailing" id="pPf-Q9-F4G"/>
+                        <constraint firstAttribute="trailing" secondItem="Yus-75-Z9J" secondAttribute="trailing" id="xRF-BX-1N8"/>
+                        <constraint firstItem="xiK-ca-ccq" firstAttribute="top" secondItem="QaU-FW-PcA" secondAttribute="bottom" constant="12" id="xbd-Vu-qOe"/>
                     </constraints>
                 </view>
-                <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hgL-Ff-jIb">
-                    <rect key="frame" x="0.0" y="43.5" width="383" height="0.5"/>
-                    <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294119999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="0.33000000000000002" id="TaS-fP-pXw"/>
-                    </constraints>
-                </view>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Ds-nQ-qqM">
-                    <rect key="frame" x="16" y="11.5" width="303" height="21"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mnd-lK-7wz">
-                    <rect key="frame" x="0.0" y="0.5" width="375" height="43"/>
-                    <state key="normal" title="Button"/>
-                    <connections>
-                        <action selector="headerDidTouch:" destination="iN0-l3-epB" eventType="touchUpInside" id="QkH-D2-3fp"/>
-                    </connections>
-                </button>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="D3l-dd-tZe">
-                    <rect key="frame" x="335" y="10" width="24" height="24"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="24" id="7Sv-0g-6RA"/>
-                        <constraint firstAttribute="width" constant="24" id="KGq-Fd-ecc"/>
-                    </constraints>
-                </imageView>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstItem="6Ds-nQ-qqM" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="25I-lZ-h7P"/>
-                <constraint firstItem="mnd-lK-7wz" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="JuB-k1-HCq"/>
-                <constraint firstItem="QaU-FW-PcA" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="PPf-RW-Kev"/>
-                <constraint firstItem="D3l-dd-tZe" firstAttribute="leading" secondItem="6Ds-nQ-qqM" secondAttribute="trailing" constant="16" id="Qlu-NZ-B1o"/>
-                <constraint firstItem="hgL-Ff-jIb" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="RpR-BU-CYO"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="mnd-lK-7wz" secondAttribute="trailing" id="V2K-1H-BXM"/>
-                <constraint firstItem="QaU-FW-PcA" firstAttribute="leadingMargin" secondItem="vUN-kp-3ea" secondAttribute="leading" id="VuT-9Z-sV5"/>
-                <constraint firstItem="D3l-dd-tZe" firstAttribute="centerY" secondItem="mnd-lK-7wz" secondAttribute="centerY" id="bbr-TU-BVM"/>
-                <constraint firstItem="6Ds-nQ-qqM" firstAttribute="centerY" secondItem="vUN-kp-3ea" secondAttribute="centerY" id="bwN-wZ-guV"/>
-                <constraint firstItem="mnd-lK-7wz" firstAttribute="top" secondItem="QaU-FW-PcA" secondAttribute="bottom" id="cGp-0j-LAD"/>
-                <constraint firstItem="hgL-Ff-jIb" firstAttribute="top" secondItem="mnd-lK-7wz" secondAttribute="bottom" id="cNr-2j-tgu"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="QaU-FW-PcA" secondAttribute="trailingMargin" id="dvf-Bj-nGA"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="hgL-Ff-jIb" secondAttribute="trailingMargin" id="hOH-aK-Jkk"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="D3l-dd-tZe" secondAttribute="trailing" constant="16" id="ntH-sC-DT2"/>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="hgL-Ff-jIb" secondAttribute="bottom" id="oZ2-Sc-2e3"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="rkz-KZ-Ayy" secondAttribute="trailing" id="32s-vC-eRb"/>
+                <constraint firstItem="rkz-KZ-Ayy" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="3LJ-Tb-Pc8"/>
+                <constraint firstItem="rkz-KZ-Ayy" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="8R4-t4-EiC"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="rkz-KZ-Ayy" secondAttribute="bottom" id="BeK-YT-USm"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
-            <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <connections>
-                <outlet property="bottomStroke" destination="hgL-Ff-jIb" id="MFe-p5-9GQ"/>
-                <outlet property="chevronView" destination="D3l-dd-tZe" id="gEj-Jr-oUn"/>
-                <outlet property="titleLabel" destination="6Ds-nQ-qqM" id="sdV-Fh-VWT"/>
+                <outlet property="bottomStroke" destination="hgL-Ff-jIb" id="xuE-EE-rcw"/>
+                <outlet property="chevronView" destination="2ag-iN-nJf" id="fe5-yH-BhN"/>
+                <outlet property="titleLabel" destination="xiK-ca-ccq" id="HrR-PQ-Mtc"/>
             </connections>
             <point key="canvasLocation" x="53.600000000000001" y="48.575712143928037"/>
         </view>
+        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="76p-ko-nof">
+            <rect key="frame" x="0.0" y="0.0" width="46" height="30"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <state key="normal" title="Button"/>
+            <point key="canvasLocation" x="27" y="-59"/>
+        </button>
     </objects>
 </document>


### PR DESCRIPTION
Refs. #10860 

This PR fixes a bug related to the QS Checklist view and its new header. Basically when a user rotates this view in Landscape, then it wasn't possible to rotate it back in portrait.

![qs-header-bug](https://user-images.githubusercontent.com/912252/51932407-0b994880-23f7-11e9-9c1e-eb539f8e6a33.jpg)

This also fixes a thread problem on the iPad.

**To test:**
- Put return true in shouldShowQuickStartCheacklist()
- From the Blog detail page select one of the 2 Quick Start row and open the Checklist
- Rotate the device from Landscape to Portrait. It should rotate and normally update the view to its size