### PR TITLE
Issues/10844 fix overlapping buttons

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,4 +2,5 @@
 * Fixed an issue where some cells in Activity Log would lay out incorrectly
 * Improved styling of Headers in the post editor
 * Adds support for sharing a blog via Reader.
-* Fix a crash in reader caused by a video with a fallback image.
+* Fixed a crash in reader caused by a video with a fallback image.
+* Fixed some over lapping buttons and cropped text when viewing the reader with the Larger Text accessibility setting enabled.

--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -134,50 +134,50 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="ut9-jn-WNM">
-                                        <rect key="frame" x="16" y="124" width="351" height="42"/>
+                                        <rect key="frame" x="16" y="124" width="351" height="24"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MYy-Lu-AaC">
-                                        <rect key="frame" x="0.0" y="166" width="383" height="6"/>
+                                        <rect key="frame" x="0.0" y="148" width="383" height="4"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="6" id="Iqd-8s-Xhu"/>
+                                            <constraint firstAttribute="height" constant="4" id="Iqd-8s-Xhu"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JFE-Nr-imf">
-                                        <rect key="frame" x="16" y="172" width="351" height="20"/>
+                                        <rect key="frame" x="16" y="152" width="351" height="44"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="LYY-JU-FkT" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
+                                                <rect key="frame" x="0.0" y="12" width="20" height="20"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="20" id="nxJ-6V-rPo"/>
                                                     <constraint firstAttribute="width" constant="20" id="ysv-U7-ucz"/>
                                                 </constraints>
                                             </imageView>
                                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BGT-ob-j9p">
-                                                <rect key="frame" x="20" y="0.0" width="331" height="20"/>
+                                                <rect key="frame" x="20" y="0.0" width="331" height="44"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="p1o-yH-3SL">
-                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="20"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="79" height="44"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UR6-eY-gQg" userLabel="Padding View">
-                                                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="20"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="0.0" height="44"/>
                                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" id="NeN-dw-2V8"/>
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QjI-iE-tIM">
-                                                                <rect key="frame" x="6" y="0.0" width="31" height="20"/>
+                                                                <rect key="frame" x="6" y="0.0" width="31" height="44"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mBC-NT-IsJ">
-                                                                <rect key="frame" x="43" y="0.0" width="30" height="20"/>
+                                                                <rect key="frame" x="43" y="0.0" width="30" height="44"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                                 <state key="normal" title="#tag">
                                                                     <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -188,7 +188,7 @@
                                                                 </connections>
                                                             </button>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AEL-5F-FbO" userLabel="Padding View">
-                                                                <rect key="frame" x="79" y="0.0" width="0.0" height="20"/>
+                                                                <rect key="frame" x="79" y="0.0" width="0.0" height="44"/>
                                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" id="5rq-de-u3C"/>
@@ -196,7 +196,6 @@
                                                             </view>
                                                         </subviews>
                                                         <constraints>
-                                                            <constraint firstAttribute="height" constant="20" id="PgD-ob-ojU"/>
                                                             <constraint firstItem="mBC-NT-IsJ" firstAttribute="baseline" secondItem="QjI-iE-tIM" secondAttribute="baseline" id="ZWZ-nP-Uox"/>
                                                         </constraints>
                                                     </stackView>
@@ -204,13 +203,12 @@
                                                 <constraints>
                                                     <constraint firstAttribute="bottom" secondItem="p1o-yH-3SL" secondAttribute="bottom" id="3hO-wz-MYi"/>
                                                     <constraint firstItem="p1o-yH-3SL" firstAttribute="leading" secondItem="BGT-ob-j9p" secondAttribute="leading" id="5wW-so-gXQ"/>
-                                                    <constraint firstAttribute="height" constant="20" id="EMH-q2-1jl"/>
                                                     <constraint firstAttribute="trailing" secondItem="p1o-yH-3SL" secondAttribute="trailing" id="GMF-gR-rAn"/>
                                                     <constraint firstItem="p1o-yH-3SL" firstAttribute="top" secondItem="BGT-ob-j9p" secondAttribute="top" id="bpu-zu-mRV"/>
                                                 </constraints>
                                             </scrollView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OvZ-NX-X1v" userLabel="Leading Gradient View" customClass="GradientView" customModule="WordPressUI">
