### PR TITLE
Rename blog type from dotcom to wpcom

### DIFF
--- a/WordPress/Classes/Models/Blog+Analytics.swift
+++ b/WordPress/Classes/Models/Blog+Analytics.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension Blog {
     enum AnalyticsType: String {
-        case dotcom
+        case wpcom
         case jetpack
         case core
     }
@@ -10,7 +10,7 @@ extension Blog {
     var analyticsType: AnalyticsType {
         if let dotComID = dotComID, dotComID.intValue > 0 {
             if isHostedAtWPcom {
-                return .dotcom
+                return .wpcom
             } else {
                 return .jetpack
             }


### PR DESCRIPTION
Follow up for #11040

When doing the Android implementation in https://github.com/wordpress-mobile/WordPress-Android/pull/9293 we discovered there's a lint check there that tells you to use `wpcom` and not `dotcom`, so we switched to that

To test:

- Create a new post on a WordPress.com blog
- Debug and inspect the editor session events, and verify that the `blog_type` property has `wpcom` and not `dotcom` in it

cc @mzorz 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.