### PR TITLE
GB: implement media cancel and retry

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -52,8 +52,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    ##pod 'WordPressKit', '~> 2.0.0-beta'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '8fb779907560f98ffa3d464d46badb5d1481cfcf'
+    pod 'WordPressKit', '~> 2.0.0-beta.3'
+    ##pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '8fb779907560f98ffa3d464d46badb5d1481cfcf'
     ##pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -94,8 +94,8 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '136ab2242042c374c9fbc8e37602b44e8878f2c9'
-    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '136ab2242042c374c9fbc8e37602b44e8878f2c9'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '32cd4315ce2f099d747eb55da60174e30c74d59d'
+    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '32cd4315ce2f099d747eb55da60174e30c74d59d'
 
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'

--- a/Podfile
+++ b/Podfile
@@ -52,8 +52,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 2.0.0-beta'
-    ##pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '28ca4a9'
+    ##pod 'WordPressKit', '~> 2.0.0-beta'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '8fb779907560f98ffa3d464d46badb5d1481cfcf'
     ##pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -94,8 +94,8 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '738dffcca0b6c1a55de28b911cf9613b33b51e03'
-    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '738dffcca0b6c1a55de28b911cf9613b33b51e03'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '136ab2242042c374c9fbc8e37602b44e8878f2c9'
+    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '136ab2242042c374c9fbc8e37602b44e8878f2c9'
 
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -224,7 +224,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `136ab2242042c374c9fbc8e37602b44e8878f2c9`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `32cd4315ce2f099d747eb55da60174e30c74d59d`)
   - HockeySDK (= 5.1.4)
   - MGSwipeTableCell (= 1.6.8)
   - MRProgress (= 0.8.3)
@@ -239,7 +239,7 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `136ab2242042c374c9fbc8e37602b44e8878f2c9`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `32cd4315ce2f099d747eb55da60174e30c74d59d`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -299,7 +299,7 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: 136ab2242042c374c9fbc8e37602b44e8878f2c9
+    :commit: 32cd4315ce2f099d747eb55da60174e30c74d59d
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
@@ -311,7 +311,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 136ab2242042c374c9fbc8e37602b44e8878f2c9
+    :commit: 32cd4315ce2f099d747eb55da60174e30c74d59d
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -324,13 +324,13 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: '0.3'
   Gutenberg:
-    :commit: 136ab2242042c374c9fbc8e37602b44e8878f2c9
+    :commit: 32cd4315ce2f099d747eb55da60174e30c74d59d
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNSVG:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 136ab2242042c374c9fbc8e37602b44e8878f2c9
+    :commit: 32cd4315ce2f099d747eb55da60174e30c74d59d
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -385,6 +385,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: e9e9e3edd7ff34399e12f72dd30f8e376b65c6db
+PODFILE CHECKSUM: f4bb8739436e8eafee524366277e0e38831666dd
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -188,7 +188,7 @@ PODS:
     - WordPressKit (~> 2.0-beta)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-  - WordPressKit (2.0.0-beta.1):
+  - WordPressKit (2.0.0-beta.3):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -245,7 +245,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.1)
   - WordPressAuthenticator (~> 1.1.9-beta)
-  - WordPressKit (~> 2.0.0-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `8fb779907560f98ffa3d464d46badb5d1481cfcf`)
   - WordPressShared (~> 1.7.0-beta)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -286,7 +286,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -313,6 +312,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 32cd4315ce2f099d747eb55da60174e30c74d59d
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressKit:
+    :commit: 8fb779907560f98ffa3d464d46badb5d1481cfcf
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -332,6 +334,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 32cd4315ce2f099d747eb55da60174e30c74d59d
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressKit:
+    :commit: 8fb779907560f98ffa3d464d46badb5d1481cfcf
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -377,7 +382,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 383ea61afd3f96ef4d0c7e3f1ab8e7a362f5cd67
   WordPress-Editor-iOS: 617116ef6b454ff11eed2cbdeafc6cf78a54aec2
   WordPressAuthenticator: 40ed3d920f134227a6ab069576378293c0bda401
-  WordPressKit: 2b6f01a7459d358b8cf6d825348c6cf7174107b2
+  WordPressKit: c70ff713b000e346aa345d71d6dcf9c8aa66c767
   WordPressShared: 9889ea6eaeb951df12e2901f98bd194df728d2a1
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
@@ -385,6 +390,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: f4bb8739436e8eafee524366277e0e38831666dd
+PODFILE CHECKSUM: 1621e3d186a296c5cbece5578a25ee6d952f4e29
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -245,7 +245,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.1)
   - WordPressAuthenticator (~> 1.1.9-beta)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `8fb779907560f98ffa3d464d46badb5d1481cfcf`)
