### PR TITLE
Quick Start V2: Fix swipe to skip

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
@@ -120,6 +120,13 @@ extension QuickStartChecklistManager: UITableViewDelegate {
         return WPDeviceIdentification.isiPhone() ? 0.0 : Sections.iPadTopInset
     }
 
+    func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+        guard let section = Sections(rawValue: indexPath.section), section == .todo else {
+            return .none
+        }
+        return .delete
+    }
+
     func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath) -> [UITableViewRowAction]? {
         guard let section = Sections(rawValue: indexPath.section), section == .todo else {
             return nil


### PR DESCRIPTION
Refs. #10860 

This pr fixes a problem @frosty found on the Quick start checklist. The swipe to left gesture to skip a tour is enabled for the completed section as well. This is wrong.

**To test:**
• Open a quick start checklist
• Skip a tour
• Expand the completed list and try to swipe to skip. It shouldn't appear any skip button.