### PR TITLE
Add `TopViewedAuthorStatsRecordValue` and `TopViewedPostStatsRecordValue` entities to Core Data

### DIFF
--- a/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
@@ -30,6 +30,8 @@ public enum StatsRecordType: Int16 {
     case publicizeConnection
     case followers
 
+    case topViewedAuthor
+    case topViewedPost
     case postStats
     case blogStats
     // those last two aren't used anywhere yet, I've left them here for illustration purposes.
@@ -42,7 +44,10 @@ public enum StatsRecordType: Int16 {
         case .lastPostInsight, .allTimeStatsInsight, .publicizeConnection, .followers:
 
             return false
-        case .postStats, .blogStats:
+        case .postStats,
+             .blogStats,
+             .topViewedAuthor,
+             .topViewedPost:
             return true
         }
     }

--- a/WordPress/Classes/Models/TopViewedAuthorStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/TopViewedAuthorStatsRecordValue+CoreDataClass.swift
@@ -1,0 +1,14 @@
+import Foundation
+import CoreData
+
+
+public class TopViewedAuthorStatsRecordValue: StatsRecordValue {
+
+    public var avatarURL: URL? {
+        guard let url = avatarURLString as String? else {
+            return nil
+        }
+        return URL(string: url)
+    }
+
+}

--- a/WordPress/Classes/Models/TopViewedAuthorStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/TopViewedAuthorStatsRecordValue+CoreDataProperties.swift
@@ -1,0 +1,51 @@
+import Foundation
+import CoreData
+
+
+extension TopViewedAuthorStatsRecordValue {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<TopViewedAuthorStatsRecordValue> {
+        return NSFetchRequest<TopViewedAuthorStatsRecordValue>(entityName: "TopViewedAuthorStatsRecordValue")
+    }
+
+    @NSManaged public var name: String?
+    @NSManaged public var avatarURLString: String?
+    @NSManaged public var viewsCount: Int64
+    @NSManaged public var posts: NSOrderedSet?
+
+}
+
+// MARK: Generated accessors for posts
+extension TopViewedAuthorStatsRecordValue {
+
+    @objc(insertObject:inPostsAtIndex:)
+    @NSManaged public func insertIntoPosts(_ value: TopViewedPostStatsRecordValue, at idx: Int)
+
+    @objc(removeObjectFromPostsAtIndex:)
+    @NSManaged public func removeFromPosts(at idx: Int)
+
+    @objc(insertPosts:atIndexes:)
+    @NSManaged public func insertIntoPosts(_ values: [TopViewedPostStatsRecordValue], at indexes: NSIndexSet)
+
+    @objc(removePostsAtIndexes:)
+    @NSManaged public func removeFromPosts(at indexes: NSIndexSet)
+
+    @objc(replaceObjectInPostsAtIndex:withObject:)
+    @NSManaged public func replacePosts(at idx: Int, with value: TopViewedPostStatsRecordValue)
+
+    @objc(replacePostsAtIndexes:withPosts:)
+    @NSManaged public func replacePosts(at indexes: NSIndexSet, with values: [TopViewedPostStatsRecordValue])
+
+    @objc(addPostsObject:)
+    @NSManaged public func addToPosts(_ value: TopViewedPostStatsRecordValue)
+
+    @objc(removePostsObject:)
+    @NSManaged public func removeFromPosts(_ value: TopViewedPostStatsRecordValue)
+
+    @objc(addPosts:)
+    @NSManaged public func addToPosts(_ values: NSOrderedSet)
+
+    @objc(removePosts:)
+    @NSManaged public func removeFromPosts(_ values: NSOrderedSet)
+
+}

--- a/WordPress/Classes/Models/TopViewedPostStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/TopViewedPostStatsRecordValue+CoreDataClass.swift
@@ -1,0 +1,14 @@
+import Foundation
+import CoreData
+
+
+public class TopViewedPostStatsRecordValue: StatsRecordValue {
+
+    public var postURL: URL? {
+        guard let url = postURLString as String? else {
+            return nil
+        }
+        return URL(string: url)
+    }
+
+}

