### PR TITLE
[Stats Refresh] Period Referrers: add detail list view

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -33,7 +33,7 @@ enum PeriodAction: Action {
     case receivedAllAuthors(_ authors: StatsGroup?)
     case refreshAuthors(date: Date, period: StatsPeriodUnit)
 
-    case receivedAllReferrers(_ authors: StatsGroup?)
+    case receivedAllReferrers(_ referrers: StatsGroup?)
     case refreshReferrers(date: Date, period: StatsPeriodUnit)
 }
 

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -32,6 +32,9 @@ enum PeriodAction: Action {
 
     case receivedAllAuthors(_ authors: StatsGroup?)
     case refreshAuthors(date: Date, period: StatsPeriodUnit)
+
+    case receivedAllReferrers(_ authors: StatsGroup?)
+    case refreshReferrers(date: Date, period: StatsPeriodUnit)
 }
 
 enum PeriodQuery {
@@ -41,6 +44,7 @@ enum PeriodQuery {
     case allVideos(date: Date, period: StatsPeriodUnit)
     case allClicks(date: Date, period: StatsPeriodUnit)
     case allAuthors(date: Date, period: StatsPeriodUnit)
+    case allReferrers(date: Date, period: StatsPeriodUnit)
 
     var date: Date {
         switch self {
@@ -55,6 +59,8 @@ enum PeriodQuery {
         case .allClicks(let date, _):
             return date
         case .allAuthors(let date, _):
+            return date
+        case .allReferrers(let date, _):
             return date
         }
     }
@@ -72,6 +78,8 @@ enum PeriodQuery {
         case .allClicks( _, let period):
             return period
         case .allAuthors( _, let period):
+            return period
+        case .allReferrers( _, let period):
             return period
         }
     }
@@ -121,6 +129,9 @@ struct PeriodStoreState {
 
     var allAuthors: [StatsItem]?
     var fetchingAllAuthors = false
+
+    var allReferrers: [StatsItem]?
+    var fetchingAllReferrers = false
 }
 
 class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
@@ -174,6 +185,10 @@ class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
             receivedAllAuthors(authors)
         case .refreshAuthors(let date, let period):
             refreshAuthors(date: date, period: period)
+        case .receivedAllReferrers(let referrers):
+            receivedAllReferrers(referrers)
+        case .refreshReferrers(let date, let period):
+            refreshReferrers(date: date, period: period)
         }
     }
 
@@ -221,6 +236,10 @@ private extension StatsPeriodStore {
             case .allAuthors:
                 if shouldFetchAuthors() {
                     fetchAllAuthors(date: query.date, period: query.period)
+                }
+            case .allReferrers:
+                if shouldFetchReferrers() {
+                    fetchAllReferrers(date: query.date, period: query.period)
                 }
             }
         }
@@ -406,6 +425,27 @@ private extension StatsPeriodStore {
         fetchAllAuthors(date: date, period: period)
     }
 
+    func fetchAllReferrers(date: Date, period: StatsPeriodUnit) {
+        state.fetchingAllReferrers = true
+
+        SiteStatsInformation.statsService()?.retrieveReferrers(for: date, andUnit: period, withCompletionHandler: { (referrers, error) in
+            if error != nil {
+                DDLogInfo("Error fetching all Referrers: \(String(describing: error?.localizedDescription))")
+            }
+            DDLogInfo("Stats: Finished fetching all referrers.")
+            self.actionDispatcher.dispatch(PeriodAction.receivedAllReferrers(referrers))
+        })
+    }
+
+    func refreshReferrers(date: Date, period: StatsPeriodUnit) {
+        guard shouldFetchReferrers() else {
+            DDLogInfo("Stats Period Referrers refresh triggered while one was in progress.")
+            return
+        }
+
+        fetchAllReferrers(date: date, period: period)
+    }
+
     // MARK: - Receive data methods
 
     func receivedPostsAndPages(_ postsAndPages: StatsGroup?) {
@@ -499,6 +539,13 @@ private extension StatsPeriodStore {
         }
     }
 