+  - WordPressKit (~> 2.0.0-beta.3)
   - WordPressShared (~> 1.7.0-beta)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -286,6 +286,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -312,9 +313,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 32cd4315ce2f099d747eb55da60174e30c74d59d
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressKit:
-    :commit: 8fb779907560f98ffa3d464d46badb5d1481cfcf
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -334,9 +332,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 32cd4315ce2f099d747eb55da60174e30c74d59d
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressKit:
-    :commit: 8fb779907560f98ffa3d464d46badb5d1481cfcf
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -390,6 +385,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 1621e3d186a296c5cbece5578a25ee6d952f4e29
+PODFILE CHECKSUM: 49ce973f75125c2f4405746a94396cea56df19d8
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -224,7 +224,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `738dffcca0b6c1a55de28b911cf9613b33b51e03`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `136ab2242042c374c9fbc8e37602b44e8878f2c9`)
   - HockeySDK (= 5.1.4)
   - MGSwipeTableCell (= 1.6.8)
   - MRProgress (= 0.8.3)
@@ -239,7 +239,7 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `738dffcca0b6c1a55de28b911cf9613b33b51e03`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `136ab2242042c374c9fbc8e37602b44e8878f2c9`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -299,7 +299,7 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: 738dffcca0b6c1a55de28b911cf9613b33b51e03
+    :commit: 136ab2242042c374c9fbc8e37602b44e8878f2c9
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
@@ -311,7 +311,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 738dffcca0b6c1a55de28b911cf9613b33b51e03
+    :commit: 136ab2242042c374c9fbc8e37602b44e8878f2c9
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -324,13 +324,13 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: '0.3'
   Gutenberg:
