### PR TITLE
Fixed crash on long press time stamp on iPad.

### DIFF
--- a/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
@@ -16,6 +16,7 @@ import WordPressFlux
         while leafViewController.presentedViewController != nil && !leafViewController.presentedViewController!.isBeingDismissed {
             leafViewController = leafViewController.presentedViewController!
         }
+        popoverPresentationController?.sourceView = view
         leafViewController.present(self, animated: true)
     }
 }

--- a/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
@@ -17,6 +17,7 @@ import WordPressFlux
             leafViewController = leafViewController.presentedViewController!
         }
         popoverPresentationController?.sourceView = view
+        popoverPresentationController?.permittedArrowDirections = []
         leafViewController.present(self, animated: true)
     }
 }


### PR DESCRIPTION
setting up the popoverPresentationController source view to fix the crash.
![copy_url_to_comment_ipad](https://user-images.githubusercontent.com/1335657/54325067-a91e9500-45bd-11e9-9016-839240bf3269.gif)


Fixes #11184 

To test:
1. Go to reader/ notifications 
2. Choose a post with comments. 
3. Long press the time stamp label. 
4. See the "Copy link to comments" pop over. 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
