### PR TITLE
Debouncer improvements

### DIFF
--- a/WordPress/Classes/Utility/Debouncer.swift
+++ b/WordPress/Classes/Utility/Debouncer.swift
@@ -14,7 +14,8 @@ final class Debouncer {
 
     deinit {
         if let timer = timer, timer.fireDate >= Date() {
-            timer.fire()
+            timer.invalidate()
+            callback()
         }
     }
 

--- a/WordPress/Classes/Utility/Debouncer.swift
+++ b/WordPress/Classes/Utility/Debouncer.swift
@@ -2,10 +2,15 @@ import Foundation
 
 //From : https://github.com/webadnan/swift-debouncer
 
+/// This class de-bounces the execution of a provided callback.
+/// It also offers a mechanism to immediately trigger the scheduled call if necessary.
+///
 final class Debouncer {
-    var callback: (() -> Void)
-    var delay: Double
-    weak var timer: Timer?
+    private let callback: (() -> Void)
+    private let delay: Double
+    private var timer: Timer?
+
+    // MARK: - Init & deinit
 
     init(delay: Double, callback: @escaping (() -> Void)) {
         self.delay = delay
@@ -19,11 +24,28 @@ final class Debouncer {
         }
     }
 
-    func call() {
+    // MARK: - Debounce Request
+
+    func call(immediate: Bool = false) {
         timer?.invalidate()
 
-        timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] timer in
-            self?.callback()
+        if immediate {
+            immediateCallback()
+        } else {
+            scheduleCallback()
+        }
+    }
+
+    // MARK: - Callback interaction
+
+    private func immediateCallback() {
+        timer = nil
+        callback()
+    }
+
+    private func scheduleCallback() {
+        timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [unowned self] timer in
+            self.callback()
         }
     }
 }

