### PR TITLE
Issue/11094 fix crash after removing self hosted

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -6,6 +6,9 @@ private var observer: NSObjectProtocol?
 extension BlogDetailsViewController {
     @objc func startObservingQuickStart() {
         observer = NotificationCenter.default.addObserver(forName: .QuickStartTourElementChangedNotification, object: nil, queue: nil) { [weak self] (notification) in
+            guard self?.blog.managedObjectContext != nil else {
+                return
+            }
             self?.configureTableViewData()
             self?.reloadTableViewPreservingSelection()
             if let index = QuickStartTourGuide.find()?.currentElementInt(),

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
@@ -79,11 +79,6 @@
                BlueprintName = "WordPressUITests"
                ReferencedContainer = "container:WordPress.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "LoginTests/testSelfHostedUsernamePasswordLoginLogout()">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -56,7 +56,7 @@ class LoginTests: XCTestCase {
 
         XCTAssert(MySiteScreen().isLoaded())
     }
-    
+
     func testSelfHostedUsernamePasswordLoginLogout() {
         _ = WelcomeScreen().login()
             .goToSiteAddressLogin()

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -56,10 +56,7 @@ class LoginTests: XCTestCase {
 
         XCTAssert(MySiteScreen().isLoaded())
     }
-
-    /*
-     This test is currently disabled pending resolution of this crash: https://github.com/wordpress-mobile/WordPress-iOS/issues/11094
-     */
+    
     func testSelfHostedUsernamePasswordLoginLogout() {
         _ = WelcomeScreen().login()
             .goToSiteAddressLogin()


### PR DESCRIPTION
Fixes #11094 

This PR adds an extra check on quick start to verify if a blog is still there when a notification for a step is received.

To test:
 - Clean the app from your simulator
 - Start the app using a self-hosted sited
 - Login to it
 - Immediately after the login is done go to site settings and press remove site.
 - Confirm
 - Check if no crash happens.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