--- a/WordPress/Classes/Models/TopViewedPostStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/TopViewedPostStatsRecordValue+CoreDataProperties.swift
@@ -1,0 +1,17 @@
+import Foundation
+import CoreData
+
+
+extension TopViewedPostStatsRecordValue {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<TopViewedPostStatsRecordValue> {
+        return NSFetchRequest<TopViewedPostStatsRecordValue>(entityName: "TopViewedPostStatsRecordValue")
+    }
+
+    @NSManaged public var postID: String?
+    @NSManaged public var viewsCount: Int64
+    @NSManaged public var title: String?
+    @NSManaged public var postURLString: String?
+    @NSManaged public var author: TopViewedAuthorStatsRecordValue?
+
+}

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
@@ -797,6 +797,19 @@
         <attribute name="version" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="themes" inverseEntity="Blog" syncable="YES"/>
     </entity>
+    <entity name="TopViewedAuthorStatsRecordValue" representedClassName=".TopViewedAuthorStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+        <attribute name="avatarURLString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="viewsCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="posts" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="TopViewedPostStatsRecordValue" inverseName="author" inverseEntity="TopViewedPostStatsRecordValue" syncable="YES"/>
+    </entity>
+    <entity name="TopViewedPostStatsRecordValue" representedClassName=".TopViewedPostStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+        <attribute name="postID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="postURLString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="viewsCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TopViewedAuthorStatsRecordValue" inverseName="posts" inverseEntity="TopViewedAuthorStatsRecordValue" syncable="YES"/>
+    </entity>
     <elements>
         <element name="AbstractPost" positionX="0" positionY="0" width="128" height="180"/>
         <element name="Account" positionX="0" positionY="0" width="128" height="210"/>
@@ -853,5 +866,7 @@
         <element name="Theme" positionX="9" positionY="153" width="128" height="360"/>
         <element name="PublicizeConnectionStatsRecordValue" positionX="27" positionY="153" width="128" height="90"/>
         <element name="FollowersStatsRecordValue" positionX="27" positionY="153" width="128" height="105"/>
+        <element name="TopViewedAuthorStatsRecordValue" positionX="36" positionY="162" width="128" height="105"/>
+        <element name="TopViewedPostStatsRecordValue" positionX="45" positionY="171" width="128" height="120"/>
     </elements>
 </model>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -254,6 +254,10 @@
 		40A71C6A220E1952002E3D25 /* StatsRecord+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A71C64220E1951002E3D25 /* StatsRecord+CoreDataClass.swift */; };
 		40A71C6B220E1952002E3D25 /* StatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A71C65220E1951002E3D25 /* StatsRecordValue+CoreDataProperties.swift */; };
 		40ADB15520686870009A9161 /* PluginStore+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40ADB15420686870009A9161 /* PluginStore+Persistence.swift */; };
+		40C403F32215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403EF2215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataClass.swift */; };
+		40C403F42215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403F02215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift */; };
+		40C403F52215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403F12215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift */; };
+		40C403F62215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403F22215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift */; };
 		40D7823A206AEA880015A3A1 /* Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D78238206ABD970015A3A1 /* Scheduler.swift */; };
 		40E4698F2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */; };
 		40E469932017F4070030DB5F /* PluginDirectoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E469922017F3D20030DB5F /* PluginDirectoryViewController.swift */; };
@@ -2075,6 +2079,10 @@
 		40A71C64220E1951002E3D25 /* StatsRecord+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StatsRecord+CoreDataClass.swift"; sourceTree = "<group>"; };
 		40A71C65220E1951002E3D25 /* StatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40ADB15420686870009A9161 /* PluginStore+Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PluginStore+Persistence.swift"; sourceTree = "<group>"; };
+		40C403EF2215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedAuthorStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		40C403F02215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedAuthorStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		40C403F12215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedPostStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		40C403F22215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedPostStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40D78238206ABD970015A3A1 /* Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scheduler.swift; sourceTree = "<group>"; };
 		40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryEntryStateTests.swift; sourceTree = "<group>"; };
 		40E469922017F3D20030DB5F /* PluginDirectoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryViewController.swift; sourceTree = "<group>"; };
@@ -4613,6 +4621,10 @@
 		40A71C5F220E1941002E3D25 /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				40C403EF2215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataClass.swift */,
