### PR TITLE
Add accessibility identifier support for filters

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1525,10 +1525,6 @@ private extension NotificationsViewController {
 
         static let sortKey = "timestamp"
         static let allFilters = [Filter.none, .unread, .comment, .follow, .like]
-
-        var accessibilityIdentifier: String {
-            return "\(self)"
-        }
     }
 
     enum Settings {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -427,7 +427,7 @@ private extension NotificationsViewController {
         filterTabBar.deselectedTabColor = WPStyleGuide.greyDarken10()
         filterTabBar.dividerColor = WPStyleGuide.greyLighten20()
 
-        filterTabBar.tabBarItems = Filter.allFilters
+        filterTabBar.items = Filter.allFilters
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1526,10 +1526,6 @@ private extension NotificationsViewController {
         static let sortKey = "timestamp"
         static let allFilters = [Filter.none, .unread, .comment, .follow, .like]
 
-        var filterTitle: String {
-            return self.title
-        }
-
         var accessibilityIdentifier: String {
             return "\(self)"
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -427,7 +427,7 @@ private extension NotificationsViewController {
         filterTabBar.deselectedTabColor = WPStyleGuide.greyDarken10()
         filterTabBar.dividerColor = WPStyleGuide.greyLighten20()
 
-        filterTabBar.items = Filter.allFilters.map { $0.title }
+        filterTabBar.tabBarItems = Filter.allFilters
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
     }
 }
@@ -1455,7 +1455,7 @@ private extension NotificationsViewController {
         }
     }
 
-    enum Filter: Int {
+    enum Filter: Int, FilterTabBarItem {
         case none = 0
         case unread = 1
         case comment = 2
@@ -1525,6 +1525,14 @@ private extension NotificationsViewController {
 
         static let sortKey = "timestamp"
         static let allFilters = [Filter.none, .unread, .comment, .follow, .like]
+
+        var filterTitle: String {
+            return self.title
+        }
+
+        var accessibilityIdentifier: String {
+            return "\(self)"
+        }
     }
 
     enum Settings {

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -290,10 +290,6 @@ private extension PeopleViewController {
                 return .viewer
             }
         }
-
-        var accessibilityIdentifier: String {
-            return self.rawValue
-        }
     }
 
     enum RestorationKeys {

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -510,7 +510,7 @@ private extension PeopleViewController {
         filterBar.deselectedTabColor = WPStyleGuide.greyDarken10()
         filterBar.dividerColor = WPStyleGuide.greyLighten20()
 
-        filterBar.tabBarItems = filtersAvailableForBlog(blog)
+        filterBar.items = filtersAvailableForBlog(blog)
         filterBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
 
         // By default, let's display the Blog's Users

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -291,10 +291,6 @@ private extension PeopleViewController {
             }
         }
 
-        var filterTitle: String {
-            return self.title
-        }
-
         var accessibilityIdentifier: String {
             return self.rawValue
         }

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -259,7 +259,8 @@ private extension PeopleViewController {
 
     // MARK: Enums
 
-    enum Filter: String, CaseIterable {
+    enum Filter: String, CaseIterable, FilterTabBarItem {
+
         case users      = "users"
         case followers  = "followers"
         case viewers    = "viewers"
@@ -288,6 +289,14 @@ private extension PeopleViewController {
             case .viewers:
                 return .viewer
             }
+        }
+
+        var filterTitle: String {
+            return self.title
+        }
+
+        var accessibilityIdentifier: String {
+            return self.rawValue
         }
     }
 
@@ -505,7 +514,7 @@ private extension PeopleViewController {
         filterBar.deselectedTabColor = WPStyleGuide.greyDarken10()
         filterBar.dividerColor = WPStyleGuide.greyLighten20()
 
-        filterBar.items = filtersAvailableForBlog(blog).map { $0.title }
+        filterBar.tabBarItems = filtersAvailableForBlog(blog)
         filterBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
 
         // By default, let's display the Blog's Users

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -271,7 +271,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         filterTabBar.deselectedTabColor = WPStyleGuide.greyDarken10()
         filterTabBar.dividerColor = WPStyleGuide.greyLighten20()
 
-        filterTabBar.items = filterSettings.availablePostListFilters().map({ $0.title })
+        filterTabBar.tabBarItems = filterSettings.availablePostListFilters()
 
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
     }

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -271,7 +271,7 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         filterTabBar.deselectedTabColor = WPStyleGuide.greyDarken10()
         filterTabBar.dividerColor = WPStyleGuide.greyLighten20()
 
-        filterTabBar.tabBarItems = filterSettings.availablePostListFilters()
+        filterTabBar.items = filterSettings.availablePostListFilters()
 
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@objc class PostListFilter: NSObject {
+@objc class PostListFilter: NSObject, FilterTabBarItem {
 
     enum Status: UInt {
         case published
@@ -115,12 +115,5 @@ import Foundation
         filter.accessibilityIdentifier = "trashed"
 
         return filter
-    }
-}
-
-extension PostListFilter: FilterTabBarItem {
-
-    var filterTitle: String {
-        return self.title
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -15,6 +15,7 @@ import Foundation
     @objc var predicateForFetchRequest: NSPredicate
     var statuses: [BasePost.Status]
     @objc var title: String
+    @objc var accessibilityIdentifier: String = ""
 
     /// For Obj-C compatibility only
     @objc(statuses)
@@ -71,7 +72,10 @@ import Foundation
 
         let title = NSLocalizedString("Published", comment: "Title of the published filter. This filter shows a list of posts that the user has published.")
 
-        return PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)
+        let filter = PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)
+        filter.accessibilityIdentifier = "published"
+
+        return filter
     }
 
     @objc class func draftFilter() -> PostListFilter {
@@ -83,7 +87,10 @@ import Foundation
 
         let title = NSLocalizedString("Drafts", comment: "Title of the drafts filter.  This filter shows a list of draft posts.")
 
-        return PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)
+        let filter = PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)
+        filter.accessibilityIdentifier = "drafts"
+
+        return filter
     }
 
     @objc class func scheduledFilter() -> PostListFilter {
@@ -92,7 +99,10 @@ import Foundation
         let predicate = NSPredicate(format: "status IN %@", statuses.strings)
         let title = NSLocalizedString("Scheduled", comment: "Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date.")
 
-        return PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)
+        let filter = PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)
+        filter.accessibilityIdentifier = "scheduled"
+
+        return filter
     }
 
     @objc class func trashedFilter() -> PostListFilter {
@@ -101,6 +111,16 @@ import Foundation
         let predicate = NSPredicate(format: "status IN %@", statuses.strings)
         let title = NSLocalizedString("Trashed", comment: "Title of the trashed filter. This filter shows posts that have been moved to the trash bin.")
 
-        return PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)
+        let filter = PostListFilter(title: title, filterType: filterType, predicate: predicate, statuses: statuses)
+        filter.accessibilityIdentifier = "trashed"
+
+        return filter
+    }
+}
+
+extension PostListFilter: FilterTabBarItem {
+
+    var filterTitle: String {
+        return self.title
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -20,10 +20,6 @@ import Gridicons
             case .sites: return NSLocalizedString("Sites", comment: "Title of a Reader tab showing Sites matching a user's search query")
             }
         }
