### PR TITLE
Fix formatting in stalebot message

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -26,9 +26,9 @@ staleLabel: "[Status] Stale"
 markComment: >
   This issue has been marked as stale because:
   
-  * It has been inactive for the past year.
-  * It isn't in a project or a milestone.
-  * It hasn’t been labeled `[Pri] Blocker`, `[Pri] High`, or `good first issue`.
+   * It has been inactive for the past year.
+   * It isn't in a project or a milestone.
+   * It hasn’t been labeled `[Pri] Blocker`, `[Pri] High`, or `good first issue`.
   
   Please comment with an update if you believe this issue is still valid or if it can be closed.
   This issue will also be reviewed for validity and priority (cc @designsimply).


### PR DESCRIPTION
The current stalebot message isn't formatting the list correctly, e.g. here: https://github.com/wordpress-mobile/WordPress-iOS/issues/5684#issuecomment-471151507

This fixes the list so it's formatted correctly in the stalebot message. (I tested in a private repo to confirm the formatting works as intended.)