-                                                <rect key="frame" x="20" y="0.0" width="6" height="20"/>
+                                                <rect key="frame" x="20" y="0.0" width="6" height="44"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="6" id="f3N-m9-zjb"/>
@@ -225,7 +223,7 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zWO-Ks-c1z" userLabel="Trailing Gradient View" customClass="GradientView" customModule="WordPressUI">
-                                                <rect key="frame" x="345" y="0.0" width="6" height="20"/>
+                                                <rect key="frame" x="345" y="0.0" width="6" height="44"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="6" id="W8g-3n-c7J"/>
@@ -247,21 +245,21 @@
                                             <constraint firstItem="OvZ-NX-X1v" firstAttribute="leading" secondItem="LYY-JU-FkT" secondAttribute="trailing" id="QoI-32-wcb"/>
                                             <constraint firstAttribute="trailing" secondItem="BGT-ob-j9p" secondAttribute="trailing" id="Snu-Iw-tCC"/>
                                             <constraint firstItem="zWO-Ks-c1z" firstAttribute="trailing" secondItem="BGT-ob-j9p" secondAttribute="trailing" id="Z53-Ag-fOb"/>
+                                            <constraint firstAttribute="height" secondItem="QjI-iE-tIM" secondAttribute="height" id="a1e-vE-fxq"/>
                                             <constraint firstItem="LYY-JU-FkT" firstAttribute="leading" secondItem="JFE-Nr-imf" secondAttribute="leading" id="aCh-pm-pua"/>
                                             <constraint firstItem="OvZ-NX-X1v" firstAttribute="top" secondItem="JFE-Nr-imf" secondAttribute="top" id="bzU-SX-MgV"/>
+                                            <constraint firstItem="LYY-JU-FkT" firstAttribute="centerY" secondItem="QjI-iE-tIM" secondAttribute="centerY" id="fIi-iF-emu"/>
                                             <constraint firstItem="zWO-Ks-c1z" firstAttribute="top" secondItem="BGT-ob-j9p" secondAttribute="top" id="rdz-Sc-f4U"/>
                                             <constraint firstItem="BGT-ob-j9p" firstAttribute="leading" secondItem="LYY-JU-FkT" secondAttribute="trailing" id="uO6-KA-LPv"/>
-                                            <constraint firstItem="LYY-JU-FkT" firstAttribute="top" secondItem="JFE-Nr-imf" secondAttribute="top" id="uho-bR-Uwa"/>
                                             <constraint firstItem="zWO-Ks-c1z" firstAttribute="bottom" secondItem="BGT-ob-j9p" secondAttribute="bottom" id="uoi-SH-aae"/>
-                                            <constraint firstAttribute="bottom" secondItem="LYY-JU-FkT" secondAttribute="bottom" id="y4F-Xg-kyq"/>
                                             <constraint firstAttribute="bottom" secondItem="OvZ-NX-X1v" secondAttribute="bottom" id="ypx-lk-GgL"/>
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aER-Yk-oAm">
-                                        <rect key="frame" x="0.0" y="192" width="383" height="8"/>
+                                        <rect key="frame" x="0.0" y="196" width="383" height="4"/>
                                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
-                                            <constraint firstAttribute="height" constant="8" id="hgy-5R-zg1"/>
+                                            <constraint firstAttribute="height" constant="4" id="hgy-5R-zg1"/>
                                         </constraints>
                                     </view>
                                 </subviews>

--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -338,11 +338,29 @@
                                             <constraint firstAttribute="height" constant="1" id="F3N-gl-Nkn"/>
                                         </constraints>
                                     </view>
-                                    <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" distribution="equalSpacing" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="PVU-1Y-fyZ">
-                                        <rect key="frame" x="272" y="13" width="95" height="24"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="PVU-1Y-fyZ">
+                                        <rect key="frame" x="16" y="0.0" width="351" height="50"/>
                                         <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="168-Gh-oaD">
