### PR TITLE
PPP: Featured image not displayed

### DIFF
--- a/WordPress/Classes/Services/MediaThumbnailCoordinator.swift
+++ b/WordPress/Classes/Services/MediaThumbnailCoordinator.swift
@@ -74,7 +74,11 @@ class MediaThumbnailCoordinator: NSObject {
         }
     }
 
-
+    /// Fetch a media from a stub media
+    ///
+    /// - Parameters:
+    ///   - media: the media object to fetch
+    ///   - onCompletion: a block that is invoked when the media is loaded and fetched with success or failure.
     func fetchStubMedia(for media: Media, onCompletion: @escaping LoadStubMediaCompletionBlock) {
         guard let mediaID = media.mediaID else {
             onCompletion(nil, MediaThumbnailExporter.ThumbnailExportError.failedToGenerateThumbnailFileURL)

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -279,7 +279,7 @@ extension ImageLoader {
     }
 
     @objc(fetchAndLoadImageForMedia:size:placeholder:success:error:)
-    /// Load an image from the given Media object, fetching first if the Media remote status is stub.
+    /// Load an image from the given Media object, fetching it first if the Media remote status is stub.
     /// If it's a gif, it will animate it.
     /// For any other type of media, this will load the corresponding static image.
     ///

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -305,15 +305,19 @@ extension ImageLoader {
 
             case .fetchAndLoad:
                 guard let mediaId = media.mediaID?.stringValue else {
+                    let error = createError(description: "The Media id doesn't exist")
+                    callErrorHandler(with: error)
                     return
                 }
 
-                MediaThumbnailCoordinator.shared.fetchStubMedia(for: media) { [weak self] (fetchedMedia, _) in
+                MediaThumbnailCoordinator.shared.fetchStubMedia(for: media) { [weak self] (fetchedMedia, fetchedMediaError) in
                     if let fetchedMedia = fetchedMedia,
                         let fetchedMediaId = fetchedMedia.mediaID?.stringValue, fetchedMediaId == mediaId {
                         DispatchQueue.main.async {
                             self?.fetchAndLoadImage(for: fetchedMedia, size: size, placeholder: placeholder, success: success, error: error)
                         }
+                    } else {
+                        self?.callErrorHandler(with: fetchedMediaError)
                     }
                 }
             }

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -297,6 +297,7 @@ extension ImageLoader {
         self.placeholder = placeholder
         successHandler = success
         errorHandler = error
+
         guard let url = url(from: media) else {
             switch action {
             case .load:

--- a/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
@@ -139,7 +139,7 @@ public class CachedAnimatedImageView: UIImageView, GIFAnimatable {
         self.prepareForReuse()
     }
 
-    public func startLoadingAnimation() {
+    @objc public func startLoadingAnimation() {
         guard shouldShowLoadingIndicator else {
             return
         }
@@ -148,7 +148,7 @@ public class CachedAnimatedImageView: UIImageView, GIFAnimatable {
         }
     }
 
-    public func stopLoadingAnimation() {
+    @objc public func stopLoadingAnimation() {
         DispatchQueue.main.async() {
             self.loadingIndicator.stopAnimating()
         }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -169,11 +169,20 @@ static CGFloat const FeaturedImageSize = 120.0;
     self.labelsContainerTrailing.active = !hideFeaturedImage;
     
     if (!hideFeaturedImage) {
-        [self.featuredImageLoader loadImageFromMedia:page.featuredImage
-                                       preferredSize:CGSizeMake(FeaturedImageSize, FeaturedImageSize)
-                                         placeholder:nil
-                                             success:nil
-                                               error:nil];
+        [self.featuredImageView startLoadingAnimation];
+
+        __weak __typeof(self) weakSelf = self;
+
+        [page.featuredImage imageWithSize:CGSizeMake(FeaturedImageSize, FeaturedImageSize)
+                        completionHandler:^(UIImage * _Nullable result, NSError * _Nullable error) {
+                            __strong __typeof(weakSelf) strongSelf = weakSelf;
+                            [strongSelf.featuredImageView stopLoadingAnimation];
+                            
+                            if (error == nil) {
+                                [strongSelf.featuredImageView setImage:result];
+                            }
+                        }];
+        
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -16,7 +16,6 @@ static CGFloat const FeaturedImageSize = 120.0;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *labelsContainerTrailing;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *leadingContentConstraint;
 
-@property (nonatomic, strong) ImageLoader *featuredImageLoader;
 @property (nonatomic, strong) NSDateFormatter *dateFormatter;
 
 @end
@@ -38,17 +37,7 @@ static CGFloat const FeaturedImageSize = 120.0;
     [super prepareForReuse];
     
     [self applyStyles];
-    [self.featuredImageLoader prepareForReuse];
     [self setNeedsDisplay];
-}
-
-- (ImageLoader *)featuredImageLoader
-{
-    if (_featuredImageLoader == nil) {
-        _featuredImageLoader = [[ImageLoader alloc] initWithImageView:self.featuredImageView
-                                                          gifStrategy:GIFStrategyLargeGIFs];
-    }
-    return _featuredImageLoader;
 }
 
 - (NSDateFormatter *)dateFormatter

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -182,7 +182,7 @@ static CGFloat const FeaturedImageSize = 120.0;
                                                 placeholder:nil
                                                     success:nil
                                                       error:^(NSError *error) {
-                                                          DDLogError(@"Failed to load the media: %@", account, error);
+                                                          DDLogError(@"Failed to load the media: %@", error);
                                                       }];
         
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -18,6 +18,7 @@ static CGFloat const FeaturedImageSize = 120.0;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *labelsContainerTrailing;
 @property (nonatomic, strong) IBOutlet NSLayoutConstraint *leadingContentConstraint;
 
+@property (nonatomic, strong) ImageLoader *featuredImageLoader;
 @property (nonatomic, strong) NSDateFormatter *dateFormatter;
 
 @end
@@ -39,7 +40,17 @@ static CGFloat const FeaturedImageSize = 120.0;
     [super prepareForReuse];
     
     [self applyStyles];
+    [self.featuredImageLoader prepareForReuse];
     [self setNeedsDisplay];
+}
+
+- (ImageLoader *)featuredImageLoader
+{
+    if (_featuredImageLoader == nil) {
+        _featuredImageLoader = [[ImageLoader alloc] initWithImageView:self.featuredImageView
+                                                          gifStrategy:GIFStrategyLargeGIFs];
+    }
+    return _featuredImageLoader;
 }
 
 - (NSDateFormatter *)dateFormatter
@@ -166,19 +177,11 @@ static CGFloat const FeaturedImageSize = 120.0;
     self.labelsContainerTrailing.active = !hideFeaturedImage;
     
     if (!hideFeaturedImage) {
-        [self.featuredImageView startLoadingAnimation];
-
-        __weak __typeof(self) weakSelf = self;
-
-        [page.featuredImage imageWithSize:CGSizeMake(FeaturedImageSize, FeaturedImageSize)
-                        completionHandler:^(UIImage * _Nullable result, NSError * _Nullable error) {
-                            __strong __typeof(weakSelf) strongSelf = weakSelf;
-                            [strongSelf.featuredImageView stopLoadingAnimation];
-                            
-                            if (error == nil) {
-                                [strongSelf.featuredImageView setImage:result];
-                            }
-                        }];
+        [self.featuredImageLoader loadImageForMedia:page.featuredImage
+                                               size:CGSizeMake(FeaturedImageSize, FeaturedImageSize)
+                                        placeholder:nil
+                                            success:nil
+                                              error:nil]; //Add here Log for error
         
     }
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -177,11 +177,13 @@ static CGFloat const FeaturedImageSize = 120.0;
     self.labelsContainerTrailing.active = !hideFeaturedImage;
     
     if (!hideFeaturedImage) {
-        [self.featuredImageLoader loadImageForMedia:page.featuredImage
-                                               size:CGSizeMake(FeaturedImageSize, FeaturedImageSize)
-                                        placeholder:nil
-                                            success:nil
-                                              error:nil]; //Add here Log for error
+        [self.featuredImageLoader fetchAndLoadImageForMedia:page.featuredImage
+                                                       size:CGSizeMake(FeaturedImageSize, FeaturedImageSize)
+                                                placeholder:nil
+                                                    success:nil
+                                                      error:^(NSError *error) {
+                                                          DDLogError(@"Failed to load the media: %@", account, error);
+                                                      }];
         
     }
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -177,13 +177,13 @@ static CGFloat const FeaturedImageSize = 120.0;
     self.labelsContainerTrailing.active = !hideFeaturedImage;
     
     if (!hideFeaturedImage) {
-        [self.featuredImageLoader fetchAndLoadImageForMedia:page.featuredImage
-                                                       size:CGSizeMake(FeaturedImageSize, FeaturedImageSize)
-                                                placeholder:nil
-                                                    success:nil
-                                                      error:^(NSError *error) {
-                                                          DDLogError(@"Failed to load the media: %@", error);
-                                                      }];
+        [self.featuredImageLoader loadImageFromMedia:page.featuredImage
+                                       preferredSize:CGSizeMake(FeaturedImageSize, FeaturedImageSize)
+                                         placeholder:nil
+                                             success:nil
+                                               error:^(NSError *error) {
+                                                   DDLogError(@"Failed to load the media: %@", error);
+                                               }];
         
     }
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -2,6 +2,8 @@
 #import "WPStyleGuide+Posts.h"
 #import "WordPress-Swift.h"
 
+@import Gridicons;
+
 
 static CGFloat const PageListTableViewCellTagLabelRadius = 2.0;
 static CGFloat const FeaturedImageSize = 120.0;
@@ -96,6 +98,7 @@ static CGFloat const FeaturedImageSize = 120.0;
     self.timestampLabel.textColor = [WPStyleGuide grey];
     self.badgesLabel.textColor = [WPStyleGuide darkYellow];
     self.menuButton.tintColor = [WPStyleGuide greyLighten10];
+    [self.menuButton setImage:[Gridicon iconOfType:GridiconTypeEllipsis] forState:UIControlStateNormal];
 
     self.backgroundColor = [WPStyleGuide greyLighten30];
     self.contentView.backgroundColor = [WPStyleGuide greyLighten30];


### PR DESCRIPTION
Fixes #11188 

This PR fixes a problem with the Page and its featured image. At the moment, if a Page featured image is set up from outside (using the website or another device), is not possible to see that image when a blog is synchronised. This because if the featured image is not present in the local data model a new model is created marked as _stub_ containing only the media id.
Also the `ImageLoader` used to load the featured image returns if a _Media_ doesn't contain a valid URL.



**To test:**
- Select a blog using another device
- Open the pages list and set a featured image
- Select the same blog on your device and open the pages list
- You should all the featured images
