### PR TITLE
[Stats Refresh] Period Posts and Pages: add detail list view

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -232,7 +232,7 @@ private extension StatsPeriodStore {
             if error != nil {
                 DDLogInfo("Error fetching all Posts and Pages: \(String(describing: error?.localizedDescription))")
             }
-            DDLogInfo("Stats: Finished fetching all Posts and Pages.")
+            DDLogInfo("Stats: Finished fetching all posts and pages.")
             self.actionDispatcher.dispatch(PeriodAction.receivedAllPostsAndPages(postsAndPages))
         })
     }

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -24,13 +24,13 @@ enum PeriodAction: Action {
 
 enum PeriodQuery {
     case periods(date: Date, period: StatsPeriodUnit)
-    case allPostAndPages(date: Date, period: StatsPeriodUnit)
+    case allPostsAndPages(date: Date, period: StatsPeriodUnit)
 
     var date: Date {
         switch self {
         case .periods(let date, _):
             return date
-        case .allPostAndPages(let date, _):
+        case .allPostsAndPages(let date, _):
             return date
         }
     }
@@ -39,7 +39,7 @@ enum PeriodQuery {
         switch self {
         case .periods( _, let period):
             return period
-        case .allPostAndPages( _, let period):
+        case .allPostsAndPages( _, let period):
             return period
         }
     }
@@ -75,7 +75,7 @@ struct PeriodStoreState {
 
     // Period details
 
-    var allPostAndPages: [StatsItem]?
+    var allPostsAndPages: [StatsItem]?
     var fetchingAllPostsAndPages = false
 }
 
@@ -142,7 +142,7 @@ private extension StatsPeriodStore {
                 if shouldFetchOverview() {
                     fetchPeriodOverviewData(date: query.date, period: query.period)
                 }
-            case .allPostAndPages:
+            case .allPostsAndPages:
                 if shouldFetchPostsAndPages() {
                     fetchAllPostsAndPages(date: query.date, period: query.period)
                 }
@@ -305,7 +305,7 @@ private extension StatsPeriodStore {
 
     func receivedAllPostsAndPages(_ postsAndPages: StatsGroup?) {
         transaction { state in
-            state.allPostAndPages = postsAndPages?.items as? [StatsItem]
+            state.allPostsAndPages = postsAndPages?.items as? [StatsItem]
             state.fetchingAllPostsAndPages = false
         }
     }
@@ -403,7 +403,7 @@ extension StatsPeriodStore {
     }
 
     func getAllPostsAndPages() -> [StatsItem]? {
-        return state.allPostAndPages
+        return state.allPostsAndPages
     }
 
     var isFetchingOverview: Bool {

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -232,6 +232,7 @@ private extension StatsPeriodStore {
             if error != nil {
                 DDLogInfo("Error fetching all Posts and Pages: \(String(describing: error?.localizedDescription))")
             }
+            DDLogInfo("Stats: Finished fetching all Posts and Pages.")
             self.actionDispatcher.dispatch(PeriodAction.receivedAllPostsAndPages(postsAndPages))
         })
     }

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -3,6 +3,9 @@ import WordPressFlux
 import WordPressComStatsiOS
 
 enum PeriodAction: Action {
+
+    // Period overview
+
     case receivedPostsAndPages(_ postsAndPages: StatsGroup?)
     case receivedPublished(_ published: StatsGroup?)
     case receivedReferrers(_ referrers: StatsGroup?)
@@ -11,15 +14,23 @@ enum PeriodAction: Action {
     case receivedSearchTerms(_ searchTerms: StatsGroup?)
     case receivedVideos(_ videos: StatsGroup?)
     case receivedCountries(_ countries: StatsGroup?)
-    case refreshPeriodData(date: Date, period: StatsPeriodUnit)
+    case refreshPeriodOverviewData(date: Date, period: StatsPeriodUnit)
+
+    // Period details
+
+    case receivedAllPostsAndPages(_ postsAndPages: StatsGroup?)
+    case refreshPostsAndPages(date: Date, period: StatsPeriodUnit)
 }
 
 enum PeriodQuery {
     case periods(date: Date, period: StatsPeriodUnit)
+    case allPostAndPages(date: Date, period: StatsPeriodUnit)
 
     var date: Date {
         switch self {
         case .periods(let date, _):
+            return date
+        case .allPostAndPages(let date, _):
             return date
         }
     }
@@ -28,11 +39,16 @@ enum PeriodQuery {
         switch self {
         case .periods( _, let period):
             return period
+        case .allPostAndPages( _, let period):
+            return period
         }
     }
 }
 
 struct PeriodStoreState {
+
+    // Period overview
+
     var topPostsAndPages: [StatsItem]?
     var fetchingPostsAndPages = false
 
@@ -56,6 +72,11 @@ struct PeriodStoreState {
 
     var topVideos: [StatsItem]?
     var fetchingVideos = false
+
+    // Period details
+
+    var allPostAndPages: [StatsItem]?
+    var fetchingAllPostsAndPages = false
 }
 
 class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
@@ -87,8 +108,12 @@ class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
             receivedVideos(videos)
         case .receivedCountries(let countries):
             receivedCountries(countries)
-        case .refreshPeriodData(let date, let period):
-            refreshPeriodData(date: date, period: period)
+        case .refreshPeriodOverviewData(let date, let period):
+            refreshPeriodOverviewData(date: date, period: period)
+        case .receivedAllPostsAndPages(let postsAndPages):
+            receivedAllPostsAndPages(postsAndPages)
+        case .refreshPostsAndPages(let date, let period):
+            refreshPostsAndPages(date: date, period: period)
         }
     }
 
@@ -107,31 +132,27 @@ private extension StatsPeriodStore {
 
     func processQueries() {
 
-        guard !activeQueries.isEmpty && shouldFetch() else {
+        guard !activeQueries.isEmpty else {
             return
         }
 
-        runPeriodsQuery()
-    }
-
-    func runPeriodsQuery() {
-        let periodsQuery = activeQueries
-            .filter {
-                if case .periods = $0 {
-                    return true
-                } else {
-                    return false
+        activeQueries.forEach { query in
+            switch query {
+            case .periods:
+                if shouldFetchOverview() {
+                    fetchPeriodOverviewData(date: query.date, period: query.period)
                 }
-            }.first
-
-        if let periodsQuery = periodsQuery {
-            fetchPeriodData(date: periodsQuery.date, period: periodsQuery.period)
+            case .allPostAndPages:
+                if shouldFetchPostsAndPages() {
+                    fetchAllPostsAndPages(date: query.date, period: query.period)
+                }
+            }
         }
     }
 
-    func fetchPeriodData(date: Date, period: StatsPeriodUnit) {
+    func fetchPeriodOverviewData(date: Date, period: StatsPeriodUnit) {
 
-        setAllAsFetching()
+        setAllAsFetchingOverview()
 
         SiteStatsInformation.statsService()?.retrieveAllStats(for: date, unit: period, withVisitsCompletionHandler: { (visits, error) in
             if error != nil {
@@ -195,13 +216,33 @@ private extension StatsPeriodStore {
 
     }
 
-    func refreshPeriodData(date: Date, period: StatsPeriodUnit) {
-        guard shouldFetch() else {
-            DDLogInfo("Stats Period refresh triggered while one was in progress.")
+    func refreshPeriodOverviewData(date: Date, period: StatsPeriodUnit) {
+        guard shouldFetchOverview() else {
+            DDLogInfo("Stats Period Overview refresh triggered while one was in progress.")
             return
         }
 
-        fetchPeriodData(date: date, period: period)
+        fetchPeriodOverviewData(date: date, period: period)
+    }
+
+    func fetchAllPostsAndPages(date: Date, period: StatsPeriodUnit) {
+        state.fetchingAllPostsAndPages = true
+
+        SiteStatsInformation.statsService()?.retrievePosts(for: date, andUnit: period, withCompletionHandler: { (postsAndPages, error) in
+            if error != nil {
+                DDLogInfo("Error fetching all Posts and Pages: \(String(describing: error?.localizedDescription))")
+            }
+            self.actionDispatcher.dispatch(PeriodAction.receivedAllPostsAndPages(postsAndPages))
+        })
+    }
+
+    func refreshPostsAndPages(date: Date, period: StatsPeriodUnit) {
+        guard shouldFetchPostsAndPages() else {
+            DDLogInfo("Stats Period Posts And Pages refresh triggered while one was in progress.")
+            return
+        }
+
+        fetchAllPostsAndPages(date: date, period: period)
     }
 
     // MARK: - Receive data methods
@@ -262,13 +303,20 @@ private extension StatsPeriodStore {
         }
     }
 
-    // MARK: - Helpers
-
-    func shouldFetch() -> Bool {
-        return !isFetching
+    func receivedAllPostsAndPages(_ postsAndPages: StatsGroup?) {
+        transaction { state in
+            state.allPostAndPages = postsAndPages?.items as? [StatsItem]
+            state.fetchingAllPostsAndPages = false
+        }
     }
 
-    func setAllAsFetching() {
+    // MARK: - Helpers
+
+    func shouldFetchOverview() -> Bool {
+        return !isFetchingOverview
+    }
+
+    func setAllAsFetchingOverview() {
         state.fetchingPostsAndPages = true
         state.fetchingReferrers = true
         state.fetchingClicks = true
@@ -277,6 +325,10 @@ private extension StatsPeriodStore {
         state.fetchingSearchTerms = true
         state.fetchingVideos = true
         state.fetchingCountries = true
+    }
+
+    func shouldFetchPostsAndPages() -> Bool {
+        return !isFetchingPostsAndPages
     }
 
     /// This method modifies the 'Unknown search terms' row and changes its location in the array.
@@ -350,7 +402,11 @@ extension StatsPeriodStore {
         return state.topCountries
     }
 
-    var isFetching: Bool {
+    func getAllPostsAndPages() -> [StatsItem]? {
+        return state.allPostAndPages
+    }
+
+    var isFetchingOverview: Bool {
         return state.fetchingPostsAndPages ||
             state.fetchingReferrers ||
             state.fetchingClicks ||
@@ -359,6 +415,10 @@ extension StatsPeriodStore {
             state.fetchingSearchTerms ||
             state.fetchingVideos ||
             state.fetchingCountries
+    }
+
+    var isFetchingPostsAndPages: Bool {
+        return state.fetchingAllPostsAndPages
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -122,8 +122,10 @@ private extension SiteStatsInsightsTableViewController {
     // MARK: - Table Refreshing
 
     func refreshTableView() {
-        guard let viewModel = viewModel else {
-            return
+
+        guard let viewModel = viewModel,
+            viewIsVisible() else {
+                return
         }
 
         tableHandler.viewModel = viewModel.tableViewModel()
@@ -148,6 +150,10 @@ private extension SiteStatsInsightsTableViewController {
 
     func clearExpandedRows() {
         StatsDataHelper.clearExpandedInsights()
+    }
+
+    func viewIsVisible() -> Bool {
+        return isViewLoaded && view.window != nil
     }
 
     // MARK: User Defaults

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -92,7 +92,7 @@ private extension SiteStatsPeriodTableViewController {
 
         changeReceipt = viewModel?.onChange { [weak self] in
             guard let store = self?.store,
-                !store.isFetching else {
+                !store.isFetchingOverview else {
                     return
             }
 
@@ -138,7 +138,7 @@ private extension SiteStatsPeriodTableViewController {
                 return
         }
 
-        viewModel?.refreshPeriodData(withDate: selectedDate, forPeriod: selectedPeriod)
+        viewModel?.refreshPeriodOverviewData(withDate: selectedDate, forPeriod: selectedPeriod)
     }
 
     func applyTableUpdates() {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -112,7 +112,9 @@ private extension SiteStatsPeriodTableViewController {
     // MARK: - Table Refreshing
 
     func refreshTableView() {
-        guard let viewModel = viewModel else {
+
+        guard let viewModel = viewModel,
+        viewIsVisible() else {
             return
         }
 
@@ -153,6 +155,10 @@ private extension SiteStatsPeriodTableViewController {
 
     func clearExpandedRows() {
         StatsDataHelper.clearExpandedPeriods()
+    }
+
+    func viewIsVisible() -> Bool {
+        return isViewLoaded && view.window != nil
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -194,7 +194,9 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
         }
 
         let detailTableViewController = SiteStatsDetailTableViewController.loadFromStoryboard()
-        detailTableViewController.configure(statSection: statSection)
+        detailTableViewController.configure(statSection: statSection,
+                                            selectedDate: selectedDate,
+                                            selectedPeriod: selectedPeriod)
         navigationController?.pushViewController(detailTableViewController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -56,8 +56,8 @@ class SiteStatsPeriodViewModel: Observable {
 
     // MARK: - Refresh Data
 
-    func refreshPeriodData(withDate date: Date, forPeriod period: StatsPeriodUnit) {
-        ActionDispatcher.dispatch(PeriodAction.refreshPeriodData(date: date, period: period))
+    func refreshPeriodOverviewData(withDate date: Date, forPeriod period: StatsPeriodUnit) {
+        ActionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: date, period: period))
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -24,6 +24,8 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
     private var viewModel: SiteStatsDetailsViewModel?
     private let insightsStore = StoreContainer.shared.statsInsights
     private var insightsChangeReceipt: Receipt?
+    private let periodStore = StoreContainer.shared.statsPeriod
+    private var periodChangeReceipt: Receipt?
 
     private lazy var tableHandler: ImmuTableViewHandler = {
         return ImmuTableViewHandler(takeOver: self)
@@ -90,7 +92,12 @@ private extension SiteStatsDetailTableViewController {
                 self?.refreshTableView()
             }
         } else {
-            // TODO: add period receipt here
+            periodChangeReceipt = viewModel?.onChange { [weak self] in
+                guard self?.storeIsFetching(statSection: statSection) == false else {
+                    return
+                }
+                self?.refreshTableView()
+            }
         }
     }
 
@@ -108,6 +115,8 @@ private extension SiteStatsDetailTableViewController {
             return insightsStore.isFetchingComments
         case .insightsTagsAndCategories:
             return insightsStore.isFetchingTagsAndCategories
+        case .periodPostsAndPages:
+            return periodStore.isFetchingPostsAndPages
         default:
             return false
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -18,6 +18,8 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
     private typealias Style = WPStyleGuide.Stats
     private var statSection: StatSection?
     private var statType: StatType = .period
+    private var selectedDate: Date?
+    private var selectedPeriod: StatsPeriodUnit?
 
     private var viewModel: SiteStatsDetailsViewModel?
     private let insightsStore = StoreContainer.shared.statsInsights
@@ -37,8 +39,10 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
     }
 
-    func configure(statSection: StatSection) {
+    func configure(statSection: StatSection, selectedDate: Date? = nil, selectedPeriod: StatsPeriodUnit? = nil) {
         self.statSection = statSection
+        self.selectedDate = selectedDate
+        self.selectedPeriod = selectedPeriod
         statType = StatSection.allInsights.contains(statSection) ? .insights : .period
         title = statSection.title
         initViewModel()
@@ -76,7 +80,7 @@ private extension SiteStatsDetailTableViewController {
             return
         }
 
-        viewModel?.fetchDataFor(statSection: statSection)
+        viewModel?.fetchDataFor(statSection: statSection, selectedDate: selectedDate, selectedPeriod: selectedPeriod)
 
         if statType == .insights {
             insightsChangeReceipt = viewModel?.onChange { [weak self] in

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -148,10 +148,11 @@ private extension SiteStatsDetailTableViewController {
             viewModel?.refreshComments()
         case .insightsTagsAndCategories:
             viewModel?.refreshTagsAndCategories()
+        case .periodPostsAndPages:
+            viewModel?.refreshPostsAndPages()
         default:
             refreshControl?.endRefreshing()
         }
-
     }
 
     func applyTableUpdates() {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -5,6 +5,7 @@ import WordPressFlux
     @objc optional func tabbedTotalsCellUpdated()
     @objc optional func displayWebViewWithURL(_ url: URL)
     @objc optional func expandedRowUpdated(_ row: StatsTotalRow)
+    @objc optional func showPostStats(withPostTitle postTitle: String?)
 }
 
 class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoadable {
@@ -206,6 +207,12 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
     func expandedRowUpdated(_ row: StatsTotalRow) {
         applyTableUpdates()
         StatsDataHelper.updatedExpandedState(forRow: row)
+    }
+
+    func showPostStats(withPostTitle postTitle: String?) {
+        let postStatsTableViewController = PostStatsTableViewController.loadFromStoryboard()
+        postStatsTableViewController.configure(postTitle: postTitle)
+        navigationController?.pushViewController(postStatsTableViewController, animated: true)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -115,6 +115,14 @@ class SiteStatsDetailsViewModel: Observable {
         ActionDispatcher.dispatch(InsightAction.refreshTagsAndCategories())
     }
 
+    func refreshPostsAndPages() {
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return
+        }
+        ActionDispatcher.dispatch(PeriodAction.refreshPostsAndPages(date: selectedDate, period: selectedPeriod))
+    }
+
 }
 
 // MARK: - Private Extension

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -82,8 +82,13 @@ class SiteStatsDetailsViewModel: Observable {
         case .insightsTagsAndCategories:
             tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.insightsTagsAndCategories.itemSubtitle,
                                                       dataSubtitle: StatSection.insightsTagsAndCategories.dataSubtitle,
-                                                      dataRows: createTagsAndCategoriesRows(),
+                                                      dataRows: tagsAndCategoriesRows(),
                                                       siteStatsDetailsDelegate: detailsDelegate))
+        case .periodPostsAndPages:
+            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodPostsAndPages.itemSubtitle,
+                                                     dataSubtitle: StatSection.periodPostsAndPages.dataSubtitle,
+                                                     dataRows: postsAndPagesRows(),
+                                                     siteStatsDetailsDelegate: detailsDelegate))
         default:
             break
         }
@@ -211,7 +216,7 @@ private extension SiteStatsDetailsViewModel {
                        dataRows: rowItems)
     }
 
-    func createTagsAndCategoriesRows() -> [StatsTotalRowData] {
+    func tagsAndCategoriesRows() -> [StatsTotalRowData] {
         guard let tagsAndCategories = insightsStore.getAllTagsAndCategories()?.topTagsAndCategories else {
             return []
         }
@@ -228,6 +233,31 @@ private extension SiteStatsDetailsViewModel {
                                      childRows: StatsDataHelper.childRowsForItems($0.children),
                                      statSection: .insightsTagsAndCategories)
         }
+    }
+
+    func postsAndPagesRows() -> [StatsTotalRowData] {
+        let postsAndPages = periodStore.getAllPostsAndPages()
+        var dataRows = [StatsTotalRowData]()
+
+        postsAndPages?.forEach { item in
+
+            // TODO: when the backend provides the item type, set the icon to either pages or posts depending that.
+            let icon = Style.imageForGridiconType(.posts)
+
+            let dataBarPercent = StatsDataHelper.dataBarPercentForRow(item, relativeToRow: postsAndPages?.first)
+
+            let row = StatsTotalRowData.init(name: item.label,
+                                             data: item.value.displayString(),
+                                             dataBarPercent: dataBarPercent,
+                                             icon: icon,
+                                             showDisclosure: true,
+                                             disclosureURL: StatsDataHelper.disclosureUrlForItem(item),
+                                             statSection: .periodPostsAndPages)
+
+            dataRows.append(row)
+        }
+
+        return dataRows
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -281,6 +281,7 @@ extension TopTotalsCell: StatsTotalRowDelegate {
 
     func showPostStats(withPostTitle postTitle: String?) {
         siteStatsPeriodDelegate?.showPostStats?(withPostTitle: postTitle)
+        siteStatsDetailsDelegate?.showPostStats?(withPostTitle: postTitle)
     }
 
 }


### PR DESCRIPTION
Fixes #11248 

On the Period Posts and Pages card, selecting `View more` will now show a full list of Posts and Pages. The rows should look and behave like they do on the Period Posts and Pages card:
- Each row as a percent data bar.
- When a row is selected, Post Stats is displayed.

**NOTE:** Depending on the number of pages/posts, it could take several seconds for the view to load (en.blog is a good example). While you're staring at a blank screen, please keep in mind there is an outstanding issue to show a loading view (#11166).

To test:
- On a site with more than 6 posts/pages, go to Period > Posts and Pages > View more.
- Verify the view is as shown below.
- Verify selecting a row displays the Post Stats view.

![pandp_flow](https://user-images.githubusercontent.com/1816888/54244157-f7b22d80-44f0-11e9-8868-a3326b7cfbe3.png)



