### PR TITLE
Reader: Use WKWebView instead of the deprecated UIWebView for rich te…

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
@@ -1,29 +1,28 @@
 import Foundation
 import CocoaLumberjack
+import WebKit
 
-class WPRichTextEmbed: UIView, UIWebViewDelegate, WPRichTextMediaAttachment {
+class WPRichTextEmbed: UIView, WPRichTextMediaAttachment {
     typealias successBlock = ((WPRichTextEmbed)->Void)
 
 
     // MARK: Properties
-
+    private var internalDocumentHeight: CGFloat = 0.0
     @objc var fixedHeight: CGFloat = 0.0
     @objc var attachmentSize = CGSize.zero
     @objc var documentSize: CGSize {
         get {
-            var contentSize = webView.scrollView.contentSize
-            if let heightStr = webView.stringByEvaluatingJavaScript(from: "document.documentElement.scrollHeight") {
-                if let height = NumberFormatter().number(from: heightStr) as? CGFloat {
-                    contentSize.height = height
-                }
+            var size = webView.scrollView.contentSize
+            if internalDocumentHeight > 0.0 {
+                size.height = internalDocumentHeight
             }
-            return contentSize
+            return size
         }
     }
     @objc var success: successBlock?
     var linkURL: URL?
     var contentURL: URL?
-    @objc var webView: UIWebView
+    @objc var webView: WKWebView
 
     override var frame: CGRect {
         didSet {
@@ -40,7 +39,7 @@ class WPRichTextEmbed: UIView, UIWebViewDelegate, WPRichTextMediaAttachment {
 
     override init(frame: CGRect) {
         // A small starting frame to avoid being sized too tall
-        webView = UIWebView(frame: CGRect(x: 0.0, y: 0.0, width: 20.0, height: 20.0))
+        webView = WKWebView(frame: CGRect(x: 0.0, y: 0.0, width: 20.0, height: 20.0))
 
         super.init(frame: frame)
 
@@ -49,10 +48,10 @@ class WPRichTextEmbed: UIView, UIWebViewDelegate, WPRichTextMediaAttachment {
     }
 
     required init?(coder aDecoder: NSCoder) {
-        if let decodedWebView = aDecoder.decodeObject(forKey: "webView") as? UIWebView {
+        if let decodedWebView = aDecoder.decodeObject(forKey: "webView") as? WKWebView {
             webView = decodedWebView
         } else {
-            webView = UIWebView(frame: CGRect(x: 0.0, y: 0.0, width: 20.0, height: 20.0))
+            webView = WKWebView(frame: CGRect(x: 0.0, y: 0.0, width: 20.0, height: 20.0))
         }
 
         super.init(coder: aDecoder)
@@ -72,8 +71,7 @@ class WPRichTextEmbed: UIView, UIWebViewDelegate, WPRichTextMediaAttachment {
     @objc func configureWebView() {
         webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
         webView.scrollView.isScrollEnabled = false
-        webView.scalesPageToFit = true
-        webView.delegate = self
+        webView.navigationDelegate = self
     }
 
 
@@ -110,7 +108,7 @@ class WPRichTextEmbed: UIView, UIWebViewDelegate, WPRichTextMediaAttachment {
 
         contentURL = url
         let request = URLRequest(url: url)
-        webView.loadRequest(request)
+        webView.load(request)
     }
 
     @objc func loadHTMLString(_ html: NSString) {
@@ -118,48 +116,71 @@ class WPRichTextEmbed: UIView, UIWebViewDelegate, WPRichTextMediaAttachment {
         webView.loadHTMLString(htmlString, baseURL: nil)
     }
 
-
-    @objc func checkIfDoneLoading() {
-        if webView.isLoading {
-            return
-        }
-
-        if let callback = success {
-            callback(self)
-        }
-        success = nil
-        webView.delegate = nil
-    }
-
-    // MARK: WebView delegate methods
-
-    func webViewDidFinishLoad(_ webView: UIWebView) {
-        // Add the webView as a subview if it hasn't been already.
-        if webView.superview == nil {
-            // Make sure that any viewport meta tag does not have a min scale incase we're display smaller than the device width.
-            let viewport =  "var tid = setInterval( function () {" +
-                "if ( document.readyState !== 'complete' ) return;" +
-                "   clearInterval( tid );" +
-                "   viewport = document.querySelector('meta[name=viewport]'); " +
-                "   if (viewport) {" +
-                "       viewport.setAttribute('content', 'width=available-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no');" +
-                "   }" +
-                "}, 100 );"
-            webView.stringByEvaluatingJavaScript(from: viewport)
-
-            webView.frame = bounds
-            addSubview(webView)
-        }
-
-        // The webViewDidFinishLoad method can be called many times for a single
-        // web page. Wait a brief moment then check if the webview is done loading content.
-        let delayTime = DispatchTime.now() + Double(Int64(0.3 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
-        DispatchQueue.main.asyncAfter(deadline: delayTime) { [weak self] in
-            self?.checkIfDoneLoading()
+    /// Query the webView for its internal document's scrollHeight and pass the
+    /// value to the supplied completion block.
+    ///
+    private func fetchInternalDocumentHeight(_ completionHandler: @escaping ((CGFloat)->Void)) {
+        webView.evaluateJavaScript("document.documentElement.scrollHeight") { (result, _) in
+            guard let height = result as? CGFloat else {
+                completionHandler(0)
+                return
+            }
+            completionHandler(height)
         }
     }
 
-    func webView(_ webView: UIWebView, didFailLoadWithError error: Error) {
+    /// Called when loading is finished and the viewport should be updated.
+    /// Adds the webView to the view hierarchy so its visible. Fetches the
+    /// internal document height now that content is fully loaded.
+    /// Finally, call our success block.
+    ///
+    private func onLoadingComplete() {
+        webView.frame = bounds
+        addSubview(webView)
+
+        fetchInternalDocumentHeight { [weak self] height in
+            guard let strongSelf = self else {
+                return
+            }
+            strongSelf.internalDocumentHeight = height
+            if let callback = strongSelf.success {
+                callback(strongSelf)
+            }
+            strongSelf.success = nil
+        }
+    }
+
+    /// Override the viewport settings of the loaded content so we're sure to render correctly.
+    ///
+    private func updateDocumentViewPortIfNeeded(_ completionHandler: @escaping (()->Void)) {
+        // Make sure that any viewport meta tag does not have a min scale incase we're display smaller than the device width.
+        let viewport =  "var tid = setInterval( function () {" +
+            "if ( document.readyState !== 'complete' ) return;" +
+            "   clearInterval( tid );" +
+            "   viewport = document.querySelector('meta[name=viewport]'); " +
+            "   if (viewport) {" +
+            "       viewport.setAttribute('content', 'width=available-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no');" +
+            "   }" +
+        "}, 100 );"
+        webView.evaluateJavaScript(viewport) {(_, _) in
+            completionHandler()
+        }
+    }
+
+}
+
+// MARK: WebView delegate methods
+extension WPRichTextEmbed : WKNavigationDelegate {
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        // We're fully loaded so we can unassign the delegate.
+        webView.navigationDelegate = nil
+        updateDocumentViewPortIfNeeded {[weak self] in
+            self?.onLoadingComplete()
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         if let url = contentURL {
             DDLogError("RichTextEmbed failed to load content URL: \(url).")
         }


### PR DESCRIPTION
Refs: #10930

While investigating #10930 I realized that we're still using the deprecated UIWebView for rich text embeds instead of the recommended WKWebView so I've whipped up this PR to make the switch.   As a bonus, WKWebView seems to be a bit smarter with its logic so I've been able to remove some hackish logic UIWebViews needed to display properly.

This doesn't completely resolve the issue with #10930.  The video reported in the issue still does not play.  However, I notice if I copy the source into my own post and add a `width` attribute to the video tag then it *does* size and play correctly on my test blog.  I'll pursue this avenue in a second PR.

To test: 
1. Set a breakpoint in `webView(_ webView: WKWebView, didFinish navigation: WKNavigation!)` (or a print statement).  While testing ensure that this method is called only *once* for each video.  Its easier to test with posts with a single video embed.
2. View a number of posts with embedded content.  The changes do not affect images, so focus on video embeds.  You might try following the youtube, or video tags in the Reader and scrolling through the content.  Alternatively you can look at [a post like this](https://aerychtest.wordpress.com/2014/10/02/embedables/) which has a variety of supported embed types.
3. Confirm that the videos play. 
4. Confirm that the layout is the same (or better!) as previously.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
