### PR TITLE
[Stats Refresh] Add Core Data mapping code for Publicize, Streak and Tags/Categories

### DIFF
--- a/WordPress/Classes/Models/AllTimeStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/AllTimeStatsRecordValue+CoreDataClass.swift
@@ -10,7 +10,7 @@ public class AllTimeStatsRecordValue: StatsRecordValue {
 }
 
 extension StatsAllTimesInsight: StatsRecordValueConvertible {
-    func statsRecordValue(in context: NSManagedObjectContext) -> StatsRecordValue {
+    func statsRecordValues(in context: NSManagedObjectContext) -> [StatsRecordValue] {
         let value = AllTimeStatsRecordValue(context: context)
 
         value.postsCount = Int64(self.postsCount)
@@ -19,7 +19,7 @@ extension StatsAllTimesInsight: StatsRecordValueConvertible {
         value.bestViewsPerDayCount = Int64(self.bestViewsPerDayCount)
         value.bestViewsDay = self.bestViewsDay as NSDate
 
-        return value
+        return [value]
     }
 
     init(statsRecordValue: StatsRecordValue) {

--- a/WordPress/Classes/Models/AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift
@@ -10,7 +10,7 @@ public class AnnualAndMostPopularTimeStatsRecordValue: StatsRecordValue {
 }
 
 extension StatsAnnualAndMostPopularTimeInsight: StatsRecordValueConvertible {
-    func statsRecordValue(in context: NSManagedObjectContext) -> StatsRecordValue {
+    func statsRecordValues(in context: NSManagedObjectContext) -> [StatsRecordValue] {
         let value = AnnualAndMostPopularTimeStatsRecordValue(context: context)
 
         value.mostPopularDayOfWeek = Int64(self.mostPopularDayOfWeek.weekday!)
@@ -35,7 +35,7 @@ extension StatsAnnualAndMostPopularTimeInsight: StatsRecordValueConvertible {
         value.totalImagesCount = Int64(self.annualInsightsTotalImagesCount)
         value.averageImagesCount = self.annualInsightsAverageImagesCount
 
-        return value
+        return [value]
     }
 
     init(statsRecordValue: StatsRecordValue) {

--- a/WordPress/Classes/Models/LastPostStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/LastPostStatsRecordValue+CoreDataClass.swift
@@ -17,7 +17,7 @@ public class LastPostStatsRecordValue: StatsRecordValue {
 }
 
 extension StatsLastPostInsight: StatsRecordValueConvertible {
-    func statsRecordValue(in context: NSManagedObjectContext) -> StatsRecordValue {
+    func statsRecordValues(in context: NSManagedObjectContext) -> [StatsRecordValue] {
         let value = LastPostStatsRecordValue(context: context)
 
         value.commentsCount = Int64(self.commentsCount)
@@ -27,7 +27,7 @@ extension StatsLastPostInsight: StatsRecordValueConvertible {
         value.urlString = self.url.absoluteString
         value.viewsCount = Int64(self.viewsCount)
 
-        return value
+        return [value]
     }
 
     init(statsRecordValue: StatsRecordValue) {

--- a/WordPress/Classes/Models/PublicizeConnectionStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/PublicizeConnectionStatsRecordValue+CoreDataClass.swift
@@ -10,3 +10,28 @@ public class PublicizeConnectionStatsRecordValue: StatsRecordValue {
         return URL(string: url)
     }
 }
+
+
+extension StatsPublicizeInsight: StatsRecordValueConvertible {
+    func statsRecordValues(in context: NSManagedObjectContext) -> [StatsRecordValue] {
+        return publicizeServices.compactMap {
+            let value = PublicizeConnectionStatsRecordValue(context: context)
+
+            value.name = $0.name
+            value.followersCount = Int64($0.followers)
+            value.iconURLString = $0.iconURL?.absoluteString
+
+            return value
+        }
+    }
+
+    init(statsRecordValue: StatsRecordValue) {
+        // We won't be needing those until later. I added them to protocol to show the intended design
+        // but it doesn't make sense to implement it yet.
+        fatalError("This shouldn't be called yet — implementation of StatsRecordValueConvertible is still in progres. This method was added to illustrate intended design, but isn't ready yet.")
+    }
+
+    static var recordType: StatsRecordType {
+        return .publicizeConnection
+    }
+}

--- a/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
@@ -36,12 +36,10 @@ public enum StatsRecordType: Int16 {
     case annualAndMostPopularTimes
     case today
 
-
     case blogVisitsSummary
     case clicks
     case countryViews
     case postViews
-    case postingStreak
     case publishedPosts
     case referrers
     case searchTerms
@@ -69,7 +67,6 @@ public enum StatsRecordType: Int16 {
         case  .blogVisitsSummary,
               .clicks,
               .countryViews,
-              .postingStreak,
               .publishedPosts,
               .referrers,
               .searchTerms,

--- a/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StatsRecord+CoreDataClass.swift
@@ -221,7 +221,7 @@ extension StatsRecord {
             managedObjectContext.deleteObject($0 as! StatsRecordValue)
         }
 
-        parentRecord.addToValues(remoteInsight.statsRecordValue(in: managedObjectContext))
+        parentRecord.addToValues(NSOrderedSet(array: remoteInsight.statsRecordValues(in: managedObjectContext)))
 
         return parentRecord
     }

--- a/WordPress/Classes/Models/StatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StatsRecordValue+CoreDataClass.swift
@@ -11,7 +11,7 @@ public class StatsRecordValue: NSManagedObject {
 }
 
 protocol StatsRecordValueConvertible {
-    func statsRecordValue(in context: NSManagedObjectContext) -> StatsRecordValue
+    func statsRecordValues(in context: NSManagedObjectContext) -> [StatsRecordValue]
     init(statsRecordValue: StatsRecordValue)
 
     static var recordType: StatsRecordType { get }

--- a/WordPress/Classes/Models/StreakInsightStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StreakInsightStatsRecordValue+CoreDataClass.swift
@@ -8,3 +8,38 @@ public class StreakInsightStatsRecordValue: StatsRecordValue {
         try singleEntryTypeValidation()
     }
 }
+
+extension StatsPostingStreakInsight: StatsRecordValueConvertible {
+    func statsRecordValues(in context: NSManagedObjectContext) -> [StatsRecordValue] {
+        let value = StreakInsightStatsRecordValue(context: context)
+
+        value.currentStreakStart = currentStreakStart as NSDate
+        value.currentStreakEnd = currentStreakEnd as NSDate
+        value.currentStreakLength = Int64(currentStreakLength)
+
+        value.longestStreakStart = longestStreakStart as NSDate
+        value.longestStreakEnd = longestStreakEnd as NSDate
+        value.longestStreakLength = Int64(longestStreakLength)
+
+        value.streakData = NSOrderedSet(array: postingEvents.compactMap {
+            let value = StreakStatsRecordValue(context: context)
+
+            value.postCount = Int64($0.postCount)
+            value.date = $0.date as NSDate
+
+            return value
+        })
+
+        return [value]
+    }
+
+    init(statsRecordValue: StatsRecordValue) {
+        fatalError("This shouldn't be called yet — implementation of StatsRecordValueConvertible is still in progres. This method was added to illustrate intended design, but isn't ready yet.")
+    }
+
+    static var recordType: StatsRecordType {
+        return .streakInsight
+    }
+
+
+}

--- a/WordPress/Classes/Models/StreakInsightStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/StreakInsightStatsRecordValue+CoreDataProperties.swift
@@ -14,5 +14,41 @@ extension StreakInsightStatsRecordValue {
     @NSManaged public var longestStreakEnd: NSDate?
     @NSManaged public var longestStreakLength: Int64
     @NSManaged public var longestStreakStart: NSDate?
+    @NSManaged public var streakData: NSOrderedSet?
+
+}
+
+// MARK: Generated accessors for streakData
+extension StreakInsightStatsRecordValue {
+
+    @objc(insertObject:inStreakDataAtIndex:)
+    @NSManaged public func insertIntoStreakData(_ value: StreakStatsRecordValue, at idx: Int)
+
+    @objc(removeObjectFromStreakDataAtIndex:)
+    @NSManaged public func removeFromStreakData(at idx: Int)
+
+    @objc(insertStreakData:atIndexes:)
+    @NSManaged public func insertIntoStreakData(_ values: [StreakStatsRecordValue], at indexes: NSIndexSet)
+
+    @objc(removeStreakDataAtIndexes:)
+    @NSManaged public func removeFromStreakData(at indexes: NSIndexSet)
+
+    @objc(replaceObjectInStreakDataAtIndex:withObject:)
+    @NSManaged public func replaceStreakData(at idx: Int, with value: StreakStatsRecordValue)
+
+    @objc(replaceStreakDataAtIndexes:withStreakData:)
+    @NSManaged public func replaceStreakData(at indexes: NSIndexSet, with values: [StreakStatsRecordValue])
+
+    @objc(addStreakDataObject:)
+    @NSManaged public func addToStreakData(_ value: StreakStatsRecordValue)
+
+    @objc(removeStreakDataObject:)
+    @NSManaged public func removeFromStreakData(_ value: StreakStatsRecordValue)
+
+    @objc(addStreakData:)
+    @NSManaged public func addToStreakData(_ values: NSOrderedSet)
+
+    @objc(removeStreakData:)
+    @NSManaged public func removeFromStreakData(_ values: NSOrderedSet)
 
 }

--- a/WordPress/Classes/Models/StreakStatsRecordValue+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/StreakStatsRecordValue+CoreDataProperties.swift
@@ -9,5 +9,7 @@ extension StreakStatsRecordValue {
     }
 
     @NSManaged public var postCount: Int64
+    @NSManaged public var date: NSDate?
+    @NSManaged public var streakInsight: StreakInsightStatsRecordValue?
 
 }

--- a/WordPress/Classes/Models/TagsCategoriesStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/TagsCategoriesStatsRecordValue+CoreDataClass.swift
@@ -30,5 +30,47 @@ public class TagsCategoriesStatsRecordValue: StatsRecordValue {
             }
         }
     }
+}
+
+fileprivate extension TagsCategoriesStatsRecordValue {
+    convenience init?(context: NSManagedObjectContext, tagCategory: StatsTagAndCategory) {
+        self.init(context: context)
+
+        self.name = tagCategory.name
+        self.urlString = tagCategory.url?.absoluteString
+        self.viewsCount = Int64(tagCategory.viewsCount ?? 0)
+
+        switch tagCategory.kind {
+        case .category:
+            self.type = TagsCategoriesType.category.rawValue
+        case .folder:
+            self.type = TagsCategoriesType.folder.rawValue
+        case .tag:
+            self.type = TagsCategoriesType.tag.rawValue
+        }
+
+        let children = tagCategory.children.compactMap { TagsCategoriesStatsRecordValue(context: context, tagCategory: $0) }
+
+        self.children = NSOrderedSet(array: children)
+    }
+}
+
+extension StatsTagsAndCategoriesInsight: StatsRecordValueConvertible {
+    func statsRecordValues(in context: NSManagedObjectContext) -> [StatsRecordValue] {
+        return topTagsAndCategories.compactMap {
+            return TagsCategoriesStatsRecordValue(context: context, tagCategory: $0)
+        }
+    }
+
+    init(statsRecordValue: StatsRecordValue) {
+        // We won't be needing those until later. I added them to protocol to show the intended design
+        // but it doesn't make sense to implement it yet.
+        fatalError("This shouldn't be called yet — implementation of StatsRecordValueConvertible is still in progres. This method was added to illustrate intended design, but isn't ready yet.")
+    }
+
+    static var recordType: StatsRecordType {
+        return .tagsAndCategories
+    }
+
 
 }

--- a/WordPress/Classes/Models/TodayStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/TodayStatsRecordValue+CoreDataClass.swift
@@ -10,7 +10,7 @@ public class TodayStatsRecordValue: StatsRecordValue {
 }
 
 extension StatsTodayInsight: StatsRecordValueConvertible {
-    func statsRecordValue(in context: NSManagedObjectContext) -> StatsRecordValue {
+    func statsRecordValues(in context: NSManagedObjectContext) -> [StatsRecordValue] {
         let value = TodayStatsRecordValue(context: context)
 
         value.commentsCount = Int64(self.commentsCount)
@@ -18,7 +18,7 @@ extension StatsTodayInsight: StatsRecordValueConvertible {
         value.viewsCount = Int64(self.viewsCount)
         value.visitorsCount = Int64(self.visitorsCount)
 
-        return value
+        return [value]
     }
 
     init(statsRecordValue: StatsRecordValue) {

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 87.xcdatamodel/contents
@@ -806,9 +806,12 @@
         <attribute name="longestStreakEnd" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="longestStreakLength" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="longestStreakStart" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
+        <relationship name="streakData" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="StreakStatsRecordValue" inverseName="streakInsight" inverseEntity="StreakStatsRecordValue" syncable="YES"/>
     </entity>
     <entity name="StreakStatsRecordValue" representedClassName=".StreakStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="postCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
+        <relationship name="streakInsight" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="StreakInsightStatsRecordValue" inverseName="streakData" inverseEntity="StreakInsightStatsRecordValue" syncable="YES"/>
     </entity>
     <entity name="TagsCategoriesStatsRecordValue" representedClassName=".TagsCategoriesStatsRecordValue" parentEntity="StatsRecordValue" syncable="YES">
         <attribute name="name" attributeType="String" syncable="YES"/>
@@ -942,16 +945,16 @@
         <element name="SourcePostAttribution" positionX="9" positionY="153" width="128" height="225"/>
         <element name="StatsRecord" positionX="27" positionY="486" width="128" height="135"/>
         <element name="StatsRecordValue" positionX="36" positionY="495" width="128" height="60"/>
-        <element name="StreakInsightStatsRecordValue" positionX="54" positionY="180" width="128" height="135"/>
-        <element name="StreakStatsRecordValue" positionX="72" positionY="198" width="128" height="60"/>
+        <element name="StreakInsightStatsRecordValue" positionX="54" positionY="180" width="128" height="150"/>
+        <element name="StreakStatsRecordValue" positionX="72" positionY="198" width="128" height="90"/>
         <element name="TagsCategoriesStatsRecordValue" positionX="45" positionY="171" width="128" height="120"/>
         <element name="Theme" positionX="9" positionY="153" width="128" height="360"/>
+        <element name="TodayStatsRecordValue" positionX="45" positionY="153" width="128" height="105"/>
         <element name="TopCommentedPostStatsRecordValue" positionX="36" positionY="162" width="128" height="105"/>
         <element name="TopCommentsAuthorStatsRecordValue" positionX="27" positionY="153" width="128" height="90"/>
         <element name="TopViewedAuthorStatsRecordValue" positionX="36" positionY="162" width="128" height="105"/>
         <element name="TopViewedPostStatsRecordValue" positionX="45" positionY="171" width="128" height="120"/>
         <element name="TopViewedVideoStatsRecordValue" positionX="36" positionY="162" width="128" height="105"/>
         <element name="VisitsSummaryStatsRecordValue" positionX="45" positionY="153" width="128" height="105"/>
-        <element name="TodayStatsRecordValue" positionX="45" positionY="153" width="128" height="105"/>
     </elements>
 </model>

--- a/WordPress/WordPressTest/StreakStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/StreakStatsRecordValueTests.swift
@@ -64,7 +64,7 @@ class StreakStatsRecordValueTests: StatsTestCase {
         XCTAssertEqual(secondValue.postCount, streakValue2.postCount)
     }
 
-    func testCoreDatConversion() {
+    func testCoreDataConversion() {
         let now = Date()
         let weekAgo = Calendar.autoupdatingCurrent.date(byAdding: .day, value: -7, to: now)
 

--- a/WordPress/WordPressTest/StreakStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/StreakStatsRecordValueTests.swift
@@ -1,4 +1,5 @@
 @testable import WordPress
+@testable import WordPressKit
 
 
 class StreakStatsRecordValueTests: StatsTestCase {
@@ -24,49 +25,101 @@ class StreakStatsRecordValueTests: StatsTestCase {
     }
 
     func testStreakCreation() {
+        let parent = createStatsRecord(in: mainContext, type: .streakInsight, date: Date())
+        let streakInsight = StreakInsightStatsRecordValue(parent: parent)
+        streakInsight.longestStreakLength = 9001
+
         let now = Date()
 
-        let streakItem1 = createStatsRecord(in: mainContext, type: .postingStreak, date: now)
-        let streakValue1 = StreakStatsRecordValue(parent: streakItem1)
+        let streakValue1 = StreakStatsRecordValue(context: mainContext)
         streakValue1.postCount = 9001
+        streakValue1.date = now as NSDate
 
         let weekAgo = Calendar.autoupdatingCurrent.date(byAdding: .day, value: -7, to: now)
 
-        let streakItem2 = createStatsRecord(in: mainContext, type: .postingStreak, date: weekAgo!)
-        let streakValue2 = StreakStatsRecordValue(parent: streakItem2)
+        let streakValue2 = StreakStatsRecordValue(context: mainContext)
         streakValue2.postCount = 9002
+        streakValue2.date = weekAgo! as NSDate
 
-        let fr = StatsRecord.fetchRequest(for: .postingStreak)
+        streakInsight.addToStreakData(NSOrderedSet(array: [streakValue1, streakValue2]))
+
+        let fr = StatsRecord.fetchRequest(for: .streakInsight)
 
         let results = try! mainContext.fetch(fr)
 
         XCTAssertEqual(results.count, 1)
 
-        let firstItem = results.first!
-        XCTAssertEqual(firstItem.values!.count, 1)
+        let firstItem = results.first?.values?.firstObject! as? StreakInsightStatsRecordValue
 
-        let firstValue = firstItem.values?.firstObject! as! StreakStatsRecordValue
+        XCTAssertEqual(firstItem?.streakData?.count, 2)
+
+        let firstValue = firstItem?.streakData?.firstObject! as! StreakStatsRecordValue
         XCTAssertNotNil(firstValue)
 
         XCTAssertEqual(firstValue.postCount, streakValue1.postCount)
 
-        // this might get potentially flaky for... seven seconds around midnight each day.
-        // hopefully this won't be a problem, but I wanted to test that fetching by dates
-        // that aren't exact matches still works.
-        let fewSecondsAfterAWeekAgo = Calendar.autoupdatingCurrent.date(byAdding: .second, value: 7, to: weekAgo!)!
-
-        let fr2 = StatsRecord.fetchRequest(for: .postingStreak, on: fewSecondsAfterAWeekAgo)
-        let results2 = try! mainContext.fetch(fr2)
-
-        XCTAssertEqual(results2.count, 1)
-
-        let secondItem = results2.first!
-        XCTAssertEqual(secondItem.values!.count, 1)
-
-        let secondValue = secondItem.values?.firstObject! as! StreakStatsRecordValue
+        let secondValue = firstItem?.streakData?[1] as! StreakStatsRecordValue
         XCTAssertNotNil(secondValue)
 
         XCTAssertEqual(secondValue.postCount, streakValue2.postCount)
+    }
+
+    func testCoreDatConversion() {
+        let now = Date()
+        let weekAgo = Calendar.autoupdatingCurrent.date(byAdding: .day, value: -7, to: now)
+
+        let postingEventToday = PostingStreakEvent(date: now, postCount: 2)
+        let postingEventWeekAgo = PostingStreakEvent(date: weekAgo!, postCount: 16)
+
+
+        let streakInsight = StatsPostingStreakInsight(currentStreakStart: now,
+                                                      currentStreakEnd: now,
+                                                      currentStreakLength: 1,
+                                                      longestStreakStart: weekAgo!,
+                                                      longestStreakEnd: weekAgo!,
+                                                      longestStreakLength: 15,
+                                                      postingEvents: [postingEventWeekAgo, postingEventToday])
+
+        let blog = defaultBlog()
+
+        _ = StatsRecord.record(from: streakInsight, for: blog)
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let fetchRequest = StatsRecord.fetchRequest(for: .streakInsight)
+
+        let result = try! mainContext.fetch(fetchRequest)
+        let statsRecord = result.first!
+
+        XCTAssertEqual(statsRecord.blog, blog)
+        XCTAssertEqual(statsRecord.period, StatsRecordPeriodType.notApplicable.rawValue)
+
+        let castedResults = statsRecord.values?.array as! [StreakInsightStatsRecordValue]
+
+        XCTAssertEqual(castedResults.count, 1)
+
+        let insight = castedResults.first!
+
+        XCTAssertEqual(insight.currentStreakStart, now as NSDate)
+        XCTAssertEqual(insight.currentStreakEnd, now as NSDate)
+        XCTAssertEqual(insight.currentStreakLength, 1)
+        XCTAssertEqual(insight.longestStreakStart, weekAgo! as NSDate)
+        XCTAssertEqual(insight.longestStreakEnd, weekAgo! as NSDate)
+        XCTAssertEqual(insight.longestStreakLength, 15)
+
+        XCTAssertEqual(insight.streakData?.count, 2)
+
+        let firstData = insight.streakData?.firstObject as? StreakStatsRecordValue
+        let secondData = insight.streakData?[1] as? StreakStatsRecordValue
+
+        XCTAssertNotNil(firstData)
+        XCTAssertNotNil(secondData)
+
+        XCTAssertEqual(firstData?.postCount, 16)
+        XCTAssertEqual(firstData?.date, weekAgo! as NSDate)
+
+        XCTAssertEqual(secondData?.postCount, 2)
+        XCTAssertEqual(secondData?.date, now as NSDate)
     }
 
 }

--- a/WordPress/WordPressTest/TagsCategoriesStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/TagsCategoriesStatsRecordValueTests.swift
@@ -1,4 +1,5 @@
 @testable import WordPress
+@testable import WordPressKit
 
 class TagsCategoriesStatsRecordValueTests: StatsTestCase {
 
@@ -134,5 +135,73 @@ class TagsCategoriesStatsRecordValueTests: StatsTestCase {
         XCTAssertNotNil(fetchedValue.linkURL)
     }
 
+    func testCoreDataConversionWorks() {
+        let standaloneTag = StatsTagAndCategory(name: "standalone", kind: .tag, url: "wp.com/tags/tag", viewsCount: 0, children: [])
+
+        let childTag = StatsTagAndCategory(name: "tag", kind: .tag, url: "whatever", viewsCount: 9001, children: [])
+        let childCategory = StatsTagAndCategory(name: "category", kind: .category, url: "", viewsCount: 9002, children: [])
+
+        let folderInsight = StatsTagAndCategory(name: "folder",
+                                                kind: .folder,
+                                                url: "https://wordpress.com",
+                                                viewsCount: 18003,
+                                                children: [childTag, childCategory])
+
+        let insight = StatsTagsAndCategoriesInsight(topTagsAndCategories: [folderInsight, standaloneTag])
+
+        let blog = defaultBlog()
+
+        _ = StatsRecord.record(from: insight, for: blog)
+
+        XCTAssertNoThrow(try mainContext.save())
+
+        let fetchRequest = StatsRecord.fetchRequest(for: .tagsAndCategories)
+
+        let result = try! mainContext.fetch(fetchRequest)
+        let statsRecord = result.first!
+
+        XCTAssertEqual(statsRecord.blog, blog)
+        XCTAssertEqual(statsRecord.period, StatsRecordPeriodType.notApplicable.rawValue)
+
+        let castedResults = statsRecord.values?.array as! [TagsCategoriesStatsRecordValue]
+
+        XCTAssertEqual(castedResults.count, 2)
+
+        let tag = castedResults.first { $0.type == TagsCategoriesType.tag.rawValue }
+        XCTAssertNotNil(tag)
+
+        XCTAssertEqual(tag?.name, "standalone")
+        XCTAssertEqual(tag?.type, TagsCategoriesType.tag.rawValue)
+        XCTAssertEqual(tag?.viewsCount, 0)
+        XCTAssertEqual(tag?.linkURL, URL(string: "wp.com/tags/tag"))
+        XCTAssertEqual(tag?.children?.count, 0)
+
+        let folder = castedResults.first { $0.type == TagsCategoriesType.folder.rawValue }
+
+        XCTAssertNotNil(folder)
+
+        XCTAssertEqual(folder?.name, "folder")
+        XCTAssertEqual(folder?.type, TagsCategoriesType.folder.rawValue)
+        XCTAssertEqual(folder?.viewsCount, 18003)
+        XCTAssertEqual(folder?.linkURL, URL(string: "https://wordpress.com"))
+
+        XCTAssertEqual(folder?.children?.count, 2)
+
+        let firstChild = folder?.children?[0] as? TagsCategoriesStatsRecordValue
+        let secondChild = folder?.children?[1] as? TagsCategoriesStatsRecordValue
+
+        XCTAssertNotNil(firstChild)
+        XCTAssertNotNil(secondChild)
+
+        XCTAssertEqual(firstChild?.name, "tag")
+        XCTAssertEqual(firstChild?.type, TagsCategoriesType.tag.rawValue)
+        XCTAssertEqual(firstChild?.viewsCount, 9001)
+        XCTAssertEqual(firstChild?.linkURL, URL(string: "whatever"))
+
+        XCTAssertEqual(secondChild?.name, "category")
+        XCTAssertEqual(secondChild?.type, TagsCategoriesType.category.rawValue)
+        XCTAssertEqual(secondChild?.viewsCount, 9002)
+        XCTAssertEqual(secondChild?.linkURL, nil)
+    }
 
 }

--- a/WordPress/WordPressTest/TagsCategoriesStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/TagsCategoriesStatsRecordValueTests.swift
@@ -174,7 +174,7 @@ class TagsCategoriesStatsRecordValueTests: StatsTestCase {
         XCTAssertEqual(tag?.type, TagsCategoriesType.tag.rawValue)
         XCTAssertEqual(tag?.viewsCount, 0)
         XCTAssertEqual(tag?.linkURL, URL(string: "wp.com/tags/tag"))
-        XCTAssertEqual(tag?.children?.count, 2)
+        XCTAssertEqual(tag?.children?.count, 0)
 
         let folder = castedResults.first { $0.type == TagsCategoriesType.folder.rawValue }
 

--- a/WordPress/WordPressTest/TagsCategoriesStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/TagsCategoriesStatsRecordValueTests.swift
@@ -174,7 +174,7 @@ class TagsCategoriesStatsRecordValueTests: StatsTestCase {
         XCTAssertEqual(tag?.type, TagsCategoriesType.tag.rawValue)
         XCTAssertEqual(tag?.viewsCount, 0)
         XCTAssertEqual(tag?.linkURL, URL(string: "wp.com/tags/tag"))
-        XCTAssertEqual(tag?.children?.count, 0)
+        XCTAssertEqual(tag?.children?.count, 2)
 
         let folder = castedResults.first { $0.type == TagsCategoriesType.folder.rawValue }
 


### PR DESCRIPTION
I was hoping to have entirety of this work wrapped by today, but it's been hard getting into the groove after AFK, so here we are :)

This adds more support for mapping more of Stats Insights into Core Data entities, namely:
* Streak
* Publicize
* Tags/Categories

This leaves us with:

* Dotcom/Email followers
* Most commented posts / top comment author

to wrap up Insights persistence and then then move on to the TimeInterval-related data.
