### PR TITLE
Allows for a wider error range in a failing test.

### DIFF
--- a/WordPress/WordPressTest/DebouncerTests.swift
+++ b/WordPress/WordPressTest/DebouncerTests.swift
@@ -7,7 +7,7 @@ class DebouncerTests: XCTestCase {
     ///
     func testDebouncerRunsNormally() {
         let timerDelay = 0.5
-        let allowedError = 0.25
+        let allowedError = 0.3
         let minDelay = timerDelay * (1 - allowedError)
         let maxDelay = timerDelay * (1 + allowedError)
         let testTimeout = maxDelay + 0.01

--- a/WordPress/WordPressTest/DebouncerTests.swift
+++ b/WordPress/WordPressTest/DebouncerTests.swift
@@ -7,7 +7,7 @@ class DebouncerTests: XCTestCase {
     ///
     func testDebouncerRunsNormally() {
         let timerDelay = 0.5
-        let allowedError = 0.2
+        let allowedError = 0.25
         let minDelay = timerDelay * (1 - allowedError)
         let maxDelay = timerDelay * (1 + allowedError)
         let testTimeout = maxDelay + 0.01


### PR DESCRIPTION
## Description:

A test was failing due to a timer set to trigger after 0.5 ms triggering after 0.61 ms.  This is normal as timer's based on `Timer` aren't 100% precise, but the error the test was allowing was 20%, which applied to 0.5ms gives us a maximum of 0.6ms allowed (short of 0.61ms).

I just changed the error value to allow for a 25% error.

## Testing:

Just make sure the tests succeed.