### PR TITLE
Stats: mapping Insights into Core Data models, part 1

### DIFF
--- a/WordPress/Classes/Models/AllTimeStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/AllTimeStatsRecordValue+CoreDataClass.swift
@@ -25,7 +25,7 @@ extension StatsAllTimesInsight: StatsRecordValueConvertible {
     init(statsRecordValue: StatsRecordValue) {
         // We won't be needing those until later. I added them to protocol to show the intended design
         // but it doesn't make sense to implement it yet.
-        fatalError()
+        fatalError("This shouldn't be called yet — implementation of StatsRecordValueConvertible is still in progres. This method was added to illustrate intended design, but isn't ready yet.")
     }
 
     static var recordType: StatsRecordType {

--- a/WordPress/Classes/Models/AllTimeStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/AllTimeStatsRecordValue+CoreDataClass.swift
@@ -8,3 +8,27 @@ public class AllTimeStatsRecordValue: StatsRecordValue {
         try singleEntryTypeValidation()
     }
 }
+
+extension StatsAllTimesInsight: StatsRecordValueConvertible {
+    func statsRecordValue(in context: NSManagedObjectContext) -> StatsRecordValue {
+        let value = AllTimeStatsRecordValue(context: context)
+
+        value.postsCount = Int64(self.postsCount)
+        value.viewsCount = Int64(self.viewsCount)
+        value.visitorsCount = Int64(self.visitorsCount)
+        value.bestViewsPerDayCount = Int64(self.bestViewsPerDayCount)
+        value.bestViewsDay = self.bestViewsDay as NSDate
+
+        return value
+    }
+
+    init(statsRecordValue: StatsRecordValue) {
+        // We won't be needing those until later. I added them to protocol to show the intended design
+        // but it doesn't make sense to implement it yet.
+        fatalError()
+    }
+
+    static var recordType: StatsRecordType {
+        return .allTimeStatsInsight
+    }
+}

--- a/WordPress/Classes/Models/AllTimeStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/AllTimeStatsRecordValue+CoreDataProperties.swift
@@ -9,9 +9,9 @@ extension AllTimeStatsRecordValue {
     }
 
     @NSManaged public var postsCount: Int64
-    @NSManaged public var viewsCount: NSNumber?
-    @NSManaged public var visitorsCount: NSNumber?
-    @NSManaged public var bestViewsPerDayCount: NSNumber?
+    @NSManaged public var viewsCount: Int64
+    @NSManaged public var visitorsCount: Int64
+    @NSManaged public var bestViewsPerDayCount: Int64
     @NSManaged public var bestViewsDay: NSDate?
 
 }

--- a/WordPress/Classes/Models/AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift
@@ -8,3 +8,43 @@ public class AnnualAndMostPopularTimeStatsRecordValue: StatsRecordValue {
         try singleEntryTypeValidation()
     }
 }
+
+extension StatsAnnualAndMostPopularTimeInsight: StatsRecordValueConvertible {
+    func statsRecordValue(in context: NSManagedObjectContext) -> StatsRecordValue {
+        let value = AnnualAndMostPopularTimeStatsRecordValue(context: context)
+
+        value.mostPopularDayOfWeek = Int64(self.mostPopularDayOfWeek.weekday!)
+        value.mostPopularDayOfWeekPercentage = Int64(self.mostPopularDayOfWeekPercentage)
+
+        value.mostPopularHour = Int64(self.mostPopularHour.hour!)
+        value.mostPopularHourPercentage = Int64(self.mostPopularHourPercentage)
+
+        value.insightYear = Int64(self.annualInsightsYear)
+
+        value.totalPostsCount = Int64(self.annualInsightsTotalPostsCount)
+
+        value.totalWordsCount = Int64(self.annualInsightsTotalWordsCount)
+        value.averageWordsCount = self.annualInsightsAverageWordsCount
+
+        value.totalLikesCount = Int64(self.annualInsightsTotalLikesCount)
+        value.averageLikesCount = self.annualInsightsAverageLikesCount
+
+        value.totalCommentsCount = Int64(self.annualInsightsTotalCommentsCount)
+        value.averageCommentsCount = self.annualInsightsAverageCommentsCount
+
+        value.totalImagesCount = Int64(self.annualInsightsTotalImagesCount)
+        value.averageImagesCount = self.annualInsightsAverageImagesCount
+
+        return value
+    }
+
+    init(statsRecordValue: StatsRecordValue) {
+        fatalError()
+    }
+
+    static var recordType: StatsRecordType {
+        return .annualAndMostPopularTimes
+    }
+
+
+}

