### PR TITLE
Add `FollowersStatsRecordValue` entity to Core Data

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,8 +5,15 @@ data model as well as any custom migrations.
 
 ## WordPress 87
 @klausa 2019-02-??
-- Added `StatsRecord`, `StatsRecordValue`, `AnnualAndMostPopularTimeStatsRecordValue`,  `AllTimeStatsRecordValue`, `LastPostStatsRecordValue`,  `StatsRecord` and `StatsRecordValue`. 
-    
+- Added following entities:
+- 
+* `StatsRecord`
+* `StatsRecordValue`
+* `AnnualAndMostPopularTimeStatsRecordValue` 
+* `AllTimeStatsRecordValue` 
+* `LastPostStatsRecordValue`
+* `FollowersStatsRecordValue`
+
 More types are incoming, hence why I'm not putting a firm date above — I'll change it when all related PRs are merged.    
 
 ## WordPress 86

--- a/WordPress/Classes/Models/FollowersStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/FollowersStatsRecordValue+CoreDataClass.swift
@@ -1,0 +1,25 @@
+import Foundation
+import CoreData
+
+public enum FollowersStatsType: Int16 {
+    case email
+    case dotCom
+}
+
+public class FollowersStatsRecordValue: StatsRecordValue {
+    public var avatarURL: URL? {
+        guard let url = avatarURLString as String? else {
+            return nil
+        }
+        return URL(string: url)
+    }
+
+    public override func validateForInsert() throws {
+        try super.validateForInsert()
+
+        guard FollowersStatsType(rawValue: type) != nil else {
+            throw StatsCoreDataValidationError.invalidEnumValue
+        }
+    }
+
+}

--- a/WordPress/Classes/Models/FollowersStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/FollowersStatsRecordValue+CoreDataProperties.swift
@@ -1,0 +1,16 @@
+import Foundation
+import CoreData
+
+
+extension FollowersStatsRecordValue {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<FollowersStatsRecordValue> {
+        return NSFetchRequest<FollowersStatsRecordValue>(entityName: "FollowersStatsRecordValue")
+    }
+
+    @NSManaged public var name: String?
+    @NSManaged public var subscribedDate: NSDate?
+    @NSManaged public var avatarURLString: String?
+    @NSManaged public var type: Int16
+
+}

--- a/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
@@ -27,6 +27,7 @@ import CoreData
 public enum StatsRecordType: Int16 {
     case lastPostInsight
     case allTimeStatsInsight
+    case followers
 
     case postStats
     case blogStats
@@ -37,7 +38,7 @@ public enum StatsRecordType: Int16 {
         // lot of sense to hold on to Insights from the past...).
         // This lets us disambiguate between which is which.
         switch self {
-        case .lastPostInsight, .allTimeStatsInsight:
+        case .lastPostInsight, .allTimeStatsInsight, .followers:
             return false
         case .postStats, .blogStats:
             return true
@@ -93,6 +94,7 @@ public enum StatsCoreDataValidationError: Error {
     case incorrectRecordType
     case noManagedObjectContext
     case noDate
+    case invalidEnumValue
 
     /// Thrown when trying to insert a second instance of a type that only supports
     /// a single entry being present in the Core Data store.

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
@@ -344,6 +344,12 @@
         <attribute name="isPrimary" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="domains" inverseEntity="Blog" syncable="YES"/>
     </entity>
+    <entity name="FollowersStatsRecordValue" representedClassName=".FollowersStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+        <attribute name="avatarURLString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" attributeType="String" syncable="YES"/>
+        <attribute name="subscribedDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="type" attributeType="Integer 16" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
     <entity name="LastPostStatsRecordValue" representedClassName="WordPress.LastPostStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
         <attribute name="commentsCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="likesCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
@@ -840,5 +846,6 @@
         <element name="StatsRecord" positionX="27" positionY="486" width="128" height="120"/>
         <element name="StatsRecordValue" positionX="36" positionY="495" width="128" height="60"/>
         <element name="Theme" positionX="9" positionY="153" width="128" height="360"/>
+        <element name="FollowersStatsRecordValue" positionX="27" positionY="153" width="128" height="105"/>
     </elements>
 </model>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -261,13 +261,13 @@
 		40E728851FF3D9070010E7C9 /* PluginDetailViewHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E728841FF3D9070010E7C9 /* PluginDetailViewHeaderCell.swift */; };
 		40E7FEC52211DF790032834E /* StatsRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E7FEC42211DF790032834E /* StatsRecordTests.swift */; };
 		40E7FEC82211EEC00032834E /* LastPostStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E7FEC72211EEC00032834E /* LastPostStatsRecordValueTests.swift */; };
-		40E7FECA2211EEFE0032834E /* StatsTestsHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E7FEC92211EEFE0032834E /* StatsTestsHelpers.swift */; };
 		40E7FECF2211FFB90032834E /* AllTimeStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E7FECB2211FFA60032834E /* AllTimeStatsRecordValue+CoreDataClass.swift */; };
 		40E7FED02211FFBC0032834E /* AllTimeStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E7FECC2211FFA70032834E /* AllTimeStatsRecordValue+CoreDataProperties.swift */; };
 		40F46B6A22121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F46B6822121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift */; };
 		40F46B6B22121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F46B6922121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift */; };
 		40F50B7D22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F50B7B22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataClass.swift */; };
 		40F50B7E22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F50B7C22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataProperties.swift */; };
