### PR TITLE
[Site Creation] Prevents interaction in preview webpage via CSS

### DIFF
--- a/WordPress/Classes/Extensions/WKWebView+Preview.swift
+++ b/WordPress/Classes/Extensions/WKWebView+Preview.swift
@@ -1,0 +1,32 @@
+import WebKit
+
+/// This extension contains a couple of small hacks used in site previews
+/// to hide various wpcom UI elements from webpages or prevent interaction.
+///
+extension WKWebView {
+
+    func prepareWPComPreview() {
+        hideWPComPreviewBanners()
+        preventInteraction()
+    }
+
+    /// Hides the 'Create your website at WordPress.com' getting started bar,
+    /// displayed on logged out sites, as well as the cookie widget banner.
+    func hideWPComPreviewBanners() {
+        let javascript = """
+        document.querySelector('html').style.cssText += '; margin-top: 0 !important;';\n        document.getElementById('wpadminbar').style.display = 'none';\n
+        document.getElementsByClassName("widget_eu_cookie_law_widget")[0].style += '; display: none !important;';\n
+        """
+
+        evaluateJavaScript(javascript, completionHandler: nil)
+    }
+
+    /// Prevents interaction on the current page using CSS.
+    func preventInteraction() {
+        let javascript = """
+        document.querySelector('*').style.cssText += '; pointer-events: none; -webkit-tap-highlight-color: rgba(0,0,0,0);';\n
+        """
+
+        evaluateJavaScript(javascript, completionHandler: nil)
+    }
+}

--- a/WordPress/Classes/ViewRelated/NUX/SiteCreationSitePreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SiteCreationSitePreviewViewController.swift
@@ -89,16 +89,7 @@ extension SiteCreationSitePreviewViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         siteLoaded = true
-        hideGetStartedBar()
+        webView.prepareWPComPreview()
         showSite()
     }
-
-    func hideGetStartedBar() {
-        let javascript = """
-        document.querySelector('html').style.cssText += '; margin-top: 0 !important;';\n
-        document.getElementById('wpadminbar').style.display = 'none';\n
-        """
-        webView?.evaluateJavaScript(javascript, completionHandler: nil)
-    }
-
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -193,6 +193,7 @@ extension AssembledSiteView: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         webViewHasLoadedContent = true
         activityIndicator.stopAnimating()
+        webView.prepareWPComPreview()
         generator.notificationOccurred(.success)
         WPAnalytics.track(.enhancedSiteCreationSuccessPreviewLoaded)
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -171,6 +171,20 @@ final class AssembledSiteView: UIView {
         layer.shadowOffset = Parameters.shadowOffset
         layer.shadowOpacity = Parameters.shadowOpacity
         layer.shadowRadius = Parameters.shadowRadius
+
+        // Used to prevent touch highlights on the webview
+        let tapRecognizer = UITapGestureRecognizer(target: nil, action: nil)
+        tapRecognizer.delegate = self
+        webView.addGestureRecognizer(tapRecognizer)
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension AssembledSiteView: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        // This prevents WKWebView's touch highlighting from activating
+        return true
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -190,6 +190,7 @@
 		17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */; };
 		17D975AF1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */; };
 		17E24F5420FCF1D900BD70A3 /* Routes+MySites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E24F5320FCF1D900BD70A3 /* Routes+MySites.swift */; };
+		17E60E09220DBD6E00848F89 /* WKWebView+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E60E08220DBD6E00848F89 /* WKWebView+Preview.swift */; };
 		17F0AE301F091563007D5A6B /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F0AE2F1F091563007D5A6B /* ConfettiView.swift */; };
 		17F0E1DA20EBDC0A001E9514 /* Routes+Me.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F0E1D920EBDC0A001E9514 /* Routes+Me.swift */; };
 		17F67C56203D81430072001E /* PostCardStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F67C55203D81430072001E /* PostCardStatusViewModel.swift */; };
@@ -1971,6 +1972,7 @@
 		17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Aztec.swift"; sourceTree = "<group>"; };
 		17E24F5320FCF1D900BD70A3 /* Routes+MySites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+MySites.swift"; sourceTree = "<group>"; };
 		17E553B520910791000D3005 /* WordPress 75.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 75.xcdatamodel"; sourceTree = "<group>"; };
+		17E60E08220DBD6E00848F89 /* WKWebView+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WKWebView+Preview.swift"; sourceTree = "<group>"; };
 		17F0AE2F1F091563007D5A6B /* ConfettiView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfettiView.swift; sourceTree = "<group>"; };
 		17F0E1D920EBDC0A001E9514 /* Routes+Me.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Me.swift"; sourceTree = "<group>"; };
 		17F2A5D020ACC70D00F0BE10 /* WordPress 76.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 76.xcdatamodel"; sourceTree = "<group>"; };
@@ -6808,6 +6810,7 @@
 				D829C33A21B12EFE00B09F12 /* UIView+Borders.swift */,
 				9A162F2421C26F5F00FDC035 /* UIViewController+ChildViewController.swift */,
 				9AF750F221EE196400DC47CA /* WPStyleGuide+Colors.swift */,
+				17E60E08220DBD6E00848F89 /* WKWebView+Preview.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -10148,6 +10151,7 @@
 				E125F1E41E8E595E00320B67 /* SharePost.swift in Sources */,
 				B56FEB791CD8E13C00E621F9 /* RoleViewController.swift in Sources */,
 				D82253DC2199411F0014D0E2 /* SiteAddressService.swift in Sources */,
+				17E60E09220DBD6E00848F89 /* WKWebView+Preview.swift in Sources */,
 				B5B56D3319AFB68800B4E29B /* WPStyleGuide+Notifications.swift in Sources */,
 				FF8DDCDF1B5DB1C10098826F /* SettingTableViewCell.m in Sources */,
 				17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */,


### PR DESCRIPTION
Fixes #10984.

This PR introduces fixes an issue where some items on a preview web view could still be interacted with. I've also extracted code which hides the WordPress.com 'get started' banner into a helper so it can be used from the site creation v2 preview.

Unfortunately there is still a dimming overlay that appears if you tap and hold on the web preview, and I'm unable to find a way to remove it. It appears to be part of the `WKWebView` itself – a `_UIHighlightView`.

![webview](https://user-images.githubusercontent.com/4780/52483321-7c84f100-2bab-11e9-9256-0c9d8a392994.gif)

**To test:**

* Build and run
* Navigate to Enhanced Site Creation and create a site
* At the end of the flow, scroll down through the site preview and attempt to tap in the search field. You shouldn't be able to.

cc @kwonye because I moved your code

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
    - Nothing user facing as this is a new feature.