### PR TITLE
Quick Start V2: Prompt for next step appearing when exiting checklist VC

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -382,6 +382,7 @@ private extension QuickStartTourGuide {
 
     func skipped(_ tour: QuickStartTour, for blog: Blog) {
         blog.skipTour(tour.key)
+        recentlyTouredBlog = nil
     }
 
     func findNoticePresenter() -> NoticePresenter? {


### PR DESCRIPTION
Fixes #11051 
Refs. #10860 

This fixes a bug with the notice appearing every time the checklist is dismissed after a tour is completed.

To fix this i set the `recentlyTouredBlog` to nil when the tour is skipped. @nheagy I saw that atm this property is used only for this purpose. If not I'd like to use another approach storing the state.

**To test:**
- Complete a task or create a new site and then enable the quick start feature
- Present and dismiss the checklist. It should trigger the notice once as soon the notice disappear.