### PR TITLE
Stats Refresh: rest of Core Data models

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -4,24 +4,32 @@ This file documents changes in the data model. Please explain any changes to the
 data model as well as any custom migrations.
 
 ## WordPress 87
-@klausa 2019-02-??
+@klausa 2019-02-15
 
 - Added following entities:
 
-* `StatsRecord`
 * `StatsRecordValue`
-* `AnnualAndMostPopularTimeStatsRecordValue` 
+* `StatsRecord`
+
 * `AllTimeStatsRecordValue` 
+* `AnnualAndMostPopularTimeStatsRecordValue` 
+* `ClicksStatsRecordValue`
+* `CountryStatsRecordValue`
+* `FollowersStatsRecordValue`
 * `LastPostStatsRecordValue`
+* `PublicizeConnectionStatsRecordValue`
+* `ReferrerStatsRecordValue`
+* `SearchResultsStatsRecordValue`
 * `StreakInsightStatsRecordValue`
 * `StreakStatsRecordValue`
 * `TagsCategoriesStatsRecordValue`
 * `TopCommentedPostStatsRecordValue`
 * `TopCommentsAuthorStatsRecordValue`
-* `PublicizeConnectionStatsRecordValue`
-* `FollowersStatsRecordValue`
+* `TopViewedAuthorStatsRecordValue`
+* `TopViewedPostStatsRecordValue`
+* `TopViewedVideoStatsRecordValue`
+* `VisitsSummaryStatsRecordValue`
 
-More types are incoming, hence why I'm not putting a firm date above — I'll change it when all related PRs are merged.    
 
 ## WordPress 86
 @aerych 2018-12-08

--- a/WordPress/Classes/Models/ClicksStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/ClicksStatsRecordValue+CoreDataClass.swift
@@ -1,0 +1,14 @@
+import Foundation
+import CoreData
+
+
+public class ClicksStatsRecordValue: StatsRecordValue {
+
+    public var clickedURL: URL? {
+        guard let url = urlString as String? else {
+            return nil
+        }
+        return URL(string: url)
+    }
+
+}

--- a/WordPress/Classes/Models/ClicksStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/ClicksStatsRecordValue+CoreDataProperties.swift
@@ -1,0 +1,35 @@
+import Foundation
+import CoreData
+
+
+extension ClicksStatsRecordValue {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ClicksStatsRecordValue> {
+        return NSFetchRequest<ClicksStatsRecordValue>(entityName: "ClicksStatsRecordValue")
+    }
+
+    @NSManaged public var clicksCount: Int64
+    @NSManaged public var label: String?
+    @NSManaged public var countryName: String?
+    @NSManaged public var urlString: String?
+    @NSManaged public var children: NSSet?
+    @NSManaged public var parent: ClicksStatsRecordValue?
+
+}
+
+// MARK: Generated accessors for children
+extension ClicksStatsRecordValue {
+
+    @objc(addChildrenObject:)
+    @NSManaged public func addToChildren(_ value: ClicksStatsRecordValue)
+
+    @objc(removeChildrenObject:)
+    @NSManaged public func removeFromChildren(_ value: ClicksStatsRecordValue)
+
+    @objc(addChildren:)
+    @NSManaged public func addToChildren(_ values: NSSet)
+
+    @objc(removeChildren:)
+    @NSManaged public func removeFromChildren(_ values: NSSet)
+
+}

