### PR TITLE
Increases the error marging in a test.

### DIFF
--- a/WordPress/WordPressTest/DebouncerTests.swift
+++ b/WordPress/WordPressTest/DebouncerTests.swift
@@ -7,7 +7,7 @@ class DebouncerTests: XCTestCase {
     ///
     func testDebouncerRunsNormally() {
         let timerDelay = 0.5
-        let allowedError = 0.3
+        let allowedError = 0.5
         let minDelay = timerDelay * (1 - allowedError)
         let maxDelay = timerDelay * (1 + allowedError)
         let testTimeout = maxDelay + 0.01


### PR DESCRIPTION
## Description:

Follow up to: https://github.com/wordpress-mobile/WordPress-iOS/pull/11089

Further raises the allowed error margin to 50%.

Kudos to @ScoutHarris for spotting this one.