+				40C403F02215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift */,
+				40C403F12215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift */,
+				40C403F22215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift */,
 				40F46B6C22121BBC00A2143B /* Insights */,
 				40A71C64220E1951002E3D25 /* StatsRecord+CoreDataClass.swift */,
 				40A71C60220E1950002E3D25 /* StatsRecord+CoreDataProperties.swift */,
@@ -9345,6 +9357,7 @@
 				B5722E421D51A28100F40C5E /* Notification.swift in Sources */,
 				1759F1801FE1460C0003EC81 /* NoticeView.swift in Sources */,
 				177B4C3321236F5C00CF8084 /* GiphyPageable.swift in Sources */,
+				40C403F42215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift in Sources */,
 				7E4A773920F80417001C706D /* ActivityPluginRange.swift in Sources */,
 				7462BFD02028C49800B552D8 /* ShareNoticeViewModel.swift in Sources */,
 				17A4A36920EE51870071C2CA /* Routes+Reader.swift in Sources */,
@@ -9385,6 +9398,7 @@
 				E102B7901E714F24007928E8 /* RecentSitesService.swift in Sources */,
 				E1D7FF381C74EB0E00E7E5E5 /* PlanService.swift in Sources */,
 				5D7DEA2919D488DD0032EE77 /* WPStyleGuide+ReaderComments.swift in Sources */,
+				40C403F62215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift in Sources */,
 				82FC61251FA8ADAD00A1757E /* ActivityListViewController.swift in Sources */,
 				E66E2A651FE4311300788F22 /* SettingsTitleSubtitleController.swift in Sources */,
 				E1222B671F878E4700D23173 /* WebViewControllerFactory.swift in Sources */,
@@ -9923,6 +9937,7 @@
 				0857C2791CE5375F0014AE99 /* MenuItemsVisualOrderingView.m in Sources */,
 				D8212CB520AA68D5008E8AE8 /* ReaderSubscribingNotificationAction.swift in Sources */,
 				FF8C54AD21F677260003ABCF /* GutenbergMediaInserterHelper.swift in Sources */,
+				40C403F32215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataClass.swift in Sources */,
 				E11C4B72201096EF00A6619C /* JetpackState.swift in Sources */,
 				437542E31DD4E19E00D6B727 /* EditPostViewController.swift in Sources */,
 				9859DF842021063600FB848E /* SiteCreationCategoryTableViewController.swift in Sources */,
@@ -10030,6 +10045,7 @@
 				9865257D2194D77F0078B916 /* SiteStatsInsightsViewModel.swift in Sources */,
 				9F74696B209EFD0C0074D52B /* CheckmarkTableViewCell.swift in Sources */,
 				FF5371631FDFF64F00619A3F /* MediaService.swift in Sources */,
+				40C403F52215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift in Sources */,
 				5DAFEAB81AF2CA6E00B3E1D7 /* PostMetaButton.m in Sources */,
 				40ADB15520686870009A9161 /* PluginStore+Persistence.swift in Sources */,
 				D83CA3A720842CD90060E310 /* ResultsPage.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 		40C403F42215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403F02215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift */; };
 		40C403F52215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403F12215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift */; };
 		40C403F62215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403F22215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift */; };
+		40C403F82215D88100E8C894 /* TopViewedStatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403F72215D88100E8C894 /* TopViewedStatsTests.swift */; };
 		40D7823A206AEA880015A3A1 /* Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D78238206ABD970015A3A1 /* Scheduler.swift */; };
 		40E4698F2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */; };
 		40E469932017F4070030DB5F /* PluginDirectoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E469922017F3D20030DB5F /* PluginDirectoryViewController.swift */; };
