### PR TITLE
Fix errors in metadata

### DIFF
--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -73,13 +73,6 @@ import "./ScreenshotFastfile"
       "app_store_screenshot-3" => File.join(source_metadata_folder, "promo_screenshot_3.txt"),
       "app_store_screenshot-4" => File.join(source_metadata_folder, "promo_screenshot_4.txt"),
       "app_store_screenshot-5" => File.join(source_metadata_folder, "promo_screenshot_5.txt"),
-
-      "enhanced_app_store_screenshot-1" => File.join(source_metadata_folder, "screenshot_1.html"),
-      "enhanced_app_store_screenshot-2" => File.join(source_metadata_folder, "screenshot_2.html"),
-      "enhanced_app_store_screenshot-3" => File.join(source_metadata_folder, "screenshot_3.html"),
-      "enhanced_app_store_screenshot-4" => File.join(source_metadata_folder, "screenshot_4.html"),
-      "enhanced_app_store_screenshot-5" => File.join(source_metadata_folder, "screenshot_5.html"),
-      "enhanced_app_store_screenshot-6" => File.join(source_metadata_folder, "screenshot_6.html"),
     }
 
     ios_update_metadata_source(po_file_path: prj_folder + "/WordPress/Resources/AppStoreStrings.po", 

--- a/WordPress/Resources/AppStoreStrings.po
+++ b/WordPress/Resources/AppStoreStrings.po
@@ -106,46 +106,6 @@ msgstr ""
 msgctxt "app_store_screenshot-5"
 msgid ""
 "All the stats\n"
-"in your hand\n"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot-1"
-msgid "<strong>Create </strong>beautiful<br />posts and pages"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot-2"
-msgid "<strong>Track </strong><span>what your<br />visitors love</span>
-"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot-3"
-msgid "<strong>Check </strong><span>what's<br />happening in real time</span>
-"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot-4"
-msgid "<strong>Share </strong> from<br />anywhere
-"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot-5"
-msgid "<strong>Capture </strong>ideas<br />on the go
-"
-msgstr ""
-
-#. translators: This is a promo message that will be attached on top of an enhanced screenshot in the App Store.
-#. No specified character limit here, but try to keep it as short as the source one. Please leave emphasis and line break tags in place, unless they don't make sense in the target language.
-msgctxt "enhanced_app_store_screenshot-6"
-msgid "<strong>Write</strong> without compromises"
+"in your hand"
 msgstr ""
 


### PR DESCRIPTION
This PR reverts https://github.com/wordpress-mobile/WordPress-iOS/pull/11110. 
As I mentioned in that PR, putting html into the strings seems to break GlotPress. 
I checked that the file can't be loaded because of a parsing error. Removing the strings with the html tags fixes it. 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
