### PR TITLE
Add `SearchResultsStatsRecordValue` entity to Core Data

### DIFF
--- a/WordPress/Classes/Models/SearchResultsStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/SearchResultsStatsRecordValue+CoreDataClass.swift
@@ -7,5 +7,8 @@ public class SearchResultsStatsRecordValue: StatsRecordValue {
     /// This is a magic value indicating that this item represents search result counts for
     /// unknown/encrypted search terms.
     public static let unknownSearchTermString = "WPiOS.search_string_unknown"
+    // specific value here is mostly irrelevant, but I wanted to choose something that's REALLY
+    // unlikely to show-up as a searched string — I could conceivably someone duckduckgoing
+    // for things like "unknown search string" and landing on some SEO-explanation-blog.
 
 }

--- a/WordPress/Classes/Models/SearchResultsStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/SearchResultsStatsRecordValue+CoreDataClass.swift
@@ -1,0 +1,11 @@
+import Foundation
+import CoreData
+
+
+public class SearchResultsStatsRecordValue: StatsRecordValue {
+
+    /// This is a magic value indicating that this item represents search result counts for
+    /// unknown/encrypted search terms.
+    public static let unknownSearchTermString = "WPiOS.search_string_unknown"
+
+}

--- a/WordPress/Classes/Models/SearchResultsStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/SearchResultsStatsRecordValue+CoreDataClass.swift
@@ -6,7 +6,7 @@ public class SearchResultsStatsRecordValue: StatsRecordValue {
 
     /// This is a magic value indicating that this item represents search result counts for
     /// unknown/encrypted search terms.
-    public static let unknownSearchTermString = "WPiOS.search_string_unknown"
+    static let unknownSearchTermString = "WPiOS.search_string_unknown"
     // specific value here is mostly irrelevant, but I wanted to choose something that's REALLY
     // unlikely to show-up as a searched string — I could conceivably someone duckduckgoing
     // for things like "unknown search string" and landing on some SEO-explanation-blog.

--- a/WordPress/Classes/Models/SearchResultsStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/SearchResultsStatsRecordValue+CoreDataProperties.swift
@@ -1,0 +1,14 @@
+import Foundation
+import CoreData
+
+
+extension SearchResultsStatsRecordValue {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<SearchResultsStatsRecordValue> {
+        return NSFetchRequest<SearchResultsStatsRecordValue>(entityName: "SearchResultsStatsRecordValue")
+    }
+
+    @NSManaged public var viewsCount: Int64
+    @NSManaged public var searchTerm: String?
+
+}

--- a/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
@@ -30,6 +30,7 @@ public enum StatsRecordType: Int16 {
     case publicizeConnection
     case followers
 
+    case searchTerms
     case postStats
     case blogStats
     // those last two aren't used anywhere yet, I've left them here for illustration purposes.
@@ -42,7 +43,9 @@ public enum StatsRecordType: Int16 {
         case .lastPostInsight, .allTimeStatsInsight, .publicizeConnection, .followers:
 
             return false
-        case .postStats, .blogStats:
+        case .postStats,
+             .blogStats,
+             .searchTerms:
             return true
         }
     }

--- a/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
@@ -57,7 +57,7 @@ public enum StatsRecordType: Int16 {
             return false
         case .postStats,
              .blogStats,
-             .searchTerms:
+             .searchTerms,
              .postingStreak:
 
             return true

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
@@ -740,6 +740,10 @@
         <attribute name="slug" attributeType="String" syncable="YES"/>
         <relationship name="blog" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="roles" inverseEntity="Blog" syncable="YES"/>
     </entity>
+    <entity name="SearchResultsStatsRecordValue" representedClassName=".SearchResultsStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+        <attribute name="searchTerm" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="viewsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
+    </entity>
     <entity name="SharingButton" representedClassName="WordPress.SharingButton" syncable="YES">
         <attribute name="buttonID" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="custom" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
@@ -853,5 +857,6 @@
         <element name="Theme" positionX="9" positionY="153" width="128" height="360"/>
         <element name="PublicizeConnectionStatsRecordValue" positionX="27" positionY="153" width="128" height="90"/>
         <element name="FollowersStatsRecordValue" positionX="27" positionY="153" width="128" height="105"/>
+        <element name="SearchResultsStatsRecordValue" positionX="27" positionY="153" width="128" height="75"/>
     </elements>
 </model>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -254,6 +254,8 @@
 		40A71C6A220E1952002E3D25 /* StatsRecord+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A71C64220E1951002E3D25 /* StatsRecord+CoreDataClass.swift */; };
 		40A71C6B220E1952002E3D25 /* StatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A71C65220E1951002E3D25 /* StatsRecordValue+CoreDataProperties.swift */; };
 		40ADB15520686870009A9161 /* PluginStore+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40ADB15420686870009A9161 /* PluginStore+Persistence.swift */; };
