### PR TITLE
GB finish uploads out of editor

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -94,8 +94,8 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '8af6464ca479784bf462c5c8bcd1f873e951ded1'
-    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '8af6464ca479784bf462c5c8bcd1f873e951ded1'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => 'be7f6dc99a91aeaed96ddc9e9de3deb67d2dfbac'
+    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => 'be7f6dc99a91aeaed96ddc9e9de3deb67d2dfbac'
 
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -224,7 +224,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `8af6464ca479784bf462c5c8bcd1f873e951ded1`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `be7f6dc99a91aeaed96ddc9e9de3deb67d2dfbac`)
   - HockeySDK (= 5.1.4)
   - MGSwipeTableCell (= 1.6.8)
   - MRProgress (= 0.8.3)
@@ -239,7 +239,7 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `8af6464ca479784bf462c5c8bcd1f873e951ded1`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `be7f6dc99a91aeaed96ddc9e9de3deb67d2dfbac`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -299,7 +299,7 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: 8af6464ca479784bf462c5c8bcd1f873e951ded1
+    :commit: be7f6dc99a91aeaed96ddc9e9de3deb67d2dfbac
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
@@ -311,7 +311,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 8af6464ca479784bf462c5c8bcd1f873e951ded1
+    :commit: be7f6dc99a91aeaed96ddc9e9de3deb67d2dfbac
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -324,13 +324,13 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.3.1
   Gutenberg:
-    :commit: 8af6464ca479784bf462c5c8bcd1f873e951ded1
+    :commit: be7f6dc99a91aeaed96ddc9e9de3deb67d2dfbac
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNSVG:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 8af6464ca479784bf462c5c8bcd1f873e951ded1
+    :commit: be7f6dc99a91aeaed96ddc9e9de3deb67d2dfbac
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -385,6 +385,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 6dd41774aeb4893ede04994d080f61d042e574e1
+PODFILE CHECKSUM: 00d25949d8d08be635506f03a4cd49b8f283fbc6
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -181,7 +181,7 @@ class PostCoordinator: NSObject {
         if media.mediaType == .image {
             let imgPostUploadProcessor = ImgUploadProcessor(mediaUploadID: mediaUploadID, remoteURLString: remoteURLStr, width: media.width?.intValue, height: media.height?.intValue)
             postContent = imgPostUploadProcessor.process(postContent)
-            let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID:mediaID, remoteURLString: remoteURLStr)
+            let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
             postContent = gutenbergImgPostUploadProcessor.process(postContent)
         } else if media.mediaType == .video {
             let videoPostUploadProcessor = VideoUploadProcessor(mediaUploadID: mediaUploadID, remoteURLString: remoteURLStr, videoPressID: media.videopressGUID)

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -168,17 +168,21 @@ class PostCoordinator: NSObject {
 
     private func updateReferences(to media: Media, in post: AbstractPost) {
         guard var postContent = post.content,
+            let mediaID = media.mediaID?.intValue,
             let remoteURLStr = media.remoteURL else {
             return
         }
 
         let mediaUploadID = media.uploadID
+        let gutenbergMediaUploadID = media.gutenbergUploadID
         if media.remoteStatus == .failed {
             return
         }
         if media.mediaType == .image {
             let imgPostUploadProcessor = ImgUploadProcessor(mediaUploadID: mediaUploadID, remoteURLString: remoteURLStr, width: media.width?.intValue, height: media.height?.intValue)
             postContent = imgPostUploadProcessor.process(postContent)
+            let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID:mediaID , remoteURLString: remoteURLStr, width: media.width?.intValue, height: media.height?.intValue)
+            postContent = gutenbergImgPostUploadProcessor.process(postContent)
         } else if media.mediaType == .video {
             let videoPostUploadProcessor = VideoUploadProcessor(mediaUploadID: mediaUploadID, remoteURLString: remoteURLStr, videoPressID: media.videopressGUID)
             postContent = videoPostUploadProcessor.process(postContent)

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -181,7 +181,7 @@ class PostCoordinator: NSObject {
         if media.mediaType == .image {
             let imgPostUploadProcessor = ImgUploadProcessor(mediaUploadID: mediaUploadID, remoteURLString: remoteURLStr, width: media.width?.intValue, height: media.height?.intValue)
             postContent = imgPostUploadProcessor.process(postContent)
-            let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID:mediaID , remoteURLString: remoteURLStr, width: media.width?.intValue, height: media.height?.intValue)
+            let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID:mediaID, remoteURLString: remoteURLStr)
             postContent = gutenbergImgPostUploadProcessor.process(postContent)
         } else if media.mediaType == .video {
             let videoPostUploadProcessor = VideoUploadProcessor(mediaUploadID: mediaUploadID, remoteURLString: remoteURLStr, videoPressID: media.videopressGUID)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -64,6 +64,11 @@ class GutenbergMediaInserterHelper: NSObject {
         if mediaObserverReceipt != nil {
             registerMediaObserver()
         }
+        for media in post.media {
+            if media.remoteStatus == .failed {
+                gutenberg.mediaUploadUpdate(id: media.gutenbergUploadID, state: .failed, progress: 0, url: nil, serverID: nil)
+            }
+        }
     }
 
     func mediaFor(uploadID: Int32) -> Media? {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaInserterHelper.swift
@@ -117,6 +117,10 @@ class GutenbergMediaInserterHelper: NSObject {
     }
 
     private func mediaObserver(media: Media, state: MediaCoordinator.MediaState) {
+        // Make sure gutenberg is loaded before seding events to it.
+        guard gutenberg.isLoaded else {
+            return
+        }
         let mediaUploadID = media.gutenbergUploadID
         switch state {
         case .processing:

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergImgUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergImgUploadProcessor.swift
@@ -35,7 +35,7 @@ class GutenbergImgUploadProcessor: Processor {
             return nil
         }
 
-        let newImgClassAttributes = imgClass.replacingOccurrences(of: imageIDAttribute, with:GutenbergImgUploadProcessor.imgClassIDPrefixAttribute + String(self.serverMediaID))
+        let newImgClassAttributes = imgClass.replacingOccurrences(of: imageIDAttribute, with: GutenbergImgUploadProcessor.imgClassIDPrefixAttribute + String(self.serverMediaID))
 
         var attributes = img.attributes
         attributes.set(.string(self.remoteURLString), forKey: "src")

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergImgUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergImgUploadProcessor.swift
@@ -4,18 +4,14 @@ import Aztec
 class GutenbergImgUploadProcessor: Processor {
 
     let mediaUploadID: Int32
-    let width: Int?
-    let height: Int?
     let remoteURLString: String
     let serverMediaID: Int
     static let imgClassIDPrefixAttribute = "wp-image-"
 
-    init(mediaUploadID: Int32, serverMediaID: Int, remoteURLString: String, width: Int?, height: Int?) {
+    init(mediaUploadID: Int32, serverMediaID: Int, remoteURLString: String) {
         self.mediaUploadID = mediaUploadID
         self.serverMediaID = serverMediaID
         self.remoteURLString = remoteURLString
-        self.width = width
-        self.height = height
     }
 
     lazy var imgPostMediaUploadProcessor = HTMLProcessor(for: "img", replacer: { (img) in
@@ -43,13 +39,6 @@ class GutenbergImgUploadProcessor: Processor {
 
         var attributes = img.attributes
         attributes.set(.string(self.remoteURLString), forKey: "src")
-        if let width = self.width {
-            attributes.set(.string("\(width)"), forKey: "width")
-        }
-        if let height = self.height {
-            attributes.set(.string("\(height)"), forKey: "height")
-        }
-
         attributes.set(.string(newImgClassAttributes), forKey: "class")
 
         var html = "<img "

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergImgUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergImgUploadProcessor.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Aztec
+
+class GutenbergImgUploadProcessor: Processor {
+
+    let mediaUploadID: Int32
+    let width: Int?
+    let height: Int?
+    let remoteURLString: String
+    let serverMediaID: Int
+    static let imgClassIDPrefixAttribute = "wp-image-"
+
+    init(mediaUploadID: Int32, serverMediaID: Int, remoteURLString: String, width: Int?, height: Int?) {
+        self.mediaUploadID = mediaUploadID
+        self.serverMediaID = serverMediaID
+        self.remoteURLString = remoteURLString
+        self.width = width
+        self.height = height
+    }
+
+    lazy var imgPostMediaUploadProcessor = HTMLProcessor(for: "img", replacer: { (img) in
+        guard let imgClassAttributeValue = img.attributes["class"]?.value,
+            case let .string(imgClass) = imgClassAttributeValue else {
+                return nil
+        }
+
+        let classAttributes = imgClass.components(separatedBy: " ")
+
+        guard let imageIDAttribute = classAttributes.filter({ (value) -> Bool in
+            value.hasPrefix(GutenbergImgUploadProcessor.imgClassIDPrefixAttribute)
+        }).first else {
+            return nil
+        }
+
+        let imageIDString = String(imageIDAttribute.dropFirst(GutenbergImgUploadProcessor.imgClassIDPrefixAttribute.count))
+        let imgUploadID = Int32(imageIDString)
+
+        guard imgUploadID == self.mediaUploadID else {
+            return nil
+        }
+
+        let newImgClassAttributes = imgClass.replacingOccurrences(of: imageIDAttribute, with:GutenbergImgUploadProcessor.imgClassIDPrefixAttribute + String(self.serverMediaID))
+
+        var attributes = img.attributes
+        attributes.set(.string(self.remoteURLString), forKey: "src")
+        if let width = self.width {
+            attributes.set(.string("\(width)"), forKey: "width")
+        }
+        if let height = self.height {
+            attributes.set(.string("\(height)"), forKey: "height")
+        }
+
+        attributes.set(.string(newImgClassAttributes), forKey: "class")
+
+        var html = "<img "
+        let attributeSerializer = ShortcodeAttributeSerializer()
+        html += attributeSerializer.serialize(attributes)
+        html += ">"
+        return html
+    })
+
+    func process(_ text: String) -> String {
+        var result = imgPostMediaUploadProcessor.process(text)
+        result = result.replacingOccurrences(of: "wp:image {\"id\":\(String(mediaUploadID))}", with: "wp:image {\"id\":\(String(serverMediaID))}")
+        return result
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1635,6 +1635,8 @@
 		FF2716A11CABC7D40006E2D4 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2716A01CABC7D40006E2D4 /* XCTest+Extensions.swift */; };
 		FF286C761DE70A4500383A62 /* NSURL+Exporters.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF286C751DE70A4500383A62 /* NSURL+Exporters.swift */; };
 		FF28B3F11AEB251200E11AAE /* InfoPListTranslator.m in Sources */ = {isa = PBXBuildFile; fileRef = FF28B3F01AEB251200E11AAE /* InfoPListTranslator.m */; };
+		FF2EC3C02209A144006176E1 /* GutenbergImgUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2EC3BF2209A144006176E1 /* GutenbergImgUploadProcessor.swift */; };
+		FF2EC3C22209AC19006176E1 /* GutenbergImgUploadProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2EC3C12209AC19006176E1 /* GutenbergImgUploadProcessorTests.swift */; };
 		FF355D981FB492DD00244E6D /* ExportableAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF355D971FB492DD00244E6D /* ExportableAsset.swift */; };
 		FF4258501BA092EE00580C68 /* RelatedPostsSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FF42584F1BA092EE00580C68 /* RelatedPostsSettingsViewController.m */; };
 		FF4C069F206560E500E0B2BC /* MediaThumbnailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4C069E206560E500E0B2BC /* MediaThumbnailCoordinator.swift */; };
@@ -3756,6 +3758,8 @@
 		FF286C751DE70A4500383A62 /* NSURL+Exporters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSURL+Exporters.swift"; sourceTree = "<group>"; };
 		FF28B3EF1AEB251200E11AAE /* InfoPListTranslator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InfoPListTranslator.h; sourceTree = "<group>"; };
 		FF28B3F01AEB251200E11AAE /* InfoPListTranslator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = InfoPListTranslator.m; sourceTree = "<group>"; };
+		FF2EC3BF2209A144006176E1 /* GutenbergImgUploadProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergImgUploadProcessor.swift; sourceTree = "<group>"; };
+		FF2EC3C12209AC19006176E1 /* GutenbergImgUploadProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GutenbergImgUploadProcessorTests.swift; path = Gutenberg/GutenbergImgUploadProcessorTests.swift; sourceTree = "<group>"; };
 		FF355D971FB492DD00244E6D /* ExportableAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportableAsset.swift; sourceTree = "<group>"; };
 		FF42584E1BA092EE00580C68 /* RelatedPostsSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RelatedPostsSettingsViewController.h; sourceTree = "<group>"; };
 		FF42584F1BA092EE00580C68 /* RelatedPostsSettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RelatedPostsSettingsViewController.m; sourceTree = "<group>"; };
@@ -5470,6 +5474,7 @@
 		7E3E9B6E2177C9C300FD5797 /* Gutenberg */ = {
 			isa = PBXGroup;
 			children = (
+				FF2EC3BE2209A105006176E1 /* Processors */,
 				7E3E9B6F2177C9DC00FD5797 /* GutenbergViewController.swift */,
 				F10E654F21B06139007AB2EE /* GutenbergViewController+MoreActions.swift */,
 				91D8364021946EFB008340B2 /* GutenbergMediaPickerHelper.swift */,
@@ -8089,6 +8094,14 @@
 			path = WordPressUITests;
 			sourceTree = "<group>";
 		};
+		FF2EC3BE2209A105006176E1 /* Processors */ = {
+			isa = PBXGroup;
+			children = (
+				FF2EC3BF2209A144006176E1 /* GutenbergImgUploadProcessor.swift */,
+			);
+			path = Processors;
+			sourceTree = "<group>";
+		};
 		FF7691661EE06CF500713F4B /* Aztec */ = {
 			isa = PBXGroup;
 			children = (
@@ -8119,6 +8132,7 @@
 			isa = PBXGroup;
 			children = (
 				FF9A6E7021F9361700D36D14 /* MediaUploadHashTests.swift */,
+				FF2EC3C12209AC19006176E1 /* GutenbergImgUploadProcessorTests.swift */,
 			);
 			name = Gutenberg;
 			sourceTree = "<group>";
@@ -9717,6 +9731,7 @@
 				D813D67F21AA8BBF0055CCA1 /* ShadowView.swift in Sources */,
 				D865721321869C590023A99C /* Wizard.swift in Sources */,
 				08C3886A1ED78EE70057BE49 /* Media+WPMediaAsset.m in Sources */,
+				FF2EC3C02209A144006176E1 /* GutenbergImgUploadProcessor.swift in Sources */,
 				E151C0C81F388A2000710A83 /* PluginListViewModel.swift in Sources */,
 				E1B9128B1BB0129C003C25B9 /* WPStyleGuide+People.swift in Sources */,
 				E6F2788121BC1A4A008B4DB5 /* PlanGroup.swift in Sources */,
@@ -10550,6 +10565,7 @@
 				5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */,
 				FF8032661EE9E22200861F28 /* MediaProgressCoordinatorTests.swift in Sources */,
 				E63C897C1CB9A0D700649C8F /* UITextFieldTextHelperTests.swift in Sources */,
+				FF2EC3C22209AC19006176E1 /* GutenbergImgUploadProcessorTests.swift in Sources */,
 				D81C2F5A20F86E94002AE1F1 /* LikeCommentActionTests.swift in Sources */,
 				FF8CD625214184EE00A33A8D /* MediaAssetExporterTests.swift in Sources */,
 				B5C0CF3F204DB92F00DB0362 /* NotificationReplyStoreTests.swift in Sources */,

--- a/WordPress/WordPressTest/Gutenberg/GutenbergImgUploadProcessorTests.swift
+++ b/WordPress/WordPressTest/Gutenberg/GutenbergImgUploadProcessorTests.swift
@@ -20,7 +20,7 @@ class GutenbergImgUploadProcessorTests: XCTestCase {
         let mediaID = 100
         let remoteURLStr = "http://www.wordpress.com/logo.jpg"
 
-        let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID:mediaID , remoteURLString: remoteURLStr)
+        let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
         let resultContent = gutenbergImgPostUploadProcessor.process(postContent)
 
         XCTAssertEqual(resultContent, postResultContent, "Post content should be updated correctly")

--- a/WordPress/WordPressTest/Gutenberg/GutenbergImgUploadProcessorTests.swift
+++ b/WordPress/WordPressTest/Gutenberg/GutenbergImgUploadProcessorTests.swift
@@ -11,7 +11,7 @@ class GutenbergImgUploadProcessorTests: XCTestCase {
 
     let postResultContent = """
 <!-- wp:image {"id":100} -->
-<figure class="wp-block-image"><img src="http://www.wordpress.com/logo.jpg" alt="" class="wp-image-100" width="100" height="100"></figure>
+<figure class="wp-block-image"><img src="http://www.wordpress.com/logo.jpg" alt="" class="wp-image-100"></figure>
 <!-- /wp:image -->
 """
 
@@ -19,10 +19,8 @@ class GutenbergImgUploadProcessorTests: XCTestCase {
         let gutenbergMediaUploadID = Int32(-181231834)
         let mediaID = 100
         let remoteURLStr = "http://www.wordpress.com/logo.jpg"
-        let width = 100
-        let height = 100
 
-        let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID:mediaID , remoteURLString: remoteURLStr, width: width, height: height)
+        let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID:mediaID , remoteURLString: remoteURLStr)
         let resultContent = gutenbergImgPostUploadProcessor.process(postContent)
 
         XCTAssertEqual(resultContent, postResultContent, "Post content should be updated correctly")

--- a/WordPress/WordPressTest/Gutenberg/GutenbergImgUploadProcessorTests.swift
+++ b/WordPress/WordPressTest/Gutenberg/GutenbergImgUploadProcessorTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import WordPress
+
+class GutenbergImgUploadProcessorTests: XCTestCase {
+
+    let postContent = """
+<!-- wp:image {"id":-181231834} -->
+<figure class="wp-block-image"><img src="file://tmp/EC856C66-7B79-4631-9503-2FB9FF0E6C66.jpg" alt="" class="wp-image--181231834"/></figure>
+<!-- /wp:image -->
+"""
+
+    let postResultContent = """
+<!-- wp:image {"id":100} -->
+<figure class="wp-block-image"><img src="http://www.wordpress.com/logo.jpg" alt="" class="wp-image-100" width="100" height="100"></figure>
+<!-- /wp:image -->
+"""
+
+    func testProcessor() {
+        let gutenbergMediaUploadID = Int32(-181231834)
+        let mediaID = 100
+        let remoteURLStr = "http://www.wordpress.com/logo.jpg"
+        let width = 100
+        let height = 100
+
+        let gutenbergImgPostUploadProcessor = GutenbergImgUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID:mediaID , remoteURLString: remoteURLStr, width: width, height: height)
+        let resultContent = gutenbergImgPostUploadProcessor.process(postContent)
+
+        XCTAssertEqual(resultContent, postResultContent, "Post content should be updated correctly")
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/206

This PR adds the possibility to async publish Post on GB while images are uploading. 

To test:
 - Start a new post using GB
 - Add an image from the device to it
 - While the upload is going on press Publish
 - See the upload finish and the post published on the post list
 - Go back to the post and see if all content is ok
 - Do the same as above but this simulate an error while the upload is going on (go offline)
 - Open the post
 - And see if the image is on error state.
