### PR TITLE
Add Gutenberg informative dialog

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3237,7 +3237,7 @@ extension AztecPostViewController {
     }
 
     struct MoreSheetAlert {
-        static let gutenbergTitle = NSLocalizedString("Switch to Gutenberg", comment: "Switches from the classic editor to Gutenberg.")
+        static let gutenbergTitle = NSLocalizedString("Switch to Block Editor", comment: "Switches from the Classic Editor to Block Editor.")
         static let htmlTitle = NSLocalizedString("Switch to HTML Mode", comment: "Switches the Editor to HTML Mode")
         static let richTitle = NSLocalizedString("Switch to Visual Mode", comment: "Switches the Editor to Rich Text Mode")
         static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -18,7 +18,7 @@ extension GutenbergViewController {
         }
         enum Alert {
             static let message = NSLocalizedString(
-                "The post was originally created in the Block Editor, so we've also enabled it on this Post. Switch back to Classic at any time by tapping ••• in the top bar.",
+                "This post was originally created in the Block Editor, so we've also enabled it on this Post. Switch back to Classic at any time by tapping ••• in the top bar.",
                 comment: "Popup content about why this post is being opened in Block Editor"
             )
             static let title = NSLocalizedString("Block Editor Enabled", comment: "Popup title about why this post is being opened in Block Editor")

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -24,16 +24,18 @@ extension GutenbergViewController {
     }
 
     func showInformativeDialogIfNecessary() {
-        GutenbergViewController.showInformativeDialogIfNecessary(on: self)
+        GutenbergViewController.showInformativeDialogIfNecessary(showing: post, on: self)
     }
 
     static func showInformativeDialogIfNecessary(
         using userDefaults: GutenbergFlagsUserDefaultsProtocol = UserDefaults.standard,
+        showing post: AbstractPost,
         on viewController: UIViewControllerTransitioningDelegate & UIViewController,
         animated: Bool = true
     ) {
-        guard !userDefaults.bool(forKey: Const.Key.informativeDialog) else {
-            // Don't show if it was shown before
+        guard !userDefaults.bool(forKey: Const.Key.informativeDialog),
+            post.containsGutenbergBlocks() else {
+            // Don't show if this was shown before or the post does not contain blocks
             return
         }
         let okButton: (title: String, handler: FancyAlertViewController.FancyAlertButtonHandler?) =

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -17,8 +17,11 @@ extension GutenbergViewController {
             static let informativeDialog = "Gutenberg.InformativeDialog"
         }
         enum Alert {
-            static let message = "The post was originally created in the Block Editor, so we've also enabled it on this Post. Switch back to Classic at any time by tapping ••• in the top bar."
-            static let title = "Block Editor Enabled"
+            static let message = NSLocalizedString(
+                "The post was originally created in the Block Editor, so we've also enabled it on this Post. Switch back to Classic at any time by tapping ••• in the top bar.",
+                comment: "Popup content about why this post is being opened in Block Editor"
+            )
+            static let title = NSLocalizedString("Block Editor Enabled", comment: "Popup title about why this post is being opened in Block Editor")
             static let okButtonTitle   = NSLocalizedString("OK", comment: "OK button to close the informative dialog on Gutenberg editor")
         }
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -13,17 +13,13 @@ extension UserDefaults: GutenbergFlagsUserDefaultsProtocol {
 extension GutenbergViewController {
 
     enum InfoDialog {
-        enum Key {
-            static let informativeDialog = "Gutenberg.InformativeDialog"
-        }
-        enum Text {
-            static let message = NSLocalizedString(
-                "This post was originally created in the Block Editor, so we've also enabled it on this Post. Switch back to Classic at any time by tapping ••• in the top bar.",
-                comment: "Popup content about why this post is being opened in Block Editor"
-            )
-            static let title = NSLocalizedString("Block Editor Enabled", comment: "Popup title about why this post is being opened in Block Editor")
-            static let okButtonTitle   = NSLocalizedString("OK", comment: "OK button to close the informative dialog on Gutenberg editor")
-        }
+        static let key = "Gutenberg.InformativeDialog"
+        static let message = NSLocalizedString(
+            "This post was originally created in the Block Editor, so we've also enabled it on this Post. Switch back to Classic at any time by tapping ••• in the top bar.",
+            comment: "Popup content about why this post is being opened in Block Editor"
+        )
+        static let title = NSLocalizedString("Block Editor Enabled", comment: "Popup title about why this post is being opened in Block Editor")
+        static let okButtonTitle   = NSLocalizedString("OK", comment: "OK button to close the informative dialog on Gutenberg editor")
     }
 
     func showInformativeDialogIfNecessary() {
@@ -36,22 +32,22 @@ extension GutenbergViewController {
         on viewController: UIViewControllerTransitioningDelegate & UIViewController,
         animated: Bool = true
     ) {
-        guard !userDefaults.bool(forKey: InfoDialog.Key.informativeDialog),
+        guard !userDefaults.bool(forKey: InfoDialog.key),
             post.containsGutenbergBlocks() else {
             // Don't show if this was shown before or the post does not contain blocks
             return
         }
         let okButton: (title: String, handler: FancyAlertViewController.FancyAlertButtonHandler?) =
         (
-            title: InfoDialog.Text.okButtonTitle,
+            title: InfoDialog.okButtonTitle,
             handler: { (alert, button) in
                 alert.dismiss(animated: animated, completion: nil)
             }
         )
 
         let config = FancyAlertViewController.Config(
-            titleText: InfoDialog.Text.title,
-            bodyText: InfoDialog.Text.message,
+            titleText: InfoDialog.title,
+            bodyText: InfoDialog.message,
             headerImage: nil,
             dividerPosition: .top,
             defaultButton: okButton,
@@ -63,6 +59,6 @@ extension GutenbergViewController {
         alert.transitioningDelegate = viewController
         viewController.present(alert, animated: animated)
         // Save that this alert is shown
-        userDefaults.set(true, forKey: InfoDialog.Key.informativeDialog)
+        userDefaults.set(true, forKey: InfoDialog.key)
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+protocol GutenbergFlagsUserDefaultsProtocol {
+    func set(_ value: Bool, forKey defaultName: String)
+    func bool(forKey defaultName: String) -> Bool
+}
+
+extension UserDefaults: GutenbergFlagsUserDefaultsProtocol {
+
+}
+
+/// This extension handles Alert operations.
+extension GutenbergViewController {
+
+    enum Const {
+        enum Key {
+            static let informativeDialog = "Gutenberg.InformativeDialog"
+        }
+        enum Alert {
+            static let message = "The post was originally created in the Block Editor, so we've also enabled it on this Post. Switch back to Classic at any time by tapping ••• in the top bar."
+            static let title = "Block Editor Enabled"
+            static let okButtonTitle   = NSLocalizedString("OK", comment: "OK button to close the informative dialog on Gutenberg editor")
+        }
+    }
+
+    func showInformativeDialogIfNecessary() {
+        GutenbergViewController.showInformativeDialogIfNecessary(on: self)
+    }
+
+    static func showInformativeDialogIfNecessary(
+        using userDefaults: GutenbergFlagsUserDefaultsProtocol = UserDefaults.standard,
+        on viewController: UIViewControllerTransitioningDelegate & UIViewController,
+        animated: Bool = true
+    ) {
+        guard !userDefaults.bool(forKey: Const.Key.informativeDialog) else {
+            // Don't show if it was shown before
+            return
+        }
+        let okButton: (title: String, handler: FancyAlertViewController.FancyAlertButtonHandler?) =
+        (
+            title: Const.Alert.okButtonTitle,
+            handler: { (alert, button) in
+                alert.dismiss(animated: animated, completion: nil)
+            }
+        )
+
+        let config = FancyAlertViewController.Config(
+            titleText: Const.Alert.title,
+            bodyText: Const.Alert.message,
+            headerImage: nil,
+            dividerPosition: .top,
+            defaultButton: okButton,
+            cancelButton: nil
+        )
+
+        let alert = FancyAlertViewController.controllerWithConfiguration(configuration: config)
+        alert.modalPresentationStyle = .custom
+        alert.transitioningDelegate = viewController
+        viewController.present(alert, animated: animated)
+        // Save that this alert is shown
+        userDefaults.set(true, forKey: Const.Key.informativeDialog)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -12,11 +12,11 @@ extension UserDefaults: GutenbergFlagsUserDefaultsProtocol {
 /// This extension handles Alert operations.
 extension GutenbergViewController {
 
-    enum Const {
+    enum InfoDialog {
         enum Key {
             static let informativeDialog = "Gutenberg.InformativeDialog"
         }
-        enum Alert {
+        enum Text {
             static let message = NSLocalizedString(
                 "This post was originally created in the Block Editor, so we've also enabled it on this Post. Switch back to Classic at any time by tapping ••• in the top bar.",
                 comment: "Popup content about why this post is being opened in Block Editor"
@@ -36,22 +36,22 @@ extension GutenbergViewController {
         on viewController: UIViewControllerTransitioningDelegate & UIViewController,
         animated: Bool = true
     ) {
-        guard !userDefaults.bool(forKey: Const.Key.informativeDialog),
+        guard !userDefaults.bool(forKey: InfoDialog.Key.informativeDialog),
             post.containsGutenbergBlocks() else {
             // Don't show if this was shown before or the post does not contain blocks
             return
         }
         let okButton: (title: String, handler: FancyAlertViewController.FancyAlertButtonHandler?) =
         (
-            title: Const.Alert.okButtonTitle,
+            title: InfoDialog.Text.okButtonTitle,
             handler: { (alert, button) in
                 alert.dismiss(animated: animated, completion: nil)
             }
         )
 
         let config = FancyAlertViewController.Config(
-            titleText: Const.Alert.title,
-            bodyText: Const.Alert.message,
+            titleText: InfoDialog.Text.title,
+            bodyText: InfoDialog.Text.message,
             headerImage: nil,
             dividerPosition: .top,
             defaultButton: okButton,
@@ -63,6 +63,6 @@ extension GutenbergViewController {
         alert.transitioningDelegate = viewController
         viewController.present(alert, animated: animated)
         // Save that this alert is shown
-        userDefaults.set(true, forKey: Const.Key.informativeDialog)
+        userDefaults.set(true, forKey: InfoDialog.Key.informativeDialog)
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -178,6 +178,7 @@ class GutenbergViewController: UIViewController, PostEditor {
         refreshInterface()
 
         gutenberg.delegate = self
+        showInformativeDialogIfNecessary()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -780,6 +780,8 @@
 		85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85F8E19C1B018698000859BB /* PushAuthenticationServiceTests.swift */; };
 		9111C15121CA59A100DA0662 /* GutenbergContainerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9111C15021CA59A100DA0662 /* GutenbergContainerView.xib */; };
 		9111C15321CA59BC00DA0662 /* GutenbergContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9111C15221CA59BB00DA0662 /* GutenbergContainerView.swift */; };
+		912347192213484300BD9F97 /* GutenbergViewController+InformativeDialog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912347182213484300BD9F97 /* GutenbergViewController+InformativeDialog.swift */; };
+		9123471B221449E200BD9F97 /* GutenbergInformativeDialogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9123471A221449E200BD9F97 /* GutenbergInformativeDialogTests.swift */; };
 		91D8364121946EFB008340B2 /* GutenbergMediaPickerHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91D8364021946EFB008340B2 /* GutenbergMediaPickerHelper.swift */; };
 		91DCE84421A6A7840062F134 /* PostEditor+BlogPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DCE84321A6A7840062F134 /* PostEditor+BlogPicker.swift */; };
 		91DCE84621A6A7F50062F134 /* PostEditor+MoreOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DCE84521A6A7F50062F134 /* PostEditor+MoreOptions.swift */; };
@@ -2659,6 +2661,8 @@
 		8D1107310486CEB800E47090 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9111C15021CA59A100DA0662 /* GutenbergContainerView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GutenbergContainerView.xib; sourceTree = "<group>"; };
 		9111C15221CA59BB00DA0662 /* GutenbergContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergContainerView.swift; sourceTree = "<group>"; };
+		912347182213484300BD9F97 /* GutenbergViewController+InformativeDialog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GutenbergViewController+InformativeDialog.swift"; sourceTree = "<group>"; };
+		9123471A221449E200BD9F97 /* GutenbergInformativeDialogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergInformativeDialogTests.swift; sourceTree = "<group>"; };
 		91D8364021946EFB008340B2 /* GutenbergMediaPickerHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergMediaPickerHelper.swift; sourceTree = "<group>"; };
 		91DCE84321A6A7840062F134 /* PostEditor+BlogPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditor+BlogPicker.swift"; sourceTree = "<group>"; };
 		91DCE84521A6A7F50062F134 /* PostEditor+MoreOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostEditor+MoreOptions.swift"; sourceTree = "<group>"; };
@@ -5451,6 +5455,7 @@
 				7EA30DB321ADA20F0092F894 /* EditorMediaUtility.swift */,
 				9111C15021CA59A100DA0662 /* GutenbergContainerView.xib */,
 				9111C15221CA59BB00DA0662 /* GutenbergContainerView.swift */,
+				912347182213484300BD9F97 /* GutenbergViewController+InformativeDialog.swift */,
 			);
 			path = Gutenberg;
 			sourceTree = "<group>";
@@ -8102,6 +8107,7 @@
 			children = (
 				FF9A6E7021F9361700D36D14 /* MediaUploadHashTests.swift */,
 				FF2EC3C12209AC19006176E1 /* GutenbergImgUploadProcessorTests.swift */,
+				9123471A221449E200BD9F97 /* GutenbergInformativeDialogTests.swift */,
 			);
 			name = Gutenberg;
 			sourceTree = "<group>";
@@ -9769,6 +9775,7 @@
 				D818FFD72191566B000E5FEE /* VerticalsWizardContent.swift in Sources */,
 				08F8CD2F1EBD29440049D0C0 /* MediaImageExporter.swift in Sources */,
 				4308ACFD210107F90059EA64 /* SiteCreationDomainSuggestionsTableViewController.swift in Sources */,
+				912347192213484300BD9F97 /* GutenbergViewController+InformativeDialog.swift in Sources */,
 				E13F23C314FE84600081D9CC /* NSMutableDictionary+Helpers.m in Sources */,
 				2FA6511721F26A24009AA935 /* ChangePasswordViewController.swift in Sources */,
 				D816C1F020E0893A00C4D82F /* LikeComment.swift in Sources */,
@@ -10493,6 +10500,7 @@
 				D81C2F5420F85DB1002AE1F1 /* ApproveCommentActionTests.swift in Sources */,
 				74B335EC1F06F9520053A184 /* MockWordPressComRestApi.swift in Sources */,
 				D848CBFF20FF010F00A9038F /* FormattableCommentContentTests.swift in Sources */,
+				9123471B221449E200BD9F97 /* GutenbergInformativeDialogTests.swift in Sources */,
 				FF1FD02620912AA900186384 /* URL+LinkNormalizationTests.swift in Sources */,
 				7E442FCF20F6C19000DEACA5 /* ActivityLogFormattableContentTests.swift in Sources */,
 				D81C2F6620F8ACCD002AE1F1 /* FormattableContentFormatterTests.swift in Sources */,

--- a/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
+++ b/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
@@ -62,49 +62,49 @@ class GutenbergInformativeDialogTests: XCTestCase {
     func testShowInformativeDialogWithUserDefaultsFlagWithGutenbergContent() {
         let post = insertPost()
         post.content = PostContent.gutenberg
-        mockUserDefaults.set(true, forKey: GutenbergViewController.Const.Key.informativeDialog)
-        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        mockUserDefaults.set(true, forKey: GutenbergViewController.InfoDialog.Key.informativeDialog)
+        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
         GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
                                                                  showing: post,
                                                                  on: viewController,
                                                                  animated: false)
-        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
         XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
     }
 
     func testShowInformativeDialogWithNoUserDefaultsFlagWithGutenbergContent() {
         let post = insertPost()
         post.content = PostContent.gutenberg
-        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
         GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
                                                                  showing: post,
                                                                  on: viewController,
                                                                  animated: false)
-        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
         XCTAssertNotNil(viewController.presentedViewController as? FancyAlertViewController)
     }
 
     func testShowInformativeDialogWithNoUserDefaultsFlagWithEmptyContent() {
         let post = insertPost()
         post.content = ""
-        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
         GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
                                                                  showing: post,
                                                                  on: viewController,
                                                                  animated: false)
-        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
         XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
     }
 
     func testShowInformativeDialogWithNoUserDefaultsFlagWithClassicContent() {
         let post = insertPost()
         post.content = PostContent.classic
-        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
         GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
                                                                  showing: post,
                                                                  on: viewController,
                                                                  animated: false)
-        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
         XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
     }
 

--- a/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
+++ b/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import UIKit
+@testable import WordPress
+
+fileprivate class MockUserDefaults: GutenbergFlagsUserDefaultsProtocol {
+
+    private var boolDictionary: [String: Bool] = [:]
+
+    func set(_ value: Bool, forKey defaultName: String) {
+        boolDictionary[defaultName] = value
+    }
+
+    func bool(forKey defaultName: String) -> Bool {
+        return boolDictionary[defaultName] ?? false
+    }
+}
+
+fileprivate class MockUIViewController: UIViewController, UIViewControllerTransitioningDelegate {
+    @objc func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
+        return FancyAlertPresentationController(presentedViewController: presented, presenting: presenting)
+    }
+}
+
+class GutenbergInformativeDialogTests: XCTestCase {
+
+    private var rootWindow: UIWindow!
+    private var viewController: MockUIViewController!
+
+    override func setUp() {
+        viewController = MockUIViewController()
+        rootWindow = UIWindow(frame: UIScreen.main.bounds)
+        rootWindow.isHidden = false
+        rootWindow.rootViewController = viewController
+    }
+
+    override func tearDown() {
+        rootWindow.rootViewController = nil
+        rootWindow.isHidden = true
+        rootWindow = nil
+        viewController = nil
+    }
+
+    func testShowInformativeDialog() {
+        let mockUserDefaults = MockUserDefaults()
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults, on: viewController, animated: false)
+        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        XCTAssertNotNil(viewController.presentedViewController as? FancyAlertViewController)
+    }
+
+    func testShowInformativeDialogNotNecessary() {
+        let mockUserDefaults = MockUserDefaults()
+        mockUserDefaults.set(true, forKey: GutenbergViewController.Const.Key.informativeDialog)
+        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults, on: viewController, animated: false)
+        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
+    }
+}

--- a/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
+++ b/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
@@ -62,49 +62,49 @@ class GutenbergInformativeDialogTests: XCTestCase {
     func testShowInformativeDialogWithUserDefaultsFlagWithGutenbergContent() {
         let post = insertPost()
         post.content = PostContent.gutenberg
-        mockUserDefaults.set(true, forKey: GutenbergViewController.InfoDialog.Key.informativeDialog)
-        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
+        mockUserDefaults.set(true, forKey: GutenbergViewController.InfoDialog.key)
+        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
                                                                  showing: post,
                                                                  on: viewController,
                                                                  animated: false)
-        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
+        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
     }
 
     func testShowInformativeDialogWithNoUserDefaultsFlagWithGutenbergContent() {
         let post = insertPost()
         post.content = PostContent.gutenberg
-        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
                                                                  showing: post,
                                                                  on: viewController,
                                                                  animated: false)
-        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
+        XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         XCTAssertNotNil(viewController.presentedViewController as? FancyAlertViewController)
     }
 
     func testShowInformativeDialogWithNoUserDefaultsFlagWithEmptyContent() {
         let post = insertPost()
         post.content = ""
-        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
                                                                  showing: post,
                                                                  on: viewController,
                                                                  animated: false)
-        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
     }
 
     func testShowInformativeDialogWithNoUserDefaultsFlagWithClassicContent() {
         let post = insertPost()
         post.content = PostContent.classic
-        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
                                                                  showing: post,
                                                                  on: viewController,
                                                                  animated: false)
-        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.Key.informativeDialog))
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
     }
 

--- a/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
+++ b/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
@@ -84,6 +84,18 @@ class GutenbergInformativeDialogTests: XCTestCase {
         XCTAssertNotNil(viewController.presentedViewController as? FancyAlertViewController)
     }
 
+    func testShowInformativeDialogWithNoUserDefaultsFlagWithEmptyContent() {
+        let post = insertPost()
+        post.content = ""
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
+                                                                 showing: post,
+                                                                 on: viewController,
+                                                                 animated: false)
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.Const.Key.informativeDialog))
+        XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
+    }
+
     func testShowInformativeDialogWithNoUserDefaultsFlagWithClassicContent() {
         let post = insertPost()
         post.content = PostContent.classic


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/10869

Also Android side issue has some additional info about the buttons, it turns out we just need a simple OK button for now. https://github.com/wordpress-mobile/WordPress-Android/issues/9034 

<img width="341" alt="screen shot 2019-02-13 at 15 33 18" src="https://user-images.githubusercontent.com/5032900/52716314-8c3b7580-2faf-11e9-84f0-a7390b72c7a6.png">

![informative-dialog](https://user-images.githubusercontent.com/5032900/52729613-8c953a00-2fca-11e9-8a01-103e40746177.gif)

Also the text "Switch to Gutenberg" is updated as "Switch to Block Editor"

<img width="360" alt="screen shot 2019-02-13 at 19 57 08" src="https://user-images.githubusercontent.com/5032900/52729584-7f784b00-2fca-11e9-9147-2a530501c351.png">

**To test**

Test 1 - Verify we don't see the dialog on Classic editor

- Reinstall the app
- Turn on the Gutenberg switch
- Create a post with Classic editor on the Web and close the editor
- Open the post on mobile
- Verify that you do NOT see the informative dialog

Test 2 - Verify we see the dialog on Gutenberg editor(and only once)
- Turn on the Gutenberg switch
- Open a post on mobile that you had created with Gutenberg editor
- Verify that you DO see the informative dialog
-----
- Close the post 
- Open a Gutenberg post again
- Verify that you do NOT see the informative dialog
-----
- Kill and reopen the app
- Open a Gutenberg post
- Verify that you do NOT see the informative dialog

Test 3 - Verify we don't see informative dialog on empty post
- Reinstall the app
- Turn on the Gutenberg switch
- Create a new post
- Verify that you do NOT see the informative dialog


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.