### PR TITLE
Plans: Always show syned plans

### DIFF
--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -46,14 +46,19 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
         plansService.getWpcomPlans({ [weak self] in
             self?.updateViewModel()
 
-        }, failure: { [weak self] error in
-            self?.viewModel = .error(String(describing: error))
+        }, failure: { error in
+            DDLogInfo(error.debugDescription)
         })
     }
 
     func updateViewModel() {
         let service = PlanService.init(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        viewModel = .ready(service.allPlans(), service.allPlanFeatures())
+        let allPlans = service.allPlans()
+        guard allPlans.count > 0 else {
+            viewModel = .error
+            return
+        }
+        viewModel = .ready(allPlans, service.allPlanFeatures())
     }
 
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewModel.swift
@@ -5,7 +5,7 @@ import WordPressUI
 enum PlanListViewModel {
     case loading
     case ready([Plan], [PlanFeature])
-    case error(String)
+    case error
 
     var noResultsViewModel: NoResultsViewController.Model? {
         switch self {
@@ -15,15 +15,9 @@ enum PlanListViewModel {
         case .ready:
             return nil
         case .error:
-            let appDelegate = WordPressAppDelegate.sharedInstance()
-            if (appDelegate?.connectionAvailable)! {
-                return NoResultsViewController.Model(title: NSLocalizedString("Oops", comment: "An informal exclaimation that means `something went wrong`."),
-                                                     subtitle: NSLocalizedString("There was an error loading plans", comment: "Text displayed when there is a failure loading the plan list"),
-                                                     buttonText: NSLocalizedString("Contact support", comment: "Button label for contacting support"))
-            } else {
-                return NoResultsViewController.Model(title: NSLocalizedString("No connection", comment: "Title for the error view when there's no connection"),
-                                                     subtitle: NSLocalizedString("An active internet connection is required to view plans", comment: "An error message shown when there is no internet connection."))
-            }
+            return NoResultsViewController.Model(title: NSLocalizedString("Oops", comment: "An informal exclaimation that means `something went wrong`."),
+                                                 subtitle: NSLocalizedString("There was an error loading plans", comment: "Text displayed when there is a failure loading the plan list"),
+                                                 buttonText: NSLocalizedString("Contact support", comment: "Button label for contacting support"))
         }
     }
 


### PR DESCRIPTION
Fixes #10962 

This PR does away with the old logic that would show a NoResultsView if Plans failed to sync.  This will allow Plans to be available to offline viewing as long as there is cached data. 

Of note:
- Plans are synced as a part of the blog sync process. We should *always* have plans data available given the blog is fully synced during login.  However, on the off chance no Plans data is present we continue to show the NoResultsView explaining there was a problem syncing plans.

To test:
Apply this patch and attempt to view the Plans feature after disabling your internet connectivity. 
Confirm that cached plans load as expected.

@frosty could I trouble you for a review?

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