+		40F50B82221310F000CBBB73 /* StatsTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F50B81221310F000CBBB73 /* StatsTestCase.swift */; };
 		40FC6B7F2072E3EC00B9A1CD /* ActivityDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FC6B7E2072E3EB00B9A1CD /* ActivityDetailViewController.swift */; };
 		430693741DD25F31009398A2 /* PostPost.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 430693731DD25F31009398A2 /* PostPost.storyboard */; };
 		4308ACFD210107F90059EA64 /* SiteCreationDomainSuggestionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4308ACFC210107F90059EA64 /* SiteCreationDomainSuggestionsTableViewController.swift */; };
@@ -2078,13 +2078,13 @@
 		40E728841FF3D9070010E7C9 /* PluginDetailViewHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDetailViewHeaderCell.swift; sourceTree = "<group>"; };
 		40E7FEC42211DF790032834E /* StatsRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsRecordTests.swift; sourceTree = "<group>"; };
 		40E7FEC72211EEC00032834E /* LastPostStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastPostStatsRecordValueTests.swift; sourceTree = "<group>"; };
-		40E7FEC92211EEFE0032834E /* StatsTestsHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTestsHelpers.swift; sourceTree = "<group>"; };
 		40E7FECB2211FFA60032834E /* AllTimeStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AllTimeStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		40E7FECC2211FFA70032834E /* AllTimeStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AllTimeStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40F46B6822121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		40F46B6922121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40F50B7B22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FollowersStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		40F50B7C22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FollowersStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		40F50B81221310F000CBBB73 /* StatsTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTestCase.swift; sourceTree = "<group>"; };
 		40FC6B7E2072E3EB00B9A1CD /* ActivityDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityDetailViewController.swift; sourceTree = "<group>"; };
 		430693731DD25F31009398A2 /* PostPost.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = PostPost.storyboard; sourceTree = "<group>"; };
 		4308ACFC210107F90059EA64 /* SiteCreationDomainSuggestionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationDomainSuggestionsTableViewController.swift; sourceTree = "<group>"; };
@@ -4619,7 +4619,7 @@
 			children = (
 				40E7FEC42211DF790032834E /* StatsRecordTests.swift */,
 				40E7FEC72211EEC00032834E /* LastPostStatsRecordValueTests.swift */,
-				40E7FEC92211EEFE0032834E /* StatsTestsHelpers.swift */,
+				40F50B81221310F000CBBB73 /* StatsTestCase.swift */,
 			);
 			name = Stats;
 			sourceTree = "<group>";
@@ -10622,6 +10622,7 @@
 				730354BA21C867E500CD18C2 /* SiteCreatorTests.swift in Sources */,
 				B566EC751B83867800278395 /* NSMutableAttributedStringTests.swift in Sources */,
 				E6B9B8AF1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift in Sources */,
