### PR TITLE
[Stats Refresh] Period Countries: add detail list view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
@@ -24,13 +24,19 @@ class CountriesCell: UITableViewCell, NibLoadable {
     func configure(itemSubtitle: String,
                    dataSubtitle: String,
                    dataRows: [StatsTotalRowData],
-                   siteStatsPeriodDelegate: SiteStatsPeriodDelegate? = nil) {
+                   siteStatsPeriodDelegate: SiteStatsPeriodDelegate? = nil,
+                   limitRowsDisplayed: Bool = true) {
         itemSubtitleLabel.text = itemSubtitle
         dataSubtitleLabel.text = dataSubtitle
         self.dataRows = dataRows
         self.siteStatsPeriodDelegate = siteStatsPeriodDelegate
 
-        addRows(dataRows, toStackView: rowsStackView, forType: .period, viewMoreDelegate: self)
+        addRows(dataRows,
+                toStackView: rowsStackView,
+                forType: .period,
+                limitRowsDisplayed: limitRowsDisplayed,
+                viewMoreDelegate: self)
+
         setSubtitleVisibility()
         applyStyles()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -111,6 +111,7 @@ private extension SiteStatsDetailTableViewController {
     func tableRowTypes() -> [ImmuTableRow.Type] {
         return [TabbedTotalsDetailStatsRow.self,
                 TopTotalsDetailStatsRow.self,
+                CountriesDetailStatsRow.self,
                 TableFooterRow.self]
     }
 
@@ -134,6 +135,8 @@ private extension SiteStatsDetailTableViewController {
             return periodStore.isFetchingAuthors
         case .periodReferrers:
             return periodStore.isFetchingReferrers
+        case .periodCountries:
+            return periodStore.isFetchingCountries
         default:
             return false
         }
@@ -177,6 +180,8 @@ private extension SiteStatsDetailTableViewController {
             viewModel?.refreshAuthors()
         case .periodReferrers:
             viewModel?.refreshReferrers()
+        case .periodCountries:
+            viewModel?.refreshCountries()
         default:
             refreshControl?.endRefreshing()
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -114,6 +114,10 @@ class SiteStatsDetailsViewModel: Observable {
                                                      dataSubtitle: StatSection.periodReferrers.dataSubtitle,
                                                      dataRows: referrersRows(),
                                                      siteStatsDetailsDelegate: detailsDelegate))
+        case .periodCountries:
+            tableRows.append(CountriesDetailStatsRow(itemSubtitle: StatSection.periodCountries.itemSubtitle,
+                                                     dataSubtitle: StatSection.periodCountries.dataSubtitle,
+                                                     dataRows: countriesRows()))
         default:
             break
         }
@@ -188,6 +192,14 @@ class SiteStatsDetailsViewModel: Observable {
         ActionDispatcher.dispatch(PeriodAction.refreshReferrers(date: selectedDate, period: selectedPeriod))
     }
 
+    func refreshCountries() {
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return
+        }
+        ActionDispatcher.dispatch(PeriodAction.refreshCountries(date: selectedDate, period: selectedPeriod))
+    }
+
 }
 
 // MARK: - Private Extension
@@ -227,6 +239,8 @@ private extension SiteStatsDetailsViewModel {
             return .allAuthors(date: selectedDate, period: selectedPeriod)
         case .periodReferrers:
             return .allReferrers(date: selectedDate, period: selectedPeriod)
+        case .periodCountries:
+            return .allCountries(date: selectedDate, period: selectedPeriod)
         default:
             return nil
         }
@@ -392,6 +406,14 @@ private extension SiteStatsDetailsViewModel {
                                                                            disclosureURL: StatsDataHelper.disclosureUrlForItem($0),
                                                                            childRows: StatsDataHelper.childRowsForReferrers($0),
                                                                            statSection: .periodReferrers) }
+            ?? []
+    }
+
+    func countriesRows() -> [StatsTotalRowData] {
+        return periodStore.getAllCountries()?.map { StatsTotalRowData.init(name: $0.label,
+                                                                           data: $0.value.displayString(),
+                                                                           countryIconURL: $0.iconURL,
+                                                                           statSection: .periodCountries) }
             ?? []
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -179,6 +179,32 @@ struct TopTotalsDetailStatsRow: ImmuTableRow {
     }
 }
 
+struct CountriesDetailStatsRow: ImmuTableRow {
+
+    typealias CellType = CountriesCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let itemSubtitle: String
+    let dataSubtitle: String
+    let dataRows: [StatsTotalRowData]
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(itemSubtitle: itemSubtitle,
+                       dataSubtitle: dataSubtitle,
+                       dataRows: dataRows,
+                       siteStatsPeriodDelegate: nil)
+    }
+}
+
 struct TopTotalsInsightStatsRow: ImmuTableRow {
 
     typealias CellType = TopTotalsCell

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -201,7 +201,8 @@ struct CountriesDetailStatsRow: ImmuTableRow {
         cell.configure(itemSubtitle: itemSubtitle,
                        dataSubtitle: dataSubtitle,
                        dataRows: dataRows,
-                       siteStatsPeriodDelegate: nil)
+                       siteStatsPeriodDelegate: nil,
+                       limitRowsDisplayed: false)
     }
 }
 


### PR DESCRIPTION
Fixes #11278    

On the Period Countries card, selecting `View more` will now show a full list of Countries. The rows should look like they do on the Period Countries card. There is no row selection action.

**NOTE:** Depending on the number of countries, it could take several seconds for the view to load. There is an outstanding issue to show a loading view (#11166).

To test:
- On a site with more than 6 countries, go to Period > Countries > View more.
- Verify the view is as shown below.

![countries_flow](https://user-images.githubusercontent.com/1816888/54387771-d4f35680-4661-11e9-8d10-46e409826e18.png)

