### PR TITLE
Replace occurrences of `setTite` with `setTitle:`

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.h
@@ -2,6 +2,6 @@
 
 @interface PageListSectionHeaderView : UIView
 
-- (void)setTite:(NSString *)title;
+- (void)setTitle:(NSString *)title;
 
 @end

--- a/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.m
@@ -10,7 +10,7 @@
 
 @implementation PageListSectionHeaderView
 
-- (void)setTite:(NSString *)title
+- (void)setTitle:(NSString *)title
 {
     self.titleLabel.text = [title uppercaseStringWithLocale:[NSLocale currentLocale]];
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -370,7 +370,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let headerView = Bundle.main.loadNibNamed(nibName, owner: nil, options: nil)![0] as! PageListSectionHeaderView
 
         if let sectionInfo = sectionInfo {
-            headerView.setTite(sectionInfo.name)
+            headerView.setTitle(sectionInfo.name)
         }
 
         return headerView

--- a/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
@@ -223,7 +223,7 @@ extension RevisionsTableViewController: WPTableViewHandlerDelegate {
                 return UIView()
         }
 
-        headerView.setTite(sectionInfo.name)
+        headerView.setTitle(sectionInfo.name)
         return headerView
     }
 


### PR DESCRIPTION
Fixes a typo of `setTite:` which should be `setTitle:`

To test:
- Ensure the app still builds and runs

Update release notes:

- [x] No user facing changes
- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
