### PR TITLE
Add analytics tracking for Enhanced Site Creation

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -30,7 +30,7 @@ def wordpress_shared
     ##pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    ##pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '30809ffa12074b347355f73661d807766eade30b'
+    ##pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '4781c4764f69ca116c93c15a1297616b8920c4de'
 end
 
 def aztec

--- a/Podfile
+++ b/Podfile
@@ -123,7 +123,7 @@ target 'WordPress' do
     ## Automattic libraries
     ## ====================
     ##
-    pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.3'
+    pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :tag => '0.3.1'
     pod 'NSURL+IDN', '0.3'
     pod 'WPMediaPicker', '1.3.2'
     pod 'Gridicons', '~> 0.16'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -99,7 +99,7 @@ PODS:
   - MRProgress/ProgressBaseClass (0.8.3)
   - MRProgress/Stopable (0.8.3):
     - MRProgress/Helper
-  - Nimble (7.3.2)
+  - Nimble (7.3.3)
   - NSObject-SafeExpectations (0.0.3)
   - "NSURL+IDN (0.3)"
   - OCMock (3.4.3)
@@ -188,14 +188,14 @@ PODS:
     - WordPressKit (~> 2.0-beta)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-  - WordPressKit (2.0.0-beta.1):
+  - WordPressKit (2.0.0-beta.4):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.4)
     - wpxmlrpc (= 0.8.4)
-  - WordPressShared (1.7.0-beta.1):
+  - WordPressShared (1.7.0-beta.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.2.0)
@@ -359,7 +359,7 @@ SPEC CHECKSUMS:
   lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
   MGSwipeTableCell: dc4eca3212ed38a563b27d6aa7b3c01ce656c1e2
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
-  Nimble: 5e94a8cacb355943c6c87198035dc4adbb0f10e4
+  Nimble: 3b434b1e7d0a92603a13550a82880b0d952f518e
   NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
   "NSURL+IDN": 82355a0afd532fe1de08f6417c134b49b1a1c4b3
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
@@ -377,14 +377,14 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 383ea61afd3f96ef4d0c7e3f1ab8e7a362f5cd67
   WordPress-Editor-iOS: 617116ef6b454ff11eed2cbdeafc6cf78a54aec2
   WordPressAuthenticator: 40ed3d920f134227a6ab069576378293c0bda401
-  WordPressKit: 2b6f01a7459d358b8cf6d825348c6cf7174107b2
-  WordPressShared: 9889ea6eaeb951df12e2901f98bd194df728d2a1
+  WordPressKit: 9f32d40719c9dbd32d2f4e36cfb61af02e952dac
+  WordPressShared: ce9d771015c70dacaad8a5748410580073937b9e
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: a2c40317ac8d99c5daf61d7698b9071cf9560005
+PODFILE CHECKSUM: 41610ed09e3c19bb26e920e2c27e4a33930a3ebe
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -571,6 +571,54 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatEditorUploadMediaRetried:
             eventName = @"editor_upload_media_retried";
             break;
+        case WPAnalyticsStatEnhancedSiteCreationAccessed:
+            eventName = @"enhanced_site_creation_accessed";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationSegmentsViewed:
+            eventName = @"enhanced_site_creation_segments_viewed";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationSegmentsSelected:
+            eventName = @"enhanced_site_creation_segments_selected";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationVerticalsViewed:
+            eventName = @"enhanced_site_creation_verticals_viewed";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationVerticalsSelected:
+            eventName = @"enhanced_site_creation_verticals_selected";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationVerticalsSkipped:
+            eventName = @"enhanced_site_creation_verticals_skipped";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationBasicInformationViewed:
+            eventName = @"enhanced_site_creation_basic_information_viewed";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationBasicInformationCompleted:
+            eventName = @"enhanced_site_creation_basic_information_completed";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationBasicInformationSkipped:
+            eventName = @"enhanced_site_creation_basic_information_skipped";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationDomainsAccessed:
+            eventName = @"enhanced_site_creation_domains_accessed";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationDomainsSelected:
+            eventName = @"enhanced_site_creation_domains_selected";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationSuccessLoading:
+            eventName = @"enhanced_site_creation_success_loading";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationSuccessPreviewViewed:
+            eventName = @"enhanced_site_creation_preview_viewed";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationSuccessPreviewLoaded:
+            eventName = @"enhanced_site_creation_preview_loaded";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationCompleted:
+            eventName = @"enhanced_site_creation_completed";
+            break;
+        case WPAnalyticsStatEnhancedSiteCreationErrorShown:
+            eventName = @"enhanced_site_creation_error_shown";
+            break;
         case WPAnalyticsStatGiphyAccessed:
             eventName = @"giphy_accessed";
             break;

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController+SiteCreation.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController+SiteCreation.swift
@@ -6,5 +6,6 @@ extension BlogListViewController {
             return
         }
         present(wizard, animated: true)
