### PR TITLE
[Stats Refresh] Period Clicks: add detail list view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -112,6 +112,20 @@ class StatsDataHelper {
         }
     }
 
+    // MARK: - Clicks Support
+
+    class func childRowsForClicks(_ item: StatsItem) -> [StatsTotalRowData] {
+
+        guard let children = item.children as? [StatsItem] else {
+            return [StatsTotalRowData]()
+        }
+
+        return children.map { StatsTotalRowData.init(name: $0.label,
+                                                     data: $0.value.displayString(),
+                                                     showDisclosure: true,
+                                                     disclosureURL: StatsDataHelper.disclosureUrlForItem($0)) }
+    }
+
 }
 
 /// These methods format stat Strings for display and usage.

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -8,20 +8,25 @@ class StatsDataHelper {
 
     // MARK: - Expanded Row Handling
 
-    // This stores the labels for expanded rows.
-    // It is used to track which rows are expanded, so the expanded view can be restored
+    // These arrays store the labels for expanded rows.
+    // They are used to track which rows are expanded, so the expanded view can be restored
     // when the cells are recreated (ex: on scrolling).
     // They are segregated by StatSection for easy access.
-    static var expandedRowLabels = [StatSection: [String]]()
 
-    class func updatedExpandedState(forRow row: StatsTotalRow) {
+    // Period and Insights tables.
+    static var expandedRowLabels = [StatSection: [String]]()
+    // Details table.
+    static var expandedRowLabelsDetails = [StatSection: [String]]()
+
+    class func updatedExpandedState(forRow row: StatsTotalRow, inDetails: Bool = false) {
 
         guard let rowData = row.rowData,
             let statSection = rowData.statSection else {
                 return
         }
 
-        var expandedRowLabels = StatsDataHelper.expandedRowLabels[statSection] ?? []
+        var expandedRowsArray = inDetails ? StatsDataHelper.expandedRowLabelsDetails : StatsDataHelper.expandedRowLabels
+        var expandedRowLabels = expandedRowsArray[statSection] ?? []
 
         // Remove from array
         expandedRowLabels = expandedRowLabels.filter { $0 != rowData.name }
@@ -35,7 +40,14 @@ class StatsDataHelper {
         if row.expanded {
             expandedRowLabels.append(rowData.name)
         }
-        StatsDataHelper.expandedRowLabels[statSection] = expandedRowLabels
+
+        expandedRowsArray[statSection] = expandedRowLabels
+
+        if inDetails {
+            StatsDataHelper.expandedRowLabelsDetails = expandedRowsArray
+        } else {
+            StatsDataHelper.expandedRowLabels = expandedRowsArray
+        }
     }
 
     class func clearExpandedInsights() {
@@ -50,8 +62,8 @@ class StatsDataHelper {
         }
     }
 
-    class func clearExpandedRowsFor(statSection: StatSection) {
-        StatsDataHelper.expandedRowLabels[statSection]?.removeAll()
+    class func clearExpandedDetails() {
+        StatsDataHelper.expandedRowLabelsDetails.removeAll()
     }
 
     // MARK: - Data Bar Percent

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -232,8 +232,6 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
             return
         }
 
-        StatsDataHelper.clearExpandedRowsFor(statSection: statSection)
-
         let detailTableViewController = SiteStatsDetailTableViewController.loadFromStoryboard()
         detailTableViewController.configure(statSection: statSection)
         navigationController?.pushViewController(detailTableViewController, animated: true)

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -187,24 +187,12 @@ private extension SiteStatsPeriodViewModel {
 
     func clicksDataRows() -> [StatsTotalRowData] {
         return store.getTopClicks()?.map { StatsTotalRowData.init(name: $0.label,
-                                                     data: $0.value.displayString(),
-                                                     showDisclosure: true,
-                                                     disclosureURL: StatsDataHelper.disclosureUrlForItem($0),
-                                                     childRows: childRowsForClicks($0),
-                                                     statSection: .periodClicks) }
+                                                                  data: $0.value.displayString(),
+                                                                  showDisclosure: true,
+                                                                  disclosureURL: StatsDataHelper.disclosureUrlForItem($0),
+                                                                  childRows: StatsDataHelper.childRowsForClicks($0),
+                                                                  statSection: .periodClicks) }
             ?? []
-    }
-
-    func childRowsForClicks(_ item: StatsItem) -> [StatsTotalRowData] {
-
-        guard let children = item.children as? [StatsItem] else {
-            return [StatsTotalRowData]()
-        }
-
-        return children.map { StatsTotalRowData.init(name: $0.label,
-                                                     data: $0.value.displayString(),
-                                                     showDisclosure: true,
-                                                     disclosureURL: StatsDataHelper.disclosureUrlForItem($0)) }
     }
 
     func authorsTableRows() -> [ImmuTableRow] {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -52,6 +52,7 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        clearExpandedRows()
         Style.configureTable(tableView)
         refreshControl?.addTarget(self, action: #selector(refreshData), for: .valueChanged)
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
@@ -73,15 +74,6 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
         coordinator.animate(alongsideTransition: { _ in
             self.tableView.reloadData()
         })
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        guard let statSection = statSection else {
-            return
-        }
-        StatsDataHelper.clearExpandedRowsFor(statSection: statSection)
     }
 
 }
@@ -159,6 +151,7 @@ private extension SiteStatsDetailTableViewController {
             return
         }
 
+        clearExpandedRows()
         refreshControl?.beginRefreshing()
 
         switch statSection {
@@ -191,6 +184,10 @@ private extension SiteStatsDetailTableViewController {
             updateStatSectionForFilterChange()
             tableView.endUpdates()
         }
+    }
+
+    func clearExpandedRows() {
+        StatsDataHelper.clearExpandedDetails()
     }
 
     func updateStatSectionForFilterChange() {
@@ -233,7 +230,7 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
 
     func expandedRowUpdated(_ row: StatsTotalRow) {
         applyTableUpdates()
-        StatsDataHelper.updatedExpandedState(forRow: row)
+        StatsDataHelper.updatedExpandedState(forRow: row, inDetails: true)
     }
 
     func showPostStats(withPostTitle postTitle: String?) {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -136,6 +136,8 @@ private extension SiteStatsDetailTableViewController {
             return periodStore.isFetchingSearchTerms
         case .periodVideos:
             return periodStore.isFetchingVideos
+        case .periodClicks:
+            return periodStore.isFetchingClicks
         default:
             return false
         }
@@ -172,6 +174,8 @@ private extension SiteStatsDetailTableViewController {
             viewModel?.refreshSearchTerms()
         case .periodVideos:
             viewModel?.refreshVideos()
+        case .periodClicks:
+            viewModel?.refreshClicks()
         default:
             refreshControl?.endRefreshing()
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -99,6 +99,11 @@ class SiteStatsDetailsViewModel: Observable {
                                                      dataSubtitle: StatSection.periodVideos.dataSubtitle,
                                                      dataRows: videosRows(),
                                                      siteStatsDetailsDelegate: detailsDelegate))
+        case .periodClicks:
+            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodClicks.itemSubtitle,
+                                                     dataSubtitle: StatSection.periodClicks.dataSubtitle,
+                                                     dataRows: clicksRows(),
+                                                     siteStatsDetailsDelegate: detailsDelegate))
         default:
             break
         }
@@ -149,6 +154,14 @@ class SiteStatsDetailsViewModel: Observable {
         ActionDispatcher.dispatch(PeriodAction.refreshVideos(date: selectedDate, period: selectedPeriod))
     }
 
+    func refreshClicks() {
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return
+        }
+        ActionDispatcher.dispatch(PeriodAction.refreshClicks(date: selectedDate, period: selectedPeriod))
+    }
+
 }
 
 // MARK: - Private Extension
