### PR TITLE
Quick Start v2: Add new tours

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -14,6 +14,7 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 @property (nonatomic, strong) UIActivityIndicatorView *blavatarUpdateActivityIndicatorView;
 @property (nonatomic, strong) UIStackView *labelsStackView;
 @property (nonatomic, strong) UIView *blavatarDropTarget;
+@property (nonatomic, strong) UIView *spotlightView;
 
 @end
 
@@ -91,6 +92,27 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     } else {
         self.blavatarImageView.image = [UIImage siteIconPlaceholderImage];
     }
+
+    if ([[QuickStartTourGuide find] isCurrentElement:QuickStartTourElementSiteIcon]) {
+        [self addQuickStartSpotlight];
+    }
+}
+
+- (void)addQuickStartSpotlight
+{
+    self.spotlightView = [QuickStartSpotlightView new];
+    [self addSubview:self.spotlightView];
+
+    self.spotlightView.translatesAutoresizingMaskIntoConstraints = false;
+    [NSLayoutConstraint activateConstraints:@[
+                                              [self.blavatarImageView.trailingAnchor constraintEqualToAnchor:self.spotlightView.trailingAnchor constant:-8.0],
+                                              [self.blavatarImageView.bottomAnchor constraintEqualToAnchor:self.spotlightView.bottomAnchor constant:-8.0]
+                                              ]];
+}
+
+- (void)removeQuickStartSpotlight
+{
+    [self.spotlightView removeFromSuperview];
 }
 
 #pragma mark - Subview setup
@@ -163,6 +185,9 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 
 -(void)blavatarImageTapped
 {
+    [[QuickStartTourGuide find] visited:QuickStartTourElementSiteIcon];
+    [self removeQuickStartSpotlight];
+
     [self.delegate siteIconTapped];
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
@@ -41,6 +41,7 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
     QuickStartTourElementReaderSearch = 12,
     QuickStartTourElementTourCompleted = 13,
     QuickStartTourElementCongratulations = 14,
+    QuickStartTourElementSiteIcon = 15
 };
 
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
@@ -41,7 +41,11 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
     QuickStartTourElementReaderSearch = 12,
     QuickStartTourElementTourCompleted = 13,
     QuickStartTourElementCongratulations = 14,
-    QuickStartTourElementSiteIcon = 15
+    QuickStartTourElementSiteIcon = 15,
+    QuickStartTourElementPages = 16,
+    QuickStartTourElementNewPage = 17,
+    QuickStartTourElementStats = 18,
+    QuickStartTourElementPlans = 19,
 };
 
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -544,12 +544,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [rows addObject:row];
     }
 
-    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
+    BlogDetailsRow *statsRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
                                   accessibilityIdentifier:@"Stats Row"
                                                     image:[Gridicon iconOfType:GridiconTypeStatsAlt]
                                                  callback:^{
                                                      [weakSelf showStats];
-                                                 }]];
+                                                 }];
+    statsRow.quickStartIdentifier = QuickStartTourElementStats;
+    [rows addObject:statsRow];
 
     if ([self.blog supports:BlogFeatureActivity]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Activity", @"Noun. Links to a blog's Activity screen.")
@@ -560,16 +562,16 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
 
     if ([self.blog supports:BlogFeaturePlans]) {
-        BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Plans", @"Action title. Noun. Links to a blog's Plans screen.")
+        BlogDetailsRow *plansRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Plans", @"Action title. Noun. Links to a blog's Plans screen.")
                                                          identifier:BlogDetailsPlanCellIdentifier
                                                               image:[Gridicon iconOfType:GridiconTypePlans]
                                                            callback:^{
                                                                [weakSelf showPlans];
                                                            }];
 
-        row.detail = self.blog.planTitle;
-
-        [rows addObject:row];
+        plansRow.detail = self.blog.planTitle;
+        plansRow.quickStartIdentifier = QuickStartTourElementPlans;
+        [rows addObject:plansRow];
     }
 
     return [[BlogDetailsSection alloc] initWithTitle:nil andRows:rows];
