### PR TITLE
[Stats Refresh] Add Period > Overview card

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
@@ -25,9 +25,9 @@ extension Double {
         let sign = num < 0 ? "-" : ""
         num = fabs(num)
 
-        let shortenLimit = forHeroNumber ? 100000.0 : 10000.0
+        let abbreviationLimit = forHeroNumber ? 100000.0 : 10000.0
 
-        if num < shortenLimit {
+        if num < abbreviationLimit {
             // Add commas to non-abbreviated values
             let numberFormatter = NumberFormatter()
             numberFormatter.numberStyle = .decimal

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
@@ -20,13 +20,19 @@ extension Double {
     ///  - 1000000000 becomes "1b"
     ///  - 1000000000000 becomes "1t"
 
-    func abbreviatedString() -> String {
+    func abbreviatedString(forHeroNumber: Bool = false) -> String {
         var num = self
         let sign = num < 0 ? "-" : ""
         num = fabs(num)
 
-        if num < 10000.0 {
-            return "\(sign)\(Int(num))"
+        let shortenLimit = forHeroNumber ? 100000.0 : 10000.0
+
+        if num < shortenLimit {
+            // Add commas to non-abbreviated values
+            let numberFormatter = NumberFormatter()
+            numberFormatter.numberStyle = .decimal
+            let formattedNumber = numberFormatter.string(from: NSNumber(value: num)) ?? ""
+            return "\(sign)\(formattedNumber)"
         }
 
         let exp: Int = Int(log10(num) / 3.0)
@@ -43,19 +49,19 @@ extension Double {
 }
 
 extension NSNumber {
-    func abbreviatedString() -> String {
-        return self.doubleValue.abbreviatedString()
+    func abbreviatedString(forHeroNumber: Bool = false) -> String {
+        return self.doubleValue.abbreviatedString(forHeroNumber: forHeroNumber)
     }
 }
 
 extension Float {
-    func abbreviatedString() -> String {
-        return Double(self).abbreviatedString()
+    func abbreviatedString(forHeroNumber: Bool = false) -> String {
+        return Double(self).abbreviatedString(forHeroNumber: forHeroNumber)
     }
 }
 
 extension Int {
-    func abbreviatedString() -> String {
-        return Double(self).abbreviatedString()
+    func abbreviatedString(forHeroNumber: Bool = false) -> String {
+        return Double(self).abbreviatedString(forHeroNumber: forHeroNumber)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -172,6 +172,9 @@ extension WPStyleGuide {
         static let overviewCardFilterTitleFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         static let overviewCardFilterDataFont = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
 
+        static let positiveColor = WPStyleGuide.validGreen()
+        static let negativeColor = WPStyleGuide.errorRed()
+
         static let gridiconSize = CGSize(width: 24, height: 24)
 
         struct PostingActivityColors {

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -123,8 +123,10 @@ extension WPStyleGuide {
             return UIImage(named: "gravatar")
         }
 
-        static func configureFilterTabBar(_ filterTabBar: FilterTabBar, forTabbedCard: Bool = false) {
-            filterTabBar.dividerColor =  filterDividerColor
+        static func configureFilterTabBar(_ filterTabBar: FilterTabBar,
+                                          forTabbedCard: Bool = false,
+                                          forOverviewCard: Bool = false) {
+            filterTabBar.dividerColor = filterDividerColor
             filterTabBar.deselectedTabColor = filterDeselectedColor
             filterTabBar.tintColor = defaultFilterTintColor
 
@@ -132,6 +134,13 @@ extension WPStyleGuide {
             if forTabbedCard {
                 filterTabBar.tabSizingStyle = .equalWidths
                 filterTabBar.tintColor = tabbedCardFilterTintColor
+                filterTabBar.selectedTitleColor = tabbedCardFilterSelectedTitleColor
+            }
+
+            // For FilterTabBar on OverviewCell
+            if forOverviewCard {
+                filterTabBar.tabSizingStyle = .equalWidths
+                filterTabBar.tintColor = defaultFilterTintColor
                 filterTabBar.selectedTitleColor = tabbedCardFilterSelectedTitleColor
             }
         }
@@ -159,6 +168,9 @@ extension WPStyleGuide {
         static let tabbedCardFilterSelectedTitleColor = WPStyleGuide.darkGrey()
         static let filterDeselectedColor = WPStyleGuide.greyDarken10()
         static let filterDividerColor = WPStyleGuide.greyLighten20()
+
+        static let overviewCardFilterTitleFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
+        static let overviewCardFilterDataFont = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .semibold)
 
         static let gridiconSize = CGSize(width: 24, height: 24)
 

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -1,5 +1,8 @@
 @objc enum StatSection: Int {
-    case periodOverview
+    case periodOverviewViews
+    case periodOverviewVisitors
+    case periodOverviewLikes
+    case periodOverviewComments
     case periodPostsAndPages
     case periodReferrers
     case periodClicks
@@ -41,7 +44,10 @@
                               .insightsPublicize
     ]
 
-    static let allPeriods = [StatSection.periodOverview,
+    static let allPeriods = [StatSection.periodOverviewViews,
+                             .periodOverviewVisitors,
+                             .periodOverviewLikes,
+                             .periodOverviewComments,
                              .periodPostsAndPages,
                              .periodReferrers,
                              .periodClicks,
@@ -162,6 +168,14 @@
             return TabTitles.followersWordPress
         case .insightsFollowersEmail:
             return TabTitles.followersEmail
+        case .periodOverviewViews:
+            return TabTitles.overviewViews
+        case .periodOverviewVisitors:
+            return TabTitles.overviewVisitors
+        case .periodOverviewLikes:
+            return TabTitles.overviewLikes
+        case .periodOverviewComments:
+            return TabTitles.overviewComments
         default:
             return ""
         }
@@ -229,6 +243,10 @@
         static let commentsPosts = NSLocalizedString("Posts and Pages", comment: "Label for comments by posts and pages")
         static let followersWordPress = NSLocalizedString("WordPress.com", comment: "Label for WordPress.com followers")
         static let followersEmail = NSLocalizedString("Email", comment: "Label for email followers")
+        static let overviewViews = NSLocalizedString("Views", comment: "Label for Period Overview views")
+        static let overviewVisitors = NSLocalizedString("Visitors", comment: "Label for Period Overview visitors")
+        static let overviewLikes = NSLocalizedString("Likes", comment: "Label for Period Overview likes")
+        static let overviewComments = NSLocalizedString("Comments", comment: "Label for Period Overview comments")
     }
 
     struct TotalFollowers {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -80,7 +80,6 @@ private extension OverviewCell {
         WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forOverviewCard: true)
         filterTabBar.items = tabsData
         filterTabBar.tabBarHeight = 60.0
-        filterTabBar.equalWidthFill = .fillProportionally
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -3,10 +3,14 @@ import UIKit
 struct OverviewTabData: FilterTabBarItem {
     var tabTitle: String
     var tabData: Int
+    var difference: Int
+    var differencePercent: Int
 
-    init(tabTitle: String, tabData: Int) {
+    init(tabTitle: String, tabData: Int, difference: Int, differencePercent: Int) {
         self.tabTitle = tabTitle
         self.tabData = tabData
+        self.difference = difference
+        self.differencePercent = differencePercent
     }
 
     var attributedTitle: NSAttributedString? {
@@ -23,6 +27,18 @@ struct OverviewTabData: FilterTabBarItem {
         attributedTitle.append(attributedData)
 
         return attributedTitle
+    }
+
+    var differenceLabel: String {
+        let stringFormat = NSLocalizedString("%@%@ (%@%%)", comment: "Difference label for Period Overview stat, indicating change from previous period. Ex: +99.9K (5%)")
+        return String.localizedStringWithFormat(stringFormat,
+                                                difference < 0 ? "" : "+",
+                                                difference.abbreviatedString(),
+                                                differencePercent.abbreviatedString())
+    }
+
+    var differenceTextColor: UIColor {
+        return difference < 0 ? WPStyleGuide.Stats.negativeColor : WPStyleGuide.Stats.positiveColor
     }
 
     var title: String {
@@ -42,6 +58,7 @@ class OverviewCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var filterTabBar: FilterTabBar!
     @IBOutlet weak var selectedLabel: UILabel!
     @IBOutlet weak var selectedData: UILabel!
+    @IBOutlet weak var differenceLabel: UILabel!
 
     private var tabsData = [OverviewTabData]()
 
@@ -50,7 +67,7 @@ class OverviewCell: UITableViewCell, NibLoadable {
     func configure(tabsData: [OverviewTabData]) {
         self.tabsData = tabsData
         setupFilterBar()
-        setSelectedLabels()
+        updateLabels()
     }
 
 }
@@ -69,12 +86,14 @@ private extension OverviewCell {
 
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
         // TODO: update chart
-        setSelectedLabels()
+        updateLabels()
     }
 
-    func setSelectedLabels() {
+    func updateLabels() {
         let tabData = tabsData[filterTabBar.selectedIndex]
         selectedLabel.text = tabData.tabTitle
         selectedData.text = tabData.tabData.abbreviatedString(forHeroNumber: true)
+        differenceLabel.text = tabData.differenceLabel
+        differenceLabel.textColor = tabData.differenceTextColor
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -80,6 +80,8 @@ private extension OverviewCell {
         WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forOverviewCard: true)
         filterTabBar.items = tabsData
         filterTabBar.tabBarHeight = 60.0
+        filterTabBar.equalWidthFill = .fillProportionally
+        filterTabBar.equalWidthSpacing = 12
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -2,9 +2,9 @@ import UIKit
 
 struct OverviewTabData: FilterTabBarItem {
     var tabTitle: String
-    var tabData: String
+    var tabData: Int
 
-    init(tabTitle: String, tabData: String) {
+    init(tabTitle: String, tabData: Int) {
         self.tabTitle = tabTitle
         self.tabData = tabData
     }
@@ -15,7 +15,7 @@ struct OverviewTabData: FilterTabBarItem {
         attributedTitle.addAttributes([.font: WPStyleGuide.Stats.overviewCardFilterTitleFont],
                                        range: NSMakeRange(0, attributedTitle.string.count))
 
-        let attributedData = NSMutableAttributedString(string: tabData)
+        let attributedData = NSMutableAttributedString(string: tabData.abbreviatedString())
         attributedData.addAttributes([.font: WPStyleGuide.Stats.overviewCardFilterDataFont],
                                        range: NSMakeRange(0, attributedData.string.count))
 
@@ -40,6 +40,8 @@ class OverviewCell: UITableViewCell, NibLoadable {
     // MARK: - Properties
 
     @IBOutlet weak var filterTabBar: FilterTabBar!
+    @IBOutlet weak var selectedLabel: UILabel!
+    @IBOutlet weak var selectedData: UILabel!
 
     private var tabsData = [OverviewTabData]()
 
@@ -48,11 +50,12 @@ class OverviewCell: UITableViewCell, NibLoadable {
     func configure(tabsData: [OverviewTabData]) {
         self.tabsData = tabsData
         setupFilterBar()
+        setSelectedLabels()
     }
 
 }
 
-// MARK: - FilterTabBar Support
+// MARK: - Private Extension
 
 private extension OverviewCell {
 
@@ -65,7 +68,13 @@ private extension OverviewCell {
     }
 
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
-        // TODO: update chart and labels
+        // TODO: update chart
+        setSelectedLabels()
     }
 
+    func setSelectedLabels() {
+        let tabData = tabsData[filterTabBar.selectedIndex]
+        selectedLabel.text = tabData.tabTitle
+        selectedData.text = tabData.tabData.abbreviatedString(forHeroNumber: true)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+class OverviewCell: UITableViewCell, NibLoadable {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+    }
+
+    func configure() {
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -1,12 +1,71 @@
 import UIKit
 
-class OverviewCell: UITableViewCell, NibLoadable {
+struct OverviewTabData: FilterTabBarItem {
+    var tabTitle: String
+    var tabData: String
 
-    override func awakeFromNib() {
-        super.awakeFromNib()
+    init(tabTitle: String, tabData: String) {
+        self.tabTitle = tabTitle
+        self.tabData = tabData
     }
 
-    func configure() {
+    var attributedTitle: NSAttributedString? {
+
+        let attributedTitle = NSMutableAttributedString(string: tabTitle)
+        attributedTitle.addAttributes([.font: WPStyleGuide.Stats.overviewCardFilterTitleFont],
+                                       range: NSMakeRange(0, attributedTitle.string.count))
+
+        let attributedData = NSMutableAttributedString(string: tabData)
+        attributedData.addAttributes([.font: WPStyleGuide.Stats.overviewCardFilterDataFont],
+                                       range: NSMakeRange(0, attributedData.string.count))
+
+        attributedTitle.append(NSAttributedString(string: "\n"))
+        attributedTitle.append(attributedData)
+
+        return attributedTitle
+    }
+
+    var title: String {
+        return self.tabTitle
+    }
+
+    var accessibilityIdentifier: String {
+        return self.tabTitle.localizedLowercase
+    }
+
+}
+
+class OverviewCell: UITableViewCell, NibLoadable {
+
+    // MARK: - Properties
+
+    @IBOutlet weak var filterTabBar: FilterTabBar!
+
+    private var tabsData = [OverviewTabData]()
+
+    // MARK: - Configure
+
+    func configure(tabsData: [OverviewTabData]) {
+        self.tabsData = tabsData
+        setupFilterBar()
+    }
+
+}
+
+// MARK: - FilterTabBar Support
+
+private extension OverviewCell {
+
+    func setupFilterBar() {
+        WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forOverviewCard: true)
+        filterTabBar.items = tabsData
+        filterTabBar.tabBarHeight = 60.0
+        filterTabBar.equalWidthFill = .fillProportionally
+        filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)
+    }
+
+    @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
+        // TODO: update chart and labels
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
@@ -31,7 +31,7 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+2,500 (5%)" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mh8-GY-DEC" userLabel="Change Data">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+2,500 (5%)" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mh8-GY-DEC" userLabel="Difference Label">
                         <rect key="frame" x="342" y="34.5" width="96" height="20.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <nil key="textColor"/>
@@ -77,6 +77,7 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="differenceLabel" destination="mh8-GY-DEC" id="G27-Xv-ACi"/>
                 <outlet property="filterTabBar" destination="0aY-pl-E5I" id="Mwy-fv-SNw"/>
                 <outlet property="selectedData" destination="gKw-lF-4O8" id="aKK-1U-o6H"/>
                 <outlet property="selectedLabel" destination="jZK-cD-I2s" id="rTe-0x-iDM"/>

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="356" id="KGk-i7-Jjw" customClass="OverviewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="454" height="300"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="454" height="299.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="40,000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKw-lF-4O8" userLabel="Selection Data">
+                        <rect key="frame" x="16" y="24" width="100.5" height="33.5"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jZK-cD-I2s" userLabel="Selection Label">
+                        <rect key="frame" x="124.5" y="37" width="45.5" height="20.5"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+2,500 (5%)" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mh8-GY-DEC" userLabel="Change Data">
+                        <rect key="frame" x="342" y="37" width="96" height="20.5"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="abh-mo-DgK" userLabel="Chart Stack View">
+                        <rect key="frame" x="16" y="73.5" width="422" height="150"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Imagine a pretty chart here" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bY0-nr-zux">
+                                <rect key="frame" x="0.0" y="0.0" width="422" height="150"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="150" id="IGu-qU-L3i"/>
+                        </constraints>
+                    </stackView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0aY-pl-E5I" customClass="FilterTabBar" customModule="WordPress">
+                        <rect key="frame" x="16" y="239.5" width="422" height="60"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="60" id="Vll-TB-dMd"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="0aY-pl-E5I" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="5cX-TG-kxs"/>
+                    <constraint firstItem="gKw-lF-4O8" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="24" id="9FM-On-UC6"/>
+                    <constraint firstAttribute="trailing" secondItem="mh8-GY-DEC" secondAttribute="trailing" constant="16" id="DHi-ub-ILb"/>
+                    <constraint firstItem="abh-mo-DgK" firstAttribute="top" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="16" id="MQP-Nc-8DO"/>
+                    <constraint firstAttribute="trailing" secondItem="0aY-pl-E5I" secondAttribute="trailing" constant="16" id="SLP-II-oop"/>
+                    <constraint firstItem="0aY-pl-E5I" firstAttribute="top" secondItem="abh-mo-DgK" secondAttribute="bottom" constant="16" id="bPI-Ta-QZk"/>
+                    <constraint firstAttribute="trailing" secondItem="abh-mo-DgK" secondAttribute="trailing" constant="16" id="bYw-n8-k6z"/>
+                    <constraint firstItem="jZK-cD-I2s" firstAttribute="leading" secondItem="gKw-lF-4O8" secondAttribute="trailing" constant="8" id="dru-cE-A0o"/>
+                    <constraint firstItem="jZK-cD-I2s" firstAttribute="bottom" secondItem="gKw-lF-4O8" secondAttribute="bottom" id="dwL-lH-n2U"/>
+                    <constraint firstItem="mh8-GY-DEC" firstAttribute="bottom" secondItem="gKw-lF-4O8" secondAttribute="bottom" id="lH9-88-SO8"/>
+                    <constraint firstItem="gKw-lF-4O8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="pOA-dn-Yoy"/>
+                    <constraint firstAttribute="bottom" secondItem="0aY-pl-E5I" secondAttribute="bottom" id="udu-TY-7zo"/>
+                    <constraint firstItem="abh-mo-DgK" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="xQG-il-XIY"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="-433.60000000000002" y="142.1289355322339"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
@@ -69,6 +69,7 @@
                     <constraint firstAttribute="trailing" secondItem="0aY-pl-E5I" secondAttribute="trailing" id="SLP-II-oop"/>
                     <constraint firstItem="jZK-cD-I2s" firstAttribute="leading" secondItem="gKw-lF-4O8" secondAttribute="trailing" constant="8" id="dru-cE-A0o"/>
                     <constraint firstItem="jZK-cD-I2s" firstAttribute="bottom" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="-5" id="dwL-lH-n2U"/>
+                    <constraint firstItem="mh8-GY-DEC" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="jZK-cD-I2s" secondAttribute="trailing" constant="5" id="lU5-Jo-nfk"/>
                     <constraint firstItem="gKw-lF-4O8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="pOA-dn-Yoy"/>
                     <constraint firstItem="LXK-k6-Sxa" firstAttribute="top" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="16" id="pZe-NH-yiM"/>
                     <constraint firstAttribute="bottom" secondItem="0aY-pl-E5I" secondAttribute="bottom" id="udu-TY-7zo"/>

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
@@ -19,20 +19,20 @@
                 <rect key="frame" x="0.0" y="0.0" width="454" height="303.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="40,000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKw-lF-4O8" userLabel="Selection Data">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="40,000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKw-lF-4O8" userLabel="Selected Data">
                         <rect key="frame" x="16" y="24" width="100.5" height="36"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jZK-cD-I2s" userLabel="Selection Label">
-                        <rect key="frame" x="124.5" y="39.5" width="45.5" height="20.5"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jZK-cD-I2s" userLabel="Selected Label">
+                        <rect key="frame" x="124.5" y="34.5" width="45.5" height="20.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+2,500 (5%)" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mh8-GY-DEC" userLabel="Change Data">
-                        <rect key="frame" x="342" y="39.5" width="96" height="20.5"/>
+                        <rect key="frame" x="342" y="34.5" width="96" height="20.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -63,12 +63,12 @@
                     <constraint firstAttribute="trailing" secondItem="LXK-k6-Sxa" secondAttribute="trailing" constant="16" id="454-qg-2dp"/>
                     <constraint firstItem="0aY-pl-E5I" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="5cX-TG-kxs"/>
                     <constraint firstItem="gKw-lF-4O8" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="24" id="9FM-On-UC6"/>
+                    <constraint firstItem="mh8-GY-DEC" firstAttribute="bottom" secondItem="jZK-cD-I2s" secondAttribute="bottom" id="B5Q-FJ-CHg"/>
                     <constraint firstAttribute="trailing" secondItem="mh8-GY-DEC" secondAttribute="trailing" constant="16" id="DHi-ub-ILb"/>
                     <constraint firstItem="LXK-k6-Sxa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="HS3-PH-hEI"/>
                     <constraint firstAttribute="trailing" secondItem="0aY-pl-E5I" secondAttribute="trailing" id="SLP-II-oop"/>
                     <constraint firstItem="jZK-cD-I2s" firstAttribute="leading" secondItem="gKw-lF-4O8" secondAttribute="trailing" constant="8" id="dru-cE-A0o"/>
-                    <constraint firstItem="jZK-cD-I2s" firstAttribute="bottom" secondItem="gKw-lF-4O8" secondAttribute="bottom" id="dwL-lH-n2U"/>
-                    <constraint firstItem="mh8-GY-DEC" firstAttribute="bottom" secondItem="gKw-lF-4O8" secondAttribute="bottom" id="lH9-88-SO8"/>
+                    <constraint firstItem="jZK-cD-I2s" firstAttribute="bottom" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="-5" id="dwL-lH-n2U"/>
                     <constraint firstItem="gKw-lF-4O8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="pOA-dn-Yoy"/>
                     <constraint firstItem="LXK-k6-Sxa" firstAttribute="top" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="16" id="pZe-NH-yiM"/>
                     <constraint firstAttribute="bottom" secondItem="0aY-pl-E5I" secondAttribute="bottom" id="udu-TY-7zo"/>
@@ -78,6 +78,8 @@
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="filterTabBar" destination="0aY-pl-E5I" id="Mwy-fv-SNw"/>
+                <outlet property="selectedData" destination="gKw-lF-4O8" id="aKK-1U-o6H"/>
+                <outlet property="selectedLabel" destination="jZK-cD-I2s" id="rTe-0x-iDM"/>
             </connections>
             <point key="canvasLocation" x="-433.60000000000002" y="143.02848575712144"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
@@ -12,71 +12,74 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="356" id="KGk-i7-Jjw" customClass="OverviewCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="454" height="300"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="360" id="KGk-i7-Jjw" customClass="OverviewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="454" height="304"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="454" height="299.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="454" height="303.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="40,000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKw-lF-4O8" userLabel="Selection Data">
-                        <rect key="frame" x="16" y="24" width="100.5" height="33.5"/>
+                        <rect key="frame" x="16" y="24" width="100.5" height="36"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jZK-cD-I2s" userLabel="Selection Label">
-                        <rect key="frame" x="124.5" y="37" width="45.5" height="20.5"/>
+                        <rect key="frame" x="124.5" y="39.5" width="45.5" height="20.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="+2,500 (5%)" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mh8-GY-DEC" userLabel="Change Data">
-                        <rect key="frame" x="342" y="37" width="96" height="20.5"/>
+                        <rect key="frame" x="342" y="39.5" width="96" height="20.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="abh-mo-DgK" userLabel="Chart Stack View">
-                        <rect key="frame" x="16" y="73.5" width="422" height="150"/>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LXK-k6-Sxa" userLabel="Chart View">
+                        <rect key="frame" x="16" y="76" width="422" height="150"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Imagine a pretty chart here" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bY0-nr-zux">
-                                <rect key="frame" x="0.0" y="0.0" width="422" height="150"/>
+                                <rect key="frame" x="107.5" y="65" width="207" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="150" id="IGu-qU-L3i"/>
-                        </constraints>
-                    </stackView>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0aY-pl-E5I" customClass="FilterTabBar" customModule="WordPress">
-                        <rect key="frame" x="16" y="239.5" width="422" height="60"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="60" id="Vll-TB-dMd"/>
+                            <constraint firstItem="bY0-nr-zux" firstAttribute="centerY" secondItem="LXK-k6-Sxa" secondAttribute="centerY" id="Iqw-5R-DLi"/>
+                            <constraint firstAttribute="height" constant="150" id="SdW-hH-eUG"/>
+                            <constraint firstItem="bY0-nr-zux" firstAttribute="centerX" secondItem="LXK-k6-Sxa" secondAttribute="centerX" id="c6X-i6-Q4z"/>
                         </constraints>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0aY-pl-E5I" customClass="FilterTabBar" customModule="WordPress">
+                        <rect key="frame" x="0.0" y="242" width="454" height="61.5"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </view>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="0aY-pl-E5I" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="5cX-TG-kxs"/>
+                    <constraint firstAttribute="trailing" secondItem="LXK-k6-Sxa" secondAttribute="trailing" constant="16" id="454-qg-2dp"/>
+                    <constraint firstItem="0aY-pl-E5I" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="5cX-TG-kxs"/>
                     <constraint firstItem="gKw-lF-4O8" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="24" id="9FM-On-UC6"/>
                     <constraint firstAttribute="trailing" secondItem="mh8-GY-DEC" secondAttribute="trailing" constant="16" id="DHi-ub-ILb"/>
-                    <constraint firstItem="abh-mo-DgK" firstAttribute="top" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="16" id="MQP-Nc-8DO"/>
-                    <constraint firstAttribute="trailing" secondItem="0aY-pl-E5I" secondAttribute="trailing" constant="16" id="SLP-II-oop"/>
-                    <constraint firstItem="0aY-pl-E5I" firstAttribute="top" secondItem="abh-mo-DgK" secondAttribute="bottom" constant="16" id="bPI-Ta-QZk"/>
-                    <constraint firstAttribute="trailing" secondItem="abh-mo-DgK" secondAttribute="trailing" constant="16" id="bYw-n8-k6z"/>
+                    <constraint firstItem="LXK-k6-Sxa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="HS3-PH-hEI"/>
+                    <constraint firstAttribute="trailing" secondItem="0aY-pl-E5I" secondAttribute="trailing" id="SLP-II-oop"/>
                     <constraint firstItem="jZK-cD-I2s" firstAttribute="leading" secondItem="gKw-lF-4O8" secondAttribute="trailing" constant="8" id="dru-cE-A0o"/>
                     <constraint firstItem="jZK-cD-I2s" firstAttribute="bottom" secondItem="gKw-lF-4O8" secondAttribute="bottom" id="dwL-lH-n2U"/>
                     <constraint firstItem="mh8-GY-DEC" firstAttribute="bottom" secondItem="gKw-lF-4O8" secondAttribute="bottom" id="lH9-88-SO8"/>
                     <constraint firstItem="gKw-lF-4O8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="pOA-dn-Yoy"/>
+                    <constraint firstItem="LXK-k6-Sxa" firstAttribute="top" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="16" id="pZe-NH-yiM"/>
                     <constraint firstAttribute="bottom" secondItem="0aY-pl-E5I" secondAttribute="bottom" id="udu-TY-7zo"/>
-                    <constraint firstItem="abh-mo-DgK" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="xQG-il-XIY"/>
+                    <constraint firstItem="0aY-pl-E5I" firstAttribute="top" secondItem="LXK-k6-Sxa" secondAttribute="bottom" constant="16" id="zFm-ns-JaB"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
-            <point key="canvasLocation" x="-433.60000000000002" y="142.1289355322339"/>
+            <connections>
+                <outlet property="filterTabBar" destination="0aY-pl-E5I" id="Mwy-fv-SNw"/>
+            </connections>
+            <point key="canvasLocation" x="-433.60000000000002" y="143.02848575712144"/>
         </tableViewCell>
     </objects>
 </document>

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -66,6 +66,7 @@ class SiteStatsPeriodTableViewController: UITableViewController {
         WPStyleGuide.Stats.configureTable(tableView)
         refreshControl?.addTarget(self, action: #selector(userInitiatedRefresh), for: .valueChanged)
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
+        tableView.estimatedRowHeight = 500
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -103,6 +103,7 @@ private extension SiteStatsPeriodTableViewController {
                 TopTotalsPeriodStatsRow.self,
                 TopTotalsNoSubtitlesPeriodStatsRow.self,
                 CountriesStatsRow.self,
+                OverviewRow.self,
                 TableFooterRow.self]
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -75,7 +75,7 @@ private extension SiteStatsPeriodViewModel {
         let one = OverviewTabData(tabTitle: StatSection.periodOverviewViews.tabTitle, tabData: 85296, difference: -987, differencePercent: 5)
         let two = OverviewTabData(tabTitle: StatSection.periodOverviewVisitors.tabTitle, tabData: 741, difference: 22222, differencePercent: 50)
         let three = OverviewTabData(tabTitle: StatSection.periodOverviewLikes.tabTitle, tabData: 12345, difference: 75324, differencePercent: 27)
-        let four = OverviewTabData(tabTitle: StatSection.periodOverviewComments.tabTitle, tabData: 987654321, difference: -258547987, differencePercent: 10)
+        let four = OverviewTabData(tabTitle: StatSection.periodOverviewComments.tabTitle, tabData: 987654321, difference: -258547987, differencePercent: -125999)
         tableRows.append(OverviewRow(tabsData: [one, two, three, four]))
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -72,10 +72,10 @@ private extension SiteStatsPeriodViewModel {
         tableRows.append(CellHeaderRow(title: ""))
 
         // TODO: replace with real data
-        let one = OverviewTabData(tabTitle: "Views", tabData: 85296.abbreviatedString())
-        let two = OverviewTabData(tabTitle: "Visitors", tabData: 741.abbreviatedString())
-        let three = OverviewTabData(tabTitle: "Likes", tabData: 123456.abbreviatedString())
-        let four = OverviewTabData(tabTitle: "Comments", tabData: 987654321.abbreviatedString())
+        let one = OverviewTabData(tabTitle: "Views", tabData: 85296)
+        let two = OverviewTabData(tabTitle: "Visitors", tabData: 741)
+        let three = OverviewTabData(tabTitle: "Likes", tabData: 12345)
+        let four = OverviewTabData(tabTitle: "Comments", tabData: 987654321)
         tableRows.append(OverviewRow(tabsData: [one, two, three, four]))
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -72,10 +72,10 @@ private extension SiteStatsPeriodViewModel {
         tableRows.append(CellHeaderRow(title: ""))
 
         // TODO: replace with real data
-        let one = OverviewTabData(tabTitle: "Views", tabData: 85296)
-        let two = OverviewTabData(tabTitle: "Visitors", tabData: 741)
-        let three = OverviewTabData(tabTitle: "Likes", tabData: 12345)
-        let four = OverviewTabData(tabTitle: "Comments", tabData: 987654321)
+        let one = OverviewTabData(tabTitle: "Views", tabData: 85296, difference: -987, differencePercent: 5)
+        let two = OverviewTabData(tabTitle: "Visitors", tabData: 741, difference: 22222, differencePercent: 50)
+        let three = OverviewTabData(tabTitle: "Likes", tabData: 12345, difference: 75324, differencePercent: 27)
+        let four = OverviewTabData(tabTitle: "Comments", tabData: 987654321, difference: -258547987, differencePercent: 10)
         tableRows.append(OverviewRow(tabsData: [one, two, three, four]))
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -70,7 +70,13 @@ private extension SiteStatsPeriodViewModel {
     func overviewTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
         tableRows.append(CellHeaderRow(title: ""))
-        tableRows.append(OverviewRow())
+
+        // TODO: replace with real data
+        let one = OverviewTabData(tabTitle: "Views", tabData: 85296.abbreviatedString())
+        let two = OverviewTabData(tabTitle: "Visitors", tabData: 741.abbreviatedString())
+        let three = OverviewTabData(tabTitle: "Likes", tabData: 123456.abbreviatedString())
+        let four = OverviewTabData(tabTitle: "Comments", tabData: 987654321.abbreviatedString())
+        tableRows.append(OverviewRow(tabsData: [one, two, three, four]))
 
         return tableRows
     }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -72,10 +72,10 @@ private extension SiteStatsPeriodViewModel {
         tableRows.append(CellHeaderRow(title: ""))
 
         // TODO: replace with real data
-        let one = OverviewTabData(tabTitle: "Views", tabData: 85296, difference: -987, differencePercent: 5)
-        let two = OverviewTabData(tabTitle: "Visitors", tabData: 741, difference: 22222, differencePercent: 50)
-        let three = OverviewTabData(tabTitle: "Likes", tabData: 12345, difference: 75324, differencePercent: 27)
-        let four = OverviewTabData(tabTitle: "Comments", tabData: 987654321, difference: -258547987, differencePercent: 10)
+        let one = OverviewTabData(tabTitle: StatSection.periodOverviewViews.tabTitle, tabData: 85296, difference: -987, differencePercent: 5)
+        let two = OverviewTabData(tabTitle: StatSection.periodOverviewVisitors.tabTitle, tabData: 741, difference: 22222, differencePercent: 50)
+        let three = OverviewTabData(tabTitle: StatSection.periodOverviewLikes.tabTitle, tabData: 12345, difference: 75324, differencePercent: 27)
+        let four = OverviewTabData(tabTitle: StatSection.periodOverviewComments.tabTitle, tabData: 987654321, difference: -258547987, differencePercent: 10)
         tableRows.append(OverviewRow(tabsData: [one, two, three, four]))
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -37,7 +37,7 @@ class SiteStatsPeriodViewModel: Observable {
 
         var tableRows = [ImmuTableRow]()
 
-        // TODO: add overview chart here
+        tableRows.append(contentsOf: overviewTableRows())
         tableRows.append(contentsOf: postsAndPagesTableRows())
         tableRows.append(contentsOf: referrersTableRows())
         tableRows.append(contentsOf: clicksTableRows())
@@ -66,6 +66,14 @@ class SiteStatsPeriodViewModel: Observable {
 private extension SiteStatsPeriodViewModel {
 
     // MARK: - Create Table Rows
+
+    func overviewTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(title: ""))
+        tableRows.append(OverviewRow())
+
+        return tableRows
+    }
 
     func postsAndPagesTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -3,10 +3,20 @@ import Gridicons
 
 class StatsCellHeader: UITableViewCell, NibLoadable {
 
+    // MARK: - Properties
+
     @IBOutlet weak var headerLabel: UILabel!
     @IBOutlet weak var manageInsightButton: UIButton!
+    @IBOutlet weak var stackViewTopConstraint: NSLayoutConstraint!
 
     private typealias Style = WPStyleGuide.Stats
+    private var defaultStackViewTopConstraint: CGFloat = 0
+
+    // MARK: - Configure
+
+    override func awakeFromNib() {
+        defaultStackViewTopConstraint = stackViewTopConstraint.constant
+    }
 
     func configure(withTitle title: String) {
         headerLabel.text = title
@@ -22,6 +32,12 @@ private extension StatsCellHeader {
     func applyStyles() {
         Style.configureLabelAsHeader(headerLabel)
         configureManageInsightButton()
+        updateStackView()
+    }
+
+    func updateStackView() {
+        // Only show the top padding if there is actually a label.
+        stackViewTopConstraint.constant = headerLabel.text == "" ? 0 : defaultStackViewTopConstraint
     }
 
     func configureManageInsightButton() {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.xib
@@ -54,6 +54,7 @@
             <connections>
                 <outlet property="headerLabel" destination="fZv-YC-hoV" id="iNM-se-RIs"/>
                 <outlet property="manageInsightButton" destination="Pmt-5q-3Mg" id="y2o-B3-h7B"/>
+                <outlet property="stackViewTopConstraint" destination="RWL-Fv-z9B" id="ywF-XN-ZM2"/>
             </connections>
             <point key="canvasLocation" x="336.80000000000001" y="-442.12893553223392"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -276,6 +276,26 @@ struct CountriesStatsRow: ImmuTableRow {
     }
 }
 
+struct OverviewRow: ImmuTableRow {
+
+    typealias CellType = OverviewCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure()
+    }
+}
+
 struct CellHeaderRow: ImmuTableRow {
 
     typealias CellType = StatsCellHeader

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -284,6 +284,7 @@ struct OverviewRow: ImmuTableRow {
         return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
     }()
 
+    let tabsData: [OverviewTabData]
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -292,7 +293,7 @@ struct OverviewRow: ImmuTableRow {
             return
         }
 
-        cell.configure()
+        cell.configure(tabsData: tabsData)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -74,6 +74,18 @@ class FilterTabBar: UIControl {
         }
     }
 
+    var equalWidthFill: UIStackView.Distribution = .fillEqually {
+        didSet {
+            stackView.distribution = equalWidthFill
+        }
+    }
+
+    var equalWidthSpacing: CGFloat = 0 {
+        didSet {
+            stackView.spacing = equalWidthSpacing
+        }
+    }
+
     // MARK: - Appearance
 
     /// Tint color will be applied to the floating selection indicator.
@@ -292,7 +304,8 @@ class FilterTabBar: UIControl {
 
         switch tabSizingStyle {
         case .equalWidths:
-            stackView.distribution = .fillEqually
+            stackView.distribution = equalWidthFill
+            stackView.spacing = equalWidthSpacing
             NSLayoutConstraint.activate([stackViewWidthConstraint])
         case .fitting:
             stackView.distribution = .fill
@@ -427,7 +440,7 @@ class FilterTabBar: UIControl {
         static let selectionIndicatorHeight: CGFloat = 2.0
         static let horizontalPadding: CGFloat = 0.0
         static let buttonInsets = UIEdgeInsets(top: 14.0, left: 12.0, bottom: 14.0, right: 12.0)
-        static let buttonInsetsAttributedTitle = UIEdgeInsets(top: 10.0, left: 5.0, bottom: 10.0, right: 5.0)
+        static let buttonInsetsAttributedTitle = UIEdgeInsets(top: 10.0, left: 16.0, bottom: 10.0, right: 16.0)
     }
 
     private enum SelectionAnimation {

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -240,7 +240,10 @@ class FilterTabBar: UIControl {
 
         tab.accessibilityIdentifier = item.accessibilityIdentifier
 
-        tab.contentEdgeInsets = AppearanceMetrics.buttonInsets
+        tab.contentEdgeInsets = item.attributedTitle != nil ?
+            AppearanceMetrics.buttonInsetsAttributedTitle :
+            AppearanceMetrics.buttonInsets
+
         tab.sizeToFit()
 
         tab.addTarget(self, action: #selector(tabTapped(_:)), for: .touchUpInside)
@@ -389,8 +392,12 @@ class FilterTabBar: UIControl {
         selectionIndicatorLeadingConstraint?.isActive = false
         selectionIndicatorTrailingConstraint?.isActive = false
 
-        let leadingConstant = (tabSizingStyle == .equalWidths) ? 0.0 : (tab.contentEdgeInsets.left - AppearanceMetrics.buttonInsets.left)
-        let trailingConstant = (tabSizingStyle == .equalWidths) ? 0.0 : (-tab.contentEdgeInsets.right + AppearanceMetrics.buttonInsets.right)
+        let buttonInsets = tab.currentAttributedTitle != nil ?
+            AppearanceMetrics.buttonInsetsAttributedTitle :
+            AppearanceMetrics.buttonInsets
+
+        let leadingConstant = (tabSizingStyle == .equalWidths) ? 0.0 : (tab.contentEdgeInsets.left - buttonInsets.left)
+        let trailingConstant = (tabSizingStyle == .equalWidths) ? 0.0 : (-tab.contentEdgeInsets.right + buttonInsets.right)
 
         selectionIndicatorLeadingConstraint = selectionIndicator.leadingAnchor.constraint(equalTo: tab.leadingAnchor, constant: leadingConstant)
         selectionIndicatorTrailingConstraint = selectionIndicator.trailingAnchor.constraint(equalTo: tab.trailingAnchor, constant: trailingConstant)
@@ -405,6 +412,7 @@ class FilterTabBar: UIControl {
         static let selectionIndicatorHeight: CGFloat = 2.0
         static let horizontalPadding: CGFloat = 0.0
         static let buttonInsets = UIEdgeInsets(top: 14.0, left: 12.0, bottom: 14.0, right: 12.0)
+        static let buttonInsetsAttributedTitle = UIEdgeInsets(top: 10.0, left: 16.0, bottom: 10.0, right: 16.0)
     }
 
     private enum SelectionAnimation {

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -69,6 +69,12 @@ class FilterTabBar: UIControl {
         }
     }
 
+    var equalWidthFill: UIStackView.Distribution = .fillEqually {
+        didSet {
+            stackView.distribution = equalWidthFill
+        }
+    }
+
     // MARK: - Appearance
 
     /// Tint color will be applied to the floating selection indicator.
@@ -287,7 +293,7 @@ class FilterTabBar: UIControl {
 
         switch tabSizingStyle {
         case .equalWidths:
-            stackView.distribution = .fillEqually
+            stackView.distribution = equalWidthFill
             NSLayoutConstraint.activate([stackViewWidthConstraint])
         case .fitting:
             stackView.distribution = .fill

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -60,18 +60,17 @@ class FilterTabBar: UIControl {
         }
     }
 
-    private var tabBarHeightConstraint: NSLayoutConstraint?
-    var tabBarHeight = AppearanceMetrics.height {
+    private var tabBarHeightConstraint: NSLayoutConstraint! {
         didSet {
-            tabBarHeightConstraint?.isActive = false
-            tabBarHeightConstraint = heightAnchor.constraint(equalToConstant: tabBarHeight)
-            tabBarHeightConstraint?.isActive = true
+            if let oldValue = oldValue {
+                NSLayoutConstraint.deactivate([oldValue])
+            }
         }
     }
 
-    var equalWidthFill: UIStackView.Distribution = .fillEqually {
+    var tabBarHeight = AppearanceMetrics.height {
         didSet {
-            stackView.distribution = equalWidthFill
+            tabBarHeightConstraint = heightAnchor.constraint(equalToConstant: tabBarHeight)
         }
     }
 
@@ -293,7 +292,7 @@ class FilterTabBar: UIControl {
 
         switch tabSizingStyle {
         case .equalWidths:
-            stackView.distribution = equalWidthFill
+            stackView.distribution = .fillEqually
             NSLayoutConstraint.activate([stackViewWidthConstraint])
         case .fitting:
             stackView.distribution = .fill
@@ -428,7 +427,7 @@ class FilterTabBar: UIControl {
         static let selectionIndicatorHeight: CGFloat = 2.0
         static let horizontalPadding: CGFloat = 0.0
         static let buttonInsets = UIEdgeInsets(top: 14.0, left: 12.0, bottom: 14.0, right: 12.0)
-        static let buttonInsetsAttributedTitle = UIEdgeInsets(top: 10.0, left: 16.0, bottom: 10.0, right: 16.0)
+        static let buttonInsetsAttributedTitle = UIEdgeInsets(top: 10.0, left: 5.0, bottom: 10.0, right: 5.0)
     }
 
     private enum SelectionAnimation {

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -60,6 +60,15 @@ class FilterTabBar: UIControl {
         }
     }
 
+    private var tabBarHeightConstraint: NSLayoutConstraint?
+    var tabBarHeight = AppearanceMetrics.height {
+        didSet {
+            tabBarHeightConstraint?.isActive = false
+            tabBarHeightConstraint = heightAnchor.constraint(equalToConstant: tabBarHeight)
+            tabBarHeightConstraint?.isActive = true
+        }
+    }
+
     // MARK: - Appearance
 
     /// Tint color will be applied to the floating selection indicator.
@@ -171,7 +180,8 @@ class FilterTabBar: UIControl {
     }
 
     private func commonInit() {
-        heightAnchor.constraint(equalToConstant: AppearanceMetrics.height).isActive = true
+        tabBarHeightConstraint = heightAnchor.constraint(equalToConstant: tabBarHeight)
+        tabBarHeightConstraint?.isActive = true
 
         addSubview(scrollView)
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/System/FilterBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterBar.swift
@@ -6,7 +6,12 @@ import UIKit
 
 protocol FilterTabBarItem {
     var title: String { get }
+    var attributedTitle: NSAttributedString? { get }
     var accessibilityIdentifier: String { get }
+}
+
+extension FilterTabBarItem {
+    var attributedTitle: NSAttributedString? { return nil }
 }
 
 extension FilterTabBarItem where Self: RawRepresentable {
@@ -67,6 +72,11 @@ class FilterTabBar: UIControl {
                 $0.tintColor = tintColor
                 $0.setTitleColor(titleColorForSelected, for: .selected)
                 $0.setTitleColor(titleColorForSelected, for: .highlighted)
+
+                $0.setAttributedTitle(addColor(titleColorForSelected, toAttributedString: $0.currentAttributedTitle),
+                                      for: .selected)
+                $0.setAttributedTitle(addColor(titleColorForSelected, toAttributedString: $0.currentAttributedTitle),
+                                      for: .highlighted)
             })
             selectionIndicator.backgroundColor = tintColor
         }
@@ -223,6 +233,11 @@ class FilterTabBar: UIControl {
         tab.setTitleColor(deselectedTabColor, for: .normal)
         tab.tintColor = tintColor
 
+        tab.setAttributedTitle(item.attributedTitle, for: .normal)
+        tab.titleLabel?.lineBreakMode = .byWordWrapping
+        tab.setAttributedTitle(addColor(titleColorForSelected, toAttributedString: item.attributedTitle), for: .selected)
+        tab.setAttributedTitle(addColor(deselectedTabColor, toAttributedString: item.attributedTitle), for: .normal)
+
         tab.accessibilityIdentifier = item.accessibilityIdentifier
 
         tab.contentEdgeInsets = AppearanceMetrics.buttonInsets
@@ -231,6 +246,18 @@ class FilterTabBar: UIControl {
         tab.addTarget(self, action: #selector(tabTapped(_:)), for: .touchUpInside)
 
         return tab
+    }
+
+    private func addColor(_ color: UIColor, toAttributedString attributedString: NSAttributedString?) -> NSAttributedString? {
+
+        guard let attributedString = attributedString else {
+            return nil
+        }
+
+        let mutableString = NSMutableAttributedString(attributedString: attributedString)
+        mutableString.addAttributes([.foregroundColor: color], range: NSMakeRange(0, mutableString.string.count))
+
+        return mutableString
     }
 
     private func updateTabSizingConstraints() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -918,6 +918,8 @@
 		9872CB30203B8A730066A293 /* SignupEpilogueTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9872CB2F203B8A730066A293 /* SignupEpilogueTableViewController.swift */; };
 		9874766F219630240080967F /* SiteStatsTableViewCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9874766E219630240080967F /* SiteStatsTableViewCells.swift */; };
 		9874767321963D330080967F /* SiteStatsInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9874767221963D320080967F /* SiteStatsInformation.swift */; };
+		98797DBC222F434500128C21 /* OverviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98797DBA222F434500128C21 /* OverviewCell.swift */; };
+		98797DBD222F434500128C21 /* OverviewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98797DBB222F434500128C21 /* OverviewCell.xib */; };
 		988056032183CCE50083B643 /* SiteStatsInsightsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988056022183CCE50083B643 /* SiteStatsInsightsTableViewController.swift */; };
 		98812966219CE42A0075FF33 /* StatsTotalRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98812964219CE42A0075FF33 /* StatsTotalRow.swift */; };
 		98812967219CE42A0075FF33 /* StatsTotalRow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98812965219CE42A0075FF33 /* StatsTotalRow.xib */; };
@@ -2865,6 +2867,8 @@
 		9872CB2F203B8A730066A293 /* SignupEpilogueTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupEpilogueTableViewController.swift; sourceTree = "<group>"; };
 		9874766E219630240080967F /* SiteStatsTableViewCells.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsTableViewCells.swift; sourceTree = "<group>"; };
 		9874767221963D320080967F /* SiteStatsInformation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsInformation.swift; sourceTree = "<group>"; };
+		98797DBA222F434500128C21 /* OverviewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewCell.swift; sourceTree = "<group>"; };
+		98797DBB222F434500128C21 /* OverviewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OverviewCell.xib; sourceTree = "<group>"; };
 		988056022183CCE50083B643 /* SiteStatsInsightsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStatsInsightsTableViewController.swift; sourceTree = "<group>"; };
 		98812964219CE42A0075FF33 /* StatsTotalRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsTotalRow.swift; sourceTree = "<group>"; };
 		98812965219CE42A0075FF33 /* StatsTotalRow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StatsTotalRow.xib; sourceTree = "<group>"; };
@@ -6242,6 +6246,7 @@
 		984B138C21F65F680004B6A2 /* Period Stats */ = {
 			isa = PBXGroup;
 			children = (
+				98797DB9222F431100128C21 /* Overview */,
 				981676D3221B7A2C00B81C3F /* Countries */,
 				984B138D21F65F860004B6A2 /* SiteStatsPeriodTableViewController.swift */,
 				984B139121F66AC50004B6A2 /* SiteStatsPeriodViewModel.swift */,
@@ -6304,6 +6309,15 @@
 				98CAD295221B4ED1003E8F45 /* StatSection.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		98797DB9222F431100128C21 /* Overview */ = {
+			isa = PBXGroup;
+			children = (
+				98797DBA222F434500128C21 /* OverviewCell.swift */,
+				98797DBB222F434500128C21 /* OverviewCell.xib */,
+			);
+			path = Overview;
 			sourceTree = "<group>";
 		};
 		98C43E841FE98041006FEF54 /* Social Signup */ = {
@@ -8684,6 +8698,7 @@
 				9881296F219CF1310075FF33 /* StatsCellHeader.xib in Resources */,
 				9826AE8C21B5CC8D00C851FA /* PostingActivityMonth.xib in Resources */,
 				08D499671CDD20450004809A /* Menus.storyboard in Resources */,
+				98797DBD222F434500128C21 /* OverviewCell.xib in Resources */,
 				98B33C88202283860071E1E2 /* NoResults.storyboard in Resources */,
 				B50421E71B680839008EEA82 /* NoteUndoOverlayView.xib in Resources */,
 				D82253EE219A8A960014D0E2 /* SiteInformationWizardContent.xib in Resources */,
@@ -10249,6 +10264,7 @@
 				E61084C01B9B47BA008050C5 /* ReaderListTopic.swift in Sources */,
 				E6374DC11C444D8B00F24720 /* PublicizeService.swift in Sources */,
 				7E4A773C20F80598001C706D /* ActivityContentFactory.swift in Sources */,
+				98797DBC222F434500128C21 /* OverviewCell.swift in Sources */,
 				931D26FE19EDA10D00114F17 /* ALIterativeMigrator.m in Sources */,
 				5DA3EE161925090A00294E0B /* MediaService.m in Sources */,
 				7E4123C520F4097B00DF8486 /* FormattableContentAction.swift in Sources */,


### PR DESCRIPTION
Fixes #11192 

This adds the Period Overview card. The data is fake for now, but the functionality can still be seen. Also, there is a temporary view for the chart area.

To test:

- Go to Stats > Period. 
- The hero value and label matches the tab selected.
- Selecting different tabs will update the hero value and label, and the difference value.
- The hero value is abbreviated after 99,999.
- The difference value and difference percent are abbreviated after 9,999.
- If the difference is negative, the text is red. If positive, green.

<img width="350" alt="one" src="https://user-images.githubusercontent.com/1816888/53921446-9fc98180-402d-11e9-8460-832d3f6dc952.png">

<img width="350" alt="two" src="https://user-images.githubusercontent.com/1816888/53921452-a3f59f00-402d-11e9-8bb1-aafc8d391b39.png">

<img width="350" alt="three" src="https://user-images.githubusercontent.com/1816888/53921457-a8ba5300-402d-11e9-9088-1319640777ab.png">

<img width="350" alt="four" src="https://user-images.githubusercontent.com/1816888/53921439-993b0a00-402d-11e9-8767-ba4cc20481f4.png">





