### PR TITLE
Quick Start v2: Update suggestion logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -7,6 +7,7 @@ open class QuickStartTourGuide: NSObject {
     private var currentTourState: TourState?
     private var suggestionWorkItem: DispatchWorkItem?
     static let notificationElementKey = "QuickStartElementKey"
+    private weak var recentlyTouredBlog: Blog?
 
     @objc static func find() -> QuickStartTourGuide? {
         guard let tabBarController = WPTabBarController.sharedInstance(),
@@ -54,6 +55,27 @@ open class QuickStartTourGuide: NSObject {
     /// - Parameter blog: The Blog for which to suggest a tour.
     /// - Returns: A QuickStartTour to suggest. `nil` if there are no appropriate tours.
     func tourToSuggest(for blog: Blog) -> QuickStartTour? {
+        guard Feature.enabled(.quickStartV2) else {
+            return tourToSuggestV1(for: blog)
+        }
+
+        let completedTours: [QuickStartTourState] = blog.completedQuickStartTours ?? []
+        let skippedTours: [QuickStartTourState] = blog.skippedQuickStartTours ?? []
+        let unavailableTours = Array(Set(completedTours + skippedTours))
+        let allTours = QuickStartTourGuide.customizeListTours + QuickStartTourGuide.growListTours
+
+        guard isQuickStartEnabled(for: blog),
+            recentlyTouredBlog == blog else {
+                return nil
+        }
+
+        let unavailableIDs = unavailableTours.map { $0.tourID }
+        let remainingTours = allTours.filter { !unavailableIDs.contains($0.key) }
+
+        return remainingTours.first
+    }
+
+    private func tourToSuggestV1(for blog: Blog) -> QuickStartTour? {
         let completedTours: [QuickStartTourState] = blog.completedQuickStartTours ?? []
         let skippedTours: [QuickStartTourState] = blog.skippedQuickStartTours ?? []
         let unavailableTours = Array(Set(completedTours + skippedTours))
@@ -279,6 +301,7 @@ private extension QuickStartTourGuide {
         }
 
         blog.completeTour(tour.key)
+        recentlyTouredBlog = blog
 
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.tourCompleted])
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -6,8 +6,8 @@ open class QuickStartTourGuide: NSObject {
     private var currentSuggestion: QuickStartTour?
     private var currentTourState: TourState?
     private var suggestionWorkItem: DispatchWorkItem?
-    static let notificationElementKey = "QuickStartElementKey"
     private weak var recentlyTouredBlog: Blog?
+    static let notificationElementKey = "QuickStartElementKey"
 
     @objc static func find() -> QuickStartTourGuide? {
         guard let tabBarController = WPTabBarController.sharedInstance(),


### PR DESCRIPTION
Updates the suggestion logic for v2. Now only suggests a tour after completing a tour manually. No automatic suggestions.

<img width="429" alt="image" src="https://user-images.githubusercontent.com/517257/52381340-ed9a9c00-2a25-11e9-8eab-bc955c197290.png">

Refs #10860

To test:
- put `return true` in `shouldShowQuickStartChecklist()`
- You'll want to review what the new logic should be, to make sure I understood it correctly:
  - No more automatic suggestions.
  - Once the user has completed a tour, suggest the next one

No release notes needed, yet.