+                                                <rect key="frame" x="0.0" y="13" width="32" height="24"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="24" id="WZJ-HW-ceD"/>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="hcl-0D-0Ha"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                <inset key="titleEdgeInsets" minX="4" minY="0.0" maxX="-4" maxY="0.0"/>
+                                                <state key="normal" title="0" image="icon-reader-comment">
+                                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="didTapSaveForLaterButton:" destination="p0j-e1-c0h" eventType="touchUpInside" id="Y38-px-Mw0"/>
+                                                </connections>
+                                            </button>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yq2-Pz-GyO">
+                                                <rect key="frame" x="48" y="0.0" width="192" height="50"/>
+                                            </view>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XmB-eN-d59" customClass="PostMetaButton">
-                                                <rect key="frame" x="0.0" y="0.0" width="32" height="24"/>
+                                                <rect key="frame" x="256" y="13" width="32" height="24"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="24" id="T1s-fS-Zer"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="nt6-Mr-9t8"/>
@@ -357,7 +375,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2yJ-O3-UEu" customClass="PostMetaButton">
-                                                <rect key="frame" x="48" y="0.0" width="47" height="24"/>
+                                                <rect key="frame" x="304" y="13" width="47" height="24"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="24" id="7k7-Il-kBP"/>
                                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="HTK-fj-KBV"/>
@@ -373,32 +391,16 @@
                                             </button>
                                         </subviews>
                                     </stackView>
-                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="168-Gh-oaD">
-                                        <rect key="frame" x="16" y="13" width="32" height="24"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="24" id="WZJ-HW-ceD"/>
-                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="30" id="hcl-0D-0Ha"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                        <inset key="titleEdgeInsets" minX="4" minY="0.0" maxX="-4" maxY="0.0"/>
-                                        <state key="normal" title="0" image="icon-reader-comment">
-                                            <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="didTapSaveForLaterButton:" destination="p0j-e1-c0h" eventType="touchUpInside" id="Y38-px-Mw0"/>
-                                        </connections>
-                                    </button>
                                 </subviews>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstItem="utM-eb-n7b" firstAttribute="leading" secondItem="vSH-j9-J3c" secondAttribute="leading" id="AGa-qi-Ch2"/>
                                     <constraint firstAttribute="height" constant="50" id="DZ4-kQ-gyy"/>
+                                    <constraint firstItem="PVU-1Y-fyZ" firstAttribute="leading" secondItem="vSH-j9-J3c" secondAttribute="leading" constant="16" id="E4Z-mS-bPj"/>
                                     <constraint firstAttribute="trailing" secondItem="utM-eb-n7b" secondAttribute="trailing" id="GbC-hh-C2d"/>
                                     <constraint firstAttribute="trailing" secondItem="PVU-1Y-fyZ" secondAttribute="trailing" constant="16" id="JCk-Bd-RtT"/>
                                     <constraint firstItem="PVU-1Y-fyZ" firstAttribute="centerY" secondItem="vSH-j9-J3c" secondAttribute="centerY" id="JGW-8Z-tGc"/>
-                                    <constraint firstItem="168-Gh-oaD" firstAttribute="centerY" secondItem="vSH-j9-J3c" secondAttribute="centerY" id="MAP-gr-lr3"/>
                                     <constraint firstItem="utM-eb-n7b" firstAttribute="top" secondItem="vSH-j9-J3c" secondAttribute="top" id="V7Y-Nt-gKt"/>
-                                    <constraint firstItem="168-Gh-oaD" firstAttribute="leading" secondItem="vSH-j9-J3c" secondAttribute="leading" constant="16" id="Yz3-fv-Y9L"/>
                                 </constraints>
                             </view>
                         </subviews>


### PR DESCRIPTION
Fixes #10844 

This PR addresses two of the visual issues identified in #10844.  Specifically, the view hierarchy has been tweaked so the bottom buttons will not overlap, and the by line should no longer be clipped when the font is sufficiently large.  There are some other issues but these two seemed to be the most pressing to me.

It would be nice to see us make a design pass of the detail and cards (probably the whole app) and identify what makes sense as a maximum supported text size. We can then update our fonts via `UIFontMetrics(forTextStyle:).scaledFont(for:, maximumPointSize:)` to ensure our layout doesn't break  if a user chooses to use the large font settings.  cc @iamthomasbishop / @mattmiklic 

To test:
- Follow the steps outlined in the issue to view large fonts, optionally in another language. 
- View the reader detail for a post with lots of likes, and comments.
- Confirm that the by line label is not cropped. 
- Confirm the buttons on the bottom bar do not overlap (tho the text may truncate).

![simulator screen shot - iphone 8 - 2019-02-07 at 16 10 14](https://user-images.githubusercontent.com/1435271/52446198-e7bebc80-2af2-11e9-8eec-1306f3671a5c.png)

@etoledom could I trouble you for a review? 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
