### PR TITLE
Fixing jumping around of text in Domains search field

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -33,8 +33,12 @@ private final class SearchTextField: UITextField {
         return bounds.insetBy(dx: Constants.textInset, dy: 0)
     }
 
-    override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
-        return bounds.insetBy(dx: Constants.textInset, dy: 0)
+    override func textRect(forBounds bounds: CGRect) -> CGRect {
+        let startX = bounds.origin.x + Constants.textInset
+        let startY = bounds.origin.y
+        let width = bounds.width - Constants.textInset * 2
+        let height = bounds.height;
+        return CGRect(x: startX, y: startY, width: width, height: height)
     }
 
     override func leftViewRect(forBounds bounds: CGRect) -> CGRect {

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -34,11 +34,8 @@ private final class SearchTextField: UITextField {
     }
 
     override func textRect(forBounds bounds: CGRect) -> CGRect {
-        let startX = bounds.origin.x + Constants.textInset
-        let startY = bounds.origin.y
-        let width = bounds.width - Constants.textInset * 2
-        let height = bounds.height;
-        return CGRect(x: startX, y: startY, width: width, height: height)
+        let textInsets = UIEdgeInsets(top: 0, left: Constants.textInset, bottom: 0, right: 0)
+        return bounds.inset(by: textInsets)
     }
 
     override func leftViewRect(forBounds bounds: CGRect) -> CGRect {


### PR DESCRIPTION
Fixes #10943 

To test:

Go to the Domains selection screen and verify the following:
1. The placeholder text is in the right place
2. When typing in the search field, the text starts at the right place
3. When selecting a domain, the text in the search field stays in the right place

![simulator screen shot - ipad pro 11-inch - 2019-02-06 at 18 56 55](https://user-images.githubusercontent.com/1158819/52388509-9d323700-2a43-11e9-9989-30bb2b4869ca.png)
![simulator screen shot - ipad pro 11-inch - 2019-02-06 at 18 56 58](https://user-images.githubusercontent.com/1158819/52388511-9e636400-2a43-11e9-9ae4-f430c09b79d2.png)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
