### PR TITLE
[Stats Refresh] Update delegates to be weak

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -27,7 +27,7 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var topSeparatorLine: UIView!
     @IBOutlet weak var bottomSeparatorLine: UIView!
 
-    private var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+    private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     private typealias Style = WPStyleGuide.Stats
     private var summaryData: StatsLatestPostSummary?
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
@@ -12,7 +12,7 @@ class PostingActivityCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var bottomSeparatorLine: UIView!
 
     private typealias Style = WPStyleGuide.Stats
-    private var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+    private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
 
     // MARK: - Init
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-protocol PostingActivityDayDelegate {
+protocol PostingActivityDayDelegate: class {
     func daySelected(_ day: PostingActivityDay)
 }
 
@@ -16,7 +16,7 @@ class PostingActivityDay: UIView, NibLoadable {
     // MARK: - Properties
 
     @IBOutlet weak var dayButton: UIButton!
-    private var delegate: PostingActivityDayDelegate?
+    private weak var delegate: PostingActivityDayDelegate?
 
     private var visible = true
     private var active = true

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
@@ -10,7 +10,7 @@ class PostingActivityMonth: UIView, NibLoadable {
 
     private var month: Date?
     private var monthData: [PostingActivityDayData]?
-    private var postingActivityDayDelegate: PostingActivityDayDelegate?
+    private weak var postingActivityDayDelegate: PostingActivityDayDelegate?
 
     // 14 = day width (12) + column margin (2).
     // Used to adjust the view width when hiding the last stack view.

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -39,7 +39,7 @@ class TabbedTotalsCell: UITableViewCell, NibLoadable {
 
     private var tabsData = [TabData]()
     private typealias Style = WPStyleGuide.Stats
-    private var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+    private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     private var showTotalCount = false
 
     // MARK: - Configure

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -23,8 +23,8 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
     private let subtitlesBottomMargin: CGFloat = 7.0
     private var dataRows = [StatsTotalRowData]()
     private var subtitlesProvided = true
-    private var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
-    private var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
+    private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+    private weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
     private typealias Style = WPStyleGuide.Stats
 
     // MARK: - Configure

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
@@ -170,7 +170,7 @@ class WPRichTextEmbed: UIView, WPRichTextMediaAttachment {
 }
 
 // MARK: WebView delegate methods
-extension WPRichTextEmbed : WKNavigationDelegate {
+extension WPRichTextEmbed: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         // We're fully loaded so we can unassign the delegate.


### PR DESCRIPTION
Fixes #n/a

This addresses an oversight @frosty noticed on a previous PR where I failed to make the delegates weak. 

To test:
Nothing should visibly/functionally change. Just give Insights and Period stats some sanity checks to ensure all works as expected.

