### PR TITLE
Resolved a crash in Reader Site Stream header follow count

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -100,9 +100,11 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     @objc func formattedFollowerCountForTopic(_ topic: ReaderSiteTopic) -> String {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
-        let count = numberFormatter.string(from: topic.subscriberCount)
+
+        let count = numberFormatter.string(from: topic.subscriberCount) ?? "0"
         let pattern = NSLocalizedString("%@ followers", comment: "The number of followers of a site. The '%@' is a placeholder for the numeric value. Example: `1000 followers`")
-        let str = String(format: pattern, count!)
+        let str = String(format: pattern, count)
+
         return str
     }
 


### PR DESCRIPTION
### Description

Fixes #10937.

The stack trace indicates that the crash occurs in`ReaderSiteStreamHeader.formattedFollowerCountForTopic(_:)`, which influences the appearance highlight in the screenshots.

As noted in [Apple's Technical Note TN2151 : Understanding and Analyzing Application Crash Reports](https://developer.apple.com/library/archive/technotes/tn2151/_index.html), `EXC_BREAKPOINT` is a tell-tale sign that (**emphasis** added):
> Swift code will terminate with this exception type if an unexpected condition is encountered at runtime such as: **a non-optional type with a nil value**; a failed forced type conversion.

On line 105, we see that `count` is an implicitly unwrapped optional. While the circumstances that lead to either `ReaderSiteTopic` or `count` being `nil` aren't well-known at this time, this PR proposes that fall back to `0`. 

While it might be a better user experience to fill in the separator (i.e., not show followers at all), this interim fix represents a better UX than crashing. I hope you'll agree.

To test:

- Checkout the branch and confirm that existing tests pass. 
- Navigate to the _Reader_ and select a site. Confirm that no regressions are visible.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

### Screenshots

<img width="504" alt="10937a" src="https://user-images.githubusercontent.com/221062/52139894-2988c800-2606-11e9-8394-acdfe46bde54.png">
<img width="504" alt="10937b" src="https://user-images.githubusercontent.com/221062/52139895-2988c800-2606-11e9-9f72-b8a7b1e33887.png">