+        WPAnalytics.track(.enhancedSiteCreationAccessed)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -141,7 +141,6 @@ final class AssembledSiteView: UIView {
         generator.prepare()
 
         webView.load(siteRequest)
-        WPAnalytics.track(.enhancedSiteCreationSuccessPreviewViewed)
     }
 
     // MARK: Private behavior
@@ -178,6 +177,10 @@ final class AssembledSiteView: UIView {
 // MARK: - WKNavigationDelegate
 
 extension AssembledSiteView: WKNavigationDelegate {
+    
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        WPAnalytics.track(.enhancedSiteCreationSuccessPreviewViewed)
+    }
 
     func webView(_ webView: WKWebView, decidePolicyFor: WKNavigationAction, decisionHandler: (WKNavigationActionPolicy) -> Void) {
         guard webViewHasLoadedContent else {

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -141,6 +141,7 @@ final class AssembledSiteView: UIView {
         generator.prepare()
 
         webView.load(siteRequest)
+        WPAnalytics.track(.enhancedSiteCreationSuccessPreviewViewed)
     }
 
     // MARK: Private behavior
@@ -190,6 +191,7 @@ extension AssembledSiteView: WKNavigationDelegate {
         webViewHasLoadedContent = true
         activityIndicator.stopAnimating()
         generator.notificationOccurred(.success)
+        WPAnalytics.track(.enhancedSiteCreationSuccessPreviewLoaded)
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -177,7 +177,7 @@ final class AssembledSiteView: UIView {
 // MARK: - WKNavigationDelegate
 
 extension AssembledSiteView: WKNavigationDelegate {
-    
+
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         WPAnalytics.track(.enhancedSiteCreationSuccessPreviewViewed)
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -66,6 +66,7 @@ final class SiteAssemblyWizardContent: UIViewController {
 
         hidesBottomBarWhenPushed = true
         installButtonViewController()
+        WPAnalytics.track(.enhancedSiteCreationSuccessLoading)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -210,6 +211,7 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
             guard let blog = createdBlog else {
                 return
             }
+            WPAnalytics.track(.enhancedSiteCreationCompleted)
             WPTabBarController.sharedInstance().switchMySitesTabToBlogDetails(for: blog)
         }
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateViewController.swift
@@ -33,5 +33,13 @@ final class ErrorStateViewController: UIViewController {
     override func loadView() {
         super.loadView()
         view = contentView
+        trackError()
+    }
+    
+    private func trackError() {
+        var errorProperties = [String: AnyObject]()
+        errorProperties["error_info"] = configuration.title as AnyObject?
+        
+        WPAnalytics.track(.enhancedSiteCreationErrorShown, withProperties: errorProperties)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateViewController.swift
@@ -37,8 +37,9 @@ final class ErrorStateViewController: UIViewController {
     }
 
     private func trackError() {
-        var errorProperties = [String: AnyObject]()
-        errorProperties["error_info"] = configuration.title as AnyObject?
+        let errorProperties: [String: AnyObject] = [
+            "error_info": configuration.title as AnyObject
+        ]
 
         WPAnalytics.track(.enhancedSiteCreationErrorShown, withProperties: errorProperties)
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateViewController.swift
@@ -35,11 +35,11 @@ final class ErrorStateViewController: UIViewController {
         view = contentView
         trackError()
     }
-    
+
     private func trackError() {
         var errorProperties = [String: AnyObject]()
         errorProperties["error_info"] = configuration.title as AnyObject?
-        
+
         WPAnalytics.track(.enhancedSiteCreationErrorShown, withProperties: errorProperties)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
@@ -57,6 +57,7 @@ final class SiteInformationWizardContent: UIViewController {
         setupTable()
         setupButtonWrapper()
         setupNextButton()
+        WPAnalytics.track(.enhancedSiteCreationBasicInformationViewed)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -195,6 +196,19 @@ final class SiteInformationWizardContent: UIViewController {
     private func goNext() {
         let collectedData = SiteInformation(title: titleString(), tagLine: taglineString())
         completion(collectedData)
+        trackBasicInformationNextStep()
+    }
+    
+    private func trackBasicInformationNextStep() {
+        if (nextStep.isPrimary) {
+            var basicInformationProperties = [String: AnyObject]()
+            basicInformationProperties["site_title"] = titleString() as AnyObject?
+            basicInformationProperties["tagline"] = taglineString() as AnyObject?
+            
+            WPAnalytics.track(.enhancedSiteCreationBasicInformationCompleted, withProperties: basicInformationProperties)
+        } else {
+            WPAnalytics.track(.enhancedSiteCreationBasicInformationSkipped)
+        }
     }
 
     private func titleString() -> String {

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
@@ -198,13 +198,13 @@ final class SiteInformationWizardContent: UIViewController {
         completion(collectedData)
         trackBasicInformationNextStep()
     }
-    
+
     private func trackBasicInformationNextStep() {
-        if (nextStep.isPrimary) {
+        if nextStep.isPrimary {
             var basicInformationProperties = [String: AnyObject]()
             basicInformationProperties["site_title"] = titleString() as AnyObject?
             basicInformationProperties["tagline"] = taglineString() as AnyObject?
-            
+
             WPAnalytics.track(.enhancedSiteCreationBasicInformationCompleted, withProperties: basicInformationProperties)
         } else {
             WPAnalytics.track(.enhancedSiteCreationBasicInformationSkipped)

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
@@ -201,9 +201,10 @@ final class SiteInformationWizardContent: UIViewController {
 
     private func trackBasicInformationNextStep() {
         if nextStep.isPrimary {
-            var basicInformationProperties = [String: AnyObject]()
-            basicInformationProperties["site_title"] = titleString() as AnyObject?
-            basicInformationProperties["tagline"] = taglineString() as AnyObject?
+            let basicInformationProperties: [String: AnyObject] = [
+                "site_title": titleString() as AnyObject,
+                "tagline": taglineString() as AnyObject
+            ]
 
             WPAnalytics.track(.enhancedSiteCreationBasicInformationCompleted, withProperties: basicInformationProperties)
         } else {

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
@@ -44,6 +44,7 @@ final class SiteSegmentsWizardContent: UIViewController {
         initCancelButton()
 
         prepareForVoiceOver()
+	WPAnalytics.track(.enhancedSiteCreationSegmentsViewed)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -220,6 +221,15 @@ final class SiteSegmentsWizardContent: UIViewController {
 
     private func didSelect(_ segment: SiteSegment) {
         selection(segment)
+        trackSegmentSelection(segment)
+    }
+    
+    private func trackSegmentSelection(_ segment: SiteSegment) {
+        var segmentProperties = [String: AnyObject]()
+        segmentProperties["segment_name"] = segment.title as AnyObject?
+        segmentProperties["segment_id"] = segment.identifier as AnyObject?
+
+        WPAnalytics.track(.enhancedSiteCreationSegmentsSelected, withProperties: segmentProperties)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
@@ -225,9 +225,10 @@ final class SiteSegmentsWizardContent: UIViewController {
     }
 
     private func trackSegmentSelection(_ segment: SiteSegment) {
-        var segmentProperties = [String: AnyObject]()
-        segmentProperties["segment_name"] = segment.title as AnyObject?
-        segmentProperties["segment_id"] = segment.identifier as AnyObject?
+        let segmentProperties: [String: AnyObject] = [
+            "segment_name": segment.title as AnyObject,
+            "segment_id": segment.identifier as AnyObject
+        ]
 
         WPAnalytics.track(.enhancedSiteCreationSegmentsSelected, withProperties: segmentProperties)
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
@@ -223,7 +223,7 @@ final class SiteSegmentsWizardContent: UIViewController {
         selection(segment)
         trackSegmentSelection(segment)
     }
-    
+
     private func trackSegmentSelection(_ segment: SiteSegment) {
         var segmentProperties = [String: AnyObject]()
         segmentProperties["segment_name"] = segment.title as AnyObject?

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
@@ -118,6 +118,7 @@ final class VerticalsWizardContent: UIViewController {
         setupButtonWrapper()
         setupNextButton()
         setupTable()
+        WPAnalytics.track(.enhancedSiteCreationVerticalsViewed)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -394,6 +395,7 @@ final class VerticalsWizardContent: UIViewController {
 
             let vertical = provider.data[selectedIndexPath.row]
             self.selection(vertical)
+            self.trackVerticalSelection(vertical)
         }
 
         self.tableViewProvider = VerticalsTableViewProvider(tableView: table, data: data, selectionHandler: handler)
@@ -401,6 +403,15 @@ final class VerticalsWizardContent: UIViewController {
 
     private func setupTableSeparator() {
         table.separatorColor = WPStyleGuide.greyLighten20()
+    }
+    
+    private func trackVerticalSelection(_ vertical: SiteVertical) {
+        var verticalProperties = [String: AnyObject]()
+        verticalProperties["vertical_name"] = vertical.title as AnyObject?
+        verticalProperties["vertical_id"] = vertical.identifier as AnyObject?
+        verticalProperties["vertical_is_user"] = vertical.isNew as AnyObject?
+        
+        WPAnalytics.track(.enhancedSiteCreationVerticalsSelected, withProperties: verticalProperties)
     }
 
     @objc

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
@@ -404,13 +404,13 @@ final class VerticalsWizardContent: UIViewController {
     private func setupTableSeparator() {
         table.separatorColor = WPStyleGuide.greyLighten20()
     }
-    
+
     private func trackVerticalSelection(_ vertical: SiteVertical) {
         var verticalProperties = [String: AnyObject]()
         verticalProperties["vertical_name"] = vertical.title as AnyObject?
         verticalProperties["vertical_id"] = vertical.identifier as AnyObject?
         verticalProperties["vertical_is_user"] = vertical.isNew as AnyObject?
-        
+
         WPAnalytics.track(.enhancedSiteCreationVerticalsSelected, withProperties: verticalProperties)
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
@@ -406,10 +406,11 @@ final class VerticalsWizardContent: UIViewController {
     }
 
     private func trackVerticalSelection(_ vertical: SiteVertical) {
-        var verticalProperties = [String: AnyObject]()
-        verticalProperties["vertical_name"] = vertical.title as AnyObject?
-        verticalProperties["vertical_id"] = vertical.identifier as AnyObject?
-        verticalProperties["vertical_is_user"] = vertical.isNew as AnyObject?
+        let verticalProperties: [String: AnyObject] = [
+            "vertical_name": vertical.title as AnyObject,
+            "vertical_id": vertical.identifier as AnyObject,
+            "vertical_is_user": vertical.isNew as AnyObject
+        ]
 
         WPAnalytics.track(.enhancedSiteCreationVerticalsSelected, withProperties: verticalProperties)
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
@@ -428,6 +428,7 @@ final class VerticalsWizardContent: UIViewController {
     @objc
     private func skip() {
         selection(nil)
+        WPAnalytics.track(.enhancedSiteCreationVerticalsSkipped)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -390,12 +390,12 @@ final class WebAddressWizardContent: UIViewController {
         table.deselectSelectedRowWithAnimation(true)
         tableViewOffsetCoordinator?.hideBottomToolbar()
     }
-    
+
     private func trackDomainsSelection(_ domainSuggestion: DomainSuggestion) {
         var domainSuggestionProperties = [String: AnyObject]()
         domainSuggestionProperties["chosen_domain"] = domainSuggestion.domainName as AnyObject?
         domainSuggestionProperties["search_term"] = lastSearchQuery as AnyObject?
-        
+
         WPAnalytics.track(.enhancedSiteCreationDomainsSelected, withProperties: domainSuggestionProperties)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -111,6 +111,7 @@ final class WebAddressWizardContent: UIViewController {
         setupButtonWrapper()
         setupCreateSiteButton()
         setupTable()
+        WPAnalytics.track(.enhancedSiteCreationDomainsAccessed)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -236,6 +236,7 @@ final class WebAddressWizardContent: UIViewController {
         }
 
         selection(selectedDomain)
+        trackDomainsSelection(selectedDomain)
     }
 
     private func setupCells() {
@@ -388,6 +389,14 @@ final class WebAddressWizardContent: UIViewController {
         selectedDomain = nil
         table.deselectSelectedRowWithAnimation(true)
         tableViewOffsetCoordinator?.hideBottomToolbar()
+    }
+    
+    private func trackDomainsSelection(_ domainSuggestion: DomainSuggestion) {
+        var domainSuggestionProperties = [String: AnyObject]()
+        domainSuggestionProperties["chosen_domain"] = domainSuggestion.domainName as AnyObject?
+        domainSuggestionProperties["search_term"] = lastSearchQuery as AnyObject?
+        
+        WPAnalytics.track(.enhancedSiteCreationDomainsSelected, withProperties: domainSuggestionProperties)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -392,9 +392,10 @@ final class WebAddressWizardContent: UIViewController {
     }
 
     private func trackDomainsSelection(_ domainSuggestion: DomainSuggestion) {
-        var domainSuggestionProperties = [String: AnyObject]()
-        domainSuggestionProperties["chosen_domain"] = domainSuggestion.domainName as AnyObject?
-        domainSuggestionProperties["search_term"] = lastSearchQuery as AnyObject?
+        let domainSuggestionProperties: [String: AnyObject] = [
+            "chosen_domain": domainSuggestion.domainName as AnyObject,
+            "search_term": lastSearchQuery as AnyObject
+        ]
 
         WPAnalytics.track(.enhancedSiteCreationDomainsSelected, withProperties: domainSuggestionProperties)
     }


### PR DESCRIPTION
Fixes #10335 

To test:

Make sure every event is hit in the correct area when going through the site creation flow.

https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/179 must be merged (and released) before this is merged!

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.