### PR TITLE
Quick Start V2: Stats as initial view controller  

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -85,6 +85,7 @@ extension BlogDetailsViewController {
                                             self?.showQuickStartCustomize()
         }
         customizeRow.quickStartIdentifier = .checklist
+        customizeRow.showsSelectionState = false
         if let customizeDetailCounts = QuickStartTourGuide.find()?.completionCount(of: QuickStartTourGuide.customizeListTours, for: blog) {
             customizeRow.detail = String(format: detailFormatStr, customizeDetailCounts.complete, customizeDetailCounts.total)
             customizeRow.quickStartTitleState = customizeDetailCounts.complete == customizeDetailCounts.total ? .completed : .customizeIncomplete
@@ -97,6 +98,7 @@ extension BlogDetailsViewController {
                                             self?.showQuickStartGrow()
                                         }
         growRow.quickStartIdentifier = .checklist
+        growRow.showsSelectionState = false
         if let growDetailCounts = QuickStartTourGuide.find()?.completionCount(of: QuickStartTourGuide.growListTours, for: blog) {
             growRow.detail = String(format: detailFormatStr, growDetailCounts.complete, growDetailCounts.total)
             growRow.quickStartTitleState = growDetailCounts.complete == growDetailCounts.total ? .completed : .growIncomplete

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -435,7 +435,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (NSIndexPath *)restorableSelectedIndexPath
 {
     if (!_restorableSelectedIndexPath) {
-        _restorableSelectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:0];
+        NSUInteger section = [Feature enabled:FeatureFlagQuickStartV2] && [self shouldShowQuickStartChecklist] ? 1 : 0;
+        _restorableSelectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:section];
     }
 
     return _restorableSelectedIndexPath;
@@ -1436,7 +1437,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (UIViewController *)initialDetailViewControllerForSplitView:(WPSplitViewController *)splitView
 {
-    if ([self shouldShowQuickStartChecklist]) {
+    if ([self shouldShowQuickStartChecklist] && ![Feature enabled:FeatureFlagQuickStartV2]) {
         QuickStartChecklistViewControllerV1 *checklist = [[QuickStartChecklistViewControllerV1 alloc] initWithBlog:self.blog];
         return checklist;
     }


### PR DESCRIPTION
Refs. #10860 

This PR set _Stats_ as initial view controller on iPad split view.
Moreover the quick start section rows don't set a `restorableSelectedIndexPath` anymore and their `showsSelectionState` value is always _false_.

**To Test**:
- Put `return true` in `shouldShowQuickStartChecklist()`
- Run the app on iPad: _Stats_ should be the first section selected
- Select one of the Quick Start row, present the checklist and then dismiss it. The previous section selected shouldn't change.
- Run the app on iPhone to check that everything works as before