@@ -182,6 +195,8 @@ private extension SiteStatsDetailsViewModel {
             return .allSearchTerms(date: selectedDate, period: selectedPeriod)
         case .periodVideos:
             return .allVideos(date: selectedDate, period: selectedPeriod)
+        case .periodClicks:
+            return .allClicks(date: selectedDate, period: selectedPeriod)
         default:
             return nil
         }
@@ -314,6 +329,16 @@ private extension SiteStatsDetailsViewModel {
                                                                         icon: Style.imageForGridiconType(.video),
                                                                         showDisclosure: true,
                                                                         statSection: .periodVideos) }
+            ?? []
+    }
+
+    func clicksRows() -> [StatsTotalRowData] {
+        return periodStore.getAllClicks()?.map { StatsTotalRowData.init(name: $0.label,
+                                                                        data: $0.value.displayString(),
+                                                                        showDisclosure: true,
+                                                                        disclosureURL: StatsDataHelper.disclosureUrlForItem($0),
+                                                                        childRows: StatsDataHelper.childRowsForClicks($0),
+                                                                        statSection: .periodClicks) }
             ?? []
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -115,6 +115,13 @@ private extension TopTotalsCell {
             guard let row = subview as? StatsTotalRow else {
                     return
             }
+
+            // On the Stats Detail view, do not expand rows initially.
+            guard siteStatsDetailsDelegate == nil else {
+                row.expanded = false
+                return
+            }
+
             toggleChildRowsForRow(row)
 
             row.childRowsView?.rowsStackView.arrangedSubviews.forEach { child in


### PR DESCRIPTION
Fixes #11262 

On the Period Clicks card, selecting `View more` will now show a full list of Clicks. The rows should look like they do on the Period Clicks card, and row selection is the same:
- If a row has child rows, the row will expand.
- If a row has no child rows, a web view is displayed for the URL.

**Bonus:** this also fixes the row expansion from stat card to details and back to stat card to be consistent with Android. Android retains the expanded state on the card independently from the details view. In other words, if a row is expanded in the card, it is not expanded on the details, but is still expanded when the details is closed. (This last step is the difference - previously, expanded rows were being reset on the card.)

**NOTE:** Depending on the number of clicks, it could take several seconds for the view to load. There is an outstanding issue to show a loading view (#11166).

To test:

---
- On a site with more than 6 clicks, go to Period > Clicks > View more.
- Verify the view is as shown below, and has no expanded rows.

![card_to_details](https://user-images.githubusercontent.com/1816888/54320765-bc2c6780-45b3-11e9-848d-00bae830b1a4.png)

---
- Verify selecting an expandable row shows child rows.
- Verify selecting a non-expandable row displays the associated web view.

![row_to_webview](https://user-images.githubusercontent.com/1816888/54320824-f6960480-45b3-11e9-99bb-9c2fe44691ca.png)

---
- Verify expanding rows on the card or expanding rows on details does not effect the other.


