### PR TITLE
Mitigated crash due to apparent use of an IUO in support VC

### DIFF
--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -18,8 +18,6 @@ class SupportTableViewController: UITableViewController {
 
     override init(style: UITableView.Style) {
         super.init(style: style)
-        NotificationCenter.default.addObserver(self, selector: #selector(refreshNotificationIndicator(_:)), name: .ZendeskPushNotificationReceivedNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(refreshNotificationIndicator(_:)), name: .ZendeskPushNotificationClearedNotification, object: nil)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -77,6 +75,11 @@ class SupportTableViewController: UITableViewController {
 
 private extension SupportTableViewController {
 
+    func registerObservers() {
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshNotificationIndicator(_:)), name: .ZendeskPushNotificationReceivedNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshNotificationIndicator(_:)), name: .ZendeskPushNotificationClearedNotification, object: nil)
+    }
+
     func setupNavBar() {
         title = LocalizedText.viewTitle
 
@@ -100,6 +103,8 @@ private extension SupportTableViewController {
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
         // remove empty cells
         tableView.tableFooterView = UIView()
+
+        registerObservers()
     }
 
     // MARK: - Table Model

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -11,7 +11,7 @@ class SupportTableViewController: UITableViewController {
     // Specifically for Me > Help & Support on the iPad.
     var showHelpFromViewController: UIViewController?
 
-    private var tableHandler: ImmuTableViewHandler!
+    private var tableHandler: ImmuTableViewHandler?
     private let userDefaults = UserDefaults.standard
 
     // MARK: - Init
@@ -146,7 +146,7 @@ private extension SupportTableViewController {
     }
 
     func reloadViewModel() {
-        tableHandler.viewModel = tableViewModel()
+        tableHandler?.viewModel = tableViewModel()
     }
 
     // MARK: - Row Handlers


### PR DESCRIPTION
### Description

Fixes #10939. 

The `EXC_BREAKPOINT` in the stack trace suggests an issue with an implicitly unwrapped optional. Under manual testing, I noted that notification method fires successfully, and calls `reloadViewModel`. In turn, that method appears to call `tableHandler` which is an IUO. If this is, in fact, the reason for the crash, that would imply that `SupportTableViewController` is responding to a notification before the table is initialized in `viewDidLoad`.

I'm suggesting we transition to an optional type here. An alternative approach might be to add the observers after `setupTable` is called. I'd welcome your thoughts.

To test:

- Checkout the branch, confirm that it builds & tests pass.
- Navigate to the _Me_ tab, select _Help & Support_, and confirm there are no regressions when interacting with ZD functions.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.