+				40F50B82221310F000CBBB73 /* StatsTestCase.swift in Sources */,
 				732A473D218787500015DA74 /* WPRichTextFormatterTests.swift in Sources */,
 				1797373720EBAA4100377B4E /* RouteMatcherTests.swift in Sources */,
 				73178C2A21BEE09300E37C9A /* SiteSegmentsCellTests.swift in Sources */,
@@ -10632,7 +10633,6 @@
 				E180BD4C1FB462FF00D0D781 /* CookieJarTests.swift in Sources */,
 				9363113F19FA996700B0C739 /* AccountServiceTests.swift in Sources */,
 				D88A649C208D7D81008AE9BC /* StockPhotosDataSourceTests.swift in Sources */,
-				40E7FECA2211EEFE0032834E /* StatsTestsHelpers.swift in Sources */,
 				40E7FEC52211DF790032834E /* StatsRecordTests.swift in Sources */,
 				74585B991F0D58F300E7E667 /* DomainsServiceTests.swift in Sources */,
 				D88A64B0208DA093008AE9BC /* StockPhotosResultsPageTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -266,6 +266,8 @@
 		40E7FED02211FFBC0032834E /* AllTimeStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E7FECC2211FFA70032834E /* AllTimeStatsRecordValue+CoreDataProperties.swift */; };
 		40F46B6A22121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F46B6822121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift */; };
 		40F46B6B22121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F46B6922121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift */; };
+		40F50B7D22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F50B7B22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataClass.swift */; };
+		40F50B7E22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F50B7C22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataProperties.swift */; };
 		40FC6B7F2072E3EC00B9A1CD /* ActivityDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FC6B7E2072E3EB00B9A1CD /* ActivityDetailViewController.swift */; };
 		430693741DD25F31009398A2 /* PostPost.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 430693731DD25F31009398A2 /* PostPost.storyboard */; };
 		4308ACFD210107F90059EA64 /* SiteCreationDomainSuggestionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4308ACFC210107F90059EA64 /* SiteCreationDomainSuggestionsTableViewController.swift */; };
@@ -2081,6 +2083,8 @@
 		40E7FECC2211FFA70032834E /* AllTimeStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AllTimeStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40F46B6822121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		40F46B6922121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		40F50B7B22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FollowersStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		40F50B7C22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FollowersStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40FC6B7E2072E3EB00B9A1CD /* ActivityDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityDetailViewController.swift; sourceTree = "<group>"; };
 		430693731DD25F31009398A2 /* PostPost.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = PostPost.storyboard; sourceTree = "<group>"; };
 		4308ACFC210107F90059EA64 /* SiteCreationDomainSuggestionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationDomainSuggestionsTableViewController.swift; sourceTree = "<group>"; };
@@ -4623,6 +4627,8 @@
 		40F46B6C22121BBC00A2143B /* Insights */ = {
 			isa = PBXGroup;
 			children = (
+				40F50B7B22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataClass.swift */,
+				40F50B7C22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataProperties.swift */,
 				40F46B6822121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift */,
 				40F46B6922121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift */,
 				40E7FECB2211FFA60032834E /* AllTimeStatsRecordValue+CoreDataClass.swift */,
@@ -9478,6 +9484,7 @@
 				177B4C3121236F0F00CF8084 /* GiphyDataLoader.swift in Sources */,
 				98EDB5FB2016627C00E2D25A /* SiteCreationCreateSiteViewController.swift in Sources */,
 				8236EB4B20248FF1007C7CF9 /* JetpackSpeedUpSiteSettingsViewController.swift in Sources */,
+				40F50B7E22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataProperties.swift in Sources */,
 				E66969DC1B9E55C300EC9C00 /* ReaderTopicToReaderListTopic37to38.swift in Sources */,
 				31C9F82E1A2368A2008BB945 /* BlogDetailHeaderView.m in Sources */,
 				B50C0C5F1EF42A4A00372C65 /* AztecPostViewController.swift in Sources */,
@@ -9486,6 +9493,7 @@
 				086E1FE01BBB35D2002D86CA /* MenusViewController.m in Sources */,
 				9F3EFCA3208E308A00268758 /* UIViewController+Notice.swift in Sources */,
 				59E1D46F1CEF77B500126697 /* Page+CoreDataProperties.swift in Sources */,
+				40F50B7D22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataClass.swift in Sources */,
 				43D74AD620FB5AD5004AD934 /* RegisterDomainSectionHeaderView.swift in Sources */,
 				986DD19C218D002500D28061 /* WPStyleGuide+Stats.swift in Sources */,
 				FF00889B204DF3ED007CCE66 /* Blog+Quota.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -267,6 +267,7 @@
 		40F46B6B22121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F46B6922121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift */; };
 		40F50B7D22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F50B7B22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataClass.swift */; };
 		40F50B7E22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F50B7C22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataProperties.swift */; };
