### PR TITLE
Absorbed defect-resolving changes to WordPressKit

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -52,8 +52,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 2.1.0'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '3886f1d'
+    #pod 'WordPressKit', '~> 2.1.0'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'f2e1d41'
     #pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -52,8 +52,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    #pod 'WordPressKit', '~> 2.1.0'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'f2e1d41'
+    pod 'WordPressKit', '~> 2.1.0.1'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'f2e1d41'
     #pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -191,7 +191,7 @@ PODS:
     - WordPressKit (~> 2.0-beta)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-  - WordPressKit (2.1.0):
+  - WordPressKit (2.1.0.1-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -249,7 +249,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.3)
   - WordPressAuthenticator (~> 1.1.9)
-  - WordPressKit (~> 2.1.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `f2e1d41`)
   - WordPressShared (= 1.7.1)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -291,7 +291,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -319,6 +318,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.0.1
+  WordPressKit:
+    :commit: f2e1d41
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -341,6 +343,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.0.1
+  WordPressKit:
+    :commit: f2e1d41
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -387,7 +392,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 0062ba96c3ea77186590c74b761427c461f89a06
   WordPress-Editor-iOS: cfaa780c3ee64ea781fe6f52ca1561667a3f3707
   WordPressAuthenticator: 9559bc45373f1b6c2f58d664d34f564bcf73111f
-  WordPressKit: 1296ce8f8b85423ddf0d993deac918e75c5b6896
+  WordPressKit: 1cdac3c4803ac35c6ced2af9158b9edb6bd73955
   WordPressShared: 2018257df3fe1de423f31a3ba50ac8d6bd24941c
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
@@ -395,6 +400,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 2c1688ad9f328bb556211b9739772c7300173c1f
+PODFILE CHECKSUM: 8b1e9b292f3af4bd10df22a2d643ee7f07da2e59
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -191,7 +191,7 @@ PODS:
     - WordPressKit (~> 2.0-beta)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-  - WordPressKit (2.1.0.1-beta.1):
+  - WordPressKit (2.1.0.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -249,7 +249,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.3)
   - WordPressAuthenticator (~> 1.1.9)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `f2e1d41`)
+  - WordPressKit (~> 2.1.0.1)
   - WordPressShared (= 1.7.1)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -291,6 +291,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -318,9 +319,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.0.1
-  WordPressKit:
-    :commit: f2e1d41
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -343,9 +341,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.0.1
-  WordPressKit:
-    :commit: f2e1d41
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -392,7 +387,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 0062ba96c3ea77186590c74b761427c461f89a06
   WordPress-Editor-iOS: cfaa780c3ee64ea781fe6f52ca1561667a3f3707
   WordPressAuthenticator: 9559bc45373f1b6c2f58d664d34f564bcf73111f
-  WordPressKit: 1cdac3c4803ac35c6ced2af9158b9edb6bd73955
+  WordPressKit: a4317495aa619fe4f5db7a6354639e098da07be1
   WordPressShared: 2018257df3fe1de423f31a3ba50ac8d6bd24941c
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
@@ -400,6 +395,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 8b1e9b292f3af4bd10df22a2d643ee7f07da2e59
+PODFILE CHECKSUM: a8f2b5f44e55e6094c4757dffdb6dcc498df9966
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Helps address a [WordPressKit issue](https://github.com/wordpress-mobile/WordPressKit-iOS/issues/109) related to nil parameters and locale handling. 

I've marked this as a Draft PR, pending the approval, merge & release of the supporting [WordPressKit PR](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/111).

To test:

- Checkout the branch and confirm that existing tests pass.
- Smoke test the app, confirm that nothing looks out of sorts.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