-
-        var accessibilityIdentifier: String {
-            return "\(self)"
-        }
     }
 
     // MARK: - Properties

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -21,10 +21,6 @@ import Gridicons
             }
         }
 
-        var filterTitle: String {
-            return self.title
-        }
-
         var accessibilityIdentifier: String {
             return "\(self)"
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -10,7 +10,7 @@ import Gridicons
     @objc static let restorationClassIdentifier = "ReaderSearchViewControllerRestorationIdentifier"
     @objc static let restorableSearchTopicPathKey: String = "RestorableSearchTopicPathKey"
 
-    fileprivate enum Section: Int {
+    fileprivate enum Section: Int, FilterTabBarItem {
         case posts
         case sites
 
@@ -19,6 +19,14 @@ import Gridicons
             case .posts: return NSLocalizedString("Posts", comment: "Title of a Reader tab showing Posts matching a user's search query")
             case .sites: return NSLocalizedString("Sites", comment: "Title of a Reader tab showing Sites matching a user's search query")
             }
+        }
+
+        var filterTitle: String {
+            return self.title
+        }
+
+        var accessibilityIdentifier: String {
+            return "\(self)"
         }
     }
 
@@ -172,7 +180,7 @@ import Gridicons
         filterBar.deselectedTabColor = WPStyleGuide.greyDarken10()
         filterBar.dividerColor = WPStyleGuide.greyLighten20()
         filterBar.tabSizingStyle = .equalWidths
-        filterBar.items = sections.map({ $0.title })
+        filterBar.tabBarItems = sections
 
         filterBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -176,7 +176,7 @@ import Gridicons
         filterBar.deselectedTabColor = WPStyleGuide.greyDarken10()
         filterBar.dividerColor = WPStyleGuide.greyLighten20()
         filterBar.tabSizingStyle = .equalWidths