--- a/WordPress/Classes/Models/ClicksStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/ClicksStatsRecordValue+CoreDataProperties.swift
@@ -10,15 +10,32 @@ extension ClicksStatsRecordValue {
 
     @NSManaged public var clicksCount: Int64
     @NSManaged public var label: String?
-    @NSManaged public var countryName: String?
     @NSManaged public var urlString: String?
-    @NSManaged public var children: NSSet?
+    @NSManaged public var children: NSOrderedSet?
     @NSManaged public var parent: ClicksStatsRecordValue?
 
 }
 
 // MARK: Generated accessors for children
 extension ClicksStatsRecordValue {
+
+    @objc(insertObject:inChildrenAtIndex:)
+    @NSManaged public func insertIntoChildren(_ value: ClicksStatsRecordValue, at idx: Int)
+
+    @objc(removeObjectFromChildrenAtIndex:)
+    @NSManaged public func removeFromChildren(at idx: Int)
+
+    @objc(insertChildren:atIndexes:)
+    @NSManaged public func insertIntoChildren(_ values: [ClicksStatsRecordValue], at indexes: NSIndexSet)
+
+    @objc(removeChildrenAtIndexes:)
+    @NSManaged public func removeFromChildren(at indexes: NSIndexSet)
+
+    @objc(replaceObjectInChildrenAtIndex:withObject:)
+    @NSManaged public func replaceChildren(at idx: Int, with value: ClicksStatsRecordValue)
+
+    @objc(replaceChildrenAtIndexes:withChildren:)
+    @NSManaged public func replaceChildren(at indexes: NSIndexSet, with values: [ClicksStatsRecordValue])
 
     @objc(addChildrenObject:)
     @NSManaged public func addToChildren(_ value: ClicksStatsRecordValue)
@@ -27,9 +44,9 @@ extension ClicksStatsRecordValue {
     @NSManaged public func removeFromChildren(_ value: ClicksStatsRecordValue)
 
     @objc(addChildren:)
-    @NSManaged public func addToChildren(_ values: NSSet)
+    @NSManaged public func addToChildren(_ values: NSOrderedSet)
 
     @objc(removeChildren:)
-    @NSManaged public func removeFromChildren(_ values: NSSet)
+    @NSManaged public func removeFromChildren(_ values: NSOrderedSet)
 
 }

--- a/WordPress/Classes/Models/CountryStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/CountryStatsRecordValue+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+
+public class CountryStatsRecordValue: StatsRecordValue {
+
+}

--- a/WordPress/Classes/Models/CountryStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/CountryStatsRecordValue+CoreDataProperties.swift
@@ -1,0 +1,15 @@
+import Foundation
+import CoreData
+
+
+extension CountryStatsRecordValue {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<CountryStatsRecordValue> {
+        return NSFetchRequest<CountryStatsRecordValue>(entityName: "CountryStatsRecordValue")
+    }
+
+    @NSManaged public var countryCode: String?
+    @NSManaged public var countryName: String?
+    @NSManaged public var viewsCount: Int64
+
+}

--- a/WordPress/Classes/Models/ReferrerStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/ReferrerStatsRecordValue+CoreDataClass.swift
@@ -1,0 +1,21 @@
+import Foundation
+import CoreData
+
+
+public class ReferrerStatsRecordValue: StatsRecordValue {
+
+    public var referrerURL: URL? {
+        guard let url = urlString as String? else {
+            return nil
+        }
+        return URL(string: url)
+    }
+
+    public var iconURL: URL? {
+        guard let url = iconURLString as String? else {
+            return nil
+        }
+        return URL(string: url)
+    }
+
+}

--- a/WordPress/Classes/Models/ReferrerStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/ReferrerStatsRecordValue+CoreDataProperties.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 import CoreData
 
@@ -9,17 +8,35 @@ extension ReferrerStatsRecordValue {
         return NSFetchRequest<ReferrerStatsRecordValue>(entityName: "ReferrerStatsRecordValue")
     }
 
-    @NSManaged public var viewsCount: Int64
     @NSManaged public var iconURLString: String?
     @NSManaged public var label: String?
     @NSManaged public var urlString: String?
-    @NSManaged public var children: NSSet?
+    @NSManaged public var viewsCount: Int64
+    @NSManaged public var children: NSOrderedSet?
     @NSManaged public var parent: ReferrerStatsRecordValue?
 
 }
 
 // MARK: Generated accessors for children
 extension ReferrerStatsRecordValue {
+
+    @objc(insertObject:inChildrenAtIndex:)
+    @NSManaged public func insertIntoChildren(_ value: ReferrerStatsRecordValue, at idx: Int)
+
+    @objc(removeObjectFromChildrenAtIndex:)
+    @NSManaged public func removeFromChildren(at idx: Int)
+
+    @objc(insertChildren:atIndexes:)
+    @NSManaged public func insertIntoChildren(_ values: [ReferrerStatsRecordValue], at indexes: NSIndexSet)
+
+    @objc(removeChildrenAtIndexes:)
+    @NSManaged public func removeFromChildren(at indexes: NSIndexSet)
+
+    @objc(replaceObjectInChildrenAtIndex:withObject:)
+    @NSManaged public func replaceChildren(at idx: Int, with value: ReferrerStatsRecordValue)
+
+    @objc(replaceChildrenAtIndexes:withChildren:)
+    @NSManaged public func replaceChildren(at indexes: NSIndexSet, with values: [ReferrerStatsRecordValue])
 
     @objc(addChildrenObject:)
     @NSManaged public func addToChildren(_ value: ReferrerStatsRecordValue)
@@ -28,9 +45,9 @@ extension ReferrerStatsRecordValue {
     @NSManaged public func removeFromChildren(_ value: ReferrerStatsRecordValue)
 
     @objc(addChildren:)
-    @NSManaged public func addToChildren(_ values: NSSet)
+    @NSManaged public func addToChildren(_ values: NSOrderedSet)
 
     @objc(removeChildren:)
-    @NSManaged public func removeFromChildren(_ values: NSSet)
+    @NSManaged public func removeFromChildren(_ values: NSOrderedSet)
 
 }

--- a/WordPress/Classes/Models/ReferrerStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/ReferrerStatsRecordValue+CoreDataProperties.swift
@@ -1,0 +1,36 @@
+
+import Foundation
+import CoreData
+
+
+extension ReferrerStatsRecordValue {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<ReferrerStatsRecordValue> {
+        return NSFetchRequest<ReferrerStatsRecordValue>(entityName: "ReferrerStatsRecordValue")
+    }
+
+    @NSManaged public var viewsCount: Int64
+    @NSManaged public var iconURLString: String?
+    @NSManaged public var label: String?
+    @NSManaged public var urlString: String?
+    @NSManaged public var children: NSSet?
+    @NSManaged public var parent: ReferrerStatsRecordValue?
+
+}
+
+// MARK: Generated accessors for children
+extension ReferrerStatsRecordValue {
+
+    @objc(addChildrenObject:)
+    @NSManaged public func addToChildren(_ value: ReferrerStatsRecordValue)
+
+    @objc(removeChildrenObject:)
+    @NSManaged public func removeFromChildren(_ value: ReferrerStatsRecordValue)
+
+    @objc(addChildren:)
+    @NSManaged public func addToChildren(_ values: NSSet)
+
+    @objc(removeChildren:)
+    @NSManaged public func removeFromChildren(_ values: NSSet)
+
+}

--- a/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
@@ -25,49 +25,60 @@ import CoreData
 // shoving all kinds of stuff into some sort of `StatsObject`.
 
 public enum StatsRecordType: Int16 {
-    case lastPostInsight
     case allTimeStatsInsight
+    case followers
+    case lastPostInsight
+    case publicizeConnection
     case streakInsight
     case tagsAndCategories
-    case topCommentedPosts
     case topCommentAuthors
-    case publicizeConnection
-    case followers
+    case topCommentedPosts
 
-    case topViewedAuthor
-    case topViewedPost
-    case searchTerms
+
+    case blogVisitsSummary
+    case clicks
+    case countryViews
+    case postViews
     case postingStreak
-    case postStats
-    case blogStats
-    // those last two aren't used anywhere yet, I've left them here for illustration purposes.
+    case publishedPosts
+    case referrers
+    case searchTerms
+    case topViewedPost
+    case videos
+    case topViewedAuthor
 
     fileprivate var requiresDate: Bool {
         // For some kinds of data, we'll only support storing one dataPoint (it doesn't make a whole
         // lot of sense to hold on to Insights from the past...).
         // This lets us disambiguate between which is which.
         switch self {
-        case .lastPostInsight,
-             .allTimeStatsInsight,
-             .tagsAndCategories,
-             .topCommentedPosts,
-             .topCommentAuthors,
-             .publicizeConnection,
-             .followers,
-             .streakInsight:
+        case  .allTimeStatsInsight,
+              .followers,
+              .publicizeConnection,
+              .streakInsight,
+              .tagsAndCategories,
+              .topCommentAuthors,
+              .topCommentedPosts,
+              .lastPostInsight:
 
             return false
-        case .postStats,
-             .blogStats,
-             .topViewedAuthor,
-             .topViewedPost,
-             .searchTerms,
-             .postingStreak:
+        case  .blogVisitsSummary,
+              .clicks,
+              .countryViews,
+              .postingStreak,
+              .publishedPosts,
+              .referrers,
+              .searchTerms,
+              .topViewedAuthor,
+              .topViewedPost,
+              .videos,
+              .postViews:
 
             return true
         }
     }
 }
+
 
 public class StatsRecord: NSManagedObject {
 

--- a/WordPress/Classes/Models/TopViewedVideoStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/TopViewedVideoStatsRecordValue+CoreDataClass.swift
@@ -1,0 +1,14 @@
+import Foundation
+import CoreData
+
+
+public class TopViewedVideoStatsRecordValue: StatsRecordValue {
+
+    public var postURL: URL? {
+        guard let url = postURLString as String? else {
+            return nil
+        }
+        return URL(string: url)
+    }
+
+}

--- a/WordPress/Classes/Models/TopViewedVideoStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/TopViewedVideoStatsRecordValue+CoreDataProperties.swift
@@ -1,0 +1,16 @@
+import Foundation
+import CoreData
+
+
+extension TopViewedVideoStatsRecordValue {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<TopViewedVideoStatsRecordValue> {
+        return NSFetchRequest<TopViewedVideoStatsRecordValue>(entityName: "TopViewedVideoStatsRecordValue")
+    }
+
+    @NSManaged public var postID: String?
+    @NSManaged public var postURLString: String?
+    @NSManaged public var title: String?
+    @NSManaged public var playsCount: Int64
+
+}

--- a/WordPress/Classes/Models/VisitsSummaryStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/VisitsSummaryStatsRecordValue+CoreDataClass.swift
@@ -1,0 +1,7 @@
+import Foundation
+import CoreData
+
+
+public class VisitsSummaryStatsRecordValue: StatsRecordValue {
+
+}

--- a/WordPress/Classes/Models/VisitsSummaryStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/VisitsSummaryStatsRecordValue+CoreDataProperties.swift
@@ -1,0 +1,16 @@
+import Foundation
+import CoreData
+
+
+extension VisitsSummaryStatsRecordValue {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<VisitsSummaryStatsRecordValue> {
+        return NSFetchRequest<VisitsSummaryStatsRecordValue>(entityName: "VisitsSummaryStatsRecordValue")
+    }
+
+    @NSManaged public var viewsCount: Int64
+    @NSManaged public var visitorsCount: Int64
+    @NSManaged public var likesCount: Int64
+    @NSManaged public var commentsCount: Int64
+
+}

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
@@ -279,7 +279,6 @@
     </entity>
     <entity name="ClicksStatsRecordValue" representedClassName=".ClicksStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
         <attribute name="clicksCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="countryName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="label" attributeType="String" syncable="YES"/>
         <attribute name="urlString" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="children" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ClicksStatsRecordValue" inverseName="parent" inverseEntity="ClicksStatsRecordValue" syncable="YES"/>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18D42" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14460.32" systemVersion="18D109" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AbstractPost" representedClassName="AbstractPost" isAbstract="YES" parentEntity="BasePost">
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
         <attribute name="metaIsLocal" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
@@ -277,6 +277,14 @@
         </relationship>
         <userInfo/>
     </entity>
+    <entity name="ClicksStatsRecordValue" representedClassName=".TopViewedPostStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+        <attribute name="clicksCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="countryName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="label" attributeType="String" syncable="YES"/>
+        <attribute name="urlString" optional="YES" attributeType="String" syncable="YES"/>
+        <relationship name="children" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ClicksStatsRecordValue" inverseName="parent" inverseEntity="ClicksStatsRecordValue" syncable="YES"/>
+        <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ClicksStatsRecordValue" inverseName="children" inverseEntity="ClicksStatsRecordValue" syncable="YES"/>
+    </entity>
     <entity name="Comment" representedClassName="Comment">
         <attribute name="author" optional="YES" attributeType="String">
             <userInfo/>
@@ -325,6 +333,11 @@
         <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="comments" inverseEntity="Blog" syncable="YES"/>
         <relationship name="post" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BasePost" inverseName="comments" inverseEntity="BasePost" syncable="YES"/>
         <userInfo/>
+    </entity>
+    <entity name="CountryStatsRecordValue" representedClassName=".TopViewedPostStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+        <attribute name="countryCode" attributeType="String" syncable="YES"/>
+        <attribute name="countryName" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="viewsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <entity name="DiffAbstractValue" representedClassName="WordPress.DiffAbstractValue" isAbstract="YES" syncable="YES">
         <attribute name="diffOperation" optional="YES" attributeType="String" syncable="YES"/>
@@ -713,6 +726,14 @@
     <entity name="ReaderTeamTopic" representedClassName="WordPress.ReaderTeamTopic" parentEntity="ReaderAbstractTopic" syncable="YES">
         <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
+    <entity name="ReferrerStatsRecordValue" representedClassName=".TopViewedPostStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+        <attribute name="iconURLString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="label" attributeType="String" syncable="YES"/>
+        <attribute name="urlString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="viewsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="children" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ReferrerStatsRecordValue" inverseName="parent" inverseEntity="ReferrerStatsRecordValue" syncable="YES"/>
+        <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ReferrerStatsRecordValue" inverseName="children" inverseEntity="ReferrerStatsRecordValue" syncable="YES"/>
+    </entity>
     <entity name="Revision" representedClassName="WordPress.Revision" syncable="YES">
         <attribute name="postAuthorId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="postContent" optional="YES" attributeType="String" syncable="YES"/>
@@ -820,6 +841,17 @@
         <attribute name="version" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="themes" inverseEntity="Blog" syncable="YES"/>
     </entity>
+    <entity name="TopCommentedPostStatsRecordValue" representedClassName=".TopCommentedPostStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+        <attribute name="commentCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="postID" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="postURLString" attributeType="String" syncable="YES"/>
+        <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
+    <entity name="TopCommentsAuthorStatsRecordValue" representedClassName=".TopCommentsAuthorStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+        <attribute name="avatarURLString" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="commentCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+    </entity>
     <entity name="TopViewedAuthorStatsRecordValue" representedClassName=".TopViewedAuthorStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
         <attribute name="avatarURLString" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
@@ -833,16 +865,17 @@
         <attribute name="viewsCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TopViewedAuthorStatsRecordValue" inverseName="posts" inverseEntity="TopViewedAuthorStatsRecordValue" syncable="YES"/>
     </entity>
-    <entity name="TopCommentedPostStatsRecordValue" representedClassName=".TopCommentedPostStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
-        <attribute name="commentCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
+    <entity name="TopViewedVideoStatsRecordValue" representedClassName=".TopViewedPostStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+        <attribute name="playsCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="postID" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="postURLString" attributeType="String" syncable="YES"/>
+        <attribute name="postURLString" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
-    <entity name="TopCommentsAuthorStatsRecordValue" representedClassName=".TopCommentsAuthorStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
-        <attribute name="avatarURLString" optional="YES" attributeType="String" syncable="YES"/>
-        <attribute name="commentCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
+    <entity name="VisitsSummaryStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+        <attribute name="commentsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="likesCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="viewsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="visitorsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <elements>
         <element name="AbstractPost" positionX="0" positionY="0" width="128" height="180"/>
@@ -860,6 +893,7 @@
         <element name="DiffContentValue" positionX="63" positionY="189" width="128" height="60"/>
         <element name="DiffTitleValue" positionX="54" positionY="180" width="128" height="60"/>
         <element name="Domain" positionX="27" positionY="153" width="128" height="105"/>
+        <element name="FollowersStatsRecordValue" positionX="27" positionY="153" width="128" height="105"/>
         <element name="LastPostStatsRecordValue" positionX="45" positionY="504" width="128" height="30"/>
         <element name="Media" positionX="0" positionY="0" width="128" height="420"/>
         <element name="Menu" positionX="63" positionY="198" width="128" height="135"/>
@@ -875,6 +909,7 @@
         <element name="PostTag" positionX="27" positionY="153" width="128" height="135"/>
         <element name="PostType" positionX="27" positionY="153" width="128" height="105"/>
         <element name="PublicizeConnection" positionX="27" positionY="162" width="128" height="330"/>
+        <element name="PublicizeConnectionStatsRecordValue" positionX="27" positionY="153" width="128" height="90"/>
         <element name="PublicizeService" positionX="18" positionY="153" width="128" height="210"/>
         <element name="QuickStartTourState" positionX="36" positionY="162" width="128" height="105"/>
         <element name="ReaderAbstractTopic" positionX="9" positionY="153" width="128" height="180"/>
@@ -893,20 +928,23 @@
         <element name="Revision" positionX="27" positionY="153" width="128" height="195"/>
         <element name="RevisionDiff" positionX="36" positionY="162" width="128" height="150"/>
         <element name="Role" positionX="36" positionY="162" width="128" height="105"/>
+        <element name="SearchResultsStatsRecordValue" positionX="27" positionY="153" width="128" height="75"/>
         <element name="SharingButton" positionX="27" positionY="153" width="128" height="165"/>
         <element name="SourcePostAttribution" positionX="9" positionY="153" width="128" height="225"/>
         <element name="StatsRecord" positionX="27" positionY="486" width="128" height="120"/>
         <element name="StatsRecordValue" positionX="36" positionY="495" width="128" height="60"/>
         <element name="StreakInsightStatsRecordValue" positionX="54" positionY="180" width="128" height="135"/>
         <element name="StreakStatsRecordValue" positionX="72" positionY="198" width="128" height="60"/>
-        <element name="Theme" positionX="9" positionY="153" width="128" height="360"/>
         <element name="TagsCategoriesStatsRecordValue" positionX="45" positionY="171" width="128" height="120"/>
-        <element name="TopCommentsAuthorStatsRecordValue" positionX="27" positionY="153" width="128" height="90"/>
-        <element name="PublicizeConnectionStatsRecordValue" positionX="27" positionY="153" width="128" height="90"/>
-        <element name="TopCommentedPostStatsRecordValue" positionX="36" positionY="162" width="128" height="105"/>
-        <element name="FollowersStatsRecordValue" positionX="27" positionY="153" width="128" height="105"/>
+        <element name="Theme" positionX="9" positionY="153" width="128" height="360"/>
         <element name="TopViewedAuthorStatsRecordValue" positionX="36" positionY="162" width="128" height="105"/>
         <element name="TopViewedPostStatsRecordValue" positionX="45" positionY="171" width="128" height="120"/>
-        <element name="SearchResultsStatsRecordValue" positionX="27" positionY="153" width="128" height="75"/>
+        <element name="TopCommentedPostStatsRecordValue" positionX="36" positionY="162" width="128" height="105"/>
+        <element name="TopCommentsAuthorStatsRecordValue" positionX="27" positionY="153" width="128" height="90"/>
+        <element name="TopViewedVideoStatsRecordValue" positionX="36" positionY="162" width="128" height="105"/>
+        <element name="CountryStatsRecordValue" positionX="54" positionY="180" width="128" height="90"/>
+        <element name="ClicksStatsRecordValue" positionX="63" positionY="189" width="128" height="135"/>
+        <element name="ReferrerStatsRecordValue" positionX="81" positionY="198" width="128" height="135"/>
+        <element name="VisitsSummaryStatsRecordValue" positionX="45" positionY="153" width="128" height="105"/>
     </elements>
 </model>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
@@ -277,7 +277,7 @@
         </relationship>
         <userInfo/>
     </entity>
-    <entity name="ClicksStatsRecordValue" representedClassName=".TopViewedPostStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+    <entity name="ClicksStatsRecordValue" representedClassName=".ClicksStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
         <attribute name="clicksCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="countryName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="label" attributeType="String" syncable="YES"/>
@@ -334,7 +334,7 @@
         <relationship name="post" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="BasePost" inverseName="comments" inverseEntity="BasePost" syncable="YES"/>
         <userInfo/>
     </entity>
-    <entity name="CountryStatsRecordValue" representedClassName=".TopViewedPostStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+    <entity name="CountryStatsRecordValue" representedClassName=".CountryStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
         <attribute name="countryCode" attributeType="String" syncable="YES"/>
         <attribute name="countryName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="viewsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
@@ -726,7 +726,7 @@
     <entity name="ReaderTeamTopic" representedClassName="WordPress.ReaderTeamTopic" parentEntity="ReaderAbstractTopic" syncable="YES">
         <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
-    <entity name="ReferrerStatsRecordValue" representedClassName=".TopViewedPostStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+    <entity name="ReferrerStatsRecordValue" representedClassName=".ReferrerStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
         <attribute name="iconURLString" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="label" attributeType="String" syncable="YES"/>
         <attribute name="urlString" optional="YES" attributeType="String" syncable="YES"/>
@@ -865,13 +865,13 @@
         <attribute name="viewsCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="TopViewedAuthorStatsRecordValue" inverseName="posts" inverseEntity="TopViewedAuthorStatsRecordValue" syncable="YES"/>
     </entity>
-    <entity name="TopViewedVideoStatsRecordValue" representedClassName=".TopViewedPostStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+    <entity name="TopViewedVideoStatsRecordValue" representedClassName=".TopViewedVideoStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
         <attribute name="playsCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="postID" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="postURLString" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
-    <entity name="VisitsSummaryStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+    <entity name="VisitsSummaryStatsRecordValue" representedClassName=".VisitsSummaryStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
         <attribute name="commentsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="likesCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="viewsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
@@ -281,7 +281,7 @@
         <attribute name="clicksCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="label" attributeType="String" syncable="YES"/>
         <attribute name="urlString" optional="YES" attributeType="String" syncable="YES"/>
-        <relationship name="children" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="ClicksStatsRecordValue" inverseName="parent" inverseEntity="ClicksStatsRecordValue" syncable="YES"/>
+        <relationship name="children" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="ClicksStatsRecordValue" inverseName="parent" inverseEntity="ClicksStatsRecordValue" syncable="YES"/>
         <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ClicksStatsRecordValue" inverseName="children" inverseEntity="ClicksStatsRecordValue" syncable="YES"/>
     </entity>
     <entity name="Comment" representedClassName="Comment">
@@ -730,7 +730,7 @@
         <attribute name="label" attributeType="String" syncable="YES"/>
         <attribute name="urlString" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="viewsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
-        <relationship name="children" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="ReferrerStatsRecordValue" inverseName="parent" inverseEntity="ReferrerStatsRecordValue" syncable="YES"/>
+        <relationship name="children" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="ReferrerStatsRecordValue" inverseName="parent" inverseEntity="ReferrerStatsRecordValue" syncable="YES"/>
         <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ReferrerStatsRecordValue" inverseName="children" inverseEntity="ReferrerStatsRecordValue" syncable="YES"/>
     </entity>
     <entity name="Revision" representedClassName="WordPress.Revision" syncable="YES">

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		400A2C912217B308000A8A59 /* CountryStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C902217B308000A8A59 /* CountryStatsRecordValueTests.swift */; };
 		400A2C932217B463000A8A59 /* ReferrerStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C922217B463000A8A59 /* ReferrerStatsRecordValueTests.swift */; };
 		400A2C952217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C942217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift */; };
