### PR TITLE
[Site Creation] Accessibility review

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
@@ -96,6 +96,20 @@ final class TitleSubtitleHeader: UIView {
     }
 }
 
+extension TitleSubtitleHeader {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            preferredContentSizeDidChange()
+        }
+    }
+
+    func preferredContentSizeDidChange() {
+        // Title needs to be forced to reset its style, otherwise the types do not change
+        styleTitle()
+    }
+}
+
 extension TitleSubtitleHeader: Accessible {
     func prepareForVoiceOver() {
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
@@ -61,6 +61,8 @@ final class TitleSubtitleHeader: UIView {
         ])
 
         setStyles()
+
+        prepareForVoiceOver()
     }
 
     private func setStyles() {
@@ -91,5 +93,11 @@ final class TitleSubtitleHeader: UIView {
     func setSubtitle(_ text: String) {
         subtitleLabel.text = text
         subtitleLabel.accessibilityLabel = text
+    }
+}
+
+extension TitleSubtitleHeader: Accessible {
+    func prepareForVoiceOver() {
+
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -60,11 +60,12 @@ private final class SearchTextField: UITextField {
 
         backgroundColor = .white
         clearButtonMode = .whileEditing
-        font = WPStyleGuide.fixedFont(for: .headline)
+        font = WPStyleGuide.fontForTextStyle(.headline)
         textColor = WPStyleGuide.darkGrey()
 
         autocapitalizationType = .none
         autocorrectionType = .no
+        adjustsFontForContentSizeCategory = true
 
         let iconSize = CGSize(width: Constants.iconDimension, height: Constants.iconDimension)
         let loupeIcon = Gridicon.iconOfType(.search, withSize: iconSize).imageWithTintColor(WPStyleGuide.readerCardCellHighlightedBorderColor())?.imageFlippedForRightToLeftLayoutDirection()

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -146,6 +146,8 @@ final class TitleSubtitleTextfieldHeader: UIView {
             ])
 
         setStyles()
+
+        prepareForVoiceOver()
     }
 
     private func setStyles() {
@@ -158,5 +160,17 @@ final class TitleSubtitleTextfieldHeader: UIView {
 
     func setSubtitle(_ text: String) {
         titleSubtitle.setSubtitle(text)
+    }
+}
+
+extension TitleSubtitleTextfieldHeader: Accessible {
+    func prepareForVoiceOver() {
+        titleSubtitle.prepareForVoiceOver()
+
+        prepareSearchFieldForVoiceOver()
+    }
+
+    private func prepareSearchFieldForVoiceOver() {
+        textField.accessibilityTraits = .searchField
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
@@ -149,6 +149,8 @@ final class SiteInformationWizardContent: UIViewController {
         header.setTitle(headerData.title)
         header.setSubtitle(headerData.subtitle)
 
+        header.accessibilityTraits = .header
+
         table.tableHeaderView = header
 
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
@@ -22,6 +22,8 @@ final class SiteInformationWizardContent: UIViewController {
         static let footerHeight: CGFloat = 42.0
         static let footerVerticalMargin: CGFloat = 6.0
         static let footerHorizontalMargin: CGFloat = 16.0
+        static let rowHeight: CGFloat = 44.0
+        static let separatorInset = UIEdgeInsets(top: 0, left: 64.0, bottom: 0, right: 0)
     }
 
     private let completion: SiteInformationCompletion
@@ -84,6 +86,7 @@ final class SiteInformationWizardContent: UIViewController {
         setupTableBackground()
         setupTableSeparator()
         registerCell()
+        setupCellHeight()
         setupHeader()
         setupFooter()
         setupConstraints()
@@ -104,6 +107,12 @@ final class SiteInformationWizardContent: UIViewController {
             InlineEditableNameValueCell.defaultNib,
             forCellReuseIdentifier: InlineEditableNameValueCell.defaultReuseID
         )
+    }
+
+    private func setupCellHeight() {
+        table.rowHeight = UITableView.automaticDimension
+        table.estimatedRowHeight = Constants.rowHeight
+        table.separatorInset = Constants.separatorInset
     }
 
     private func setupButtonWrapper() {
@@ -158,11 +167,11 @@ final class SiteInformationWizardContent: UIViewController {
         title.textColor = WPStyleGuide.greyDarken20()
         title.font = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular)
         title.text = TableStrings.footer
+        title.adjustsFontForContentSizeCategory = true
 
         footer.addSubview(title)
 
         NSLayoutConstraint.activate([
-            title.heightAnchor.constraint(equalTo: footer.heightAnchor),
             title.leadingAnchor.constraint(equalTo: footer.leadingAnchor, constant: Constants.footerHorizontalMargin),
             title.trailingAnchor.constraint(equalTo: footer.trailingAnchor, constant: -1 * Constants.footerHorizontalMargin),
             title.topAnchor.constraint(equalTo: footer.topAnchor, constant: Constants.footerVerticalMargin)

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.xib
@@ -25,11 +25,8 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="r6F-pP-AOC">
-                    <rect key="frame" x="0.0" y="20" width="375" height="360"/>
+                    <rect key="frame" x="0.0" y="20" width="375" height="565"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="360" id="4Cq-p8-GS5"/>
-                    </constraints>
                 </tableView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UkU-4z-E9I" customClass="ShadowView" customModule="WordPress" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="593" width="375" height="74"/>
@@ -61,6 +58,7 @@
                 <constraint firstItem="r6F-pP-AOC" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="TBi-Iw-igH"/>
                 <constraint firstItem="UkU-4z-E9I" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="bhT-do-jHe"/>
                 <constraint firstItem="r6F-pP-AOC" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="nLU-Y5-HN0"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="r6F-pP-AOC" secondAttribute="bottom" constant="82" id="qaO-Zj-Exj"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="UkU-4z-E9I" secondAttribute="trailing" id="t9g-Qb-YAv"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.xib
@@ -32,9 +32,8 @@
                     <rect key="frame" x="0.0" y="593" width="375" height="74"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="f1h-X0-IMG" customClass="NUXButton" customModule="WordPressAuthenticator">
-                            <rect key="frame" x="275" y="16" width="80" height="42"/>
+                            <rect key="frame" x="309" y="16" width="46" height="42"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="80" id="TLh-gc-cZT"/>
                                 <constraint firstAttribute="height" constant="42" id="gbb-cb-sNW"/>
                             </constraints>
                             <state key="normal" title="Button"/>

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
@@ -79,3 +79,17 @@ final class SiteSegmentsCell: UITableViewCell, ModelSettableCell {
         accessoryType = .disclosureIndicator
     }
 }
+
+extension SiteSegmentsCell {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            preferredContentSizeDidChange()
+        }
+    }
+
+    func preferredContentSizeDidChange() {
+        // Title needs to be forced to reset its style, otherwise the types do not change
+        styleTitle()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
@@ -93,3 +93,14 @@ extension SiteSegmentsCell {
         styleTitle()
     }
 }
+
+extension SiteSegmentsCell: Accessible {
+    func prepareForVoiceOver() {
+        prepareIconForVoiceOver()
+    }
+
+    private func prepareIconForVoiceOver() {
+        icon.accessibilityLabel = NSLocalizedString("Icon representing ", comment: "Accessibility description for Site Segment icon. Will be followed by the kind of site") + (model?.title ?? NSLocalizedString("Kind of site", comment: "Default accessibilty label for an unknown kind of site "))
+        icon.accessibilityTraits = .image
+    }
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
@@ -66,11 +66,13 @@ final class SiteSegmentsCell: UITableViewCell, ModelSettableCell {
     private func styleTitle() {
         title.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
         title.textColor = WPStyleGuide.darkGrey()
+        title.adjustsFontForContentSizeCategory = true
     }
 
     private func styleSubtitle() {
         subtitle.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .regular)
         subtitle.textColor = WPStyleGuide.darkGrey()
+        subtitle.adjustsFontForContentSizeCategory = true
     }
 
     private func styleAccessoryView() {

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
@@ -237,7 +237,6 @@ private extension SiteSegmentsWizardContent {
     }
 }
 
-
 extension SiteSegmentsWizardContent: Accessible {
     func prepareForVoiceOver() {
         prepareTableForVoiceOver()

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
@@ -42,6 +42,8 @@ final class SiteSegmentsWizardContent: UIViewController {
         setupBackground()
         setupTable()
         initCancelButton()
+
+        prepareForVoiceOver()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -106,6 +108,8 @@ final class SiteSegmentsWizardContent: UIViewController {
         let header = TitleSubtitleHeader(frame: initialHeaderFrame)
         header.setTitle(headerData.title)
         header.setSubtitle(headerData.subtitle)
+
+        header.accessibilityTraits = .header
 
         table.tableHeaderView = header
 
@@ -230,5 +234,17 @@ private extension SiteSegmentsWizardContent {
         // TODO : using viaDone, capture analytics event via #10335
         clearErrorStateViewController()
         fetchSegments()
+    }
+}
+
+
+extension SiteSegmentsWizardContent: Accessible {
+    func prepareForVoiceOver() {
+        prepareTableForVoiceOver()
+    }
+
+    private func prepareTableForVoiceOver() {
+        table.accessibilityLabel = NSLocalizedString("The kinds of sites that can be created", comment: "Accessibility hint for list ")
+        table.accessibilityTraits = UIAccessibilityTraits.allowsDirectInteraction
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsCell.swift
@@ -27,3 +27,16 @@ final class VerticalsCell: UITableViewCell, SiteVerticalPresenter {
         title.adjustsFontForContentSizeCategory = true
     }
 }
+
+extension VerticalsCell {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            preferredContentSizeDidChange()
+        }
+    }
+
+    func preferredContentSizeDidChange() {
+        styleTitle()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsCell.swift
@@ -24,5 +24,6 @@ final class VerticalsCell: UITableViewCell, SiteVerticalPresenter {
     private func styleTitle() {
         title.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
         title.textColor = WPStyleGuide.darkGrey()
+        title.adjustsFontForContentSizeCategory = true
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsCell.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsCell.xib
@@ -19,7 +19,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="286" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vsr-JN-gsO">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Vsr-JN-gsO">
                         <rect key="frame" x="16" y="11.5" width="262" height="20.5"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
@@ -436,3 +436,16 @@ extension VerticalsWizardContent: UITextFieldDelegate {
         return true
     }
 }
+
+extension VerticalsWizardContent {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            preferredContentSizeDidChange()
+        }
+    }
+
+    func preferredContentSizeDidChange() {
+        tableViewOffsetCoordinator?.adjustTableOffsetIfNeeded()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
@@ -371,6 +371,8 @@ final class VerticalsWizardContent: UIViewController {
         header.textField.addTarget(self, action: #selector(textChanged), for: .editingChanged)
         header.textField.delegate = self
 
+        header.accessibilityTraits = .header
+
         let placeholderText = prompt.hint
         let attributes = WPStyleGuide.defaultSearchBarTextAttributesSwifted(WPStyleGuide.grey())
         let attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: attributes)

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.xib
@@ -35,10 +35,9 @@
                     <rect key="frame" x="0.0" y="593" width="375" height="74"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vaK-ii-Amu" customClass="NUXButton" customModule="WordPressAuthenticator">
-                            <rect key="frame" x="275" y="16" width="80" height="42"/>
+                            <rect key="frame" x="309" y="16" width="46" height="42"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="42" id="Xwj-pA-YCa"/>
-                                <constraint firstAttribute="width" constant="80" id="vQE-60-zNs"/>
                             </constraints>
                             <state key="normal" title="Button"/>
                         </button>

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
@@ -64,3 +64,16 @@ final class AddressCell: UITableViewCell, ModelSettableCell {
         return completeDomainName
     }
 }
+
+extension AddressCell {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            preferredContentSizeDidChange()
+        }
+    }
+
+    func preferredContentSizeDidChange() {
+        title.attributedText = processName(model?.domainName)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.xib
@@ -19,13 +19,17 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hQm-TV-IDW">
-                        <rect key="frame" x="16" y="12" width="288" height="21"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hQm-TV-IDW">
+                        <rect key="frame" x="16" y="12" width="288" height="20"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="hQm-TV-IDW" secondAttribute="bottom" constant="11.5" id="Ha9-TU-iXg"/>
+                    <constraint firstItem="hQm-TV-IDW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="p5U-pr-Me7"/>
+                </constraints>
             </tableViewCellContentView>
             <constraints>
                 <constraint firstItem="hQm-TV-IDW" firstAttribute="leading" secondItem="njF-e1-oar" secondAttribute="leading" constant="16" id="QB9-fd-Zsn"/>

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -262,6 +262,8 @@ final class WebAddressWizardContent: UIViewController {
         header.textField.addTarget(self, action: #selector(textChanged), for: .editingChanged)
         header.textField.delegate = self
 
+        header.accessibilityTraits = .header
+
         let placeholderText = NSLocalizedString("Search Domains", comment: "Site creation. Seelect a domain, search field placeholder")
         let attributes = WPStyleGuide.defaultSearchBarTextAttributesSwifted(WPStyleGuide.grey())
         let attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: attributes)

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -355,3 +355,16 @@ extension WebAddressWizardContent: UITextFieldDelegate {
         return true
     }
 }
+
+extension WebAddressWizardContent {
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            preferredContentSizeDidChange()
+        }
+    }
+
+    func preferredContentSizeDidChange() {
+        tableViewOffsetCoordinator?.adjustTableOffsetIfNeeded()
+    }
+}


### PR DESCRIPTION
Implements #10336 

A round of improvements to support for [Dynamic Type](https://github.com/wordpress-mobile/WordPress-iOS/wiki/Dynamic-type-guideline), and [Voice Over](https://github.com/wordpress-mobile/WordPress-iOS/wiki/VoiceOver-guideline)

![simulator screen shot - iphone xr - 2019-02-01 at 06 38 34](https://user-images.githubusercontent.com/2722505/52121213-d8200f00-25ec-11e9-8fee-7e65f838c35d.png)
![simulator screen shot - iphone xr - 2019-02-01 at 06 38 47](https://user-images.githubusercontent.com/2722505/52121216-dbb39600-25ec-11e9-9efa-96243469d284.png)
![simulator screen shot - iphone xr - 2019-02-01 at 06 39 22](https://user-images.githubusercontent.com/2722505/52121223-e110e080-25ec-11e9-914f-6004b4fcdec0.png)
![simulator screen shot - iphone xr - 2019-02-01 at 06 41 25](https://user-images.githubusercontent.com/2722505/52121227-e4a46780-25ec-11e9-9f39-c6d3572b711d.png)

The Site Creation flow should support changing types on the fly. My suggestion would be filling separate issues for those cases not handled in this PR.

To test dynamic type:
- On your test device, go to: iOS Settings > Control Center > Customize Controls > Search for and add the `Text Size` short cut.
- To add the extra large font sizes: iOS Settings > General > Accessibility > Larger Text > Switch On the `Larger Accessibility Sizes`
- The font size can be changed from Control Center

To test support for voice over:
- Activate Voice Over, and use the Site Creation flow

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.