### PR TITLE
Quick Start v2: Add Ellipsis Menu

### DIFF
--- a/WordPress/Classes/Models/Blog+QuickStart.swift
+++ b/WordPress/Classes/Models/Blog+QuickStart.swift
@@ -25,7 +25,7 @@ extension Blog {
         ContextManager.sharedInstance().saveContextAndWait(context)
     }
 
-    public func removeAllTours(onError: (NSError) -> ()) {
+    public func removeAllTours() {
         guard let quickStartTours = quickStartTours else {
             return
         }

--- a/WordPress/Classes/Models/Blog+QuickStart.swift
+++ b/WordPress/Classes/Models/Blog+QuickStart.swift
@@ -32,7 +32,7 @@ extension Blog {
 
         let context = managedObjectContext ?? ContextManager.sharedInstance().mainContext
 
-        quickStartTours.map {
+        quickStartTours.forEach {
             context.delete($0)
         }
         ContextManager.sharedInstance().saveContextAndWait(context)

--- a/WordPress/Classes/Models/Blog+QuickStart.swift
+++ b/WordPress/Classes/Models/Blog+QuickStart.swift
@@ -25,6 +25,19 @@ extension Blog {
         ContextManager.sharedInstance().saveContextAndWait(context)
     }
 
+    public func removeAllTours(onError: (NSError) -> ()) {
+        guard let quickStartTours = quickStartTours else {
+            return
+        }
+
+        let context = managedObjectContext ?? ContextManager.sharedInstance().mainContext
+
+        quickStartTours.map {
+            context.delete($0)
+        }
+        ContextManager.sharedInstance().saveContextAndWait(context)
+    }
+
     public func tourState(for tourID: String) -> QuickStartTourState? {
         return quickStartTours?.filter { $0.tourID == tourID }.first
     }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.swift
@@ -1,19 +1,14 @@
 import Gridicons
 
-class BlogDetailsSectionHeaderView: UIView {
+class BlogDetailsSectionHeaderView: UITableViewHeaderFooterView {
     typealias EllipsisCallback = () -> Void
 
-    @IBOutlet private var titleLabel: UILabel?
     @IBOutlet private var ellipsisButton: UIButton? {
         didSet {
             ellipsisButton?.setImage(Gridicon.iconOfType(.ellipsis).imageWithTintColor(WPStyleGuide.grey()), for: .normal)
         }
     }
-    @objc var title: String = "" {
-        didSet {
-            titleLabel?.text = title.uppercased()
-        }
-    }
+
     @objc var callback: EllipsisCallback?
 
     @IBAction func ellipsisTapped() {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.swift
@@ -1,0 +1,22 @@
+import Gridicons
+
+class BlogDetailsSectionHeaderView: UIView {
+    typealias EllipsisCallback = () -> Void
+
+    @IBOutlet private var titleLabel: UILabel?
+    @IBOutlet private var ellipsisButton: UIButton? {
+        didSet {
+            ellipsisButton?.setImage(Gridicon.iconOfType(.ellipsis).imageWithTintColor(WPStyleGuide.grey()), for: .normal)
+        }
+    }
+    @objc var title: String = "" {
+        didSet {
+            titleLabel?.text = title.uppercased()
+        }
+    }
+    @objc var callback: EllipsisCallback?
+
+    @IBAction func ellipsisTapped() {
+        callback?()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.xib
@@ -23,7 +23,7 @@
                     <nil key="highlightedColor"/>
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OEo-2z-Cmk">
-                    <rect key="frame" x="260" y="8" width="44" height="32"/>
+                    <rect key="frame" x="273" y="8" width="44" height="32"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="44" id="NQj-8B-nY9"/>
                     </constraints>
@@ -36,7 +36,7 @@
             <constraints>
                 <constraint firstItem="OEo-2z-Cmk" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="topMargin" id="0ab-DS-gfb"/>
                 <constraint firstAttribute="trailingMargin" secondItem="T0w-kY-8uW" secondAttribute="trailing" priority="999" id="DfH-Qk-uHM"/>
-                <constraint firstAttribute="trailingMargin" secondItem="OEo-2z-Cmk" secondAttribute="trailing" id="EWN-SE-Ilb"/>
+                <constraint firstAttribute="trailingMargin" secondItem="OEo-2z-Cmk" secondAttribute="trailing" constant="-13" id="EWN-SE-Ilb"/>
                 <constraint firstAttribute="trailing" secondItem="T0w-kY-8uW" secondAttribute="trailingMargin" constant="16" id="UYn-hJ-O0G"/>
                 <constraint firstAttribute="bottom" secondItem="OEo-2z-Cmk" secondAttribute="bottom" id="a35-Lf-TpM"/>
                 <constraint firstAttribute="bottom" secondItem="T0w-kY-8uW" secondAttribute="bottom" constant="3" id="bEL-Gi-2rw"/>

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.xib
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" customClass="BlogDetailsSectionHeaderView" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DATE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T0w-kY-8uW">
+                    <rect key="frame" x="16" y="13" width="296" height="24"/>
+                    <color key="backgroundColor" red="0.91372549020000005" green="0.93725490199999995" blue="0.95294117649999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                    <color key="textColor" red="0.30980392156862746" green="0.45490196078431372" blue="0.55686274509803924" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OEo-2z-Cmk">
+                    <rect key="frame" x="260" y="8" width="44" height="32"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="44" id="NQj-8B-nY9"/>
+                    </constraints>
+                    <connections>
+                        <action selector="ellipsisTapped" destination="iN0-l3-epB" eventType="touchUpInside" id="39J-kD-m13"/>
+                    </connections>
+                </button>
+            </subviews>
+            <color key="backgroundColor" red="0.9137254901960784" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <constraints>
+                <constraint firstItem="OEo-2z-Cmk" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="topMargin" id="0ab-DS-gfb"/>
+                <constraint firstAttribute="trailingMargin" secondItem="T0w-kY-8uW" secondAttribute="trailing" priority="999" id="DfH-Qk-uHM"/>
+                <constraint firstAttribute="trailingMargin" secondItem="OEo-2z-Cmk" secondAttribute="trailing" id="EWN-SE-Ilb"/>
+                <constraint firstAttribute="trailing" secondItem="T0w-kY-8uW" secondAttribute="trailingMargin" constant="16" id="UYn-hJ-O0G"/>
+                <constraint firstAttribute="bottom" secondItem="OEo-2z-Cmk" secondAttribute="bottom" id="a35-Lf-TpM"/>
+                <constraint firstAttribute="bottom" secondItem="T0w-kY-8uW" secondAttribute="bottom" constant="3" id="bEL-Gi-2rw"/>
+                <constraint firstItem="T0w-kY-8uW" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" id="eA8-WK-DnH"/>
+                <constraint firstItem="T0w-kY-8uW" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="13" id="p5g-Am-UlJ"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="ellipsisButton" destination="OEo-2z-Cmk" id="8N1-SW-wiK"/>
+                <outlet property="titleLabel" destination="T0w-kY-8uW" id="K25-0x-Mm9"/>
+            </connections>
+            <point key="canvasLocation" x="235" y="185"/>
+        </view>
+    </objects>
+</document>

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.xib
@@ -12,20 +12,14 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" id="iN0-l3-epB" customClass="BlogDetailsSectionHeaderView" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="40"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="36"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DATE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T0w-kY-8uW">
-                    <rect key="frame" x="16" y="13" width="296" height="24"/>
-                    <color key="backgroundColor" red="0.91372549020000005" green="0.93725490199999995" blue="0.95294117649999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                    <color key="textColor" red="0.30980392156862746" green="0.45490196078431372" blue="0.55686274509803924" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <nil key="highlightedColor"/>
-                </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="OEo-2z-Cmk">
-                    <rect key="frame" x="273" y="8" width="44" height="32"/>
+                    <rect key="frame" x="273" y="6" width="44" height="30"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="44" id="NQj-8B-nY9"/>
+                        <constraint firstAttribute="height" constant="30" id="j12-ha-Xlw"/>
                     </constraints>
                     <connections>
                         <action selector="ellipsisTapped" destination="iN0-l3-epB" eventType="touchUpInside" id="39J-kD-m13"/>
@@ -34,14 +28,8 @@
             </subviews>
             <color key="backgroundColor" red="0.9137254901960784" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="OEo-2z-Cmk" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="topMargin" id="0ab-DS-gfb"/>
-                <constraint firstAttribute="trailingMargin" secondItem="T0w-kY-8uW" secondAttribute="trailing" priority="999" id="DfH-Qk-uHM"/>
                 <constraint firstAttribute="trailingMargin" secondItem="OEo-2z-Cmk" secondAttribute="trailing" constant="-13" id="EWN-SE-Ilb"/>
-                <constraint firstAttribute="trailing" secondItem="T0w-kY-8uW" secondAttribute="trailingMargin" constant="16" id="UYn-hJ-O0G"/>
                 <constraint firstAttribute="bottom" secondItem="OEo-2z-Cmk" secondAttribute="bottom" id="a35-Lf-TpM"/>
-                <constraint firstAttribute="bottom" secondItem="T0w-kY-8uW" secondAttribute="bottom" constant="3" id="bEL-Gi-2rw"/>
-                <constraint firstItem="T0w-kY-8uW" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leadingMargin" id="eA8-WK-DnH"/>
-                <constraint firstItem="T0w-kY-8uW" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="13" id="p5g-Am-UlJ"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>
@@ -49,9 +37,8 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="ellipsisButton" destination="OEo-2z-Cmk" id="8N1-SW-wiK"/>
-                <outlet property="titleLabel" destination="T0w-kY-8uW" id="K25-0x-Mm9"/>
             </connections>
-            <point key="canvasLocation" x="235" y="185"/>
+            <point key="canvasLocation" x="233.59999999999999" y="186.65667166416793"/>
         </view>
     </objects>
 </document>

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -102,7 +102,7 @@ extension BlogDetailsViewController {
             growRow.quickStartTitleState = growDetailCount == QuickStartTourGuide.growListTours.count ? .completed : .growIncomplete
         }
 
-        let sectionTitle = NSLocalizedString("Quick Start", comment: "Table view title for the quick start section.")
+        let sectionTitle = NSLocalizedString("Next Steps", comment: "Table view title for the quick start section.")
         let section = BlogDetailsSection(title: sectionTitle, andRows: [customizeRow, growRow])
         section.showQuickStartMenu = true
         return section

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -85,9 +85,9 @@ extension BlogDetailsViewController {
                                             self?.showQuickStartCustomize()
         }
         customizeRow.quickStartIdentifier = .checklist
-        if let customizeDetailCounts = QuickStartTourGuide.find()?.completionCount(of: QuickStartTourGuide.customizeListTours, for: blog) {
-            customizeRow.detail = String(format: detailFormatStr, customizeDetailCounts.complete, customizeDetailCounts.total)
-            customizeRow.quickStartTitleState = customizeDetailCounts.complete == customizeDetailCounts.total ? .completed : .customizeIncomplete
+        if let customizeDetailCount = QuickStartTourGuide.find()?.countChecklistCompleted(in: QuickStartTourGuide.customizeListTours, for: blog) {
+            customizeRow.detail = String(format: detailFormatStr, customizeDetailCount, QuickStartTourGuide.customizeListTours.count)
+            customizeRow.quickStartTitleState = customizeDetailCount == QuickStartTourGuide.customizeListTours.count ? .completed : .customizeIncomplete
         }
 
         let growRow = BlogDetailsRow(title: NSLocalizedString("Grow Your Audience", comment: "Name of the Quick Start list that guides users through a few tasks to customize their new website."),
@@ -97,9 +97,9 @@ extension BlogDetailsViewController {
                                             self?.showQuickStartGrow()
                                         }
         growRow.quickStartIdentifier = .checklist
-        if let growDetailCounts = QuickStartTourGuide.find()?.completionCount(of: QuickStartTourGuide.growListTours, for: blog) {
-            growRow.detail = String(format: detailFormatStr, growDetailCounts.complete, growDetailCounts.total)
-            growRow.quickStartTitleState = growDetailCounts.complete == growDetailCounts.total ? .completed : .growIncomplete
+        if let growDetailCount = QuickStartTourGuide.find()?.countChecklistCompleted(in: QuickStartTourGuide.growListTours, for: blog) {
+            growRow.detail = String(format: detailFormatStr, growDetailCount, QuickStartTourGuide.growListTours.count)
+            growRow.quickStartTitleState = growDetailCount == QuickStartTourGuide.growListTours.count ? .completed : .growIncomplete
         }
 
         let sectionTitle = NSLocalizedString("Quick Start", comment: "Table view title for the quick start section.")

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -103,7 +103,9 @@ extension BlogDetailsViewController {
         }
 
         let sectionTitle = NSLocalizedString("Quick Start", comment: "Table view title for the quick start section.")
-        return BlogDetailsSection(title: sectionTitle, andRows: [customizeRow, growRow])
+        let section = BlogDetailsSection(title: sectionTitle, andRows: [customizeRow, growRow])
+        section.showQuickStartMenu = true
+        return section
     }
 
     private func showNotificationPrimerAlert() {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.h
@@ -53,6 +53,7 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
 
 @property (nonatomic, strong, nonnull) NSString *title;
 @property (nonatomic, strong, nonnull) NSArray *rows;
+@property (nonatomic) BOOL showQuickStartMenu;
 
 - (instancetype _Nonnull)initWithTitle:(NSString * __nonnull)title andRows:(NSArray * __nonnull)rows;
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1029,8 +1029,28 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)sectionNum {
     BlogDetailsSection *section = [self.tableSections objectAtIndex:sectionNum];
     if (section.showQuickStartMenu) {
-        PageListSectionHeaderView *view = [[[NSBundle mainBundle] loadNibNamed:[PageListSectionHeaderView classNameWithoutNamespaces] owner:nil options:nil] firstObject];
-        [view setTite:@"TEST"];
+        NSString *removeTitle = NSLocalizedString(@"Remove Next Steps", @"Title for action that will remove the next steps/quick start menus.");
+        NSString *removeMessage = NSLocalizedString(@"Removing Next Steps will hide all tours on this site. This action cannot be undone.", @"Explanation of what will happen if the user confirms this alert.");
+        NSString *confirmationTitle = NSLocalizedString(@"Remove", @"Title for button that will confirm removing the next steps/quick start menus.");
+        NSString *cancelTitle = NSLocalizedString(@"Cancel", @"Cancel button");
+
+        UIAlertController *removeConfirmation = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleAlert];
+        [removeConfirmation addCancelActionWithTitle:cancelTitle handler:nil];
+        [removeConfirmation addDefaultActionWithTitle:confirmationTitle handler:^(UIAlertAction * _Nonnull action) {
+            // do the remove
+        }];
+
+        UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+        [removeSheet addDestructiveActionWithTitle:removeTitle handler:^(UIAlertAction * _Nonnull action) {
+            [self presentViewController:removeConfirmation animated:YES completion:nil];
+        }];
+        [removeSheet addCancelActionWithTitle:cancelTitle handler:nil];
+
+        BlogDetailsSectionHeaderView *view = [[[NSBundle mainBundle] loadNibNamed:[BlogDetailsSectionHeaderView classNameWithoutNamespaces] owner:nil options:nil] firstObject];
+        [view setTitle:section.title];
+        view.callback = ^{
+            [self presentViewController:removeSheet animated:YES completion:nil];
+        };
         return view;
     } else {
         return [super tableView:tableView viewForHeaderInSection:sectionNum];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1029,32 +1029,37 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)sectionNum {
     BlogDetailsSection *section = [self.tableSections objectAtIndex:sectionNum];
     if (section.showQuickStartMenu) {
-        NSString *removeTitle = NSLocalizedString(@"Remove Next Steps", @"Title for action that will remove the next steps/quick start menus.");
-        NSString *removeMessage = NSLocalizedString(@"Removing Next Steps will hide all tours on this site. This action cannot be undone.", @"Explanation of what will happen if the user confirms this alert.");
-        NSString *confirmationTitle = NSLocalizedString(@"Remove", @"Title for button that will confirm removing the next steps/quick start menus.");
-        NSString *cancelTitle = NSLocalizedString(@"Cancel", @"Cancel button");
-
-        UIAlertController *removeConfirmation = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleAlert];
-        [removeConfirmation addCancelActionWithTitle:cancelTitle handler:nil];
-        [removeConfirmation addDefaultActionWithTitle:confirmationTitle handler:^(UIAlertAction * _Nonnull action) {
-            [[QuickStartTourGuide find] removeFrom:self.blog];
-        }];
-
-        UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
-        [removeSheet addDestructiveActionWithTitle:removeTitle handler:^(UIAlertAction * _Nonnull action) {
-            [self presentViewController:removeConfirmation animated:YES completion:nil];
-        }];
-        [removeSheet addCancelActionWithTitle:cancelTitle handler:nil];
-
-        BlogDetailsSectionHeaderView *view = [[[NSBundle mainBundle] loadNibNamed:[BlogDetailsSectionHeaderView classNameWithoutNamespaces] owner:nil options:nil] firstObject];
-        [view setTitle:section.title];
-        view.callback = ^{
-            [self presentViewController:removeSheet animated:YES completion:nil];
-        };
-        return view;
+        return [self quickStartHeaderWithTitle:section.title];
     } else {
         return [super tableView:tableView viewForHeaderInSection:sectionNum];
     }
+}
+
+- (UIView *)quickStartHeaderWithTitle:(NSString *)title
+{
+    NSString *removeTitle = NSLocalizedString(@"Remove Next Steps", @"Title for action that will remove the next steps/quick start menus.");
+    NSString *removeMessage = NSLocalizedString(@"Removing Next Steps will hide all tours on this site. This action cannot be undone.", @"Explanation of what will happen if the user confirms this alert.");
+    NSString *confirmationTitle = NSLocalizedString(@"Remove", @"Title for button that will confirm removing the next steps/quick start menus.");
+    NSString *cancelTitle = NSLocalizedString(@"Cancel", @"Cancel button");
+
+    UIAlertController *removeConfirmation = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleAlert];
+    [removeConfirmation addCancelActionWithTitle:cancelTitle handler:nil];
+    [removeConfirmation addDefaultActionWithTitle:confirmationTitle handler:^(UIAlertAction * _Nonnull action) {
+        [[QuickStartTourGuide find] removeFrom:self.blog];
+    }];
+
+    UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    [removeSheet addDestructiveActionWithTitle:removeTitle handler:^(UIAlertAction * _Nonnull action) {
+        [self presentViewController:removeConfirmation animated:YES completion:nil];
+    }];
+    [removeSheet addCancelActionWithTitle:cancelTitle handler:nil];
+
+    BlogDetailsSectionHeaderView *view = [[[NSBundle mainBundle] loadNibNamed:[BlogDetailsSectionHeaderView classNameWithoutNamespaces] owner:nil options:nil] firstObject];
+    [view setTitle:title];
+    view.callback = ^{
+        [self presentViewController:removeSheet animated:YES completion:nil];
+    };
+    return view;
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -532,7 +532,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     NSMutableArray *rows = [NSMutableArray array];
 
     if ([self shouldShowQuickStartChecklist] && ![Feature enabled:FeatureFlagQuickStartV2]) {
-        BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Quick Start", @"Name of the Quick Start feature that guides users through a few tasks to setup their new website.")
+        BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Next Steps", @"Name of the Quick Start feature that guides users through a few tasks to setup their new website.")
                                                          identifier:BlogDetailsPlanCellIdentifier
                                                               image:[Gridicon iconOfType:GridiconTypeListCheckmark]
                                                            callback:^{

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1037,7 +1037,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         UIAlertController *removeConfirmation = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleAlert];
         [removeConfirmation addCancelActionWithTitle:cancelTitle handler:nil];
         [removeConfirmation addDefaultActionWithTitle:confirmationTitle handler:^(UIAlertAction * _Nonnull action) {
-            // do the remove
+            [[QuickStartTourGuide find] removeFrom:self.blog];
         }];
 
         UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
@@ -1447,16 +1447,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     NSSet *updatedObjects = note.userInfo[NSUpdatedObjectsKey];
     if ([updatedObjects containsObject:self.blog] || [updatedObjects containsObject:self.blog.settings]) {
         self.navigationItem.title = self.blog.settings.name;
-        if ([self shouldShowQuickStartChecklist]) {
-            [self configureTableViewData];
-            NSUInteger generalSectionCountAfter = self.tableSections[0].rows.count;
-            if (generalSectionCountBefore != generalSectionCountAfter) {
-                // quick start was just enabled
-                if ([Feature enabled:FeatureFlagQuickStartV2]) {
-                    [self showQuickStartCustomize];
-                } else {
-                    [self showQuickStartV1];
-                }
+        [self configureTableViewData];
+        NSUInteger generalSectionCountAfter = self.tableSections[0].rows.count;
+        // quick start was just enabled
+        if (generalSectionCountBefore != generalSectionCountAfter && [self shouldShowQuickStartChecklist]) {
+            if ([Feature enabled:FeatureFlagQuickStartV2]) {
+                [self showQuickStartCustomize];
+            } else {
+                [self showQuickStartV1];
             }
         }
         [self reloadTableViewPreservingSelection];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1026,6 +1026,17 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     return detailSection.title;
 }
 
+- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)sectionNum {
+    BlogDetailsSection *section = [self.tableSections objectAtIndex:sectionNum];
+    if (section.showQuickStartMenu) {
+        PageListSectionHeaderView *view = [[[NSBundle mainBundle] loadNibNamed:[PageListSectionHeaderView classNameWithoutNamespaces] owner:nil options:nil] firstObject];
+        [view setTite:@"TEST"];
+        return view;
+    } else {
+        return [super tableView:tableView viewForHeaderInSection:sectionNum];
+    }
+}
+
 - (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
 {
     [WPStyleGuide configureTableViewSectionHeader:view];

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartListTitleCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartListTitleCell.swift
@@ -27,6 +27,19 @@ class QuickStartListTitleCell: UITableViewCell {
     override func layoutSubviews() {
         super.layoutSubviews()
         refreshIconColor()
+        refreshTitleLabel()
+    }
+
+    private func refreshTitleLabel() {
+        guard let label = titleLabel,
+            let text = label.text else {
+                return
+        }
+
+        if state == .completed {
+            label.textColor = WPStyleGuide.grey()
+            label.attributedText = NSAttributedString(string: text, attributes: [NSAttributedString.Key.strikethroughStyle: NSUnderlineStyle.single.rawValue])
+        }
     }
 
     private func refreshIconColor() {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -24,7 +24,7 @@ open class QuickStartTourGuide: NSObject {
 
     @objc func remove(from blog: Blog) {
         blog.removeAllTours { (error) in
-            // TODO: handle error
+            DDLogError("Error: couldn't remove quick start from \(String(describing: blog)) with error \(error.description)")
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -44,12 +44,6 @@ open class QuickStartTourGuide: NSObject {
         return "\(completedCount)/\(totalCount)"
     }
 
-    func completionCount(of list: [QuickStartTour], for blog: Blog) -> (complete: Int, total: Int) {
-        let completedCount = countChecklistCompleted(in: list, for: blog)
-        let totalCount = list.count
-        return (complete: completedCount, total: totalCount)
-    }
-
     /// Provides a tour to suggest to the user
     ///
     /// - Parameter blog: The Blog for which to suggest a tour.
@@ -321,10 +315,14 @@ private extension QuickStartTourGuide {
     }
 
     func allToursCompleted(for blog: Blog) -> Bool {
-        // TODO: this needs to become a argument to deal with multiple lists
-        let list = QuickStartTourGuide.checklistTours
+        let list: [QuickStartTour]
+        if Feature.enabled(.quickStartV2) {
+            list = QuickStartTourGuide.customizeListTours + QuickStartTourGuide.growListTours
+        } else {
+            list = QuickStartTourGuide.checklistTours
+        }
 
-        return countChecklistCompleted(in: list, for: blog) >= QuickStartTourGuide.checklistTours.count
+        return countChecklistCompleted(in: list, for: blog) >= list.count
     }
 
     func showCurrentStep() {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -22,6 +22,12 @@ open class QuickStartTourGuide: NSObject {
         completed(tour: createTour, for: blog)
     }
 
+    @objc func remove(from blog: Blog) {
+        blog.removeAllTours { (error) in
+            // TODO: handle error
+        }
+    }
+
     @objc static func shouldShowChecklist(for blog: Blog) -> Bool {
         let list: [QuickStartTour]
         if Feature.enabled(.quickStartV2) {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -23,9 +23,7 @@ open class QuickStartTourGuide: NSObject {
     }
 
     @objc func remove(from blog: Blog) {
-        blog.removeAllTours { (error) in
-            DDLogError("Error: couldn't remove quick start from \(String(describing: blog)) with error \(error.description)")
-        }
+        blog.removeAllTours()
     }
 
     @objc static func shouldShowChecklist(for blog: Blog) -> Bool {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -23,17 +23,26 @@ open class QuickStartTourGuide: NSObject {
     }
 
     @objc static func shouldShowChecklist(for blog: Blog) -> Bool {
-        // TODO: this needs to become a argument to deal with multiple lists
-        let list = checklistTours
+        let list: [QuickStartTour]
+        if Feature.enabled(.quickStartV2) {
+            list = QuickStartTourGuide.customizeListTours + QuickStartTourGuide.growListTours
+        } else {
+            list = QuickStartTourGuide.checklistTours
+        }
 
         let checklistCompletedCount = countChecklistCompleted(in: list, for: blog)
         let completedIDs = blog.completedQuickStartTours?.map { $0.tourID } ?? []
-
         let quickStartIsEnabled = checklistCompletedCount > 0
-        let checklistIsUnfinished = checklistCompletedCount < QuickStartTourGuide.checklistTours.count
-        let congratulationsShown = completedIDs.contains(QuickStartCongratulationsTour().key)
 
-        return quickStartIsEnabled && (checklistIsUnfinished || !congratulationsShown)
+        if Feature.enabled(.quickStartV2) {
+            // in QSv2 the checklists appear even after completion
+            return quickStartIsEnabled
+        } else {
+            let checklistIsUnfinished = checklistCompletedCount < QuickStartTourGuide.checklistTours.count
+            let congratulationsShown = completedIDs.contains(QuickStartCongratulationsTour().key)
+
+            return quickStartIsEnabled && (checklistIsUnfinished || !congratulationsShown)
+        }
     }
 
     /// Note: this is only used for QS v1, and can be removed once the feature flag

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -272,6 +272,8 @@
 		4349B0AC218A45270034118A /* RevisionsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4349B0AB218A45270034118A /* RevisionsTableViewController.swift */; };
 		4349B0AF218A477F0034118A /* RevisionsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4349B0AD218A477F0034118A /* RevisionsTableViewCell.swift */; };
 		4349B0B0218A477F0034118A /* RevisionsTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4349B0AE218A477F0034118A /* RevisionsTableViewCell.xib */; };
+		4349BFF5221205540084F200 /* BlogDetailsSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4349BFF4221205540084F200 /* BlogDetailsSectionHeaderView.xib */; };
+		4349BFF7221205740084F200 /* BlogDetailsSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4349BFF6221205740084F200 /* BlogDetailsSectionHeaderView.swift */; };
 		435035971EDCAB99004ECF47 /* jetpack.json in Resources */ = {isa = PBXBuildFile; fileRef = 435035921EDCAB99004ECF47 /* jetpack.json */; };
 		435035981EDCAB99004ECF47 /* notifications.json in Resources */ = {isa = PBXBuildFile; fileRef = 435035931EDCAB99004ECF47 /* notifications.json */; };
 		435035991EDCAB99004ECF47 /* post.json in Resources */ = {isa = PBXBuildFile; fileRef = 435035941EDCAB99004ECF47 /* post.json */; };
@@ -2080,6 +2082,8 @@
 		4349B0AB218A45270034118A /* RevisionsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevisionsTableViewController.swift; sourceTree = "<group>"; };
 		4349B0AD218A477F0034118A /* RevisionsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevisionsTableViewCell.swift; sourceTree = "<group>"; };
 		4349B0AE218A477F0034118A /* RevisionsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RevisionsTableViewCell.xib; sourceTree = "<group>"; };
+		4349BFF4221205540084F200 /* BlogDetailsSectionHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BlogDetailsSectionHeaderView.xib; sourceTree = "<group>"; };
+		4349BFF6221205740084F200 /* BlogDetailsSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDetailsSectionHeaderView.swift; sourceTree = "<group>"; };
 		435035921EDCAB99004ECF47 /* jetpack.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = jetpack.json; sourceTree = "<group>"; };
 		435035931EDCAB99004ECF47 /* notifications.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = notifications.json; sourceTree = "<group>"; };
 		435035941EDCAB99004ECF47 /* post.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = post.json; sourceTree = "<group>"; };
@@ -6440,6 +6444,7 @@
 				462F4E0718369F0B0028D2F8 /* BlogDetailsViewController.m */,
 				435D10192130C2AB00BB2AA8 /* BlogDetailsViewController+FancyAlerts.swift */,
 				74989B8B2088E3650054290B /* BlogDetailsViewController+Activity.swift */,
+				4349BFF4221205540084F200 /* BlogDetailsSectionHeaderView.xib */,
 				D8EB1FD021900810002AE1C4 /* BlogListViewController+SiteCreation.swift */,
 				BE13B3E41B2B58D800A4211D /* BlogListViewController.h */,
 				BE13B3E51B2B58D800A4211D /* BlogListViewController.m */,
@@ -6469,6 +6474,7 @@
 				82B85DF81EDDB807004FD510 /* SiteIconPickerPresenter.swift */,
 				433A550120F693A100757928 /* ManyDelegateNavigationController.swift */,
 				4395A15E210672C900844E8E /* QuickStart */,
+				4349BFF6221205740084F200 /* BlogDetailsSectionHeaderView.swift */,
 			);
 			path = Blog;
 			sourceTree = "<group>";
@@ -8641,6 +8647,7 @@
 				747084101E269669002CA726 /* JetpackLoginViewController.xib in Resources */,
 				43D74AD420FB5ABA004AD934 /* RegisterDomainSectionHeaderView.xib in Resources */,
 				D818FFD82191566B000E5FEE /* VerticalsWizardContent.xib in Resources */,
+				4349BFF5221205540084F200 /* BlogDetailsSectionHeaderView.xib in Resources */,
 				5D6C4B021B603D1F005E3C43 /* WPWebViewController.xib in Resources */,
 				982BED981FBCF392000B848E /* SiteCreation.storyboard in Resources */,
 				E6D3E84B1BEBD888002692E8 /* ReaderCrossPostCell.xib in Resources */,
@@ -10157,6 +10164,7 @@
 				7E3E7A5920E44D2F0075D159 /* FooterContentStyles.swift in Sources */,
 				E19B17B21E5C8F36007517C6 /* AbstractPost.swift in Sources */,
 				D816C1F420E0895E00C4D82F /* MarkAsSpam.swift in Sources */,
+				4349BFF7221205740084F200 /* BlogDetailsSectionHeaderView.swift in Sources */,
 				5D577D361891360900B964C3 /* PostGeolocationView.m in Sources */,
 				E1C9AA511C10419200732665 /* Math.swift in Sources */,
 				B50C0C5A1EF42A2600372C65 /* MediaProgressCoordinator.swift in Sources */,


### PR DESCRIPTION
Refs #10860

This adds the ellipsis menu that allows quick start to be removed.

![ellipsis menu pr](https://user-images.githubusercontent.com/517257/52742131-f04c4280-2f8b-11e9-9eb4-0d1b7136cb37.gif)


To test:
- Don't force quick start to appear. You'll have to actually have QS enabled—putting a `QuickStartTourGuide.find()?.setup(for: blog)` somewhere makes this a big easier 😆
- Ensure that you can use the ellipsis menu to remove the QS cells