### PR TITLE
[Stats Refresh] Insights Tags and Categories: add detail list view

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -26,12 +26,16 @@ enum InsightAction: Action {
     case receivedAllAuthorsComments()
     case receivedAllPostsComments()
     case refreshComments()
+
+    case receivedAllTagsAndCategories()
+    case refreshTagsAndCategories()
 }
 
 enum InsightQuery {
     case insights
     case allFollowers
     case allComments
+    case allTagsAndCategories
 }
 
 struct InsightStoreState {
@@ -82,6 +86,9 @@ struct InsightStoreState {
 
     var allPostsComments: StatsCommentsInsight?
     var fetchingAllPostsComments = false
+
+    var allTagsAndCategories: StatsTagsAndCategoriesInsight?
+    var fetchingAllTagsAndCategories = false
 }
 
 class StatsInsightsStore: QueryStore<InsightStoreState, InsightQuery> {
@@ -131,6 +138,10 @@ class StatsInsightsStore: QueryStore<InsightStoreState, InsightQuery> {
             receivedAllPostsComments()
         case .refreshComments:
             refreshComments()
+        case .receivedAllTagsAndCategories:
+            receivedAllTagsAndCategories()
+        case .refreshTagsAndCategories:
+            refreshTagsAndCategories()
         }
     }
 
@@ -164,6 +175,10 @@ private extension StatsInsightsStore {
             case .allComments:
                 if shouldFetchComments() {
                     fetchAllComments()
+                }
+            case .allTagsAndCategories:
+                if shouldFetchTagsAndCategories() {
+                    fetchAllTagsAndCategories()
                 }
             }
         }
@@ -387,6 +402,13 @@ private extension StatsInsightsStore {
         actionDispatcher.dispatch(InsightAction.receivedAllPostsComments())
     }
 
