### PR TITLE
Quick Start v2: Turn it on!

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,7 @@
 11.9
 ------
+* Quick Start v2: After creating a new site with WordPress.com there are more tutorials available, now including tips to improve growth.
+* Quick Start will also be suggested less often, but when it's more likely to be helpful.
 * Added connection error alert in Sharing screen.
 * Increased padding at the bottom of the share extension's editor, to make typing a longer post a bit more comfortable.
 * Removes the white background color applied to the site icon on the site details screen.

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -35,7 +35,7 @@ enum FeatureFlag: Int {
         case .gutenberg:
             return true
         case .quickStartV2:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         }
     }
 }


### PR DESCRIPTION
Refs #10860

This makes Quick Start v2 live for everyone.

Depends on #11132 being merged.

To test:
- Make sure QS v2 is on for everyone 😉

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
```
* Quick Start v2: After creating a new site with WordPress.com there are more tutorials available, now including tips to improve growth.
* Quick Start will also be suggested less often, but when it's more likely to be helpful.
```