### PR TITLE
Add as input file for credentials build phase

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -9310,6 +9310,7 @@
 			);
 			inputPaths = (
 				"$(SRCROOT)/Credentials/gencredentials.rb",
+				"$(WPCOM_CONFIG)",
 			);
 			name = "Generate API credentials";
 			outputPaths = (


### PR DESCRIPTION
I noticed that the "Generate API credentials" does not have the config file as an input. This means that when it is updated, Xcode won't know it needs to re-generate it.

This is what I added:

<img width="372" alt="inputs" src="https://user-images.githubusercontent.com/1773641/53896738-870c9c00-402c-11e9-9f10-5e0192b3e81e.png">

To test:

- Change a value in `~/.mobile-secrets/iOS/WPiOS/wpcom_app_credentials`
- Re-build and see that `Derived Sources/Api Credentials.m` has been updated.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