@@ -2083,6 +2084,7 @@
 		40C403F02215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedAuthorStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40C403F12215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedPostStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		40C403F22215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedPostStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		40C403F72215D88100E8C894 /* TopViewedStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopViewedStatsTests.swift; sourceTree = "<group>"; };
 		40D78238206ABD970015A3A1 /* Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scheduler.swift; sourceTree = "<group>"; };
 		40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryEntryStateTests.swift; sourceTree = "<group>"; };
 		40E469922017F3D20030DB5F /* PluginDirectoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryViewController.swift; sourceTree = "<group>"; };
@@ -4637,6 +4639,7 @@
 		40E7FEC32211DF490032834E /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				40C403F72215D88100E8C894 /* TopViewedStatsTests.swift */,
 				40EE948122132F5800CD264F /* PublicizeConectionStatsRecordValueTests.swift */,
 				40F50B7F221310D400CBBB73 /* FollowersStatsRecordValueTests.swift */,
 				40E7FEC42211DF790032834E /* StatsRecordTests.swift */,
@@ -10611,6 +10614,7 @@
 				D8B6BEB7203E11F2007C8A19 /* Bundle+LoadFromNib.swift in Sources */,
 				E135965D1E7152D1006C6606 /* RecentSitesServiceTests.swift in Sources */,
 				D88A64AC208D9B09008AE9BC /* StockPhotosPageableTests.swift in Sources */,
+				40C403F82215D88100E8C894 /* TopViewedStatsTests.swift in Sources */,
 				59ECF87B1CB7061D00E68F25 /* PostSharingControllerTests.swift in Sources */,
 				E157D5E01C690A6C00F04FB9 /* ImmuTableTestUtils.swift in Sources */,
 				FF7C89A31E3A1029000472A8 /* MediaLibraryPickerDataSourceTests.swift in Sources */,

--- a/WordPress/WordPressTest/TopViewedStatsTests.swift
+++ b/WordPress/WordPressTest/TopViewedStatsTests.swift
@@ -1,0 +1,77 @@
+@testable import WordPress
+
+class TopViewedStatsTests: StatsTestCase {
+
+    func testAuthorCreation() {
+        let parent = createStatsRecord(in: mainContext, type: .topViewedAuthor, date: Date())
+
+        let author = TopViewedAuthorStatsRecordValue(parent: parent)
+        author.viewsCount = 22
+        author.name = "Saylor Twift"
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let fr = StatsRecord.fetchRequest(for: .topViewedAuthor)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first!.values?.count, 1)
+
+        let fetchedAuthor = results.first?.values?.firstObject! as! TopViewedAuthorStatsRecordValue
+
+        XCTAssertEqual(fetchedAuthor.name, author.name)
+        XCTAssertEqual(fetchedAuthor.viewsCount, author.viewsCount)
+    }
+
+    func testPostCreation() {
+        let parent = createStatsRecord(in: mainContext, type: .topViewedPost, date: Date())
+
+        let post = TopViewedPostStatsRecordValue(parent: parent)
+        post.viewsCount = 1989
+        post.title = "(blank space)"
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let fr = StatsRecord.fetchRequest(for: .topViewedPost)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first!.values?.count, 1)
+
+        let fetchedPost = results.first?.values?.firstObject! as! TopViewedPostStatsRecordValue
+
+        XCTAssertEqual(fetchedPost.title, post.title)
+        XCTAssertEqual(fetchedPost.viewsCount, post.viewsCount)
+    }
+
+    func testRelationshipCreation() {
+        let parent = createStatsRecord(in: mainContext, type: .topViewedAuthor, date: Date())
+
+        let author = TopViewedAuthorStatsRecordValue(parent: parent)
+        author.viewsCount = 22
+        author.name = "Saylor Twift"
+
+        let post = TopViewedPostStatsRecordValue(context: mainContext)
+        post.viewsCount = 1989
+        post.title = "(blank space)"
+
+        author.addToPosts(post)
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let fr = StatsRecord.fetchRequest(for: .topViewedAuthor)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first!.values?.count, 1)
+
+        let fetchedAuthor = results.first?.values?.firstObject! as! TopViewedAuthorStatsRecordValue
+
+        XCTAssertNotNil(fetchedAuthor.posts)
+        XCTAssertEqual(fetchedAuthor.posts!.count, 1)
+    }
+
+}


### PR DESCRIPTION
Follow-up to #11000, another one in line with #11010, #11011 (all those PR have binary numbers!), #11016, #11017, #11038, #11038 and #11047.

There's gonna be a whole bunch of those coming in over the past few days — I'll try to keep to one entity/PR for ease of review.

To test:

* Verify that the app builds
* Verify that the tests pass.