### PR TITLE
[Site Creation] Add "Create Site" button to Domain screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TableViewOffsetCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TableViewOffsetCoordinator.swift
@@ -120,29 +120,6 @@ final class TableViewOffsetCoordinator {
         })
     }
 
-    func updateTableOffsetIfToolbarVisible() {
-        guard let table = tableView, let footerControl = footerControl, footerControl.isHidden == true else {
-            return
-        }
-
-        let currentInsets = table.contentInset
-
-        let bottomInset = currentInsets.bottom + footerControl.frame.size.height
-
-        let targetInsets = UIEdgeInsets(top: -1 * currentInsets.top, left: 0, bottom: bottomInset, right: 0)
-
-        UIView.animate(withDuration: Constants.headerAnimationDuration, delay: 0, options: .beginFromCurrentState, animations: { [weak self] in
-            guard let self = self, let tableView = self.tableView else {
-                return
-            }
-
-            tableView.contentInset = targetInsets
-            tableView.scrollIndicatorInsets = targetInsets
-            }, completion: { [weak self] _ in
-                self?.tableViewHasBeenAdjusted = true
-        })
-    }
-
     @objc
     func keyboardWillShow(_ notification: Foundation.Notification) {
         guard let payload = KeyboardInfo(notification) else {

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TableViewOffsetCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TableViewOffsetCoordinator.swift
@@ -120,6 +120,29 @@ final class TableViewOffsetCoordinator {
         })
     }
 
