### PR TITLE
Quick Start V2: Fix notice bug

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -8,6 +8,10 @@ extension BlogDetailsViewController {
         observer = NotificationCenter.default.addObserver(forName: .QuickStartTourElementChangedNotification, object: nil, queue: nil) { [weak self] (notification) in
             self?.configureTableViewData()
             self?.reloadTableViewPreservingSelection()
+            if let index = QuickStartTourGuide.find()?.currentElementInt(),
+                let element = QuickStartTourElement(rawValue: index) {
+                self?.scroll(to: element)
+            }
         }
     }
 
@@ -64,14 +68,7 @@ extension BlogDetailsViewController {
 
     private func showQuickStart(with type: QuickStartType? = nil) {
         if let type = type, Feature.enabled(.quickStartV2) {
-            let checklist = QuickStartChecklistViewController(blog: blog, type: type) { [unowned self] tour in
-                DispatchQueue.main.async {
-                    if let tourGuide = QuickStartTourGuide.find() {
-                        tourGuide.start(tour: tour, for: self.blog)
-                        self.scrollToElementBlock()
-                    }
-                }
-            }
+            let checklist = QuickStartChecklistViewController(blog: blog, type: type)
             let navigationViewController = UINavigationController(rootViewController: checklist)
             present(navigationViewController, animated: true, completion: nil)
         } else {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -9,7 +9,8 @@ extension BlogDetailsViewController {
             self?.configureTableViewData()
             self?.reloadTableViewPreservingSelection()
             if let index = QuickStartTourGuide.find()?.currentElementInt(),
-                let element = QuickStartTourElement(rawValue: index) {
+                let element = QuickStartTourElement(rawValue: index),
+                Feature.enabled(.quickStartV2) {
                 self?.scroll(to: element)
             }
         }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -64,7 +64,14 @@ extension BlogDetailsViewController {
 
     private func showQuickStart(with type: QuickStartType? = nil) {
         if let type = type, Feature.enabled(.quickStartV2) {
-            let checklist = QuickStartChecklistViewController(blog: blog, type: type)
+            let checklist = QuickStartChecklistViewController(blog: blog, type: type) { [unowned self] tour in
+                DispatchQueue.main.async {
+                    if let tourGuide = QuickStartTourGuide.find() {
+                        tourGuide.start(tour: tour, for: self.blog)
+                        self.scrollToElementBlock()
+                    }
+                }
+            }
             let navigationViewController = UINavigationController(rootViewController: checklist)
             present(navigationViewController, animated: true, completion: nil)
         } else {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
@@ -87,6 +87,7 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
 }
 
 @property (nonatomic, strong, nonnull) Blog * blog;
+@property (nonatomic, copy, readonly, nonnull) void (^scrollToElementBlock)(void);
 
 - (void)showDetailViewForSubsection:(BlogDetailsSubsection)section;
 - (void)reloadTableViewPreservingSelection;

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
@@ -87,9 +87,9 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
 }
 
 @property (nonatomic, strong, nonnull) Blog * blog;
-@property (nonatomic, copy, readonly, nonnull) void (^scrollToElementBlock)(void);
 
 - (void)showDetailViewForSubsection:(BlogDetailsSubsection)section;
 - (void)reloadTableViewPreservingSelection;
 - (void)configureTableViewData;
+- (void)scrollToElement:(QuickStartTourElement)element;
 @end

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -287,6 +287,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [super viewDidAppear:animated];
     [self createUserActivity];
     [self startAlertTimer];
+
+    if (![Feature enabled:FeatureFlagQuickStartV2]) {
+        [self scrollToElement:[[QuickStartTourGuide find] currentElementInt]];
+    }
 }
 
 - (void)viewWillDisappear:(BOOL)animated

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -124,7 +124,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 @property (nonatomic, strong) BlogService *blogService;
 @property (nonatomic, strong) SiteIconPickerPresenter *siteIconPickerPresenter;
 @property (nonatomic, strong) ImageCropViewController *imageCropViewController;
-@property (nonatomic, copy) void (^scrollToElementBlock)(void);
 
 /// Used to restore the tableview selection during state restoration, and
 /// also when switching between a collapsed and expanded split view controller presentation
@@ -288,12 +287,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [super viewDidAppear:animated];
     [self createUserActivity];
     [self startAlertTimer];
-
-    __typeof(self) weakSelf = self;
-    self.scrollToElementBlock = ^{
-        [weakSelf scrollToElement:[[QuickStartTourGuide find] currentElementInt]];
-    };
-    self.scrollToElementBlock();
 }
 
 - (void)viewWillDisappear:(BOOL)animated

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -124,6 +124,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 @property (nonatomic, strong) BlogService *blogService;
 @property (nonatomic, strong) SiteIconPickerPresenter *siteIconPickerPresenter;
 @property (nonatomic, strong) ImageCropViewController *imageCropViewController;
+@property (nonatomic, copy) void (^scrollToElementBlock)(void);
 
 /// Used to restore the tableview selection during state restoration, and
 /// also when switching between a collapsed and expanded split view controller presentation
@@ -288,7 +289,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self createUserActivity];
     [self startAlertTimer];
 
-    [self scrollToElement:[[QuickStartTourGuide find] currentElementInt]];
+    __typeof(self) weakSelf = self;
+    self.scrollToElementBlock = ^{
+        [weakSelf scrollToElement:[[QuickStartTourGuide find] currentElementInt]];
+    };
+    self.scrollToElementBlock();
 }
 
 - (void)viewWillDisappear:(BOOL)animated

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
@@ -1,5 +1,5 @@
 class QuickStartChecklistManager: NSObject {
-    typealias QuickStartChecklistDidSelectTour = (String) -> Void
+    typealias QuickStartChecklistDidSelectTour = (QuickStartTour) -> Void
     typealias QuickStartChecklistDidTapHeader = (Bool) -> Void
 
     private var blog: Blog
@@ -70,13 +70,8 @@ extension QuickStartChecklistManager: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let tourGuide = QuickStartTourGuide.find() else {
-                return
-        }
-
         let tour = self.tour(at: indexPath)
-        tourGuide.start(tour: tour, for: blog)
-        didSelectTour(tour.analyticsKey)
+        didSelectTour(tour)
     }
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -6,9 +6,6 @@ import Gridicons
 }
 
 class QuickStartChecklistViewController: UITableViewController {
-    typealias QuickStartChecklistDidDismiss = (QuickStartTour) -> Void
-
-    private var didDismiss: QuickStartChecklistDidDismiss
     private var blog: Blog
     private var type: QuickStartType
     private var observer: NSObjectProtocol?
@@ -58,10 +55,9 @@ class QuickStartChecklistViewController: UITableViewController {
         return UIBarButtonItem(customView: cancelButton)
     }()
 
-    init(blog: Blog, type: QuickStartType, viewController didDismiss: @escaping QuickStartChecklistDidDismiss) {
+    init(blog: Blog, type: QuickStartType) {
         self.blog = blog
         self.type = type
-        self.didDismiss = didDismiss
         super.init(style: .plain)
         startObservingForQuickStart()
     }
@@ -84,7 +80,10 @@ class QuickStartChecklistViewController: UITableViewController {
             DispatchQueue.main.async {
                 WPAnalytics.track(.quickStartChecklistItemTapped, withProperties: ["task_name": tour.analyticsKey])
                 self?.dismiss(animated: true) {
-                    self?.didDismiss(tour)
+                    if let blog = self?.blog,
+                        let tourGuide = QuickStartTourGuide.find() {
+                        tourGuide.start(tour: tour, for: blog)
+                    }
                 }
             }
         }, didTapHeader: { [weak self] collapse in


### PR DESCRIPTION
Refs. #10860 

This PR fix a bug introduced changing the checklist presentation style. After the checklist is dismissed the notice doesn't appear correctly. It appears over the tab bar.

![image](https://user-images.githubusercontent.com/912252/52739325-8ef69480-2fc8-11e9-9e35-9eb178d1f27c.png)

To fix it the selected tour starts after the checklist is definitely dismissed.

**To Test:**
• Open a qs checklist and select a tour
• The notice won't be displayed over the tab bar anymore