### PR TITLE
Editor: Fixes UISearchController issues in SelectPostViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
@@ -87,7 +87,7 @@ extension SelectPostViewController {
         } else {
             cell.detailTextLabel?.text = NSLocalizedString("Post", comment: "Noun. Type of content being selected is a blog post")
         }
-        if post.permaLink == self.selectedLink {
+        if post.permaLink == selectedLink {
             cell.accessoryType = .checkmark
         } else {
             cell.accessoryType = .none
@@ -119,7 +119,7 @@ extension SelectPostViewController: UISearchResultsUpdating {
 
     func updateSearchResults(for searchController: UISearchController) {
         let searchText = searchController.searchBar.text ?? ""
-        fetchController = PostCoordinator.shared.posts(for: self.blog, wichTitleContains: searchText)
+        fetchController = PostCoordinator.shared.posts(for: blog, wichTitleContains: searchText)
         tableView.reloadData()
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
@@ -39,7 +39,12 @@ class SelectPostViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.tableView.tableHeaderView = searchController.searchBar
+        tableView.tableHeaderView = searchController.searchBar
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        searchController.dismiss(animated: false, completion: nil)
     }
 }
 
@@ -115,6 +120,6 @@ extension SelectPostViewController: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
         let searchText = searchController.searchBar.text ?? ""
         fetchController = PostCoordinator.shared.posts(for: self.blog, wichTitleContains: searchText)
-        self.tableView.reloadData()
+        tableView.reloadData()
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
@@ -1,9 +1,12 @@
 import UIKit
 
-class SelectPostViewController: UITableViewController, UISearchResultsUpdating {
+
+class SelectPostViewController: UITableViewController {
+
+    typealias SelectPostCallback = (_ url: String, _ title: String) -> ()
+    private var callback: SelectPostCallback?
 
     private var blog: Blog!
-
     private var selectedLink: String?
 
     private lazy var searchController: UISearchController = {
@@ -19,9 +22,7 @@ class SelectPostViewController: UITableViewController, UISearchResultsUpdating {
         return PostCoordinator.shared.posts(for: self.blog, wichTitleContains: "")
     }()
 
-    typealias SelectPostCallback = (_ url: String, _ title: String) -> ()
-
-    private var callback: SelectPostCallback?
+    // MARK: - Initialization
 
     init(blog: Blog, selectedLink: String? = nil, callback: SelectPostCallback? = nil) {
         self.blog = blog
@@ -33,25 +34,33 @@ class SelectPostViewController: UITableViewController, UISearchResultsUpdating {
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
+
+    // MARK: - Lifecycle methods
+
     override func viewDidLoad() {
         super.viewDidLoad()
-
         self.tableView.tableHeaderView = searchController.searchBar
     }
+}
 
-    // MARK: - Table view data source
+
+// MARK: - UITableViewDataSource Conformance
+//
+extension SelectPostViewController {
 
     override func numberOfSections(in tableView: UITableView) -> Int {
-        if let count =  fetchController.sections?.count {
-            return count
+        guard let count =  fetchController.sections?.count else {
+            return 0
         }
-        return 0
+
+        return count
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         guard let sections = self.fetchController.sections else {
             return 0
         }
+
         let sectionInfo = sections[section]
         return sectionInfo.numberOfObjects
     }
@@ -81,9 +90,14 @@ class SelectPostViewController: UITableViewController, UISearchResultsUpdating {
 
         return cell
     }
+}
+
+
+// MARK: - UITableViewDelegate Conformance
+//
+extension SelectPostViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-
         let post = fetchController.object(at: indexPath)
         guard let title = post.titleForDisplay(), let url = post.permaLink else {
             return
@@ -91,6 +105,12 @@ class SelectPostViewController: UITableViewController, UISearchResultsUpdating {
 
         callback?(url, title)
     }
+}
+
+
+// MARK: - UISearchResultsUpdating Conformance
+//
+extension SelectPostViewController: UISearchResultsUpdating {
 
     func updateSearchResults(for searchController: UISearchController) {
         let searchText = searchController.searchBar.text ?? ""


### PR DESCRIPTION
This PR addresses `UISearchController` issues when selecting an existing page/post to link to within the editor:

![link_existing_fix](https://user-images.githubusercontent.com/154014/52238956-edb66280-2892-11e9-83e2-d16f2f2c0780.gif)

Previously, the `UISearchController` would hang around after the VC it belonged to was dismissed (`SelectPostViewController`). This caused a number of visual glitches and potentially the crasher reported in #10858.

<img width="302" alt="screen shot 2019-02-04 at 3 40 57 pm" src="https://user-images.githubusercontent.com/154014/52239168-6fa68b80-2893-11e9-999f-c43a446791aa.png">

The fix here was to simply add `searchController.dismiss(animated: false, completion: nil)` in `viewWillDisappear`. Additionally in this PR, I gave `SelectPostViewController` some organizational ❤️.

Fixes #10858 

## Testing

### Scenario 1: No more crashers
1. Start a new post.
2. Tap the link button to add a link to the post.
3. Choose "link to existing content."
4. Search for a post/page to link to.
5. Dismiss the keyboard (you can do this by pressing the blue "Search" button on the keyboard)
6. Select a post/page.
    - [x] On link settings, verify the `UISearchController` is not hanging around (aka was dismissed)
7. In the link settings, tap "Insert" to add the link.
    - [x] Verify VC dismiss animation is smooth (e.g. [not this](https://cloudup.com/c4ruwdbyKi2))
    - [x] Verify the app does not crash

### Scenario 2: Nav back
1. Open an existing post.
2. Tap the link button to add a link to the post.
3. Choose "link to existing content."
4. Search for a post/page to link to.
5. Press the back nav button
    - [x] On link settings, verify the `UISearchController` is not hanging around (aka was dismissed)

### Scenario 3: Keyboard fun
1. Open an existing post.
2. Tap the link button to add a link to the post.
3. Choose "link to existing content."
4. Search for a post/page to link to.
5. Without dismissing the keyboard, select a specific post
    - [x] On link settings, verify the `UISearchController` is not hanging around (aka was dismissed)
    - [x] On link settings, verify the the keyboard was dismissed (e.g. [not this](https://cloudup.com/cPtyZ1Q8AT4))

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

----

@aerych  would you mind giving this a quick review? 😄 