### PR TITLE
Issue/merge fix for security token

### DIFF
--- a/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
+++ b/WordPress/Classes/Extensions/UIImageView+SiteIcon.swift
@@ -67,7 +67,7 @@ extension UIImageView {
         }
 
         let request: URLRequest
-        if blog.isPrivate() {
+        if blog.isPrivate(), PrivateSiteURLProtocol.urlGoes(toWPComSite: siteIconURL) {
             request = PrivateSiteURLProtocol.requestForPrivateSite(from: siteIconURL)
         } else {
             request = URLRequest(url: siteIconURL)

--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -137,7 +137,7 @@ extension URL {
             return false
         }
 
-        return host.contains("wordpress.com")
+        return host.hasSuffix(".wordpress.com")
     }
 
     var isWordPressDotComPost: Bool {

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -131,10 +131,7 @@ import MobileCoreServices
         let request: URLRequest
         if url.isFileURL {
             request = URLRequest(url: url)
-        } else if let source = source,
-            source.isPrivateOnWPCom,
-            PrivateSiteURLProtocol.urlGoes(toWPComSite: url)
-        {
+        } else if let source = source, source.isPrivateOnWPCom, PrivateSiteURLProtocol.urlGoes(toWPComSite: url) {
             request = PrivateSiteURLProtocol.requestForPrivateSite(from: url)
         } else {
             if let photonUrl = getPhotonUrl(for: url, size: size),
@@ -153,7 +150,7 @@ import MobileCoreServices
         if url.isFileURL {
             downloadImage(from: url)
         } else if let source = source {
-            if source.isPrivateOnWPCom {
+            if source.isPrivateOnWPCom && PrivateSiteURLProtocol.urlGoes(toWPComSite: url) {
                 loadPrivateImage(with: url, from: source, preferredSize: size)
             } else if source.isSelfHostedWithCredentials {
                 downloadImage(from: url)

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -131,7 +131,10 @@ import MobileCoreServices
         let request: URLRequest
         if url.isFileURL {
             request = URLRequest(url: url)
-        } else if let source = source, source.isPrivateOnWPCom {
+        } else if let source = source,
+            source.isPrivateOnWPCom,
+            PrivateSiteURLProtocol.urlGoes(toWPComSite: url)
+        {
             request = PrivateSiteURLProtocol.requestForPrivateSite(from: url)
         } else {
             if let photonUrl = getPhotonUrl(for: url, size: size),

--- a/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/EditorMediaUtility.swift
@@ -60,7 +60,7 @@ class EditorMediaUtility {
 
         if url.isFileURL {
             request = URLRequest(url: url)
-        } else if post.blog.isPrivate() && (url.host?.hasSuffix("wordpress.com") ?? false) {
+        } else if post.blog.isPrivate() && PrivateSiteURLProtocol.urlGoes(toWPComSite: url) {
             // private wpcom image needs special handling.
             // the size that WPImageHelper expects is pixel size
             size.width = size.width * scale

--- a/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.h
+++ b/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.h
@@ -22,4 +22,6 @@
 
 + (nonnull NSURLRequest *)requestForPrivateSiteFromURL:(nonnull NSURL *)url;
 
++ (BOOL)urlGoesToWPComSite:(nonnull NSURL *)url;
+
 @end

--- a/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.m
+++ b/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.m
@@ -98,7 +98,12 @@ static NSString *cachedToken;
 
 + (BOOL)requestGoesToWPComSite:(NSURLRequest *)request
 {
-    if ([request.URL.scheme isEqualToString:@"https"] && [request.URL.host hasSuffix:@".wordpress.com"]) {
+    return [self urlGoesToWPComSite:request.URL];
+}
+
++ (BOOL)urlGoesToWPComSite:(NSURL *)url
+{
+    if ([url.scheme isEqualToString:@"https"] && [url.host hasSuffix:@".wordpress.com"]) {
         return YES;
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.m
+++ b/WordPress/Classes/ViewRelated/Post/PrivateSiteURLProtocol.m
@@ -112,6 +112,9 @@ static NSString *cachedToken;
 
 + (NSURLRequest *)requestForPrivateSiteFromURL:(NSURL *)url
 {
+    if (![self urlGoesToWPComSite:url]) {
+        return [NSURLRequest requestWithURL:url];
+    }
     NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:YES];
     //make sure the scheme used is https
     [urlComponents setScheme:@"https"];


### PR DESCRIPTION
This PR brings the fixes we did here: https://github.com/wordpress-mobile/WordPress-iOS/pull/11208 to develop.

I cherry-picked the commits we did for 11.0 to avoid any future problems in the merge of 11.9 to develop.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
