### PR TITLE
Remove old comments from Deliverfile

### DIFF
--- a/Scripts/fastlane/Deliverfile
+++ b/Scripts/fastlane/Deliverfile
@@ -1,16 +1,3 @@
-#
-# For more information about each property, visit the GitHub documentation: https://github.com/krausefx/deliver
-# Everything next to a # is a comment and will be ignored
-
-# hide_transporter_output # remove the '#' in the beginning of the line, to hide the output while uploading
-
-########################################
-# App Metadata
-########################################
-
-# This folder has to include one folder for each language
-# More information about automatic screenshot upload:
-# https://github.com/KrauseFx/deliver#upload-screenshots-to-itunes-connect
 screenshots_path "./screenshots/"
 app_identifier "org.wordpress"
 
@@ -26,41 +13,3 @@ copyright('2019 Automattic Inc.')
 skip_binary_upload true
 overwrite_screenshots true
 phased_release true
-
-# version '1.2' # you can pass this if you want to verify the version number with the ipa file
-
-# config_json_folder './deliver'
-
-########################################
-# Building and Testing
-########################################
-
-# Dynamic generation of the ipa file
-# I'm using Shenzhen by Mattt, but you can use any build tool you want
-# Remove the whole block if you do not want to upload an ipa file
-# ipa do
-    # Add any code you want, like incrementing the build 
-    # number or changing the app identifier
-
-    # Attention: When you return a valid ipa file, this file will get uploaded and released
-    # If you only want to upload app metadata, remove the complete ipa block.
-
-    # system("ipa build --verbose") # build your project using Shenzhen
-    # "./WordPress-Deliver-iOS.ipa" # Tell 'Deliver' where it can find the finished ipa file
-# end
-
-# ipa "./latest.ipa" # this can be used instead of the `do` block, if you prefer manually building the ipa file
-
-# beta_ipa do
-    # system("ipa build --verbose") # customize this to build beta version
-    # "./ad_hoc_build.ipa" # upload ipa file using `deliver --beta`
-# end
-
-# unit_tests do
-#   If you use fastlane (http://github.com/krausefx/fastlane), run the tests there
-#   system("xctool test")
-# end
-
-# success do
-  # system("say 'Successfully deployed a new version.'")
-# end


### PR DESCRIPTION
Cherry picking the commit from https://github.com/wordpress-mobile/WordPress-iOS/pull/11259 to apply it to `develop`.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
