### PR TITLE
Gutenberg: Focus title on new posts.

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -244,6 +244,13 @@ class GutenbergViewController: UIViewController, PostEditor {
         gutenberg.requestHTML()
     }
 
+    func focusTitleIfNeeded() {
+        guard !post.hasContent() else {
+            return
+        }
+        gutenberg.setFocusOnTitle()
+    }
+
     // MARK: - Event handlers
 
     @objc func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
@@ -403,6 +410,12 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
     }
 
     func gutenbergDidLayout() {
+        defer {
+            isFirstGutenbergLayout = false
+        }
+        if isFirstGutenbergLayout {
+            focusTitleIfNeeded()
+        }
     }
 
     func gutenbergDidMount(hasUnsupportedBlocks: Bool) {


### PR DESCRIPTION
This PR implements focus title on new posts. Following from https://github.com/wordpress-mobile/gutenberg-mobile/pull/633.

To test:
- Please refer to the `gutenberg-mobile` [side PR](https://github.com/wordpress-mobile/gutenberg-mobile/pull/633).