### PR TITLE
Quick Start V2: Local notifications for the next available tour

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -105,7 +105,7 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     [self disableAnimationsForUITests:application];
 
     if ([Feature enabled:FeatureFlagQuickStartV2]) {
-        [QuickStartTourGuide deletePendingLocalNotifications];
+        [[PushNotificationsManager shared] deletePendingLocalNotifications];
     }
 
     return YES;

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -104,6 +104,10 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     [self setupComponentsAppearance];
     [self disableAnimationsForUITests:application];
 
+    if ([Feature enabled:FeatureFlagQuickStartV2]) {
+        [QuickStartTourGuide deletePendingLocalNotifications];
+    }
+
     return YES;
 }
 

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -380,9 +380,7 @@ extension PushNotificationsManager {
                                                      to: Date()) else {
             return
         }
-        let triggerDate = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second],
-                                                          from: futureDate)
-        let trigger = UNCalendarNotificationTrigger(dateMatching: triggerDate, repeats: false)
+        let trigger = UNCalendarNotificationTrigger(dateMatching: futureDate.components, repeats: false)
         let request = UNNotificationRequest(identifier: Constants.localNotificationIdentifier,
                                             content: content,
                                             trigger: trigger)
@@ -399,6 +397,12 @@ extension PushNotificationsManager {
     }
 }
 