+		40F50B80221310D400CBBB73 /* FollowersStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F50B7F221310D400CBBB73 /* FollowersStatsRecordValueTests.swift */; };
 		40F50B82221310F000CBBB73 /* StatsTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40F50B81221310F000CBBB73 /* StatsTestCase.swift */; };
 		40FC6B7F2072E3EC00B9A1CD /* ActivityDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40FC6B7E2072E3EB00B9A1CD /* ActivityDetailViewController.swift */; };
 		430693741DD25F31009398A2 /* PostPost.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 430693731DD25F31009398A2 /* PostPost.storyboard */; };
@@ -2084,6 +2085,7 @@
 		40F46B6922121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40F50B7B22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FollowersStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		40F50B7C22130E6C00CBBB73 /* FollowersStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FollowersStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		40F50B7F221310D400CBBB73 /* FollowersStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowersStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		40F50B81221310F000CBBB73 /* StatsTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTestCase.swift; sourceTree = "<group>"; };
 		40FC6B7E2072E3EB00B9A1CD /* ActivityDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityDetailViewController.swift; sourceTree = "<group>"; };
 		430693731DD25F31009398A2 /* PostPost.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = PostPost.storyboard; sourceTree = "<group>"; };
@@ -4617,6 +4619,7 @@
 		40E7FEC32211DF490032834E /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				40F50B7F221310D400CBBB73 /* FollowersStatsRecordValueTests.swift */,
 				40E7FEC42211DF790032834E /* StatsRecordTests.swift */,
 				40E7FEC72211EEC00032834E /* LastPostStatsRecordValueTests.swift */,
 				40F50B81221310F000CBBB73 /* StatsTestCase.swift */,
@@ -10686,6 +10689,7 @@
 				D800D87C20999CA200E7C7E5 /* SearchMenuItemCreatorTests.swift in Sources */,
 				436D55F02115CB6800CEAA33 /* RegisterDomainDetailsSectionTests.swift in Sources */,
 				E1B921BC1C0ED5A3003EA3CB /* MediaSizeSliderCellTest.swift in Sources */,
+				40F50B80221310D400CBBB73 /* FollowersStatsRecordValueTests.swift in Sources */,
 				0885A3671E837AFE00619B4D /* URLIncrementalFilenameTests.swift in Sources */,
 				D848CBF920FEF82100A9038F /* NotificationsContentFactoryTests.swift in Sources */,
 				F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */,

--- a/WordPress/WordPressTest/FollowersStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/FollowersStatsRecordValueTests.swift
@@ -67,4 +67,17 @@ class FollowersStatsRecordValueTests: StatsTestCase {
         XCTAssertEqual(dotComFollowers.first!.name, follower2.name)
     }
 
+    func testURLConversionWorks() {
+        let parent = createStatsRecord(in: mainContext, type: .followers, date: Date())
+
+        let follower = FollowersStatsRecordValue(parent: parent)
+        follower.type = FollowersStatsType.email.rawValue
+        follower.avatarURLString = "www.wordpress.com"
+
+        let fetchRequest = StatsRecord.fetchRequest(for: .followers)
+        let result = try! mainContext.fetch(fetchRequest)
+
+        let fetchedValue = result.first!.values!.firstObject as! FollowersStatsRecordValue
+        XCTAssertNotNil(fetchedValue.avatarURL)
+    }
 }

