### PR TITLE
Enable Gutenberg for all builds

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -33,7 +33,7 @@ enum FeatureFlag: Int {
         case .statsRefresh:
             return BuildConfiguration.current == .localDeveloper
         case .gutenberg:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cPrereleaseTesting]
+            return true
         case .quickStartV2:
             return BuildConfiguration.current == .localDeveloper
         }


### PR DESCRIPTION
Fixes iOS part of https://github.com/wordpress-mobile/gutenberg-mobile/issues/566

To test:

What I tried was editing the scheme to build the `Release` configuration. The Gutenberg setting in app settings wasn't available in develop but it is on this PR