--- a/WordPress/Classes/Models/AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift
@@ -39,7 +39,9 @@ extension StatsAnnualAndMostPopularTimeInsight: StatsRecordValueConvertible {
     }
 
     init(statsRecordValue: StatsRecordValue) {
-        fatalError()
+        // We won't be needing those until later. I added them to protocol to show the intended design
+        // but it doesn't make sense to implement it yet.
+        fatalError("This shouldn't be called yet — implementation of StatsRecordValueConvertible is still in progres. This method was added to illustrate intended design, but isn't ready yet.")
     }
 
     static var recordType: StatsRecordType {

--- a/WordPress/Classes/Models/LastPostStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/LastPostStatsRecordValue+CoreDataClass.swift
@@ -15,3 +15,28 @@ public class LastPostStatsRecordValue: StatsRecordValue {
         try singleEntryTypeValidation()
     }
 }
+
+extension StatsLastPostInsight: StatsRecordValueConvertible {
+    func statsRecordValue(in context: NSManagedObjectContext) -> StatsRecordValue {
+        let value = LastPostStatsRecordValue(context: context)
+
+        value.commentsCount = Int64(self.commentsCount)
+        value.likesCount = Int64(self.likesCount)
+        value.publishedDate = self.publishedDate as NSDate
+        value.title = self.title
+        value.urlString = self.url.absoluteString
+        value.viewsCount = Int64(self.viewsCount)
+
+        return value
+    }
+
+    init(statsRecordValue: StatsRecordValue) {
+        // We won't be needing those until later. I added them to protocol to show the intended design
+        // but it doesn't make sense to implement it yet.
+        fatalError()
+    }
+
+    static var recordType: StatsRecordType {
+        return .lastPostInsight
+    }
+}

--- a/WordPress/Classes/Models/LastPostStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/LastPostStatsRecordValue+CoreDataClass.swift
@@ -33,7 +33,7 @@ extension StatsLastPostInsight: StatsRecordValueConvertible {
     init(statsRecordValue: StatsRecordValue) {
         // We won't be needing those until later. I added them to protocol to show the intended design
         // but it doesn't make sense to implement it yet.
-        fatalError()
+        fatalError("This shouldn't be called yet — implementation of StatsRecordValueConvertible is still in progres. This method was added to illustrate intended design, but isn't ready yet.")
     }
 
     static var recordType: StatsRecordType {

--- a/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
@@ -33,6 +33,7 @@ public enum StatsRecordType: Int16 {
     case tagsAndCategories
     case topCommentAuthors
     case topCommentedPosts
+    case annualAndMostPopularTimes
 
 
     case blogVisitsSummary
@@ -59,7 +60,8 @@ public enum StatsRecordType: Int16 {
               .streakInsight,
               .tagsAndCategories,
               .topCommentAuthors,
-              .topCommentedPosts:
+              .topCommentedPosts,
+              .annualAndMostPopularTimes:
 
             return false
         case  .blogVisitsSummary,

--- a/WordPress/Classes/Models/StatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StatsRecordValue+CoreDataClass.swift
@@ -9,3 +9,10 @@ public class StatsRecordValue: NSManagedObject {
         parent.addToValues(self)
     }
 }
+
+protocol StatsRecordValueConvertible {
+    func statsRecordValue(in context: NSManagedObjectContext) -> StatsRecordValue
+    init(statsRecordValue: StatsRecordValue)
+
+    static var recordType: StatsRecordType { get }
+}

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
@@ -42,10 +42,10 @@
     </entity>
     <entity name="AllTimeStatsRecordValue" representedClassName=".AllTimeStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
         <attribute name="bestViewsDay" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="bestViewsPerDayCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="postsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
-        <attribute name="viewsCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
-        <attribute name="visitorsCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="bestViewsPerDayCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="postsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="viewsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
+        <attribute name="visitorsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <entity name="AnnualAndMostPopularTimeStatsRecordValue" representedClassName=".AnnualAndMostPopularTimeStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
         <attribute name="averageCommentsCount" attributeType="Double" usesScalarValueType="YES" syncable="YES"/>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 		374CB16215B93C0800DD0EBC /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 374CB16115B93C0800DD0EBC /* AudioToolbox.framework */; };
 		37EAAF4D1A11799A006D6306 /* CircularImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EAAF4C1A11799A006D6306 /* CircularImageView.swift */; };
 		400199AB222590E100EB0906 /* AllTimeStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400199AA222590E100EB0906 /* AllTimeStatsRecordValueTests.swift */; };
