### PR TITLE
Integrated locale handling changes in WordPressKit

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -52,8 +52,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    #pod 'WordPressKit', '~> 2.0.0-beta.3'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0469f41'
+    pod 'WordPressKit', '~> 2.0.0-beta.4'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0469f41'
     ##pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -53,7 +53,7 @@ end
 
 def wordpress_kit
     #pod 'WordPressKit', '~> 2.0.0-beta.3'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'fea283d'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0469f41'
     ##pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -52,8 +52,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 2.0.0-beta.3'
-    ##pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '8fb779907560f98ffa3d464d46badb5d1481cfcf'
+    #pod 'WordPressKit', '~> 2.0.0-beta.3'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'fea283d'
     ##pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -245,7 +245,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.2)
   - WordPressAuthenticator (~> 1.1.9-beta)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `0469f41`)
+  - WordPressKit (~> 2.0.0-beta.4)
   - WordPressShared (~> 1.7.0-beta)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -286,6 +286,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -312,9 +313,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 8af6464ca479784bf462c5c8bcd1f873e951ded1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressKit:
-    :commit: 0469f41
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -334,9 +332,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 8af6464ca479784bf462c5c8bcd1f873e951ded1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPressKit:
-    :commit: 0469f41
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -390,6 +385,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: a0e62ef46d7991727677a9127fb0812217bb3a95
+PODFILE CHECKSUM: 4051af86a8ff0412cf4addbe5e42347cca8e6021
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -245,7 +245,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.2)
   - WordPressAuthenticator (~> 1.1.9-beta)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `fea283d`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `0469f41`)
   - WordPressShared (~> 1.7.0-beta)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -313,7 +313,7 @@ EXTERNAL SOURCES:
     :commit: 8af6464ca479784bf462c5c8bcd1f873e951ded1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressKit:
-    :commit: fea283d
+    :commit: 0469f41
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -335,7 +335,7 @@ CHECKOUT OPTIONS:
     :commit: 8af6464ca479784bf462c5c8bcd1f873e951ded1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressKit:
-    :commit: fea283d
+    :commit: 0469f41
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -390,6 +390,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 9ecb45edd5ef832b4e20692bef970c7b25e9d404
+PODFILE CHECKSUM: a0e62ef46d7991727677a9127fb0812217bb3a95
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -188,7 +188,7 @@ PODS:
     - WordPressKit (~> 2.0-beta)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-  - WordPressKit (2.0.0-beta.3):
+  - WordPressKit (2.0.0-beta.4):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -245,7 +245,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.2)
   - WordPressAuthenticator (~> 1.1.9-beta)
-  - WordPressKit (~> 2.0.0-beta.3)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `fea283d`)
   - WordPressShared (~> 1.7.0-beta)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -286,7 +286,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -313,6 +312,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 8af6464ca479784bf462c5c8bcd1f873e951ded1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressKit:
+    :commit: fea283d
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -332,6 +334,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 8af6464ca479784bf462c5c8bcd1f873e951ded1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressKit:
+    :commit: fea283d
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -377,7 +382,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: d9e816350ab1e200681d433287fbb079675e9159
   WordPress-Editor-iOS: 5a09651534181c9f3ab43516b7666e9c55b2330e
   WordPressAuthenticator: 40ed3d920f134227a6ab069576378293c0bda401
-  WordPressKit: c70ff713b000e346aa345d71d6dcf9c8aa66c767
+  WordPressKit: 9f32d40719c9dbd32d2f4e36cfb61af02e952dac
   WordPressShared: 9889ea6eaeb951df12e2901f98bd194df728d2a1
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
@@ -385,6 +390,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: d53f6597e345ff4aed738da51e4a65d64f7aa360
+PODFILE CHECKSUM: 9ecb45edd5ef832b4e20692bef970c7b25e9d404
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Models/WPAccount+RestApi.swift
+++ b/WordPress/Classes/Models/WPAccount+RestApi.swift
@@ -1,0 +1,16 @@
+
+import Foundation
+import WordPressKit
+
+extension WPAccount {
+    /// Returns an instance of the WPCOM REST API suitable for v2 endpoints.
+    /// If the user is not authenticated, this will be anonymous.
+    ///
+    var wordPressComRestV2Api: WordPressComRestApi {
+        let token = authToken
+        let userAgent = WPUserAgent.wordPress()
+        let localeKey = WordPressComRestApi.LocaleKeyV2
+
+        return WordPressComRestApi(oAuthToken: token, userAgent: userAgent, localeKey: localeKey)
+    }
+}

