### PR TITLE
CircleCI: Update Orb for improved build performance

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,8 @@
 version: 2.1
 
 orbs:
-  ios: wordpress-mobile/ios@0.0.12
-  danger: wordpress-mobile/danger@0.0.12
-
-jobs:
-  build_and_test:
-    macos:
-      xcode: "10.1.0"
-    steps:
-      - checkout
-      - ios/cached-pod-install:
-          # If you want to reset the CircleCI cache, increment the number in the cache prefix below
-          cache-prefix: cocoapods-cache-v1
-      - run:
-          name: Build
-          command: xcodebuild -scheme "WordPress" -configuration "Debug" -workspace "WordPress.xcworkspace" -sdk iphonesimulator build-for-testing | bundle exec xcpretty
-      - run:
-          name: Test
-          command: xcodebuild -scheme "WordPress" -configuration "Debug" -workspace "WordPress.xcworkspace" -destination 'platform=iOS Simulator,name=iPhone XS,OS=latest' test-without-building | bundle exec xcpretty -r junit
-      - store_test_results:
-          path: build/reports
+  ios: wordpress-mobile/ios@0.0.20
+  danger: wordpress-mobile/danger@0.0.20
 
 workflows:
   wordpress_ios:
@@ -31,4 +13,11 @@ workflows:
             branches:
               # Disable Danger on develop
               ignore: develop
-      - build_and_test
+      - ios/test:
+          name: build_and_test
+          workspace: WordPress.xcworkspace
+          scheme: WordPress
+          device: iPhone XS
+          ios-version: "12.1"
+          # If you want to reset the CircleCI cache, increment the number in the cache prefix below
+          cache-prefix: dependency-cache-v1


### PR DESCRIPTION
This updates the iOS Orb from 0.0.12 to 0.0.20 for lots of incremental improvements.

Here are some of the relevant changes this includes:

- iOS: Disable indexing while building: https://github.com/wordpress-mobile/circleci-orbs/pull/12
- Preboot simulator to improve xcodebuild stability: https://github.com/wordpress-mobile/circleci-orbs/pull/5

These have combined to give a modest improvement in build times (it seems to be around 30 seconds faster).

This is a draft until https://github.com/wordpress-mobile/circleci-orbs/pull/12 is reviewed and merged.

To test:

- CircleCI checks are green

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