+		400199AD22259FF300EB0906 /* AnnualAndMostPopularTimeStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400199AC22259FF300EB0906 /* AnnualAndMostPopularTimeStatsRecordValueTests.swift */; };
 		400A2C772217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C752217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift */; };
 		400A2C782217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C762217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift */; };
 		400A2C832217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C792217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift */; };
@@ -2114,6 +2115,7 @@
 		37EAAF4C1A11799A006D6306 /* CircularImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircularImageView.swift; sourceTree = "<group>"; };
 		3B28C7D4D65D0CA6AB9FCFDC /* Pods-WordPressDraftActionExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressDraftActionExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressDraftActionExtension/Pods-WordPressDraftActionExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		400199AA222590E100EB0906 /* AllTimeStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllTimeStatsRecordValueTests.swift; sourceTree = "<group>"; };
+		400199AC22259FF300EB0906 /* AnnualAndMostPopularTimeStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnualAndMostPopularTimeStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		400A2C752217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisitsSummaryStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		400A2C762217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisitsSummaryStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		400A2C792217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedVideoStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -4800,6 +4802,7 @@
 				40E7FEC72211EEC00032834E /* LastPostStatsRecordValueTests.swift */,
 				40F50B81221310F000CBBB73 /* StatsTestCase.swift */,
 				400199AA222590E100EB0906 /* AllTimeStatsRecordValueTests.swift */,
+				400199AC22259FF300EB0906 /* AnnualAndMostPopularTimeStatsRecordValueTests.swift */,
 			);
 			name = Stats;
 			sourceTree = "<group>";
@@ -10856,6 +10859,7 @@
 				08B6E51C1F037ADD00268F57 /* MediaFileManagerTests.swift in Sources */,
 				5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */,
 				73178C2C21BEE09300E37C9A /* SiteCreationHeaderDataTests.swift in Sources */,
+				400199AD22259FF300EB0906 /* AnnualAndMostPopularTimeStatsRecordValueTests.swift in Sources */,
 				08A2AD7B1CCED8E500E84454 /* PostCategoryServiceTests.m in Sources */,
 				172D7825212D93B800D513F7 /* GiphyPageableTests.swift in Sources */,
 				D88A64A8208D9733008AE9BC /* ThumbnailCollectionTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 		37022D931981C19000F322B7 /* VerticallyStackedButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 37022D901981BF9200F322B7 /* VerticallyStackedButton.m */; };
 		374CB16215B93C0800DD0EBC /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 374CB16115B93C0800DD0EBC /* AudioToolbox.framework */; };
 		37EAAF4D1A11799A006D6306 /* CircularImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EAAF4C1A11799A006D6306 /* CircularImageView.swift */; };
+		400199AB222590E100EB0906 /* AllTimeStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400199AA222590E100EB0906 /* AllTimeStatsRecordValueTests.swift */; };
 		400A2C772217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C752217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift */; };
 		400A2C782217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C762217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift */; };
 		400A2C832217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C792217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift */; };
@@ -2112,6 +2113,7 @@
 		37E3F5EA2ED7005A5E0BBEC3 /* Pods-WordPressTodayWidget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTodayWidget.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTodayWidget/Pods-WordPressTodayWidget.release.xcconfig"; sourceTree = "<group>"; };
 		37EAAF4C1A11799A006D6306 /* CircularImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CircularImageView.swift; sourceTree = "<group>"; };
 		3B28C7D4D65D0CA6AB9FCFDC /* Pods-WordPressDraftActionExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressDraftActionExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressDraftActionExtension/Pods-WordPressDraftActionExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		400199AA222590E100EB0906 /* AllTimeStatsRecordValueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllTimeStatsRecordValueTests.swift; sourceTree = "<group>"; };
 		400A2C752217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisitsSummaryStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
 		400A2C762217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VisitsSummaryStatsRecordValue+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		400A2C792217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TopViewedVideoStatsRecordValue+CoreDataClass.swift"; sourceTree = "<group>"; };
@@ -4797,6 +4799,7 @@
 				40E7FEC42211DF790032834E /* StatsRecordTests.swift */,
 				40E7FEC72211EEC00032834E /* LastPostStatsRecordValueTests.swift */,
 				40F50B81221310F000CBBB73 /* StatsTestCase.swift */,
