### PR TITLE
Quick Start V2: UI fix

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
@@ -4,7 +4,15 @@ class QuickStartChecklistCell: UITableViewCell {
     @IBOutlet private var titleLabel: UILabel!
     @IBOutlet private var descriptionLabel: UILabel!
     @IBOutlet private var iconView: UIImageView?
-    @IBOutlet private var bottomStrokeLeading: NSLayoutConstraint?
+    @IBOutlet private var stroke: UIView?
+
+    private var bottomStrokeLeading: NSLayoutConstraint?
+    private var contentViewLeadingAnchor: NSLayoutXAxisAnchor {
+        return WPDeviceIdentification.isiPhone() ? contentView.leadingAnchor : contentView.readableContentGuide.leadingAnchor
+    }
+    private var contentViewTrailingAnchor: NSLayoutXAxisAnchor {
+        return WPDeviceIdentification.isiPhone() ? contentView.trailingAnchor : contentView.readableContentGuide.trailingAnchor
+    }
 
     public var completed = false {
         didSet {
@@ -32,7 +40,6 @@ class QuickStartChecklistCell: UITableViewCell {
             }
         }
     }
-
     public var tour: QuickStartTour? {
         didSet {
             titleLabel.text = tour?.title
@@ -57,9 +64,16 @@ class QuickStartChecklistCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        if Feature.enabled(.quickStartV2) {
+        if let stroke = stroke, Feature.enabled(.quickStartV2) {
             WPStyleGuide.configureLabel(titleLabel, textStyle: .headline)
             WPStyleGuide.configureLabel(descriptionLabel, textStyle: .subheadline)
+
+            bottomStrokeLeading = stroke.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor)
+            bottomStrokeLeading?.isActive = true
+            let strokeSuperviewLeading = stroke.leadingAnchor.constraint(equalTo: contentViewLeadingAnchor)
+            strokeSuperviewLeading.priority = UILayoutPriority(999.0)
+            strokeSuperviewLeading.isActive = true
+            stroke.trailingAnchor.constraint(equalTo: contentViewTrailingAnchor).isActive = true
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
@@ -44,11 +44,9 @@ class QuickStartChecklistCell: UITableViewCell {
         didSet {
             titleLabel.text = tour?.title
             descriptionLabel.text = tour?.description
+            iconView?.image = tour?.icon.imageWithTintColor(WPStyleGuide.greyLighten10())
 
-            if Feature.enabled(.quickStartV2) {
-                imageView?.image = tour?.icon.imageWithTintColor(WPStyleGuide.greyLighten10())
-            } else {
-                iconView?.image = tour?.icon.imageWithTintColor(WPStyleGuide.greyLighten10())
+            if !Feature.enabled(.quickStartV2) {
                 accessoryType = .disclosureIndicator
             }
         }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
@@ -1,10 +1,19 @@
 import Gridicons
 
 class QuickStartChecklistCell: UITableViewCell {
-    @IBOutlet private var titleLabel: UILabel!
-    @IBOutlet private var descriptionLabel: UILabel!
+    @IBOutlet private var titleLabel: UILabel! {
+        didSet {
+            WPStyleGuide.configureLabel(titleLabel, textStyle: .headline)
+        }
+    }
+    @IBOutlet private var descriptionLabel: UILabel! {
+        didSet {
+            WPStyleGuide.configureLabel(descriptionLabel, textStyle: .subheadline)
+        }
+    }
     @IBOutlet private var iconView: UIImageView?
     @IBOutlet private var stroke: UIView?
+    @IBOutlet private var topSeparator: UIView?
 
     private var bottomStrokeLeading: NSLayoutConstraint?
     private var contentViewLeadingAnchor: NSLayoutXAxisAnchor {
@@ -58,22 +67,38 @@ class QuickStartChecklistCell: UITableViewCell {
         }
     }
 
+    public var topSeparatorIsHidden: Bool = false {
+        didSet {
+            topSeparator?.isHidden = topSeparatorIsHidden
+        }
+    }
+
 
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        if let stroke = stroke, Feature.enabled(.quickStartV2) {
-            WPStyleGuide.configureLabel(titleLabel, textStyle: .headline)
-            WPStyleGuide.configureLabel(descriptionLabel, textStyle: .subheadline)
-
-            bottomStrokeLeading = stroke.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor)
-            bottomStrokeLeading?.isActive = true
-            let strokeSuperviewLeading = stroke.leadingAnchor.constraint(equalTo: contentViewLeadingAnchor)
-            strokeSuperviewLeading.priority = UILayoutPriority(999.0)
-            strokeSuperviewLeading.isActive = true
-            stroke.trailingAnchor.constraint(equalTo: contentViewTrailingAnchor).isActive = true
+        if Feature.enabled(.quickStartV2) {
+            setupConstraints()
         }
     }
 
     static let reuseIdentifier = "QuickStartChecklistCell"
+}
+
+extension QuickStartChecklistCell {
+    private func setupConstraints() {
+        guard let stroke = stroke,
+            let topSeparator = topSeparator else {
+            return
+        }
+
+        bottomStrokeLeading = stroke.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor)
+        bottomStrokeLeading?.isActive = true
+        let strokeSuperviewLeading = stroke.leadingAnchor.constraint(equalTo: contentViewLeadingAnchor)
+        strokeSuperviewLeading.priority = UILayoutPriority(999.0)
+        strokeSuperviewLeading.isActive = true
+        stroke.trailingAnchor.constraint(equalTo: contentViewTrailingAnchor).isActive = true
+        topSeparator.leadingAnchor.constraint(equalTo: contentViewLeadingAnchor).isActive = true
+        topSeparator.trailingAnchor.constraint(equalTo: contentViewTrailingAnchor).isActive = true
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
@@ -85,8 +85,8 @@ class QuickStartChecklistCell: UITableViewCell {
     static let reuseIdentifier = "QuickStartChecklistCell"
 }
 
-extension QuickStartChecklistCell {
-    private func setupConstraints() {
+private extension QuickStartChecklistCell {
+    func setupConstraints() {
         guard let stroke = stroke,
             let topSeparator = topSeparator else {
             return

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
+    <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -31,7 +31,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q9O-Tl-jRn" userLabel="Stroke">
-                        <rect key="frame" x="64" y="71" width="295" height="0.5"/>
+                        <rect key="frame" x="64" y="71" width="311" height="0.5"/>
                         <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294117647056" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0.33000000000000002" id="I9A-zJ-Npt"/>
@@ -39,22 +39,21 @@
                     </view>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="q9O-Tl-jRn" firstAttribute="leading" secondItem="fK0-aP-tbW" secondAttribute="leadingMargin" priority="750" id="3eA-72-02A"/>
                     <constraint firstAttribute="bottom" secondItem="q9O-Tl-jRn" secondAttribute="bottom" id="6zL-eP-5kL"/>
                     <constraint firstItem="KNn-zz-lLY" firstAttribute="top" secondItem="Yc4-11-laP" secondAttribute="bottom" priority="999" constant="2" id="GKD-om-l0b"/>
-                    <constraint firstItem="q9O-Tl-jRn" firstAttribute="leading" secondItem="KNn-zz-lLY" secondAttribute="leading" id="IP9-A7-b0C"/>
+                    <constraint firstItem="q9O-Tl-jRn" firstAttribute="leading" secondItem="KNn-zz-lLY" secondAttribute="leading" placeholder="YES" id="IP9-A7-b0C"/>
                     <constraint firstItem="KNn-zz-lLY" firstAttribute="leading" secondItem="Yc4-11-laP" secondAttribute="leading" id="WKU-rc-bUU"/>
                     <constraint firstAttribute="trailingMargin" secondItem="Yc4-11-laP" secondAttribute="trailing" constant="6" id="ZAh-HX-yVH"/>
                     <constraint firstItem="Yc4-11-laP" firstAttribute="top" secondItem="fK0-aP-tbW" secondAttribute="top" constant="16" id="dCt-t5-oGk"/>
                     <constraint firstItem="Yc4-11-laP" firstAttribute="leading" secondItem="fK0-aP-tbW" secondAttribute="leadingMargin" constant="48" id="eWp-sF-urj"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="q9O-Tl-jRn" secondAttribute="trailing" id="iWA-GZ-njV"/>
+                    <constraint firstAttribute="trailing" secondItem="q9O-Tl-jRn" secondAttribute="trailing" placeholder="YES" id="iWA-GZ-njV"/>
                     <constraint firstAttribute="trailingMargin" secondItem="KNn-zz-lLY" secondAttribute="trailing" constant="6" id="imd-Jt-Xqm"/>
                     <constraint firstAttribute="bottom" secondItem="KNn-zz-lLY" secondAttribute="bottom" constant="15.5" id="oba-ae-wVR"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="bottomStrokeLeading" destination="IP9-A7-b0C" id="NTx-c6-R5k"/>
                 <outlet property="descriptionLabel" destination="KNn-zz-lLY" id="wd6-dY-ajZ"/>
+                <outlet property="stroke" destination="q9O-Tl-jRn" id="MDI-tG-fCN"/>
                 <outlet property="titleLabel" destination="Yc4-11-laP" id="fxd-Fh-PS5"/>
             </connections>
             <point key="canvasLocation" x="-157.59999999999999" y="-20.689655172413794"/>

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="ipad9_7" orientation="portrait">
+    <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -15,23 +15,30 @@
             <rect key="frame" x="0.0" y="0.0" width="375" height="72"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AyJ-E5-JK1" id="fK0-aP-tbW">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="71.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="71.666666666666671"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
+                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iDO-LH-Tnw">
+                        <rect key="frame" x="20" y="24" width="24" height="24"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="24" id="T71-iR-XpD"/>
+                            <constraint firstAttribute="height" constant="24" id="m64-PM-I3A"/>
+                        </constraints>
+                    </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Yc4-11-laP">
-                        <rect key="frame" x="64" y="16" width="289" height="20.5"/>
+                        <rect key="frame" x="64" y="15.999999999999998" width="289" height="20.333333333333329"/>
                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                         <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KNn-zz-lLY">
-                        <rect key="frame" x="64" y="38.5" width="289" height="17.5"/>
+                        <rect key="frame" x="64" y="38.333333333333336" width="289" height="18"/>
                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="q9O-Tl-jRn" userLabel="Stroke">
-                        <rect key="frame" x="64" y="71" width="311" height="0.5"/>
+                        <rect key="frame" x="64" y="71.333333333333329" width="311" height="0.3333333333333286"/>
                         <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294117647056" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0.33000000000000002" id="I9A-zJ-Npt"/>
@@ -44,19 +51,24 @@
                     <constraint firstItem="q9O-Tl-jRn" firstAttribute="leading" secondItem="KNn-zz-lLY" secondAttribute="leading" placeholder="YES" id="IP9-A7-b0C"/>
                     <constraint firstItem="KNn-zz-lLY" firstAttribute="leading" secondItem="Yc4-11-laP" secondAttribute="leading" id="WKU-rc-bUU"/>
                     <constraint firstAttribute="trailingMargin" secondItem="Yc4-11-laP" secondAttribute="trailing" constant="6" id="ZAh-HX-yVH"/>
+                    <constraint firstItem="iDO-LH-Tnw" firstAttribute="leading" secondItem="fK0-aP-tbW" secondAttribute="leadingMargin" constant="4" id="asw-6i-Zac">
+                        <variation key="heightClass=regular-widthClass=regular" constant="20"/>
+                    </constraint>
                     <constraint firstItem="Yc4-11-laP" firstAttribute="top" secondItem="fK0-aP-tbW" secondAttribute="top" constant="16" id="dCt-t5-oGk"/>
-                    <constraint firstItem="Yc4-11-laP" firstAttribute="leading" secondItem="fK0-aP-tbW" secondAttribute="leadingMargin" constant="48" id="eWp-sF-urj"/>
+                    <constraint firstItem="iDO-LH-Tnw" firstAttribute="centerY" secondItem="fK0-aP-tbW" secondAttribute="centerY" id="hrh-hQ-gVn"/>
                     <constraint firstAttribute="trailing" secondItem="q9O-Tl-jRn" secondAttribute="trailing" placeholder="YES" id="iWA-GZ-njV"/>
                     <constraint firstAttribute="trailingMargin" secondItem="KNn-zz-lLY" secondAttribute="trailing" constant="6" id="imd-Jt-Xqm"/>
                     <constraint firstAttribute="bottom" secondItem="KNn-zz-lLY" secondAttribute="bottom" constant="15.5" id="oba-ae-wVR"/>
+                    <constraint firstItem="Yc4-11-laP" firstAttribute="leading" secondItem="iDO-LH-Tnw" secondAttribute="trailing" constant="20" id="yPX-QA-rpb"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
                 <outlet property="descriptionLabel" destination="KNn-zz-lLY" id="wd6-dY-ajZ"/>
+                <outlet property="iconView" destination="iDO-LH-Tnw" id="459-AF-gTi"/>
                 <outlet property="stroke" destination="q9O-Tl-jRn" id="MDI-tG-fCN"/>
                 <outlet property="titleLabel" destination="Yc4-11-laP" id="fxd-Fh-PS5"/>
             </connections>
-            <point key="canvasLocation" x="-157.59999999999999" y="-20.689655172413794"/>
+            <point key="canvasLocation" x="-158.203125" y="-21.09375"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.xib
@@ -18,6 +18,13 @@
                 <rect key="frame" x="0.0" y="0.0" width="375" height="71.666666666666671"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
+                    <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vlx-fb-Uco" userLabel="Stroke">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="0.33333333333333331"/>
+                        <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294119999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.33000000000000002" id="hlC-PA-7aV"/>
+                        </constraints>
+                    </view>
                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iDO-LH-Tnw">
                         <rect key="frame" x="20" y="24" width="24" height="24"/>
                         <constraints>
@@ -46,15 +53,18 @@
                     </view>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="vlx-fb-Uco" firstAttribute="leading" secondItem="fK0-aP-tbW" secondAttribute="leading" placeholder="YES" id="0Kg-c0-gu6"/>
                     <constraint firstAttribute="bottom" secondItem="q9O-Tl-jRn" secondAttribute="bottom" id="6zL-eP-5kL"/>
                     <constraint firstItem="KNn-zz-lLY" firstAttribute="top" secondItem="Yc4-11-laP" secondAttribute="bottom" priority="999" constant="2" id="GKD-om-l0b"/>
                     <constraint firstItem="q9O-Tl-jRn" firstAttribute="leading" secondItem="KNn-zz-lLY" secondAttribute="leading" placeholder="YES" id="IP9-A7-b0C"/>
+                    <constraint firstAttribute="trailing" secondItem="vlx-fb-Uco" secondAttribute="trailing" placeholder="YES" id="KAE-hZ-gmS"/>
                     <constraint firstItem="KNn-zz-lLY" firstAttribute="leading" secondItem="Yc4-11-laP" secondAttribute="leading" id="WKU-rc-bUU"/>
                     <constraint firstAttribute="trailingMargin" secondItem="Yc4-11-laP" secondAttribute="trailing" constant="6" id="ZAh-HX-yVH"/>
                     <constraint firstItem="iDO-LH-Tnw" firstAttribute="leading" secondItem="fK0-aP-tbW" secondAttribute="leadingMargin" constant="4" id="asw-6i-Zac">
                         <variation key="heightClass=regular-widthClass=regular" constant="20"/>
                     </constraint>
                     <constraint firstItem="Yc4-11-laP" firstAttribute="top" secondItem="fK0-aP-tbW" secondAttribute="top" constant="16" id="dCt-t5-oGk"/>
+                    <constraint firstItem="vlx-fb-Uco" firstAttribute="top" secondItem="fK0-aP-tbW" secondAttribute="top" id="ew5-JN-0t6"/>
                     <constraint firstItem="iDO-LH-Tnw" firstAttribute="centerY" secondItem="fK0-aP-tbW" secondAttribute="centerY" id="hrh-hQ-gVn"/>
                     <constraint firstAttribute="trailing" secondItem="q9O-Tl-jRn" secondAttribute="trailing" placeholder="YES" id="iWA-GZ-njV"/>
                     <constraint firstAttribute="trailingMargin" secondItem="KNn-zz-lLY" secondAttribute="trailing" constant="6" id="imd-Jt-Xqm"/>
@@ -67,6 +77,7 @@
                 <outlet property="iconView" destination="iDO-LH-Tnw" id="459-AF-gTi"/>
                 <outlet property="stroke" destination="q9O-Tl-jRn" id="MDI-tG-fCN"/>
                 <outlet property="titleLabel" destination="Yc4-11-laP" id="fxd-Fh-PS5"/>
+                <outlet property="topSeparator" destination="vlx-fb-Uco" id="Tiu-qo-Q0n"/>
             </connections>
             <point key="canvasLocation" x="-158.203125" y="-21.09375"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.swift
@@ -1,6 +1,5 @@
 import Gridicons
 
-
 class QuickStartChecklistHeader: UIView {
     var collapseListener: ((Bool) -> Void)?
     var collapse: Bool = false {
@@ -24,23 +23,41 @@ class QuickStartChecklistHeader: UIView {
         }
     }
 
-    @IBOutlet private var titleLabel: UILabel!
+    @IBOutlet private var titleLabel: UILabel! {
+        didSet {
+            WPStyleGuide.configureLabel(titleLabel, textStyle: .body)
+            titleLabel.textColor = WPStyleGuide.grey()
+        }
+    }
+    @IBOutlet private var chevronView: UIImageView! {
+        didSet {
+            chevronView.image = Gridicon.iconOfType(.chevronDown)
+            chevronView.tintColor = WPStyleGuide.cellGridiconAccessoryColor()
+        }
+    }
     @IBOutlet private var bottomStroke: UIView!
-    @IBOutlet private var chevronView: UIImageView!
-
-    private let animator = Animator()
-
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-
-        WPStyleGuide.configureLabel(titleLabel, textStyle: .body)
-        titleLabel.textColor = WPStyleGuide.grey()
-        chevronView.image = Gridicon.iconOfType(.chevronDown)
-        chevronView.tintColor = WPStyleGuide.cellGridiconAccessoryColor()
+    @IBOutlet private var contentView: UIView! {
+        didSet {
+            contentView.leadingAnchor.constraint(equalTo: contentViewLeadingAnchor).isActive = true
+            contentView.trailingAnchor.constraint(equalTo: contentViewTrailingAnchor).isActive = true
+        }
     }
 
-    @IBAction func headerDidTouch(_ sender: UIButton) {
+    private let animator = Animator()
+    private var contentViewLeadingAnchor: NSLayoutXAxisAnchor {
+        if #available(iOS 11.0, *) {
+            return WPDeviceIdentification.isiPhone() ? safeAreaLayoutGuide.leadingAnchor : layoutMarginsGuide.leadingAnchor
+        }
+        return WPDeviceIdentification.isiPhone() ? leadingAnchor : layoutMarginsGuide.leadingAnchor
+    }
+    private var contentViewTrailingAnchor: NSLayoutXAxisAnchor {
+        if #available(iOS 11.0, *) {
+            return WPDeviceIdentification.isiPhone() ? safeAreaLayoutGuide.trailingAnchor : layoutMarginsGuide.trailingAnchor
+        }
+        return WPDeviceIdentification.isiPhone() ? trailingAnchor : layoutMarginsGuide.trailingAnchor
+    }
+
+    @IBAction private func headerDidTouch(_ sender: UIButton) {
         collapse.toggle()
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.xib
@@ -12,7 +12,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="iN0-l3-epB" customClass="QuickStartChecklistHeader" customModule="WordPress" customModuleProvider="target">
+        <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" customClass="QuickStartChecklistHeader" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
@@ -20,14 +20,14 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                     <subviews>
                         <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QaU-FW-PcA" userLabel="Top Stroke">
-                            <rect key="frame" x="8" y="0.0" width="359" height="0.5"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="0.5"/>
                             <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294119999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="0.33000000000000002" id="R8g-s7-4QD"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hgL-Ff-jIb" userLabel="Bottom Stroke">
-                            <rect key="frame" x="8" y="43.5" width="359" height="0.5"/>
+                            <rect key="frame" x="0.0" y="43.5" width="375" height="0.5"/>
                             <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294119999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="0.33000000000000002" id="TaS-fP-pXw"/>
@@ -47,7 +47,7 @@
                             </constraints>
                         </imageView>
                         <button opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yus-75-Z9J">
-                            <rect key="frame" x="8" y="0.0" width="359" height="44"/>
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                             <connections>
                                 <action selector="headerDidTouch:" destination="iN0-l3-epB" eventType="touchUpInside" id="g6s-7J-Fwg"/>
                             </connections>
@@ -59,26 +59,26 @@
                         <constraint firstAttribute="bottom" secondItem="Yus-75-Z9J" secondAttribute="bottom" id="FvG-Uj-huH"/>
                         <constraint firstItem="2ag-iN-nJf" firstAttribute="top" secondItem="rkz-KZ-Ayy" secondAttribute="top" constant="10" id="K8N-yy-qzD"/>
                         <constraint firstItem="QaU-FW-PcA" firstAttribute="top" secondItem="rkz-KZ-Ayy" secondAttribute="top" id="KE0-Mv-gQE"/>
-                        <constraint firstItem="Yus-75-Z9J" firstAttribute="leading" secondItem="rkz-KZ-Ayy" secondAttribute="leadingMargin" id="Rx0-3q-tA8"/>
+                        <constraint firstItem="Yus-75-Z9J" firstAttribute="leading" secondItem="rkz-KZ-Ayy" secondAttribute="leading" id="Rx0-3q-tA8"/>
                         <constraint firstAttribute="trailingMargin" secondItem="2ag-iN-nJf" secondAttribute="trailing" constant="8" id="TIG-45-jVS"/>
                         <constraint firstItem="Yus-75-Z9J" firstAttribute="top" secondItem="rkz-KZ-Ayy" secondAttribute="top" id="X3c-u2-Ek8"/>
-                        <constraint firstItem="hgL-Ff-jIb" firstAttribute="leading" secondItem="rkz-KZ-Ayy" secondAttribute="leadingMargin" id="ax6-VY-Phy"/>
-                        <constraint firstAttribute="trailingMargin" secondItem="hgL-Ff-jIb" secondAttribute="trailing" id="dIb-vm-arH"/>
+                        <constraint firstItem="hgL-Ff-jIb" firstAttribute="leading" secondItem="rkz-KZ-Ayy" secondAttribute="leading" id="ax6-VY-Phy"/>
+                        <constraint firstAttribute="trailing" secondItem="hgL-Ff-jIb" secondAttribute="trailing" id="dIb-vm-arH"/>
                         <constraint firstAttribute="bottom" secondItem="hgL-Ff-jIb" secondAttribute="bottom" id="ela-vm-u3P"/>
-                        <constraint firstItem="QaU-FW-PcA" firstAttribute="leading" secondItem="rkz-KZ-Ayy" secondAttribute="leadingMargin" id="hdF-lS-dwe"/>
+                        <constraint firstItem="QaU-FW-PcA" firstAttribute="leading" secondItem="rkz-KZ-Ayy" secondAttribute="leading" id="hdF-lS-dwe"/>
                         <constraint firstItem="2ag-iN-nJf" firstAttribute="leading" secondItem="xiK-ca-ccq" secondAttribute="trailing" constant="16" id="lJ6-qk-wDP"/>
                         <constraint firstItem="hgL-Ff-jIb" firstAttribute="top" secondItem="xiK-ca-ccq" secondAttribute="bottom" constant="12" id="m1h-Vt-iic"/>
                         <constraint firstAttribute="bottom" secondItem="2ag-iN-nJf" secondAttribute="bottom" constant="10" id="nNG-B9-9qB"/>
-                        <constraint firstAttribute="trailingMargin" secondItem="QaU-FW-PcA" secondAttribute="trailing" id="pPf-Q9-F4G"/>
-                        <constraint firstAttribute="trailingMargin" secondItem="Yus-75-Z9J" secondAttribute="trailing" id="xRF-BX-1N8"/>
+                        <constraint firstAttribute="trailing" secondItem="QaU-FW-PcA" secondAttribute="trailing" id="pPf-Q9-F4G"/>
+                        <constraint firstAttribute="trailing" secondItem="Yus-75-Z9J" secondAttribute="trailing" id="xRF-BX-1N8"/>
                         <constraint firstItem="xiK-ca-ccq" firstAttribute="top" secondItem="QaU-FW-PcA" secondAttribute="bottom" constant="12" id="xbd-Vu-qOe"/>
                     </constraints>
                 </view>
             </subviews>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="rkz-KZ-Ayy" secondAttribute="trailing" id="32s-vC-eRb"/>
-                <constraint firstItem="rkz-KZ-Ayy" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="3LJ-Tb-Pc8"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="rkz-KZ-Ayy" secondAttribute="trailing" placeholder="YES" id="32s-vC-eRb"/>
+                <constraint firstItem="rkz-KZ-Ayy" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" placeholder="YES" id="3LJ-Tb-Pc8"/>
                 <constraint firstItem="rkz-KZ-Ayy" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="8R4-t4-EiC"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="rkz-KZ-Ayy" secondAttribute="bottom" id="BeK-YT-USm"/>
             </constraints>
@@ -88,6 +88,7 @@
             <connections>
                 <outlet property="bottomStroke" destination="hgL-Ff-jIb" id="xuE-EE-rcw"/>
                 <outlet property="chevronView" destination="2ag-iN-nJf" id="fe5-yH-BhN"/>
+                <outlet property="contentView" destination="rkz-KZ-Ayy" id="NET-gR-3xr"/>
                 <outlet property="titleLabel" destination="xiK-ca-ccq" id="HrR-PQ-Mtc"/>
             </connections>
             <point key="canvasLocation" x="53.600000000000001" y="48.575712143928037"/>

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
@@ -141,7 +141,16 @@ private extension QuickStartChecklistManager {
     }
 
     func hideTopSeparator(at indexPath: IndexPath) -> Bool {
-        return !(WPDeviceIdentification.isiPad() && !todoTours.isEmpty && indexPath.row == 0)
+        guard let section = Sections(rawValue: indexPath.section) else {
+            return true
+        }
+
+        switch section {
+        case .todo:
+            return !(WPDeviceIdentification.isiPad() && !todoTours.isEmpty && indexPath.row == 0)
+        case .completed:
+            return true
+        }
     }
 
     func tours(at section: Int) -> [QuickStartTour] {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
@@ -53,6 +53,7 @@ extension QuickStartChecklistManager: UITableViewDataSource {
             let tour = self.tour(at: indexPath)
             cell.tour = tour
             cell.completed = isCompleted(tour: tour)
+            cell.topSeparatorIsHidden = hideTopSeparator(at: indexPath)
             cell.lastRow = isLastTour(at: indexPath)
             return cell
         }
@@ -108,7 +109,7 @@ extension QuickStartChecklistManager: UITableViewDelegate {
             }
             return headerView
         }
-        return nil
+        return WPDeviceIdentification.isiPhone() ? nil : UIView()
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
@@ -116,7 +117,7 @@ extension QuickStartChecklistManager: UITableViewDelegate {
             !completedTours.isEmpty {
             return Sections.headerHeight
         }
-        return 0.0
+        return WPDeviceIdentification.isiPhone() ? 0.0 : Sections.iPadTopInset
     }
 
     func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
@@ -137,6 +138,10 @@ private extension QuickStartChecklistManager {
     func isLastTour(at indexPath: IndexPath) -> Bool {
         let tours = self.tours(at: indexPath.section)
         return (tours.count - 1) == indexPath.row
+    }
+
+    func hideTopSeparator(at indexPath: IndexPath) -> Bool {
+        return !(WPDeviceIdentification.isiPad() && !todoTours.isEmpty && indexPath.row == 0)
     }
 
     func tours(at section: Int) -> [QuickStartTour] {
@@ -231,6 +236,7 @@ private extension UITableView {
 private enum Sections: Int, CaseIterable {
     static let footerHeight: CGFloat = 20.0
     static let headerHeight: CGFloat = 44.0
+    static let iPadTopInset: CGFloat = 36.0
 
     case todo
     case completed

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartListTitleCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartListTitleCell.swift
@@ -26,10 +26,14 @@ class QuickStartListTitleCell: UITableViewCell {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+        accessoryView = nil
+        accessoryType = .none
         refreshIconColor()
     }
+}
 
-    private func refreshIconColor() {
+private extension QuickStartListTitleCell {
+    func refreshIconColor() {
         switch state {
         case .customizeIncomplete:
             circleImageView?.backgroundColor = .mediumBlue
@@ -41,7 +45,7 @@ class QuickStartListTitleCell: UITableViewCell {
 
         guard let iconImageView = iconImageView,
             let iconImage = iconImageView.image else {
-            return
+                return
         }
 
         iconImageView.image = iconImage.imageWithTintColor(.white)

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartListTitleCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartListTitleCell.xib
@@ -65,6 +65,7 @@
                     <constraint firstItem="0G7-da-TFG" firstAttribute="leading" secondItem="bAc-r5-9Gc" secondAttribute="leading" constant="16" id="yYf-Se-IiO"/>
                 </constraints>
             </tableViewCellContentView>
+            <inset key="separatorInset" minX="70" minY="0.0" maxX="0.0" maxY="0.0"/>
             <connections>
                 <outlet property="circleImageView" destination="0G7-da-TFG" id="SnF-gE-qQ9"/>
                 <outlet property="countLabel" destination="4zs-C7-CtU" id="Ad1-1E-dfN"/>

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
@@ -170,7 +170,7 @@ class WPRichTextEmbed: UIView, WPRichTextMediaAttachment {
 }
 
 // MARK: WebView delegate methods
-extension WPRichTextEmbed : WKNavigationDelegate {
+extension WPRichTextEmbed: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         // We're fully loaded so we can unassign the delegate.


### PR DESCRIPTION
Refs. #10860 

This PR adds some UI fix:
### Quick Start Section
- Remove disclosure indicator on iPhone
- Fix separator inset width

<img width="383" alt="screenshot 2019-02-08 at 08 58 25" src="https://user-images.githubusercontent.com/912252/52470243-809e1800-2b85-11e9-8085-7afbc9afa7b3.png">

### Checklist
- iPhone: separators are edge to edge based on the safe area layout guide
- iPad: separators are following the readable layout guide
- iPad: the list has a section header and the first todo row has a top separator
- The icon imageview is aligned correctly

**iPhone portrait**
![simulator screen shot - iphone x - 2019-02-08 at 08 53 26](https://user-images.githubusercontent.com/912252/52470357-d4106600-2b85-11e9-898d-9164604cec5a.png)

**iPhone landscape**
![simulator screen shot - iphone x - 2019-02-08 at 08 53 21](https://user-images.githubusercontent.com/912252/52470344-c824a400-2b85-11e9-98b3-8838c6f76b0f.png)

**iPad**
![img_0133](https://user-images.githubusercontent.com/912252/52470487-28b3e100-2b86-11e9-9c1d-f39babe051db.PNG)

**To Test:**
* Put `return true` in `shouldShowQuickStartChecklist()`
* Open the blog detail on iPhone to check the QS section rows
* Open the checklist to check the separator insets (on both iPhone and iPad)