+		400A2C972217B883000A8A59 /* VisitsSummaryStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C962217B883000A8A59 /* VisitsSummaryStatsRecordValueTests.swift */; };
 		400F4625201E74EE000CFD9E /* CollectionViewContainerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400F4624201E74EE000CFD9E /* CollectionViewContainerRow.swift */; };
 		4019B27120885AB900A0C7EB /* Activity.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4019B27020885AB900A0C7EB /* Activity.storyboard */; };
 		401A3D022027DBD80099A127 /* PluginListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 401A3D012027DBD80099A127 /* PluginListCell.xib */; };
@@ -2101,6 +2102,7 @@
 		400A2C902217B308000A8A59 /* CountryStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		400A2C922217B463000A8A59 /* ReferrerStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		400A2C942217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopViewedVideoStatsRecordValueTests.swift; sourceTree = "<group>"; };
+		400A2C962217B883000A8A59 /* VisitsSummaryStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisitsSummaryStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		400F4624201E74EE000CFD9E /* CollectionViewContainerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewContainerRow.swift; sourceTree = "<group>"; };
 		4019B27020885AB900A0C7EB /* Activity.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Activity.storyboard; sourceTree = "<group>"; };
 		401A3D012027DBD80099A127 /* PluginListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListCell.xib; sourceTree = "<group>"; };
@@ -4734,6 +4736,7 @@
 				400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */,
 				400A2C922217B463000A8A59 /* ReferrerStatsRecordValueTests.swift */,
 				400A2C942217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift */,
