### PR TITLE
[Stats Refresh] Remove duplicates from expanded row tracking

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -1,0 +1,51 @@
+enum StatSection: Int {
+    case periodOverview
+    case periodPostsAndPages
+    case periodReferrers
+    case periodClicks
+    case periodAuthors
+    case periodCountries
+    case periodSearchTerms
+    case periodPublished
+    case periodVideos
+    case insightsLatestPostSummary
+    case insightsAllTime
+    case insightsFollowerTotals
+    case insightsMostPopularTime
+    case insightsTagsAndCategories
+    case insightsAnnualSiteStats
+    case insightsComments
+    case insightsFollowers
+    case insightsTodaysStats
+    case insightsPostActivity
+    case insightsPublicize
+    case postDetailsGraph
+    case postDetailsMonthsYears
+    case postDetailsAveragePerDay
+    case postDetailsRecentWeeks
+
+    static let allInsights = [StatSection.insightsLatestPostSummary,
+                              .insightsAllTime,
+                              .insightsFollowerTotals,
+                              .insightsMostPopularTime,
+                              .insightsTagsAndCategories,
+                              .insightsAnnualSiteStats,
+                              .insightsComments,
+                              .insightsFollowers,
+                              .insightsTodaysStats,
+                              .insightsPostActivity,
+                              .insightsPublicize
+    ]
+
+    static let allPeriods = [StatSection.periodOverview,
+                             .periodPostsAndPages,
+                             .periodReferrers,
+                             .periodClicks,
+                             .periodAuthors,
+                             .periodCountries,
+                             .periodSearchTerms,
+                             .periodPublished,
+                             .periodVideos
+    ]
+
+}

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -141,7 +141,7 @@ private extension SiteStatsInsightsTableViewController {
     }
 
     func clearExpandedRows() {
-        StatsDataHelper.expandedRowLabels[.insights]?.removeAll()
+        StatsDataHelper.clearExpandedInsights()
     }
 
     // MARK: User Defaults
@@ -211,25 +211,8 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
     }
 
     func expandedRowUpdated(_ row: StatsTotalRow) {
-        // Go ahead an update the table. The remaining logic just updates
-        // the array that tracks the expanded rows.
         applyTableUpdates()
-
-        guard let rowData = row.rowData else {
-            return
-        }
-
-        var insightsExpandedRowLabels = StatsDataHelper.expandedRowLabels[.insights] ?? []
-
-        // Remove from array
-        insightsExpandedRowLabels = insightsExpandedRowLabels.filter { $0 != rowData.name }
-
-        // If expanded, add to array.
-        if row.expanded {
-            insightsExpandedRowLabels.append(rowData.name)
-        }
-
-        StatsDataHelper.expandedRowLabels[.insights] = insightsExpandedRowLabels
+        StatsDataHelper.updatedExpandedState(forRow: row)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -398,8 +398,8 @@ private extension SiteStatsInsightsViewModel {
                                      icon: tagsAndCategoriesIconForKind($0.kind),
                                      showDisclosure: true,
                                      disclosureURL: $0.url,
-                                     childRows: childRowsForItems($0.children))
-
+                                     childRows: childRowsForItems($0.children),
+                                     statSection: .insightsTagsAndCategories)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -136,8 +136,13 @@ private extension SiteStatsPeriodTableViewController {
         viewModel?.refreshPeriodData(withDate: selectedDate, forPeriod: selectedPeriod)
     }
 
+    func applyTableUpdates() {
+        tableView.beginUpdates()
+        tableView.endUpdates()
+    }
+
     func clearExpandedRows() {
-        StatsDataHelper.expandedRowLabels[.period]?.removeAll()
+        StatsDataHelper.clearExpandedPeriods()
     }
 
 }