--- a/WordPress/Classes/Utility/Debouncer.swift
+++ b/WordPress/Classes/Utility/Debouncer.swift
@@ -3,22 +3,26 @@ import Foundation
 //From : https://github.com/webadnan/swift-debouncer
 
 final class Debouncer {
-    var callback: (() -> Void)?
+    var callback: (() -> Void)
     var delay: Double
     weak var timer: Timer?
 
-    init(delay: Double, callback: (() -> Void)? = nil) {
+    init(delay: Double, callback: @escaping (() -> Void)) {
         self.delay = delay
         self.callback = callback
     }
 
-    func call() {
-        timer?.invalidate()
-        let nextTimer = Timer.scheduledTimer(timeInterval: delay, target: self, selector: #selector(Debouncer.fireNow), userInfo: nil, repeats: false)
-        timer = nextTimer
+    deinit {
+        if let timer = timer, timer.fireDate >= Date() {
+            timer.fire()
+        }
     }
 
-    @objc func fireNow() {
-        self.callback?()
+    func call() {
+        timer?.invalidate()
+
+        timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] timer in
+            self?.callback()
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -5,12 +5,12 @@ extension PostEditor where Self: UIViewController {
     // The debouncer will perform this callback every 500ms in order to save the post locally with a delay.
     var debouncerCallback: (() -> Void) {
         return { [weak self] in
-            guard let strongSelf = self else {
-                assertionFailure("self was nil while trying to save a post using Debouncer")
+            guard let self = self else {
                 return
             }
-            if strongSelf.post.hasLocalChanges() {
-                guard let context = strongSelf.post.managedObjectContext else {
+
+            if self.post.hasLocalChanges() {
+                guard let context = self.post.managedObjectContext else {
                     return
                 }
                 ContextManager.sharedInstance().save(context)
@@ -334,7 +334,7 @@ extension PostEditor where Self: UIViewController {
     fileprivate func asyncUploadPost(action: PostEditorAction) {
         postEditorStateContext.updated(isBeingPublished: true)
 
-        mapUIContentToPostAndSave()
+        mapUIContentToPostAndSave(immediate: true)
 
         post.updatePathForDisplayImageBasedOnContent()
 
@@ -351,7 +351,7 @@ extension PostEditor where Self: UIViewController {
     ///     - completion: the closure to execute when the publish operation completes.
     ///
     private func uploadPost(completion: ((_ post: AbstractPost?, _ error: Error?) -> Void)?) {
-        mapUIContentToPostAndSave()
+        mapUIContentToPostAndSave(immediate: true)
 
         let managedObjectContext = ContextManager.sharedInstance().mainContext
         let postService = PostService(managedObjectContext: managedObjectContext)
@@ -380,10 +380,10 @@ extension PostEditor where Self: UIViewController {
         view.endEditing(true)
     }
 
-    func mapUIContentToPostAndSave() {
+    func mapUIContentToPostAndSave(immediate: Bool = false) {
         post.postTitle = postTitle
         post.content = getHTML()
-        debouncer.call()
+        debouncer.call(immediate: immediate)
     }
 
     // TODO: Rip this out and put it into the PostService

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1600,6 +1600,7 @@
 		F15A230420A3EBE300625EA2 /* ImgUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F126FDFE20A33BDB0010EB6E /* ImgUploadProcessor.swift */; };
 		F15A230520A3ECC500625EA2 /* ImgUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F126FDFE20A33BDB0010EB6E /* ImgUploadProcessor.swift */; };
 		F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18B43771F849F580089B817 /* PostAttachmentTests.swift */; };
+		F1CE42AA2213475000316683 /* DebouncerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CE42A92213475000316683 /* DebouncerTests.swift */; };
 		F1D690161F82913F00200E30 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
 		F1D690171F82914200200E30 /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
 		F9463A7321C05EE90081F11E /* ScreenshotCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9463A7221C05EE90081F11E /* ScreenshotCredentials.swift */; };
@@ -3702,6 +3703,7 @@
 		F14B5F74208E64F900439554 /* Version.public.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.public.xcconfig; sourceTree = "<group>"; };
 		F14B5F75208E64F900439554 /* Version.internal.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Version.internal.xcconfig; sourceTree = "<group>"; };
 		F18B43771F849F580089B817 /* PostAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostAttachmentTests.swift; path = Posts/PostAttachmentTests.swift; sourceTree = "<group>"; };
+		F1CE42A92213475000316683 /* DebouncerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebouncerTests.swift; sourceTree = "<group>"; };
 		F1D690141F828FF000200E30 /* BuildConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuildConfiguration.swift; sourceTree = "<group>"; };
 		F1D690151F828FF000200E30 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
 		F262DFCA1F94418CE76D1D78 /* Pods-WordPressNotificationContentExtension.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationContentExtension.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationContentExtension/Pods-WordPressNotificationContentExtension.release-internal.xcconfig"; sourceTree = "<group>"; };
@@ -5703,6 +5705,7 @@
 				82301B8E1E787420009C9C4E /* AppRatingUtilityTests.swift */,
 				17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */,
 				E180BD4B1FB462FF00D0D781 /* CookieJarTests.swift */,
+				F1CE42A92213475000316683 /* DebouncerTests.swift */,
 				E1AB5A391E0C464700574B4E /* DelayTests.swift */,
 				732B99162180D3A600C4EBDB /* FeatureFlagTests.swift */,
 				E1EBC3721C118ED200F638E0 /* ImmuTableTest.swift */,
@@ -10492,6 +10495,7 @@
 				82301B8F1E787420009C9C4E /* AppRatingUtilityTests.swift in Sources */,
 				D81C2F5420F85DB1002AE1F1 /* ApproveCommentActionTests.swift in Sources */,
 				74B335EC1F06F9520053A184 /* MockWordPressComRestApi.swift in Sources */,
+				F1CE42AA2213475000316683 /* DebouncerTests.swift in Sources */,
 				D848CBFF20FF010F00A9038F /* FormattableCommentContentTests.swift in Sources */,
 				FF1FD02620912AA900186384 /* URL+LinkNormalizationTests.swift in Sources */,
 				7E442FCF20F6C19000DEACA5 /* ActivityLogFormattableContentTests.swift in Sources */,

--- a/WordPress/WordPressTest/DebouncerTests.swift
+++ b/WordPress/WordPressTest/DebouncerTests.swift
@@ -22,6 +22,8 @@ class DebouncerTests: XCTestCase {
                 && actualDelay <= maxDelay {
 
                 debouncerHasRunAccurately.fulfill()
+            } else {
+                XCTFail("Actual delay was: \(actualDelay))")
             }
         }
         debouncer.call()

--- a/WordPress/WordPressTest/DebouncerTests.swift
+++ b/WordPress/WordPressTest/DebouncerTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import WordPress
+
+class DebouncerTests: XCTestCase {
+
+    /// Tests that the debouncer runs within an accurate time range normally.
+    ///
+    func testDebouncerRunsNormally() {
+        let timerDelay = 0.5
+        let allowedError = 0.05
+        let minDelay = timerDelay * (1 - allowedError)
+        let maxDelay = timerDelay * (1 + allowedError)
+        let testTimeout = maxDelay + 0.01
+
+        let startDate = Date()
+        let debouncerHasRunAccurately = XCTestExpectation(description: "The debouncer should run within an accurate time range normally.")
+
+        let debouncer = Debouncer(delay: timerDelay) {
+            let actualDelay = Date().timeIntervalSince(startDate)
+
+            if actualDelay >= minDelay
+                && actualDelay <= maxDelay {
+
+                debouncerHasRunAccurately.fulfill()
+            }
+        }
+        debouncer.call()
+
+        wait(for: [debouncerHasRunAccurately], timeout: testTimeout)
+    }
+
+    /// Tests that the debouncer runs immediately if its released.
+    ///
+    func testDebouncerRunsImmediatelyIfReleased() {
+        let debouncerHasRun = XCTestExpectation(description: "The debouncer should run immediately if it's released")
+
+        Debouncer(delay: 0.5) {
+            debouncerHasRun.fulfill()
+        }.call()
+
+        wait(for: [debouncerHasRun], timeout: 0)
+    }
+}

--- a/WordPress/WordPressTest/DebouncerTests.swift
+++ b/WordPress/WordPressTest/DebouncerTests.swift
@@ -7,7 +7,7 @@ class DebouncerTests: XCTestCase {
     ///
     func testDebouncerRunsNormally() {
         let timerDelay = 0.5
-        let allowedError = 0.05
+        let allowedError = 0.1
         let minDelay = timerDelay * (1 - allowedError)
         let maxDelay = timerDelay * (1 + allowedError)
         let testTimeout = maxDelay + 0.01


### PR DESCRIPTION
## Description:

This PR improves the `Debouncer` class in three ways:

1. It no longer waits to trigger if it's being released.  This ensures that if the owner of the `Debouncer` is being released, it will be able to trigger the last call before it's actually released.
2. [The callback is no longer optional](https://github.com/wordpress-mobile/WordPress-iOS/pull/11015/files#diff-d025383eb1161f651ad2ec8c7b154b2cR6), as the debouncer would make no sense without a callback.
3. [Adds automated tests](https://github.com/wordpress-mobile/WordPress-iOS/pull/11015/files#diff-87b0abffcbd8e06248ecc2d337dff76fR4) covering both the regular scenario, and the scenario in which we want the `Debouncer` to be released immediately.

## Original issue:

To test the original issue, check out `develop` and change this line:

https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/Utility/Debouncer.swift#L11

To:

```swift
self.delay = 10
```

Then run the app, go to the editor, make a change, publish it and exit.
You'll get an assertion failure after a bit.

## Testing:

### Test 1:

Follow the steps mentioned in the section above, to see the original issue is no longer a problem.

### Test 2:

Analyze the logic of the automated tests and run them.