### PR TITLE
Gutenberg auto-save improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -390,7 +390,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         }
 
         editorContentWasUpdated()
-
+        mapUIContentToPostAndSave(immediate: true)
         if let reason = requestHTMLReason {
             requestHTMLReason = nil // clear the reason
             switch reason {


### PR DESCRIPTION
This PR makes sure we are saving a revision every time we get new HTML from the GB-JS

To test:
 - Create a new post
 - Start writing to it
 - Open the Post Settings or Switch to Aztec
 - Kill the app
 - Open the app again
 - See if changes are saved.
