### PR TITLE
Period at the end of Gutenberg setting footer

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AppSettingsViewController.swift
@@ -324,7 +324,7 @@ private extension AppSettingsViewController {
         )
 
         let headerText = NSLocalizedString("Editor", comment: "Title for the editor settings section")
-        let footerText = NSLocalizedString("Edit new posts and pages with the block editor", comment: "Explanation for the option to enable the block editor")
+        let footerText = NSLocalizedString("Edit new posts and pages with the block editor.", comment: "Explanation for the option to enable the block editor")
 
         return ImmuTableSection(headerText: headerText, rows: [gutenbergEditor], footerText: footerText)
     }


### PR DESCRIPTION
Follow-up to #11044

To test:

* Go to app settings
* The Gutenberg setting explanation has a period at the end

cc @iamthomasbishop 