### PR TITLE
Add new gutenbergDidMount method to delegate

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -94,8 +94,8 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '7139ba29ccccc5eb46691d6152f9494a063bd93c'
-    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '7139ba29ccccc5eb46691d6152f9494a063bd93c'
+    pod 'Gutenberg', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '3aca8d421f234dc7d52790297619322454cdcb03'
+    pod 'RNTAztecView', :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '3aca8d421f234dc7d52790297619322454cdcb03'
 
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -224,7 +224,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `7139ba29ccccc5eb46691d6152f9494a063bd93c`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `3aca8d421f234dc7d52790297619322454cdcb03`)
   - HockeySDK (= 5.1.4)
   - MGSwipeTableCell (= 1.6.8)
   - MRProgress (= 0.8.3)
@@ -239,7 +239,7 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/develop/react-native-gutenberg-bridge/third-party-podspecs/react-native-keyboard-aware-scroll-view.podspec.json`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `7139ba29ccccc5eb46691d6152f9494a063bd93c`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `3aca8d421f234dc7d52790297619322454cdcb03`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -299,7 +299,7 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: 7139ba29ccccc5eb46691d6152f9494a063bd93c
+    :commit: 3aca8d421f234dc7d52790297619322454cdcb03
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
@@ -311,7 +311,7 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 7139ba29ccccc5eb46691d6152f9494a063bd93c
+    :commit: 3aca8d421f234dc7d52790297619322454cdcb03
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -324,13 +324,13 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.3.1
   Gutenberg:
-    :commit: 7139ba29ccccc5eb46691d6152f9494a063bd93c
+    :commit: 3aca8d421f234dc7d52790297619322454cdcb03
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   RNSVG:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: 7139ba29ccccc5eb46691d6152f9494a063bd93c
+    :commit: 3aca8d421f234dc7d52790297619322454cdcb03
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -385,6 +385,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 648a43c01d8075c3fbf6705a5e2793e44d14e0b9
+PODFILE CHECKSUM: 8d95a6d8686cd22fad94d94bef1015291e64cb24
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -389,6 +389,9 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
 
     func gutenbergDidLayout() {
     }
+
+    func gutenbergDidMount(hasUnsupportedBlocks: Bool) {
+    }
 }
 
 // MARK: - GutenbergBridgeDataSource


### PR DESCRIPTION
Adds an empty implementation for the new bridge method introduced in https://github.com/wordpress-mobile/gutenberg-mobile/pull/587

Part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/556

I'll add the actual tracking code in a future PR

To test:

* Set a breakpoint on the new `gutenbergDidMount` method
* Open a Gutenberg post
* Verify the new method gets called and the parameter reflects correctly if the post has unsupported blocks.