--- a/WordPress/WordPressTest/FollowersStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/FollowersStatsRecordValueTests.swift
@@ -1,0 +1,70 @@
+@testable import WordPress
+
+class FollowersStatsRecordValueTests: StatsTestCase {
+
+    func testCreation() {
+        let parent = createStatsRecord(in: mainContext, type: .followers, date: Date())
+
+        let follower = FollowersStatsRecordValue(parent: parent)
+        follower.name = "test"
+        follower.type = FollowersStatsType.dotCom.rawValue
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let fr = StatsRecord.fetchRequest(for: .followers)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first!.values?.count, 1)
+
+        let followerRecord = results.first?.values?.firstObject! as! FollowersStatsRecordValue
+
+        XCTAssertEqual(followerRecord.name, follower.name)
+        XCTAssertEqual(followerRecord.type, follower.type)
+    }
+
+    func testTypeValidation() {
+        let parent = createStatsRecord(in: mainContext, type: .followers, date: Date())
+
+        let follower = FollowersStatsRecordValue(parent: parent)
+        follower.name = "test"
+        follower.type = 9001
+
+        XCTAssertThrowsError(try mainContext.save()) { error in
+            XCTAssertEqual(error._domain, StatsCoreDataValidationError.invalidEnumValue._domain)
+            XCTAssertEqual(error._code, StatsCoreDataValidationError.invalidEnumValue._code)
+        }
+    }
+
+    func testMultipleFollowers() {
+        let parent = createStatsRecord(in: mainContext, type: .followers, date: Date())
+
+        let follower1 = FollowersStatsRecordValue(parent: parent)
+        follower1.name = "email"
+        follower1.type = FollowersStatsType.email.rawValue
+
+        let follower2 = FollowersStatsRecordValue(parent: parent)
+        follower2.name = "dotcom"
+        follower2.type = FollowersStatsType.dotCom.rawValue
+
+        let fr = StatsRecord.fetchRequest(for: .followers)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first!.values?.count, 2)
+
+        let followers = results.first?.values?.array as! [FollowersStatsRecordValue]
+
+        let emailFollowers = followers.filter { $0.type == FollowersStatsType.email.rawValue }
+        let dotComFollowers = followers.filter { $0.type == FollowersStatsType.dotCom.rawValue }
+
+        XCTAssertEqual(emailFollowers.count, 1)
+        XCTAssertEqual(dotComFollowers.count, 1)
+
+        XCTAssertEqual(emailFollowers.first!.name, follower1.name)
+        XCTAssertEqual(dotComFollowers.first!.name, follower2.name)
+    }
+
+}

--- a/WordPress/WordPressTest/LastPostStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/LastPostStatsRecordValueTests.swift
@@ -1,25 +1,8 @@
-import XCTest
-import CoreData
 @testable import WordPress
-
 
 // Note: This also tests a bunch of behavior that is actually provided by `StatsRecordValue` —
 // but that's an a abstract entity and we can't instantiate it directly, so I put it together here.
