### PR TITLE
PPP: Fix gridicon icon

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -2,6 +2,8 @@
 #import "WPStyleGuide+Posts.h"
 #import "WordPress-Swift.h"
 
+@import Gridicons;
+
 
 static CGFloat const PageListTableViewCellTagLabelRadius = 2.0;
 static CGFloat const FeaturedImageSize = 120.0;
@@ -112,6 +114,7 @@ static CGFloat const FeaturedImageSize = 120.0;
     self.timestampLabel.textColor = [WPStyleGuide grey];
     self.badgesLabel.textColor = [WPStyleGuide darkYellow];
     self.menuButton.tintColor = [WPStyleGuide greyLighten10];
+    [self.menuButton setImage:[Gridicon iconOfType:GridiconTypeEllipsis] forState:UIControlStateNormal];
 
     self.backgroundColor = [WPStyleGuide greyLighten30];
     self.contentView.backgroundColor = [WPStyleGuide greyLighten30];


### PR DESCRIPTION
This is part of #11187 

Because I didn't push the change before, this Pr fix the menu icon used by the page list cell, replacing the local image with the image generated by _Gridicon_.

![simulator screen shot - iphone x - 2019-03-06 at 11 42 48](https://user-images.githubusercontent.com/912252/53883919-51f35000-4012-11e9-96f1-1f8bdff951cf.png)