+				400199AA222590E100EB0906 /* AllTimeStatsRecordValueTests.swift */,
 			);
 			name = Stats;
 			sourceTree = "<group>";
@@ -10992,6 +10995,7 @@
 				BE1071FF1BC75FFA00906AFF /* WPStyleGuide+BlogTests.swift in Sources */,
 				932645A41E7C206600134988 /* GutenbergSettingsTests.swift in Sources */,
 				933D1F471EA64108009FB462 /* TestingAppDelegate.m in Sources */,
+				400199AB222590E100EB0906 /* AllTimeStatsRecordValueTests.swift in Sources */,
 				4054F4642214F94D00D261AB /* StreakStatsRecordValueTests.swift in Sources */,
 				85B125411B028E34008A3D95 /* PushAuthenticationManagerTests.swift in Sources */,
 				D821C81B21003AE9002ED995 /* FormattableContentGroupTests.swift in Sources */,

--- a/WordPress/WordPressTest/AllTimeStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/AllTimeStatsRecordValueTests.swift
@@ -1,0 +1,37 @@
+@testable import WordPress
+@testable import WordPressKit
+
+class AllTimeStatsRecordValueTests: StatsTestCase {
+
+    func testCoreDataConversion() {
+        let date = Calendar.autoupdatingCurrent.date(from: DateComponents(year: 2018, month: 2, day: 28))!
+
+        let insight = StatsAllTimesInsight(postsCount: 9001,
+                                           viewsCount: 9002,
+                                           bestViewsDay: date,
+                                           visitorsCount: 9003,
+                                           bestViewsPerDayCount: 9004)
+
+        let blog = defaultBlog()
+
+        _ = StatsRecord.record(from: insight, for: blog)
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let fetchRequest = StatsRecord.fetchRequest(for: .allTimeStatsInsight)
+        let result = try! mainContext.fetch(fetchRequest)
+        let statsRecord = result.first!
+
+        XCTAssertEqual(statsRecord.blog, blog)
+        XCTAssertEqual(statsRecord.period, StatsRecordPeriodType.notApplicable.rawValue)
+
+        let castedResults = statsRecord.values?.array.first! as! AllTimeStatsRecordValue
+
+        XCTAssertEqual(castedResults.postsCount, 9001)
+        XCTAssertEqual(castedResults.viewsCount, 9002)
+        XCTAssertEqual(castedResults.visitorsCount, 9003)
+        XCTAssertEqual(castedResults.bestViewsPerDayCount, 9004)
+        XCTAssertEqual(castedResults.bestViewsDay, date as NSDate)
+    }
+
+}