+    func fetchAllTagsAndCategories() {
+        state.fetchingAllTagsAndCategories = true
+
+        // TODO: replace with api call when fetch all tags & categories is supported.
+        actionDispatcher.dispatch(InsightAction.receivedAllTagsAndCategories())
+    }
+
     func receivedAllDotComFollowers(_ allDotComFollowers: StatsGroup?) {
         transaction { state in
             state.allDotComFollowers = allDotComFollowers?.items as? [StatsItem]
@@ -441,6 +463,27 @@ private extension StatsInsightsStore {
 
     func shouldFetchComments() -> Bool {
         return !isFetchingComments
+    }
+
+    func receivedAllTagsAndCategories() {
+        transaction { state in
+            // TODO: replace with real allTagsAndCategories when API supports it.
+            state.allTagsAndCategories = state.topTagsAndCategories
+            state.fetchingAllTagsAndCategories = false
+        }
+    }
+
+    func refreshTagsAndCategories() {
+        guard shouldFetchTagsAndCategories() else {
+            DDLogInfo("Stats Insights Tags And Categories refresh triggered while one was in progress.")
+            return
+        }
+
+        fetchAllTagsAndCategories()
+    }
+
+    func shouldFetchTagsAndCategories() -> Bool {
+        return !isFetchingTagsAndCategories
     }
 
 }
@@ -560,6 +603,10 @@ extension StatsInsightsStore {
         return state.allPostsComments
     }
 
+    func getAllTagsAndCategories() -> StatsTagsAndCategoriesInsight? {
+        return state.allTagsAndCategories
+    }
+
     var isFetchingOverview: Bool {
         return
             state.fetchingLastPostInsight ||
@@ -584,6 +631,10 @@ extension StatsInsightsStore {
         return
             state.fetchingAllAuthorsComments ||
             state.fetchingAllPostsComments
+    }
+
+    var isFetchingTagsAndCategories: Bool {
+        return state.fetchingAllTagsAndCategories
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -4,6 +4,8 @@ import Foundation
 ///
 class StatsDataHelper {
 
+    private typealias Style = WPStyleGuide.Stats
+
     // MARK: - Expanded Row Handling
 
     // This stores the labels for expanded rows.
@@ -82,6 +84,30 @@ class StatsDataHelper {
 
         return disclosureURL
     }
+
+    // MARK: - Tags and Categories Support
+
+    class func tagsAndCategoriesIconForKind(_ kind: StatsTagAndCategory.Kind) -> UIImage? {
+        switch kind {
+        case .folder:
+            return Style.imageForGridiconType(.folderMultiple)
+        case .category:
+            return Style.imageForGridiconType(.folder)
+        case .tag:
+            return Style.imageForGridiconType(.tag)
+        }
+    }
+
+    class func childRowsForItems(_ children: [StatsTagAndCategory]) -> [StatsTotalRowData] {
+        return children.map {
+            StatsTotalRowData.init(name: $0.name,
+                                   data: "",
+                                   icon: StatsDataHelper.tagsAndCategoriesIconForKind($0.kind),
+                                   showDisclosure: true,
+                                   disclosureURL: $0.url)
+        }
+    }
+
 }
 
 /// These methods format stat Strings for display and usage.

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -50,6 +50,10 @@ class StatsDataHelper {
         }
     }
 
+    class func clearExpandedRowsFor(statSection: StatSection) {
+        StatsDataHelper.expandedRowLabels[statSection]?.removeAll()
+    }
+
     // MARK: - Data Bar Percent
 
     class func dataBarPercentForRow(_ row: StatsItem, relativeToRow maxValueRow: StatsItem?) -> Float? {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -226,6 +226,8 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
             return
         }
 
+        StatsDataHelper.clearExpandedRowsFor(statSection: statSection)
+
         let detailTableViewController = SiteStatsDetailTableViewController.loadFromStoryboard()
         detailTableViewController.configure(statSection: statSection)
         navigationController?.pushViewController(detailTableViewController, animated: true)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -326,32 +326,11 @@ private extension SiteStatsInsightsViewModel {
             return StatsTotalRowData(name: $0.name,
                                      data: viewsCount.abbreviatedString(),
                                      dataBarPercent: Float(viewsCount) / Float(tagsAndCategories.first?.viewsCount ?? 1),
-                                     icon: tagsAndCategoriesIconForKind($0.kind),
+                                     icon: StatsDataHelper.tagsAndCategoriesIconForKind($0.kind),
                                      showDisclosure: true,
                                      disclosureURL: $0.url,
-                                     childRows: childRowsForItems($0.children),
+                                     childRows: StatsDataHelper.childRowsForItems($0.children),
                                      statSection: .insightsTagsAndCategories)
-        }
-    }
-
-    func tagsAndCategoriesIconForKind(_ kind: StatsTagAndCategory.Kind) -> UIImage? {
-        switch kind {
-        case .folder:
-            return Style.imageForGridiconType(.folderMultiple)
-        case .category:
-            return Style.imageForGridiconType(.folder)
-        case .tag:
-            return Style.imageForGridiconType(.tag)
-        }
-    }
-
-    func childRowsForItems(_ children: [StatsTagAndCategory]) -> [StatsTotalRowData] {
-        return children.map {
-            StatsTotalRowData.init(name: $0.name,
-                                   data: "",
-                                   icon: tagsAndCategoriesIconForKind($0.kind),
-                                   showDisclosure: true,
-                                   disclosureURL: $0.url)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -53,6 +53,16 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
         })
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        guard let statSection = statSection else {
+            return
+        }
+        StatsDataHelper.clearExpandedRowsFor(statSection: statSection)
+    }
+
+
 }
 
 // MARK: - Table Methods

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -81,6 +81,7 @@ private extension SiteStatsDetailTableViewController {
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
         return [TabbedTotalsDetailStatsRow.self,
+                TopTotalsDetailStatsRow.self,
                 TableFooterRow.self]
     }
 
@@ -90,6 +91,8 @@ private extension SiteStatsDetailTableViewController {
             return insightsStore.isFetchingFollowers
         case .insightsCommentsAuthors, .insightsCommentsPosts:
             return insightsStore.isFetchingComments
+        case .insightsTagsAndCategories:
+            return insightsStore.isFetchingTagsAndCategories
         default:
             return false
         }
@@ -118,6 +121,8 @@ private extension SiteStatsDetailTableViewController {
             viewModel?.refreshFollowers()
         case .insightsCommentsAuthors, .insightsCommentsPosts:
             viewModel?.refreshComments()
+        case .insightsTagsAndCategories:
+            viewModel?.refreshTagsAndCategories()
         default:
             refreshControl?.endRefreshing()
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -4,6 +4,7 @@ import WordPressFlux
 @objc protocol SiteStatsDetailsDelegate {
     @objc optional func tabbedTotalsCellUpdated()
     @objc optional func displayWebViewWithURL(_ url: URL)
+    @objc optional func expandedRowUpdated(_ row: StatsTotalRow)
 }
 
 class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoadable {
@@ -156,7 +157,8 @@ private extension SiteStatsDetailTableViewController {
         case .insightsCommentsPosts:
             statSection = .insightsCommentsAuthors
         default:
-            break
+            // Return here as `initViewModel` is only needed for filtered cards.
+            return
         }
 
         initViewModel()
@@ -176,6 +178,11 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
         let navController = UINavigationController.init(rootViewController: webViewController)
         present(navController, animated: true, completion: nil)
+    }
+
+    func expandedRowUpdated(_ row: StatsTotalRow) {
+        applyTableUpdates()
+        StatsDataHelper.updatedExpandedState(forRow: row)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -64,6 +64,11 @@ class SiteStatsDetailsViewModel: Observable {
                                                         siteStatsDetailsDelegate: detailsDelegate,
                                                         showTotalCount: false,
                                                         selectedIndex: selectedIndex))
+        case .insightsTagsAndCategories:
+            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.insightsTagsAndCategories.itemSubtitle,
+                                                      dataSubtitle: StatSection.insightsTagsAndCategories.dataSubtitle,
+                                                      dataRows: createTagsAndCategoriesRows(),
+                                                      siteStatsDetailsDelegate: detailsDelegate))
         default:
             break
         }
