### PR TITLE
Updating aztec and gutenberg refs to test Aztec v1.4.4

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -26,8 +26,8 @@ def aztec
     ## When using a tagged version, feel free to comment out the WordPress-Aztec-iOS line below.
     ## When using a commit number (during development) you should provide the same commit number for both pods.
     ##
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ddb854283b982934d251d6fc4aa976cf79043cba'
-    pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ddb854283b982934d251d6fc4aa976cf79043cba'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'a61fb769c1e0c8cabd0ff46234f0f1c72740faac'
+    pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'a61fb769c1e0c8cabd0ff46234f0f1c72740faac'
     ## pod 'WordPress-Editor-iOS', '1.4.3'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -26,9 +26,9 @@ def aztec
     ## When using a tagged version, feel free to comment out the WordPress-Aztec-iOS line below.
     ## When using a commit number (during development) you should provide the same commit number for both pods.
     ##
-    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'a61fb769c1e0c8cabd0ff46234f0f1c72740faac'
-    pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'a61fb769c1e0c8cabd0ff46234f0f1c72740faac'
-    ## pod 'WordPress-Editor-iOS', '1.4.3'
+    ## pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'a61fb769c1e0c8cabd0ff46234f0f1c72740faac'
+    ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'a61fb769c1e0c8cabd0ff46234f0f1c72740faac'
+    pod 'WordPress-Editor-iOS', '1.4.4'
 end
 
 def wordpress_ui

--- a/Podfile
+++ b/Podfile
@@ -8,17 +8,6 @@ workspace 'WordPress.xcworkspace'
 
 plugin 'cocoapods-repo-update'
 
-post_install do |installer|
-    installer.pods_project.targets.each do |target|
-        if ['WordPress-Aztec-iOS', 'WordPress-Editor-iOS'].include? target.name
-            target.build_configurations.each do |config|
-                config.build_settings['SWIFT_VERSION'] = '4.0'
-            end
-        end
-    end
-end
-
-
 ## Pods shared between all the targets
 ## ===================================
 ##
@@ -37,9 +26,9 @@ def aztec
     ## When using a tagged version, feel free to comment out the WordPress-Aztec-iOS line below.
     ## When using a commit number (during development) you should provide the same commit number for both pods.
     ##
-    ## pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'e0fc55abb4809b3b23b6d8b56791798af864025d'
-    ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'e0fc55abb4809b3b23b6d8b56791798af864025d'
-    pod 'WordPress-Editor-iOS', '1.4.3'
+    pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ddb854283b982934d251d6fc4aa976cf79043cba'
+    pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'ddb854283b982934d251d6fc4aa976cf79043cba'
+    ## pod 'WordPress-Editor-iOS', '1.4.3'
 end
 
 def wordpress_ui
@@ -100,7 +89,7 @@ target 'WordPress' do
     ## React Native
     ## =====================
     ##
-    gutenberg :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => 'a7af71c0398d0a3901583ba26a91ecbed56bf2d2'
+    gutenberg :git => 'http://github.com/wordpress-mobile/gutenberg-mobile/', :commit => '8ba8b195b024809a3de545f34f8d777e5c76dba1'
 
     gutenberg_pod 'React'
     gutenberg_pod 'yoga'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -176,9 +176,9 @@ PODS:
   - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPress-Aztec-iOS (1.4.3)
-  - WordPress-Editor-iOS (1.4.3):
-    - WordPress-Aztec-iOS (= 1.4.3)
+  - WordPress-Aztec-iOS (1.4.4)
+  - WordPress-Editor-iOS (1.4.4):
+    - WordPress-Aztec-iOS (= 1.4.4)
   - WordPressAuthenticator (1.1.10-beta.1):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
