### PR TITLE
Improved the appearance of the Period chart with highlights & overlaid bars

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Styling.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Styling.swift
@@ -9,7 +9,8 @@ class PeriodPerformanceStyling: BarChartStyling {
 
     let primaryBarColor: UIColor
     let secondaryBarColor: UIColor?
-    let highlightColor: UIColor?
+    let primaryHighlightColor: UIColor?
+    let secondaryHighlightColor: UIColor?
     let labelColor: UIColor
     let legendTitle: String?
     let lineColor: UIColor
@@ -19,14 +20,15 @@ class PeriodPerformanceStyling: BarChartStyling {
     init(initialDateInterval: TimeInterval, highlightColor: UIColor? = nil) {
         let xAxisFormatter = HorizontalAxisFormatter(initialDateInterval: initialDateInterval)
 
-        self.primaryBarColor        = WPStyleGuide.wordPressBlue()
-        self.secondaryBarColor      = WPStyleGuide.darkBlue()
-        self.highlightColor         = WPStyleGuide.jazzyOrange()
-        self.labelColor             = WPStyleGuide.grey()
-        self.legendTitle            = "Visitors"    // we do not localized stub data...
-        self.lineColor              = WPStyleGuide.greyLighten30()
-        self.xAxisValueFormatter    = xAxisFormatter
-        self.yAxisValueFormatter    = VerticalAxisFormatter()
+        self.primaryBarColor            = WPStyleGuide.wordPressBlue()
+        self.secondaryBarColor          = WPStyleGuide.darkBlue()
+        self.primaryHighlightColor      = WPStyleGuide.jazzyOrange()
+        self.secondaryHighlightColor    = WPStyleGuide.fireOrange()
+        self.labelColor                 = WPStyleGuide.grey()
+        self.legendTitle                = "Visitors"    // we do not localized stub data...
+        self.lineColor                  = WPStyleGuide.greyLighten30()
+        self.xAxisValueFormatter        = xAxisFormatter
+        self.yAxisValueFormatter        = VerticalAxisFormatter()
     }
 }
 
@@ -36,7 +38,8 @@ class PostSummaryStyling: BarChartStyling {
 
     let primaryBarColor: UIColor
     let secondaryBarColor: UIColor?
-    let highlightColor: UIColor?
+    let primaryHighlightColor: UIColor?
+    let secondaryHighlightColor: UIColor?
     let labelColor: UIColor
     let legendTitle: String?
     let lineColor: UIColor
@@ -44,13 +47,14 @@ class PostSummaryStyling: BarChartStyling {
     let yAxisValueFormatter: IAxisValueFormatter
 
     init(barColor: UIColor, highlightColor: UIColor?, labelColor: UIColor, lineColor: UIColor, xAxisValueFormatter: IAxisValueFormatter, yAxisValueFormatter: IAxisValueFormatter) {
-        self.primaryBarColor        = barColor
-        self.secondaryBarColor      = nil
-        self.highlightColor         = highlightColor
-        self.labelColor             = labelColor
-        self.legendTitle            = nil
-        self.lineColor              = lineColor
-        self.xAxisValueFormatter    = xAxisValueFormatter
-        self.yAxisValueFormatter    = yAxisValueFormatter
+        self.primaryBarColor            = barColor
+        self.secondaryBarColor          = nil
+        self.primaryHighlightColor      = highlightColor
+        self.secondaryHighlightColor    = nil
+        self.labelColor                 = labelColor
+        self.legendTitle                = nil
+        self.lineColor                  = lineColor
+        self.xAxisValueFormatter        = xAxisValueFormatter
+        self.yAxisValueFormatter        = yAxisValueFormatter
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
@@ -28,8 +28,11 @@ protocol BarChartStyling {
     /// This bar color is used if bars are overlayed.
     var secondaryBarColor: UIColor? { get }
 
-    /// This corresponds to the color of a selected bar
-    var highlightColor: UIColor? { get }
+    /// This corresponds to the color of a single selected bar
+    var primaryHighlightColor: UIColor? { get }
+
+    /// This corresponds to the color of a second selected bar; currently only applicable when Views/Visitors overlaid.
+    var secondaryHighlightColor: UIColor? { get }
 
     /// This corresponds to the color of labels on the chart
     var labelColor: UIColor { get }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -132,7 +132,7 @@ class StatsBarChartView: BarChartView {
         primaryDataSet.drawValuesEnabled = false
 
         primaryDataSet.highlightAlpha = Constants.highlightAlpha
-        if let initialHighlightColor = styling.highlightColor {
+        if let initialHighlightColor = styling.primaryHighlightColor {
             primaryDataSet.highlightColor = initialHighlightColor
         }
 
@@ -146,8 +146,9 @@ class StatsBarChartView: BarChartView {
         secondaryDataSet.drawValuesEnabled = false
 
         secondaryDataSet.highlightAlpha = Constants.highlightAlpha
-        let secondaryHighlightColor = WPStyleGuide.fireOrange()
-        secondaryDataSet.highlightColor = secondaryHighlightColor
+        if let secondaryHighlightColor = styling.secondaryHighlightColor {
+            secondaryDataSet.highlightColor = secondaryHighlightColor
+        }
     }
 
     private func configureChartForSingleDataSet(_ dataSet: BarChartDataSet) {
@@ -155,7 +156,7 @@ class StatsBarChartView: BarChartView {
         dataSet.colors = [ styling.primaryBarColor ]
         dataSet.drawValuesEnabled = false
 
-        if let barHighlightColor = styling.highlightColor {
+        if let barHighlightColor = styling.primaryHighlightColor {
             dataSet.highlightAlpha = Constants.highlightAlpha
             dataSet.highlightColor = barHighlightColor
             dataSet.highlightEnabled = true
@@ -218,7 +219,7 @@ class StatsBarChartView: BarChartView {
         marker.offset = markerOffset
 
         let markerColor: NSUIColor
-        if let primaryHighlightColor = styling.highlightColor {
+        if let primaryHighlightColor = styling.primaryHighlightColor {
             markerColor = primaryHighlightColor
         } else {
             markerColor = WPStyleGuide.jazzyOrange()

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -87,6 +87,23 @@ class StatsBarChartView: BarChartView {
         return (rect, offset)
     }
 
+    private func configureAndPopulateData() {
+        let barChartData = self.barChartData.barChartData
+
+        guard let dataSets = barChartData.dataSets as? [BarChartDataSet], let initialDataSet = dataSets.first else {
+            return
+        }
+
+        if dataSets.count > 1 {
+            configureChartForMultipleDataSets(dataSets)
+        } else {
+            configureChartForSingleDataSet(initialDataSet)
+        }
+
+        configureLegendIfNeeded()
+        data = barChartData
+    }
+
     private func configureBarChartViewProperties() {
         drawBarShadowEnabled = false
         drawValueAboveBarEnabled = false
@@ -110,12 +127,55 @@ class StatsBarChartView: BarChartView {
         scaleYEnabled = false
     }
 
+    private func configureChartForMultipleDataSets(_ dataSets: [BarChartDataSet]) {
+        guard let initialDataSet = dataSets.first else {
+            return
+        }
+        configureDataSet(dataSet: initialDataSet, with: styling.primaryBarColor, enableHighlight: true)
+
+        guard dataSets.count > 1, let secondaryBarColor = styling.secondaryBarColor else {
+            return
+        }
+        let secondaryDataSet = dataSets[1]
+        configureDataSet(dataSet: secondaryDataSet, with: secondaryBarColor, enableHighlight: false)
+    }
+
+    private func configureChartForSingleDataSet(_ dataSet: BarChartDataSet) {
+
+        dataSet.colors = [ styling.primaryBarColor ]
+        dataSet.drawValuesEnabled = false
+
+        if let barHighlightColor = styling.highlightColor {
+            dataSet.highlightAlpha = Constants.highlightAlpha
+            dataSet.highlightColor = barHighlightColor
+            dataSet.highlightEnabled = true
+        } else {
+            dataSet.highlightEnabled = false
+            highlightPerTapEnabled = false
+        }
+    }
+
     private func configureChartViewBaseProperties() {
         dragDecelerationEnabled = false
 
         extraRightOffset = Constants.offset
 
         animate(yAxisDuration: Constants.animationDuration)
+    }
+
+    private func configureDataSet(dataSet: BarChartDataSet, with color: NSUIColor, enableHighlight: Bool) {
+        dataSet.colors = [ color ]
+
+        dataSet.drawValuesEnabled = false
+
+        guard let barHighlightColor = styling.highlightColor else {
+            highlightPerTapEnabled = false
+            return
+        }
+
+        dataSet.highlightAlpha = (styling.secondaryBarColor != nil) ? Constants.highlightAlpha : CGFloat(1)
+        dataSet.highlightColor = barHighlightColor
+        dataSet.highlightEnabled = enableHighlight
     }
 
     private func configureLegendIfNeeded() {
@@ -155,39 +215,6 @@ class StatsBarChartView: BarChartView {
         yAxis.drawZeroLineEnabled = true
         yAxis.labelTextColor = styling.labelColor
         yAxis.valueFormatter = styling.yAxisValueFormatter
-    }
-
-    private func configureDataSet(dataSet: BarChartDataSet, with color: NSUIColor, enableHighlight: Bool) {
-        dataSet.colors = [ color ]
-
-        dataSet.drawValuesEnabled = false
-
-        guard let barHighlightColor = styling.highlightColor else {
-            highlightPerTapEnabled = false
-            return
-        }
-
-        dataSet.highlightAlpha = (styling.secondaryBarColor != nil) ? Constants.highlightAlpha : CGFloat(1)
-        dataSet.highlightColor = barHighlightColor
-        dataSet.highlightEnabled = enableHighlight
-    }
-
-    private func configureAndPopulateData() {
-        let barChartData = self.barChartData.barChartData
-
-        guard let dataSets = barChartData.dataSets as? [BarChartDataSet], let initialDataSet = dataSets.first else {
-            return
-        }
-        configureDataSet(dataSet: initialDataSet, with: styling.primaryBarColor, enableHighlight: true)
-
-        if dataSets.count > 1, let secondaryBarColor = styling.secondaryBarColor {
-            let secondaryDataSet = dataSets[1]
-            configureDataSet(dataSet: secondaryDataSet, with: secondaryBarColor, enableHighlight: false)
-        }
-
-        configureLegendIfNeeded()
-
-        data = barChartData
     }
 
     private func drawChartMarker(for entry: ChartDataEntry, triggerRedraw: Bool = false) {

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -12,7 +12,7 @@ class StatsBarChartView: BarChartView {
     private struct Constants {
         static let animationDuration    = TimeInterval(1)
         static let intrinsicHeight      = CGFloat(170)      // height via Zeplin
-        static let highlightAlpha       = CGFloat(0.75)
+        static let highlightAlpha       = CGFloat(1)
         static let markerAlpha          = CGFloat(0.2)
         static let offset               = CGFloat(20)
     }
@@ -63,25 +63,21 @@ class StatsBarChartView: BarChartView {
     /// - Parameter entry: the selected entry for which to determine highlight information
     /// - Returns: the frame & offset from the bar that should be used to render the marker
     ///
-    private func calculateHighlightFrameAndOffset(for entry: ChartDataEntry) -> (CGRect, CGPoint) {
+    private func calculateMarkerFrameAndOffset(for entry: ChartDataEntry) -> (frame: CGRect, offset: CGPoint) {
         guard let barChartDataEntry = entry as? BarChartDataEntry else {
             return (.zero, .zero)
         }
 
         let barBounds = getBarBounds(entry: barChartDataEntry)
 
-        let highlightX = barBounds.origin.x
-        let highlightY = CGFloat(0)
-        let highlightOrigin = CGPoint(x: highlightX, y: highlightY)
+        let markerWidth = barBounds.width
+        let markerHeight = viewPortHandler.contentRect.height * 2   // 2x addresses a visual glitch with two data sets
+        let markerSize = CGSize(width: markerWidth, height: markerHeight)
 
-        let highlightWidth = barBounds.width
-        let highlightHeight = bounds.height - barBounds.height
-        let highlightSize = CGSize(width: highlightWidth, height: highlightHeight)
-
-        let rect = CGRect(origin: highlightOrigin, size: highlightSize)
+        let rect = CGRect(origin: barBounds.origin, size: markerSize)
 
         let offsetWidth = -(barBounds.width / 2)
-        let offsetHeight = -highlightHeight
+        let offsetHeight = -markerHeight
         let offset = CGPoint(x: offsetWidth, y: offsetHeight)
 
         return (rect, offset)
@@ -116,28 +112,42 @@ class StatsBarChartView: BarChartView {
         dragYEnabled = false
         pinchZoomEnabled = false
 
-        rightAxis.enabled = false
-
         drawBordersEnabled = false
         drawGridBackgroundEnabled = false
 
         minOffset = CGFloat(0)
+
+        rightAxis.enabled = false
 
         scaleXEnabled = false
         scaleYEnabled = false
     }
 
     private func configureChartForMultipleDataSets(_ dataSets: [BarChartDataSet]) {
-        guard let initialDataSet = dataSets.first else {
+        // Primary
+        guard let primaryDataSet = dataSets.first else {
             return
         }
-        configureDataSet(dataSet: initialDataSet, with: styling.primaryBarColor, enableHighlight: true)
+        primaryDataSet.colors = [ styling.primaryBarColor ]
+        primaryDataSet.drawValuesEnabled = false
 
+        primaryDataSet.highlightAlpha = Constants.highlightAlpha
+        if let initialHighlightColor = styling.highlightColor {
+            primaryDataSet.highlightColor = initialHighlightColor
+        }
+
+        // Secondary
         guard dataSets.count > 1, let secondaryBarColor = styling.secondaryBarColor else {
             return
         }
         let secondaryDataSet = dataSets[1]
-        configureDataSet(dataSet: secondaryDataSet, with: secondaryBarColor, enableHighlight: false)
+
+        secondaryDataSet.colors = [ secondaryBarColor ]
+        secondaryDataSet.drawValuesEnabled = false
+
+        secondaryDataSet.highlightAlpha = Constants.highlightAlpha
+        let secondaryHighlightColor = WPStyleGuide.fireOrange()
+        secondaryDataSet.highlightColor = secondaryHighlightColor
     }
 
     private func configureChartForSingleDataSet(_ dataSet: BarChartDataSet) {
@@ -161,21 +171,6 @@ class StatsBarChartView: BarChartView {
         extraRightOffset = Constants.offset
 
         animate(yAxisDuration: Constants.animationDuration)
-    }
-
-    private func configureDataSet(dataSet: BarChartDataSet, with color: NSUIColor, enableHighlight: Bool) {
-        dataSet.colors = [ color ]
-
-        dataSet.drawValuesEnabled = false
-
-        guard let barHighlightColor = styling.highlightColor else {
-            highlightPerTapEnabled = false
-            return
-        }
-
-        dataSet.highlightAlpha = (styling.secondaryBarColor != nil) ? Constants.highlightAlpha : CGFloat(1)
-        dataSet.highlightColor = barHighlightColor
-        dataSet.highlightEnabled = enableHighlight
     }
 
     private func configureLegendIfNeeded() {
@@ -217,19 +212,40 @@ class StatsBarChartView: BarChartView {
         yAxis.valueFormatter = styling.yAxisValueFormatter
     }
 
-    private func drawChartMarker(for entry: ChartDataEntry, triggerRedraw: Bool = false) {
-        let (markerRect, markerOffset) = calculateHighlightFrameAndOffset(for: entry)
+    private func drawChartMarker(for entry: ChartDataEntry) {
+        let (markerRect, markerOffset) = calculateMarkerFrameAndOffset(for: entry)
         let marker = StatsBarChartMarker(frame: markerRect)
         marker.offset = markerOffset
 
-        let markerColor = (styling.highlightColor ?? UIColor.clear).withAlphaComponent(Constants.markerAlpha)
-        marker.backgroundColor = markerColor
+        let markerColor: NSUIColor
+        if let primaryHighlightColor = styling.highlightColor {
+            markerColor = primaryHighlightColor
+        } else {
+            markerColor = WPStyleGuide.jazzyOrange()
+        }
+        marker.backgroundColor = markerColor.withAlphaComponent(Constants.markerAlpha)
 
         self.marker = marker
+    }
 
-        if triggerRedraw {
-            setNeedsDisplay()
+    private func drawSecondaryHighlightIfNeeded(for primaryEntry: ChartDataEntry, with primaryHighlight: Highlight) {
+        guard let chartData = data, chartData.dataSets.count > 1 else {
+            return
         }
+
+        let primaryDataSet = chartData.dataSets[0]
+        let primaryIndex = primaryDataSet.entryIndex(entry: primaryEntry)
+
+        let secondaryIndex = 1
+        let secondaryDataSet = chartData.dataSets[secondaryIndex]
+        guard let secondaryEntry = secondaryDataSet.entryForIndex(primaryIndex) as? BarChartDataEntry else {
+            return
+        }
+
+        let secondaryHighlight = Highlight(x: secondaryEntry.x, y: secondaryEntry.y, dataSetIndex: secondaryIndex)
+        let values: [Highlight] = [primaryHighlight, secondaryHighlight]
+
+        highlightValues(values)
     }
 
     private func initialize() {
@@ -250,7 +266,8 @@ class StatsBarChartView: BarChartView {
 
         let postRotationDelay = DispatchTime.now() + TimeInterval(0.35)
         DispatchQueue.main.asyncAfter(deadline: postRotationDelay) {
-            self.drawChartMarker(for: entry, triggerRedraw: true)
+            self.drawChartMarker(for: entry)
+            self.drawSecondaryHighlightIfNeeded(for: entry, with: highlight)
         }
     }
 }
@@ -261,6 +278,7 @@ private typealias StatsBarChartMarker = MarkerView
 
 extension StatsBarChartView: ChartViewDelegate {
     func chartValueSelected(_ chartView: ChartViewBase, entry: ChartDataEntry, highlight: Highlight) {
+        drawSecondaryHighlightIfNeeded(for: entry, with: highlight)
         drawChartMarker(for: entry)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -84,7 +84,7 @@ class OverviewCell: UITableViewCell, NibLoadable {
 
         setupFilterBar()
         updateLabels()
-        configureChartView()
+        configureChartViewIfNeeded()
     }
 }
 
@@ -152,16 +152,8 @@ private extension OverviewCell {
 
     // MARK: Chart support
 
-    func resetChartView() {
-        for subview in chartContainerView.subviews {
-            subview.removeFromSuperview()
-        }
-    }
-
-    func configureChartView() {
-        resetChartView()
-
-        guard let barChartData = chartData, let barChartStyling = chartStyling else {
+    func configureChartViewIfNeeded() {
+        guard chartContainerView.subviews.isEmpty, let barChartData = chartData, let barChartStyling = chartStyling else {
             return
         }
 


### PR DESCRIPTION
Fixes #11230.

To test:

- Checkout the branch, confirm that it builds & tests pass.
- For a site, navigate to Stats, and select a given period (i.e., Days, Weeks, Months, Years). The image should look like those below.
- Please note that at the moment, the chart is the same regardless of period or dimension (Views, Visitors, Likes, Comments).

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.