### PR TITLE
Improve re-authentication prompts

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -52,8 +52,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    #pod 'WordPressKit', '~> 2.1.0.2'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '9971cb763091604fde1b6efe5babf2c2772ba11d'
+    pod 'WordPressKit', '~> 2.1.0.2'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '66976dbece28fbfc50b7c1e1c292a54b8cdd1ea1'
     #pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -52,8 +52,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 2.1.0.1'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'f2e1d41'
+    #pod 'WordPressKit', '~> 2.1.0.2'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '9971cb763091604fde1b6efe5babf2c2772ba11d'
     #pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -191,7 +191,7 @@ PODS:
     - WordPressKit (~> 2.0-beta)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-  - WordPressKit (2.1.0.1):
+  - WordPressKit (2.1.0.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -249,7 +249,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.3)
   - WordPressAuthenticator (~> 1.1.9)
-  - WordPressKit (~> 2.1.0.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `9971cb763091604fde1b6efe5babf2c2772ba11d`)
   - WordPressShared (= 1.7.1)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -291,7 +291,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -319,6 +318,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.0.2
+  WordPressKit:
+    :commit: 9971cb763091604fde1b6efe5babf2c2772ba11d
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -341,6 +343,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.0.2
+  WordPressKit:
+    :commit: 9971cb763091604fde1b6efe5babf2c2772ba11d
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -387,7 +392,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 0062ba96c3ea77186590c74b761427c461f89a06
   WordPress-Editor-iOS: cfaa780c3ee64ea781fe6f52ca1561667a3f3707
   WordPressAuthenticator: 9559bc45373f1b6c2f58d664d34f564bcf73111f
-  WordPressKit: a4317495aa619fe4f5db7a6354639e098da07be1
+  WordPressKit: 8e3292642bc420ddaf896fe98286f9f16ee18d9f
   WordPressShared: 2018257df3fe1de423f31a3ba50ac8d6bd24941c
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
@@ -395,6 +400,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: ad60e366ca92306182888e050ecfccfa45511585
+PODFILE CHECKSUM: 37cd342515d07b7a9de47b419bc46b2a8a715ea6
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -249,7 +249,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.3)
   - WordPressAuthenticator (~> 1.1.9)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `9971cb763091604fde1b6efe5babf2c2772ba11d`)
+  - WordPressKit (~> 2.1.0.2)
   - WordPressShared (= 1.7.1)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -291,6 +291,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -318,9 +319,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.0.2
