### PR TITLE
Display error message provided by the server when setting change fails.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 12.1
 -----
- 
+* Improve messages when updates to user account details fail because of server logic, for exanple email being used for another account.
+
 12.0
 -----
 * Redesigned Notices

--- a/WordPress/Classes/Services/AccountSettingsService.swift
+++ b/WordPress/Classes/Services/AccountSettingsService.swift
@@ -120,9 +120,8 @@ class AccountSettingsService {
                 DDLogError("Error reverting change \(error)")
             }
             DDLogError("Error saving account settings change \(error)")
-            // TODO: show/return error to the user (@koke 2015-11-24)
-            // What should be showing the error? Let's post a notification for now so something else can handle it
-            NotificationCenter.default.post(name: NSNotification.Name.AccountSettingsServiceChangeSaveFailed, object: error as NSError)
+            
+            NotificationCenter.default.post(name: NSNotification.Name.AccountSettingsServiceChangeSaveFailed, object: self, userInfo: [NSUnderlyingErrorKey: error])
 
             finished?(false)
         }

--- a/WordPress/Classes/Services/AccountSettingsService.swift
+++ b/WordPress/Classes/Services/AccountSettingsService.swift
@@ -120,7 +120,7 @@ class AccountSettingsService {
                 DDLogError("Error reverting change \(error)")
             }
             DDLogError("Error saving account settings change \(error)")
