### PR TITLE
Issue/10341 site creation feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,3 +4,4 @@
 * Increased padding at the bottom of the share extension's editor, to make typing a longer post a bit more comfortable.
 * Removes the white background color applied to the site icon on the site details screen.
 * Updated No Results View illustration and copy displayed on connectivity issue.
+* Enhanced Site Creation flow for smarter, more personalized sites.

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -27,7 +27,7 @@ enum FeatureFlag: Int {
         case .giphy:
             return true
         case .enhancedSiteCreation:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .revisions:
             return true
         case .statsRefresh:

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController+SiteCreation.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController+SiteCreation.swift
@@ -1,5 +1,14 @@
 extension BlogListViewController {
     @objc
+    func launchSiteCreation() {
+        if FeatureFlag.enhancedSiteCreation.enabled {
+            enhancedSiteCreation()
+        } else {
+            showAddNewWordPress()
+        }
+    }
+
+    @objc
     func enhancedSiteCreation() {
         let wizardLauncher = SiteCreationWizardLauncher()
         guard let wizard = wizardLauncher.ui else {

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.h
@@ -11,5 +11,6 @@
 - (void)presentInterfaceForAddingNewSiteFrom:(UIView *)sourceView;
 - (void)bypassBlogListViewController;
 - (BOOL)shouldBypassBlogListViewControllerWhenSelectedFromTabBar;
+- (void)showAddNewWordPressController;
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -865,19 +865,9 @@ static NSInteger HideSearchMinSites = 3;
         UIAlertAction *addNewWordPressAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Create WordPress.com site", @"Create WordPress.com site button")
                                                                         style:UIAlertActionStyleDefault
                                                                       handler:^(UIAlertAction *action) {
-                                                                          [self showAddNewWordPressController];
+                                                                          [self launchSiteCreation];
                                                                       }];
         [addSiteAlertController addAction:addNewWordPressAction];
-
-        if ([Feature enabled: FeatureFlagEnhancedSiteCreation]) {
-            UIAlertAction *enhancedSiteAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Enhanced site creation", @"Enhanced site creation")
-                                                                         style:UIAlertActionStyleDefault
-                                                                       handler:^(UIAlertAction *action) {
-                                                                           [self enhancedSiteCreation];
-                                                                       }];
-
-            [addSiteAlertController addAction:enhancedSiteAction];
-        }
     }
 
     UIAlertAction *addSiteAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Add self-hosted site", @"Add self-hosted site button")

--- a/WordPress/WordPressTest/FeatureFlagTests.swift
+++ b/WordPress/WordPressTest/FeatureFlagTests.swift
@@ -15,21 +15,21 @@ final class FeatureFlagTests: XCTestCase {
     func testFeatureFlag_EnhancedSiteCreation_Disabled_ForBranchTestBuildConfiguration() {
         BuildConfiguration.a8cBranchTest.test {
             let actualValue = FeatureFlag.enhancedSiteCreation.enabled
-            XCTAssertFalse(actualValue, "Enhanced site creation should be disabled for .a8cBranchTest BuildConfiguration")
+            XCTAssertTrue(actualValue, "Enhanced site creation should be enabled for .a8cBranchTest BuildConfiguration")
         }
     }
 
     func testFeatureFlag_EnhancedSiteCreation_Disabled_ForPrereleaseTestingBuildConfiguration() {
         BuildConfiguration.a8cPrereleaseTesting.test {
             let actualValue = FeatureFlag.enhancedSiteCreation.enabled
-            XCTAssertFalse(actualValue, "Enhanced site creation should be disabled for .a8cPrereleaseTesting BuildConfiguration")
+            XCTAssertTrue(actualValue, "Enhanced site creation should be enabled for .a8cPrereleaseTesting BuildConfiguration")
         }
     }
 
     func testFeatureFlag_EnhancedSiteCreation_Disabled_ForAppStoreBuildConfiguration() {
         BuildConfiguration.appStore.test {
             let actualValue = FeatureFlag.enhancedSiteCreation.enabled
-            XCTAssertFalse(actualValue, "Enhanced site creation should be disabled for .appStore BuildConfiguration")
+            XCTAssertTrue(actualValue, "Enhanced site creation should be enabled for .appStore BuildConfiguration")
         }
     }
 }


### PR DESCRIPTION
Fixes #10341 

To test:

Verify when clicking "Create WordPress.com site" it shows the Enhanced Site Creation flow.

@ctarda if everything looks good, please merge yourself. We need this in before @loremattei cuts 11.9

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
