### PR TITLE
Fix post not uploaded before preview.

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1190,6 +1190,8 @@ private extension AztecPostViewController {
                 guard let context = self.post.managedObjectContext else {
                     return
                 }
+
+                self.publishPost(action: .saveAsDraft, dismissWhenDone: false, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
                 ContextManager.sharedInstance().save(context)
             }
             self.displayPreview()

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1186,14 +1186,6 @@ private extension AztecPostViewController {
         }
 
         alert.addDefaultActionWithTitle(MoreSheetAlert.previewTitle) { [unowned self] _ in
-            if self.post.isDraft(), self.post.hasLocalChanges() {
-                guard let context = self.post.managedObjectContext else {
-                    return
-                }
-
-                self.publishPost(action: .saveAsDraft, dismissWhenDone: false, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
-                ContextManager.sharedInstance().save(context)
-            }
             self.displayPreview()
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -179,7 +179,7 @@ extension PostEditor where Self: UIViewController {
     func cancelEditing() {
         stopEditing()
 
-        if post.canSave() && post.hasUnsavedChanges() {
+        if post.canSave() {
             showPostHasChangesAlert()
         } else {
             discardChangesAndUpdateGUI()

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
@@ -19,8 +19,7 @@ class PostPreviewGenerator: NSObject {
     }
 
     @objc func generate() {
-        guard let url = post.permaLink.flatMap(URL.init(string:)),
-            (!post.hasLocalChanges() || post.isDraft()) else {
+        guard let url = post.permaLink.flatMap(URL.init(string:)) else {
                 showFakePreview()
                 return
         }

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewGenerator.swift
@@ -19,7 +19,8 @@ class PostPreviewGenerator: NSObject {
     }
 
     @objc func generate() {
-        guard let url = post.permaLink.flatMap(URL.init(string:)) else {
+        guard let url = post.permaLink.flatMap(URL.init(string:)),
+            !post.hasLocalChanges() else {
                 showFakePreview()
                 return
         }


### PR DESCRIPTION
In the last PR #10787  I was saving the post locally but not uploading it. 
Calling uploadPost with saveAsDraft action before previewing.
removing the conditions in post generator that bring up the fake preview for draft posts

Fixes #9286

To test:
Open an existing draft.
Make changes to the post.
Preview the post.

![draft_preview](https://user-images.githubusercontent.com/1335657/51929884-22677d00-23ae-11e9-86b6-bf17cd65082c.gif)

** The "You have unsaved changes" action sheet does not display when dismissing a newly created draft after previewing it. 
Steps to reproduce:
1. Create new draft
2. Edit it
3. Preview it
4. dismiss the draft (tap on X)

expected: "You have unsaved changes" action sheet gives the user the option to keep editing/ discard.
Actual: The action sheet is not displayed because the post.canSave property is false (hasLocalChanges = false || hasRemoteChanges = false) but *the post is saved*

Not sure whats the best solution for this issue, but wanted to bring it up here in addition to fixing the original issue. 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
