### PR TITLE
Gutenberg settings tracking

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -24,13 +24,13 @@ end
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.7.0'
+    pod 'WordPressShared', '~> 1.7.1-beta.1'
 
     ## for development:
     ##pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    ##pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '4781c4764f69ca116c93c15a1297616b8920c4de'
+    ##pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '76335ba41b1cc57057b8372dfcd866681f70a13c'
 end
 
 def aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -195,7 +195,7 @@ PODS:
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.4)
     - wpxmlrpc (= 0.8.4)
-  - WordPressShared (1.7.0):
+  - WordPressShared (1.7.1-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.2.0)
@@ -246,7 +246,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.4.2)
   - WordPressAuthenticator (~> 1.1.9)
   - WordPressKit (~> 2.1.0-beta.1)
-  - WordPressShared (~> 1.7.0)
+  - WordPressShared (~> 1.7.1-beta.1)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -378,13 +378,13 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 5a09651534181c9f3ab43516b7666e9c55b2330e
   WordPressAuthenticator: 9559bc45373f1b6c2f58d664d34f564bcf73111f
   WordPressKit: 8605e6564f1dfa846265b2d3b48f950d02ae3173
-  WordPressShared: cfbda56868419842dd7a106a4e807069a0c17aa9
+  WordPressShared: 50f9cfe6a79884898264e8ec8dc6bfebae942d85
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: b0031fbde249e07b38ca065c97828fb3f73cb4ee
+PODFILE CHECKSUM: 9b8fefba87c767c3293fc0eabb826bb202ef134e
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -4,6 +4,7 @@
 #import "BlogService.h"
 #import "WPAccount.h"
 #import "Blog.h"
+#import "WordPress-Swift.h"
 @import AutomatticTracks;
 
 @interface  TracksEventPair : NSObject
@@ -118,6 +119,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     }];
     
     BOOL dotcom_user = (accountPresent && username.length > 0);
+    BOOL gutenbergEnabled = [GutenbergSettings isGutenbergEnabled];
     
     NSMutableDictionary *userProperties = [NSMutableDictionary new];
     userProperties[@"platform"] = @"iOS";
@@ -126,6 +128,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     userProperties[@"number_of_blogs"] = @(blogCount);
     userProperties[@"accessibility_voice_over_enabled"] = @(UIAccessibilityIsVoiceOverRunning());
     userProperties[@"is_rtl_language"] = @(UIApplication.sharedApplication.userInterfaceLayoutDirection == UIUserInterfaceLayoutDirectionRightToLeft);
+    userProperties[@"gutenberg_enabled"] = @(gutenbergEnabled);
 
     [self.tracksService.userProperties removeAllObjects];
     [self.tracksService.userProperties addEntriesFromDictionary:userProperties];

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -277,6 +277,12 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatAppSettingsVideoOptimizationChanged:
             eventName = @"app_settings_video_optimization_changed";
             break;
+        case WPAnalyticsStatAppSettingsGutenbergEnabled:
+            eventName = @"gutenberg_enabled";
+            break;
+        case WPAnalyticsStatAppSettingsGutenbergDisabled:
+            eventName = @"gutenberg_disabled";
+            break;
         case WPAnalyticsStatAutomatedTransferCustomDomainDialogShown:
             eventName = @"automated_transfer_custom_domain_dialog_shown";
             break;
@@ -462,6 +468,15 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             break;
         case WPAnalyticsStatEditorScheduledPost:
             eventName = @"editor_post_scheduled";
+            break;
+        case WPAnalyticsStatEditorSessionStart:
+            eventName = @"editor_session_start";
+            break;
+        case WPAnalyticsStatEditorSessionSwitchEditor:
+            eventName = @"editor_session_switch";
+            break;
+        case WPAnalyticsStatEditorSessionEnd:
+            eventName = @"editor_session_end";
             break;
         case WPAnalyticsStatEditorPublishedPost:
             eventName = @"editor_post_published";

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -34,6 +34,7 @@ class GutenbergSettings {
             WPAppAnalytics.track(.appSettingsGutenbergEnabled)
             database.set(true, forKey: gutenbergEditorEnabledKey)
         }
+        WPAnalytics.refreshMetadata()
     }
 
     // MARK: - Gutenberg Choice Logic

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -48,3 +48,11 @@ class GutenbergSettings {
             && (!post.hasRemote() || post.containsGutenbergBlocks() || post.isContentEmpty())
     }
 }
+
+@objc(GutenbergSettings)
+class GutenbergSettingsBridge: NSObject {
+    @objc
+    static func isGutenbergEnabled() -> Bool {
+        return GutenbergSettings().isGutenbergEnabled()
+    }
+}

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -28,8 +28,10 @@ class GutenbergSettings {
 
     func toggleGutenberg() {
         if isGutenbergEnabled() {
+            WPAppAnalytics.track(.appSettingsGutenbergDisabled)
             database.set(false, forKey: gutenbergEditorEnabledKey)
         } else {
+            WPAppAnalytics.track(.appSettingsGutenbergEnabled)
             database.set(true, forKey: gutenbergEditorEnabledKey)
         }
     }


### PR DESCRIPTION
Adds the Gutenberg setting tracking described on https://github.com/wordpress-mobile/gutenberg-mobile/issues/556:

* App setting to enable Gutenberg: `gutenberg_setting_enabled` when switched on, `gutenberg_setting_disabled` when switched off.
* Add a `gutenberg_enabled` property to the user properties that are sent with every event.

To test:

The best way to test the events is to look at the logs, but it gets too noisy with React Native. You can edit the Xcode scheme, and in Run > Arguments enable the `OS_ACTIVITY_MODE=disable` environment variable. You can also search for `🔵` in the log but that would filter out the event properties 😞

You can't see the userProperties in the logs, so you can add a breakpoint and inspect `self.tracksService.userProperties`

<img width="469" alt="debug-user-properties" src="https://user-images.githubusercontent.com/8739/52792206-14cb1c00-306b-11e9-9194-71842769f61d.png">

Also, it's a good idea to do a final check and see if the expected events made it into the backend, you might have to wait ~5 minutes for those to appear.

cc @hypest 