### PR TITLE
Reader: Set video tag height to auto, remove padding and margins.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextEmbed.swift
@@ -112,7 +112,7 @@ class WPRichTextEmbed: UIView, WPRichTextMediaAttachment {
     }
 
     @objc func loadHTMLString(_ html: NSString) {
-        let htmlString = String(format: "<html><head><meta name=\"viewport\" content=\"width=available-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no\" /><style>video { width: 100vw; }</style></head><body>%@</body></html>", html)
+        let htmlString = String(format: "<html><head><meta name=\"viewport\" content=\"width=available-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no\" /><style>html, body { margin: 0; padding: 0; } video { width: 100vw; height: auto; }</style></head><body>%@</body></html>", html)
         webView.loadHTMLString(htmlString, baseURL: nil)
     }
 


### PR DESCRIPTION
Refs: #11078

This is a partial fix for the issues outlined in #11078. The complete fix is going to be more involved and not something I'd be comfortable landing in a release branch this close to submitting to the app store.

By setting the height to auto, we force the tag to preserve its aspect ratio. With this change, a video tag that has a width and height defined via attributes will be correctly sized even tho we override the width to match the viewport.

This change also removes some extra white space around the top and left of the video by setting margins and padding to zero.

### Before
Notice the cropping on the bottom video. This appears to be because its internal document height is matching the height of the video tag's height attribute.
![simulator screen shot - iphone 8 - 2019-02-21 at 10 00 15](https://user-images.githubusercontent.com/1435271/53183014-31fa7000-35c0-11e9-8a3d-cce9b3d78f73.png)

### After:
Notice the video is correctly centered.
![simulator screen shot - iphone 8 - 2019-02-21 at 10 02 57](https://user-images.githubusercontent.com/1435271/53183103-57877980-35c0-11e9-8194-752c27ef53ae.png)

To test:
View a post with a video tag that has a width and height defined and confirm it is correctly sized.  The bottom video in this test post is what I used: https://tame-sacred.jurassic.ninja/2019/02/18/videopress-block-test/

@jkmassel could I trouble you with this one? 