-            
+
             NotificationCenter.default.post(name: NSNotification.Name.AccountSettingsServiceChangeSaveFailed, object: self, userInfo: [NSUnderlyingErrorKey: error])
 
             finished?(false)

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -47,7 +47,7 @@ private class AccountSettingsController: SettingsController {
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(self, selector: #selector(AccountSettingsController.loadStatus), name: NSNotification.Name.AccountSettingsServiceRefreshStatusChanged, object: nil)
         notificationCenter.addObserver(self, selector: #selector(AccountSettingsController.loadSettings), name: NSNotification.Name.AccountSettingsChanged, object: nil)
-        notificationCenter.addObserver(self, selector: #selector(AccountSettingsController.showSettingsChangeErrorMessage), name: NSNotification.Name.AccountSettingsServiceChangeSaveFailed, object:nil)
+        notificationCenter.addObserver(self, selector: #selector(AccountSettingsController.showSettingsChangeErrorMessage), name: NSNotification.Name.AccountSettingsServiceChangeSaveFailed, object: nil)
     }
 
     func refreshModel() {
@@ -202,7 +202,7 @@ private class AccountSettingsController: SettingsController {
         }
     }
 
-    @objc fileprivate func showSettingsChangeErrorMessage(notification: NSNotification){
+    @objc fileprivate func showSettingsChangeErrorMessage(notification: NSNotification) {
         guard let error = notification.userInfo?[NSUnderlyingErrorKey] as? NSError,
             let errorMessage = error.userInfo[WordPressComRestApi.ErrorKeyErrorMessage] as? String else {
                 return

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -47,6 +47,7 @@ private class AccountSettingsController: SettingsController {
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(self, selector: #selector(AccountSettingsController.loadStatus), name: NSNotification.Name.AccountSettingsServiceRefreshStatusChanged, object: nil)
         notificationCenter.addObserver(self, selector: #selector(AccountSettingsController.loadSettings), name: NSNotification.Name.AccountSettingsChanged, object: nil)
+        notificationCenter.addObserver(self, selector: #selector(AccountSettingsController.showSettingsChangeErrorMessage), name: NSNotification.Name.AccountSettingsServiceChangeSaveFailed, object:nil)
     }
 
     func refreshModel() {
@@ -201,6 +202,13 @@ private class AccountSettingsController: SettingsController {
         }
     }
 
+    @objc fileprivate func showSettingsChangeErrorMessage(notification: NSNotification){
+        guard let error = notification.userInfo?[NSUnderlyingErrorKey] as? NSError,
+            let errorMessage = error.userInfo[WordPressComRestApi.ErrorKeyErrorMessage] as? String else {
+                return
+        }
+        SVProgressHUD.showError(withStatus: errorMessage)
+    }
 
     // MARK: - Private Helpers
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1680,6 +1680,7 @@
 		FF2EC3C02209A144006176E1 /* GutenbergImgUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2EC3BF2209A144006176E1 /* GutenbergImgUploadProcessor.swift */; };
 		FF2EC3C22209AC19006176E1 /* GutenbergImgUploadProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2EC3C12209AC19006176E1 /* GutenbergImgUploadProcessorTests.swift */; };
 		FF355D981FB492DD00244E6D /* ExportableAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF355D971FB492DD00244E6D /* ExportableAsset.swift */; };
+		FF37F90922385CA000AFA3DB /* RELEASE-NOTES.txt in Resources */ = {isa = PBXBuildFile; fileRef = FF37F90822385C9F00AFA3DB /* RELEASE-NOTES.txt */; };
 		FF4258501BA092EE00580C68 /* RelatedPostsSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = FF42584F1BA092EE00580C68 /* RelatedPostsSettingsViewController.m */; };
 		FF4C069F206560E500E0B2BC /* MediaThumbnailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF4C069E206560E500E0B2BC /* MediaThumbnailCoordinator.swift */; };
 		FF5371631FDFF64F00619A3F /* MediaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF5371621FDFF64F00619A3F /* MediaService.swift */; };
@@ -3844,6 +3845,7 @@
 		FF2EC3BF2209A144006176E1 /* GutenbergImgUploadProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergImgUploadProcessor.swift; sourceTree = "<group>"; };
 		FF2EC3C12209AC19006176E1 /* GutenbergImgUploadProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GutenbergImgUploadProcessorTests.swift; path = Gutenberg/GutenbergImgUploadProcessorTests.swift; sourceTree = "<group>"; };
 		FF355D971FB492DD00244E6D /* ExportableAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExportableAsset.swift; sourceTree = "<group>"; };
+		FF37F90822385C9F00AFA3DB /* RELEASE-NOTES.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "RELEASE-NOTES.txt"; path = "../RELEASE-NOTES.txt"; sourceTree = "<group>"; };
 		FF42584E1BA092EE00580C68 /* RelatedPostsSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RelatedPostsSettingsViewController.h; sourceTree = "<group>"; };
 		FF42584F1BA092EE00580C68 /* RelatedPostsSettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RelatedPostsSettingsViewController.m; sourceTree = "<group>"; };
 		FF4C069E206560E500E0B2BC /* MediaThumbnailCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaThumbnailCoordinator.swift; sourceTree = "<group>"; };
@@ -4377,6 +4379,7 @@
 				93FA0F0118E451A80007903B /* LICENSE */,
 				93FA0F0218E451A80007903B /* README.md */,
 				E16273E21B2AD89A00088AF7 /* MIGRATIONS.md */,
+				FF37F90822385C9F00AFA3DB /* RELEASE-NOTES.txt */,
 				B565D41C3DB27630CD503F9A /* Pods */,
 			);
 			name = CustomTemplate;
@@ -8781,6 +8784,7 @@
 				747D09862034837C0085EABF /* WordPressShare.js in Resources */,
 				B5C66B721ACF071100F68370 /* NoteBlockTextTableViewCell.xib in Resources */,
 				E60C2ED51DE5048200488630 /* ReaderCommentCell.xib in Resources */,
+				FF37F90922385CA000AFA3DB /* RELEASE-NOTES.txt in Resources */,
 				9808655A203D075E00D58786 /* EpilogueUserInfoCell.xib in Resources */,
 				E6D2E1611B8AA4410000ED14 /* ReaderTagStreamHeader.xib in Resources */,
 				B5CEEB901B79244D00E7B7B0 /* CommentsTableViewCell.xib in Resources */,


### PR DESCRIPTION
Fixes #11214

This PR adds the error message to the notification when account settings fail to update and display an error message if one is provided by the server.

![Simulator Screen Shot - iPhone XR - 2019-03-11 at 16 04 19](https://user-images.githubusercontent.com/651601/54138443-6327cc80-4417-11e9-801a-eae10258a673.png)

To test:
 - Open the app
 - Make sure you are logged in with a WP account
 - Open Me->Account Settings
 - Try to change your email to an email already being used.
 - Check that an error notification is displayed like above

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
