### PR TITLE
Disabled text field in assembled site view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 12.0
 -----
 * Redesigned Notices
+* Resolved a defect in the new Site Creation flow where the site preview address bar could be edited.
  
 11.9
 ------

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -85,6 +85,7 @@ final class AssembledSiteView: UIView {
 
             textField.backgroundColor = WPStyleGuide.greyLighten30()
             textField.font = WPStyleGuide.fontForTextStyle(.footnote)
+            textField.isEnabled = false
             textField.textAlignment = .center
             textField.textColor = WPStyleGuide.darkGrey()
             textField.text = domainName


### PR DESCRIPTION
Fixes #11150.

| Before | After |
|--------|-------|
| ![11150pr_before](https://user-images.githubusercontent.com/221062/53895927-e7c5b580-3fe7-11e9-9ef1-896a06ad467c.png) | ![11150pr_after](https://user-images.githubusercontent.com/221062/53895926-e7c5b580-3fe7-11e9-9410-44cbd0cd6602.png) |

To test:

- Checkout the branch, confirm that it builds, and that existing tests pass.
- Execute the site creation flow, and attempt to interact with the status bar post-creation. Observe that it does not become first responder.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.