### PR TITLE
Rakefile: Don't use 'cocoapods-check' to check if pods should be installed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org' do
   gem 'rake'
   gem 'cocoapods', '1.5.3'
   gem 'cocoapods-repo-update', '~> 0.0.3'
-  gem 'cocoapods-check'
   gem 'xcpretty-travis-formatter'
   gem 'danger'
   gem 'octokit', "~> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,8 +44,6 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.1)
       xcodeproj (>= 1.5.7, < 2.0)
-    cocoapods-check (1.0.2)
-      cocoapods (~> 1.0)
     cocoapods-core (1.5.3)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
@@ -242,7 +240,6 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (= 1.5.3)!
-  cocoapods-check!
   cocoapods-repo-update (~> 0.0.3)!
   danger!
   dotenv!
@@ -254,4 +251,4 @@ DEPENDENCIES
   xcpretty-travis-formatter!
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/Rakefile
+++ b/Rakefile
@@ -55,8 +55,7 @@ namespace :dependencies do
 
   namespace :pod do
     task :check do
-      sh "bundle exec pod check &> /dev/null", verbose: false do |ok, res|
-        next if ok && podfile_locked?
+      unless podfile_locked? && lockfiles_match?
         dependency_failed("CocoaPods")
         Rake::Task["dependencies:pod:install"].invoke
       end
@@ -256,6 +255,10 @@ end
 def pod(args)
   args = %w[bundle exec pod] + args
   sh(*args)
+end
+
+def lockfiles_match?
+  File.file?('Pods/Manifest.lock') && FileUtils.compare_file('Podfile.lock', 'Pods/Manifest.lock')
 end
 
 def podfile_locked?


### PR DESCRIPTION
There have been a few cases recently where `rake dependencies` didn't trigger a `pod install` when it should have. This is because `cocoapods-check` sometimes think there are no pods to install when this is not the case (particularly when dealing with commit hashes).

This is a small change to just check if `Podfile.lock` matches `Pods/Manifest.lock` to decide if pods should be installed.

To test:

- If you removed `Pods/Manifest.lock` `rake dependencies` should install pods.
- Running `rake dependencies` again should do nothing.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