@@ -247,8 +247,8 @@ DEPENDENCIES:
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `ddb854283b982934d251d6fc4aa976cf79043cba`)
-  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `ddb854283b982934d251d6fc4aa976cf79043cba`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `a61fb769c1e0c8cabd0ff46234f0f1c72740faac`)
+  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `a61fb769c1e0c8cabd0ff46234f0f1c72740faac`)
   - WordPressAuthenticator (~> 1.1.10-beta.1)
   - WordPressKit (~> 3.0.0-beta.2)
   - WordPressShared (= 1.7.2-beta.1)
@@ -319,10 +319,10 @@ EXTERNAL SOURCES:
     :commit: 8ba8b195b024809a3de545f34f8d777e5c76dba1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPress-Aztec-iOS:
-    :commit: ddb854283b982934d251d6fc4aa976cf79043cba
+    :commit: a61fb769c1e0c8cabd0ff46234f0f1c72740faac
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPress-Editor-iOS:
-    :commit: ddb854283b982934d251d6fc4aa976cf79043cba
+    :commit: a61fb769c1e0c8cabd0ff46234f0f1c72740faac
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -347,10 +347,10 @@ CHECKOUT OPTIONS:
     :commit: 8ba8b195b024809a3de545f34f8d777e5c76dba1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPress-Aztec-iOS:
-    :commit: ddb854283b982934d251d6fc4aa976cf79043cba
+    :commit: a61fb769c1e0c8cabd0ff46234f0f1c72740faac
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPress-Editor-iOS:
-    :commit: ddb854283b982934d251d6fc4aa976cf79043cba
+    :commit: a61fb769c1e0c8cabd0ff46234f0f1c72740faac
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -395,8 +395,8 @@ SPEC CHECKSUMS:
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPress-Aztec-iOS: 303eba6120a17dd2798e15c8ecb7d9995cb36d99
-  WordPress-Editor-iOS: 0836f494be83657541dff61d32ea25851d5566fd
+  WordPress-Aztec-iOS: b4a1fac03f617eea9882336bf64f122cbc60e727
+  WordPress-Editor-iOS: 9787d07b2362457952fb74e4f09fa63bbf22cf14
   WordPressAuthenticator: 80cda36379dfee8772ad1b2e9c7f4541ccba0500
   WordPressKit: 819f7573ab38312138f78a0394cd2576404a7f98
   WordPressShared: 02a2f4d490c44536b55fe59eeb2e72e95bd56697
@@ -406,6 +406,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 8d8c356ccd95d42dd3be0e50a5379778f2528b4a
+PODFILE CHECKSUM: d46e51478ec7ae41b765c36575a8d87179ab7123
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -247,8 +247,7 @@ DEPENDENCIES:
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `a61fb769c1e0c8cabd0ff46234f0f1c72740faac`)
-  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `a61fb769c1e0c8cabd0ff46234f0f1c72740faac`)
+  - WordPress-Editor-iOS (= 1.4.4)
   - WordPressAuthenticator (~> 1.1.10-beta.1)
   - WordPressKit (~> 3.0.0-beta.2)
   - WordPressShared (= 1.7.2-beta.1)
@@ -289,6 +288,8 @@ SPEC REPOS:
     - Starscream
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPress-Aztec-iOS
+    - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
@@ -318,12 +319,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 8ba8b195b024809a3de545f34f8d777e5c76dba1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPress-Aztec-iOS:
-    :commit: a61fb769c1e0c8cabd0ff46234f0f1c72740faac
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WordPress-Editor-iOS:
-    :commit: a61fb769c1e0c8cabd0ff46234f0f1c72740faac
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -346,12 +341,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 8ba8b195b024809a3de545f34f8d777e5c76dba1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
-  WordPress-Aztec-iOS:
-    :commit: a61fb769c1e0c8cabd0ff46234f0f1c72740faac
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WordPress-Editor-iOS:
-    :commit: a61fb769c1e0c8cabd0ff46234f0f1c72740faac
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -406,6 +395,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: d46e51478ec7ae41b765c36575a8d87179ab7123
+PODFILE CHECKSUM: 231b6e68fd84d9fd681649cd84d7e492d73e5955
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -228,7 +228,7 @@ DEPENDENCIES:
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `a7af71c0398d0a3901583ba26a91ecbed56bf2d2`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `8ba8b195b024809a3de545f34f8d777e5c76dba1`)
   - HockeySDK (= 5.1.4)
   - MGSwipeTableCell (= 1.6.8)
   - MRProgress (= 0.8.3)
