### PR TITLE
An attempt to fix crash in Debouncer callback.

### DIFF
--- a/WordPress/Classes/Utility/Debouncer.swift
+++ b/WordPress/Classes/Utility/Debouncer.swift
@@ -44,8 +44,8 @@ final class Debouncer {
     }
 
     private func scheduleCallback() {
-        timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [unowned self] timer in
-            self.callback()
+        timer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [callback] timer in
+            callback()
         }
     }
 }


### PR DESCRIPTION
*** At the time of writing this fix we were not able to reproduce this issue.
We assume that the fireDate is somehow in the past for a valid timer and so it never gets invalidated in digit.
As a result, the callback has an unowned self that is pointing to a deallocated object.

Since the callback is already handling weak references, we're removing the capture of self and instead capturing only the callback.

Fixes #11257 

To test:
Could not reproduce. 
Seems like this issue happens after editing a post and then discarding. 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
