### PR TITLE
[Stats Refresh] Period Videos: add detail list view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -69,7 +69,6 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
         StatsDataHelper.clearExpandedRowsFor(statSection: statSection)
     }
 
-
 }
 
 // MARK: - Table Methods
@@ -120,6 +119,8 @@ private extension SiteStatsDetailTableViewController {
             return periodStore.isFetchingPostsAndPages
         case .periodSearchTerms:
             return periodStore.isFetchingSearchTerms
+        case .periodVideos:
+            return periodStore.isFetchingVideos
         default:
             return false
         }
@@ -154,6 +155,8 @@ private extension SiteStatsDetailTableViewController {
             viewModel?.refreshPostsAndPages()
         case .periodSearchTerms:
             viewModel?.refreshSearchTerms()
+        case .periodVideos:
+            viewModel?.refreshVideos()
         default:
             refreshControl?.endRefreshing()
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -6,6 +6,7 @@ import WordPressFlux
     @objc optional func displayWebViewWithURL(_ url: URL)
     @objc optional func expandedRowUpdated(_ row: StatsTotalRow)
     @objc optional func showPostStats(withPostTitle postTitle: String?)
+    @objc optional func displayMediaWithID(_ mediaID: NSNumber)
 }
 
 class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoadable {
@@ -30,6 +31,20 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
 
     private lazy var tableHandler: ImmuTableViewHandler = {
         return ImmuTableViewHandler(takeOver: self)
+    }()
+
+    private let siteID = SiteStatsInformation.sharedInstance.siteID
+
+    private lazy var mainContext: NSManagedObjectContext = {
+        return ContextManager.sharedInstance().mainContext
+    }()
+
+    private lazy var mediaService: MediaService = {
+        return MediaService(managedObjectContext: mainContext)
+    }()
+
+    private lazy var blogService: BlogService = {
+        return BlogService(managedObjectContext: mainContext)
     }()
 
     // MARK: - View
@@ -221,6 +236,22 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
         let postStatsTableViewController = PostStatsTableViewController.loadFromStoryboard()
         postStatsTableViewController.configure(postTitle: postTitle)
         navigationController?.pushViewController(postStatsTableViewController, animated: true)
+    }
+
+    func displayMediaWithID(_ mediaID: NSNumber) {
+
+        guard let siteID = siteID,
+            let blog = blogService.blog(byBlogId: siteID) else {
+                DDLogInfo("Unable to get blog when trying to show media from Stats details.")
+                return
+        }
+
+        mediaService.getMediaWithID(mediaID, in: blog, success: { (media) in
+            let viewController = MediaItemViewController(media: media)
+            self.navigationController?.pushViewController(viewController, animated: true)
+        }, failure: { (error) in
+            DDLogInfo("Unable to get media when trying to show from Stats details: \(error.localizedDescription)")
+        })
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -94,6 +94,11 @@ class SiteStatsDetailsViewModel: Observable {
                                                      dataSubtitle: StatSection.periodSearchTerms.dataSubtitle,
                                                      dataRows: searchTermsRows(),
                                                      siteStatsDetailsDelegate: detailsDelegate))
+        case .periodVideos:
+            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodVideos.itemSubtitle,
+                                                     dataSubtitle: StatSection.periodVideos.dataSubtitle,
+                                                     dataRows: videosRows(),
+                                                     siteStatsDetailsDelegate: detailsDelegate))
         default:
             break
         }
@@ -136,6 +141,14 @@ class SiteStatsDetailsViewModel: Observable {
         ActionDispatcher.dispatch(PeriodAction.refreshSearchTerms(date: selectedDate, period: selectedPeriod))
     }
 
+    func refreshVideos() {
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return
+        }
+        ActionDispatcher.dispatch(PeriodAction.refreshVideos(date: selectedDate, period: selectedPeriod))
+    }
+
 }
 
 // MARK: - Private Extension
@@ -167,6 +180,8 @@ private extension SiteStatsDetailsViewModel {
             return .allPostsAndPages(date: selectedDate, period: selectedPeriod)
         case .periodSearchTerms:
             return .allSearchTerms(date: selectedDate, period: selectedPeriod)
+        case .periodVideos:
+            return .allVideos(date: selectedDate, period: selectedPeriod)
         default:
             return nil
         }
@@ -289,6 +304,16 @@ private extension SiteStatsDetailsViewModel {
         return periodStore.getAllSearchTerms()?.map { StatsTotalRowData.init(name: $0.label,
                                                                              data: $0.value.displayString(),
                                                                              statSection: .periodSearchTerms) }
+            ?? []
+    }
+
+    func videosRows() -> [StatsTotalRowData] {
+        return periodStore.getAllVideos()?.map { StatsTotalRowData.init(name: $0.label,
+                                                                        data: $0.value.displayString(),
+                                                                        mediaID: $0.itemID,
+                                                                        icon: Style.imageForGridiconType(.video),
+                                                                        showDisclosure: true,
+                                                                        statSection: .periodVideos) }
             ?? []
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -269,6 +269,7 @@ extension TopTotalsCell: StatsTotalRowDelegate {
 
     func displayMediaWithID(_ mediaID: NSNumber) {
         siteStatsPeriodDelegate?.displayMediaWithID?(mediaID)
+        siteStatsDetailsDelegate?.displayMediaWithID?(mediaID)
     }
 
     func toggleChildRowsForRow(_ row: StatsTotalRow) {


### PR DESCRIPTION
Fixes #11254 

On the Period Videos card, selecting `View more` will now show a full list of Videos. The rows should look like they do on the Period Videos card, and row selection is the same, i.e. media details is displayed.

**NOTE:** Depending on the number of videos, it could take several seconds for the view to load. There is an outstanding issue to show a loading view (#11166).

To test:
- On a site with more than 6 videos, go to Period > Videos > View more.
- Verify the view is as shown below.
- Verify selecting a row displays the media details.

![video_flow](https://user-images.githubusercontent.com/1816888/54311363-0c96cb80-459a-11e9-9f2c-6821d2c92fa7.png)