-        filterBar.tabBarItems = sections
+        filterBar.items = sections
 
         filterBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-struct TabData {
+struct TabData: FilterTabBarItem {
     var tabTitle: String
     var itemSubtitle: String
     var dataSubtitle: String
@@ -17,6 +17,14 @@ struct TabData {
         self.dataSubtitle = dataSubtitle
         self.totalCount = totalCount
         self.dataRows = dataRows
+    }
+
+    var filterTitle: String {
+        return self.tabTitle
+    }
+
+    var accessibilityIdentifier: String {
+        return self.tabTitle.localizedLowercase
     }
 }
 
@@ -75,7 +83,7 @@ private extension TabbedTotalsCell {
 
     func setupFilterBar(selectedIndex: Int) {
         WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forTabbedCard: true)
-        filterTabBar.items = tabsData.map { $0.tabTitle }
+        filterTabBar.tabBarItems = tabsData
         filterTabBar.setSelectedIndex(selectedIndex)
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
         toggleFilterTabBar()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -19,7 +19,7 @@ struct TabData: FilterTabBarItem {
         self.dataRows = dataRows
     }
 
-    var filterTitle: String {
+    var title: String {
         return self.tabTitle
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -83,7 +83,7 @@ private extension TabbedTotalsCell {
 
     func setupFilterBar(selectedIndex: Int) {
         WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forTabbedCard: true)
-        filterTabBar.tabBarItems = tabsData
+        filterTabBar.items = tabsData
         filterTabBar.setSelectedIndex(selectedIndex)
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
         toggleFilterTabBar()

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -60,10 +60,6 @@ private extension SiteStatsDashboardViewController {
             case .years: return NSLocalizedString("Years", comment: "Title of Years stats filter.")
             }
         }
-
-        var accessibilityIdentifier: String {
-            return "\(self)"
-        }
     }
 
     var currentSelectedPeriod: StatsPeriodType {

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -51,7 +51,7 @@ private extension SiteStatsDashboardViewController {
 
         static let allPeriods = [StatsPeriodType.insights, .days, .weeks, .months, .years]
 
-        var filterTitle: String {
+        var title: String {
             switch self {
             case .insights: return NSLocalizedString("Insights", comment: "Title of Insights stats filter.")
             case .days: return NSLocalizedString("Days", comment: "Title of Days stats filter.")

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -92,7 +92,7 @@ private extension SiteStatsDashboardViewController {
 
     func setupFilterBar() {
         WPStyleGuide.Stats.configureFilterTabBar(filterTabBar)
-        filterTabBar.tabBarItems = StatsPeriodType.allPeriods
+        filterTabBar.items = StatsPeriodType.allPeriods
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -42,7 +42,7 @@ private extension SiteStatsDashboardViewController {
         static let progressViewHideDuration = 0.15
     }
 
-    enum StatsPeriodType: Int {
+    enum StatsPeriodType: Int, FilterTabBarItem {
         case insights = 0
         case days
         case weeks
@@ -59,6 +59,10 @@ private extension SiteStatsDashboardViewController {
             case .months: return NSLocalizedString("Months", comment: "Title of Months stats filter.")
             case .years: return NSLocalizedString("Years", comment: "Title of Years stats filter.")
             }
+        }
+
+        var accessibilityIdentifier: String {
+            return "\(self)"
         }
     }
 
@@ -88,7 +92,7 @@ private extension SiteStatsDashboardViewController {
 
     func setupFilterBar() {
         WPStyleGuide.Stats.configureFilterTabBar(filterTabBar)
-        filterTabBar.items = StatsPeriodType.allPeriods.map { $0.filterTitle }
+        filterTabBar.tabBarItems = StatsPeriodType.allPeriods
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
     }
 

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -5,7 +5,7 @@ import UIKit
 ///
 
 protocol FilterTabBarItem {
-    var filterTitle: String { get }
+    var title: String { get }
     var accessibilityIdentifier: String { get }
 }
 
@@ -211,7 +211,7 @@ class FilterTabBar: UIControl {
     private func makeTab(_ item: FilterTabBarItem) -> UIButton {
 
         let tab = TabBarButton(type: .custom)
-        tab.setTitle(item.filterTitle, for: .normal)
+        tab.setTitle(item.title, for: .normal)
         tab.setTitleColor(titleColorForSelected, for: .selected)
         tab.setTitleColor(deselectedTabColor, for: .normal)
         tab.tintColor = tintColor

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -3,6 +3,12 @@ import UIKit
 /// Filter Tab Bar is a tabbed control (much like a segmented control), but
 /// has an appearance similar to Android tabs.
 ///
+
+protocol FilterTabBarItem {
+    var filterTitle: String { get }
+    var accessibilityIdentifier: String { get }
+}
+
 class FilterTabBar: UIControl {
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -36,9 +42,7 @@ class FilterTabBar: UIControl {
         return divider
     }()
 
-    /// Titles of tabs to display.
-    ///
-    @IBInspectable var items: [String] = [] {
+    var tabBarItems: [FilterTabBarItem] = [] {
         didSet {
             refreshTabs()
         }
@@ -143,15 +147,6 @@ class FilterTabBar: UIControl {
     }
 
     // MARK: - Initialization
-
-    init(items: [String]) {
-        self.items = items
-
-        super.init(frame: .zero)
-
-        refreshTabs()
-    }
-
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 
@@ -205,20 +200,23 @@ class FilterTabBar: UIControl {
 
     private func refreshTabs() {
         tabs.forEach({ $0.removeFromSuperview() })
-        tabs = items.map(makeTab(_:))
-        tabs.forEach(stackView.addArrangedSubview(_:))
+        tabs = tabBarItems.map(makeTab)
+        tabs.forEach(stackView.addArrangedSubview)
 
         layoutIfNeeded()
 
         setSelectedIndex(selectedIndex, animated: false)
     }
 
-    private func makeTab(_ title: String) -> UIButton {
+    private func makeTab(_ item: FilterTabBarItem) -> UIButton {
+
         let tab = TabBarButton(type: .custom)
-        tab.setTitle(title, for: .normal)
+        tab.setTitle(item.filterTitle, for: .normal)
         tab.setTitleColor(titleColorForSelected, for: .selected)
         tab.setTitleColor(deselectedTabColor, for: .normal)
         tab.tintColor = tintColor
+
+        tab.accessibilityIdentifier = item.accessibilityIdentifier
 
         tab.contentEdgeInsets = AppearanceMetrics.buttonInsets
         tab.sizeToFit()

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -9,6 +9,13 @@ protocol FilterTabBarItem {
     var accessibilityIdentifier: String { get }
 }
 
+extension FilterTabBarItem where Self: RawRepresentable {
+
+    var accessibilityIdentifier: String {
+        return "\(self)"
+    }
+}
+
 class FilterTabBar: UIControl {
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -201,7 +201,7 @@ class FilterTabBar: UIControl {
     private func refreshTabs() {
         tabs.forEach({ $0.removeFromSuperview() })
         tabs = tabBarItems.map(makeTab)
-        tabs.forEach(stackView.addArrangedSubview)
+        stackView.addArrangedSubviews(tabs)
 
         layoutIfNeeded()
 

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -42,7 +42,7 @@ class FilterTabBar: UIControl {
         return divider
     }()
 
-    var tabBarItems: [FilterTabBarItem] = [] {
+    var items: [FilterTabBarItem] = [] {
         didSet {
             refreshTabs()
         }
@@ -200,7 +200,7 @@ class FilterTabBar: UIControl {
 
     private func refreshTabs() {
         tabs.forEach({ $0.removeFromSuperview() })
-        tabs = tabBarItems.map(makeTab)
+        tabs = items.map(makeTab)
         stackView.addArrangedSubviews(tabs)
 
         layoutIfNeeded()


### PR DESCRIPTION
While working on UI Test Automation, I needed to add support for accessibility identifiers on a couple of different filters (Posts List and Stats). This allows the XCUITest runner to properly tap buttons on-screen, regardless of their position or translated labels.

Because the work was being done in a couple of places, and I suspect we'll do be doing more soon, I  added a protocol for individual tab items that'll ensure the required fields that are always available.

I considered stopping here, as the protocol for the updated `FilterTabBar` _can_ live side-by-side with the `[String]` methods, but it seemed messy to leave two implementations in place across the codebase, especially as there are only five instances of `FilterTabBar` being used.

I went through and conformed all of the data types used with the tab bar to the new protocol, but I'm happy to remove this if we'd rather keep the two implementations side-by-side – I don't want to make a bunch of extra work for anyone, so I'm happy to reduce the scope of this if needed.

It should be noted that this removes `@IBInspectable` from the `FilterTabBar` for the time being – I've tested the tab bar in each location and it works for me, so I don't think it was being used.