+    func updateTableOffsetIfToolbarVisible() {
+        guard let table = tableView, let footerControl = footerControl, footerControl.isHidden == true else {
+            return
+        }
+
+        let currentInsets = table.contentInset
+
+        let bottomInset = currentInsets.bottom + footerControl.frame.size.height
+
+        let targetInsets = UIEdgeInsets(top: -1 * currentInsets.top, left: 0, bottom: bottomInset, right: 0)
+
+        UIView.animate(withDuration: Constants.headerAnimationDuration, delay: 0, options: .beginFromCurrentState, animations: { [weak self] in
+            guard let self = self, let tableView = self.tableView else {
+                return
+            }
+
+            tableView.contentInset = targetInsets
+            tableView.scrollIndicatorInsets = targetInsets
+            }, completion: { [weak self] _ in
+                self?.tableViewHasBeenAdjusted = true
+        })
+    }
+
     @objc
     func keyboardWillShow(_ notification: Foundation.Notification) {
         guard let payload = KeyboardInfo(notification) else {

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
@@ -38,6 +38,10 @@ final class AddressCell: UITableViewCell, ModelSettableCell {
         accessoryType = highlighted ? .checkmark : .none
     }
 
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        accessoryType = selected ? .checkmark : .none
+    }
+
     private func styleCheckmark() {
         tintColor = WPStyleGuide.mediumBlue()
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressTableViewProvider.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressTableViewProvider.swift
@@ -63,7 +63,6 @@ final class WebAddressTableViewProvider: NSObject, TableViewProvider {
     // MARK: UITableViewDelegate
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        tableView.deselectRow(at: indexPath, animated: true)
         selectionHandler?(indexPath)
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -102,7 +102,9 @@ final class WebAddressWizardContent: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        self.tableViewOffsetCoordinator = TableViewOffsetCoordinator(coordinated: table)
+        self.tableViewOffsetCoordinator = TableViewOffsetCoordinator(coordinated: table, footerControlContainer: view, footerControl: buttonWrapper, toolbarBottomConstraint: bottomConstraint)
+
+        tableViewOffsetCoordinator?.hideBottomToolbar()
 
         applyTitle()
         setupBackground()
@@ -143,6 +145,8 @@ final class WebAddressWizardContent: UIViewController {
 
     private func clearContent() {
         throttle.cancel()
+
+        tableViewOffsetCoordinator?.hideBottomToolbar()
 
         guard let validDataProvider = tableViewProvider as? WebAddressTableViewProvider else {
             setupTableDataProvider()
@@ -359,6 +363,7 @@ final class WebAddressWizardContent: UIViewController {
 
             let domainSuggestion = provider.data[selectedIndexPath.row]
             self.selectedDomain = domainSuggestion
+            self.tableViewOffsetCoordinator?.showBottomToolbar()
         }
 
         self.tableViewProvider = WebAddressTableViewProvider(tableView: table, data: data, selectionHandler: handler)

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -246,7 +246,7 @@ final class WebAddressWizardContent: UIViewController {
     }
 
     private func resignTextFieldResponderIfNeeded() {
-        guard WPDeviceIdentification.isiPhone(), let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader else {
+        guard let header = self.table.tableHeaderView as? TitleSubtitleTextfieldHeader else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -365,7 +365,7 @@ final class WebAddressWizardContent: UIViewController {
 
             let domainSuggestion = provider.data[selectedIndexPath.row]
             self.selectedDomain = domainSuggestion
-            self.tableViewOffsetCoordinator?.updateTableOffsetIfToolbarVisible()
+            self.resignTextFieldResponderIfNeeded()
             self.tableViewOffsetCoordinator?.showBottomToolbar()
         }
 
@@ -381,6 +381,10 @@ final class WebAddressWizardContent: UIViewController {
 
         performSearchIfNeeded(query: searchTerm)
         tableViewOffsetCoordinator?.adjustTableOffsetIfNeeded()
+    }
+
+    private func hideKeyboard() {
+
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressAuthenticator
 
 /// Contains the UI corresponding to the list of Domain suggestions.
 ///
@@ -18,8 +19,20 @@ final class WebAddressWizardContent: UIViewController {
 
     private let selection: (DomainSuggestion) -> Void
 
-    @IBOutlet
-    private weak var table: UITableView!
+    /// Tracks the site address selected by users
+    private var selectedDomain: DomainSuggestion?
+
+    /// The table view renders our server content
+    @IBOutlet private weak var table: UITableView!
+
+    /// The view wrapping the skip button
+    @IBOutlet private weak var buttonWrapper: ShadowView!
+
+    /// The Create Site button
+    @IBOutlet private weak var createSite: NUXButton!
+
+    /// The constraint between the bottom of the buttonWrapper and this view controller's view
+    @IBOutlet private weak var bottomConstraint: NSLayoutConstraint!
 
     /// Serves as both the data source & delegate of the table view
     private(set) var tableViewProvider: TableViewProvider?
@@ -93,6 +106,8 @@ final class WebAddressWizardContent: UIViewController {
 
         applyTitle()
         setupBackground()
+        setupButtonWrapper()
+        setupCreateSiteButton()
         setupTable()
     }
 
@@ -192,6 +207,30 @@ final class WebAddressWizardContent: UIViewController {
 
     private func setupBackground() {
         view.backgroundColor = WPStyleGuide.greyLighten30()
+    }
+
+    private func setupButtonWrapper() {
+        buttonWrapper.backgroundColor = WPStyleGuide.greyLighten30()
+    }
+
+    private func setupCreateSiteButton() {
+        createSite.addTarget(self, action: #selector(commitSelection), for: .touchUpInside)
+
+        let buttonTitle = NSLocalizedString("Create Site", comment: "Button to progress to the next step")
+        createSite.setTitle(buttonTitle, for: .normal)
+        createSite.accessibilityLabel = buttonTitle
+        createSite.accessibilityHint = NSLocalizedString("Creates a new Site", comment: "Site creation. Navigates to the next step")
+
+        createSite.isPrimary = true
+    }
+
+    @objc
+    private func commitSelection() {
+        guard let selectedDomain = selectedDomain else {
+            return
+        }
+
+        selection(selectedDomain)
     }
 
     private func setupCells() {
@@ -319,7 +358,7 @@ final class WebAddressWizardContent: UIViewController {
             }
 
             let domainSuggestion = provider.data[selectedIndexPath.row]
-            self.selection(domainSuggestion)
+            self.selectedDomain = domainSuggestion
         }
 
         self.tableViewProvider = WebAddressTableViewProvider(tableView: table, data: data, selectionHandler: handler)

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -383,8 +383,10 @@ final class WebAddressWizardContent: UIViewController {
         tableViewOffsetCoordinator?.adjustTableOffsetIfNeeded()
     }
 
-    private func hideKeyboard() {
-
+    private func clearSelectionAndCreateSiteButton() {
+        selectedDomain = nil
+        table.deselectSelectedRowWithAnimation(true)
+        tableViewOffsetCoordinator?.hideBottomToolbar()
     }
 }
 
@@ -401,6 +403,11 @@ extension WebAddressWizardContent: NetworkStatusDelegate {
 extension WebAddressWizardContent: UITextFieldDelegate {
     func textFieldShouldClear(_ textField: UITextField) -> Bool {
         tableViewOffsetCoordinator?.resetTableOffsetIfNeeded()
+        return true
+    }
+
+    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
+        clearSelectionAndCreateSiteButton()
         return true
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -363,6 +363,7 @@ final class WebAddressWizardContent: UIViewController {
 
             let domainSuggestion = provider.data[selectedIndexPath.row]
             self.selectedDomain = domainSuggestion
+            self.tableViewOffsetCoordinator?.updateTableOffsetIfToolbarVisible()
             self.tableViewOffsetCoordinator?.showBottomToolbar()
         }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.xib
@@ -12,6 +12,9 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="WebAddressWizardContent" customModule="WordPress" customModuleProvider="target">
             <connections>
+                <outlet property="bottomConstraint" destination="NwM-aT-uUs" id="dhP-0e-POG"/>
+                <outlet property="buttonWrapper" destination="Tlo-3p-qcj" id="MQL-hV-Msf"/>
+                <outlet property="createSite" destination="67Z-L0-vE2" id="wob-fY-gQx"/>
                 <outlet property="table" destination="yJE-cr-Vx8" id="Qv6-dh-90b"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
@@ -22,16 +25,39 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="yJE-cr-Vx8">
-                    <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                    <rect key="frame" x="0.0" y="20" width="375" height="360"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="360" id="FWW-yb-ptt"/>
+                    </constraints>
                 </tableView>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tlo-3p-qcj" userLabel="Button Wrapper" customClass="ShadowView" customModule="WordPress" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="567" width="375" height="74"/>
+                    <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="67Z-L0-vE2" userLabel="Create Site" customClass="NUXButton" customModule="WordPressAuthenticator">
+                            <rect key="frame" x="309" y="16" width="46" height="42"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="42" id="5ke-lq-B5o"/>
+                            </constraints>
+                            <state key="normal" title="Button"/>
+                        </button>
+                    </subviews>
+                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <constraints>
+                        <constraint firstItem="67Z-L0-vE2" firstAttribute="centerY" secondItem="Tlo-3p-qcj" secondAttribute="centerY" id="6kq-aB-YHN"/>
+                        <constraint firstAttribute="height" constant="74" id="8iX-S9-u82"/>
+                    </constraints>
+                </view>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="yJE-cr-Vx8" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" placeholder="YES" id="KUd-R4-fA5"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="Tlo-3p-qcj" secondAttribute="bottom" constant="26" id="NwM-aT-uUs"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Tlo-3p-qcj" secondAttribute="trailing" id="Tk4-p5-6jv"/>
                 <constraint firstItem="yJE-cr-Vx8" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" placeholder="YES" id="fMg-JB-ghl"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="yJE-cr-Vx8" secondAttribute="bottom" placeholder="YES" id="ltc-hv-YFg"/>
+                <constraint firstItem="67Z-L0-vE2" firstAttribute="trailing" secondItem="yJE-cr-Vx8" secondAttribute="trailing" constant="-20" id="kF3-K4-Nk5"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="yJE-cr-Vx8" secondAttribute="trailing" placeholder="YES" id="q8i-9J-XqT"/>
+                <constraint firstItem="Tlo-3p-qcj" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="w6R-hK-z8O"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="138.40000000000001" y="120.98950524737631"/>

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.xib
@@ -32,7 +32,7 @@
                     </constraints>
                 </tableView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Tlo-3p-qcj" userLabel="Button Wrapper" customClass="ShadowView" customModule="WordPress" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="567" width="375" height="74"/>
+                    <rect key="frame" x="0.0" y="593" width="375" height="74"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="67Z-L0-vE2" userLabel="Create Site" customClass="NUXButton" customModule="WordPressAuthenticator">
                             <rect key="frame" x="309" y="16" width="46" height="42"/>
@@ -52,7 +52,7 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="yJE-cr-Vx8" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" placeholder="YES" id="KUd-R4-fA5"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="Tlo-3p-qcj" secondAttribute="bottom" constant="26" id="NwM-aT-uUs"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="Tlo-3p-qcj" secondAttribute="bottom" id="NwM-aT-uUs"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Tlo-3p-qcj" secondAttribute="trailing" id="Tk4-p5-6jv"/>
                 <constraint firstItem="yJE-cr-Vx8" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" placeholder="YES" id="fMg-JB-ghl"/>
                 <constraint firstItem="67Z-L0-vE2" firstAttribute="trailing" secondItem="yJE-cr-Vx8" secondAttribute="trailing" constant="-20" id="kF3-K4-Nk5"/>


### PR DESCRIPTION
Fixes #10922 

iPhone X:
![screen recording 2019-01-31 at 11 47 10 pm mov](https://user-images.githubusercontent.com/2722505/52103343-33cda680-25b3-11e9-88d1-a8434efadfbb.gif)

iPhone SE: 
![screen recording 2019-01-31 at 11 44 17 pm mov](https://user-images.githubusercontent.com/2722505/52103435-9d4db500-25b3-11e9-8d2f-b7f21e85c406.gif)

iPad Pro 11:
![simulator screen shot - ipad pro 11-inch - 2019-01-31 at 23 58 03](https://user-images.githubusercontent.com/2722505/52103530-15b47600-25b4-11e9-96b7-c379637a5b95.png)

To test:
- Checkout the branch, run the tests
- Launch the Enhanced Site Creation flow, navigate to the Domains step, and select a domain. The Create Site button should then be visible, and wizard should not progress until the "Create Site" button is tapped.
