### PR TITLE
Preliminary implementation of Period Chart

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
@@ -3,7 +3,7 @@ import Foundation
 
 import Charts
 
-// MARK: - PostSummaryHorizontalAxisFormatter
+// MARK: - HorizontalAxisFormatter
 
 /// This formatter requires some explanation. The framework does not necessarily respond well to large values, and/or
 /// large ranges of values as originally encountered using the naive TimeInterval representation of current dates.
@@ -18,7 +18,7 @@ import Charts
 /// The workaround employed here (recommended in 2410 above) relies on the time series data being ordered, and simply
 /// transforms the adjusted values by the time interval associated with the first date in the series.
 ///
-class PostSummaryHorizontalAxisFormatter: IAxisValueFormatter {
+class HorizontalAxisFormatter: IAxisValueFormatter {
 
     // MARK: Properties
 
@@ -31,7 +31,7 @@ class PostSummaryHorizontalAxisFormatter: IAxisValueFormatter {
         return formatter
     }()
 
-    // MARK: PostSummaryHorizontalAxisFormatter
+    // MARK: HorizontalAxisFormatter
 
     init(initialDateInterval: TimeInterval) {
         self.initialDateInterval = initialDateInterval
@@ -48,9 +48,9 @@ class PostSummaryHorizontalAxisFormatter: IAxisValueFormatter {
     }
 }
 
-// MARK: - PostSummaryVerticalAxisFormatter
+// MARK: - VerticalAxisFormatter
 
-class PostSummaryVerticalAxisFormatter: IAxisValueFormatter {
+class VerticalAxisFormatter: IAxisValueFormatter {
 
     // MARK: Properties
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Styling.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Styling.swift
@@ -3,20 +3,52 @@ import Foundation
 
 import Charts
 
+// MARK: - PeriodPerformanceStyling
+
+class PeriodPerformanceStyling: BarChartStyling {
+
+    let primaryBarColor: UIColor
+    let secondaryBarColor: UIColor?
+    let highlightColor: UIColor?
+    let labelColor: UIColor
+    let legendTitle: String?
+    let lineColor: UIColor
+    let xAxisValueFormatter: IAxisValueFormatter
+    let yAxisValueFormatter: IAxisValueFormatter
+
+    init(initialDateInterval: TimeInterval, highlightColor: UIColor? = nil) {
+        let xAxisFormatter = HorizontalAxisFormatter(initialDateInterval: initialDateInterval)
+
+        self.primaryBarColor        = WPStyleGuide.wordPressBlue()
+        self.secondaryBarColor      = WPStyleGuide.darkBlue()
+        self.highlightColor         = WPStyleGuide.jazzyOrange()
+        self.labelColor             = WPStyleGuide.grey()
+        self.legendTitle            = "Visitors"    // we do not localized stub data...
+        self.lineColor              = WPStyleGuide.greyLighten30()
+        self.xAxisValueFormatter    = xAxisFormatter
+        self.yAxisValueFormatter    = VerticalAxisFormatter()
+    }
+}
+
 // MARK: - PostSummaryStyling
 
 class PostSummaryStyling: BarChartStyling {
-    let barColor: UIColor
+
+    let primaryBarColor: UIColor
+    let secondaryBarColor: UIColor?
     let highlightColor: UIColor?
     let labelColor: UIColor
+    let legendTitle: String?
     let lineColor: UIColor
     let xAxisValueFormatter: IAxisValueFormatter
     let yAxisValueFormatter: IAxisValueFormatter
 
     init(barColor: UIColor, highlightColor: UIColor?, labelColor: UIColor, lineColor: UIColor, xAxisValueFormatter: IAxisValueFormatter, yAxisValueFormatter: IAxisValueFormatter) {
-        self.barColor               = barColor
+        self.primaryBarColor        = barColor
+        self.secondaryBarColor      = nil
         self.highlightColor         = highlightColor
         self.labelColor             = labelColor
+        self.legendTitle            = nil
         self.lineColor              = lineColor
         self.xAxisValueFormatter    = xAxisValueFormatter
         self.yAxisValueFormatter    = yAxisValueFormatter

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
@@ -22,14 +22,20 @@ extension BarChartDataSet {
 ///
 protocol BarChartStyling {
 
-    /// This corresponds to the bar color
-    var barColor: UIColor { get }
+    /// This corresponds to the primary bar color.
+    var primaryBarColor: UIColor { get }
+
+    /// This bar color is used if bars are overlayed.
+    var secondaryBarColor: UIColor? { get }
 
     /// This corresponds to the color of a selected bar
     var highlightColor: UIColor? { get }
 
     /// This corresponds to the color of labels on the chart
     var labelColor: UIColor { get }
+
+    /// If specified, a legend will be presented with this value. It maps to the secondary bar color above.
+    var legendTitle: String? { get }
 
     /// This corresponds to the color of lines on the chart
     var lineColor: UIColor { get }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -220,7 +220,7 @@ class StatsBarChartView: BarChartView {
 
         notifyDataSetChanged()
 
-        let postRotationDelay = DispatchTime.now() + TimeInterval(0.3)
+        let postRotationDelay = DispatchTime.now() + TimeInterval(0.35)
         DispatchQueue.main.asyncAfter(deadline: postRotationDelay) {
             self.drawChartMarker(for: entry, triggerRedraw: true)
         }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -10,8 +10,11 @@ class StatsBarChartView: BarChartView {
     // MARK: Properties
 
     private struct Constants {
-        static let intrinsicHeight  = CGFloat(170)   // height via Zeplin
-        static let highlightAlpha   = CGFloat(0.1)
+        static let animationDuration    = TimeInterval(1)
+        static let intrinsicHeight      = CGFloat(170)      // height via Zeplin
+        static let highlightAlpha       = CGFloat(0.75)
+        static let markerAlpha          = CGFloat(0.2)
+        static let offset               = CGFloat(20)
     }
 
     private let barChartData: BarChartDataConvertible
@@ -66,11 +69,19 @@ class StatsBarChartView: BarChartView {
         }
 
         let barBounds = getBarBounds(entry: barChartDataEntry)
-        let highlightOrigin = CGPoint(x: barBounds.origin.x, y: 0)
-        let rect = CGRect(origin: highlightOrigin, size: barBounds.size)
+
+        let highlightX = barBounds.origin.x
+        let highlightY = CGFloat(0)
+        let highlightOrigin = CGPoint(x: highlightX, y: highlightY)
+
+        let highlightWidth = barBounds.width
+        let highlightHeight = bounds.height - barBounds.height
+        let highlightSize = CGSize(width: highlightWidth, height: highlightHeight)
+
+        let rect = CGRect(origin: highlightOrigin, size: highlightSize)
 
         let offsetWidth = -(barBounds.width / 2)
-        let offsetHeight = -barBounds.height
+        let offsetHeight = -highlightHeight
         let offset = CGPoint(x: offsetWidth, y: offsetHeight)
 
         return (rect, offset)
@@ -102,12 +113,24 @@ class StatsBarChartView: BarChartView {
     private func configureChartViewBaseProperties() {
         dragDecelerationEnabled = false
 
-        extraRightOffset = CGFloat(20)
+        extraRightOffset = Constants.offset
 
-        legend.enabled = false
+        animate(yAxisDuration: Constants.animationDuration)
+    }
 
-        let animationDuration = TimeInterval(1)
-        animate(yAxisDuration: animationDuration)
+    private func configureLegendIfNeeded() {
+        guard let legendTitle = styling.legendTitle, let legendColor = styling.secondaryBarColor else {
+            return
+        }
+
+        legend.enabled = true
+        legend.verticalAlignment = .top
+
+        let entry = LegendEntry()
+        entry.label = legendTitle
+        entry.formColor = legendColor
+
+        legend.setCustom(entries: [entry])
     }
 
     private func configureXAxis() {
@@ -133,24 +156,35 @@ class StatsBarChartView: BarChartView {
         yAxis.valueFormatter = styling.yAxisValueFormatter
     }
 
+    private func configureDataSet(dataSet: BarChartDataSet, with color: NSUIColor, enableHighlight: Bool) {
+        dataSet.colors = [ color ]
+
+        dataSet.drawValuesEnabled = false
+
+        guard let barHighlightColor = styling.highlightColor else {
+            highlightPerTapEnabled = false
+            return
+        }
+
+        dataSet.highlightAlpha = (styling.secondaryBarColor != nil) ? Constants.highlightAlpha : CGFloat(1)
+        dataSet.highlightColor = barHighlightColor
+        dataSet.highlightEnabled = enableHighlight
+    }
+
     private func configureAndPopulateData() {
         let barChartData = self.barChartData.barChartData
 
-        if let dataSets = barChartData.dataSets as? [BarChartDataSet] {
-            for dataSet in dataSets {
-                dataSet.colors = [ styling.barColor ]
-
-                dataSet.drawValuesEnabled = false
-
-                if let barHighlightColor = styling.highlightColor {
-                    dataSet.highlightColor = barHighlightColor
-                    dataSet.highlightEnabled = true
-                    dataSet.highlightAlpha = CGFloat(1)
-                } else {
-                    highlightPerTapEnabled = false
-                }
-            }
+        guard let dataSets = barChartData.dataSets as? [BarChartDataSet], let initialDataSet = dataSets.first else {
+            return
         }
+        configureDataSet(dataSet: initialDataSet, with: styling.primaryBarColor, enableHighlight: true)
+
+        if dataSets.count > 1, let secondaryBarColor = styling.secondaryBarColor {
+            let secondaryDataSet = dataSets[1]
+            configureDataSet(dataSet: secondaryDataSet, with: secondaryBarColor, enableHighlight: false)
+        }
+
+        configureLegendIfNeeded()
 
         data = barChartData
     }
@@ -160,7 +194,7 @@ class StatsBarChartView: BarChartView {
         let marker = StatsBarChartMarker(frame: markerRect)
         marker.offset = markerOffset
 
-        let markerColor = (styling.highlightColor ?? UIColor.clear).withAlphaComponent(Constants.highlightAlpha)
+        let markerColor = (styling.highlightColor ?? UIColor.clear).withAlphaComponent(Constants.markerAlpha)
         marker.backgroundColor = markerColor
 
         self.marker = marker
@@ -198,7 +232,6 @@ class StatsBarChartView: BarChartView {
 private typealias StatsBarChartMarker = MarkerView
 
 extension StatsBarChartView: ChartViewDelegate {
-
     func chartValueSelected(_ chartView: ChartViewBase, entry: ChartDataEntry, highlight: Highlight) {
         drawChartMarker(for: entry)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PeriodDataStub.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PeriodDataStub.swift
@@ -1,0 +1,81 @@
+
+import Foundation
+
+import Charts
+
+// MARK: - PeriodDatum
+
+struct PeriodDatum: Decodable {
+    let date: Date
+    let viewCount: Int
+    let visitorCount: Int
+    let likeCount: Int
+    let commentCount: Int
+}
+
+// MARK: - PeriodDataStub
+
+class PeriodDataStub: DataStub<[PeriodDatum]> {
+    init() {
+        super.init([PeriodDatum].self, fileName: "period_data")
+    }
+
+    var periodData: [PeriodDatum] {
+        return data as? [PeriodDatum] ?? []
+    }
+}
+
+// MARK: - BarChartDataConvertible
+
+extension PeriodDataStub: BarChartDataConvertible {
+    var barChartData: BarChartData {
+
+        let data = periodData
+
+        // Our stub data is ordered
+        let firstDateInterval: TimeInterval
+        let lastDateInterval: TimeInterval
+        let effectiveWidth: Double
+
+        if data.isEmpty {
+            firstDateInterval = 0
+            lastDateInterval = 0
+            effectiveWidth = 1
+        } else {
+            firstDateInterval = data.first!.date.timeIntervalSince1970
+            lastDateInterval = data.last!.date.timeIntervalSince1970
+
+            let range = lastDateInterval - firstDateInterval
+
+            let effectiveBars = Double(Double(data.count) * 1.2)
+
+            effectiveWidth = range / effectiveBars
+        }
+
+        var viewEntries = [BarChartDataEntry]()
+        var visitorEntries = [BarChartDataEntry]()
+        for datum in data {
+            let dateInterval = datum.date.timeIntervalSince1970
+            let offset = dateInterval - firstDateInterval
+
+            let x = offset
+
+            let viewY = Double(datum.viewCount)
+            let viewEntry = BarChartDataEntry(x: x, y: viewY)
+            viewEntries.append(viewEntry)
+
+            let visitorY = Double(datum.visitorCount)
+            let visitorEntry = BarChartDataEntry(x: x, y: visitorY)
+            visitorEntries.append(visitorEntry)
+        }
+
+        let viewsDataSet = BarChartDataSet(values: viewEntries)
+        let visitorsDataSet = BarChartDataSet(values: visitorEntries)
+        let dataSets = [ viewsDataSet, visitorsDataSet ]
+
+        let chartData = BarChartData(dataSets: dataSets)
+        chartData.barWidth = effectiveWidth
+
+        return chartData
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PostSummaryDataStub.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PostSummaryDataStub.swift
@@ -15,6 +15,18 @@ struct PostSummaryDatum: Decodable {
     }
 }
 
+// MARK: - PostSummaryDataStub
+
+class PostSummaryDataStub: DataStub<[PostSummaryDatum]> {
+    init(fileName: String) {
+        super.init([PostSummaryDatum].self, fileName: fileName)
+    }
+
+    var summaryData: [PostSummaryDatum] {
+        return data as? [PostSummaryDatum] ?? []
+    }
+}
+
 // MARK: - LatestPostSummaryDataStub
 
 class LatestPostSummaryDataStub: PostSummaryDataStub {
@@ -31,45 +43,12 @@ class SelectedPostSummaryDataStub: PostSummaryDataStub {
     }
 }
 
-/// Stub structure informed by https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/post/%24post_id/
-/// Values approximate what's depicted in Zeplin
-///
-class PostSummaryDataStub {
-
-    private static let jsonFileExtension = "json"
-
-    private(set) var data: [PostSummaryDatum]
-
-    init(fileName: String) {
-        let bundle = Bundle(for: type(of: self))
-
-        guard let url = bundle.url(
-            forResource: fileName,
-            withExtension: PostSummaryDataStub.jsonFileExtension) else {
-
-            fatalError("Failed to locate \(fileName).\(PostSummaryDataStub.jsonFileExtension) in bundle.")
-        }
-
-        guard let jsonData = try? Data(contentsOf: url) else {
-            fatalError("Failed to parse \(fileName).\(PostSummaryDataStub.jsonFileExtension) as Data.")
-        }
-
-        let decoder = JSONDecoder()
-        let dateFormatter = PostSummaryDateFormatter()
-        decoder.dateDecodingStrategy = .formatted(dateFormatter)
-
-        guard let decoded = try? decoder.decode([PostSummaryDatum].self, from: jsonData) else {
-            fatalError("Failed to decode \(fileName).\(PostSummaryDataStub.jsonFileExtension) from data")
-        }
-
-        self.data = decoded
-    }
-}
-
 // MARK: - BarChartDataConvertible
 
 extension PostSummaryDataStub: BarChartDataConvertible {
     var barChartData: BarChartData {
+
+        let data = summaryData
 
         // Our stub data is ordered
         let firstDateInterval: TimeInterval
@@ -110,26 +89,11 @@ extension PostSummaryDataStub: BarChartDataConvertible {
     }
 }
 
-// MARK: - PostSummaryDateFormatter
-
-private class PostSummaryDateFormatter: DateFormatter {
-    override init() {
-        super.init()
-
-        self.locale = Locale(identifier: "en_US_POSIX")
-        self.dateFormat = "yyyy-MM-dd"
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
-
 // MARK: - PostSummaryStubStyling
 
 extension PostSummaryStyling {
     convenience init(initialDateInterval: TimeInterval, highlightColor: UIColor? = nil) {
-        let xAxisFormatter = PostSummaryHorizontalAxisFormatter(initialDateInterval: initialDateInterval)
+        let xAxisFormatter = HorizontalAxisFormatter(initialDateInterval: initialDateInterval)
 
         self.init(
             barColor: WPStyleGuide.wordPressBlue(),
@@ -137,7 +101,7 @@ extension PostSummaryStyling {
             labelColor: WPStyleGuide.grey(),
             lineColor: WPStyleGuide.greyLighten30(),
             xAxisValueFormatter: xAxisFormatter,
-            yAxisValueFormatter: PostSummaryVerticalAxisFormatter())
+            yAxisValueFormatter: VerticalAxisFormatter())
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/Stub+Shared.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/Stub+Shared.swift
@@ -1,0 +1,69 @@
+
+import Foundation
+
+import Charts
+
+// MARK: - Bundle support
+
+extension Bundle {
+    func jsonData(from fileName: String) -> Data? {
+        guard let url = url(forResource: fileName, withExtension: "json") else {
+            fatalError("Failed to locate \(fileName).json in bundle.")
+        }
+
+        guard let data = try? Data(contentsOf: url) else {
+            fatalError("Failed to parse \(fileName).json as Data.")
+        }
+
+        return data
+    }
+}
+
+// MARK: - StubData
+
+/// Stub structure informed by https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/post/%24post_id/
+/// Values approximate what's depicted in Zeplin
+///
+class DataStub<T: Decodable> {
+
+    private(set) var data: Decodable
+
+    init<T: Decodable>(_ type: T.Type, fileName: String) {
+        let bundle = Bundle.main
+        let decoder = StubDataJSONDecoder()
+
+        guard let jsonData = bundle.jsonData(from: fileName),
+            let decoded = try? decoder.decode(T.self, from: jsonData) else {
+
+            fatalError("Failed to decode data from \(fileName).json")
+        }
+
+        self.data = decoded
+    }
+}
+
+// MARK: - StubDataDateFormatter
+
+private class StubDataDateFormatter: DateFormatter {
+    override init() {
+        super.init()
+
+        self.locale = Locale(identifier: "en_US_POSIX")
+        self.dateFormat = "yyyy-MM-dd"
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: - StubDataJSONDecoder
+
+private class StubDataJSONDecoder: JSONDecoder {
+    override init() {
+        super.init()
+
+        let dateFormatter = StubDataDateFormatter()
+        dateDecodingStrategy = .formatted(dateFormatter)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/period_data.json
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/period_data.json
@@ -1,0 +1,72 @@
+[
+    {
+        "date": "2019-02-19",
+        "viewCount": 3600,
+        "visitorCount": 2900,
+        "likeCount": 29,
+        "commentCount": 3
+    },
+    {
+        "date": "2019-02-20",
+        "viewCount": 3900,
+        "visitorCount": 3100,
+        "likeCount": 31,
+        "commentCount": 3
+    },
+    {
+        "date": "2019-02-21",
+        "viewCount": 5400,
+        "visitorCount": 4300,
+        "likeCount": 43,
+        "commentCount": 4
+    },
+    {
+        "date": "2019-02-22",
+        "viewCount": 5700,
+        "visitorCount": 4500,
+        "likeCount": 45,
+        "commentCount": 4
+    },
+    {
+        "date": "2019-02-23",
+        "viewCount": 6300,
+        "visitorCount": 5000,
+        "likeCount": 50,
+        "commentCount": 5
+    },
+    {
+        "date": "2019-02-24",
+        "viewCount": 8400,
+        "visitorCount": 6700,
+        "likeCount": 67,
+        "commentCount": 6
+    },
+    {
+        "date": "2019-02-25",
+        "viewCount": 6600,
+        "visitorCount": 5300,
+        "likeCount": 53,
+        "commentCount": 5
+    },
+    {
+        "date": "2019-02-26",
+        "viewCount": 7800,
+        "visitorCount": 6200,
+        "likeCount": 62,
+        "commentCount": 6
+    },
+    {
+        "date": "2019-02-27",
+        "viewCount": 6300,
+        "visitorCount": 5000,
+        "likeCount": 50,
+        "commentCount": 5
+    },
+    {
+        "date": "2019-02-28",
+        "viewCount": 6000,
+        "visitorCount": 4800,
+        "likeCount": 48,
+        "commentCount": 5
+    }
+]

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -40,7 +40,7 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
     // Introduced via #11061, to be replaced with real data via #11067
     private lazy var latestPostSummaryStub: (data: BarChartDataConvertible, styling: BarChartStyling) = {
         let stubbedData = LatestPostSummaryDataStub()
-        let firstStubbedDateInterval = stubbedData.data.first?.date.timeIntervalSince1970 ?? 0
+        let firstStubbedDateInterval = stubbedData.summaryData.first?.date.timeIntervalSince1970 ?? 0
         let styling = LatestPostSummaryStyling(initialDateInterval: firstStubbedDateInterval)
 
         return (stubbedData, styling)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -37,6 +37,15 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
         }
     }
 
+    // Introduced via #11061, to be replaced with real data via #11067
+    private lazy var latestPostSummaryStub: (data: BarChartDataConvertible, styling: BarChartStyling) = {
+        let stubbedData = LatestPostSummaryDataStub()
+        let firstStubbedDateInterval = stubbedData.data.first?.date.timeIntervalSince1970 ?? 0
+        let styling = LatestPostSummaryStyling(initialDateInterval: firstStubbedDateInterval)
+
+        return (stubbedData, styling)
+    }()
+
     // MARK: - View
 
     override func awakeFromNib() {
@@ -229,12 +238,7 @@ private extension LatestPostSummaryCell {
     func configureChartView() {
         resetChartView()
 
-        // Introduced via #11061, to be replaced with real data via #11067
-        let stubbedData = LatestPostSummaryDataStub()
-        let firstStubbedDateInterval = stubbedData.data.first?.date.timeIntervalSince1970 ?? 0
-        let styling = LatestPostSummaryStyling(initialDateInterval: firstStubbedDateInterval)
-
-        let chartView = StatsBarChartView(data: stubbedData, styling: styling)
+        let chartView = StatsBarChartView(data: latestPostSummaryStub.data, styling: latestPostSummaryStub.styling)
         chartStackView.addArrangedSubview(chartView)
 
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -83,7 +83,7 @@ class OverviewCell: UITableViewCell, NibLoadable {
         self.tabsData = tabsData
         setupFilterBar()
         updateLabels()
-        configureChartViewIfNeeded()
+        configureChartView()
     }
 }
 
@@ -120,7 +120,7 @@ private extension OverviewCell {
     }
 
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
-        // TODO: update chart - configureChartViewIfNeeded() - via #11064
+        // TODO: update chart - configureChartView() - via #11064
         updateLabels()
     }
 
@@ -140,7 +140,7 @@ private extension OverviewCell {
         }
     }
 
-    func configureChartViewIfNeeded() {
+    func configureChartView() {
         resetChartView()
 
         let chartView = StatsBarChartView(data: periodDataStub.data, styling: periodDataStub.styling)

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -74,6 +74,11 @@ class OverviewCell: UITableViewCell, NibLoadable {
 
     // MARK: - Configure
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureFonts()
+    }
+
     func configure(tabsData: [OverviewTabData]) {
         self.tabsData = tabsData
         setupFilterBar()
@@ -85,6 +90,25 @@ class OverviewCell: UITableViewCell, NibLoadable {
 // MARK: - Private Extension
 
 private extension OverviewCell {
+
+    /// This method squelches two Xcode warnings that I encountered:
+    /// 1. Attribute Unavailable: Large Title font text style before iOS 11.0
+    /// 2. Automatically Adjusts Font requires using a Dynamic Type text style
+    /// The second emerged as part of my attempt to resolve the first.
+    ///
+    func configureFonts() {
+
+        let prevailingFont: UIFont
+        if #available(iOS 11.0, *) {
+            prevailingFont = WPStyleGuide.fontForTextStyle(UIFont.TextStyle.largeTitle)
+        } else {
+            let fontSize = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.title1).pointSize
+            prevailingFont = WPFontManager.systemRegularFont(ofSize: fontSize)
+        }
+        selectedData.font = prevailingFont
+
+        selectedData.adjustsFontForContentSizeCategory = true   // iOS 10
+    }
 
     func setupFilterBar() {
         WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forOverviewCard: true)

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
@@ -39,19 +39,9 @@
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LXK-k6-Sxa" userLabel="Chart View">
                         <rect key="frame" x="16" y="76" width="422" height="150"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Imagine a pretty chart here" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bY0-nr-zux">
-                                <rect key="frame" x="107.5" y="65" width="207" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="bY0-nr-zux" firstAttribute="centerY" secondItem="LXK-k6-Sxa" secondAttribute="centerY" id="Iqw-5R-DLi"/>
                             <constraint firstAttribute="height" constant="150" id="SdW-hH-eUG"/>
-                            <constraint firstItem="bY0-nr-zux" firstAttribute="centerX" secondItem="LXK-k6-Sxa" secondAttribute="centerX" id="c6X-i6-Q4z"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0aY-pl-E5I" customClass="FilterTabBar" customModule="WordPress">
@@ -78,6 +68,7 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="chartContainerView" destination="LXK-k6-Sxa" id="0yE-3G-QlU"/>
                 <outlet property="differenceLabel" destination="mh8-GY-DEC" id="G27-Xv-ACi"/>
                 <outlet property="filterTabBar" destination="0aY-pl-E5I" id="Mwy-fv-SNw"/>
                 <outlet property="selectedData" destination="gKw-lF-4O8" id="aKK-1U-o6H"/>

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
@@ -19,9 +19,9 @@
                 <rect key="frame" x="0.0" y="0.0" width="454" height="303.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="40,000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKw-lF-4O8" userLabel="Selected Data">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="40,000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKw-lF-4O8" userLabel="Selected Data">
                         <rect key="frame" x="16" y="24" width="100.5" height="36"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="30"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -495,6 +495,9 @@
 		738B9A5C21B85EB00005062B /* UIView+ContentLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738B9A5B21B85EB00005062B /* UIView+ContentLayout.swift */; };
 		738B9A5E21B8632E0005062B /* UITableView+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738B9A5D21B8632E0005062B /* UITableView+Header.swift */; };
 		7396FE66210F730600496D0D /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7396FE65210F730600496D0D /* NotificationService.swift */; };
+		73AC468722319CB4002F7F39 /* period_data.json in Resources */ = {isa = PBXBuildFile; fileRef = 73AC468422319CB3002F7F39 /* period_data.json */; };
+		73AC468822319CB4002F7F39 /* PeriodDataStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AC468522319CB3002F7F39 /* PeriodDataStub.swift */; };
+		73AC468922319CB4002F7F39 /* Stub+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AC468622319CB4002F7F39 /* Stub+Shared.swift */; };
 		73ACDF992114FE4500233AD4 /* NotificationSupportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73ACDF982114FE4500233AD4 /* NotificationSupportService.swift */; };
 		73ACDF9C2118AF7000233AD4 /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		73ACDF9D2118AF7D00233AD4 /* Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = B5CC05F51962150600975CAC /* Constants.m */; };
@@ -2401,6 +2404,9 @@
 		738B9A5B21B85EB00005062B /* UIView+ContentLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ContentLayout.swift"; sourceTree = "<group>"; };
 		738B9A5D21B8632E0005062B /* UITableView+Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableView+Header.swift"; sourceTree = "<group>"; };
 		7396FE65210F730600496D0D /* NotificationService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
+		73AC468422319CB3002F7F39 /* period_data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = period_data.json; sourceTree = "<group>"; };
+		73AC468522319CB3002F7F39 /* PeriodDataStub.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PeriodDataStub.swift; sourceTree = "<group>"; };
+		73AC468622319CB4002F7F39 /* Stub+Shared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Stub+Shared.swift"; sourceTree = "<group>"; };
 		73ACDF982114FE4500233AD4 /* NotificationSupportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationSupportService.swift; sourceTree = "<group>"; };
 		73ACDF9F2118B03700233AD4 /* WordPressNotificationServiceExtension-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WordPressNotificationServiceExtension-Bridging-Header.h"; sourceTree = "<group>"; };
 		73B05D2A21374FE50073ECAA /* WordPressNotificationContentExtension-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WordPressNotificationContentExtension-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -5338,8 +5344,11 @@
 		73FF7035221F4C9400541798 /* Stubs */ = {
 			isa = PBXGroup;
 			children = (
+				73AC468522319CB3002F7F39 /* PeriodDataStub.swift */,
 				73FF7037221F4C9400541798 /* PostSummaryDataStub.swift */,
+				73AC468622319CB4002F7F39 /* Stub+Shared.swift */,
 				73F76E1A222754AE00FDDAD2 /* latestPost_data.json */,
+				73AC468422319CB3002F7F39 /* period_data.json */,
 				73F76E19222754AD00FDDAD2 /* selectedPost_data.json */,
 			);
 			path = Stubs;
@@ -8692,6 +8701,7 @@
 				430693741DD25F31009398A2 /* PostPost.storyboard in Resources */,
 				98563DDE21BF30C40006F5E9 /* TabbedTotalsCell.xib in Resources */,
 				5DFA7EC81AF814E40072023B /* PageListTableViewCell.xib in Resources */,
+				73AC468722319CB4002F7F39 /* period_data.json in Resources */,
 				B5C66B781ACF073900F68370 /* NoteBlockImageTableViewCell.xib in Resources */,
 				B59F34A1207678480069992D /* SignupEpilogue.storyboard in Resources */,
 				B5683DB81B6C03810043447C /* NoteTableHeaderView.xib in Resources */,
@@ -9967,6 +9977,7 @@
 				B58C4ECA207C5E1A00E32E4D /* UIImage+Assets.swift in Sources */,
 				5D5D0027187DA9D30027CEF6 /* PostCategoriesViewController.m in Sources */,
 				E684383E221F535900752258 /* LoadMoreCounter.swift in Sources */,
+				73AC468922319CB4002F7F39 /* Stub+Shared.swift in Sources */,
 				E6158ACA1ECDF518005FA441 /* LoginEpilogueUserInfo.swift in Sources */,
 				E1E4CE0B1773C59B00430844 /* WPAvatarSource.m in Sources */,
 				983DBBAB22125DD500753988 /* StatsTableFooter.swift in Sources */,
@@ -10298,6 +10309,7 @@
 				7E3E7A5920E44D2F0075D159 /* FooterContentStyles.swift in Sources */,
 				E19B17B21E5C8F36007517C6 /* AbstractPost.swift in Sources */,
 				912347762216E27200BD9F97 /* GutenbergViewController+Localization.swift in Sources */,
+				73AC468822319CB4002F7F39 /* PeriodDataStub.swift in Sources */,
 				D816C1F420E0895E00C4D82F /* MarkAsSpam.swift in Sources */,
 				4349BFF7221205740084F200 /* BlogDetailsSectionHeaderView.swift in Sources */,
 				5D577D361891360900B964C3 /* PostGeolocationView.m in Sources */,


### PR DESCRIPTION
### Description
Fixes #11063, which calls for the introduction of chart styling for period data, with an emphasis on the overlay of Visitors / Views data. 

To test:

- Checkout the branch, confirm that it builds & tests pass.
- For a site, navigate to Stats, and select a given period (i.e., Days, Weeks, Months, Years). 
- Please note that at the moment, the chart is the same regardless of period or dimension (Views, Visitors, Likes, Comments).

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

### Exhibits

![11063pr](https://user-images.githubusercontent.com/221062/53986264-81699180-40d2-11e9-9d8b-18c5aca0ef6a.gif)

_iPad - Portrait_
<img width="878" alt="11063pr_ipadportrait" src="https://user-images.githubusercontent.com/221062/53986211-626aff80-40d2-11e9-9357-bece93442141.png">

_iPad - Landscape_
<img width="1109" alt="11063pr_ipadlandscape" src="https://user-images.githubusercontent.com/221062/53986210-626aff80-40d2-11e9-99c2-66e45cd3289b.png">

_iPhone SE_
<img width="504" alt="11063pr_iphonese" src="https://user-images.githubusercontent.com/221062/53986212-626aff80-40d2-11e9-836c-c72a72665752.png">