+				400A2C962217B883000A8A59 /* VisitsSummaryStatsRecordValueTests.swift */,
 				400A2C902217B308000A8A59 /* CountryStatsRecordValueTests.swift */,
 				40C403F72215D88100E8C894 /* TopViewedStatsTests.swift */,
 				40C403ED2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift */,
@@ -10877,6 +10880,7 @@
 				0885A3671E837AFE00619B4D /* URLIncrementalFilenameTests.swift in Sources */,
 				D848CBF920FEF82100A9038F /* NotificationsContentFactoryTests.swift in Sources */,
 				F18B43781F849F580089B817 /* PostAttachmentTests.swift in Sources */,
+				400A2C972217B883000A8A59 /* VisitsSummaryStatsRecordValueTests.swift in Sources */,
 				E180BD4E1FB4681E00D0D781 /* MockCookieJar.swift in Sources */,
 				D81C2F6A20F8B449002AE1F1 /* NotificationActionParserTest.swift in Sources */,
 				732B99172180D3A600C4EBDB /* FeatureFlagTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		400A2C892217A985000A8A59 /* CountryStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C7F2217A985000A8A59 /* CountryStatsRecordValue+CoreDataProperties.swift */; };
 		400A2C8B2217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C812217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift */; };
 		400A2C8C2217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C822217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift */; };
+		400A2C8F2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */; };
 		400F4625201E74EE000CFD9E /* CollectionViewContainerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400F4624201E74EE000CFD9E /* CollectionViewContainerRow.swift */; };
 		4019B27120885AB900A0C7EB /* Activity.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4019B27020885AB900A0C7EB /* Activity.storyboard */; };
 		401A3D022027DBD80099A127 /* PluginListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 401A3D012027DBD80099A127 /* PluginListCell.xib */; };
@@ -2093,6 +2094,7 @@
 		400A2C7F2217A985000A8A59 /* CountryStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CountryStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		400A2C812217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClicksStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		400A2C822217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClicksStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClicksStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		400F4624201E74EE000CFD9E /* CollectionViewContainerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewContainerRow.swift; sourceTree = "<group>"; };
 		4019B27020885AB900A0C7EB /* Activity.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Activity.storyboard; sourceTree = "<group>"; };
 		401A3D012027DBD80099A127 /* PluginListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListCell.xib; sourceTree = "<group>"; };
@@ -4723,6 +4725,7 @@
 		40E7FEC32211DF490032834E /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */,
 				40C403F72215D88100E8C894 /* TopViewedStatsTests.swift */,
 				40C403ED2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift */,
 				4054F4632214F94D00D261AB /* StreakStatsRecordValueTests.swift */,
@@ -10717,6 +10720,7 @@
 				D816B8D12112D5960052CE4D /* DefaultNewsManagerTests.swift in Sources */,
 				748437EE1F1D4A7300E8DDAF /* RichContentFormatterTests.swift in Sources */,
 				D88A649E208D82D2008AE9BC /* XCTestCase+Wait.swift in Sources */,
+				400A2C8F2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift in Sources */,
 				7320C8BD2190C9FC0082FED5 /* UITextView+SummaryTests.swift in Sources */,
 				7E53AB0420FE6681005796FE /* ActivityContentRouterTests.swift in Sources */,
 				17AF92251C46634000A99CFB /* BlogSiteVisibilityHelperTest.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 		400A2C8F2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */; };
 		400A2C912217B308000A8A59 /* CountryStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C902217B308000A8A59 /* CountryStatsRecordValueTests.swift */; };
 		400A2C932217B463000A8A59 /* ReferrerStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C922217B463000A8A59 /* ReferrerStatsRecordValueTests.swift */; };
+		400A2C952217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C942217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift */; };
 		400F4625201E74EE000CFD9E /* CollectionViewContainerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400F4624201E74EE000CFD9E /* CollectionViewContainerRow.swift */; };
 		4019B27120885AB900A0C7EB /* Activity.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4019B27020885AB900A0C7EB /* Activity.storyboard */; };
 		401A3D022027DBD80099A127 /* PluginListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 401A3D012027DBD80099A127 /* PluginListCell.xib */; };
@@ -2099,6 +2100,7 @@
 		400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClicksStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		400A2C902217B308000A8A59 /* CountryStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		400A2C922217B463000A8A59 /* ReferrerStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerStatsRecordValueTests.swift; sourceTree = "<group>"; };
+		400A2C942217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopViewedVideoStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		400F4624201E74EE000CFD9E /* CollectionViewContainerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewContainerRow.swift; sourceTree = "<group>"; };
 		4019B27020885AB900A0C7EB /* Activity.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Activity.storyboard; sourceTree = "<group>"; };
 		401A3D012027DBD80099A127 /* PluginListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListCell.xib; sourceTree = "<group>"; };
@@ -4731,6 +4733,7 @@
 			children = (
 				400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */,
 				400A2C922217B463000A8A59 /* ReferrerStatsRecordValueTests.swift */,
+				400A2C942217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift */,
 				400A2C902217B308000A8A59 /* CountryStatsRecordValueTests.swift */,
 				40C403F72215D88100E8C894 /* TopViewedStatsTests.swift */,
 				40C403ED2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift */,
@@ -10753,6 +10756,7 @@
 				9123471B221449E200BD9F97 /* GutenbergInformativeDialogTests.swift in Sources */,
 				FF1FD02620912AA900186384 /* URL+LinkNormalizationTests.swift in Sources */,
 				7E442FCF20F6C19000DEACA5 /* ActivityLogFormattableContentTests.swift in Sources */,
+				400A2C952217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift in Sources */,
 				D81C2F6620F8ACCD002AE1F1 /* FormattableContentFormatterTests.swift in Sources */,
 				D8B6BEB7203E11F2007C8A19 /* Bundle+LoadFromNib.swift in Sources */,
 				E135965D1E7152D1006C6606 /* RecentSitesServiceTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -237,6 +237,7 @@
 		400A2C8B2217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C812217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift */; };
 		400A2C8C2217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C822217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift */; };
 		400A2C8F2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */; };
+		400A2C912217B308000A8A59 /* CountryStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C902217B308000A8A59 /* CountryStatsRecordValueTests.swift */; };
 		400F4625201E74EE000CFD9E /* CollectionViewContainerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400F4624201E74EE000CFD9E /* CollectionViewContainerRow.swift */; };
 		4019B27120885AB900A0C7EB /* Activity.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4019B27020885AB900A0C7EB /* Activity.storyboard */; };
 		401A3D022027DBD80099A127 /* PluginListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 401A3D012027DBD80099A127 /* PluginListCell.xib */; };
@@ -2095,6 +2096,7 @@
 		400A2C812217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClicksStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		400A2C822217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClicksStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClicksStatsRecordValueTests.swift; sourceTree = "<group>"; };
+		400A2C902217B308000A8A59 /* CountryStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		400F4624201E74EE000CFD9E /* CollectionViewContainerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewContainerRow.swift; sourceTree = "<group>"; };
 		4019B27020885AB900A0C7EB /* Activity.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Activity.storyboard; sourceTree = "<group>"; };
 		401A3D012027DBD80099A127 /* PluginListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListCell.xib; sourceTree = "<group>"; };
@@ -4726,6 +4728,7 @@
 			isa = PBXGroup;
 			children = (
 				400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */,
+				400A2C902217B308000A8A59 /* CountryStatsRecordValueTests.swift */,
 				40C403F72215D88100E8C894 /* TopViewedStatsTests.swift */,
 				40C403ED2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift */,
 				4054F4632214F94D00D261AB /* StreakStatsRecordValueTests.swift */,
@@ -10858,6 +10861,7 @@
 				4054F445221363D300D261AB /* TopCommentsAuthorStatsRecordValueTests.swift in Sources */,
 				73178C2921BEE09300E37C9A /* SiteSegmentsStepTests.swift in Sources */,
 				08F8CD311EBD2A960049D0C0 /* MediaImageExporterTests.swift in Sources */,
+				400A2C912217B308000A8A59 /* CountryStatsRecordValueTests.swift in Sources */,
 				D800D87C20999CA200E7C7E5 /* SearchMenuItemCreatorTests.swift in Sources */,
 				436D55F02115CB6800CEAA33 /* RegisterDomainDetailsSectionTests.swift in Sources */,
 				E1B921BC1C0ED5A3003EA3CB /* MediaSizeSliderCellTest.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -226,6 +226,16 @@
 		37022D931981C19000F322B7 /* VerticallyStackedButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 37022D901981BF9200F322B7 /* VerticallyStackedButton.m */; };
 		374CB16215B93C0800DD0EBC /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 374CB16115B93C0800DD0EBC /* AudioToolbox.framework */; };
 		37EAAF4D1A11799A006D6306 /* CircularImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EAAF4C1A11799A006D6306 /* CircularImageView.swift */; };