@@ -86,6 +91,10 @@ class SiteStatsDetailsViewModel: Observable {
         ActionDispatcher.dispatch(InsightAction.refreshComments())
     }
 
+    func refreshTagsAndCategories() {
+        ActionDispatcher.dispatch(InsightAction.refreshTagsAndCategories())
+    }
+
 }
 
 // MARK: - Private Extension
@@ -98,6 +107,8 @@ private extension SiteStatsDetailsViewModel {
             return .allFollowers
         case .insightsCommentsAuthors, .insightsCommentsPosts:
             return .allComments
+        case .insightsTagsAndCategories:
+            return .allTagsAndCategories
         default:
             return nil
         }
@@ -170,6 +181,25 @@ private extension SiteStatsDetailsViewModel {
                        itemSubtitle: commentType.itemSubtitle,
                        dataSubtitle: commentType.dataSubtitle,
                        dataRows: rowItems)
+    }
+
+    func createTagsAndCategoriesRows() -> [StatsTotalRowData] {
+        guard let tagsAndCategories = insightsStore.getAllTagsAndCategories()?.topTagsAndCategories else {
+            return []
+        }
+
+        return tagsAndCategories.map {
+            let viewsCount = $0.viewsCount ?? 0
+
+            return StatsTotalRowData(name: $0.name,
+                                     data: viewsCount.abbreviatedString(),
+                                     dataBarPercent: Float(viewsCount) / Float(tagsAndCategories.first?.viewsCount ?? 1),
+                                     icon: StatsDataHelper.tagsAndCategoriesIconForKind($0.kind),
+                                     showDisclosure: true,
+                                     disclosureURL: $0.url,
+                                     childRows: StatsDataHelper.childRowsForItems($0.children),
+                                     statSection: .insightsTagsAndCategories)
+        }
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -24,6 +24,7 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var topSeparatorLine: UIView!
     @IBOutlet weak var bottomSeparatorLine: UIView!
 
+    private var limitRowsDisplayed = true
     private let maxChildRowsToDisplay = 10
     private var dataRows = [StatsTotalRowData]()
     private var subtitlesProvided = true
@@ -39,7 +40,8 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
                    dataRows: [StatsTotalRowData],
                    siteStatsInsightsDelegate: SiteStatsInsightsDelegate? = nil,
                    siteStatsPeriodDelegate: SiteStatsPeriodDelegate? = nil,
-                   siteStatsDetailsDelegate: SiteStatsDetailsDelegate? = nil) {
+                   siteStatsDetailsDelegate: SiteStatsDetailsDelegate? = nil,
+                   limitRowsDisplayed: Bool = true) {
         itemSubtitleLabel.text = itemSubtitle
         dataSubtitleLabel.text = dataSubtitle
         subtitlesProvided = (itemSubtitle != nil && dataSubtitle != nil)
@@ -47,9 +49,17 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
         self.siteStatsPeriodDelegate = siteStatsPeriodDelegate
         self.siteStatsDetailsDelegate = siteStatsDetailsDelegate
+        self.limitRowsDisplayed = limitRowsDisplayed
 
         let statType: StatType = (siteStatsPeriodDelegate != nil) ? .period : .insights
-        addRows(dataRows, toStackView: rowsStackView, forType: statType, rowDelegate: self, viewMoreDelegate: self)
+
+        addRows(dataRows,
+                toStackView: rowsStackView,
+                forType: statType,
+                limitRowsDisplayed: limitRowsDisplayed,
+                rowDelegate: self,
+                viewMoreDelegate: self)
+
         setSubtitleVisibility()
         initChildRows()
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -266,6 +266,7 @@ extension TopTotalsCell: StatsTotalRowDelegate {
         toggleSeparatorsAroundRow(row)
         siteStatsInsightsDelegate?.expandedRowUpdated?(row)
         siteStatsPeriodDelegate?.expandedRowUpdated?(row)
+        siteStatsDetailsDelegate?.expandedRowUpdated?(row)
     }
 
     func showPostStats(withPostTitle postTitle: String?) {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -29,6 +29,7 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
     private var subtitlesProvided = true
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     private weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
+    private weak var siteStatsDetailsDelegate: SiteStatsDetailsDelegate?
     private typealias Style = WPStyleGuide.Stats
 
     // MARK: - Configure
@@ -37,13 +38,15 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
                    dataSubtitle: String? = nil,
                    dataRows: [StatsTotalRowData],
                    siteStatsInsightsDelegate: SiteStatsInsightsDelegate? = nil,
-                   siteStatsPeriodDelegate: SiteStatsPeriodDelegate? = nil) {
+                   siteStatsPeriodDelegate: SiteStatsPeriodDelegate? = nil,
+                   siteStatsDetailsDelegate: SiteStatsDetailsDelegate? = nil) {
         itemSubtitleLabel.text = itemSubtitle
         dataSubtitleLabel.text = dataSubtitle
         subtitlesProvided = (itemSubtitle != nil && dataSubtitle != nil)
         self.dataRows = dataRows
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
         self.siteStatsPeriodDelegate = siteStatsPeriodDelegate
+        self.siteStatsDetailsDelegate = siteStatsDetailsDelegate
 
         let statType: StatType = (siteStatsPeriodDelegate != nil) ? .period : .insights
         addRows(dataRows, toStackView: rowsStackView, forType: statType, rowDelegate: self, viewMoreDelegate: self)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -254,6 +254,7 @@ extension TopTotalsCell: StatsTotalRowDelegate {
     func displayWebViewWithURL(_ url: URL) {
         siteStatsInsightsDelegate?.displayWebViewWithURL?(url)
         siteStatsPeriodDelegate?.displayWebViewWithURL?(url)
+        siteStatsDetailsDelegate?.displayWebViewWithURL?(url)
     }
 
     func displayMediaWithID(_ mediaID: NSNumber) {

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -174,7 +174,8 @@ struct TopTotalsDetailStatsRow: ImmuTableRow {
                        dataRows: dataRows,
                        siteStatsInsightsDelegate: nil,
                        siteStatsPeriodDelegate: nil,
-                       siteStatsDetailsDelegate: siteStatsDetailsDelegate)
+                       siteStatsDetailsDelegate: siteStatsDetailsDelegate,
+                       limitRowsDisplayed: false)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -149,6 +149,35 @@ struct TabbedTotalsDetailStatsRow: ImmuTableRow {
     }
 }
 
+struct TopTotalsDetailStatsRow: ImmuTableRow {
+
+    typealias CellType = TopTotalsCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let itemSubtitle: String
+    let dataSubtitle: String
+    let dataRows: [StatsTotalRowData]
+    let siteStatsDetailsDelegate: SiteStatsDetailsDelegate
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(itemSubtitle: itemSubtitle,
+                       dataSubtitle: dataSubtitle,
+                       dataRows: dataRows,
+                       siteStatsInsightsDelegate: nil,
+                       siteStatsPeriodDelegate: nil,
+                       siteStatsDetailsDelegate: siteStatsDetailsDelegate)
+    }
+}
+
 struct TopTotalsInsightStatsRow: ImmuTableRow {
 
     typealias CellType = TopTotalsCell


### PR DESCRIPTION
Fixes #11232 

On the Insights Tags and Categories card, selecting `View more` will now show a full list of Tags and Categories.
- When a row is selected, a web view is displayed for that tag/category (same behavior as the Insights card).
- Expanding rows are supported, and behave the same as on the Insights card.

**NOTE:** Currently, there is no API call to get the full list of Tags and Categories. So for now, this displays the data fetched from the "top" Tags and Categories API call used for the Insights card. (cc @jklausa issue #11238 )

To test:

---
- On a site with more than 6 tags/categories, go to Insights > Tags and Categories > View more.
  - Hogwarts and en.blog usually have some.
- Verify the view is:

<img width="350" alt="initial_view" src="https://user-images.githubusercontent.com/1816888/54167432-426b7100-442f-11e9-9086-3ea3cc953412.png">

<img width="350" alt="expanded_row" src="https://user-images.githubusercontent.com/1816888/54167514-a3934480-442f-11e9-9a5a-40d9cfb67bbc.png">


