### PR TITLE
Fix/release notes issue

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,2 +1,4 @@
+11.9
+------
 * Added connection error alert in Sharing screen.
 * Increased padding at the bottom of the share extension's editor, to make typing a longer post a bit more comfortable.

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -34,6 +34,7 @@ import "./ScreenshotFastfile"
     
     ios_bump_version_release()
     new_version = ios_get_app_version()
+    ios_update_release_notes(new_version: new_version)
     setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
 

--- a/Scripts/fastlane/actions/ios_update_release_notes.rb
+++ b/Scripts/fastlane/actions/ios_update_release_notes.rb
@@ -1,0 +1,54 @@
+module Fastlane
+    module Actions    
+      class IosUpdateReleaseNotesAction < Action
+        def self.run(params)
+          # fastlane will take care of reading in the parameter and fetching the environment variable:
+          UI.message "Updating the release notes..."
+
+          require_relative '../helpers/ios_git_helper.rb'
+          require_relative '../helpers/ios_version_helper.rb'
+          next_version = Fastlane::Helpers::IosVersionHelper.calc_next_release_version(params[:new_version])
+          Fastlane::Helpers::IosGitHelper.update_release_notes(next_version)
+          
+          UI.message "Done."
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Updates the release notes file for the next app version"
+        end
+  
+        def self.details
+          "Updates the release notes file for the next app version"
+        end
+  
+        def self.available_options
+            [
+              FastlaneCore::ConfigItem.new(key: :new_version,
+                                           env_name: "FL_IOS_UPDATE_RELEASE_NOTES_VERSION", 
+                                           description: "The new version to add to the release notes",
+                                           is_string: true)
+            ]
+          end
+
+        def self.output
+          
+        end
+  
+        def self.return_value
+          
+        end
+  
+        def self.authors
+          ["loremattei"]
+        end
+  
+        def self.is_supported?(platform)
+          platform == :ios
+        end
+      end
+    end
+  end

--- a/Scripts/fastlane/helpers/ios_git_helper.rb
+++ b/Scripts/fastlane/helpers/ios_git_helper.rb
@@ -31,9 +31,6 @@ module Fastlane
         Action.sh("git add fastlane/Deliverfile")
         Action.sh("git add fastlane/download_metadata.swift")
         Action.sh("git add ../WordPress/Resources/AppStoreStrings.po")
-        Action.sh("cp ../RELEASE-NOTES.txt ../WordPress/Resources/release_notes.txt ")
-        Action.sh("echo > ../RELEASE-NOTES.txt")
-        Action.sh("git add ../RELEASE-NOTES.txt ../WordPress/Resources/release_notes.txt")
         Action.sh("git commit -m \"Bump version number\"")
         Action.sh("git push")
       end
@@ -78,6 +75,15 @@ module Fastlane
         Action.sh("cd .. && ./Scripts/localize.py")
         Action.sh("git add ../WordPress/*.lproj/Localizable.strings")
         Action.sh("git commit -m \"Updates strings for localization\"")
+        Action.sh("git push")
+      end
+
+      def self.update_release_notes(new_version)
+        Action.sh("cp ../RELEASE-NOTES.txt ../WordPress/Resources/release_notes.txt ")
+        Action.sh("echo \"#{new_version}\n-----\n \" > ../RELEASE-NOTES.txt")
+        Action.sh("cat ../WordPress/Resources/release_notes.txt >> ../RELEASE-NOTES.txt")
+        Action.sh("git add ../RELEASE-NOTES.txt ../WordPress/Resources/release_notes.txt")
+        Action.sh("git commit -m \"Update release notes.\"")
         Action.sh("git push")
       end
 


### PR DESCRIPTION
This PR adds a headline with the version number in RELEASE-NOTES.txt.

Also, it updates Fastlane to handle the new file format in the right way during the code freeze: 
- RELEASE-NOTES.txt is copied to WordPress/Resources/release-notes.txt, so that it can be reviewed and edited.
- A new version is added on top of RELEASE-NOTES.txt. The file will contain the collaborative release notes, not the edited ones, in order to help git diff to do its stuff.


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