+		400A2C772217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C752217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift */; };
+		400A2C782217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C762217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift */; };
+		400A2C832217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C792217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift */; };
+		400A2C842217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C7A2217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift */; };
+		400A2C862217A985000A8A59 /* ReferrerStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C7C2217A985000A8A59 /* ReferrerStatsRecordValue+CoreDataClass.swift */; };
+		400A2C872217A985000A8A59 /* ReferrerStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C7D2217A985000A8A59 /* ReferrerStatsRecordValue+CoreDataProperties.swift */; };
+		400A2C882217A985000A8A59 /* CountryStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C7E2217A985000A8A59 /* CountryStatsRecordValue+CoreDataClass.swift */; };
+		400A2C892217A985000A8A59 /* CountryStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C7F2217A985000A8A59 /* CountryStatsRecordValue+CoreDataProperties.swift */; };
+		400A2C8B2217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C812217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift */; };
+		400A2C8C2217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C822217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift */; };
 		400F4625201E74EE000CFD9E /* CollectionViewContainerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400F4624201E74EE000CFD9E /* CollectionViewContainerRow.swift */; };
 		4019B27120885AB900A0C7EB /* Activity.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4019B27020885AB900A0C7EB /* Activity.storyboard */; };
 		401A3D022027DBD80099A127 /* PluginListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 401A3D012027DBD80099A127 /* PluginListCell.xib */; };
@@ -239,20 +249,20 @@
 		4034FDEE2007D4F700153B87 /* ExpandableCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4034FDED2007D4F700153B87 /* ExpandableCell.xib */; };
 		403E192B21377DEA00E4E657 /* BlogService+JetpackConvenience.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403E192A21377DEA00E4E657 /* BlogService+JetpackConvenience.swift */; };
 		403F57BC20E5CA6A004E889A /* RewindStatusRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403F57BB20E5CA6A004E889A /* RewindStatusRow.swift */; };
-		4054F45F2214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F45B2214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataClass.swift */; };
-		4054F4602214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F45C2214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataProperties.swift */; };
-		4054F4612214F50300D261AB /* StreakStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F45D2214F50300D261AB /* StreakStatsRecordValue+CoreDataClass.swift */; };
-		4054F4622214F50300D261AB /* StreakStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F45E2214F50300D261AB /* StreakStatsRecordValue+CoreDataProperties.swift */; };
-		4054F4642214F94D00D261AB /* StreakStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F4632214F94D00D261AB /* StreakStatsRecordValueTests.swift */; };
-		4054F4562214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F4542214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataClass.swift */; };
-		4054F4572214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F4552214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataProperties.swift */; };
-		4054F4592214E6FE00D261AB /* TagsCategoriesStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F4582214E6FE00D261AB /* TagsCategoriesStatsRecordValueTests.swift */; };
 		4054F43B221354E000D261AB /* TopCommentedPostStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F439221354E000D261AB /* TopCommentedPostStatsRecordValue+CoreDataClass.swift */; };
 		4054F43C221354E000D261AB /* TopCommentedPostStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F43A221354E000D261AB /* TopCommentedPostStatsRecordValue+CoreDataProperties.swift */; };
 		4054F43E221357B600D261AB /* TopCommentedPostStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F43D221357B600D261AB /* TopCommentedPostStatsRecordValueTests.swift */; };
 		4054F4422213635000D261AB /* TopCommentsAuthorStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F4402213635000D261AB /* TopCommentsAuthorStatsRecordValue+CoreDataClass.swift */; };
 		4054F4432213635000D261AB /* TopCommentsAuthorStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F4412213635000D261AB /* TopCommentsAuthorStatsRecordValue+CoreDataProperties.swift */; };
 		4054F445221363D300D261AB /* TopCommentsAuthorStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F444221363D300D261AB /* TopCommentsAuthorStatsRecordValueTests.swift */; };
+		4054F4562214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F4542214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataClass.swift */; };
+		4054F4572214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F4552214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataProperties.swift */; };
+		4054F4592214E6FE00D261AB /* TagsCategoriesStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F4582214E6FE00D261AB /* TagsCategoriesStatsRecordValueTests.swift */; };
+		4054F45F2214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F45B2214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataClass.swift */; };
+		4054F4602214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F45C2214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataProperties.swift */; };
+		4054F4612214F50300D261AB /* StreakStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F45D2214F50300D261AB /* StreakStatsRecordValue+CoreDataClass.swift */; };
+		4054F4622214F50300D261AB /* StreakStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F45E2214F50300D261AB /* StreakStatsRecordValue+CoreDataProperties.swift */; };
+		4054F4642214F94D00D261AB /* StreakStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4054F4632214F94D00D261AB /* StreakStatsRecordValueTests.swift */; };
 		4058F41A1FF40EE1000D5559 /* PluginDetailViewHeaderCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4058F4191FF40EE1000D5559 /* PluginDetailViewHeaderCell.xib */; };
 		405B53FB1F83C369002E19BF /* FancyAlerts+VerificationPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405B53FA1F83C369002E19BF /* FancyAlerts+VerificationPrompt.swift */; };
 		40640046200ED30300106789 /* TextWithAccessoryButtonCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 40640045200ED30300106789 /* TextWithAccessoryButtonCell.xib */; };
@@ -268,14 +278,14 @@
 		40A71C6A220E1952002E3D25 /* StatsRecord+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A71C64220E1951002E3D25 /* StatsRecord+CoreDataClass.swift */; };
 		40A71C6B220E1952002E3D25 /* StatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A71C65220E1951002E3D25 /* StatsRecordValue+CoreDataProperties.swift */; };
 		40ADB15520686870009A9161 /* PluginStore+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40ADB15420686870009A9161 /* PluginStore+Persistence.swift */; };
+		40C403EB2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403E92215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift */; };
+		40C403EC2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403EA2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift */; };
+		40C403EE2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403ED2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift */; };
 		40C403F32215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403EF2215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataClass.swift */; };
 		40C403F42215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403F02215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift */; };
 		40C403F52215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403F12215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift */; };
 		40C403F62215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403F22215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift */; };
 		40C403F82215D88100E8C894 /* TopViewedStatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403F72215D88100E8C894 /* TopViewedStatsTests.swift */; };
-		40C403EB2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403E92215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift */; };
-		40C403EC2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403EA2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift */; };
-		40C403EE2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C403ED2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift */; };
 		40D7823A206AEA880015A3A1 /* Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D78238206ABD970015A3A1 /* Scheduler.swift */; };
 		40E4698F2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */; };
 		40E469932017F4070030DB5F /* PluginDirectoryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E469922017F3D20030DB5F /* PluginDirectoryViewController.swift */; };
