### PR TITLE
Code freeze: Don't add branch protection to individual release branches

### DIFF
--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -35,7 +35,6 @@ import "./ScreenshotFastfile"
     ios_bump_version_release()
     new_version = ios_get_app_version()
     ios_update_release_notes(new_version: new_version)
-    setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
 
     ios_localize_project()


### PR DESCRIPTION
As discussed this removes the step to set branch protection on every release branch.

Since Github now supports patterns for branch protection rules we no longer need to set it on individual branches through the API.

I have set up a protection rule for `release/*` so release branches are automatically protected.

Related to https://github.com/wordpress-mobile/release-toolkit/pull/24.

I don't think there is any need to update the release-toolkit since the only change is that this action is removed.

To test:

- See that we no longer call `setbranchprotection `.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
