### PR TITLE
Update copy for Gutenberg toggle

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -318,16 +318,13 @@ private extension AppSettingsViewController {
         let gutenbergSettings = GutenbergSettings()
         let enabled = gutenbergSettings.isGutenbergEnabled()
         let gutenbergEditor = SwitchRow(
-            title: "(A8C) Enable Gutenberg editor",
+            title: NSLocalizedString("Use Block Editor", comment: "Option to enable the block editor for new posts"),
             value: enabled,
             onChange: toggleGutenberg()
         )
 
-        // I'm intentionally not localizing strings since this is a temporary workaround for internal versions
-        let headerText = "Gutenberg"
-        let footerTextDisabled = "💣 This is still an experimental version of Gutenberg 🙈"
-        let footerTextEnabled = "💣 This is still an experimental version of Gutenberg 🙊"
-        let footerText = enabled ? footerTextEnabled : footerTextDisabled
+        let headerText = NSLocalizedString("Editor", comment: "Title for the editor settings section")
+        let footerText = NSLocalizedString("Edit new posts and pages with the block editor", comment: "Explanation for the option to enable the block editor")
 
         return ImmuTableSection(headerText: headerText, rows: [gutenbergEditor], footerText: footerText)
     }


### PR DESCRIPTION
👋🙉🙊😢

![togglecopy](https://user-images.githubusercontent.com/8739/52793190-77bdb280-306d-11e9-81ef-c897027753ce.png)

Fixes the iOS part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/567

To test:

1. Go to App Settings
2. Notice the lack of emoji and tension around the copy
3. 😭 

cc @hypest @iamthomasbishop 