-class LastPostStatsRecordValueTests: XCTestCase {
-
-    fileprivate var manager: TestContextManager!
-
-    override func setUp() {
-        manager = TestContextManager()
-    }
-
-    override func tearDown() {
-        mainContext.reset()
-    }
-
-    var mainContext: NSManagedObjectContext {
-        return manager.mainContext
-    }
+class LastPostStatsRecordValueTests: StatsTestCase {
 
     // MARK: - StatsRecordValue tests
     func testEntityCreationWorks() {
@@ -30,8 +13,8 @@ class LastPostStatsRecordValueTests: XCTestCase {
 
         let result = try! mainContext.fetch(fetchRequest)
 
-        XCTAssert(result.count == 1)
-        XCTAssert(result.first!.values!.count == 1)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first!.values!.count, 1)
     }
 
     func testCastingWorks() {
@@ -46,8 +29,8 @@ class LastPostStatsRecordValueTests: XCTestCase {
 
         let castedResults = statsRecord.values?.array as? [LastPostStatsRecordValue]
 
-        XCTAssert(castedResults != nil)
-        XCTAssert(castedResults!.count == 1)
+        XCTAssertNotNil(castedResults)
+        XCTAssertEqual(castedResults!.count, 1)
     }
 
     func testInverseRelationShipWorks() {
@@ -58,8 +41,8 @@ class LastPostStatsRecordValueTests: XCTestCase {
 
         let result = try! mainContext.fetch(fetchRequest)
 
-        XCTAssert(result.count == 1)
-        XCTAssert((result.first!.values!.firstObject! as! LastPostStatsRecordValue).statsRecord != nil)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertNotNil((result.first!.values!.firstObject! as! LastPostStatsRecordValue).statsRecord)
     }
 
     func testInsertingSingleValueWorks() {
@@ -68,13 +51,7 @@ class LastPostStatsRecordValueTests: XCTestCase {
         let parent = createStatsRecord(in: mainContext, type: .lastPostInsight, date: Date())
         createLastPostStatsRecordValue(parent: parent)
 
-        do {
-            try mainContext.save()
-            XCTAssert(true)
-        }
-        catch {
-            XCTAssert(false, "this should never fail and always succeed, the error was \(error)")
-        }
+        XCTAssertNoThrow(try mainContext.save())
     }
 
     func testInsertingMultipleFails() {
@@ -85,11 +62,7 @@ class LastPostStatsRecordValueTests: XCTestCase {
         createLastPostStatsRecordValue(parent: parent)
         createLastPostStatsRecordValue(parent: parent)
 
-        do {
-            try mainContext.save()
-            XCTAssert(false, "this should never succeed and fail with validation warning")
-        }
-        catch {
+        XCTAssertThrowsError(try mainContext.save()) { error in
             // the error is being bubbled up trough Obj-C Core Data innards, which means we can't just compare the enums.
             let thrownErrorAsNSError = error as NSError
             let expectedErrorAsNSErrror = StatsCoreDataValidationError.singleEntryTypeViolation as NSError
@@ -115,7 +88,7 @@ class LastPostStatsRecordValueTests: XCTestCase {
         let result = try! mainContext.fetch(fetchRequest)
 
         let fetchedValue = result.first!.values!.firstObject as! LastPostStatsRecordValue
-        XCTAssert(fetchedValue.url != nil)
+        XCTAssertNotNil(fetchedValue.url)
     }
 
     @discardableResult func createLastPostStatsRecordValue(parent: StatsRecord) -> LastPostStatsRecordValue {

--- a/WordPress/WordPressTest/StatsRecordTests.swift
+++ b/WordPress/WordPressTest/StatsRecordTests.swift
@@ -1,44 +1,20 @@
-import XCTest
-import CoreData
 @testable import WordPress
 
-class StatsRecordTests: XCTestCase {
-
-    fileprivate var manager: TestContextManager!
-
-    override func setUp() {
-        manager = TestContextManager()
-    }
-
-    var mainContext: NSManagedObjectContext {
-        return manager.mainContext
-    }
-
-    override func tearDown() {
-        mainContext.reset()
-    }
+class StatsRecordTests: StatsTestCase {
 
     func testCreatingAndSaving() {
         createStatsRecord(in: mainContext, type: .blogStats, date: Date())
         createStatsRecord(in: mainContext, type: .blogStats, date: Date())
         createStatsRecord(in: mainContext, type: .blogStats, date: Date())
 
-        do {
-            try mainContext.save()
-            XCTAssert(true)
-        } catch {
-            XCTAssert(false, "error while saving, should never be true")
-        }
+        XCTAssertNoThrow(try mainContext.save())
     }
 
     func testDateValidationWorks() {
         let record = createStatsRecord(in: mainContext, type: .blogStats, date: Date())
         record.date = nil
 
-        do {
-            try mainContext.save()
-            XCTAssert(false, "this should throw a validation error")
-        } catch {
+        XCTAssertThrowsError(try mainContext.save()) { error in
             let thrownErrorAsNSError = error as NSError
             let expectedErrorAsNSErrror = StatsCoreDataValidationError.noDate as NSError
 
@@ -52,12 +28,7 @@ class StatsRecordTests: XCTestCase {
         let record = createStatsRecord(in: mainContext, type: .allTimeStatsInsight, date: Date())
         record.date = nil
 
-        do {
-            try mainContext.save()
-            XCTAssert(true)
-        } catch {
-            XCTAssert(false, "error while saving, should never be true")
-        }
+        XCTAssertNoThrow(try mainContext.save())
     }
 
     func testSingleElementValidation() {
@@ -67,11 +38,7 @@ class StatsRecordTests: XCTestCase {
         createStatsRecord(in: mainContext, type: .allTimeStatsInsight, date: Date())
         createStatsRecord(in: mainContext, type: .allTimeStatsInsight, date: Date())
 
-        do {
-            try mainContext.save()
-            XCTAssert(false, "this should never succeed and fail with validation warning")
-        }
-        catch {
+        XCTAssertThrowsError(try mainContext.save()) { error in
             let thrownErrorAsNSError = error as NSError
             let expectedErrorAsNSErrror = StatsCoreDataValidationError.singleEntryTypeViolation as NSError
 
@@ -94,8 +61,8 @@ class StatsRecordTests: XCTestCase {
         let allResults = try! mainContext.fetch(StatsRecord.fetchRequest())
         let results = try! mainContext.fetch(fetchRequest)
 
-        XCTAssert(allResults.isEmpty == false)
-        XCTAssert(results.count == 3)
+        XCTAssertEqual(allResults.isEmpty, false)
+        XCTAssertEqual(results.count, 3)
     }
 
     func testFetchingProperTypeOnly() {
@@ -106,7 +73,7 @@ class StatsRecordTests: XCTestCase {
 
         let results = try! mainContext.fetch(fetchRequest)
 
-        XCTAssert(results.count == 1)
+        XCTAssertEqual(results.count, 1)
     }
 
     func testFetchingForYesterday() {
@@ -123,7 +90,7 @@ class StatsRecordTests: XCTestCase {
 
         let results = try! mainContext.fetch(fetchRequest)
 
-        XCTAssert(results.count == 2)
+        XCTAssertEqual(results.count, 2)
     }
 
     func testFetchingForAnywhereInADay() {
@@ -145,6 +112,6 @@ class StatsRecordTests: XCTestCase {
 
         let results = try! mainContext.fetch(fetchRequest)
 
-        XCTAssert(results.count == 5)
+        XCTAssertEqual(results.count, 5)
     }
 }

--- a/WordPress/WordPressTest/StatsTestCase.swift
+++ b/WordPress/WordPressTest/StatsTestCase.swift
@@ -1,0 +1,30 @@
+import XCTest
+import CoreData
+@testable import WordPress
+
+// A thin wrapper round XCTestCase for Stats test to avoid repeating boilerplate.
+class StatsTestCase: XCTestCase {
+
+    fileprivate var manager: TestContextManager!
+
+    override func setUp() {
+        manager = TestContextManager()
+    }
+
+    var mainContext: NSManagedObjectContext {
+        return manager.mainContext
+    }
+
+    override func tearDown() {
+        mainContext.reset()
+    }
+
+    @discardableResult func createStatsRecord(in context: NSManagedObjectContext, type: StatsRecordType, date: Date) -> StatsRecord {
+        let newRecord = StatsRecord(context: context)
+        newRecord.type = type.rawValue
+        newRecord.date = date as NSDate
+
+        return newRecord
+    }
+
+}

--- a/WordPress/WordPressTest/StatsTestsHelpers.swift
+++ b/WordPress/WordPressTest/StatsTestsHelpers.swift
@@ -1,9 +1,0 @@
-@testable import WordPress
-
-@discardableResult func createStatsRecord(in context: NSManagedObjectContext, type: StatsRecordType, date: Date) -> StatsRecord {
-    let newRecord = StatsRecord(context: context)
-    newRecord.type = type.rawValue
-    newRecord.date = date as NSDate
-
-    return newRecord
-}


### PR DESCRIPTION
Follow-up to #11000.

There's gonna be a whole bunch of those coming in over the past few days — I'll try to keep to one entity/PR for ease of review. 

For now, this is targeting the branch that #11000 is based off of — after that'll get merged, I'll change the base to `feature/stats-core-data-finished`.

To test:
* Verify that the app builds
* Verify that the tests pass.
