### PR TITLE
Fix invalid token on release 12.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -41,8 +41,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 3.0.0'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/fix_tag_sync'
+    #pod 'WordPressKit', '~> 3.0.0'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/invalid-token'
     #pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -41,8 +41,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    #pod 'WordPressKit', '~> 3.0.0'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/invalid-token'
+    pod 'WordPressKit', '~> 3.1.1'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/invalid-token'
     #pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 
@@ -124,7 +124,7 @@ target 'WordPress' do
     ## while PR is in review:
     ## pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'e546205cd2a992838837b0a4de502507b89b6e63'
 
-    pod 'WordPressAuthenticator', '~> 1.1.10'
+    pod 'WordPressAuthenticator', '~> 1.1.11'
     #pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
     #pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git' , :commit => 'f19542a'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -179,21 +179,21 @@ PODS:
   - WordPress-Aztec-iOS (1.4.4)
   - WordPress-Editor-iOS (1.4.4):
     - WordPress-Aztec-iOS (= 1.4.4)
-  - WordPressAuthenticator (1.1.10):
+  - WordPressAuthenticator (1.1.11):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
-    - CocoaLumberjack (= 3.4.2)
+    - CocoaLumberjack (~> 3.4)
     - GoogleSignInRepacked (= 4.1.2)
     - Gridicons (~> 0.15)
     - lottie-ios (= 2.5.2)
     - "NSURL+IDN (= 0.3)"
     - SVProgressHUD (= 2.2.5)
-    - WordPressKit (~> 3.0.0-beta.1)
+    - WordPressKit (~> 3.1.1)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-  - WordPressKit (3.0.0):
+  - WordPressKit (3.1.1):
     - Alamofire (~> 4.7.3)
-    - CocoaLumberjack (= 3.4.2)
+    - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.4)
@@ -248,8 +248,8 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.4)
-  - WordPressAuthenticator (~> 1.1.10)
-  - WordPressKit (~> 3.0.0)
+  - WordPressAuthenticator (~> 1.1.11)
+  - WordPressKit (~> 3.1.1)
   - WordPressShared (= 1.7.2)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -386,8 +386,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-Aztec-iOS: b4a1fac03f617eea9882336bf64f122cbc60e727
   WordPress-Editor-iOS: 9787d07b2362457952fb74e4f09fa63bbf22cf14