@@ -2073,6 +2083,16 @@
 		37E3F5EA2ED7005A5E0BBEC3 /* Pods-WordPressTodayWidget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTodayWidget.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTodayWidget/Pods-WordPressTodayWidget.release.xcconfig"; sourceTree = "<group>"; };
 		37EAAF4C1A11799A006D6306 /* CircularImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircularImageView.swift; sourceTree = "<group>"; };
 		3B28C7D4D65D0CA6AB9FCFDC /* Pods-WordPressDraftActionExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressDraftActionExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressDraftActionExtension/Pods-WordPressDraftActionExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		400A2C752217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisitsSummaryStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		400A2C762217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisitsSummaryStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		400A2C792217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedVideoStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		400A2C7A2217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedVideoStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		400A2C7C2217A985000A8A59 /* ReferrerStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReferrerStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		400A2C7D2217A985000A8A59 /* ReferrerStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReferrerStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		400A2C7E2217A985000A8A59 /* CountryStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CountryStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		400A2C7F2217A985000A8A59 /* CountryStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CountryStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		400A2C812217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClicksStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		400A2C822217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClicksStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		400F4624201E74EE000CFD9E /* CollectionViewContainerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewContainerRow.swift; sourceTree = "<group>"; };
 		4019B27020885AB900A0C7EB /* Activity.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Activity.storyboard; sourceTree = "<group>"; };
 		401A3D012027DBD80099A127 /* PluginListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListCell.xib; sourceTree = "<group>"; };
@@ -2087,20 +2107,20 @@
 		4034FDED2007D4F700153B87 /* ExpandableCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ExpandableCell.xib; sourceTree = "<group>"; };
 		403E192A21377DEA00E4E657 /* BlogService+JetpackConvenience.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogService+JetpackConvenience.swift"; sourceTree = "<group>"; };
 		403F57BB20E5CA6A004E889A /* RewindStatusRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewindStatusRow.swift; sourceTree = "<group>"; };
-		4054F45B2214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StreakInsightStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
-		4054F45C2214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StreakInsightStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		4054F45D2214F50300D261AB /* StreakStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StreakStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
-		4054F45E2214F50300D261AB /* StreakStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StreakStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		4054F4632214F94D00D261AB /* StreakStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreakStatsRecordValueTests.swift; sourceTree = "<group>"; };
-		4054F4542214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TagsCategoriesStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
-		4054F4552214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TagsCategoriesStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		4054F4582214E6FE00D261AB /* TagsCategoriesStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagsCategoriesStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		4054F439221354E000D261AB /* TopCommentedPostStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopCommentedPostStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		4054F43A221354E000D261AB /* TopCommentedPostStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopCommentedPostStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		4054F43D221357B600D261AB /* TopCommentedPostStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCommentedPostStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		4054F4402213635000D261AB /* TopCommentsAuthorStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopCommentsAuthorStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		4054F4412213635000D261AB /* TopCommentsAuthorStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopCommentsAuthorStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		4054F444221363D300D261AB /* TopCommentsAuthorStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopCommentsAuthorStatsRecordValueTests.swift; sourceTree = "<group>"; };
+		4054F4542214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TagsCategoriesStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		4054F4552214E3C800D261AB /* TagsCategoriesStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TagsCategoriesStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		4054F4582214E6FE00D261AB /* TagsCategoriesStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagsCategoriesStatsRecordValueTests.swift; sourceTree = "<group>"; };
+		4054F45B2214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StreakInsightStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		4054F45C2214F50300D261AB /* StreakInsightStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StreakInsightStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		4054F45D2214F50300D261AB /* StreakStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StreakStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		4054F45E2214F50300D261AB /* StreakStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StreakStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		4054F4632214F94D00D261AB /* StreakStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreakStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		4058F4191FF40EE1000D5559 /* PluginDetailViewHeaderCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginDetailViewHeaderCell.xib; sourceTree = "<group>"; };
 		405B53FA1F83C369002E19BF /* FancyAlerts+VerificationPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FancyAlerts+VerificationPrompt.swift"; sourceTree = "<group>"; };
 		40640045200ED30300106789 /* TextWithAccessoryButtonCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextWithAccessoryButtonCell.xib; sourceTree = "<group>"; };
@@ -2116,14 +2136,14 @@
 		40A71C64220E1951002E3D25 /* StatsRecord+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StatsRecord+CoreDataClass.swift"; sourceTree = "<group>"; };
 		40A71C65220E1951002E3D25 /* StatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40ADB15420686870009A9161 /* PluginStore+Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PluginStore+Persistence.swift"; sourceTree = "<group>"; };
+		40C403E92215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchResultsStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
+		40C403EA2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchResultsStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		40C403ED2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		40C403EF2215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedAuthorStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		40C403F02215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedAuthorStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40C403F12215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedPostStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		40C403F22215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedPostStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		40C403F72215D88100E8C894 /* TopViewedStatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopViewedStatsTests.swift; sourceTree = "<group>"; };
-		40C403E92215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchResultsStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
-		40C403EA2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SearchResultsStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
-		40C403ED2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		40D78238206ABD970015A3A1 /* Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scheduler.swift; sourceTree = "<group>"; };
 		40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryEntryStateTests.swift; sourceTree = "<group>"; };
 		40E469922017F3D20030DB5F /* PluginDirectoryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryViewController.swift; sourceTree = "<group>"; };
@@ -4638,6 +4658,29 @@
 			path = Stats;
 			sourceTree = "<group>";
 		};
+		400A2C8D2217AAA1000A8A59 /* Time-based data */ = {
+			isa = PBXGroup;
+			children = (
+				400A2C792217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift */,
+				400A2C7A2217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift */,
+				400A2C7C2217A985000A8A59 /* ReferrerStatsRecordValue+CoreDataClass.swift */,
+				400A2C7D2217A985000A8A59 /* ReferrerStatsRecordValue+CoreDataProperties.swift */,
+				400A2C7E2217A985000A8A59 /* CountryStatsRecordValue+CoreDataClass.swift */,
+				400A2C7F2217A985000A8A59 /* CountryStatsRecordValue+CoreDataProperties.swift */,
+				400A2C812217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift */,
+				400A2C822217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift */,
+				400A2C752217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift */,
+				400A2C762217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift */,
+				40C403EF2215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataClass.swift */,
+				40C403F02215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift */,
+				40C403F12215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift */,
+				40C403F22215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift */,
+				40C403E92215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift */,
+				40C403EA2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift */,
+			);
+			name = "Time-based data";
+			sourceTree = "<group>";
+		};
 		40247E002120FE2300AE1C3C /* Automated Transfer */ = {
 			isa = PBXGroup;
 			children = (
@@ -4667,12 +4710,7 @@
 		40A71C5F220E1941002E3D25 /* Stats */ = {
 			isa = PBXGroup;
 			children = (
-				40C403EF2215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataClass.swift */,
-				40C403F02215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataProperties.swift */,
-				40C403F12215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataClass.swift */,
-				40C403F22215D66A00E8C894 /* TopViewedPostStatsRecordValue+CoreDataProperties.swift */,
-				40C403E92215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataClass.swift */,
-				40C403EA2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift */,
+				400A2C8D2217AAA1000A8A59 /* Time-based data */,
 				40F46B6C22121BBC00A2143B /* Insights */,
 				40A71C64220E1951002E3D25 /* StatsRecord+CoreDataClass.swift */,
 				40A71C60220E1950002E3D25 /* StatsRecord+CoreDataProperties.swift */,
@@ -9490,6 +9528,7 @@
 				E16A76F11FC4758300A661E3 /* JetpackSiteRef.swift in Sources */,
 				B5B56D3219AFB68800B4E29B /* WPStyleGuide+Reply.swift in Sources */,
 				30EABE0918A5903400B73A9C /* WPBlogTableViewCell.m in Sources */,
+				400A2C842217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift in Sources */,
 				7E4123BE20F4097B00DF8486 /* NotificationContentRangeFactory.swift in Sources */,
 				5D13FA551AF99C0300F06492 /* PageListSectionHeaderView.m in Sources */,
 				E6D170371EF9D8D10046D433 /* SiteInfo.swift in Sources */,
@@ -9685,6 +9724,7 @@
 				E66E2A691FE432BC00788F22 /* TitleBadgeDisclosureCell.swift in Sources */,
 				7E4123BF20F4097B00DF8486 /* FormattableContent.swift in Sources */,
 				D82253DF2199418B0014D0E2 /* WebAddressWizardContent.swift in Sources */,
+				400A2C782217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift in Sources */,
 				D853723C21952DC90076F461 /* SiteSegmentsStep.swift in Sources */,
 				FF70A3221FD5840500BC270D /* PHAsset+Metadata.swift in Sources */,
 				5DA5BF4418E32DCF005F11F9 /* Theme.m in Sources */,
@@ -9735,6 +9775,7 @@
 				FAE4201A1C5AEFE100C1D036 /* StartOverViewController.swift in Sources */,
 				B57B99D519A2C20200506504 /* NoteTableHeaderView.swift in Sources */,
 				1790A4531E28F0ED00AE54C2 /* UINavigationController+Helpers.swift in Sources */,
+				400A2C882217A985000A8A59 /* CountryStatsRecordValue+CoreDataClass.swift in Sources */,
 				08D345561CD7FBA900358E8C /* MenuHeaderViewController.m in Sources */,
 				B5120B381D47CC6C0059361A /* NotificationDetailsViewController.swift in Sources */,
 				83418AAA11C9FA6E00ACF00C /* Comment.m in Sources */,
@@ -9849,10 +9890,12 @@
 				436D56252117312700CEAA33 /* RegisterDomainDetailsViewController+Cells.swift in Sources */,
 				7371E6D221FA730700596C0A /* ReaderStreamViewController+Sharing.swift in Sources */,
 				17A28DC3205001A900EA6D9E /* FilterBar.swift in Sources */,
+				400A2C8C2217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift in Sources */,
 				D858F30320E201F4007E8A1C /* EditComment.swift in Sources */,
 				9A4E61F621A2C37B0017A925 /* WPStyleSuide+Revisions.swift in Sources */,
 				B538F3891EF46EC8001003D5 /* UnknownEditorViewController.swift in Sources */,
 				937D9A1119F838C2007B9D5F /* AccountToAccount22to23.swift in Sources */,
+				400A2C772217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift in Sources */,
 				D8212CB320AA6861008E8AE8 /* ReaderFollowAction.swift in Sources */,
 				E6F2788421BC1A4A008B4DB5 /* PlanFeature.swift in Sources */,
 				D8A3A5AF206A442800992576 /* StockPhotosDataSource.swift in Sources */,
@@ -10022,6 +10065,7 @@
 				9859DF842021063600FB848E /* SiteCreationCategoryTableViewController.swift in Sources */,
 				595CB3761D2317D50082C7E9 /* PostListFilter.swift in Sources */,
 				08E77F451EE87FCF006F9515 /* MediaThumbnailExporter.swift in Sources */,
+				400A2C862217A985000A8A59 /* ReferrerStatsRecordValue+CoreDataClass.swift in Sources */,
 				B5EB19EC20C6DACC008372B9 /* ImageDownloader.swift in Sources */,
 				E240859C183D82AE002EB0EF /* WPAnimatedBox.m in Sources */,
 				17BEE0041FC867C20074C124 /* WordPressAppDelegate+Swift.swift in Sources */,
@@ -10217,6 +10261,7 @@
 				93DEB88219E5BF7100F9546D /* TodayExtensionService.m in Sources */,
 				17CE77EF20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift in Sources */,
 				98D60B9E1FFEE3D800145190 /* SiteCreationThemeSelectionCell.swift in Sources */,
+				400A2C832217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift in Sources */,
 				5D42A3E2175E7452005CFF05 /* ReaderPost.m in Sources */,
 				2FA6511A21F26A57009AA935 /* InlineErrorTableViewProvider.swift in Sources */,
 				D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */,
@@ -10264,6 +10309,7 @@
 				FFB1FAA01BF0EC4E0090C761 /* PHAsset+Exporters.swift in Sources */,
 				D816B8D92112D85F0052CE4D /* News.swift in Sources */,
 				8298F38F1EEF2B15008EB7F0 /* AppFeedbackPromptView.swift in Sources */,
+				400A2C892217A985000A8A59 /* CountryStatsRecordValue+CoreDataProperties.swift in Sources */,
 				9881296E219CF1310075FF33 /* StatsCellHeader.swift in Sources */,
 				E1823E6C1E42231C00C19F53 /* UIEdgeInsets.swift in Sources */,
 				98921EF921372E30004949AA /* LocalNewsService.swift in Sources */,
@@ -10272,6 +10318,7 @@
 				FFB1FA9E1BF0EB840090C761 /* UIImage+Exporters.swift in Sources */,
 				E1556CF2193F6FE900FC52EA /* CommentService.m in Sources */,
 				D80BC7A22074739400614A59 /* MediaLibraryStrings.swift in Sources */,
+				400A2C8B2217A985000A8A59 /* ClicksStatsRecordValue+CoreDataClass.swift in Sources */,
 				5DB3BA0518D0E7B600F3F3E9 /* WPPickerView.m in Sources */,
 				B5E94D151FE04815000E7C20 /* UIImageView+SiteIcon.swift in Sources */,
 				17CE77ED20C6C2F3001DEA5A /* ReaderSiteSearchService.swift in Sources */,
@@ -10450,6 +10497,7 @@
 				319D6E7E19E447C80013871C /* SuggestionService.m in Sources */,
 				436D56212117312700CEAA33 /* RegisterDomainDetailsViewModel+SectionDefinitions.swift in Sources */,
 				FFA162311CB7031A00E2E110 /* AppSettingsViewController.swift in Sources */,
+				400A2C872217A985000A8A59 /* ReferrerStatsRecordValue+CoreDataProperties.swift in Sources */,
 				B5CEEB8E1B7920BE00E7B7B0 /* CommentsTableViewCell.swift in Sources */,
 				9A938C5D21FB3B10009D0C24 /* QuickStartChecklistViewControllerV1.swift in Sources */,
 			);

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		400A2C8C2217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C822217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift */; };
 		400A2C8F2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */; };
 		400A2C912217B308000A8A59 /* CountryStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C902217B308000A8A59 /* CountryStatsRecordValueTests.swift */; };