@@ -579,11 +581,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
-    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Site Pages", @"Noun. Title. Links to the blog's Pages screen.")
+    BlogDetailsRow *pagesRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Site Pages", @"Noun. Title. Links to the blog's Pages screen.")
                                                     image:[Gridicon iconOfType:GridiconTypePages]
                                                  callback:^{
                                                      [weakSelf showPageList];
-                                                 }]];
+                                                 }];
+    pagesRow.quickStartIdentifier = QuickStartTourElementPages;
+    [rows addObject:pagesRow];
 
     [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Blog Posts", @"Noun. Title. Links to the blog's Posts screen.")
                                   accessibilityIdentifier:@"Blog Post Row"
@@ -1191,7 +1195,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     PageListViewController *controller = [PageListViewController controllerWithBlog:self.blog];
     [self showDetailViewController:controller sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
+    [[QuickStartTourGuide find] visited:QuickStartTourElementPages];
 }
 
 - (void)showMediaLibrary
@@ -1227,7 +1231,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     PlanListViewController *controller = [[PlanListViewController alloc] initWithStyle:UITableViewStyleGrouped];
     [self showDetailViewController:controller sender:self];
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
+    [[QuickStartTourGuide find] visited:QuickStartTourElementPlans];
 }
 
 - (void)showSettings
@@ -1274,7 +1278,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self showDetailViewController:statsView sender:self];
     }
 