-  WordPressKit:
-    :commit: 9971cb763091604fde1b6efe5babf2c2772ba11d
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -343,9 +341,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.0.2
-  WordPressKit:
-    :commit: 9971cb763091604fde1b6efe5babf2c2772ba11d
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -400,6 +395,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 37cd342515d07b7a9de47b419bc46b2a8a715ea6
+PODFILE CHECKSUM: 214d3456cd1c972eaabffcaafdaf776e95cba7f2
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Services/NotificationSettingsService.swift
+++ b/WordPress/Classes/Services/NotificationSettingsService.swift
@@ -17,7 +17,9 @@ open class NotificationSettingsService: LocalCoreDataService {
     public override init(managedObjectContext context: NSManagedObjectContext) {
         super.init(managedObjectContext: context)
 
-        if let restApi = AccountService(managedObjectContext: context).defaultWordPressComAccount()?.wordPressComRestApi {
+        if let defaultAccount = AccountService(managedObjectContext: context).defaultWordPressComAccount(),
+            defaultAccount.authToken != nil,
+            let restApi = defaultAccount.wordPressComRestApi {
             remoteApi = restApi.hasCredentials() ? restApi : nil
         }
     }

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -359,8 +359,8 @@ extension WordPressAppDelegate {
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)
 
-        if let account = accountService.defaultWordPressComAccount() {
-            ShareExtensionService.configureShareExtensionToken(account.authToken)
+        if let account = accountService.defaultWordPressComAccount(), let authToken = account.authToken {
+            ShareExtensionService.configureShareExtensionToken(authToken)
             ShareExtensionService.configureShareExtensionUsername(account.username)
         }
     }
@@ -381,11 +381,11 @@ extension WordPressAppDelegate {
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)
 
-        if let account = accountService.defaultWordPressComAccount() {
-            NotificationSupportService.insertContentExtensionToken(account.authToken)
+        if let account = accountService.defaultWordPressComAccount(), let authToken = account.authToken {
+            NotificationSupportService.insertContentExtensionToken(authToken)
             NotificationSupportService.insertContentExtensionUsername(account.username)
 
-            NotificationSupportService.insertServiceExtensionToken(account.authToken)
+            NotificationSupportService.insertServiceExtensionToken(authToken)
             NotificationSupportService.insertServiceExtensionUsername(account.username)
         }
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -76,9 +76,6 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     // Set the main window up
     [self.window makeKeyAndVisible];
 
-    // Local Notifications
-    [self addNotificationObservers];
-
     WPAuthTokenIssueSolver *authTokenIssueSolver = [[WPAuthTokenIssueSolver alloc] init];
     
     __weak __typeof(self) weakSelf = self;
@@ -338,6 +335,9 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
 
 - (void)runStartupSequenceWithLaunchOptions:(NSDictionary *)launchOptions
 {
+    // Local Notifications
+    [self addNotificationObservers];
+    
     // Crash reporting, logging
     self.logger = [[WPLogger alloc] init];
     [self configureHockeySDK];

--- a/WordPress/Classes/Utility/PingHubManager.swift
+++ b/WordPress/Classes/Utility/PingHubManager.swift
@@ -10,7 +10,6 @@ private func defaultAccountToken() -> String? {
         return nil
     }
     guard let token = account.authToken, !token.isEmpty else {
-        assertionFailure("Can't create a PingHub client if the account has no auth token")
         return nil
     }
     return token

--- a/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
+++ b/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
@@ -18,13 +18,17 @@
     if ([self hasAuthTokenIssues]) {
         UIViewController *controller = [WordPressAuthenticationManager signinForWPComFixingAuthToken:^(BOOL cancelled) {
             if (cancelled) {
-                [self showCancelReAuthenticationAlertAndOnOK:^{
-                    NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
-                    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:mainContext];
+                // We present asynchronously to prevent an issue where the Login VC would dismiss the
+                // alert instead of itself.
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self showCancelReAuthenticationAlertAndOnOK:^{
+                        NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
+                        AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:mainContext];
 
-                    [accountService removeDefaultWordPressComAccount];
-                    onComplete();
-                }];
+                        [accountService removeDefaultWordPressComAccount];
+                        onComplete();
+                    }];
+                });
             } else {
                 onComplete();
             }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -7,6 +7,7 @@ import WordPressAuthenticator
 //
 @objc
 class WordPressAuthenticationManager: NSObject {
+    static var isPresentingSignIn = false
 
     /// Support is only available to the WordPress iOS App. Our Authentication Framework doesn't have direct access.
     /// We'll setup a mechanism to relay the Support event back to the Authenticator.
@@ -61,7 +62,14 @@ extension WordPressAuthenticationManager {
             return
         }
 
-        let controller = signinForWPComFixingAuthToken()
+        guard !isPresentingSignIn else {
+            return
+        }
+
+        isPresentingSignIn = true
+        let controller = signinForWPComFixingAuthToken({ (_) in
+            isPresentingSignIn = false
+        })
         presenter.present(controller, animated: true)
     }
 }


### PR DESCRIPTION
Currently, when the oAuth2 token is revoked, the app doesn't notice unless you refresh the posts list.
This PR will add a handler to, whenever we receive an `invalid_token` response from WordPress.com, present the login screen and remove that token from the keychain

To test:

1. Log in to the app
2. Go to https://wordpress.com/me/security/connected-applications and disconnect WordPress for iOS
3. Navigate somewhere in the app, any network request should trigger the login screen

If you kill and relaunch the app, you should also get a prompt to log in
