### PR TITLE
SiteCreation: Use a formatted string and placeholder vs concatenation.

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
@@ -100,7 +100,9 @@ extension SiteSegmentsCell: Accessible {
     }
 
     private func prepareIconForVoiceOver() {
-        icon.accessibilityLabel = NSLocalizedString("Icon representing ", comment: "Accessibility description for Site Segment icon. Will be followed by the kind of site") + (model?.title ?? NSLocalizedString("Kind of site", comment: "Default accessibilty label for an unknown kind of site "))
+        let format = NSLocalizedString("Icon representing %@", comment: "Accessibility description for Site Segment icon. The %@ is a placeholder for the name of the kind of site. If the kind of site is unknown the phrase 'kind of site' is used.")
+        let site = model?.title ?? NSLocalizedString("Kind of site", comment: "Default accessibilty label for an unknown kind of site.")
+        icon.accessibilityLabel =  String(format: format, site )
         icon.accessibilityTraits = .image
     }
 }


### PR DESCRIPTION
Fixes an issue with localization reported by our trusty polyglots in the [dot org mobile slack](https://wordpress.slack.com/archives/C02RQC4LY/p1549966157003600).  Rather than concatenate strings in a set order, we'll use a placeholder so the translations can be composed in the correct order.

To test:
- Confirm the accessibility label is composed correctly.
- Bonus, test with voice over enabled

@ctarda could I trouble you for the review?