+		400A2C932217B463000A8A59 /* ReferrerStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C922217B463000A8A59 /* ReferrerStatsRecordValueTests.swift */; };
 		400F4625201E74EE000CFD9E /* CollectionViewContainerRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400F4624201E74EE000CFD9E /* CollectionViewContainerRow.swift */; };
 		4019B27120885AB900A0C7EB /* Activity.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4019B27020885AB900A0C7EB /* Activity.storyboard */; };
 		401A3D022027DBD80099A127 /* PluginListCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 401A3D012027DBD80099A127 /* PluginListCell.xib */; };
@@ -2097,6 +2098,7 @@
 		400A2C822217A985000A8A59 /* ClicksStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClicksStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClicksStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		400A2C902217B308000A8A59 /* CountryStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryStatsRecordValueTests.swift; sourceTree = "<group>"; };
+		400A2C922217B463000A8A59 /* ReferrerStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReferrerStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		400F4624201E74EE000CFD9E /* CollectionViewContainerRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewContainerRow.swift; sourceTree = "<group>"; };
 		4019B27020885AB900A0C7EB /* Activity.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Activity.storyboard; sourceTree = "<group>"; };
 		401A3D012027DBD80099A127 /* PluginListCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PluginListCell.xib; sourceTree = "<group>"; };
@@ -4728,6 +4730,7 @@
 			isa = PBXGroup;
 			children = (
 				400A2C8E2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift */,
+				400A2C922217B463000A8A59 /* ReferrerStatsRecordValueTests.swift */,
 				400A2C902217B308000A8A59 /* CountryStatsRecordValueTests.swift */,
 				40C403F72215D88100E8C894 /* TopViewedStatsTests.swift */,
 				40C403ED2215CE9500E8C894 /* SearchResultsStatsRecordValueTests.swift */,
@@ -10857,6 +10860,7 @@
 				85B125411B028E34008A3D95 /* PushAuthenticationManagerTests.swift in Sources */,
 				D821C81B21003AE9002ED995 /* FormattableContentGroupTests.swift in Sources */,
 				93D86B981C691E71003D8E3E /* LocalCoreDataServiceTests.m in Sources */,
+				400A2C932217B463000A8A59 /* ReferrerStatsRecordValueTests.swift in Sources */,
 				E1928B2E1F8369F100E076C8 /* WebViewAuthenticatorTests.swift in Sources */,
 				4054F445221363D300D261AB /* TopCommentsAuthorStatsRecordValueTests.swift in Sources */,
 				73178C2921BEE09300E37C9A /* SiteSegmentsStepTests.swift in Sources */,

--- a/WordPress/WordPressTest/ClicksStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/ClicksStatsRecordValueTests.swift
@@ -1,0 +1,79 @@
+@testable import WordPress
+
+class ClicksStatsRecordValueTests: StatsTestCase {
+
+    func testCreation() {
+        let parent = createStatsRecord(in: mainContext, type: .clicks, date: Date())
+
+        let clicks = ClicksStatsRecordValue(parent: parent)
+        clicks.label = "test"
+        clicks.clicksCount = 9001
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let fr = StatsRecord.fetchRequest(for: .clicks)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first!.values?.count, 1)
+
+        let fetchedClicks = results.first?.values?.firstObject! as! ClicksStatsRecordValue
+
+        XCTAssertEqual(fetchedClicks.label, clicks.label)
+        XCTAssertEqual(fetchedClicks.clicksCount, clicks.clicksCount)
+    }
+
+    func testChildrenRelationships() {
+        let parent = createStatsRecord(in: mainContext, type: .clicks, date: Date())
+
+        let clicks = ClicksStatsRecordValue(parent: parent)
+        clicks.label = "parent"
+        clicks.clicksCount = 5000
+
+        let child = ClicksStatsRecordValue(context: mainContext)
+        child.label = "child"
+        child.clicksCount = 4000
+
+        let child2 = ClicksStatsRecordValue(context: mainContext)
+        child2.label = "child2"
+        child2.clicksCount = 1
+
+        clicks.addToChildren([child, child2])
+
+        let fr = StatsRecord.fetchRequest(for: .clicks)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first!.values?.count, 1)
+
+        let fetchedClicks = results.first?.values?.firstObject! as! ClicksStatsRecordValue
+
+        XCTAssertEqual(fetchedClicks.label, clicks.label)
+
+        let children = fetchedClicks.children?.array as? [ClicksStatsRecordValue]
+
+        XCTAssertNotNil(children)
+        XCTAssertEqual(children!.count, 2)
+        XCTAssertEqual(children!.first!.label, child.label)
+        XCTAssertEqual(children![1].label, child2.label)
+
+        XCTAssertEqual(9001, fetchedClicks.clicksCount + children!.first!.clicksCount + children![1].clicksCount)
+    }
+
+
+    func testURLConversionWorks() {
+        let parent = createStatsRecord(in: mainContext, type: .clicks, date: Date())
+
+        let tag = ClicksStatsRecordValue(parent: parent)
+        tag.urlString = "www.wordpress.com"
+
+        let fetchRequest = StatsRecord.fetchRequest(for: .clicks)
+        let result = try! mainContext.fetch(fetchRequest)
+
+        let fetchedValue = result.first!.values!.firstObject as! ClicksStatsRecordValue
+        XCTAssertNotNil(fetchedValue.clickedURL)
+    }
+
+}

--- a/WordPress/WordPressTest/CountryStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/CountryStatsRecordValueTests.swift
@@ -1,0 +1,29 @@
+@testable import WordPress
+
+class CountryStatsRecordValueTests: StatsTestCase {
+
+    func testCreation() {
+        let parent = createStatsRecord(in: mainContext, type: .countryViews, date: Date())
+
+        let country = CountryStatsRecordValue(parent: parent)
+        country.viewsCount = 9001
+        country.countryCode = "de"
+        country.countryName = "🇩🇪"
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let fr = StatsRecord.fetchRequest(for: .countryViews)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first!.values?.count, 1)
+
+        let fetchedCountry = results.first?.values?.firstObject! as! CountryStatsRecordValue
+
+        XCTAssertEqual(fetchedCountry.viewsCount, country.viewsCount)
+        XCTAssertEqual(fetchedCountry.countryCode, country.countryCode)
+        XCTAssertEqual(fetchedCountry.countryName, country.countryName)
+    }
+
+}