-  WordPressAuthenticator: 300f81a9171072657bcf39ed5e8c791ced85f2e4
-  WordPressKit: cb235685297f99e6a6ee1d4ba35275e5bf7e63d6
+  WordPressAuthenticator: 50e1119773a78fde89c39da83d2e503eceb971b7
+  WordPressKit: 9af12361492d12c6c5512d3d7de594aa415ad670
   WordPressShared: 63d57a4a07ad9f9a1ee5e8a7162e48fbb5192014
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
@@ -395,6 +395,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 83c799cba6638d34e1d25fd70319a829d59fe089
+PODFILE CHECKSUM: 032952b6504c3e925c36ced3f2a0b7f24f086b3b
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Services/NotificationSettingsService.swift
+++ b/WordPress/Classes/Services/NotificationSettingsService.swift
@@ -17,7 +17,9 @@ open class NotificationSettingsService: LocalCoreDataService {
     public override init(managedObjectContext context: NSManagedObjectContext) {
         super.init(managedObjectContext: context)
 
-        if let restApi = AccountService(managedObjectContext: context).defaultWordPressComAccount()?.wordPressComRestApi {
+        if let defaultAccount = AccountService(managedObjectContext: context).defaultWordPressComAccount(),
+            defaultAccount.authToken != nil,
+            let restApi = defaultAccount.wordPressComRestApi {
             remoteApi = restApi.hasCredentials() ? restApi : nil
         }
     }

--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -359,8 +359,8 @@ extension WordPressAppDelegate {
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)
 
-        if let account = accountService.defaultWordPressComAccount() {
-            ShareExtensionService.configureShareExtensionToken(account.authToken)
+        if let account = accountService.defaultWordPressComAccount(), let authToken = account.authToken {
+            ShareExtensionService.configureShareExtensionToken(authToken)
             ShareExtensionService.configureShareExtensionUsername(account.username)
         }
     }
@@ -381,11 +381,11 @@ extension WordPressAppDelegate {
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)
 
-        if let account = accountService.defaultWordPressComAccount() {
-            NotificationSupportService.insertContentExtensionToken(account.authToken)
+        if let account = accountService.defaultWordPressComAccount(), let authToken = account.authToken {
+            NotificationSupportService.insertContentExtensionToken(authToken)
             NotificationSupportService.insertContentExtensionUsername(account.username)
 
-            NotificationSupportService.insertServiceExtensionToken(account.authToken)
+            NotificationSupportService.insertServiceExtensionToken(authToken)
             NotificationSupportService.insertServiceExtensionUsername(account.username)
         }
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -76,9 +76,6 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
     // Set the main window up
     [self.window makeKeyAndVisible];
 
-    // Local Notifications
-    [self addNotificationObservers];
-
     WPAuthTokenIssueSolver *authTokenIssueSolver = [[WPAuthTokenIssueSolver alloc] init];
     
     __weak __typeof(self) weakSelf = self;
@@ -260,6 +257,9 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
 
 - (void)runStartupSequenceWithLaunchOptions:(NSDictionary *)launchOptions
 {
+    // Local Notifications
+    [self addNotificationObservers];
+    
     // Crash reporting, logging
     self.logger = [[WPLogger alloc] init];
     [self configureHockeySDK];

--- a/WordPress/Classes/Utility/PingHubManager.swift
+++ b/WordPress/Classes/Utility/PingHubManager.swift
@@ -10,7 +10,6 @@ private func defaultAccountToken() -> String? {
         return nil
     }
     guard let token = account.authToken, !token.isEmpty else {
-        assertionFailure("Can't create a PingHub client if the account has no auth token")
         return nil
     }
     return token

--- a/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
+++ b/WordPress/Classes/Utility/WPAuthTokenIssueSolver.m
@@ -18,13 +18,17 @@
     if ([self hasAuthTokenIssues]) {
         UIViewController *controller = [WordPressAuthenticationManager signinForWPComFixingAuthToken:^(BOOL cancelled) {
             if (cancelled) {
-                [self showCancelReAuthenticationAlertAndOnOK:^{
-                    NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
-                    AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:mainContext];
+                // We present asynchronously to prevent an issue where the Login VC would dismiss the
+                // alert instead of itself.
+                dispatch_async(dispatch_get_main_queue(), ^{
+                    [self showCancelReAuthenticationAlertAndOnOK:^{
+                        NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
+                        AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:mainContext];
 
-                    [accountService removeDefaultWordPressComAccount];
-                    onComplete();
-                }];
+                        [accountService removeDefaultWordPressComAccount];
+                        onComplete();
+                    }];
+                });
             } else {
                 onComplete();
             }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -7,6 +7,7 @@ import WordPressAuthenticator
 //
 @objc
 class WordPressAuthenticationManager: NSObject {
+    static var isPresentingSignIn = false
 
     /// Support is only available to the WordPress iOS App. Our Authentication Framework doesn't have direct access.
     /// We'll setup a mechanism to relay the Support event back to the Authenticator.
@@ -61,7 +62,14 @@ extension WordPressAuthenticationManager {
             return
         }
 
-        let controller = signinForWPComFixingAuthToken()
+        guard !isPresentingSignIn else {
+            return
+        }
+
+        isPresentingSignIn = true
+        let controller = signinForWPComFixingAuthToken({ (_) in
+            isPresentingSignIn = false
+        })
         presenter.present(controller, animated: true)
     }
 }


### PR DESCRIPTION
This brings the invalid token fix up release 12.0 the same work that was done here for 11.9 https://github.com/wordpress-mobile/WordPress-iOS/pull/11245

To test:
 - Check the original PR above to see the steps needed.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