@@ -169,28 +174,8 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
     }
 
     func expandedRowUpdated(_ row: StatsTotalRow) {
-        tableView.beginUpdates()
-        tableView.endUpdates()
-
-        guard let rowData = row.rowData else {
-            return
-        }
-
-        var periodExpandedRowLabels = StatsDataHelper.expandedRowLabels[.period] ?? []
-
-        // Remove from array
-        periodExpandedRowLabels = periodExpandedRowLabels.filter { $0 != rowData.name }
-
-        // Remove children from array
-        row.rowData?.childRows?.forEach { child in
-            periodExpandedRowLabels = periodExpandedRowLabels.filter { $0 != child.name }
-        }
-
-        // If expanded, add to array.
-        if row.expanded {
-            periodExpandedRowLabels.append(rowData.name)
-        }
-
-        StatsDataHelper.expandedRowLabels[.period] = periodExpandedRowLabels
+        applyTableUpdates()
+        StatsDataHelper.updatedExpandedState(forRow: row)
     }
+
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -160,7 +160,8 @@ private extension SiteStatsPeriodViewModel {
                                                                   socialIconURL: $0.iconURL,
                                                                   showDisclosure: true,
                                                                   disclosureURL: StatsDataHelper.disclosureUrlForItem($0),
-                                                                  childRows: childRowsForReferrers($0)) }
+                                                                  childRows: childRowsForReferrers($0),
+                                                                  statSection: .periodReferrers) }
             ?? [StatsTotalRowData]()
     }
 
@@ -185,7 +186,8 @@ private extension SiteStatsPeriodViewModel {
                                                     data: child.value.displayString(),
                                                     showDisclosure: true,
                                                     disclosureURL: StatsDataHelper.disclosureUrlForItem(child),
-                                                    childRows: childsChildrenRows))
+                                                    childRows: childsChildrenRows,
+                                                    statSection: .periodReferrers))
         }
 
         return childRows
@@ -207,7 +209,8 @@ private extension SiteStatsPeriodViewModel {
                                                      data: $0.value.displayString(),
                                                      showDisclosure: true,
                                                      disclosureURL: StatsDataHelper.disclosureUrlForItem($0),
-                                                     childRows: childRowsForClicks($0)) }
+                                                     childRows: childRowsForClicks($0),
+                                                     statSection: .periodClicks) }
             ?? [StatsTotalRowData]()
     }
 
@@ -241,7 +244,8 @@ private extension SiteStatsPeriodViewModel {
                                                      dataBarPercent: StatsDataHelper.dataBarPercentForRow($0, relativeToRow: authors?.first),
                                                      userIconURL: $0.iconURL,
                                                      showDisclosure: true,
-                                                     childRows: childRowsForAuthor($0)) }
+                                                     childRows: childRowsForAuthor($0),
+                                                     statSection: .periodAuthors) }
             ?? [StatsTotalRowData]()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -12,6 +12,7 @@ struct StatsTotalRowData {
     var showDisclosure: Bool
     var disclosureURL: URL?
     var childRows: [StatsTotalRowData]?
+    var statSection: StatSection?
 
     init(name: String,
          data: String,
@@ -23,7 +24,8 @@ struct StatsTotalRowData {
          nameDetail: String? = nil,
          showDisclosure: Bool = false,
          disclosureURL: URL? = nil,
-         childRows: [StatsTotalRowData]? = [StatsTotalRowData]()) {
+         childRows: [StatsTotalRowData]? = [StatsTotalRowData](),
+         statSection: StatSection? = nil) {
         self.name = name
         self.data = data
         self.mediaID = mediaID
@@ -35,6 +37,7 @@ struct StatsTotalRowData {
         self.showDisclosure = showDisclosure
         self.disclosureURL = disclosureURL
         self.childRows = childRows
+        self.statSection = statSection
     }
 }
 
@@ -176,13 +179,13 @@ private extension StatsTotalRow {
 
     func configureExpandedState() {
 
-        guard let name = rowData?.name else {
+        guard let name = rowData?.name,
+        let statSection = rowData?.statSection else {
             expanded = false
             return
         }
 
-        expanded = (StatsDataHelper.expandedRowLabels[.insights]?.contains(name) ?? false) ||
-            (StatsDataHelper.expandedRowLabels[.period]?.contains(name) ?? false)
+        expanded = StatsDataHelper.expandedRowLabels[statSection]?.contains(name) ?? false
     }
 
     func configureIcon() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -930,6 +930,7 @@
 		98B3FA8621C05BF000148DD4 /* ViewMoreRow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98B3FA8521C05BF000148DD4 /* ViewMoreRow.xib */; };
 		98B52AE121F7AF4A006FF6B4 /* StatsDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */; };
 		98BDFF6B20D0732900C72C58 /* SupportTableViewController+Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BDFF6A20D0732900C72C58 /* SupportTableViewController+Activity.swift */; };
+		98CAD296221B4ED2003E8F45 /* StatSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98CAD295221B4ED1003E8F45 /* StatSection.swift */; };
 		98D60B9B1FFEE39500145190 /* SiteCreationThemeSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D60B9A1FFEE39500145190 /* SiteCreationThemeSelectionViewController.swift */; };
 		98D60B9E1FFEE3D800145190 /* SiteCreationThemeSelectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D60B9C1FFEE3D800145190 /* SiteCreationThemeSelectionCell.swift */; };
 		98D60B9F1FFEE3D800145190 /* SiteCreationThemeSelectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D60B9D1FFEE3D800145190 /* SiteCreationThemeSelectionHeaderView.swift */; };