--- a/WordPress/WordPressTest/ReferrerStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/ReferrerStatsRecordValueTests.swift
@@ -1,0 +1,91 @@
+@testable import WordPress
+class ReferrerStatsRecordValueTests: StatsTestCase {
+
+    func testCreation() {
+        let parent = createStatsRecord(in: mainContext, type: .referrers, date: Date())
+
+        let referrer = ReferrerStatsRecordValue(parent: parent)
+        referrer.label = "test"
+        referrer.viewsCount = 9001
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let fr = StatsRecord.fetchRequest(for: .referrers)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first!.values?.count, 1)
+
+        let fetchedReferrer = results.first?.values?.firstObject! as! ReferrerStatsRecordValue
+
+        XCTAssertEqual(fetchedReferrer.label, referrer.label)
+        XCTAssertEqual(fetchedReferrer.viewsCount, referrer.viewsCount)
+    }
+
+    func testChildrenRelationships() {
+        let parent = createStatsRecord(in: mainContext, type: .referrers, date: Date())
+
+        let referer = ReferrerStatsRecordValue(parent: parent)
+        referer.label = "parent"
+        referer.viewsCount = 5000
+
+        let child = ReferrerStatsRecordValue(context: mainContext)
+        child.label = "child"
+        child.viewsCount = 4000
+
+        let child2 = ReferrerStatsRecordValue(context: mainContext)
+        child2.label = "child2"
+        child2.viewsCount = 1
+
+        referer.addToChildren([child, child2])
+
+        let fr = StatsRecord.fetchRequest(for: .referrers)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first!.values?.count, 1)
+
+        let fetchedReferer = results.first?.values?.firstObject! as! ReferrerStatsRecordValue
+
+        XCTAssertEqual(fetchedReferer.label, referer.label)
+
+        let children = fetchedReferer.children?.array as? [ReferrerStatsRecordValue]
+
+        XCTAssertNotNil(children)
+        XCTAssertEqual(children!.count, 2)
+        XCTAssertEqual(children!.first!.label, child.label)
+        XCTAssertEqual(children![1].label, child2.label)
+
+        XCTAssertEqual(9001, fetchedReferer.viewsCount + children!.first!.viewsCount + children![1].viewsCount)
+    }
+
+
+    func testURLConversionWorks() {
+        let parent = createStatsRecord(in: mainContext, type: .referrers, date: Date())
+
+        let tag = ReferrerStatsRecordValue(parent: parent)
+        tag.urlString = "www.wordpress.com"
+
+        let fetchRequest = StatsRecord.fetchRequest(for: .referrers)
+        let result = try! mainContext.fetch(fetchRequest)
+
+        let fetchedValue = result.first!.values!.firstObject as! ReferrerStatsRecordValue
+        XCTAssertNotNil(fetchedValue.referrerURL)
+    }
+
+    func testIconURLConversionWorks() {
+        let parent = createStatsRecord(in: mainContext, type: .referrers, date: Date())
+
+        let tag = ReferrerStatsRecordValue(parent: parent)
+        tag.iconURLString = "www.wordpress.com"
+
+        let fetchRequest = StatsRecord.fetchRequest(for: .referrers)
+        let result = try! mainContext.fetch(fetchRequest)
+
+        let fetchedValue = result.first!.values!.firstObject as! ReferrerStatsRecordValue
+        XCTAssertNotNil(fetchedValue.iconURL)
+    }
+
+}

--- a/WordPress/WordPressTest/StatsRecordTests.swift
+++ b/WordPress/WordPressTest/StatsRecordTests.swift
@@ -3,15 +3,15 @@
 class StatsRecordTests: StatsTestCase {
 
     func testCreatingAndSaving() {
-        createStatsRecord(in: mainContext, type: .blogStats, date: Date())
-        createStatsRecord(in: mainContext, type: .blogStats, date: Date())
-        createStatsRecord(in: mainContext, type: .blogStats, date: Date())
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: Date())
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: Date())
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: Date())
 
         XCTAssertNoThrow(try mainContext.save())
     }
 
     func testDateValidationWorks() {
-        let record = createStatsRecord(in: mainContext, type: .blogStats, date: Date())
+        let record = createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: Date())
         record.date = nil
 
         XCTAssertThrowsError(try mainContext.save()) { error in
@@ -52,11 +52,11 @@ class StatsRecordTests: StatsTestCase {
     }
 
     func testFetchingForToday() {
-        createStatsRecord(in: mainContext, type: .blogStats, date: Date())
-        createStatsRecord(in: mainContext, type: .blogStats, date: Date())
-        createStatsRecord(in: mainContext, type: .blogStats, date: Date())
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: Date())
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: Date())
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: Date())
 
-        let fetchRequest = StatsRecord.fetchRequest(for: .blogStats)
+        let fetchRequest = StatsRecord.fetchRequest(for: .blogVisitsSummary)
 
         let allResults = try! mainContext.fetch(StatsRecord.fetchRequest())
         let results = try! mainContext.fetch(fetchRequest)
@@ -66,10 +66,10 @@ class StatsRecordTests: StatsTestCase {
     }
 
     func testFetchingProperTypeOnly() {
-        createStatsRecord(in: mainContext, type: .blogStats, date: Date())
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: Date())
         createStatsRecord(in: mainContext, type: .lastPostInsight, date: Date())
 
-        let fetchRequest = StatsRecord.fetchRequest(for: .blogStats)
+        let fetchRequest = StatsRecord.fetchRequest(for: .blogVisitsSummary)
 
         let results = try! mainContext.fetch(fetchRequest)
 
@@ -80,13 +80,13 @@ class StatsRecordTests: StatsTestCase {
         let calendar = Calendar.autoupdatingCurrent
         let yesterday = calendar.date(byAdding: .day, value: -1, to: Date())!
 
-        createStatsRecord(in: mainContext, type: .blogStats, date: yesterday)
-        createStatsRecord(in: mainContext, type: .blogStats, date: yesterday)
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: yesterday)
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: yesterday)
         createStatsRecord(in: mainContext, type: .lastPostInsight, date: yesterday)
-        createStatsRecord(in: mainContext, type: .blogStats, date: Date())
-        createStatsRecord(in: mainContext, type: .blogStats, date: Date())
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: Date())
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: Date())
 
-        let fetchRequest = StatsRecord.fetchRequest(for: .blogStats, on: yesterday)
+        let fetchRequest = StatsRecord.fetchRequest(for: .blogVisitsSummary, on: yesterday)
 
         let results = try! mainContext.fetch(fetchRequest)
 
@@ -102,13 +102,13 @@ class StatsRecordTests: StatsTestCase {
 
         let yesterdayRange = calendar.dateInterval(of: .day, for: yesterday)!
 
-        createStatsRecord(in: mainContext, type: .blogStats, date: yesterday)
-        createStatsRecord(in: mainContext, type: .blogStats, date: yesterdayHourLater)
-        createStatsRecord(in: mainContext, type: .blogStats, date: yesterdayHourEarlier)
-        createStatsRecord(in: mainContext, type: .blogStats, date: yesterdayRange.start)
-        createStatsRecord(in: mainContext, type: .blogStats, date: yesterdayRange.end)
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: yesterday)
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: yesterdayHourLater)
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: yesterdayHourEarlier)
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: yesterdayRange.start)
+        createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: yesterdayRange.end)
 
-        let fetchRequest = StatsRecord.fetchRequest(for: .blogStats, on: yesterday)
+        let fetchRequest = StatsRecord.fetchRequest(for: .blogVisitsSummary, on: yesterday)
 
         let results = try! mainContext.fetch(fetchRequest)
 

--- a/WordPress/WordPressTest/TopViewedVideoStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/TopViewedVideoStatsRecordValueTests.swift
@@ -1,0 +1,41 @@
+@testable import WordPress
+class TopViewedVideoStatsTests: StatsTestCase {
+
+    func testCreation() {
+        let parent = createStatsRecord(in: mainContext, type: .videos, date: Date())
+
+        let video = TopViewedVideoStatsRecordValue(parent: parent)
+        video.playsCount = 900000001
+        video.title = "Selfies — how to do em good???????"
+        video.postID = "test"
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let fr = StatsRecord.fetchRequest(for: .videos)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first!.values?.count, 1)
+
+        let fetchedVideo = results.first?.values?.firstObject! as! TopViewedVideoStatsRecordValue
+
+        XCTAssertEqual(fetchedVideo.title, video.title)
+        XCTAssertEqual(fetchedVideo.playsCount, video.playsCount)
+        XCTAssertEqual(fetchedVideo.postID, video.postID)
+    }
+
+    func testURLConversionWorks() {
+        let parent = createStatsRecord(in: mainContext, type: .videos, date: Date())
+
+        let video = TopViewedVideoStatsRecordValue(parent: parent)
+        video.postURLString = "www.wordpress.com"
+
+        let fetchRequest = StatsRecord.fetchRequest(for: .videos)
+        let result = try! mainContext.fetch(fetchRequest)
+
+        let fetchedValue = result.first!.values!.firstObject as! TopViewedVideoStatsRecordValue
+        XCTAssertNotNil(fetchedValue.postURL)
+    }
+
+}

--- a/WordPress/WordPressTest/VisitsSummaryStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/VisitsSummaryStatsRecordValueTests.swift
@@ -1,0 +1,30 @@
+@testable import WordPress
+class VisitsSummaryStatsRecordValueTests: StatsTestCase {
+
+    func testCreation() {
+        let parent = createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: Date())
+
+        let visits = VisitsSummaryStatsRecordValue(parent: parent)
+        visits.viewsCount = 1
+        visits.visitorsCount = 2
+        visits.likesCount = 3
+        visits.commentsCount = 4
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let fr = StatsRecord.fetchRequest(for: .blogVisitsSummary)
+
+        let results = try! mainContext.fetch(fr)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first!.values?.count, 1)
+
+        let fetchedVisits = results.first?.values?.firstObject! as! VisitsSummaryStatsRecordValue
+
+        XCTAssertEqual(fetchedVisits.viewsCount, visits.viewsCount)
+        XCTAssertEqual(fetchedVisits.visitorsCount, visits.visitorsCount)
+        XCTAssertEqual(fetchedVisits.likesCount, visits.likesCount)
+        XCTAssertEqual(fetchedVisits.commentsCount, visits.commentsCount)
+    }
+
+}


### PR DESCRIPTION
Follow-up to #11000, another one in line with #11010, #11011 (all those PR have binary numbers!), #11016, #11017, #11038, #11038, #11047 and #11048.

This should be the last one for now! :) 

It's a bigger one, since I rolled up five new entities into one PR, but if I had to manually resolve conflicts five more times I think I would lose some marbles.

Hopefully it's still palatable — a fair amount of the +703/-94 is the auto-generated Core Data interfaces, so the actual changes to look over shouldn't be too bad :)

To test:

* Verify that the app builds
* Verify that the tests pass.

