### PR TITLE
Hides the get started bar in Site Preview

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -194,6 +194,7 @@ extension AssembledSiteView: WKNavigationDelegate {
         webViewHasLoadedContent = true
         activityIndicator.stopAnimating()
         generator.notificationOccurred(.success)
+        hideGetStartedBar()
         WPAnalytics.track(.enhancedSiteCreationSuccessPreviewLoaded)
     }
 
@@ -204,5 +205,13 @@ extension AssembledSiteView: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
         completionHandler(.performDefaultHandling, nil)
+    }
+
+    func hideGetStartedBar() {
+        let javascript = """
+        document.querySelector('html').style.cssText += '; margin-top: 0 !important;';\n
+        document.getElementById('wpadminbar').style.display = 'none';\n
+        """
+        webView.evaluateJavaScript(javascript, completionHandler: nil)
     }
 }


### PR DESCRIPTION
Fixes #10978 

To test:
1. Go through the site creation steps and verify in the preview that the Site Creation webview does not contain a "get started" bar in the top.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
