### PR TITLE
[Stats Refresh] Post Stats: add chart card

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -109,6 +109,10 @@ extension WPStyleGuide {
             label.font = postTitleFont
         }
 
+        static func configureLabelForOverview(_ label: UILabel) {
+            label.textColor = defaultTextColor
+        }
+
         static func highlightString(_ subString: String, inString: String) -> NSAttributedString {
             let attributedString = NSMutableAttributedString(string: inString)
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -55,13 +55,16 @@ class OverviewCell: UITableViewCell, NibLoadable {
 
     // MARK: - Properties
 
-    @IBOutlet weak var filterTabBar: FilterTabBar!
+    @IBOutlet weak var topSeparatorLine: UIView!
     @IBOutlet weak var selectedLabel: UILabel!
     @IBOutlet weak var selectedData: UILabel!
     @IBOutlet weak var differenceLabel: UILabel!
     @IBOutlet weak var chartContainerView: UIView!
     @IBOutlet weak var chartBottomConstraint: NSLayoutConstraint!
+    @IBOutlet weak var filterTabBar: FilterTabBar!
+    @IBOutlet weak var bottomSeparatorLine: UIView!
 
+    private typealias Style = WPStyleGuide.Stats
     private var tabsData = [OverviewTabData]()
 
     // Introduced via #11063, to be replaced with real data via #11069
@@ -77,7 +80,7 @@ class OverviewCell: UITableViewCell, NibLoadable {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        configureFonts()
+        applyStyles()
     }
 
     func configure(tabsData: [OverviewTabData]) {
@@ -91,6 +94,12 @@ class OverviewCell: UITableViewCell, NibLoadable {
 // MARK: - Private Extension
 
 private extension OverviewCell {
+
+    func applyStyles() {
+        Style.configureViewAsSeparator(topSeparatorLine)
+        Style.configureViewAsSeparator(bottomSeparatorLine)
+        configureFonts()
+    }
 
     /// This method squelches two Xcode warnings that I encountered:
     /// 1. Attribute Unavailable: Large Title font text style before iOS 11.0
@@ -121,7 +130,7 @@ private extension OverviewCell {
             ChartBottomMargin.filterTabBarHidden :
             ChartBottomMargin.filterTabBarShown
 
-        WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forOverviewCard: true)
+        Style.configureFilterTabBar(filterTabBar, forOverviewCard: true)
         filterTabBar.items = tabsData
         filterTabBar.tabBarHeight = 60.0
         filterTabBar.equalWidthFill = .fillProportionally

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -60,6 +60,7 @@ class OverviewCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var selectedData: UILabel!
     @IBOutlet weak var differenceLabel: UILabel!
     @IBOutlet weak var chartContainerView: UIView!
+    @IBOutlet weak var chartBottomConstraint: NSLayoutConstraint!
 
     private var tabsData = [OverviewTabData]()
 
@@ -111,6 +112,15 @@ private extension OverviewCell {
     }
 
     func setupFilterBar() {
+
+        // If there is only one tab data, this is being displayed on the
+        // Post Stats view, which does not have a filterTabBar.
+        filterTabBar.isHidden = tabsData.count == 1
+
+        chartBottomConstraint.constant = filterTabBar.isHidden ?
+            ChartBottomMargin.filterTabBarHidden :
+            ChartBottomMargin.filterTabBarShown
+
         WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forOverviewCard: true)
         filterTabBar.items = tabsData
         filterTabBar.tabBarHeight = 60.0
@@ -153,4 +163,10 @@ private extension OverviewCell {
             chartView.bottomAnchor.constraint(equalTo: chartContainerView.bottomAnchor)
         ])
     }
+
+    private enum ChartBottomMargin {
+        static let filterTabBarShown = CGFloat(16)
+        static let filterTabBarHidden = CGFloat(24)
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -96,6 +96,8 @@ class OverviewCell: UITableViewCell, NibLoadable {
 private extension OverviewCell {
 
     func applyStyles() {
+        Style.configureLabelForOverview(selectedLabel)
+        Style.configureLabelForOverview(selectedData)
         Style.configureViewAsSeparator(topSeparatorLine)
         Style.configureViewAsSeparator(bottomSeparatorLine)
         configureFonts()

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
@@ -19,6 +19,13 @@
                 <rect key="frame" x="0.0" y="0.0" width="454" height="303.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sij-a6-mJ5" userLabel="Top Separator Line">
+                        <rect key="frame" x="0.0" y="0.0" width="454" height="0.5"/>
+                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.5" id="Pdm-u4-3uG"/>
+                        </constraints>
+                    </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="40,000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gKw-lF-4O8" userLabel="Selected Data">
                         <rect key="frame" x="16" y="24" width="100.5" height="36"/>
                         <fontDescription key="fontDescription" type="system" pointSize="30"/>
@@ -53,12 +60,23 @@
                             </view>
                         </subviews>
                     </stackView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JKw-M5-MmY" userLabel="Bottom Separator Line">
+                        <rect key="frame" x="0.0" y="303" width="454" height="0.5"/>
+                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.5" id="9YE-mu-3ZR"/>
+                        </constraints>
+                    </view>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="sij-a6-mJ5" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="0Or-8K-9tS"/>
+                    <constraint firstItem="sij-a6-mJ5" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="1hn-rO-HQO"/>
                     <constraint firstAttribute="bottom" secondItem="OOf-64-W6S" secondAttribute="bottom" id="3O1-ab-zrX"/>
                     <constraint firstAttribute="trailing" secondItem="OOf-64-W6S" secondAttribute="trailing" id="3zN-y7-vSh"/>
                     <constraint firstAttribute="trailing" secondItem="LXK-k6-Sxa" secondAttribute="trailing" constant="16" id="454-qg-2dp"/>
                     <constraint firstItem="OOf-64-W6S" firstAttribute="top" secondItem="LXK-k6-Sxa" secondAttribute="bottom" priority="999" constant="16" id="45u-jA-D6l"/>
+                    <constraint firstAttribute="trailing" secondItem="sij-a6-mJ5" secondAttribute="trailing" id="4tM-Kt-WmO"/>
+                    <constraint firstAttribute="bottom" secondItem="JKw-M5-MmY" secondAttribute="bottom" id="7ie-6i-dY4"/>
                     <constraint firstItem="gKw-lF-4O8" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="24" id="9FM-On-UC6"/>
                     <constraint firstItem="mh8-GY-DEC" firstAttribute="bottom" secondItem="jZK-cD-I2s" secondAttribute="bottom" id="B5Q-FJ-CHg"/>
                     <constraint firstAttribute="trailing" secondItem="mh8-GY-DEC" secondAttribute="trailing" constant="16" id="DHi-ub-ILb"/>
@@ -66,19 +84,23 @@
                     <constraint firstItem="jZK-cD-I2s" firstAttribute="leading" secondItem="gKw-lF-4O8" secondAttribute="trailing" constant="8" id="dru-cE-A0o"/>
                     <constraint firstItem="jZK-cD-I2s" firstAttribute="bottom" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="-5" id="dwL-lH-n2U"/>
                     <constraint firstItem="mh8-GY-DEC" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="jZK-cD-I2s" secondAttribute="trailing" constant="5" id="lU5-Jo-nfk"/>
+                    <constraint firstAttribute="trailing" secondItem="JKw-M5-MmY" secondAttribute="trailing" id="o73-YK-rux"/>
                     <constraint firstItem="gKw-lF-4O8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="pOA-dn-Yoy"/>
                     <constraint firstItem="LXK-k6-Sxa" firstAttribute="top" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="16" id="pZe-NH-yiM"/>
                     <constraint firstItem="OOf-64-W6S" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="r8Y-d5-su4"/>
+                    <constraint firstItem="JKw-M5-MmY" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="tUf-r7-46a"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="bottomSeparatorLine" destination="JKw-M5-MmY" id="VUu-ZD-CdC"/>
                 <outlet property="chartBottomConstraint" destination="45u-jA-D6l" id="2z3-wy-1Su"/>
                 <outlet property="chartContainerView" destination="LXK-k6-Sxa" id="0yE-3G-QlU"/>
                 <outlet property="differenceLabel" destination="mh8-GY-DEC" id="G27-Xv-ACi"/>
                 <outlet property="filterTabBar" destination="0aY-pl-E5I" id="Mwy-fv-SNw"/>
                 <outlet property="selectedData" destination="gKw-lF-4O8" id="aKK-1U-o6H"/>
                 <outlet property="selectedLabel" destination="jZK-cD-I2s" id="rTe-0x-iDM"/>
+                <outlet property="topSeparatorLine" destination="sij-a6-mJ5" id="Rrp-Qf-xtx"/>
             </connections>
             <point key="canvasLocation" x="-433.60000000000002" y="143.02848575712144"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.xib
@@ -44,30 +44,36 @@
                             <constraint firstAttribute="height" constant="150" id="SdW-hH-eUG"/>
                         </constraints>
                     </view>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0aY-pl-E5I" customClass="FilterTabBar" customModule="WordPress">
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="OOf-64-W6S" userLabel="Filter Bar Stack View">
                         <rect key="frame" x="0.0" y="242" width="454" height="61.5"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    </view>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0aY-pl-E5I" customClass="FilterTabBar" customModule="WordPress">
+                                <rect key="frame" x="0.0" y="0.0" width="454" height="61.5"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </view>
+                        </subviews>
+                    </stackView>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="bottom" secondItem="OOf-64-W6S" secondAttribute="bottom" id="3O1-ab-zrX"/>
+                    <constraint firstAttribute="trailing" secondItem="OOf-64-W6S" secondAttribute="trailing" id="3zN-y7-vSh"/>
                     <constraint firstAttribute="trailing" secondItem="LXK-k6-Sxa" secondAttribute="trailing" constant="16" id="454-qg-2dp"/>
-                    <constraint firstItem="0aY-pl-E5I" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="5cX-TG-kxs"/>
+                    <constraint firstItem="OOf-64-W6S" firstAttribute="top" secondItem="LXK-k6-Sxa" secondAttribute="bottom" priority="999" constant="16" id="45u-jA-D6l"/>
                     <constraint firstItem="gKw-lF-4O8" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="24" id="9FM-On-UC6"/>
                     <constraint firstItem="mh8-GY-DEC" firstAttribute="bottom" secondItem="jZK-cD-I2s" secondAttribute="bottom" id="B5Q-FJ-CHg"/>
                     <constraint firstAttribute="trailing" secondItem="mh8-GY-DEC" secondAttribute="trailing" constant="16" id="DHi-ub-ILb"/>
                     <constraint firstItem="LXK-k6-Sxa" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="HS3-PH-hEI"/>
-                    <constraint firstAttribute="trailing" secondItem="0aY-pl-E5I" secondAttribute="trailing" id="SLP-II-oop"/>
                     <constraint firstItem="jZK-cD-I2s" firstAttribute="leading" secondItem="gKw-lF-4O8" secondAttribute="trailing" constant="8" id="dru-cE-A0o"/>
                     <constraint firstItem="jZK-cD-I2s" firstAttribute="bottom" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="-5" id="dwL-lH-n2U"/>
                     <constraint firstItem="mh8-GY-DEC" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="jZK-cD-I2s" secondAttribute="trailing" constant="5" id="lU5-Jo-nfk"/>
                     <constraint firstItem="gKw-lF-4O8" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="pOA-dn-Yoy"/>
                     <constraint firstItem="LXK-k6-Sxa" firstAttribute="top" secondItem="gKw-lF-4O8" secondAttribute="bottom" constant="16" id="pZe-NH-yiM"/>
-                    <constraint firstAttribute="bottom" secondItem="0aY-pl-E5I" secondAttribute="bottom" id="udu-TY-7zo"/>
-                    <constraint firstItem="0aY-pl-E5I" firstAttribute="top" secondItem="LXK-k6-Sxa" secondAttribute="bottom" constant="16" id="zFm-ns-JaB"/>
+                    <constraint firstItem="OOf-64-W6S" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="r8Y-d5-su4"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="chartBottomConstraint" destination="45u-jA-D6l" id="2z3-wy-1Su"/>
                 <outlet property="chartContainerView" destination="LXK-k6-Sxa" id="0yE-3G-QlU"/>
                 <outlet property="differenceLabel" destination="mh8-GY-DEC" id="G27-Xv-ACi"/>
                 <outlet property="filterTabBar" destination="0aY-pl-E5I" id="Mwy-fv-SNw"/>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -44,6 +44,7 @@ private extension PostStatsTableViewController {
     func tableRowTypes() -> [ImmuTableRow.Type] {
         return [CellHeaderRow.self,
                 PostStatsTitleRow.self,
+                OverviewRow.self,
                 TableFooterRow.self]
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -23,6 +23,7 @@ class PostStatsViewModel: Observable {
         var tableRows = [ImmuTableRow]()
 
         tableRows.append(titleTableRow())
+        tableRows.append(contentsOf: overviewTableRows())
 
         tableRows.append(TableFooterRow())
 
@@ -42,6 +43,18 @@ private extension PostStatsViewModel {
 
     func titleTableRow() -> ImmuTableRow {
         return PostStatsTitleRow(postTitle: postTitle ?? NSLocalizedString("(No Title)", comment: "Empty Post Title"))
+    }
+
+    func overviewTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(title: ""))
+
+        // TODO: replace with real data
+        let data = OverviewTabData(tabTitle: StatSection.periodOverviewVisitors.tabTitle, tabData: 741, difference: 22222, differencePercent: 50)
+
+        tableRows.append(OverviewRow(tabsData: [data]))
+
+        return tableRows
     }
 
 }


### PR DESCRIPTION
Ref #11189 

This adds a chart card to the Post Stats view. The chart card is the same as the Period Overview card, with the Filter Bar hidden. For now, it is displaying fake data.

To test:
- Go to Post Stats. From either:
  - Insights > Latest Post Summary > View more.
  - Period > Posts and Pages > row selection.
- Verify the chart appears.

<img width="350" alt="post_stats_chart" src="https://user-images.githubusercontent.com/1816888/54156771-8ac56780-440c-11e9-9b63-eb9d1b6b7c2b.png">