--- a/WordPress/Classes/Services/SiteSegmentsService.swift
+++ b/WordPress/Classes/Services/SiteSegmentsService.swift
@@ -26,14 +26,11 @@ final class SiteCreationSegmentsService: LocalCoreDataService, SiteSegmentsServi
     override init(managedObjectContext context: NSManagedObjectContext) {
         self.accountService = AccountService(managedObjectContext: context)
 
-        let userAgent = WPUserAgent.wordPress()
-        let localeKey = WordPressComRestApi.LocaleKeyV2
-
         let api: WordPressComRestApi
-        if let account = accountService.defaultWordPressComAccount(), let token = account.authToken {
-            api = WordPressComRestApi(oAuthToken: token, userAgent: userAgent, localeKey: localeKey)
+        if let account = accountService.defaultWordPressComAccount() {
+            api = account.wordPressComRestV2Api
         } else {
-            api = WordPressComRestApi(userAgent: userAgent, localeKey: localeKey)
+            api = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
         }
 
         self.remoteService = WordPressComServiceRemote(wordPressComRestApi: api)

--- a/WordPress/Classes/Services/SiteSegmentsService.swift
+++ b/WordPress/Classes/Services/SiteSegmentsService.swift
@@ -26,12 +26,16 @@ final class SiteCreationSegmentsService: LocalCoreDataService, SiteSegmentsServi
     override init(managedObjectContext context: NSManagedObjectContext) {
         self.accountService = AccountService(managedObjectContext: context)
 
+        let userAgent = WPUserAgent.wordPress()
+        let localeKey = WordPressComRestApi.LocaleKeyV2
+
         let api: WordPressComRestApi
-        if let wpcomApi = accountService.defaultWordPressComAccount()?.wordPressComRestApi {
-            api = wpcomApi
+        if let account = accountService.defaultWordPressComAccount(), let token = account.authToken {
+            api = WordPressComRestApi(oAuthToken: token, userAgent: userAgent, localeKey: localeKey)
         } else {
-            api = WordPressComRestApi(userAgent: WPUserAgent.wordPress())
+            api = WordPressComRestApi(userAgent: userAgent, localeKey: localeKey)
         }
+
         self.remoteService = WordPressComServiceRemote(wordPressComRestApi: api)
 
         super.init(managedObjectContext: context)

--- a/WordPress/Classes/Services/SiteVerticalsPromptService.swift
+++ b/WordPress/Classes/Services/SiteVerticalsPromptService.swift
@@ -41,12 +41,16 @@ final class SiteCreationVerticalsPromptService: LocalCoreDataService, SiteVertic
     override init(managedObjectContext context: NSManagedObjectContext) {
         self.accountService = AccountService(managedObjectContext: context)
 
+        let userAgent = WPUserAgent.wordPress()
+        let localeKey = WordPressComRestApi.LocaleKeyV2
+
         let api: WordPressComRestApi
-        if let wpcomApi = accountService.defaultWordPressComAccount()?.wordPressComRestApi {
-            api = wpcomApi
+        if let account = accountService.defaultWordPressComAccount(), let token = account.authToken {
+            api = WordPressComRestApi(oAuthToken: token, userAgent: userAgent, localeKey: localeKey)
         } else {
-            api = WordPressComRestApi(userAgent: WPUserAgent.wordPress())
+            api = WordPressComRestApi(userAgent: userAgent, localeKey: localeKey)
         }
+
         self.remoteService = WordPressComServiceRemote(wordPressComRestApi: api)
 
         super.init(managedObjectContext: context)

--- a/WordPress/Classes/Services/SiteVerticalsPromptService.swift
+++ b/WordPress/Classes/Services/SiteVerticalsPromptService.swift
@@ -41,14 +41,11 @@ final class SiteCreationVerticalsPromptService: LocalCoreDataService, SiteVertic
     override init(managedObjectContext context: NSManagedObjectContext) {
         self.accountService = AccountService(managedObjectContext: context)
 
-        let userAgent = WPUserAgent.wordPress()
-        let localeKey = WordPressComRestApi.LocaleKeyV2
-
         let api: WordPressComRestApi
-        if let account = accountService.defaultWordPressComAccount(), let token = account.authToken {
-            api = WordPressComRestApi(oAuthToken: token, userAgent: userAgent, localeKey: localeKey)
+        if let account = accountService.defaultWordPressComAccount() {
+            api = account.wordPressComRestV2Api
         } else {
-            api = WordPressComRestApi(userAgent: userAgent, localeKey: localeKey)
+            api = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
         }
 
         self.remoteService = WordPressComServiceRemote(wordPressComRestApi: api)

--- a/WordPress/Classes/Services/SiteVerticalsService.swift
+++ b/WordPress/Classes/Services/SiteVerticalsService.swift
@@ -43,12 +43,16 @@ final class SiteCreationVerticalsService: LocalCoreDataService, SiteVerticalsSer
     override init(managedObjectContext context: NSManagedObjectContext) {
         self.accountService = AccountService(managedObjectContext: context)
 
+        let userAgent = WPUserAgent.wordPress()
+        let localeKey = WordPressComRestApi.LocaleKeyV2
+
         let api: WordPressComRestApi
-        if let wpcomApi = accountService.defaultWordPressComAccount()?.wordPressComRestApi {
-            api = wpcomApi
+        if let account = accountService.defaultWordPressComAccount(), let token = account.authToken {
+            api = WordPressComRestApi(oAuthToken: token, userAgent: userAgent, localeKey: localeKey)
         } else {
-            api = WordPressComRestApi(userAgent: WPUserAgent.wordPress())
+            api = WordPressComRestApi(userAgent: userAgent, localeKey: localeKey)
         }
+
         self.remoteService = WordPressComServiceRemote(wordPressComRestApi: api)
 
         super.init(managedObjectContext: context)

--- a/WordPress/Classes/Services/SiteVerticalsService.swift
+++ b/WordPress/Classes/Services/SiteVerticalsService.swift
@@ -43,16 +43,12 @@ final class SiteCreationVerticalsService: LocalCoreDataService, SiteVerticalsSer
     override init(managedObjectContext context: NSManagedObjectContext) {
         self.accountService = AccountService(managedObjectContext: context)
 
-        let userAgent = WPUserAgent.wordPress()
-        let localeKey = WordPressComRestApi.LocaleKeyV2
-
         let api: WordPressComRestApi
-        if let account = accountService.defaultWordPressComAccount(), let token = account.authToken {
-            api = WordPressComRestApi(oAuthToken: token, userAgent: userAgent, localeKey: localeKey)
+        if let account = accountService.defaultWordPressComAccount() {
+            api = account.wordPressComRestV2Api
         } else {
-            api = WordPressComRestApi(userAgent: userAgent, localeKey: localeKey)
+            api = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
         }
-
         self.remoteService = WordPressComServiceRemote(wordPressComRestApi: api)
 
         super.init(managedObjectContext: context)

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -237,7 +237,7 @@ private extension ActivityStore {
             return
         }
 
-        remote(site: site)?.restoreSite(
+        remoteV1(site: site)?.restoreSite(
             site.siteID,
             rewindID: rewindID,
             success: { [actionDispatcher] restoreID in
@@ -374,13 +374,25 @@ private extension ActivityStore {
     }
 
     // MARK: - Helpers
+
     func remote(site: JetpackSiteRef) -> ActivityServiceRemote? {
+        guard let token = CredentialsService().getOAuthToken(site: site) else {
+            return nil
+        }
+
+        let api = WordPressComRestApi(oAuthToken: token, userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
+        api.appendsPreferredLanguageLocale = false  // ActivityServiceRemote currently injects "locale"
+
+        return ActivityServiceRemote(wordPressComRestApi: api)
+    }
+
+    func remoteV1(site: JetpackSiteRef) -> ActivityServiceRemote_ApiVersion1_0? {
         guard let token = CredentialsService().getOAuthToken(site: site) else {
             return nil
         }
         let api = WordPressComRestApi(oAuthToken: token, userAgent: WPUserAgent.wordPress())
 
-        return ActivityServiceRemote(wordPressComRestApi: api)
+        return ActivityServiceRemote_ApiVersion1_0(wordPressComRestApi: api)
     }
 
     private func mediumString(from date: Date, adjustingTimezoneTo site: JetpackSiteRef) -> String {

--- a/WordPress/Classes/Stores/TimeZoneStore.swift
+++ b/WordPress/Classes/Stores/TimeZoneStore.swift
@@ -71,7 +71,11 @@ class TimeZoneStore: QueryStore<TimeZoneStoreState, TimeZoneQuery> {
 private extension TimeZoneStore {
     func fetchTimeZones() {
         state = .loading
-        let remote = TimeZoneServiceRemote(wordPressComRestApi: .anonymousApi(userAgent: WPUserAgent.wordPress()))
+
+        let api: WordPressComRestApi = .anonymousApi(userAgent: WPUserAgent.wordPress())
+        api.appendsPreferredLanguageLocale = false  // TimeZoneServiceRemote currently injects "_locale"
+
+        let remote = TimeZoneServiceRemote(wordPressComRestApi: api)
         remote.getTimezones(
             success: { [weak self] (groups) in
                 self?.state = .loaded(groups)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -526,6 +526,7 @@
 		73F6DD42212BA54700CE447D /* RichNotificationContentFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6DD41212BA54700CE447D /* RichNotificationContentFormatter.swift */; };
 		73F6DD44212C714F00CE447D /* RichNotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6DD43212C714F00CE447D /* RichNotificationViewModel.swift */; };
 		73F6DD45212C714F00CE447D /* RichNotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6DD43212C714F00CE447D /* RichNotificationViewModel.swift */; };
+		73FEC871220B358500CEF791 /* WPAccount+RestApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FEC870220B358500CEF791 /* WPAccount+RestApi.swift */; };
 		740219FE202E12F4006CC39F /* UploadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741E22441FC0CC55007967AB /* UploadOperation.swift */; };
 		740219FF202E12F4006CC39F /* PostUploadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AF4D711FE417D200E3EBFE /* PostUploadOperation.swift */; };
 		74021A00202E12F4006CC39F /* MediaUploadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AF4D6D1FE417D200E3EBFE /* MediaUploadOperation.swift */; };
@@ -2389,6 +2390,7 @@
 		73EDC709212E5D6700E5E3ED /* RemoteNotificationStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationStyles.swift; sourceTree = "<group>"; };
 		73F6DD41212BA54700CE447D /* RichNotificationContentFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichNotificationContentFormatter.swift; sourceTree = "<group>"; };
 		73F6DD43212C714F00CE447D /* RichNotificationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichNotificationViewModel.swift; sourceTree = "<group>"; };
+		73FEC870220B358500CEF791 /* WPAccount+RestApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPAccount+RestApi.swift"; sourceTree = "<group>"; };
 		73FEFF1991AE9912FB2DA9BC /* Pods-WordPressNotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationServiceExtension.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationServiceExtension/Pods-WordPressNotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		740516882087B73400252FD0 /* SearchableActivityConvertable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchableActivityConvertable.swift; sourceTree = "<group>"; };
 		740BD8331A0D4C3600F04D18 /* WPUploadStatusButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPUploadStatusButton.h; sourceTree = "<group>"; };
@@ -4480,6 +4482,7 @@
 				E105E9CD1726955600C0D9E7 /* WPAccount.h */,
 				E105E9CE1726955600C0D9E7 /* WPAccount.m */,
 				E12DB07A1C48D1C200A6C1D4 /* WPAccount+AccountSettings.swift */,
+				73FEC870220B358500CEF791 /* WPAccount+RestApi.swift */,
 				46F84612185A8B7E009D0DA5 /* PostContentProvider.h */,
 				5D35F7581A042255004E7B0D /* WPCommentContentViewProvider.h */,
 				173BCE781CEB780800AE8817 /* Domain.swift */,
@@ -10224,6 +10227,7 @@
 				E66969E01B9E648100EC9C00 /* ReaderTopicToReaderDefaultTopic37to38.swift in Sources */,
 				9822AFA021EECB8E007D922D /* AnnualSiteStatsCell.swift in Sources */,
 				82A062DE2017BCBA0084CE7C /* ActivityListSectionHeaderView.swift in Sources */,
+				73FEC871220B358500CEF791 /* WPAccount+RestApi.swift in Sources */,
 				B5FF3BE71CAD881100C1D597 /* ImageCropOverlayView.swift in Sources */,
 				E6A338501BB0A70F00371587 /* ReaderGapMarkerCell.swift in Sources */,
 				98BDFF6B20D0732900C72C58 /* SupportTableViewController+Activity.swift in Sources */,


### PR DESCRIPTION
### Description

Fixes [#78](https://github.com/wordpress-mobile/WordPressKit-iOS/issues/78), which exposes the ability to inject different locale keys into `WordPressComRestApi`.

The code can be reviewed as-is; I have only affixed the `DO NOT MERGE` label to reflect the fact that it is dependent on the review, approval, merge, & versioning of [this PR](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/87) in `WordPressKit`.

**Note:** A [separate issue](
https://github.com/wordpress-mobile/WordPressKit-iOS/issues/86) has been created in `WordPressKit` to transition the existing service methods to leverage this implicit locale-handling behavior.

To test:

- Checkout the branch, confirm that it builds & that existing tests pass.
- Review the changes here, which are limited to implicit locale handling of current v2 endpoint calls, as well as the separate of v1 & v2 service methods in `ActivityServiceRemote`. 
- Smoke-test network behavior to confirm no regressions, with an emphasis on modified services (e.g. Rewind, Enhanced Site Creation).

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.