+		40C403EB2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403E92215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift */; };
+		40C403EC2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403EA2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift */; };
 		40D7823A206AEA880015A3A1 /* Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D78238206ABD970015A3A1 /* Scheduler.swift */; };
 		40E4698F2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */; };
 		40E469932017F4070030DB5F /* PluginDirectoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E469922017F3D20030DB5F /* PluginDirectoryViewController.swift */; };
@@ -2075,6 +2077,8 @@
 		40A71C64220E1951002E3D25 /* StatsRecord+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StatsRecord+CoreDataClass.swift"; sourceTree = "<group>"; };
 		40A71C65220E1951002E3D25 /* StatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40ADB15420686870009A9161 /* PluginStore+Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PluginStore+Persistence.swift"; sourceTree = "<group>"; };
+		40C403E92215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchResultsStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		40C403EA2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchResultsStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40D78238206ABD970015A3A1 /* Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scheduler.swift; sourceTree = "<group>"; };
 		40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryEntryStateTests.swift; sourceTree = "<group>"; };
 		40E469922017F3D20030DB5F /* PluginDirectoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryViewController.swift; sourceTree = "<group>"; };
@@ -4613,6 +4617,8 @@
 		40A71C5F220E1941002E3D25 /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				40C403E92215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift */,
+				40C403EA2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift */,
 				40F46B6C22121BBC00A2143B /* Insights */,
 				40A71C64220E1951002E3D25 /* StatsRecord+CoreDataClass.swift */,
 				40A71C60220E1950002E3D25 /* StatsRecord+CoreDataProperties.swift */,
@@ -9395,6 +9401,7 @@
 				E1E89C6C1FD80E74006E7A33 /* Plugin.swift in Sources */,
 				7E4123BD20F4097B00DF8486 /* FormattableMediaContent.swift in Sources */,
 				E1C265C91BECFCDD00DC4C6B /* WPCrashlyticsLogger.m in Sources */,
+				40C403EB2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift in Sources */,
 				D87A329620ABD60700F4726F /* ReaderTableContent.swift in Sources */,
 				738B9A5A21B85CF20005062B /* SiteCreationHeaderData.swift in Sources */,
 				319D6E7B19E447500013871C /* Suggestion.m in Sources */,
@@ -10085,6 +10092,7 @@
 				7EB5824720EC41B200002702 /* NotificationContentFactory.swift in Sources */,
 				7E7947AD210BAC7B005BB851 /* FormattableNoticonRange.swift in Sources */,
 				B55086211CC15CCB004EADB4 /* PromptViewController.swift in Sources */,
+				40C403EC2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift in Sources */,
 				82FC612C1FA8B7FC00A1757E /* ActivityListRow.swift in Sources */,
 				FF0A4FEA1F16C9BD00D6CC69 /* ImageAttachment+WordPress.swift in Sources */,
 				B5B68BD41C19AAED00EB59E0 /* InteractiveNotificationsManager.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -256,6 +256,7 @@
 		40ADB15520686870009A9161 /* PluginStore+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40ADB15420686870009A9161 /* PluginStore+Persistence.swift */; };
 		40C403EB2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403E92215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift */; };
 		40C403EC2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403EA2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift */; };
+		40C403EE2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403ED2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift */; };
 		40D7823A206AEA880015A3A1 /* Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D78238206ABD970015A3A1 /* Scheduler.swift */; };
 		40E4698F2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */; };
 		40E469932017F4070030DB5F /* PluginDirectoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E469922017F3D20030DB5F /* PluginDirectoryViewController.swift */; };
@@ -2079,6 +2080,7 @@
 		40ADB15420686870009A9161 /* PluginStore+Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PluginStore+Persistence.swift"; sourceTree = "<group>"; };
 		40C403E92215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchResultsStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		40C403EA2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchResultsStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		40C403ED2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		40D78238206ABD970015A3A1 /* Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scheduler.swift; sourceTree = "<group>"; };
 		40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryEntryStateTests.swift; sourceTree = "<group>"; };
 		40E469922017F3D20030DB5F /* PluginDirectoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryViewController.swift; sourceTree = "<group>"; };
@@ -4631,6 +4633,7 @@
 		40E7FEC32211DF490032834E /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				40C403ED2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift */,
 				40EE948122132F5800CD264F /* PublicizeConectionStatsRecordValueTests.swift */,
 				40F50B7F221310D400CBBB73 /* FollowersStatsRecordValueTests.swift */,
 				40E7FEC42211DF790032834E /* StatsRecordTests.swift */,
