### PR TITLE
Fix a reader crash caused by images in video tags

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,3 @@
 * Fixed an issue where some cells in Activity Log would lay out incorrectly
 * Adds support for sharing a blog via Reader.
+* Fix a crash in reader caused by a video with a fallback image.

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextFormatter.swift
@@ -79,6 +79,11 @@ class WPRichTextFormatter {
         for attachment in attachments {
             let str = attrString.string as NSString
             let range = str.range(of: attachment.identifier)
+
+            guard range.location != NSNotFound else {
+                continue
+            }
+
             let attributes = attrString.attributes(at: range.location, effectiveRange: nil)
 
             let attachmentString = NSMutableAttributedString(attributedString: NSAttributedString(attachment: attachment))

--- a/WordPress/WordPressTest/ViewRelated/Views/WPRichText/WPRichTextFormatterTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Views/WPRichText/WPRichTextFormatterTests.swift
@@ -119,4 +119,14 @@ class WPRichTextFormatterTests: XCTestCase {
         XCTAssert(attributes["title"] == "Example")
     }
 
+    func testThatParsingImageTagInsideVideoTagDoesntCrash() {
+        let html = "<video><img /></video>"
+
+        do {
+            _ = try WPRichTextFormatter().attributedStringFromHTMLString(html, defaultDocumentAttributes: nil)
+        }
+        catch let err {
+            XCTFail(err.localizedDescription)
+        }
+    }
 }


### PR DESCRIPTION
Fixes a bug caused by viewing this post in Reader: https://marco.org/2019/01/28/overcast-instant-search. The presence of the `<img>` tag in the `<video>` tag causes a crash.

**To test:**

1. Comment out the change in WPRichTextFormatter.swift. 
2. Run the new test
3. See that it crashes
4. Put the change back
5. Run the new test
6. See that it doesn't crash anymore.

**Update release notes:**

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

**Future Work**

This PR fixes the crash, but doesn't properly resolve the issue – `<img>` tags within a `<video>` tag are used for fallback in case the users browser can't play any of the sources. Right now, this won't crash, but it won't properly display the video either – the `<img>` tag will replace the video.

If this PR looks ok, will open a new one / file an issue about it.