### PR TITLE
Prevent loadSite from being called twice

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -39,6 +39,9 @@ final class AssembledSiteView: UIView {
     /// The web view that renders our newly assembled site
     private let webView: WKWebView
 
+    /// The request formulated to present the site to the user for first time.
+    private var initialSiteRequest: URLRequest?
+
     /// This interacts with our `WKNavigationDelegate` to influence the policy behavior before & after site loading.
     /// After the site has been loaded, we want to disable user interaction with the rendered site.
     private var webViewHasLoadedContent: Bool = false
@@ -125,12 +128,17 @@ final class AssembledSiteView: UIView {
 
     // MARK: Internal behavior
 
-    /// Triggers the new site to load for the first time.
-    func loadSite() {
-        generator.prepare()
+    /// Triggers the new site to load, once, and only once.
+    ///
+    func loadSiteIfNeeded() {
+        guard initialSiteRequest == nil, let siteURL = URL(string: siteURLString) else {
+            return
+        }
 
-        let siteURL = URL(string: siteURLString)!
         let siteRequest = URLRequest(url: siteURL)
+        self.initialSiteRequest = siteRequest
+
+        generator.prepare()
 
         webView.load(siteRequest)
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
@@ -311,7 +311,7 @@ final class SiteAssemblyContentView: UIView {
     }
 
     private func layoutSucceeded() {
-        assembledSiteView?.loadSite()
+        assembledSiteView?.loadSiteIfNeeded()
 
         UIView.animate(withDuration: Parameters.animationDuration, delay: 0, options: .curveEaseOut, animations: { [statusStackView] in
             statusStackView.alpha = 0

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -138,8 +138,12 @@ final class WebAddressWizardContent: UIViewController {
     }
 
     private func fetchAddresses(_ searchTerm: String) {
-        // 10908 Workaround - DO NOT MERGE THIS!
-        let suggestionType: DomainsServiceRemote.DomainSuggestionType = .wordPressDotComAndDotBlogSubdomains
+        let suggestionType: DomainsServiceRemote.DomainSuggestionType
+        if let segmentID = siteCreator.segment?.identifier, segmentID == SiteSegment.blogSegmentIdentifier {
+            suggestionType = .wordPressDotComAndDotBlogSubdomains
+        } else {
+            suggestionType = .onlyWordPressDotCom
+        }
 
         service.addresses(for: searchTerm, domainSuggestionType: suggestionType) { [weak self] results in
             switch results {

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -138,12 +138,8 @@ final class WebAddressWizardContent: UIViewController {
     }
 
     private func fetchAddresses(_ searchTerm: String) {
-        let suggestionType: DomainsServiceRemote.DomainSuggestionType
-        if let segmentID = siteCreator.segment?.identifier, segmentID == SiteSegment.blogSegmentIdentifier {
-            suggestionType = .wordPressDotComAndDotBlogSubdomains
-        } else {
-            suggestionType = .onlyWordPressDotCom
-        }
+        // 10908 Workaround - DO NOT MERGE THIS!
+        let suggestionType: DomainsServiceRemote.DomainSuggestionType = .wordPressDotComAndDotBlogSubdomains
 
         service.addresses(for: searchTerm, domainSuggestionType: suggestionType) { [weak self] results in
             switch results {


### PR DESCRIPTION
Fixes #10927.

To test:

- Checkout the branch and confirm that existing tests pass.
- Revert the commit `edacf39` (i.e., reverting this commit revert will temporarily restore the workaround for #10919, allowing site creation to proceed to completion).
- Place a breakpoint on line 138 of `AssembledSiteView.loadSiteIfNeeded()`
- Proceed through the enhanced site creation flow, following the steps in the issue report.
- Observe that this method only loads the web view once.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.