@@ -10605,6 +10608,7 @@
 				D88A64AC208D9B09008AE9BC /* StockPhotosPageableTests.swift in Sources */,
 				59ECF87B1CB7061D00E68F25 /* PostSharingControllerTests.swift in Sources */,
 				E157D5E01C690A6C00F04FB9 /* ImmuTableTestUtils.swift in Sources */,
+				40C403EE2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift in Sources */,
 				FF7C89A31E3A1029000472A8 /* MediaLibraryPickerDataSourceTests.swift in Sources */,
 				D81C2F5E20F88CE5002AE1F1 /* MarkAsSpamActionTests.swift in Sources */,
 				D848CC1520FF33FC00A9038F /* NotificationContentRangeTests.swift in Sources */,

--- a/WordPress/WordPressTest/SearchResultsStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/SearchResultsStatsRecordValueTests.swift
@@ -1,0 +1,77 @@
+@testable import WordPress
+class SearchResultsStatsRecordValueTests: StatsTestCase {
+
+    func testSearchResultsCreation() {
+        let now = Date()
+
+        let searchItem1 = createStatsRecord(in: mainContext, type: .searchTerms, date: now)
+        let searchValue1 = SearchResultsStatsRecordValue(parent: searchItem1)
+        searchValue1.viewsCount = 9001
+
+        let weekAgo = Calendar.autoupdatingCurrent.date(byAdding: .day, value: -7, to: now)
+
+        let searchItem2 = createStatsRecord(in: mainContext, type: .searchTerms, date: weekAgo!)
+        let searchValue2 = SearchResultsStatsRecordValue(parent: searchItem2)
+        searchValue2.viewsCount = 9002
+
+        let fr = StatsRecord.fetchRequest(for: .searchTerms)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+
+        let firstItem = results.first!
+        XCTAssertEqual(firstItem.values!.count, 1)
+
+        let firstValue = firstItem.values?.firstObject! as! SearchResultsStatsRecordValue
+        XCTAssertNotNil(firstValue)
+
+        XCTAssertEqual(firstValue.viewsCount, searchValue1.viewsCount)
+
+        // this might get potentially flaky for... seven seconds around midnight each day.
+        // hopefully this won't be a problem, but I wanted to test that fetching by dates
+        // that aren't exact matches still works.
+        let fewSecondsAfterAWeekAgo = Calendar.autoupdatingCurrent.date(byAdding: .second, value: 7, to: weekAgo!)!
+
+        let fr2 = StatsRecord.fetchRequest(for: .searchTerms, on: fewSecondsAfterAWeekAgo)
+        let results2 = try! mainContext.fetch(fr2)
+
+        XCTAssertEqual(results2.count, 1)
+
+        let secondItem = results2.first!
+        XCTAssertEqual(secondItem.values!.count, 1)
+
+        let secondValue = secondItem.values?.firstObject! as! SearchResultsStatsRecordValue
+        XCTAssertNotNil(secondValue)
+
+        XCTAssertEqual(secondValue.viewsCount, searchValue2.viewsCount)
+    }
+
+
+    func testSavingWithMagicValueWorks() {
+        let now = Date()
+
+        let searchItem = createStatsRecord(in: mainContext, type: .searchTerms, date: now)
+        let searchValue = SearchResultsStatsRecordValue(parent: searchItem)
+        searchValue.viewsCount = 9001
+        searchValue.searchTerm = SearchResultsStatsRecordValue.unknownSearchTermString
+
+        let fr = StatsRecord.fetchRequest(for: .searchTerms)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+
+        let firstItem = results.first!
+        XCTAssertEqual(firstItem.values!.count, 1)
+
+        let firstValue = firstItem.values?.firstObject! as! SearchResultsStatsRecordValue
+        XCTAssertNotNil(firstValue)
+
+        XCTAssertEqual(firstValue.viewsCount, searchValue.viewsCount)
+        XCTAssertEqual(firstValue.searchTerm, searchValue.searchTerm)
+
+    }
+
+
+}


### PR DESCRIPTION
Follow-up to #11000, another one in line with #11010, #11011 (all those PR have binary numbers!), #11016, #11017, #11038 and #11038.

There's gonna be a whole bunch of those coming in over the past few days — I'll try to keep to one entity/PR for ease of review.

To test:

* Verify that the app builds
* Verify that the tests pass.