### PR TITLE
Fixed bg color warning in EpilogueSectionHeaderFooter

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/EpilogueSectionHeaderFooter.xib
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueSectionHeaderFooter.xib
@@ -26,7 +26,6 @@
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
-            <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
             <constraints>
                 <constraint firstItem="h2s-FQ-khG" firstAttribute="leading" secondItem="21a-RX-ZhF" secondAttribute="leading" constant="20" id="3Uz-6C-ppc"/>
                 <constraint firstItem="21a-RX-ZhF" firstAttribute="bottom" secondItem="h2s-FQ-khG" secondAttribute="bottom" constant="7" id="3bI-dr-T8V"/>


### PR DESCRIPTION
This PR fixes the console warning:

`[TableView] Setting the background color on UITableViewHeaderFooterView has been deprecated. Please set a custom UIView with your desired background color to the backgroundView property instead.`

that appears when the login epilogue becomes visible.  

Fixes #10959 

## Testing

0. Build and run the app, log out if needed
1. Log into the app
2. When the login epilogue VC displays, verify the warning above ☝️ does not appear in the console.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

----

@aerych would you mind giving this a quick 👀 ?