+    func receivedAllReferrers(_ referrers: StatsGroup?) {
+        transaction { state in
+            state.allReferrers = referrers?.items as? [StatsItem]
+            state.fetchingAllReferrers = false
+        }
+    }
+
     // MARK: - Helpers
 
     func shouldFetchOverview() -> Bool {
@@ -534,6 +581,10 @@ private extension StatsPeriodStore {
 
     func shouldFetchAuthors() -> Bool {
         return !isFetchingAuthors
+    }
+
+    func shouldFetchReferrers() -> Bool {
+        return !isFetchingReferrers
     }
 
     /// This method modifies the 'Unknown search terms' row and changes its location in the array.
@@ -627,6 +678,10 @@ extension StatsPeriodStore {
         return state.allAuthors
     }
 
+    func getAllReferrers() -> [StatsItem]? {
+        return state.allReferrers
+    }
+
     var isFetchingOverview: Bool {
         return state.fetchingPostsAndPages ||
             state.fetchingReferrers ||
@@ -656,6 +711,10 @@ extension StatsPeriodStore {
 
     var isFetchingAuthors: Bool {
         return state.fetchingAllAuthors
+    }
+
+    var isFetchingReferrers: Bool {
+        return state.fetchingAllReferrers
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -148,6 +148,34 @@ class StatsDataHelper {
                                                      data: $0.value.displayString()) }
     }
 
+    class func childRowsForReferrers(_ item: StatsItem) -> [StatsTotalRowData] {
+
+        var childRows = [StatsTotalRowData]()
+
+        guard let children = item.children as? [StatsItem] else {
+            return childRows
+        }
+
+        children.forEach { child in
+            var childsChildrenRows = [StatsTotalRowData]()
+            if let childsChildren = child.children as? [StatsItem] {
+                childsChildrenRows = childsChildren.map { StatsTotalRowData.init(name: $0.label,
+                                                                                 data: $0.value.displayString(),
+                                                                                 showDisclosure: true,
+                                                                                 disclosureURL: StatsDataHelper.disclosureUrlForItem($0)) }
+            }
+
+            childRows.append(StatsTotalRowData.init(name: child.label,
+                                                    data: child.value.displayString(),
+                                                    showDisclosure: true,
+                                                    disclosureURL: StatsDataHelper.disclosureUrlForItem(child),
+                                                    childRows: childsChildrenRows,
+                                                    statSection: .periodReferrers))
+        }
+
+        return childRows
+    }
+
 }
 
 /// These methods format stat Strings for display and usage.

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -141,37 +141,9 @@ private extension SiteStatsPeriodViewModel {
                                                                   socialIconURL: $0.iconURL,
                                                                   showDisclosure: true,
                                                                   disclosureURL: StatsDataHelper.disclosureUrlForItem($0),
-                                                                  childRows: childRowsForReferrers($0),
+                                                                  childRows: StatsDataHelper.childRowsForReferrers($0),
                                                                   statSection: .periodReferrers) }
             ?? []
-    }
-
-    func childRowsForReferrers(_ item: StatsItem) -> [StatsTotalRowData] {
-
-        var childRows = [StatsTotalRowData]()
-
-        guard let children = item.children as? [StatsItem] else {
-            return childRows
-        }
-
-        children.forEach { child in
-            var childsChildrenRows = [StatsTotalRowData]()
-            if let childsChildren = child.children as? [StatsItem] {
-                childsChildrenRows = childsChildren.map { StatsTotalRowData.init(name: $0.label,
-                                                                                 data: $0.value.displayString(),
-                                                                                 showDisclosure: true,
-                                                                                 disclosureURL: StatsDataHelper.disclosureUrlForItem($0)) }
-            }
-
-            childRows.append(StatsTotalRowData.init(name: child.label,
-                                                    data: child.value.displayString(),
-                                                    showDisclosure: true,
-                                                    disclosureURL: StatsDataHelper.disclosureUrlForItem(child),
-                                                    childRows: childsChildrenRows,
-                                                    statSection: .periodReferrers))
-        }
-
-        return childRows
     }
 
     func clicksTableRows() -> [ImmuTableRow] {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -132,6 +132,8 @@ private extension SiteStatsDetailTableViewController {
             return periodStore.isFetchingClicks
         case .periodAuthors:
             return periodStore.isFetchingAuthors
+        case .periodReferrers:
+            return periodStore.isFetchingReferrers
         default:
             return false
         }
@@ -173,6 +175,8 @@ private extension SiteStatsDetailTableViewController {
             viewModel?.refreshClicks()
         case .periodAuthors:
             viewModel?.refreshAuthors()
+        case .periodReferrers:
+            viewModel?.refreshReferrers()
         default:
             refreshControl?.endRefreshing()
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -109,6 +109,11 @@ class SiteStatsDetailsViewModel: Observable {
                                                      dataSubtitle: StatSection.periodAuthors.dataSubtitle,
                                                      dataRows: authorsRows(),
                                                      siteStatsDetailsDelegate: detailsDelegate))
+        case .periodReferrers:
+            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,
+                                                     dataSubtitle: StatSection.periodReferrers.dataSubtitle,
+                                                     dataRows: referrersRows(),
+                                                     siteStatsDetailsDelegate: detailsDelegate))
         default:
             break
         }