+private extension Date {
+    var components: DateComponents {
+        return Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second],
+                                               from: self)
+    }
+}
 
 // MARK: - Nested Types
 //

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -169,7 +169,8 @@ final public class PushNotificationsManager: NSObject {
         let handlers = [ handleSupportNotification,
                          handleAuthenticationNotification,
                          handleInactiveNotification,
-                         handleBackgroundNotification ]
+                         handleBackgroundNotification,
+                         handleQuickStartLocalNotification ]
 
         for handler in handlers {
             if handler(userInfo, completionHandler) {
@@ -332,6 +333,32 @@ extension PushNotificationsManager {
             let result = newData ? UIBackgroundFetchResult.newData : .noData
             completionHandler?(result)
         }
+
+        return true
+    }
+
+    /// Handles a Quick Start Local Notification
+    ///
+    /// - Note: This should actually be *private*. BUT: for unit testing purposes (within ObjC code, because of OCMock),
+    ///         we'll temporarily keep it as public. Sorry.
+    ///
+    /// - Parameters:
+    ///     - userInfo: The Notification's Payload
+    ///     - completionHandler: A callback, to be executed on completion
+    ///
+    /// - Returns: True when handled. False otherwise
+    @objc func handleQuickStartLocalNotification(_ userInfo: NSDictionary, completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Bool {
+        guard let type = userInfo.string(forKey: Notification.typeKey),
+            type == QuickStartTourGuide.Notification.local else {
+                return false
+        }
+
+        if WPTabBarController.sharedInstance()?.presentedViewController != nil {
+            WPTabBarController.sharedInstance()?.dismiss(animated: false)
+        }
+        WPTabBarController.sharedInstance()?.showMySitesTab()
+
+        completionHandler?(.newData)
 
         return true
     }

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -166,11 +166,11 @@ final public class PushNotificationsManager: NSObject {
         }
 
         // Handling!
-        let handlers = [ handleSupportNotification,
-                         handleAuthenticationNotification,
-                         handleInactiveNotification,
-                         handleBackgroundNotification,
-                         handleQuickStartLocalNotification ]
+        let handlers = [handleSupportNotification,
+                        handleAuthenticationNotification,
+                        handleInactiveNotification,
+                        handleBackgroundNotification,
+                        handleQuickStartLocalNotification]
 
         for handler in handlers {
             if handler(userInfo, completionHandler) {

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -730,6 +730,10 @@ static NSInteger HideSearchMinSites = 3;
         RecentSitesService *recentSites = [RecentSitesService new];
         [recentSites touchBlog:blog];
 
+        if (![blog isEqual:self.selectedBlog]) {
+            [QuickStartTourGuide deletePendingLocalNotifications];
+        }
+
         self.selectedBlog = blog;
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -730,8 +730,8 @@ static NSInteger HideSearchMinSites = 3;
         RecentSitesService *recentSites = [RecentSitesService new];
         [recentSites touchBlog:blog];
 
-        if (![blog isEqual:self.selectedBlog]) {
-            [QuickStartTourGuide deletePendingLocalNotifications];
+        if (![blog isEqual:self.selectedBlog] && [Feature enabled:FeatureFlagQuickStartV2]) {
+            [[PushNotificationsManager shared] deletePendingLocalNotifications];
         }
 
         self.selectedBlog = blog;

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -411,6 +411,7 @@ private extension QuickStartTourGuide {
         content.title = nextTour.title
         content.body = nextTour.description
         content.sound = UNNotificationSound.default
+        content.userInfo = [Notification.typeKey: Notification.local]
 
         let interval = BuildConfiguration.current == .localDeveloper ? 30 : Constants.localNotificationInterval
         let triggerDate = Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second],
@@ -432,6 +433,13 @@ private extension QuickStartTourGuide {
         static let suggestionTimeout = 10.0
         static let localNotificationInterval: TimeInterval = 60*60*24*2
         static let localNotificationIdentifier = "QuickStartTourNotificationIdentifier"
+    }
+}
+
+extension QuickStartTourGuide {
+    enum Notification {
+        static let typeKey = "type"
+        static let local = "qs-local-notification"
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -403,7 +403,7 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         service.removeDefaultWordPressComAccount()
 
         // Delete local notification on logout
-        QuickStartTourGuide.deletePendingLocalNotifications()
+        PushNotificationsManager.shared.deletePendingLocalNotifications()
 
         // Also clear the spotlight index
         SearchManager.shared.deleteAllSearchableItems()

--- a/WordPress/Classes/ViewRelated/Me/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/MeViewController.swift
@@ -402,6 +402,9 @@ class MeViewController: UITableViewController, UIViewControllerRestoration {
         let service = AccountService(managedObjectContext: context)
         service.removeDefaultWordPressComAccount()
 
+        // Delete local notification on logout
+        QuickStartTourGuide.deletePendingLocalNotifications()
+
         // Also clear the spotlight index
         SearchManager.shared.deleteAllSearchableItems()
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
@@ -33,14 +33,14 @@ extension FancyAlertViewController {
 
         let notNowButton = ButtonConfig(Strings.notNowText) { controller, _ in
             controller.dismiss(animated: true)
-            QuickStartTourGuide.deletePendingLocalNotifications()
+            PushNotificationsManager.shared.deletePendingLocalNotifications()
             WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "neutral"])
         }
 
         let neverButton = ButtonConfig(Strings.neverText) { controller, _ in
             UserDefaults.standard.quickStartWasDismissedPermanently = true
             controller.dismiss(animated: true)
-            QuickStartTourGuide.deletePendingLocalNotifications()
+            PushNotificationsManager.shared.deletePendingLocalNotifications()
             WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "negative"])
         }
 

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+QuickStart.swift
@@ -33,14 +33,14 @@ extension FancyAlertViewController {
 
         let notNowButton = ButtonConfig(Strings.notNowText) { controller, _ in
             controller.dismiss(animated: true)
-
+            QuickStartTourGuide.deletePendingLocalNotifications()
             WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "neutral"])
         }
 
         let neverButton = ButtonConfig(Strings.neverText) { controller, _ in
             UserDefaults.standard.quickStartWasDismissedPermanently = true
             controller.dismiss(animated: true)
-
+            QuickStartTourGuide.deletePendingLocalNotifications()
             WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "negative"])
         }
 

--- a/WordPress/WordPressTest/PushNotificationsManagerTests.m
+++ b/WordPress/WordPressTest/PushNotificationsManagerTests.m
@@ -76,6 +76,7 @@
     [[mockManager reject] handleSupportNotification:OCMOCK_ANY completionHandler:OCMOCK_ANY];
     [[mockManager reject] handleInactiveNotification:OCMOCK_ANY completionHandler:OCMOCK_ANY];
     [[mockManager reject] handleBackgroundNotification:OCMOCK_ANY completionHandler:OCMOCK_ANY];
+    [[mockManager reject] handleQuickStartLocalNotification:OCMOCK_ANY completionHandler:OCMOCK_ANY];
 #pragma clang diagnostic pop
     
     [mockManager handleNotification:userInfo completionHandler:nil];
@@ -92,7 +93,8 @@
     XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling Zendesk");
     XCTAssertFalse([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling Zendesk");
     XCTAssertFalse([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling Zendesk");
-    
+    XCTAssertFalse([mockManager handleQuickStartLocalNotification:userInfo completionHandler:nil], @"Error handling Zendesk");
+
     OCMExpect([manager handleSupportNotification:userInfo completionHandler:nil]);
     [mockManager handleNotification:userInfo completionHandler:nil];
     OCMVerify(mockManager);
@@ -108,7 +110,8 @@
     XCTAssertFalse([mockManager handleSupportNotification:userInfo completionHandler:nil], @"Error handling PushAuth");
     XCTAssertFalse([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling PushAuth");
     XCTAssertFalse([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling PushAuth");
-    
+    XCTAssertFalse([mockManager handleQuickStartLocalNotification:userInfo completionHandler:nil], @"Error handling PushAuth");
+
     OCMExpect([manager handleAuthenticationNotification:userInfo completionHandler:nil]);
     [mockManager handleNotification:userInfo completionHandler:nil];
     OCMVerify(mockManager);
@@ -130,6 +133,7 @@
     XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling Note");
     XCTAssertFalse([mockManager handleSupportNotification:userInfo completionHandler:nil], @"Error handling Note");
     XCTAssertFalse([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling Note");
+    XCTAssertFalse([mockManager handleQuickStartLocalNotification:userInfo completionHandler:nil], @"Error handling Note");
 
     OCMExpect([manager handleInactiveNotification:userInfo completionHandler:nil]);
     [mockManager handleNotification:userInfo completionHandler:nil];
@@ -153,6 +157,31 @@
     XCTAssertFalse([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling Note");
     XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling Note");
     XCTAssertFalse([mockManager handleSupportNotification:userInfo completionHandler:nil], @"Error handling Note");
+    XCTAssertFalse([mockManager handleQuickStartLocalNotification:userInfo completionHandler:nil], @"Error handling Note");
+
+    OCMExpect([manager handleBackgroundNotification:userInfo completionHandler:nil]);
+    [mockManager handleNotification:userInfo completionHandler:nil];
+    OCMVerify(mockManager);
+}
+
+- (void)testQuickStartLocalNotificationIsProperlyHandled
+{
+    NSDictionary *userInfo = @{ @"type" : @"qs-local-notification" };
+    
+    id mockApplication = OCMPartialMock([UIApplication sharedApplication]);
+    [OCMStub([mockApplication applicationState]) andReturnValue:OCMOCK_VALUE(UIApplicationStateBackground)];
+    
+    PushNotificationsManager *manager = [PushNotificationsManager new];
+    id mockManager = OCMPartialMock(manager);
+    [OCMStub([mockManager sharedApplication]) andReturn:mockApplication];
+    
+    XCTAssert([mockManager applicationState] == UIApplicationStateBackground);
+    
+    XCTAssertTrue([mockManager handleQuickStartLocalNotification:userInfo completionHandler:nil], @"Error handling Quick Start");
+    XCTAssertFalse([mockManager handleInactiveNotification:userInfo completionHandler:nil], @"Error handling Quick Start");
+    XCTAssertFalse([mockManager handleAuthenticationNotification:userInfo completionHandler:nil], @"Error handling Quick Start");
+    XCTAssertFalse([mockManager handleSupportNotification:userInfo completionHandler:nil], @"Error handling Quick Start");
+    XCTAssertFalse([mockManager handleBackgroundNotification:userInfo completionHandler:nil], @"Error handling Quick Start");
     
     OCMExpect([manager handleBackgroundNotification:userInfo completionHandler:nil]);
     [mockManager handleNotification:userInfo completionHandler:nil];


### PR DESCRIPTION
Refs. #10860 

This PR adds the local notification (as reminder for the next available tour) when a tour is completed.

![qs-local-notification](https://user-images.githubusercontent.com/912252/52726838-dd496a80-2fab-11e9-895d-b38dccb67b76.gif)

• Reminder for the next uncompleted task is scheduled to go off in 48 hours after completing a task.
• Completing a task cancels current reminder and schedules a new one.
• Clicking on the notification will open the app even if it was closed and navigate to MySite tab.
• A reminder will not be scheduled when you complete Edit Post task before starting QS.
• A reminder will be canceled on logout.
• A reminder will be canceled on new site creation.
• A reminder will be canceled when you switch active site.

**To Test**:
• create a new site (otherwise the 'create a site' item won't appear) **OR** open a site that previously started (or completed) quick start
• Complete or skip a task then put the app in background. The interval for the `localDeveloper` as _build configuration_ is **30 seconds**.