### PR TITLE
[WIP] Improve handling of invalid tokens

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -41,9 +41,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 3.0.0'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/fix_tag_sync'
-    #pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
+    #pod 'WordPressKit', '~> 3.0.0'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/invalid-token'
+    #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 
 def shared_with_all_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -249,7 +249,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.4)
   - WordPressAuthenticator (~> 1.1.10)
-  - WordPressKit (~> 3.0.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/invalid-token`)
   - WordPressShared (= 1.7.2)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -291,7 +291,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -319,6 +318,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.1.0
+  WordPressKit:
+    :branch: feature/invalid-token
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -341,6 +343,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.1.0
+  WordPressKit:
+    :commit: 7d479eaccab1bdbc929077ecdfe82b900e0b1ee5
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -395,6 +400,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 83c799cba6638d34e1d25fd70319a829d59fe089
+PODFILE CHECKSUM: 4462d154b429066f65a96a4cfb5ab641553c6331
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Services/NotificationSettingsService.swift
+++ b/WordPress/Classes/Services/NotificationSettingsService.swift
@@ -17,7 +17,9 @@ open class NotificationSettingsService: LocalCoreDataService {
     public override init(managedObjectContext context: NSManagedObjectContext) {
         super.init(managedObjectContext: context)
 
-        if let restApi = AccountService(managedObjectContext: context).defaultWordPressComAccount()?.wordPressComRestApi {
+        if let defaultAccount = AccountService(managedObjectContext: context).defaultWordPressComAccount(),
+            defaultAccount.authToken != nil,
+            let restApi = defaultAccount.wordPressComRestApi {
             remoteApi = restApi.hasCredentials() ? restApi : nil
         }
     }

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -359,8 +359,8 @@ extension WordPressAppDelegate {
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)
 
-        if let account = accountService.defaultWordPressComAccount() {
-            ShareExtensionService.configureShareExtensionToken(account.authToken)
+        if let account = accountService.defaultWordPressComAccount(), let authToken = account.authToken {
+            ShareExtensionService.configureShareExtensionToken(authToken)
             ShareExtensionService.configureShareExtensionUsername(account.username)
         }
     }
@@ -381,11 +381,11 @@ extension WordPressAppDelegate {
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)
 
-        if let account = accountService.defaultWordPressComAccount() {
-            NotificationSupportService.insertContentExtensionToken(account.authToken)
+        if let account = accountService.defaultWordPressComAccount(), let authToken = account.authToken {
+            NotificationSupportService.insertContentExtensionToken(authToken)
             NotificationSupportService.insertContentExtensionUsername(account.username)
 
-            NotificationSupportService.insertServiceExtensionToken(account.authToken)
+            NotificationSupportService.insertServiceExtensionToken(authToken)
             NotificationSupportService.insertServiceExtensionUsername(account.username)
         }
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -76,9 +76,6 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     // Set the main window up
     [self.window makeKeyAndVisible];
 
-    // Local Notifications
-    [self addNotificationObservers];
-
     WPAuthTokenIssueSolver *authTokenIssueSolver = [[WPAuthTokenIssueSolver alloc] init];
     
     __weak __typeof(self) weakSelf = self;
@@ -260,6 +257,9 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
 
 - (void)runStartupSequenceWithLaunchOptions:(NSDictionary *)launchOptions
 {
+    // Local Notifications
+    [self addNotificationObservers];
+    
     // Crash reporting, logging
     self.logger = [[WPLogger alloc] init];
     [self configureHockeySDK];

--- a/WordPress/Classes/Utility/AccountHelper.swift
+++ b/WordPress/Classes/Utility/AccountHelper.swift
@@ -7,15 +7,27 @@ import Foundation
     /// Threadsafe Helper that indicates whether a Default Dotcom Account is available, or not
     ///
     @objc static func isDotcomAvailable() -> Bool {
+        return isDotcomAvailable(withValidToken: false)
+    }
+
+    @objc static func isDotcomAvailable(withValidToken: Bool = false) -> Bool {
         let context = ContextManager.sharedInstance().mainContext
         let service = AccountService(managedObjectContext: context)
-        var available = false
+        var defaultAccount: WPAccount? = nil
 
         context.performAndWait {
-            available = service.defaultWordPressComAccount() != nil
+            defaultAccount = service.defaultWordPressComAccount()
         }
 
-        return available
+        guard let account = defaultAccount else {
+            return false
+        }
+
+        if withValidToken {
+            return account.authToken != nil
+        } else {
+            return true
+        }
     }
 
     @objc static var isLoggedIn: Bool {

--- a/WordPress/Classes/Utility/PingHubManager.swift
+++ b/WordPress/Classes/Utility/PingHubManager.swift
@@ -10,7 +10,6 @@ private func defaultAccountToken() -> String? {
         return nil
     }
     guard let token = account.authToken, !token.isEmpty else {
-        assertionFailure("Can't create a PingHub client if the account has no auth token")
         return nil
     }
     return token

--- a/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
+++ b/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
@@ -18,13 +18,17 @@
     if ([self hasAuthTokenIssues]) {
         UIViewController *controller = [WordPressAuthenticationManager signinForWPComFixingAuthToken:^(BOOL cancelled) {
             if (cancelled) {
-                [self showCancelReAuthenticationAlertAndOnOK:^{
-                    NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
-                    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:mainContext];
+                // We present asynchronously to prevent an issue where the Login VC would dismiss the
+                // alert instead of itself.
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self showCancelReAuthenticationAlertAndOnOK:^{
+                        NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
+                        AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:mainContext];
 
-                    [accountService removeDefaultWordPressComAccount];
-                    onComplete();
-                }];
+                        [accountService removeDefaultWordPressComAccount];
+                        onComplete();
+                    }];
+                });
             } else {
                 onComplete();
             }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -93,7 +93,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         let context = ContextManager.sharedInstance().mainContext
         let blogService = BlogService(managedObjectContext: context)
 
-        return AccountHelper.isDotcomAvailable() || blogService.blogCountForAllAccounts() > 0
+        return AccountHelper.isDotcomAvailable(withValidToken: true) || blogService.blogCountForAllAccounts() > 0
     }
 
     /// Indicates whether if the Support Action should be enabled, or not.

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -7,6 +7,7 @@ import WordPressAuthenticator
 //
 @objc
 class WordPressAuthenticationManager: NSObject {
+    static var isPresentingSignIn = false
 
     /// Support is only available to the WordPress iOS App. Our Authentication Framework doesn't have direct access.
     /// We'll setup a mechanism to relay the Support event back to the Authenticator.
@@ -61,7 +62,14 @@ extension WordPressAuthenticationManager {
             return
         }
 
-        let controller = signinForWPComFixingAuthToken()
+        guard !isPresentingSignIn else {
+            return
+        }
+
+        isPresentingSignIn = true
+        let controller = signinForWPComFixingAuthToken({ (_) in
+            isPresentingSignIn = false
+        })
         presenter.present(controller, animated: true)
     }
 }


### PR DESCRIPTION
I'm creating this one early to gather some feedback, since I'm stuck on one remaining issue.

To test:

1. Log in to the app
2. Go to https://wordpress.com/me/security/connected-applications and disconnect WordPress for iOS
3. Navigate somewhere in the app, any network request should trigger the login screen
4. Kill the app and relaunch
5. On launch, the login screen should appear
6. Tap Cancel, and confirm that you want to sign out
7. Go through the sign in flow and sign in to your WordPress.com account (I only tested with
 password)

After this, it shows the blogs list, then it goes back to ask for the password. If you enter it again and log in a second time, you get the same login screen again, but it has a glitch with the wrong vertical offset, and it doesn't let you cancel or continue so you have to force quit.

![Simulator Screen Shot - iPhone XS - 2019-03-12 at 00 04 35](https://user-images.githubusercontent.com/8739/54163788-714b0c80-445a-11e9-83b5-3919b7661d93.png)



Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.