@@ -175,6 +180,14 @@ class SiteStatsDetailsViewModel: Observable {
         ActionDispatcher.dispatch(PeriodAction.refreshAuthors(date: selectedDate, period: selectedPeriod))
     }
 
+    func refreshReferrers() {
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return
+        }
+        ActionDispatcher.dispatch(PeriodAction.refreshReferrers(date: selectedDate, period: selectedPeriod))
+    }
+
 }
 
 // MARK: - Private Extension
@@ -212,6 +225,8 @@ private extension SiteStatsDetailsViewModel {
             return .allClicks(date: selectedDate, period: selectedPeriod)
         case .periodAuthors:
             return .allAuthors(date: selectedDate, period: selectedPeriod)
+        case .periodReferrers:
+            return .allReferrers(date: selectedDate, period: selectedPeriod)
         default:
             return nil
         }
@@ -366,6 +381,17 @@ private extension SiteStatsDetailsViewModel {
                                                      showDisclosure: true,
                                                      childRows: StatsDataHelper.childRowsForAuthor($0),
                                                      statSection: .periodAuthors) }
+            ?? []
+    }
+
+    func referrersRows() -> [StatsTotalRowData] {
+        return periodStore.getAllReferrers()?.map { StatsTotalRowData.init(name: $0.label,
+                                                                           data: $0.value.displayString(),
+                                                                           socialIconURL: $0.iconURL,
+                                                                           showDisclosure: true,
+                                                                           disclosureURL: StatsDataHelper.disclosureUrlForItem($0),
+                                                                           childRows: StatsDataHelper.childRowsForReferrers($0),
+                                                                           statSection: .periodReferrers) }
             ?? []
     }
 


### PR DESCRIPTION
Fixes #11276   

On the Period Referrers card, selecting `View more` will now show a full list of Referrers. The rows should look like they do on the Period Referrers card, and row selection is the same:
- If a row has child rows, the row will expand.
- If a row has no child rows, a web view is displayed.

**NOTE:** Depending on the number of referrers, it could take several seconds for the view to load. There is an outstanding issue to show a loading view (#11166).

To test:

---
- On a site with more than 6 referrers, go to Period > Referrers > View more.
- Verify the view is as shown below.

![referrers_flow](https://user-images.githubusercontent.com/1816888/54384319-8b9f0900-4659-11e9-9c85-4b0429ba1a40.png)

---
- Verify selecting an expandable row shows child rows.
<img width="350" alt="expanded" src="https://user-images.githubusercontent.com/1816888/54384219-572b4d00-4659-11e9-971d-b4a5446c7fa6.png">

---
- Verify selecting a non-expandable row shows a web view.

![row_selection](https://user-images.githubusercontent.com/1816888/54384349-a07b9c80-4659-11e9-9b14-d315a9d9f986.png)


