### PR TITLE
Auto save post in Gutenberg.

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -13,6 +13,7 @@ class GutenbergViewController: UIViewController, PostEditor {
         case more
         case switchToAztec
         case switchBlog
+        case autoSave
     }
 
     // MARK: - UI
@@ -82,6 +83,10 @@ class GutenbergViewController: UIViewController, PostEditor {
     func cancelUploadOfAllMedia(for post: AbstractPost) {
         return mediaInserterHelper.cancelUploadOfAllMedia()
     }
+
+    static let autoSaveInterval: TimeInterval = 5
+
+    var autoSaveTimer: Timer?
 
     func setTitle(_ title: String) {
         guard gutenberg.isLoaded else {
@@ -178,6 +183,7 @@ class GutenbergViewController: UIViewController, PostEditor {
     }
 
     deinit {
+        stopAutoSave()
         gutenberg.invalidate()
         attachmentDelegate.cancelAllPendingMediaRequests()
     }
@@ -408,6 +414,8 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
                 EditorFactory().switchToAztec(from: self)
             case .switchBlog:
                 blogPickerWasPressed()
+            case .autoSave:
+                break
             }
         }
     }
@@ -422,6 +430,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
     }
 
     func gutenbergDidMount(hasUnsupportedBlocks: Bool) {
+        startAutoSave()
         if !editorSession.started {
             editorSession.start(hasUnsupportedBlocks: hasUnsupportedBlocks)
         }
@@ -510,6 +519,22 @@ extension GutenbergViewController: PostEditorNavigationBarManagerDelegate {
     }
 }
 
+// MARK: - Auto Save
+
+extension GutenbergViewController {
+
+    func startAutoSave() {
+        autoSaveTimer = Timer.scheduledTimer(withTimeInterval: GutenbergViewController.autoSaveInterval, repeats: true, block: { [weak self](timer) in
+            self?.requestHTML(for: .autoSave)
+        })
+    }
+
+    func stopAutoSave() {
+        autoSaveTimer?.invalidate()
+        autoSaveTimer = nil
+    }
+}
+
 // MARK: - Constants
 
 private extension GutenbergViewController {
@@ -517,6 +542,7 @@ private extension GutenbergViewController {
     enum Analytics {
         static let editorSource = "gutenberg"
     }
+
 }
 
 private extension GutenbergViewController {


### PR DESCRIPTION
Implements autosave of posts in Gutenberg using a timer with a 5s interval.

To test:
 - Start a new post
 - Write some test
 - Wait at least 5s
 - Stop the app or force quit.
 - Restart the app
 - See if the post content is kept/saved.

