### PR TITLE
[Stats Refresh] Add Period > Authors card

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -35,6 +35,8 @@ class SiteStatsPeriodTableViewController: UITableViewController {
                 return
             }
 
+            clearExpandedRows()
+
             // If this is the first time setting the Period, need to initialize the view model.
             // Otherwise, just refresh the data.
             if oldValue == nil {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -38,6 +38,7 @@ class SiteStatsPeriodViewModel: Observable {
         var tableRows = [ImmuTableRow]()
 
         tableRows.append(contentsOf: postsAndPagesTableRows())
+        tableRows.append(contentsOf: authorsTableRows())
         tableRows.append(contentsOf: searchTermsTableRows())
         tableRows.append(contentsOf: publishedTableRows())
         tableRows.append(contentsOf: videosTableRows())
@@ -63,6 +64,7 @@ private extension SiteStatsPeriodViewModel {
 
     struct PeriodHeaders {
         static let postsAndPages = NSLocalizedString("Posts and Pages", comment: "Period Stats 'Posts and Pages' header")
+        static let authors = NSLocalizedString("Authors", comment: "Period Stats 'Authors' header")
         static let searchTerms = NSLocalizedString("Search Terms", comment: "Period Stats 'Search Terms' header")
         static let published = NSLocalizedString("Published", comment: "Period Stats 'Published' header")
         static let videos = NSLocalizedString("Videos", comment: "Period Stats 'Videos' header")
@@ -71,6 +73,11 @@ private extension SiteStatsPeriodViewModel {
     struct PostsAndPages {
         static let itemSubtitle = NSLocalizedString("Title", comment: "Posts and Pages label for post/page title")
         static let dataSubtitle = NSLocalizedString("Views", comment: "Posts and Pages label for number of views")
+    }
+
+    struct Authors {
+        static let itemSubtitle = NSLocalizedString("Author", comment: "Authors label for post author")
+        static let dataSubtitle = NSLocalizedString("Views", comment: "Authors label for number of views")
     }
 
     struct SearchTerms {
@@ -117,6 +124,36 @@ private extension SiteStatsPeriodViewModel {
         }
 
         return dataRows
+    }
+
+    func authorsTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(title: PeriodHeaders.authors))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: Authors.itemSubtitle,
+                                                 dataSubtitle: Authors.dataSubtitle,
+                                                 dataRows: authorsDataRows(),
+                                                 siteStatsPeriodDelegate: periodDelegate))
+
+        return tableRows
+    }
+
+    func authorsDataRows() -> [StatsTotalRowData] {
+        return store.getTopAuthors()?.map { StatsTotalRowData.init(name: $0.label,
+                                                                   data: $0.value.displayString(),
+                                                                   userIconURL: $0.iconURL,
+                                                                   showDisclosure: true,
+                                                                   childRows: childRowsForAuthor($0)) }
+            ?? [StatsTotalRowData]()
+    }
+
+    func childRowsForAuthor(_ item: StatsItem) -> [StatsTotalRowData] {
+
+        guard let children = item.children as? [StatsItem] else {
+            return [StatsTotalRowData]()
+        }
+
+        return children.map { StatsTotalRowData.init(name: $0.label,
+                                                     data: $0.value.displayString()) }
     }
 
     func searchTermsTableRows() -> [ImmuTableRow] {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -138,11 +138,13 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func authorsDataRows() -> [StatsTotalRowData] {
-        return store.getTopAuthors()?.map { StatsTotalRowData.init(name: $0.label,
-                                                                   data: $0.value.displayString(),
-                                                                   userIconURL: $0.iconURL,
-                                                                   showDisclosure: true,
-                                                                   childRows: childRowsForAuthor($0)) }
+        let authors = store.getTopAuthors()
+        return authors?.map { StatsTotalRowData.init(name: $0.label,
+                                                     data: $0.value.displayString(),
+                                                     dataBarPercent: StatsDataHelper.dataBarPercentForRow($0, relativeToRow: authors?.first),
+                                                     userIconURL: $0.iconURL,
+                                                     showDisclosure: true,
+                                                     childRows: childRowsForAuthor($0)) }
             ?? [StatsTotalRowData]()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -229,7 +229,7 @@ private extension StatsTotalRow {
         // Determine the distance from the bar to the max width.
         // Set that distance as the bar width.
 
-        let dataWidth = rightStackView.frame.width + rightStackViewLeadingConstraint.constant
+        let dataWidth = rightStackView.frame.width + rightStackViewLeadingConstraint.constant + rightStackView.spacing
         var maxBarWidth = Float(contentView.frame.width - dataWidth)
 
         if !imageView.isHidden {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -85,7 +85,7 @@ class StatsTotalRow: UIView, NibLoadable {
 
     // This stack view is modified by the containing cell, to show/hide
     // child rows when a parent row is selected.
-    var childRowsStackView = UIStackView()
+    var childRowsStackView: UIStackView?
 
     var showSeparator = true {
         didSet {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.xib
@@ -75,7 +75,7 @@
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="999" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ivc-26-vsM" userLabel="Data Label">
                                     <rect key="frame" x="0.0" y="19" width="31.5" height="20.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
@@ -101,7 +101,7 @@
                         <constraint firstItem="RuI-Jr-EKZ" firstAttribute="centerY" secondItem="BAZ-QX-R74" secondAttribute="centerY" id="zYS-28-7cr"/>
                     </constraints>
                 </view>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KoQ-BR-jDc" userLabel="Disclosure Button">
+                <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KoQ-BR-jDc" userLabel="Disclosure Button">
                     <rect key="frame" x="0.0" y="0.0" width="442" height="79.5"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <connections>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.xib
@@ -101,7 +101,7 @@
                         <constraint firstItem="RuI-Jr-EKZ" firstAttribute="centerY" secondItem="BAZ-QX-R74" secondAttribute="centerY" id="zYS-28-7cr"/>
                     </constraints>
                 </view>
-                <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KoQ-BR-jDc" userLabel="Disclosure Button">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KoQ-BR-jDc" userLabel="Disclosure Button">
                     <rect key="frame" x="0.0" y="0.0" width="442" height="79.5"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <connections>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -176,6 +176,7 @@ extension TopTotalsCell: StatsTotalRowDelegate {
         row.expanded ? addChildRowsForRow(row) : removeChildRowsForRow(row)
         toggleSeparatorForRowPreviousTo(row)
         siteStatsInsightsDelegate?.expandedRowUpdated?(row)
+        siteStatsPeriodDelegate?.expandedRowUpdated?(row)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -54,6 +54,16 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+
+        rowsStackView.arrangedSubviews.forEach { subview in
+            guard let row = subview as? StatsTotalRow,
+                row.hasChildRows else {
+                    return
+            }
+
+            removeChildRowsForRow(row)
+        }
+
         removeRowsFromStackView(rowsStackView)
     }
 
@@ -129,8 +139,14 @@ private extension TopTotalsCell {
     }
 
     func removeChildRowsForRow(_ row: StatsTotalRow) {
-        rowsStackView.removeArrangedSubview(row.childRowsStackView)
-        row.childRowsStackView.removeFromSuperview()
+
+        guard let childRowsStackView = row.childRowsStackView else {
+            return
+        }
+
+        removeRowsFromStackView(childRowsStackView)
+        rowsStackView.removeArrangedSubview(childRowsStackView)
+        childRowsStackView.removeFromSuperview()
     }
 
     func toggleSeparatorForRowPreviousTo(_ row: StatsTotalRow) {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -114,6 +114,10 @@ private extension TopTotalsCell {
             childRow.configure(rowData: childRowData, delegate: self)
             childRow.showSeparator = false
 
+            // Never hide the image for a child row. It will either display
+            // an image or an intentional blank space.
+            childRow.imageView.isHidden = false
+
             // Show the expanded bottom separator on the last row
             childRow.showBottomExpandedSeparator = (childRowsIndex == numberOfRowsToAdd - 1)
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -35,12 +35,11 @@
                     </subviews>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="bottom" secondItem="Umw-QX-aI2" secondAttribute="bottom" constant="12" id="29t-dT-7i2"/>
+                        <constraint firstAttribute="bottom" secondItem="Umw-QX-aI2" secondAttribute="bottom" priority="999" constant="12" id="29t-dT-7i2"/>
                         <constraint firstItem="gbG-Q7-nUb" firstAttribute="leading" secondItem="Umw-QX-aI2" secondAttribute="trailing" constant="16" id="2Lb-6u-lbm"/>
                         <constraint firstAttribute="trailing" secondItem="gbG-Q7-nUb" secondAttribute="trailing" constant="16" id="2oK-CI-3Zd"/>
                         <constraint firstItem="gbG-Q7-nUb" firstAttribute="centerY" secondItem="N97-9D-WNI" secondAttribute="centerY" id="DpW-YP-ewg"/>
                         <constraint firstItem="Umw-QX-aI2" firstAttribute="top" secondItem="N97-9D-WNI" secondAttribute="top" constant="12" id="Ifk-YO-ipw"/>
-                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="f3R-CD-B7v"/>
                         <constraint firstItem="Umw-QX-aI2" firstAttribute="leading" secondItem="N97-9D-WNI" secondAttribute="leading" constant="16" id="wMp-ZA-nkO"/>
                     </constraints>
                 </view>


### PR DESCRIPTION
Fixes #10946 

To test:

---
- On a site with some posts, go to Stats > Period > Authors.
  - Note when switching between the Period filters, the expanded rows will reset.
- Verify the view is:

<img width="250" alt="authors_init" src="https://user-images.githubusercontent.com/1816888/52313888-83262500-296d-11e9-82f2-0cf625407ed0.png">

---
- Select an Author row.
  - Max 10 child rows will be displayed, showing the Author's posts.
  - There is no action for selecting a child row.
- Verify the view is:

<img width="250" alt="authors_expanded" src="https://user-images.githubusercontent.com/1816888/52313927-a81a9800-296d-11e9-9998-c46a2691c5f4.png">