-    :commit: 738dffcca0b6c1a55de28b911cf9613b33b51e03
+    :commit: 136ab2242042c374c9fbc8e37602b44e8878f2c9
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNSVG:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 738dffcca0b6c1a55de28b911cf9613b33b51e03
+    :commit: 136ab2242042c374c9fbc8e37602b44e8878f2c9
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -385,6 +385,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: a2c40317ac8d99c5daf61d7698b9071cf9560005
+PODFILE CHECKSUM: e9e9e3edd7ff34399e12f72dd30f8e376b65c6db
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -252,9 +252,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
     }];
     void (^successBlock)(RemoteMedia *media) = ^(RemoteMedia *media) {
         [self.managedObjectContext performBlock:^{
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadSuccessful withBlog:blog];
-            });
+            [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadSuccessful withBlog:blog];            
             NSError * error = nil;
             Media *mediaInContext = (Media *)[self.managedObjectContext existingObjectWithID:mediaObjectID error:&error];
             if (!mediaInContext){

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -252,8 +252,9 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
     }];
     void (^successBlock)(RemoteMedia *media) = ^(RemoteMedia *media) {
         [self.managedObjectContext performBlock:^{
-            [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadSuccessful withBlog:blog];
-
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [WPAppAnalytics track:WPAnalyticsStatMediaServiceUploadSuccessful withBlog:blog];
+            });
             NSError * error = nil;
             Media *mediaInContext = (Media *)[self.managedObjectContext existingObjectWithID:mediaObjectID error:&error];
             if (!mediaInContext){

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -220,7 +220,13 @@ static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_
  *  @brief      Tracks stats with the blog_id when available
  */
 + (void)track:(WPAnalyticsStat)stat withBlogID:(NSNumber *)blogID {
-    [WPAppAnalytics track:stat withProperties:nil withBlogID:blogID];
+    if (NSThread.isMainThread) {
+        [WPAppAnalytics track:stat withProperties:nil withBlogID:blogID];
+    } else {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [WPAppAnalytics track:stat withProperties:nil withBlogID:blogID];
+        });
+    }
 }
 
 /**

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -66,6 +66,24 @@ class GutenbergMediaInserterHelper: NSObject {
         }
     }
 
+    func mediaFor(uploadID: Int32) -> Media? {
+        for media in post.media {
+            if media.gutenbergUploadID == uploadID {
+                return media
+            }
+        }
+        return nil
+    }
+
+    func cancelUploadOf(media: Media) {
+        mediaCoordinator.cancelUpload(of: media)
+        gutenberg.mediaUploadUpdate(id: media.gutenbergUploadID, state: .reset, progress: 0, url: nil, serverID: nil)
+    }
+
+    func retryUploadOf(media: Media) {
+        mediaCoordinator.retryMedia(media)
+    }
+
     private func insert(exportableAsset: ExportableAsset, source: MediaSource) -> Media {
         switch exportableAsset.assetMediaType {
         case .image:

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -139,6 +139,6 @@ class GutenbergMediaInserterHelper: NSObject {
 
 extension Media {
     var gutenbergUploadID: Int32 {
-        return Int32(truncatingIfNeeded:objectID.uriRepresentation().absoluteString.hash)
+        return Int32(truncatingIfNeeded: objectID.uriRepresentation().absoluteString.hash)
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -116,10 +116,10 @@ class GutenbergMediaInserterHelper: NSObject {
         switch state {
         case .processing:
             gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .uploading, progress: 0, url: nil, serverID: nil)
-        case .thumbnailReady(let url):
-            gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .uploading, progress: 0, url: url, serverID: nil)
+        case .thumbnailReady:
+            break
         case .uploading:
-            gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .uploading, progress: 0, url: nil, serverID: nil)
+            break
         case .ended:
             guard let urlString = media.remoteURL, let url = URL(string: urlString), let mediaServerID = media.mediaID?.int32Value else {
                 break

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -31,7 +31,7 @@ class GutenbergMediaInserterHelper: NSObject {
     }
 
     func insertFromSiteMediaLibrary(media: Media, callback: @escaping MediaPickerDidPickMediaCallback) {
-        callback(media.mediaID?.intValue, media.remoteURL)
+        callback(media.mediaID?.int32Value, media.remoteURL)
     }
 
     func insertFromDevice(asset: PHAsset, callback: @escaping MediaPickerDidPickMediaCallback) {
@@ -103,7 +103,7 @@ class GutenbergMediaInserterHelper: NSObject {
         case .uploading:
             gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .uploading, progress: 0, url: nil, serverID: nil)
         case .ended:
-            guard let urlString = media.remoteURL, let url = URL(string: urlString), let mediaServerID = media.mediaID?.intValue else {
+            guard let urlString = media.remoteURL, let url = URL(string: urlString), let mediaServerID = media.mediaID?.int32Value else {
                 break
             }
             gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .succeeded, progress: 1, url: url, serverID: mediaServerID)
@@ -116,7 +116,7 @@ class GutenbergMediaInserterHelper: NSObject {
 }
 
 extension Media {
-    var gutenbergUploadID: Int {
-        return objectID.uriRepresentation().absoluteString.hash
+    var gutenbergUploadID: Int32 {
+        return Int32(truncatingIfNeeded:objectID.uriRepresentation().absoluteString.hash)
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -125,7 +125,11 @@ class GutenbergMediaInserterHelper: NSObject {
                 break
             }
             gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .succeeded, progress: 1, url: url, serverID: mediaServerID)
-        case .failed:
+        case .failed(let error):
+            if error.code == NSURLErrorCancelled {
+                gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .reset, progress: 0, url: nil, serverID: nil)
+                return
+            }
             gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .failed, progress: 0, url: nil, serverID: nil)
         case .progress(let value):
             gutenberg.mediaUploadUpdate(id: mediaUploadID, state: .uploading, progress: Float(value), url: nil, serverID: nil)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -80,7 +80,7 @@ class GutenbergMediaPickerHelper: NSObject {
     func presentCameraCaptureFullScreen(animated: Bool,
                                         callback: @escaping GutenbergMediaPickerHelperCallback) {
 
-        guard UIImagePickerController.isSourceTypeAvailable(.camera) else{
+        guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
             callback(nil)
             return
         }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -80,6 +80,11 @@ class GutenbergMediaPickerHelper: NSObject {
     func presentCameraCaptureFullScreen(animated: Bool,
                                         callback: @escaping GutenbergMediaPickerHelperCallback) {
 
+        guard UIImagePickerController.isSourceTypeAvailable(.camera) else{
+            callback(nil)
+            return
+        }
+
         didPickMediaCallback = callback
         //reset the selected assets from previous uses
         cameraPicker.resetState(false)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -73,7 +73,7 @@ class GutenbergMediaPickerHelper: NSObject {
         let cameraPicker = WPMediaPickerViewController()
         cameraPicker.options = mediaPickerOptions
         cameraPicker.mediaPickerDelegate = self
-        cameraPicker.dataSource = devicePhotoLibraryDataSource
+        cameraPicker.dataSource = WPPHAssetDataSource.sharedInstance()
         return cameraPicker
     }()
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -328,7 +328,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
     }
 
     func gutenbergDidRequestMediaUploadActionDialog(for mediaID: Int32) {
-        
+
         guard let media = mediaInserterHelper.mediaFor(uploadID: mediaID) else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -327,6 +327,10 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         self.mediaInserterHelper.syncUploads()
     }
 
+    func gutenbergDidRequestMediaUploadActionDialog(for mediaID: Int32) {
+        print("Actions")
+    }
+
     func gutenbergDidProvideHTML(title: String, html: String, changed: Bool) {
         if changed {
             self.html = html

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -334,7 +334,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         }
 
         let title: String = MediaAttachmentActionSheet.title
-        var message: String? = ""
+        var message: String? = nil
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
         let dismissAction = UIAlertAction(title: MediaAttachmentActionSheet.dismissActionTitle, style: .cancel) { (action) in
 


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/gutenberg-mobile/issues/206

This PR implements the possibility of canceling and retry media uploads.

To test:
 - Start a new post using GB
 - Add an image block
 - Tap on the image while the upload is happening
 - Tap Cancel, and see if the image block is reset
 - Add another image
 - Turn off the internet while the upload is going.
 - Check if the error status shows
 - Turn on the internet again
 - Tap on the image
 - Check if an error message shows in the action sheet
 - Tap on Retry
 - See if upload resumes and works to the end.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