-    [[QuickStartTourGuide find] visited:QuickStartTourElementBlogDetailNavigation];
+    [[QuickStartTourGuide find] visited:QuickStartTourElementStats];
 }
 
 - (void)showActivity

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -254,7 +254,7 @@ open class QuickStartTourGuide: NSObject {
     ]
 
     static let growListTours: [QuickStartTour] = [
-        QuickStartPostSharingTour(),
+        QuickStartShareTour(),
         QuickStartPublishTour(),
         QuickStartFollowTour(),
         QuickStartCheckStatsTour(),

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -111,8 +111,8 @@ struct QuickStartCustomizeTour: QuickStartTour {
 struct QuickStartShareTour: QuickStartTour {
     let key = "quick-start-share-tour"
     let analyticsKey = "share_site"
-    let title = NSLocalizedString("Share your site", comment: "Title of a Quick Start Tour")
-    let description = NSLocalizedString("Connect to your social media accounts -- your site will automatically share new posts.", comment: "Description of a Quick Start Tour")
+    let title = NSLocalizedString("Enable post sharing", comment: "Title of a Quick Start Tour")
+    let description = NSLocalizedString("Automatically share new posts to your social media accounts.", comment: "Description of a Quick Start Tour")
     let icon = Gridicon.iconOfType(.share)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
@@ -190,8 +190,8 @@ struct QuickStartSiteIconTour: QuickStartTour {
 
     var waypoints: [WayPoint] = {
         let descriptionBase = NSLocalizedString("Tap %@ to upload a new one.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
-        let descriptionTarget = NSLocalizedString("Your Site Icon", comment: "The icon to tap during a guided tour.")
-        return [(element: .siteIcon, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: Gridicon.iconOfType(.create)))]
+        let descriptionTarget = NSLocalizedString("Your Site Icon", comment: "The item to tap during a guided tour.")
+        return [(element: .siteIcon, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: nil))]
     }()
 }
 
@@ -203,16 +203,18 @@ struct QuickStartNewPageTour: QuickStartTour {
     let icon = Gridicon.iconOfType(.pages)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
-}
 
-struct QuickStartPostSharingTour: QuickStartTour {
-    let key = "quick-start-post-sharing-tour"
-    let analyticsKey = "post_sharing"
-    let title = NSLocalizedString("Enable post sharing", comment: "Title of a Quick Start Tour")
-    let description = NSLocalizedString("Automatically share new posts to your social media accounts.", comment: "Description of a Quick Start Tour")
-    let icon = Gridicon.iconOfType(.share)
-    let suggestionNoText = Strings.notNow
-    let suggestionYesText = Strings.yesShowMe
+    var waypoints: [WayPoint] = {
+        let pagesStepDesc = NSLocalizedString("Tap %@ to continue.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+        let pagesStepTarget = NSLocalizedString("Site Pages", comment: "The item to tap during a guided tour.")
+
+        let newStepDesc = NSLocalizedString("Tap %@ to create a new page.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+
+        return [
+            (element: .pages, description: pagesStepDesc.highlighting(phrase: pagesStepTarget, icon: nil)),
+            (element: .newPage, description: newStepDesc.highlighting(phrase: "", icon: Gridicon.iconOfType(.plus)))
+        ]
+    }()
 }
 
 struct QuickStartCheckStatsTour: QuickStartTour {
@@ -223,6 +225,12 @@ struct QuickStartCheckStatsTour: QuickStartTour {
     let icon = Gridicon.iconOfType(.statsAlt)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
+
+    var waypoints: [WayPoint] = {
+        let descriptionBase = NSLocalizedString("Tap %@ to see how your site is performing.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+        let descriptionTarget = NSLocalizedString("Stats", comment: "The item to tap during a guided tour.")
+        return [(element: .stats, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: Gridicon.iconOfType(.stats)))]
+    }()
 }
 
 struct QuickStartExplorePlansTour: QuickStartTour {
@@ -233,6 +241,12 @@ struct QuickStartExplorePlansTour: QuickStartTour {
     let icon = Gridicon.iconOfType(.plans)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
+
+    var waypoints: [WayPoint] = {
+        let descriptionBase = NSLocalizedString("Tap %@ to see your current plan and other available plans.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+        let descriptionTarget = NSLocalizedString("Plan", comment: "The item to tap during a guided tour.")
+        return [(element: .plans, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: Gridicon.iconOfType(.plans)))]
+    }()
 }
 
 private let congratsTitle = NSLocalizedString("Congrats on finishing Quick Start  🎉", comment: "Title of a Quick Start Tour")

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -187,6 +187,12 @@ struct QuickStartSiteIconTour: QuickStartTour {
     let icon = Gridicon.iconOfType(.globe)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
+
+    var waypoints: [WayPoint] = {
+        let descriptionBase = NSLocalizedString("Tap %@ to upload a new one.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to tap.")
+        let descriptionTarget = NSLocalizedString("Your Site Icon", comment: "The icon to tap during a guided tour.")
+        return [(element: .siteIcon, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: Gridicon.iconOfType(.create)))]
+    }()
 }
 
 struct QuickStartNewPageTour: QuickStartTour {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -112,6 +112,11 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        if QuickStartTourGuide.find()?.isCurrentElement(.newPage) ?? false {
+            updateFilterWithPostStatus(.publish)
+        }
+
         super.updateAndPerformFetchRequest()
 
         title = NSLocalizedString("Site Pages", comment: "Title of the screen showing the list of pages for a blog.")
@@ -448,6 +453,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let page = postService.createDraftPage(for: blog)
         WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "posts_view"], with: blog)
         showEditor(post: page)
+
+        QuickStartTourGuide.find()?.visited(.newPage)
     }
 
     fileprivate func editPage(_ apost: AbstractPost) {


### PR DESCRIPTION
Refs #10860 

![new-qs-v2-tours](https://user-images.githubusercontent.com/517257/52304179-f7999d80-2946-11e9-9f8a-b551268ebaf6.png)

To test:
- Put `return true` in `shouldShowQuickStartChecklist()`
- Ensure the new tours work correctly:
  1. Site Icon
  2. Plans
  3. Stats
  4. New Page
  4. Renamed sharing tour

Update release notes:

- [ ] Not visible yet