### PR TITLE
Stop marking skipped tours as complete

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -328,18 +328,19 @@ private extension QuickStartTourGuide {
         }
 
         blog.completeTour(tour.key)
-        recentlyTouredBlog = blog
 
         if postNotification {
             NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.tourCompleted])
+            WPAnalytics.track(.quickStartTourCompleted, withProperties: ["task_name": tour.analyticsKey])
+            recentlyTouredBlog = blog
+        } else {
+            recentlyTouredBlog = nil
         }
 
         guard !(tour is QuickStartCongratulationsTour) else {
             WPAnalytics.track(.quickStartCongratulationsViewed)
             return
         }
-
-        WPAnalytics.track(.quickStartTourCompleted, withProperties: ["task_name": tour.analyticsKey])
 
         if allToursCompleted(for: blog) {
             WPAnalytics.track(.quickStartAllToursCompleted)


### PR DESCRIPTION
Fixes #11149

After skipping a tour in one of the quick start checklists, there will no longer be a suggestion.

To test:
- Skip a QS checklist (let me know if you need advice how to get this list)
- Ensure that when the list is dismissed a suggestion doesn't appear
- Also ensure that only the skipping event fires, and that no analytics for completion.

