### PR TITLE
CircleCI: Update Orb version for strict CocoaPods caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 version: 2.1
 
 orbs:
-  ios: wordpress-mobile/ios@0.0.11
-  danger: wordpress-mobile/danger@0.0.11
+  ios: wordpress-mobile/ios@0.0.12
+  danger: wordpress-mobile/danger@0.0.12
 
 jobs:
   build_and_test:


### PR DESCRIPTION
This uses the changes from https://github.com/wordpress-mobile/circleci-orbs/pull/3 to be stricter about how CocoaPods caching works.

To test:

- CircleCI is green.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