@@ -2852,6 +2853,7 @@
 		98B3FA8521C05BF000148DD4 /* ViewMoreRow.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ViewMoreRow.xib; sourceTree = "<group>"; };
 		98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsDataHelper.swift; sourceTree = "<group>"; };
 		98BDFF6A20D0732900C72C58 /* SupportTableViewController+Activity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SupportTableViewController+Activity.swift"; sourceTree = "<group>"; };
+		98CAD295221B4ED1003E8F45 /* StatSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatSection.swift; sourceTree = "<group>"; };
 		98D60B9A1FFEE39500145190 /* SiteCreationThemeSelectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteCreationThemeSelectionViewController.swift; sourceTree = "<group>"; };
 		98D60B9C1FFEE3D800145190 /* SiteCreationThemeSelectionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteCreationThemeSelectionCell.swift; sourceTree = "<group>"; };
 		98D60B9D1FFEE3D800145190 /* SiteCreationThemeSelectionHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteCreationThemeSelectionHeaderView.swift; sourceTree = "<group>"; };
@@ -6206,6 +6208,7 @@
 			children = (
 				9874767221963D320080967F /* SiteStatsInformation.swift */,
 				98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */,
+				98CAD295221B4ED1003E8F45 /* StatSection.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -9793,6 +9796,7 @@
 				749197EE209B9A2E006F5E66 /* ReaderCardContent+PostInformation.swift in Sources */,
 				FF355D981FB492DD00244E6D /* ExportableAsset.swift in Sources */,
 				E15644EF1CE0E53B00D96E64 /* PlanListViewModel.swift in Sources */,
+				98CAD296221B4ED2003E8F45 /* StatSection.swift in Sources */,
 				93C1147F18EC5DD500DAC95C /* AccountService.m in Sources */,
 				FF945F701B28242300FB8AC4 /* MediaLibraryPickerDataSource.m in Sources */,
 				BE87E1A21BD405790075D45B /* WP3DTouchShortcutHandler.swift in Sources */,


### PR DESCRIPTION
Fixes #n/a (problem mentioned in https://github.com/wordpress-mobile/WordPress-iOS/pull/11079 description)

Previously, because tracking expanded rows was done only by Insights or Periods, it allowed for duplicate entries. This changes the tracking to be done by what `StatSection` the expanded row is in.

To test:
This fix is applicable to all expandable rows, but it is easily testable by these specific stat rows:
- On the en.blog site, go to Stats > Period.
- Expand _either_ Referrers _or_ Clicks `en.support.wordpress.com`

<img width="350" alt="dupe_rows" src="https://user-images.githubusercontent.com/1816888/52978759-dba6ea80-338f-11e9-8c91-740af95531d7.png">


- Scroll down so that neither card is visible.
- Scroll back up, and verify only the one you expanded is still expanded.



