### PR TITLE
Update Fastlane to upload dSYMs to Fabric for the internal version

### DIFF
--- a/Scripts/fastlane/Fastfile
+++ b/Scripts/fastlane/Fastfile
@@ -207,6 +207,7 @@ import "./ScreenshotFastfile"
         ipa: "../build/WordPress Internal.ipa",
         dsym: "../build/WordPress.app.dSYM.zip")
     
+    upload_symbols_to_crashlytics(dsym_path: "../build/WordPress.app.dSYM.zip", api_token: ENV["FABRIC_APP_TOKEN"])
   end
 
   #####################################################################################


### PR DESCRIPTION
This PR fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/11169 by adding the upload of the symbols to Fabric.

It will probably make sense to remove the upload of the symbols to HockeyApp in the future, as they have little usage there. Let's tackle it as a part of the upcoming migration.

To test:
1. Update the internal version of the app.
2. run `bundle exec fastlane build_and_upload_internal` (you need to remove some checks or to commit the previous changes in order to make this work).
3. Verify that the previous command finishes without errors.
4. Verity that the symbols have been uploaded.
5. Delete the app from Hockey and the dSYM from Fabric.


I tested it while building the latest beta.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