@@ -243,11 +243,12 @@ DEPENDENCIES:
   - react-native-keyboard-aware-scroll-view (from `https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git`, tag `gb-v0.8.6`)
   - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `8.0.9-gb.0`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `a7af71c0398d0a3901583ba26a91ecbed56bf2d2`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `8ba8b195b024809a3de545f34f8d777e5c76dba1`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
-  - WordPress-Editor-iOS (= 1.4.3)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `ddb854283b982934d251d6fc4aa976cf79043cba`)
+  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `ddb854283b982934d251d6fc4aa976cf79043cba`)
   - WordPressAuthenticator (~> 1.1.10-beta.1)
   - WordPressKit (~> 3.0.0-beta.2)
   - WordPressShared (= 1.7.2-beta.1)
@@ -288,8 +289,6 @@ SPEC REPOS:
     - Starscream
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPress-Aztec-iOS
-    - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
@@ -304,7 +303,7 @@ EXTERNAL SOURCES:
   Folly:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: a7af71c0398d0a3901583ba26a91ecbed56bf2d2
+    :commit: 8ba8b195b024809a3de545f34f8d777e5c76dba1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/master/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
@@ -317,8 +316,14 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: a7af71c0398d0a3901583ba26a91ecbed56bf2d2
+    :commit: 8ba8b195b024809a3de545f34f8d777e5c76dba1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPress-Aztec-iOS:
+    :commit: ddb854283b982934d251d6fc4aa976cf79043cba
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPress-Editor-iOS:
+    :commit: ddb854283b982934d251d6fc4aa976cf79043cba
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -330,7 +335,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.3.2
   Gutenberg:
-    :commit: a7af71c0398d0a3901583ba26a91ecbed56bf2d2
+    :commit: 8ba8b195b024809a3de545f34f8d777e5c76dba1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   react-native-keyboard-aware-scroll-view:
     :git: https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git
@@ -339,8 +344,14 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 8.0.9-gb.0
   RNTAztecView:
-    :commit: a7af71c0398d0a3901583ba26a91ecbed56bf2d2
+    :commit: 8ba8b195b024809a3de545f34f8d777e5c76dba1
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPress-Aztec-iOS:
+    :commit: ddb854283b982934d251d6fc4aa976cf79043cba
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPress-Editor-iOS:
+    :commit: ddb854283b982934d251d6fc4aa976cf79043cba
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -384,8 +395,8 @@ SPEC CHECKSUMS:
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPress-Aztec-iOS: 0062ba96c3ea77186590c74b761427c461f89a06
-  WordPress-Editor-iOS: cfaa780c3ee64ea781fe6f52ca1561667a3f3707
+  WordPress-Aztec-iOS: 303eba6120a17dd2798e15c8ecb7d9995cb36d99
+  WordPress-Editor-iOS: 0836f494be83657541dff61d32ea25851d5566fd
   WordPressAuthenticator: 80cda36379dfee8772ad1b2e9c7f4541ccba0500
   WordPressKit: 819f7573ab38312138f78a0394cd2576404a7f98
   WordPressShared: 02a2f4d490c44536b55fe59eeb2e72e95bd56697
@@ -395,6 +406,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: bf5ac6f453746919c96d6fef5cf917a405354b07
+PODFILE CHECKSUM: 8d8c356ccd95d42dd3be0e50a5379778f2528b4a
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
This PR updates Aztec to 1.4.4. It also updates Gutenberg with the changes needed to handle the changes on Aztec.

Starting with commit hashes before the formal Aztec release.