### PR TITLE
Reader: Force video tags to 100% the width of the viewport

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
@@ -112,7 +112,7 @@ class WPRichTextEmbed: UIView, WPRichTextMediaAttachment {
     }
 
     @objc func loadHTMLString(_ html: NSString) {
-        let htmlString = String(format: "<html><head><meta name=\"viewport\" content=\"width=available-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no\" /></head><body>%@</body></html>", html)
+        let htmlString = String(format: "<html><head><meta name=\"viewport\" content=\"width=available-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no\" /><style>video { width: 100vw; }</style></head><body>%@</body></html>", html)
         webView.loadHTMLString(htmlString, baseURL: nil)
     }
 


### PR DESCRIPTION
Fixes #10930 

The video reported in #10930 was appearing much larger than it should. The cause seems to be that the markup for the `video` tag omitted a `width` attribute.  Width was defined via inline styling but we remove style information when consuming the feed.  

This PR adds a style rule to the `WPRichTextEmbed` markup to force videos to 100% of the view port width.  This seems to be the lightest touch to get the correct width. Other options were to add more string parsing to either WPRichTextFormatter (which wasn't the best fit) or RichContentFormatter but I'm loath to add even more string parsing to the Reader. 

Props to @aut0poietic for the hint to try specifying size in terms of `vw` instead of `%`. Setting to `100%` seemed to be interpreted as pixels 😱, but `100vw` matches the viewport width perfectly.

To test:
View the sample post reported in #10930 and confirm that it renders at the correct size.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
