### PR TITLE
Revert "Code freeze: Don't add branch protection to individual release branches"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/wordpress-mobile/release-toolkit
-  revision: 1cfb99dcb2d7284165a6ee4fa149f1c9374db312
-  tag: 0.1.8
+  revision: a7f414b31dc383075d3489b3d9d4ec039529ef67
+  tag: 0.1.9
   specs:
-    fastlane-plugin-wpmreleasetoolkit (0.1.8)
+    fastlane-plugin-wpmreleasetoolkit (0.1.9)
       diffy
       git
       nokogiri

--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -35,6 +35,7 @@ import "./ScreenshotFastfile"
     ios_bump_version_release()
     new_version = ios_get_app_version()
     ios_update_release_notes(new_version: new_version)
+    setbranchprotection(repository:GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository:GHHELPER_REPO, milestone: new_version)
 
     ios_localize_project()

--- a/Scripts/fastlane/Pluginfile
+++ b/Scripts/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.1.8'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'https://github.com/wordpress-mobile/release-toolkit', tag: '0.1.9'


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-iOS#11117 and updates release toolkit to 0.1.9 (so the action is available).