### PR TITLE
Gutenberg: Fix dictation issue

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -100,7 +100,7 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    gutenberg :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :tag => 'v1.0.1'
+    gutenberg :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => 'a109055ed95c4787f71d55e8c247016a157659e7'
 
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -228,7 +228,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v1.0.1`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `a109055ed95c4787f71d55e8c247016a157659e7`)
   - HockeySDK (= 5.1.4)
   - MGSwipeTableCell (= 1.6.8)
   - MRProgress (= 0.8.3)
@@ -243,7 +243,7 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git`, tag `gb-v0.8.6`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v1.0.1`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `a109055ed95c4787f71d55e8c247016a157659e7`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -304,8 +304,8 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
+    :commit: a109055ed95c4787f71d55e8c247016a157659e7
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-    :tag: v1.0.1
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   react-native-keyboard-aware-scroll-view:
@@ -317,8 +317,8 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
+    :commit: a109055ed95c4787f71d55e8c247016a157659e7
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-    :tag: v1.0.1
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -330,8 +330,8 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.3.2
   Gutenberg:
+    :commit: a109055ed95c4787f71d55e8c247016a157659e7
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-    :tag: v1.0.1
   react-native-keyboard-aware-scroll-view:
     :git: https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git
     :tag: gb-v0.8.6
@@ -339,8 +339,8 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
+    :commit: a109055ed95c4787f71d55e8c247016a157659e7
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-    :tag: v1.0.1
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -395,6 +395,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 0f6a92fb3263053f913023dc505e34d25fc12e6c
+PODFILE CHECKSUM: ad118fe2911030b0de57cb477c3d973b78de6435
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/673

This PR updates the gutenberg ref to add a fix on dictation.

The original issue was that, after dictation finishes, the inserted (dictated) string would disappear, leaving the block empty again.

More info:
https://github.com/wordpress-mobile/gutenberg-mobile/pull/700

To test:
- Run `rake dependencies`.
- Clean build folder.
- Run the app **without** metro running.
- Test the dictation feature on an empty paragraph block.
- Check that it behaves as expected.
