### PR TITLE
Added Quick Start to Enhanced Site Creation flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -207,12 +207,29 @@ extension SiteAssemblyWizardContent: NetworkStatusDelegate {
 
 extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
     func primaryButtonPressed() {
-        dismissTapped(viaDone: true) { [createdBlog] in
+        dismissTapped(viaDone: true) { [createdBlog, weak self] in
             guard let blog = createdBlog else {
                 return
             }
             WPAnalytics.track(.enhancedSiteCreationCompleted)
             WPTabBarController.sharedInstance().switchMySitesTabToBlogDetails(for: blog)
+
+            self?.showQuickStartAlert(for: blog)
         }
+    }
+
+    private func showQuickStartAlert(for blog: Blog) {
+        guard !UserDefaults.standard.quickStartWasDismissedPermanently else {
+            return
+        }
+
+        guard let tabBar = WPTabBarController.sharedInstance() else {
+            return
+        }
+
+        let fancyAlert = FancyAlertViewController.makeQuickStartAlertController(blog: blog)
+        fancyAlert.modalPresentationStyle = .custom
+        fancyAlert.transitioningDelegate = tabBar
+        tabBar.present(fancyAlert, animated: true)
     }
 }


### PR DESCRIPTION
While testing https://github.com/wordpress-mobile/WordPress-iOS/pull/11132, I noticed that Quick Start hasn't been added to the Enhanced Site Creation flow, which is [now the only way of creating sites](https://github.com/wordpress-mobile/WordPress-iOS/pull/11133). This PR is my attempt at adding Quick Start there, but let me know if I've done it wrong.

**To test:**

* Build and run
* Create a site using the new site creation flow
* Ensure you see Quick Start after dismissing the preview at the end of the flow.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`. (N/A)
