### PR TITLE
CircleCI: Allow resetting of CocoaPods cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  ios: wordpress-mobile/ios@0.0.7
-  danger: wordpress-mobile/danger@0.0.7
+  ios: wordpress-mobile/ios@0.0.11
+  danger: wordpress-mobile/danger@0.0.11
 
 jobs:
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,9 @@ jobs:
       xcode: "10.1.0"
     steps:
       - checkout
-      - ios/cached-pod-install
+      - ios/cached-pod-install:
+          # If you want to reset the CircleCI cache, increment the number in the cache prefix below
+          cache-prefix: cocoapods-cache-v1
       - run:
           name: Build
           command: xcodebuild -scheme "WordPress" -configuration "Debug" -workspace "WordPress.xcworkspace" -sdk iphonesimulator build-for-testing | bundle exec xcpretty


### PR DESCRIPTION
This is a small change (along with an update in https://github.com/wordpress-mobile/circleci-orbs) that allows modifying the cache key so that it can be changed if the cache should be reset.

To test:

- Checks should be green on this PR.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
