### PR TITLE
[Stats Refresh] Period Authors: add detail list view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -124,7 +124,7 @@ class StatsDataHelper {
         }
     }
 
-    // MARK: - Clicks Support
+    // MARK: - Child Rows Support
 
     class func childRowsForClicks(_ item: StatsItem) -> [StatsTotalRowData] {
 
@@ -136,6 +136,16 @@ class StatsDataHelper {
                                                      data: $0.value.displayString(),
                                                      showDisclosure: true,
                                                      disclosureURL: StatsDataHelper.disclosureUrlForItem($0)) }
+    }
+
+    class func childRowsForAuthor(_ item: StatsItem) -> [StatsTotalRowData] {
+
+        guard let children = item.children as? [StatsItem] else {
+            return [StatsTotalRowData]()
+        }
+
+        return children.map { StatsTotalRowData.init(name: $0.label,
+                                                     data: $0.value.displayString()) }
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -213,19 +213,9 @@ private extension SiteStatsPeriodViewModel {
                                                      dataBarPercent: StatsDataHelper.dataBarPercentForRow($0, relativeToRow: authors?.first),
                                                      userIconURL: $0.iconURL,
                                                      showDisclosure: true,
-                                                     childRows: childRowsForAuthor($0),
+                                                     childRows: StatsDataHelper.childRowsForAuthor($0),
                                                      statSection: .periodAuthors) }
             ?? []
-    }
-
-    func childRowsForAuthor(_ item: StatsItem) -> [StatsTotalRowData] {
-
-        guard let children = item.children as? [StatsItem] else {
-            return [StatsTotalRowData]()
-        }
-
-        return children.map { StatsTotalRowData.init(name: $0.label,
-                                                     data: $0.value.displayString()) }
     }
 
     func countriesTableRows() -> [ImmuTableRow] {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -130,6 +130,8 @@ private extension SiteStatsDetailTableViewController {
             return periodStore.isFetchingVideos
         case .periodClicks:
             return periodStore.isFetchingClicks
+        case .periodAuthors:
+            return periodStore.isFetchingAuthors
         default:
             return false
         }
@@ -169,6 +171,8 @@ private extension SiteStatsDetailTableViewController {
             viewModel?.refreshVideos()
         case .periodClicks:
             viewModel?.refreshClicks()
+        case .periodAuthors:
+            viewModel?.refreshAuthors()
         default:
             refreshControl?.endRefreshing()
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -104,6 +104,11 @@ class SiteStatsDetailsViewModel: Observable {
                                                      dataSubtitle: StatSection.periodClicks.dataSubtitle,
                                                      dataRows: clicksRows(),
                                                      siteStatsDetailsDelegate: detailsDelegate))
+        case .periodAuthors:
+            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodAuthors.itemSubtitle,
+                                                     dataSubtitle: StatSection.periodAuthors.dataSubtitle,
+                                                     dataRows: authorsRows(),
+                                                     siteStatsDetailsDelegate: detailsDelegate))
         default:
             break
         }
@@ -162,6 +167,14 @@ class SiteStatsDetailsViewModel: Observable {
         ActionDispatcher.dispatch(PeriodAction.refreshClicks(date: selectedDate, period: selectedPeriod))
     }
 
+    func refreshAuthors() {
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return
+        }
+        ActionDispatcher.dispatch(PeriodAction.refreshAuthors(date: selectedDate, period: selectedPeriod))
+    }
+
 }
 
 // MARK: - Private Extension
@@ -197,6 +210,8 @@ private extension SiteStatsDetailsViewModel {
             return .allVideos(date: selectedDate, period: selectedPeriod)
         case .periodClicks:
             return .allClicks(date: selectedDate, period: selectedPeriod)
+        case .periodAuthors:
+            return .allAuthors(date: selectedDate, period: selectedPeriod)
         default:
             return nil
         }
@@ -339,6 +354,18 @@ private extension SiteStatsDetailsViewModel {
                                                                         disclosureURL: StatsDataHelper.disclosureUrlForItem($0),
                                                                         childRows: StatsDataHelper.childRowsForClicks($0),
                                                                         statSection: .periodClicks) }
+            ?? []
+    }
+
+    func authorsRows() -> [StatsTotalRowData] {
+        let authors = periodStore.getAllAuthors()
+        return authors?.map { StatsTotalRowData.init(name: $0.label,
+                                                     data: $0.value.displayString(),
+                                                     dataBarPercent: StatsDataHelper.dataBarPercentForRow($0, relativeToRow: authors?.first),
+                                                     userIconURL: $0.iconURL,
+                                                     showDisclosure: true,
+                                                     childRows: StatsDataHelper.childRowsForAuthor($0),
+                                                     statSection: .periodAuthors) }
             ?? []
     }
 


### PR DESCRIPTION
Fixes #11267  

On the Period Authors card, selecting `View more` will now show a full list of Authors. The rows should look like they do on the Period Authors card, and row selection is the same:
- If a row has child rows, the row will expand.
- If a row has no child rows, there is no row selection action.

**NOTE:** Depending on the number of authors, it could take several seconds for the view to load. There is an outstanding issue to show a loading view (#11166).

To test:

---
- On a site with more than 6 authors, go to Period > Authors > View more.
- Verify the view is as shown below.

![authors_flow](https://user-images.githubusercontent.com/1816888/54325403-99a44980-45c7-11e9-8768-85ed193626c0.png)

---
- Verify selecting an expandable row shows child rows.
<img width="350" alt="authors_expanded" src="https://user-images.githubusercontent.com/1816888/54325408-a1fc8480-45c7-11e9-94df-c99169a8a152.png">

