### PR TITLE
Sharing: Treat any non-ok status as broken.

### DIFF
--- a/WordPress/Classes/Models/PublicizeConnection.swift
+++ b/WordPress/Classes/Models/PublicizeConnection.swift
@@ -26,7 +26,7 @@ open class PublicizeConnection: NSManagedObject {
     @NSManaged open var userID: NSNumber
 
     @objc open func isBroken() -> Bool {
-        return status == "broken"
+        return status != "ok"
     }
 
     @objc open func mustDisconnect() -> Bool {


### PR DESCRIPTION
See p9dueE-vy-p2 for additional context. 

LinkedIn is soon making changes to their sharing API that will invalidate existing connections. Users will have to reauth and the publicize API is updating to return a new status code for the affected connections. 

This PR updates the `isBroken` check to return true for any status that does not equal "OK". This seems like some nice future proofing as affected connections will be flagged as needing to be either reconnected or disconnected.

Any custom messaging specific to the upcoming LinkedIn event will be addressed in a subsequent PR.

To test:
On an blog that has configured one or more publicize connections:
- View the Sharing screen and confirm that good connections are not flagged as needing attention (i.e. no orange exclamation mark for their cell's accessory icon)
- Make an edit to SharingService.swift at line 503 to set `pubConnection?.status = "must_reauth"` or any value other than "ok".  View the Sharing screen again and confirm that connections are flagged for attention.  Tap through to the next couple of screens to view the connection detail screen.  Confirm that you see options to reconnect and disconnect the connection.
![simulator screen shot - iphone 8 - 2019-02-06 at 18 59 40](https://user-images.githubusercontent.com/1435271/52384445-1c733b00-2a43-11e9-8aba-c4accc8d6866.png)


@ScoutHarris could I trouble you for the review?  Maybe @rachelmcr could also help by confirming existing connections are not affected by this change?

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
