### PR TITLE
Properly Placed Pages: using dynamic font size

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -102,6 +102,11 @@ static CGFloat const FeaturedImageSize = 120.0;
 - (void)applyStyles
 {
     [WPStyleGuide configureTableViewCell:self];
+    [WPStyleGuide configureLabel:self.timestampLabel textStyle:UIFontTextStyleSubheadline];
+    [WPStyleGuide configureLabel:self.badgesLabel textStyle:UIFontTextStyleSubheadline];
+
+    self.titleLabel.font = [WPStyleGuide notoBoldFontForTextStyle:UIFontTextStyleHeadline];
+    self.titleLabel.adjustsFontForContentSizeCategory = YES;
     
     self.titleLabel.textColor = [WPStyleGuide darkGrey];
     self.timestampLabel.textColor = [WPStyleGuide grey];

--- a/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
@@ -4,8 +4,6 @@ import UIKit
 private struct Row: ImmuTableRow {
     static let cell = ImmuTableCell.class(CheckmarkTableViewCell.self)
 
-    let titleFont = UIFont.systemFont(ofSize: 17.0)
-
     enum RowType {
         case topLevel
         case child
@@ -28,8 +26,10 @@ private struct Row: ImmuTableRow {
     }
 
     func configureCell(_ cell: UITableViewCell) {
+        if let label = cell.textLabel {
+            WPStyleGuide.configureLabel(label, textStyle: .body)
+        }
         let cell = cell as! CheckmarkTableViewCell
-        cell.textLabel?.font = titleFont
         cell.title = title
     }
 }


### PR DESCRIPTION
Fixes #11186 

This PR introduces the dynamic font size to the PPP Page cell and the set parent cell.
It also fixes a bug where the _Noto bold_ font wasn't load correctly in the PPP Page cell.

_Before_
![ppp-font](https://user-images.githubusercontent.com/912252/53814943-8dc9df00-3f58-11e9-8f99-0888ca10d8a7.jpg)

_After_
![ppp-font-ok](https://user-images.githubusercontent.com/912252/53814954-94f0ed00-3f58-11e9-92ab-e71938ca7bfd.jpg)


**To test:**
- Open the page list, you should see the title label using the _Noto bold_ as font.