### PR TITLE
Make handleDataModelChange more resilient

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1474,20 +1474,27 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
 
     NSUInteger generalSectionCountBefore = self.tableSections[0].rows.count;
+    BlogDetailsSection *firstSectionBefore = [self.tableSections objectAtIndex:0];
 
     NSSet *updatedObjects = note.userInfo[NSUpdatedObjectsKey];
     if ([updatedObjects containsObject:self.blog] || [updatedObjects containsObject:self.blog.settings]) {
         self.navigationItem.title = self.blog.settings.name;
         [self configureTableViewData];
         NSUInteger generalSectionCountAfter = self.tableSections[0].rows.count;
+        BlogDetailsSection *firstSectionAfter = [self.tableSections objectAtIndex:0];
+
         // quick start was just enabled
-        if (generalSectionCountBefore != generalSectionCountAfter && [self shouldShowQuickStartChecklist]) {
-            if ([Feature enabled:FeatureFlagQuickStartV2]) {
+
+        if ([Feature enabled:FeatureFlagQuickStartV2]) {
+            if (!firstSectionBefore.showQuickStartMenu && firstSectionAfter.showQuickStartMenu) {
                 [self showQuickStartCustomize];
-            } else {
+            }
+        } else {
+            if (generalSectionCountBefore != generalSectionCountAfter && [self shouldShowQuickStartChecklist]) {
                 [self showQuickStartV1];
             }
         }
+
         [self reloadTableViewPreservingSelection];
     }
 }


### PR DESCRIPTION
This is an attempt to resolve the issue of Quick Start's customization checklist appearing at app launch.

I have been unable to recreate this issue, so I've attempted to make the code that decides to show the customize checklist more specific, such that it hopefully won't trigger in error.

To test:
 - Ensure that creating a site can cause the quick start checklist to appear _as intended_.
 - If you can reliably get the customize checklist to appear in error before this change, please try after it! 🤞

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
