### PR TITLE
[Stats Refresh] Period Search Terms: add detail list view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -118,6 +118,8 @@ private extension SiteStatsDetailTableViewController {
             return insightsStore.isFetchingTagsAndCategories
         case .periodPostsAndPages:
             return periodStore.isFetchingPostsAndPages
+        case .periodSearchTerms:
+            return periodStore.isFetchingSearchTerms
         default:
             return false
         }
@@ -150,6 +152,8 @@ private extension SiteStatsDetailTableViewController {
             viewModel?.refreshTagsAndCategories()
         case .periodPostsAndPages:
             viewModel?.refreshPostsAndPages()
+        case .periodSearchTerms:
+            viewModel?.refreshSearchTerms()
         default:
             refreshControl?.endRefreshing()
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -89,6 +89,11 @@ class SiteStatsDetailsViewModel: Observable {
                                                      dataSubtitle: StatSection.periodPostsAndPages.dataSubtitle,
                                                      dataRows: postsAndPagesRows(),
                                                      siteStatsDetailsDelegate: detailsDelegate))
+        case .periodSearchTerms:
+            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodSearchTerms.itemSubtitle,
+                                                     dataSubtitle: StatSection.periodSearchTerms.dataSubtitle,
+                                                     dataRows: searchTermsRows(),
+                                                     siteStatsDetailsDelegate: detailsDelegate))
         default:
             break
         }
@@ -123,6 +128,14 @@ class SiteStatsDetailsViewModel: Observable {
         ActionDispatcher.dispatch(PeriodAction.refreshPostsAndPages(date: selectedDate, period: selectedPeriod))
     }
 
+    func refreshSearchTerms() {
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return
+        }
+        ActionDispatcher.dispatch(PeriodAction.refreshSearchTerms(date: selectedDate, period: selectedPeriod))
+    }
+
 }
 
 // MARK: - Private Extension
@@ -143,13 +156,17 @@ private extension SiteStatsDetailsViewModel {
     }
 
     func queryForPeriodStatSection(_ statSection: StatSection) -> PeriodQuery? {
+
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return nil
+        }
+
         switch statSection {
         case .periodPostsAndPages:
-            guard let selectedDate = selectedDate,
-                let selectedPeriod = selectedPeriod else {
-                    return nil
-            }
             return .allPostsAndPages(date: selectedDate, period: selectedPeriod)
+        case .periodSearchTerms:
+            return .allSearchTerms(date: selectedDate, period: selectedPeriod)
         default:
             return nil
         }
@@ -266,6 +283,13 @@ private extension SiteStatsDetailsViewModel {
         }
 
         return dataRows
+    }
+
+    func searchTermsRows() -> [StatsTotalRowData] {
+        return periodStore.getAllSearchTerms()?.map { StatsTotalRowData.init(name: $0.label,
+                                                                             data: $0.value.displayString(),
+                                                                             statSection: .periodSearchTerms) }
+            ?? []
     }
 
 }


### PR DESCRIPTION
Fixes #11252 

On the Period Search Terms card, selecting `View more` will now show a full list of Search Terms. The rows should look like they do on the Period Search Terms card. There is no row selection action.

**NOTE:** Depending on the number of search terms, it could take several seconds for the view to load (en.blog is a good example). There is an outstanding issue to show a loading view (#11166).

To test:
- On a site with more than 6 search terms, go to Period > Search Terms > View more.
- Verify the view is as shown below.

![search_terms_flow](https://user-images.githubusercontent.com/1816888/54246715-a3f91180-44fb-11e9-871e-10cd1e774f48.png)

