### PR TITLE
[Stats Refresh] Make stat section labels accessible

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -78,6 +78,22 @@ enum StatSection: Int {
             return InsightsHeaders.postingActivity
         case .insightsPublicize:
             return InsightsHeaders.publicize
+        case .periodPostsAndPages:
+            return PeriodHeaders.postsAndPages
+        case .periodReferrers:
+            return PeriodHeaders.referrers
+        case .periodClicks:
+            return PeriodHeaders.clicks
+        case .periodAuthors:
+            return PeriodHeaders.authors
+        case .periodCountries:
+            return PeriodHeaders.countries
+        case .periodSearchTerms:
+            return PeriodHeaders.searchTerms
+        case .periodPublished:
+            return PeriodHeaders.published
+        case .periodVideos:
+            return PeriodHeaders.videos
         default:
             return ""
         }
@@ -85,14 +101,27 @@ enum StatSection: Int {
 
     var itemSubtitle: String {
         switch self {
-        case .insightsCommentsPosts, .insightsTagsAndCategories:
+        case .insightsCommentsPosts,
+             .insightsTagsAndCategories,
+             .periodPostsAndPages,
+             .periodVideos:
             return ItemSubtitles.title
-        case .insightsCommentsAuthors:
+        case .insightsCommentsAuthors,
+             .periodAuthors:
             return ItemSubtitles.author
         case .insightsPublicize:
             return ItemSubtitles.service
-        case .insightsFollowersWordPress, .insightsFollowersEmail:
+        case .insightsFollowersWordPress,
+             .insightsFollowersEmail:
             return ItemSubtitles.follower
+        case .periodReferrers:
+            return ItemSubtitles.referrer
+        case .periodClicks:
+            return ItemSubtitles.link
+        case .periodCountries:
+            return ItemSubtitles.country
+        case .periodSearchTerms:
+            return ItemSubtitles.searchTerm
         default:
             return ""
         }
@@ -100,14 +129,24 @@ enum StatSection: Int {
 
     var dataSubtitle: String {
         switch self {
-        case .insightsCommentsAuthors, .insightsCommentsPosts:
+        case .insightsCommentsAuthors,
+             .insightsCommentsPosts:
             return DataSubtitles.comments
-        case .insightsTagsAndCategories:
+        case .insightsTagsAndCategories,
+             .periodPostsAndPages,
+             .periodReferrers,
+             .periodAuthors,
+             .periodCountries,
+             .periodSearchTerms,
+             .periodVideos:
             return DataSubtitles.views
         case .insightsPublicize:
             return DataSubtitles.followers
-        case .insightsFollowersWordPress, .insightsFollowersEmail:
+        case .insightsFollowersWordPress,
+             .insightsFollowersEmail:
             return DataSubtitles.since
+        case .periodClicks:
+            return DataSubtitles.clicks
         default:
             return ""
         }
@@ -155,11 +194,26 @@ enum StatSection: Int {
         static let annualSiteStats = NSLocalizedString("Annual Site Stats", comment: "Insights 'Annual Site Stats' header")
     }
 
+    struct PeriodHeaders {
+        static let postsAndPages = NSLocalizedString("Posts and Pages", comment: "Period Stats 'Posts and Pages' header")
+        static let referrers = NSLocalizedString("Referrers", comment: "Period Stats 'Referrers' header")
+        static let clicks = NSLocalizedString("Clicks", comment: "Period Stats 'Clicks' header")
+        static let authors = NSLocalizedString("Authors", comment: "Period Stats 'Authors' header")
+        static let countries = NSLocalizedString("Countries", comment: "Period Stats 'Countries' header")
+        static let searchTerms = NSLocalizedString("Search Terms", comment: "Period Stats 'Search Terms' header")
+        static let published = NSLocalizedString("Published", comment: "Period Stats 'Published' header")
+        static let videos = NSLocalizedString("Videos", comment: "Period Stats 'Videos' header")
+    }
+
     struct ItemSubtitles {
         static let author = NSLocalizedString("Author", comment: "Author label for list of commenters.")
         static let title = NSLocalizedString("Title", comment: "Title label for list of posts.")
         static let service = NSLocalizedString("Service", comment: "Publicize label for connected service")
         static let follower = NSLocalizedString("Follower", comment: "Followers label for list of followers.")
+        static let referrer = NSLocalizedString("Referrer", comment: "Referrers label for link title")
+        static let link = NSLocalizedString("Link", comment: "Clicks label for link title")
+        static let country = NSLocalizedString("Country", comment: "Countries label for country")
+        static let searchTerm = NSLocalizedString("Search Term", comment: "Search Terms label for search term")
     }
 
     struct DataSubtitles {
@@ -167,6 +221,7 @@ enum StatSection: Int {
         static let views = NSLocalizedString("Views", comment: "'Tags and Categories' label for tag/category number of views.")
         static let followers = NSLocalizedString("Followers", comment: "Publicize label for number of followers")
         static let since = NSLocalizedString("Since", comment: "Followers label for time period in list of follower.")
+        static let clicks = NSLocalizedString("Clicks", comment: "Clicks label for number of clicks")
     }
 
     struct TabTitles {

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -14,10 +14,12 @@ enum StatSection: Int {
     case insightsMostPopularTime
     case insightsTagsAndCategories
     case insightsAnnualSiteStats
-    case insightsComments
-    case insightsFollowers
+    case insightsCommentsAuthors
+    case insightsCommentsPosts
+    case insightsFollowersWordPress
+    case insightsFollowersEmail
     case insightsTodaysStats
-    case insightsPostActivity
+    case insightsPostingActivity
     case insightsPublicize
     case postDetailsGraph
     case postDetailsMonthsYears
@@ -30,10 +32,12 @@ enum StatSection: Int {
                               .insightsMostPopularTime,
                               .insightsTagsAndCategories,
                               .insightsAnnualSiteStats,
-                              .insightsComments,
-                              .insightsFollowers,
+                              .insightsCommentsAuthors,
+                              .insightsCommentsPosts,
+                              .insightsFollowersWordPress,
+                              .insightsFollowersEmail,
                               .insightsTodaysStats,
-                              .insightsPostActivity,
+                              .insightsPostingActivity,
                               .insightsPublicize
     ]
 
@@ -47,5 +51,134 @@ enum StatSection: Int {
                              .periodPublished,
                              .periodVideos
     ]
+
+    // MARK: - String Accessors
+
+    var title: String {
+        switch self {
+        case .insightsLatestPostSummary:
+            return InsightsHeaders.latestPostSummary
+        case .insightsAllTime:
+            return InsightsHeaders.allTimeStats
+        case .insightsFollowerTotals:
+            return InsightsHeaders.followerTotals
+        case .insightsMostPopularTime:
+            return InsightsHeaders.mostPopularTime
+        case .insightsTagsAndCategories:
+            return InsightsHeaders.tagsAndCategories
+        case .insightsAnnualSiteStats:
+            return InsightsHeaders.annualSiteStats
+        case .insightsCommentsAuthors, .insightsCommentsPosts:
+            return InsightsHeaders.comments
+        case .insightsFollowersWordPress, .insightsFollowersEmail:
+            return InsightsHeaders.followers
+        case .insightsTodaysStats:
+            return InsightsHeaders.todaysStats
+        case .insightsPostingActivity:
+            return InsightsHeaders.postingActivity
+        case .insightsPublicize:
+            return InsightsHeaders.publicize
+        default:
+            return ""
+        }
+    }
+
+    var itemSubtitle: String {
+        switch self {
+        case .insightsCommentsPosts, .insightsTagsAndCategories:
+            return ItemSubtitles.title
+        case .insightsCommentsAuthors:
+            return ItemSubtitles.author
+        case .insightsPublicize:
+            return ItemSubtitles.service
+        case .insightsFollowersWordPress, .insightsFollowersEmail:
+            return ItemSubtitles.follower
+        default:
+            return ""
+        }
+    }
+
+    var dataSubtitle: String {
+        switch self {
+        case .insightsCommentsAuthors, .insightsCommentsPosts:
+            return DataSubtitles.comments
+        case .insightsTagsAndCategories:
+            return DataSubtitles.views
+        case .insightsPublicize:
+            return DataSubtitles.followers
+        case .insightsFollowersWordPress, .insightsFollowersEmail:
+            return DataSubtitles.since
+        default:
+            return ""
+        }
+    }
+
+    var tabTitle: String {
+        switch self {
+        case .insightsCommentsAuthors:
+            return TabTitles.commentsAuthors
+        case .insightsCommentsPosts:
+            return TabTitles.commentsPosts
+        case .insightsFollowersWordPress:
+            return TabTitles.followersWordPress
+        case .insightsFollowersEmail:
+            return TabTitles.followersEmail
+        default:
+            return ""
+        }
+    }
+
+    var totalFollowers: String {
+        switch self {
+        case .insightsFollowersWordPress:
+            return TotalFollowers.wordPress
+        case .insightsFollowersEmail:
+            return TotalFollowers.email
+        default:
+            return ""
+        }
+    }
+
+    // MARK: String Structs
+
+    struct InsightsHeaders {
+        static let latestPostSummary = NSLocalizedString("Latest Post Summary", comment: "Insights latest post summary header")
+        static let allTimeStats = NSLocalizedString("All Time Stats", comment: "Insights 'All Time Stats' header")
+        static let mostPopularTime = NSLocalizedString("Most Popular Time", comment: "Insights 'Most Popular Time' header")
+        static let followerTotals = NSLocalizedString("Follower Totals", comment: "Insights 'Follower Totals' header")
+        static let publicize = NSLocalizedString("Publicize", comment: "Insights 'Publicize' header")
+        static let todaysStats = NSLocalizedString("Today's Stats", comment: "Insights 'Today's Stats' header")
+        static let postingActivity = NSLocalizedString("Posting Activity", comment: "Insights 'Posting Activity' header")
+        static let comments = NSLocalizedString("Comments", comment: "Insights 'Comments' header")
+        static let followers = NSLocalizedString("Followers", comment: "Insights 'Followers' header")
+        static let tagsAndCategories = NSLocalizedString("Tags and Categories", comment: "Insights 'Tags and Categories' header")
+        static let annualSiteStats = NSLocalizedString("Annual Site Stats", comment: "Insights 'Annual Site Stats' header")
+    }
+
+    struct ItemSubtitles {
+        static let author = NSLocalizedString("Author", comment: "Author label for list of commenters.")
+        static let title = NSLocalizedString("Title", comment: "Title label for list of posts.")
+        static let service = NSLocalizedString("Service", comment: "Publicize label for connected service")
+        static let follower = NSLocalizedString("Follower", comment: "Followers label for list of followers.")
+    }
+
+    struct DataSubtitles {
+        static let comments = NSLocalizedString("Comments", comment: "Label for comment count, either by author or post.")
+        static let views = NSLocalizedString("Views", comment: "'Tags and Categories' label for tag/category number of views.")
+        static let followers = NSLocalizedString("Followers", comment: "Publicize label for number of followers")
+        static let since = NSLocalizedString("Since", comment: "Followers label for time period in list of follower.")
+    }
+
+    struct TabTitles {
+        static let commentsAuthors = NSLocalizedString("Authors", comment: "Label for comments by author")
+        static let commentsPosts = NSLocalizedString("Posts and Pages", comment: "Label for comments by posts and pages")
+        static let followersWordPress = NSLocalizedString("WordPress.com", comment: "Label for WordPress.com followers")
+        static let followersEmail = NSLocalizedString("Email", comment: "Label for email followers")
+    }
+
+    struct TotalFollowers {
+        static let wordPress = NSLocalizedString("Total WordPress.com Followers: %@", comment: "Label displaying total number of WordPress.com followers. %@ is the total.")
+        static let email = NSLocalizedString("Total Email Followers: %@", comment: "Label displaying total number of Email followers. %@ is the total.")
+    }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -206,22 +206,22 @@ enum StatSection: Int {
     }
 
     struct ItemSubtitles {
-        static let author = NSLocalizedString("Author", comment: "Author label for list of commenters.")
-        static let title = NSLocalizedString("Title", comment: "Title label for list of posts.")
-        static let service = NSLocalizedString("Service", comment: "Publicize label for connected service")
-        static let follower = NSLocalizedString("Follower", comment: "Followers label for list of followers.")
-        static let referrer = NSLocalizedString("Referrer", comment: "Referrers label for link title")
-        static let link = NSLocalizedString("Link", comment: "Clicks label for link title")
-        static let country = NSLocalizedString("Country", comment: "Countries label for country")
-        static let searchTerm = NSLocalizedString("Search Term", comment: "Search Terms label for search term")
+        static let author = NSLocalizedString("Author", comment: "Label for list of stats by content author.")
+        static let title = NSLocalizedString("Title", comment: "Label for list of stats by content title.")
+        static let service = NSLocalizedString("Service", comment: "Label for connected service in Publicize stat.")
+        static let follower = NSLocalizedString("Follower", comment: "Label for list of followers.")
+        static let referrer = NSLocalizedString("Referrer", comment: "Label for link title in Referrers stat.")
+        static let link = NSLocalizedString("Link", comment: "Label for link title in Clicks stat.")
+        static let country = NSLocalizedString("Country", comment: "Label for list of countries.")
+        static let searchTerm = NSLocalizedString("Search Term", comment: "Label for list of search term")
     }
 
     struct DataSubtitles {
-        static let comments = NSLocalizedString("Comments", comment: "Label for comment count, either by author or post.")
-        static let views = NSLocalizedString("Views", comment: "'Tags and Categories' label for tag/category number of views.")
-        static let followers = NSLocalizedString("Followers", comment: "Publicize label for number of followers")
-        static let since = NSLocalizedString("Since", comment: "Followers label for time period in list of follower.")
-        static let clicks = NSLocalizedString("Clicks", comment: "Clicks label for number of clicks")
+        static let comments = NSLocalizedString("Comments", comment: "Label for number of comments.")
+        static let views = NSLocalizedString("Views", comment: "Label for number of views.")
+        static let followers = NSLocalizedString("Followers", comment: "Label for number of followers.")
+        static let since = NSLocalizedString("Since", comment: "Label for time period in list of followers.")
+        static let clicks = NSLocalizedString("Clicks", comment: "Label for number of clicks.")
     }
 
     struct TabTitles {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -41,43 +41,43 @@ class SiteStatsInsightsViewModel: Observable {
         insightsToShow.forEach { insightType in
             switch insightType {
             case .latestPostSummary:
-                tableRows.append(CellHeaderRow(title: InsightsHeaders.latestPostSummary))
+                tableRows.append(CellHeaderRow(title: StatSection.insightsLatestPostSummary.title))
                 tableRows.append(LatestPostSummaryRow(summaryData: store.getLastPostInsight(),
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
             case .allTimeStats:
-                tableRows.append(CellHeaderRow(title: InsightsHeaders.allTimeStats))
+                tableRows.append(CellHeaderRow(title: StatSection.insightsAllTime.title))
                 tableRows.append(SimpleTotalsStatsRow(dataRows: createAllTimeStatsRows()))
             case .followersTotals:
-                tableRows.append(CellHeaderRow(title: InsightsHeaders.followerTotals))
+                tableRows.append(CellHeaderRow(title: StatSection.insightsFollowerTotals.title))
                 tableRows.append(SimpleTotalsStatsRow(dataRows: createTotalFollowersRows()))
             case .mostPopularDayAndHour:
-                tableRows.append(CellHeaderRow(title: InsightsHeaders.mostPopularStats))
+                tableRows.append(CellHeaderRow(title: StatSection.insightsMostPopularTime.title))
                 tableRows.append(SimpleTotalsStatsRow(dataRows: createMostPopularStatsRows()))
             case .tagsAndCategories:
-                tableRows.append(CellHeaderRow(title: InsightsHeaders.tagsAndCategories))
-                tableRows.append(TopTotalsInsightStatsRow(itemSubtitle: TagsAndCategories.itemSubtitle,
-                                                   dataSubtitle: TagsAndCategories.dataSubtitle,
+                tableRows.append(CellHeaderRow(title: StatSection.insightsTagsAndCategories.title))
+                tableRows.append(TopTotalsInsightStatsRow(itemSubtitle: StatSection.insightsTagsAndCategories.itemSubtitle,
+                                                   dataSubtitle: StatSection.insightsTagsAndCategories.dataSubtitle,
                                                    dataRows: createTagsAndCategoriesRows(),
                                                    siteStatsInsightsDelegate: siteStatsInsightsDelegate))
             case .annualSiteStats:
-                tableRows.append(CellHeaderRow(title: InsightsHeaders.annualSiteStats))
+                tableRows.append(CellHeaderRow(title: StatSection.insightsAnnualSiteStats.title))
                 tableRows.append(createAnnualSiteStatsRow())
             case .comments:
-                tableRows.append(CellHeaderRow(title: InsightsHeaders.comments))
+                tableRows.append(CellHeaderRow(title: StatSection.insightsCommentsPosts.title))
                 tableRows.append(createCommentsRow())
             case .followers:
-                tableRows.append(CellHeaderRow(title: InsightsHeaders.followers))
+                tableRows.append(CellHeaderRow(title: StatSection.insightsFollowersWordPress.title))
                 tableRows.append(createFollowersRow())
             case .todaysStats:
-                tableRows.append(CellHeaderRow(title: InsightsHeaders.todaysStats))
+                tableRows.append(CellHeaderRow(title: StatSection.insightsTodaysStats.title))
                 tableRows.append(SimpleTotalsStatsRow(dataRows: createTodaysStatsRows()))
             case .postingActivity:
-                tableRows.append(CellHeaderRow(title: InsightsHeaders.postingActivity))
+                tableRows.append(CellHeaderRow(title: StatSection.insightsPostingActivity.title))
                 tableRows.append(createPostingActivityRow())
             case .publicize:
-                tableRows.append(CellHeaderRow(title: InsightsHeaders.publicize))
-                tableRows.append(SimpleTotalsStatsSubtitlesRow(itemSubtitle: Publicize.itemSubtitle,
-                                                               dataSubtitle: Publicize.dataSubtitle,
+                tableRows.append(CellHeaderRow(title: StatSection.insightsPublicize.title))
+                tableRows.append(SimpleTotalsStatsSubtitlesRow(itemSubtitle: StatSection.insightsPublicize.itemSubtitle,
+                                                               dataSubtitle: StatSection.insightsPublicize.dataSubtitle,
                                                                dataRows: createPublicizeRows()))
             }
         }
@@ -102,20 +102,6 @@ class SiteStatsInsightsViewModel: Observable {
 
 private extension SiteStatsInsightsViewModel {
 
-    struct InsightsHeaders {
-        static let latestPostSummary = NSLocalizedString("Latest Post Summary", comment: "Insights latest post summary header")
-        static let allTimeStats = NSLocalizedString("All Time Stats", comment: "Insights 'All Time Stats' header")
-        static let mostPopularStats = NSLocalizedString("Most Popular Time", comment: "Insights 'Most Popular Time' header")
-        static let followerTotals = NSLocalizedString("Follower Totals", comment: "Insights 'Follower Totals' header")
-        static let publicize = NSLocalizedString("Publicize", comment: "Insights 'Publicize' header")
-        static let todaysStats = NSLocalizedString("Today's Stats", comment: "Insights 'Today's Stats' header")
-        static let postingActivity = NSLocalizedString("Posting Activity", comment: "Insights 'Posting Activity' header")
-        static let comments = NSLocalizedString("Comments", comment: "Insights 'Comments' header")
-        static let followers = NSLocalizedString("Followers", comment: "Insights 'Followers' header")
-        static let tagsAndCategories = NSLocalizedString("Tags and Categories", comment: "Insights 'Tags and Categories' header")
-        static let annualSiteStats = NSLocalizedString("Annual Site Stats", comment: "Insights 'Annual Site Stats' header")
-    }
-
     struct AllTimeStats {
         static let postsTitle = NSLocalizedString("Posts", comment: "All Time Stats 'Posts' label")
         static let postsIcon = Style.imageForGridiconType(.posts)
@@ -132,78 +118,23 @@ private extension SiteStatsInsightsViewModel {
     }
 
     struct FollowerTotals {
+        static let wordPress = NSLocalizedString("WordPress.com", comment: "Label for WordPress.com followers")
+        static let email = NSLocalizedString("Email", comment: "Label for email followers")
+        static let social = NSLocalizedString("Social", comment: "Follower Totals label for social media followers")
         static let wordPressIcon = Style.imageForGridiconType(.mySites)
         static let emailIcon = Style.imageForGridiconType(.mail)
-        static let socialTitle = NSLocalizedString("Social", comment: "Follower Totals label for social media followers")
         static let socialIcon = Style.imageForGridiconType(.share)
-    }
-
-    struct Followers {
-        static let totalFollowers = NSLocalizedString("Total %@ Followers: %@", comment: "Label displaying total number of followers for a type. The first %@ is the type (WordPress.com or Email), the second %@ is the total.")
-        static let itemSubtitle = NSLocalizedString("Follower", comment: "Followers label for list of followers.")
-        static let dataSubtitle = NSLocalizedString("Since", comment: "Followers label for time period in list of follower.")
-    }
-
-    enum FollowerType {
-        case wordPressDotCom
-        case email
-
-        var title: String {
-            switch self {
-            case .wordPressDotCom:
-                return NSLocalizedString("WordPress.com", comment: "Label for WordPress.com followers")
-            case .email:
-                return NSLocalizedString("Email", comment: "Label for email followers")
-            }
-        }
-    }
-
-    struct Comments {
-        static let dataSubtitle = NSLocalizedString("Comments", comment: "Label for comment count, either by author or post.")
-    }
-
-    enum CommentType {
-        case author
-        case post
-
-        var title: String {
-            switch self {
-            case .author:
-                return NSLocalizedString("Authors", comment: "Label for comments by author")
-            case .post:
-                return NSLocalizedString("Posts and Pages", comment: "Label for comments by posts and pages")
-            }
-        }
-
-        var itemSubtitle: String {
-            switch self {
-            case .author:
-                return NSLocalizedString("Author", comment: "Author label for list of commenters.")
-            case .post:
-                return NSLocalizedString("Title", comment: "Title label for list of posts.")
-            }
-        }
-    }
-
-    struct Publicize {
-        static let itemSubtitle = NSLocalizedString("Service", comment: "Publicize label for connected service")
-        static let dataSubtitle = NSLocalizedString("Followers", comment: "Publicize label for number of followers")
     }
 
     struct TodaysStats {
         static let viewsTitle = NSLocalizedString("Views", comment: "Today's Stats 'Views' label")
-        static let viewsIcon = Style.imageForGridiconType(.visible)
         static let visitorsTitle = NSLocalizedString("Visitors", comment: "Today's Stats 'Visitors' label")
-        static let visitorsIcon = Style.imageForGridiconType(.user)
         static let likesTitle = NSLocalizedString("Likes", comment: "Today's Stats 'Likes' label")
         static let likesIcon = Style.imageForGridiconType(.star)
         static let commentsTitle = NSLocalizedString("Comments", comment: "Today's Stats 'Comments' label")
+        static let viewsIcon = Style.imageForGridiconType(.visible)
+        static let visitorsIcon = Style.imageForGridiconType(.user)
         static let commentsIcon = Style.imageForGridiconType(.comment)
-    }
-
-    struct TagsAndCategories {
-        static let itemSubtitle = NSLocalizedString("Title", comment: "'Tags and Categories' label for the tag/category name.")
-        static let dataSubtitle = NSLocalizedString("Views", comment: "'Tags and Categories' label for tag/category number of views.")
     }
 
     struct AnnualSiteStats {
@@ -214,6 +145,16 @@ private extension SiteStatsInsightsViewModel {
         static let commentsPerPost = NSLocalizedString("Comments Per Post", comment: "'Annual Site Stats' label for average comments per post.")
         static let likesPerPost = NSLocalizedString("Likes Per Post", comment: "'Annual Site Stats' label for average likes per post.")
         static let wordsPerPost = NSLocalizedString("Words Per Post", comment: "'Annual Site Stats' label for average words per post.")
+    }
+
+    enum FollowerType {
+        case wordPressDotCom
+        case email
+    }
+
+    enum CommentType {
+        case author
+        case post
     }
 
     func createAllTimeStatsRows() -> [StatsTotalRowData] {
@@ -300,14 +241,14 @@ private extension SiteStatsInsightsViewModel {
 
         if let totalDotComFollowers = store.getDotComFollowers()?.dotComFollowersCount,
             totalDotComFollowers > 0 {
-            dataRows.append(StatsTotalRowData.init(name: FollowerType.wordPressDotCom.title,
+            dataRows.append(StatsTotalRowData.init(name: FollowerTotals.wordPress,
                                                    data: totalDotComFollowers.abbreviatedString(),
                                                    icon: FollowerTotals.wordPressIcon))
         }
 
         if let totalEmailFollowers = store.getEmailFollowers()?.emailFollowersCount,
             totalEmailFollowers > 0 {
-            dataRows.append(StatsTotalRowData.init(name: FollowerType.email.title,
+            dataRows.append(StatsTotalRowData.init(name: FollowerTotals.email,
                                                    data: totalEmailFollowers.abbreviatedString(),
                                                    icon: FollowerTotals.emailIcon))
         }
@@ -315,7 +256,7 @@ private extension SiteStatsInsightsViewModel {
         if let publicize = store.getPublicize(), !publicize.publicizeServices.isEmpty {
             let publicizeSum = publicize.publicizeServices.reduce(0) { $0 + $1.followers }
 
-            dataRows.append(StatsTotalRowData.init(name: FollowerTotals.socialTitle,
+            dataRows.append(StatsTotalRowData.init(name: FollowerTotals.social,
                                                    data: publicizeSum.abbreviatedString(),
                                                    icon: FollowerTotals.socialIcon))
         }
@@ -475,34 +416,33 @@ private extension SiteStatsInsightsViewModel {
         switch commentType {
         case .author:
             let authors = commentsInsight?.topAuthors ?? []
-
-            tabTitle = CommentType.author.title
-            itemSubtitle = CommentType.author.itemSubtitle
+            tabTitle = StatSection.insightsCommentsAuthors.tabTitle
+            itemSubtitle = StatSection.insightsCommentsAuthors.itemSubtitle
 
             rowItems = authors.map {
                 StatsTotalRowData(name: $0.name,
                                   data: $0.commentCount.abbreviatedString(),
                                   userIconURL: $0.iconURL,
-                                  showDisclosure: false)
+                                  showDisclosure: false,
+                                  statSection: .insightsCommentsAuthors)
             }
         case .post:
             let posts = commentsInsight?.topPosts ?? []
-
-            tabTitle = CommentType.post.title
-            itemSubtitle = CommentType.post.itemSubtitle
+            tabTitle = StatSection.insightsCommentsPosts.tabTitle
+            itemSubtitle = StatSection.insightsCommentsPosts.itemSubtitle
 
             rowItems = posts.map {
                 StatsTotalRowData(name: $0.name,
                                   data: $0.commentCount.abbreviatedString(),
                                   showDisclosure: true,
-                                  disclosureURL: $0.postURL)
-
+                                  disclosureURL: $0.postURL,
+                                  statSection: .insightsCommentsPosts)
             }
         }
 
         return TabData(tabTitle: tabTitle,
                        itemSubtitle: itemSubtitle,
-                       dataSubtitle: Comments.dataSubtitle,
+                       dataSubtitle: StatSection.insightsCommentsPosts.dataSubtitle,
                        dataRows: rowItems)
     }
 
@@ -518,33 +458,36 @@ private extension SiteStatsInsightsViewModel {
         var tabTitle: String
         var followers: [StatsFollower]?
         var totalFollowers: Int?
+        var statSection: StatSection?
+        var totalCount: String
 
         switch followerType {
         case .wordPressDotCom:
-
-            tabTitle = FollowerType.wordPressDotCom.title
+            tabTitle = StatSection.insightsFollowersWordPress.tabTitle
             followers = store.getDotComFollowers()?.topDotComFollowers
             totalFollowers = store.getDotComFollowers()?.dotComFollowersCount
+            statSection = .insightsFollowersWordPress
+            totalCount = String(format: StatSection.insightsFollowersWordPress.totalFollowers,
+                                (totalFollowers ?? 0).abbreviatedString())
         case .email:
-
-            tabTitle = FollowerType.email.title
+            tabTitle = StatSection.insightsFollowersEmail.tabTitle
             followers = store.getEmailFollowers()?.topEmailFollowers
             totalFollowers = store.getEmailFollowers()?.emailFollowersCount
-        }
-
-        let totalCount = String(format: Followers.totalFollowers,
-                                tabTitle,
+            statSection = .insightsFollowersEmail
+            totalCount = String(format: StatSection.insightsFollowersEmail.totalFollowers,
                                 (totalFollowers ?? 0).abbreviatedString())
+        }
 
         let followersData = followers?.compactMap {
             return StatsTotalRowData(name: $0.name,
                                      data: $0.subscribedDate.relativeStringInPast(),
-                                     userIconURL: $0.avatarURL)
+                                     userIconURL: $0.avatarURL,
+                                     statSection: statSection)
         }
 
         return TabData(tabTitle: tabTitle,
-                       itemSubtitle: Followers.itemSubtitle,
-                       dataSubtitle: Followers.dataSubtitle,
+                       itemSubtitle: StatSection.insightsFollowersWordPress.itemSubtitle,
+                       dataSubtitle: StatSection.insightsFollowersWordPress.dataSubtitle,
                        totalCount: totalCount,
                        dataRows: followersData ?? [])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -65,61 +65,13 @@ class SiteStatsPeriodViewModel: Observable {
 
 private extension SiteStatsPeriodViewModel {
 
-    // MARK: - Period Stats strings
-
-    struct PeriodHeaders {
-        static let postsAndPages = NSLocalizedString("Posts and Pages", comment: "Period Stats 'Posts and Pages' header")
-        static let referrers = NSLocalizedString("Referrers", comment: "Period Stats 'Referrers' header")
-        static let clicks = NSLocalizedString("Clicks", comment: "Period Stats 'Clicks' header")
-        static let authors = NSLocalizedString("Authors", comment: "Period Stats 'Authors' header")
-        static let countries = NSLocalizedString("Countries", comment: "Period Stats 'Countries' header")
-        static let searchTerms = NSLocalizedString("Search Terms", comment: "Period Stats 'Search Terms' header")
-        static let published = NSLocalizedString("Published", comment: "Period Stats 'Published' header")
-        static let videos = NSLocalizedString("Videos", comment: "Period Stats 'Videos' header")
-    }
-
-    struct PostsAndPages {
-        static let itemSubtitle = NSLocalizedString("Title", comment: "Posts and Pages label for post/page title")
-        static let dataSubtitle = NSLocalizedString("Views", comment: "Posts and Pages label for number of views")
-    }
-
-    struct Referrers {
-        static let itemSubtitle = NSLocalizedString("Referrer", comment: "Referrers label for link title")
-        static let dataSubtitle = NSLocalizedString("Views", comment: "Referrers label for number of views")
-    }
-
-    struct Clicks {
-        static let itemSubtitle = NSLocalizedString("Link", comment: "Clicks label for link title")
-        static let dataSubtitle = NSLocalizedString("Clicks", comment: "Clicks label for number of clicks")
-    }
-
-    struct Authors {
-        static let itemSubtitle = NSLocalizedString("Author", comment: "Authors label for post author")
-        static let dataSubtitle = NSLocalizedString("Views", comment: "Authors label for number of views")
-    }
-
-    struct Countries {
-        static let itemSubtitle = NSLocalizedString("Country", comment: "Countries label for country")
-        static let dataSubtitle = NSLocalizedString("Views", comment: "Countries label for number of views")
-    }
-
-    struct SearchTerms {
-        static let itemSubtitle = NSLocalizedString("Search Term", comment: "Search Terms label for search term")
-        static let dataSubtitle = NSLocalizedString("Views", comment: "Search Terms label for number of views")
-    }
-
-    struct Videos {
-        static let itemSubtitle = NSLocalizedString("Title", comment: "Videos label for post/page title")
-        static let dataSubtitle = NSLocalizedString("Views", comment: "Videos label for number of views")
-    }
-
     // MARK: - Create Table Rows
 
     func postsAndPagesTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(title: PeriodHeaders.postsAndPages))
-        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: PostsAndPages.itemSubtitle,
-                                           dataSubtitle: PostsAndPages.dataSubtitle,
+        tableRows.append(CellHeaderRow(title: StatSection.periodPostsAndPages.title))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodPostsAndPages.itemSubtitle,
+                                           dataSubtitle: StatSection.periodPostsAndPages.dataSubtitle,
                                            dataRows: postsAndPagesDataRows(),
                                            siteStatsPeriodDelegate: periodDelegate))
 
@@ -151,9 +103,9 @@ private extension SiteStatsPeriodViewModel {
 
     func referrersTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(title: PeriodHeaders.referrers))
-        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: Referrers.itemSubtitle,
-                                                 dataSubtitle: Referrers.dataSubtitle,
+        tableRows.append(CellHeaderRow(title: StatSection.periodReferrers.title))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodReferrers.dataSubtitle,
                                                  dataRows: referrersDataRows(),
                                                  siteStatsPeriodDelegate: periodDelegate))
 
@@ -201,9 +153,9 @@ private extension SiteStatsPeriodViewModel {
 
     func clicksTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(title: PeriodHeaders.clicks))
-        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: Clicks.itemSubtitle,
-                                                 dataSubtitle: Clicks.dataSubtitle,
+        tableRows.append(CellHeaderRow(title: StatSection.periodClicks.title))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodClicks.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodClicks.dataSubtitle,
                                                  dataRows: clicksDataRows(),
                                                  siteStatsPeriodDelegate: periodDelegate))
 
@@ -234,9 +186,9 @@ private extension SiteStatsPeriodViewModel {
 
     func authorsTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(title: PeriodHeaders.authors))
-        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: Authors.itemSubtitle,
-                                                 dataSubtitle: Authors.dataSubtitle,
+        tableRows.append(CellHeaderRow(title: StatSection.periodAuthors.title))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodAuthors.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodAuthors.dataSubtitle,
                                                  dataRows: authorsDataRows(),
                                                  siteStatsPeriodDelegate: periodDelegate))
 
@@ -267,9 +219,9 @@ private extension SiteStatsPeriodViewModel {
 
     func countriesTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(title: PeriodHeaders.countries))
-        tableRows.append(CountriesStatsRow(itemSubtitle: Countries.itemSubtitle,
-                                           dataSubtitle: Countries.dataSubtitle,
+        tableRows.append(CellHeaderRow(title: StatSection.periodCountries.title))
+        tableRows.append(CountriesStatsRow(itemSubtitle: StatSection.periodCountries.itemSubtitle,
+                                           dataSubtitle: StatSection.periodCountries.dataSubtitle,
                                            dataRows: countriesDataRows()))
         return tableRows
     }
@@ -283,9 +235,9 @@ private extension SiteStatsPeriodViewModel {
 
     func searchTermsTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(title: PeriodHeaders.searchTerms))
-        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: SearchTerms.itemSubtitle,
-                                                 dataSubtitle: SearchTerms.dataSubtitle,
+        tableRows.append(CellHeaderRow(title: StatSection.periodSearchTerms.title))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodSearchTerms.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodSearchTerms.dataSubtitle,
                                                  dataRows: searchTermsDataRows(),
                                                  siteStatsPeriodDelegate: periodDelegate))
 
@@ -299,7 +251,7 @@ private extension SiteStatsPeriodViewModel {
 
     func publishedTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(title: PeriodHeaders.published))
+        tableRows.append(CellHeaderRow(title: StatSection.periodPublished.title))
         tableRows.append(TopTotalsNoSubtitlesPeriodStatsRow(dataRows: publishedDataRows(),
                                                             siteStatsPeriodDelegate: periodDelegate))
 
@@ -316,9 +268,9 @@ private extension SiteStatsPeriodViewModel {
 
     func videosTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(title: PeriodHeaders.videos))
-        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: Videos.itemSubtitle,
-                                                 dataSubtitle: Videos.dataSubtitle,
+        tableRows.append(CellHeaderRow(title: StatSection.periodVideos.title))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodVideos.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodVideos.dataSubtitle,
                                                  dataRows: videosDataRows(),
                                                  siteStatsPeriodDelegate: periodDelegate))
 


### PR DESCRIPTION
Fixes #n/a

While working on the Stats detail list view, I realized it needed access to the strings for the stat cards (i.e. card title and column titles). However, these strings were private and in different view models. So I took advantage of the `StatSection` enum, and moved all the strings out of the view models and into `StatSection`. And since it was a considerable refactor, it gets its very own PR.

Now, these strings can be accessed just by knowing the `StatSection`. As an added bonus, this refactor allowed several duplicate strings to be removed. 🎉 

To test:
Visibly, nothing should change. Just verify all the cards have the correct card titles and column titles (where applicable), i.e. these three labels:

<img width="350" alt="strings" src="https://user-images.githubusercontent.com/1816888/53134604-0d0ceb00-3535-11e9-9059-c8858e78cad0.png">