--- a/WordPress/WordPressTest/AnnualAndMostPopularTimeStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/AnnualAndMostPopularTimeStatsRecordValueTests.swift
@@ -1,0 +1,65 @@
+@testable import WordPress
+@testable import WordPressKit
+
+class AnnualAndMostPopularTimeStatsRecordValueTests: StatsTestCase {
+
+    func testCoreDataConversion() {
+        let insight = StatsAnnualAndMostPopularTimeInsight(mostPopularDayOfWeek: DateComponents(weekday: 3),
+                                                           mostPopularDayOfWeekPercentage: 15,
+
+                                                           mostPopularHour: DateComponents(hour: 16),
+                                                           mostPopularHourPercentage: 99,
+
+                                                           annualInsightsYear: 2018,
+                                                           annualInsightsTotalPostsCount: 9001,
+
+                                                           annualInsightsTotalWordsCount: 9002,
+                                                           annualInsightsAverageWordsCount: 2.5,
+
+                                                           annualInsightsTotalLikesCount: 9003,
+                                                           annualInsightsAverageLikesCount: 3.5,
+
+                                                           annualInsightsTotalCommentsCount: 9004,
+                                                           annualInsightsAverageCommentsCount: 4.5,
+
+                                                           annualInsightsTotalImagesCount: 9005,
+                                                           annualInsightsAverageImagesCount: 5.5)
+
+        let blog = defaultBlog()
+
+        _ = StatsRecord.record(from: insight, for: blog)
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let statsRecord = StatsRecord.insight(for: blog, type: .annualAndMostPopularTimes)
+
+        XCTAssertNotNil(statsRecord)
+
+        XCTAssertEqual(statsRecord!.blog, blog)
+        XCTAssertEqual(statsRecord!.period, StatsRecordPeriodType.notApplicable.rawValue)
+
+        let castedResults = statsRecord!.values?.array.first! as! AnnualAndMostPopularTimeStatsRecordValue
+
+        XCTAssertEqual(castedResults.mostPopularDayOfWeek, 3)
+        XCTAssertEqual(castedResults.mostPopularDayOfWeekPercentage, 15)
+
+        XCTAssertEqual(castedResults.mostPopularHour, 16)
+        XCTAssertEqual(castedResults.mostPopularHourPercentage, 99)
+
+        XCTAssertEqual(castedResults.insightYear, 2018)
+        XCTAssertEqual(castedResults.totalPostsCount, 9001)
+
+        XCTAssertEqual(castedResults.totalWordsCount, 9002)
+        XCTAssertEqual(castedResults.averageWordsCount, 2.5)
+
+        XCTAssertEqual(castedResults.totalLikesCount, 9003)
+        XCTAssertEqual(castedResults.averageLikesCount, 3.5)
+
+        XCTAssertEqual(castedResults.totalCommentsCount, 9004)
+        XCTAssertEqual(castedResults.averageCommentsCount, 4.5)
+
+        XCTAssertEqual(castedResults.totalImagesCount, 9005)
+        XCTAssertEqual(castedResults.averageImagesCount, 5.5)
+    }
+
+}

--- a/WordPress/WordPressTest/LastPostStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/LastPostStatsRecordValueTests.swift
@@ -103,7 +103,7 @@ class LastPostStatsRecordValueTests: StatsTestCase {
                                            viewsCount: 3,
                                            postID: 4)
 
-        let blog = discardableBlog()
+        let blog = defaultBlog()
 
         _ = StatsRecord.record(from: insight, for: blog)
 
@@ -124,10 +124,6 @@ class LastPostStatsRecordValueTests: StatsTestCase {
         XCTAssertEqual(castedResults.commentsCount, 2)
         XCTAssertEqual(castedResults.viewsCount, 3)
         XCTAssertEqual(castedResults.url, URL(string: "google.com") )
-    }
-
-    private func discardableBlog() -> Blog {
-        return ModelTestHelper.insertDotComBlog(context: mainContext)
     }
 
     @discardableResult func createLastPostStatsRecordValue(parent: StatsRecord) -> LastPostStatsRecordValue {

--- a/WordPress/WordPressTest/StatsTestCase.swift
+++ b/WordPress/WordPressTest/StatsTestCase.swift
@@ -31,4 +31,9 @@ class StatsTestCase: XCTestCase {
         return newRecord
     }
 
+    func defaultBlog() -> Blog {
+        return ModelTestHelper.insertDotComBlog(context: mainContext)
+    }
+
+
 }


### PR DESCRIPTION
This is first part of addressing #11153.

The basic shape/idea of it is sorta analogous to how `StatsServiceRemoteV2` works: one centralized, generic function where a lot of "magic" takes place, with a bunch of boring/mundane data marshalling between formats in appropriate subclasses.

In this case, most of the work is being done in Core Data `StatsRecordValue` subclasses implementing conformance to `StatsRecordValueConvertible` protocol for their respective `WordPressKit` counterparts.

My plan for tackling the entirety of Peristence work in Stats is roughly:

1. Handle mapping Insights data from WPKit format into Core Data entities (#11153) 
2. Make the `StatsInsightsStore` able to use the persisted data and persist new one to disk
3. Optional, TBD if I'll end up going this route: 
    Ideally we'd keep using the immutable `struct`s in ViewModel part of the app, instead of exposing the persistence implementation details to the rest of the app. This would include having to add a way to go "back" from Core Data objects back into the WPKit objects. This is expressed as the `    init(statsRecordValue: StatsRecordValue)` method in `StatsRecordValueConvertible` — I haven't worked on any implementations yet — that part of the design is still very much up in the air and I might end up changing it.
4. Repeat the above for the `TimeInterval` data

To test:

* Verify the tests pass.