### PR TITLE
Cleanup QS v2 events

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -24,13 +24,13 @@ end
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '1.7.1'
+ #   pod 'WordPressShared', '1.7.1'
 
     ## for development:
-    ##pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
+ #   pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-#    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => '43ee0cb3a24fa9fdfc93116b6ec91f6be51f2b07'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'c37c645aaa4e000eb53e8a9537798162c072a321'
 end
 
 def aztec

--- a/Podfile
+++ b/Podfile
@@ -24,13 +24,13 @@ end
 ##
 def wordpress_shared
     ## for production:
- #   pod 'WordPressShared', '1.7.1'
+    pod 'WordPressShared', '1.7.2-beta.1'
 
     ## for development:
- #   pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
+    # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'c37c645aaa4e000eb53e8a9537798162c072a321'
+    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit => 'c37c645aaa4e000eb53e8a9537798162c072a321'
 end
 
 def aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -250,7 +250,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.4.3)
   - WordPressAuthenticator (~> 1.1.10-beta.1)
   - WordPressKit (~> 3.0.0-beta.1)
-  - WordPressShared (= 1.7.1)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `c37c645aaa4e000eb53e8a9537798162c072a321`)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -292,7 +292,6 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
-    - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
@@ -319,6 +318,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.0.1
+  WordPressShared:
+    :commit: c37c645aaa4e000eb53e8a9537798162c072a321
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -341,6 +343,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.0.1
+  WordPressShared:
+    :commit: c37c645aaa4e000eb53e8a9537798162c072a321
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -395,6 +400,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 50d2adfc9635737d9a969d6584dc4cffada48828
+PODFILE CHECKSUM: 79146732ceb481903fd8d5fa1d31ec9d3e0bdd32
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -198,7 +198,7 @@ PODS:
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.4)
     - wpxmlrpc (= 0.8.4)
-  - WordPressShared (1.7.1):
+  - WordPressShared (1.7.2-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.2.0)
@@ -250,7 +250,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (= 1.4.3)
   - WordPressAuthenticator (~> 1.1.10-beta.1)
   - WordPressKit (~> 3.0.0-beta.1)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `c37c645aaa4e000eb53e8a9537798162c072a321`)
+  - WordPressShared (= 1.7.2-beta.1)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -292,6 +292,7 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
+    - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskSDK
@@ -318,9 +319,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.0.1
-  WordPressShared:
-    :commit: c37c645aaa4e000eb53e8a9537798162c072a321
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -343,9 +341,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.0.1
-  WordPressShared:
-    :commit: c37c645aaa4e000eb53e8a9537798162c072a321
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -393,13 +388,13 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: cfaa780c3ee64ea781fe6f52ca1561667a3f3707
   WordPressAuthenticator: 80cda36379dfee8772ad1b2e9c7f4541ccba0500
   WordPressKit: 843906cb26fb8a92dddefd9a324a821555bf2b94
-  WordPressShared: 2018257df3fe1de423f31a3ba50ac8d6bd24941c
+  WordPressShared: 02a2f4d490c44536b55fe59eeb2e72e95bd56697
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 79146732ceb481903fd8d5fa1d31ec9d3e0bdd32
+PODFILE CHECKSUM: 36e537b03f064371246743c5713561b2d6c2b4d6
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1235,8 +1235,13 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             eventName = @"quick_start_migration_dialog_button_tapped";
             eventProperties = @{ @"type" : @"positive" };
             break;
-        case WPAnalyticsStatQuickStartRemoveDialogButtonTapped:
+        case WPAnalyticsStatQuickStartRemoveDialogButtonRemoveTapped:
             eventName = @"quick_start_remove_dialog_button_tapped";
+            eventProperties = @{ @"type" : @"positive" };
+            break;
+        case WPAnalyticsStatQuickStartRemoveDialogButtonCancelTapped:
+            eventName = @"quick_start_remove_dialog_button_tapped";
+            eventProperties = @{ @"type" : @"negative" };
             break;
         case WPAnalyticsStatQuickStartTypeDismissed:
             eventName = @"quick_start_type_dismissed";

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1066,10 +1066,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     UIAlertController *removeConfirmation = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleAlert];
     [removeConfirmation addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * _Nonnull action) {
-        [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonTapped withProperties:@{@"type": @"negative"}];
+        [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonCancelTapped];
     }];
     [removeConfirmation addDefaultActionWithTitle:confirmationTitle handler:^(UIAlertAction * _Nonnull action) {
-        [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonTapped withProperties:@{@"type": @"positive"}];
+        [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonRemoveTapped];
 
         [[QuickStartTourGuide find] removeFrom:self.blog];
     }];


### PR DESCRIPTION
This makes the `WPAnalyticsStatQuickStartRemoveDialogButtonTapped` into two events with properties set in the definition instead of when used.

@stevebaranski got a moment to check this out?