### PR TITLE
Dismiss Notices using ActionDispatcher

### DIFF
--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -106,8 +106,24 @@ enum NoticeAction: Action {
     /// The specified notice will be queued for display to the user
     case post(Notice)
     /// The currently displayed notice should be removed from the notice store
+    ///
+    /// Prefer to use `clear` or `clearWithTag` whenever possible to make sure the correct
+    /// `Notice` is being dismissed. Here is an example fake scenario that may make `dismiss`
+    /// not ideal:
+    ///
+    /// 1. MediaBrowser posts NoticeA. NoticeA is displayed.
+    /// 2. Editor posts NoticeB.
+    /// 3. Eventually, NoticeB is displayed.
+    /// 4. MediaBrowser dispatches `dismiss` which dismisses NoticeB.
+    ///
+    /// If MediaBrowser used `clear` or `clearWithTag`, the NoticeB should not have been dismissed
+    /// prematurely. 
     case dismiss
+    /// Removes the given `Notice` from the Store.
     case clear(Notice)
+    /// Removes all Notices that have the given tag.
+    ///
+    /// - SeeAlso: `Notice.tag`
     case clearWithTag(Notice.Tag)
     case empty
 }

--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -114,7 +114,7 @@ enum NoticeAction: Action {
     /// 1. MediaBrowser posts NoticeA. NoticeA is displayed.
     /// 2. Editor posts NoticeB.
     /// 3. Eventually, NoticeB is displayed.
-    /// 4. MediaBrowser dispatches `dismiss` which dismisses NoticeB.
+    /// 4. MediaBrowser dispatches `dismiss` which dismisses **NoticeB**!
     ///
     /// If MediaBrowser used `clear` or `clearWithTag`, the NoticeB should not have been dismissed
     /// prematurely. 
@@ -136,6 +136,15 @@ struct NoticeStoreState {
 
 /// NoticeStore queues notices for display to the user.
 ///
+/// To interact with or modify the `NoticeStore`, use `ActionDispatcher` and dispatch Actions of
+/// type `NoticeAction`. Example:
+///
+/// ```
+/// let notice = Notice(title: "Hello, my old friend!")
+/// ActionDispatcher.dispatch(NoticeAction.post(notice))
+/// ```
+///
+/// - SeeAlso: `NoticeAction`
 class NoticeStore: StatefulStore<NoticeStoreState> {
     private var pending = Queue<Notice>()
 

--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -5,7 +5,7 @@ import WordPressFlux
 /// the app, much like Android toasts or snackbars.
 /// Once you've created a Notice, you can dispatch a `NoticeAction` to display it.
 ///
-struct Notice: Equatable {
+struct Notice {
     typealias ActionHandlerFunction = ((_ accepted: Bool) -> Void)
     typealias Tag = String
 
@@ -66,6 +66,9 @@ struct Notice: Equatable {
         self.style = style
     }
 
+}
+
+extension Notice: Equatable {
     static func ==(lhs: Notice, rhs: Notice) -> Bool {
         return lhs.identifier == rhs.identifier
     }

--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -125,6 +125,7 @@ enum NoticeAction: Action {
     ///
     /// - SeeAlso: `Notice.tag`
     case clearWithTag(Notice.Tag)
+    /// Removes all Notices except the current one.
     case empty
 }
 
@@ -198,6 +199,6 @@ class NoticeStore: StatefulStore<NoticeStoreState> {
     }
 
     private func emptyQueue() {
-        pending.clear()
+        pending.removeAll()
     }
 }

--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -5,8 +5,10 @@ import WordPressFlux
 /// the app, much like Android toasts or snackbars.
 /// Once you've created a Notice, you can dispatch a `NoticeAction` to display it.
 ///
-struct Notice {
+struct Notice: Equatable {
     typealias ActionHandlerFunction = ((_ accepted: Bool) -> Void)
+
+    private let identifier = UUID().uuidString
 
     /// The title of the notice
     let title: String
@@ -61,6 +63,10 @@ struct Notice {
         self.tag = tag
         self.actionHandler = actionHandler
         self.style = style
+    }
+
+    static func ==(lhs: Notice, rhs: Notice) -> Bool {
+        return lhs.identifier == rhs.identifier
     }
 }
 

--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -106,6 +106,7 @@ enum NoticeAction: Action {
     case post(Notice)
     /// The currently displayed notice should be removed from the notice store
     case dismiss
+    case remove(Notice)
     case empty
 }
 
@@ -130,6 +131,8 @@ class NoticeStore: StatefulStore<NoticeStoreState> {
         switch action {
         case .post(let notice):
             enqueueNotice(notice)
+        case .remove(let notice):
+            removeNotice(notice)
         case .dismiss:
             dequeueNotice()
         case .empty:
@@ -160,7 +163,15 @@ class NoticeStore: StatefulStore<NoticeStoreState> {
         state.notice = pending.pop()
     }
 
+    private func removeNotice(_ notice: Notice) {
+        pending.removeAll { $0 == notice }
+
+        if state.notice == notice {
+            state.notice = pending.pop()
+        }
+    }
+
     private func emptyQueue() {
-        pending = Queue<Notice>()
+        pending.clear()
     }
 }

--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -146,10 +146,8 @@ class NoticeStore: StatefulStore<NoticeStoreState> {
 
     // MARK: - Accessors
 
-    /// Returns the next notice that should be displayed to the user, if
-    /// one is available
-    ///
-    var nextNotice: Notice? {
+    /// Returns the notice that should be displayed to the user, if one is available.
+    var currentNotice: Notice? {
         return state.notice
     }
 

--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -160,9 +160,9 @@ class NoticeStore: StatefulStore<NoticeStoreState> {
         case .post(let notice):
             enqueueNotice(notice)
         case .clear(let notice):
-            clearNotice(notice)
+            clear(notice: notice)
         case .clearWithTag(let tag):
-            clearNoticesWithTag(tag)
+            clear(tag: tag)
         case .dismiss:
             dequeueNotice()
         case .empty:
@@ -191,7 +191,7 @@ class NoticeStore: StatefulStore<NoticeStoreState> {
         state.notice = pending.pop()
     }
 
-    private func clearNotice(_ notice: Notice) {
+    private func clear(notice: Notice) {
         pending.removeAll { $0 == notice }
 
         if state.notice == notice {
@@ -199,7 +199,7 @@ class NoticeStore: StatefulStore<NoticeStoreState> {
         }
     }
 
-    private func clearNoticesWithTag(_ tag: Notice.Tag) {
+    private func clear(tag: Notice.Tag) {
         pending.removeAll { $0.tag == tag }
 
         if state.notice?.tag == tag {

--- a/WordPress/Classes/System/WordPressAppDelegate.h
+++ b/WordPress/Classes/System/WordPressAppDelegate.h
@@ -6,7 +6,6 @@
 @class HockeyManager;
 @class NoticePresenter;
 @class Reachability;
-@class ReaderPostsViewController;
 @class WPUserAgent;
 @class WPAppAnalytics;
 @class WPCrashlytics;
@@ -27,7 +26,6 @@
 @property (nonatomic, strong, readwrite) Reachability                   *internetReachability;
 @property (nonatomic, strong, readwrite) WordPressAuthenticationManager *authManager;
 @property (nonatomic, assign, readwrite) BOOL                           connectionAvailable;
-@property (nonatomic, strong, readwrite) NoticePresenter                *noticePresenter;
 
 + (WordPressAppDelegate *)sharedInstance;
 

--- a/WordPress/Classes/System/WordPressAppDelegate.m
+++ b/WordPress/Classes/System/WordPressAppDelegate.m
@@ -48,6 +48,7 @@ DDLogLevel ddLogLevel = DDLogLevelInfo;
 @property (nonatomic, assign, readwrite) BOOL                           shouldRestoreApplicationState;
 @property (nonatomic, strong, readwrite) PingHubManager                 *pinghubManager;
 @property (nonatomic, strong, readwrite) WP3DTouchShortcutCreator       *shortcutCreator;
+@property (nonatomic, strong, readwrite) NoticePresenter                *noticePresenter;
 
 @end
 

--- a/WordPress/Classes/Utility/Queue.swift
+++ b/WordPress/Classes/Utility/Queue.swift
@@ -18,11 +18,13 @@ public struct Queue<Element> {
         return elements.popLast()
     }
 
-    mutating func clear() {
-        elements = [Element]()
-    }
-
-    mutating func removeAll(where shouldBeRemoved: (Element) -> Bool) {
-        elements.removeAll(where: shouldBeRemoved)
+    /// Removes all elements; If `where` is given, only the elements matching the
+    /// predicate will be removed.
+    mutating func removeAll(where shouldBeRemoved: ((Element) -> Bool)? = nil) {
+        if let shouldBeRemoved = shouldBeRemoved {
+            elements.removeAll(where: shouldBeRemoved)
+        } else {
+            elements.removeAll()
+        }
     }
 }

--- a/WordPress/Classes/Utility/Queue.swift
+++ b/WordPress/Classes/Utility/Queue.swift
@@ -17,4 +17,12 @@ public struct Queue<Element> {
     mutating func pop() -> Element? {
         return elements.popLast()
     }
+
+    mutating func clear() {
+        elements = [Element]()
+    }
+
+    mutating func removeAll(where shouldBeRemoved: (Element) -> Bool) {
+        elements.removeAll(where: shouldBeRemoved)
+    }
 }

--- a/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
+++ b/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
@@ -6,7 +6,7 @@ extension ReachabilityUtils {
         static let title = NSLocalizedString("No Connection",
                 comment: "Title of error prompt when no internet connection is available.")
         static let message = noConnectionMessage()
-        static let tag = "ReachabilityUtils.NoConnection"
+        static let tag: Notice.Tag = "ReachabilityUtils.NoConnection"
     }
 
     /// Performs the action when an internet connection is available
@@ -52,6 +52,6 @@ extension ReachabilityUtils {
 
     /// Dismiss the currently shown Notice if it was created using showNoInternetConnectionNotice()
     static func dismissNoInternetConnectionNotice() {
-        ActionDispatcher.dispatch(NoticeAction.dismiss)
+        ActionDispatcher.dispatch(NoticeAction.clearWithTag(NoConnectionMessage.tag))
     }
 }

--- a/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
+++ b/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
@@ -52,10 +52,6 @@ extension ReachabilityUtils {
 
     /// Dismiss the currently shown Notice if it was created using showNoInternetConnectionNotice()
     static func dismissNoInternetConnectionNotice() {
-        noticePresenter?.dismissCurrentNotice(tagged: NoConnectionMessage.tag)
-    }
-
-    private static var noticePresenter: NoticePresenter? {
-        return (UIApplication.shared.delegate as? WordPressAppDelegate)?.noticePresenter
+        ActionDispatcher.dispatch(NoticeAction.dismiss)
     }
 }

--- a/WordPress/Classes/Utility/WPError+Swift.swift
+++ b/WordPress/Classes/Utility/WPError+Swift.swift
@@ -26,10 +26,6 @@ extension WPError {
 
     /// Dismiss the currently shown Notice if it was created using showNetworkingNotice()
     static func dismissNetworkingNotice() {
-        noticePresenter?.dismissCurrentNotice(tagged: noticeTag)
-    }
-
-    private static var noticePresenter: NoticePresenter? {
-        return (UIApplication.shared.delegate as? WordPressAppDelegate)?.noticePresenter
+        ActionDispatcher.dispatch(NoticeAction.dismiss)
     }
 }

--- a/WordPress/Classes/Utility/WPError+Swift.swift
+++ b/WordPress/Classes/Utility/WPError+Swift.swift
@@ -3,7 +3,7 @@ import Foundation
 import WordPressFlux
 
 extension WPError {
-    private static let noticeTag = "WPError.Networking"
+    private static let noticeTag: Notice.Tag = "WPError.Networking"
 
     /// Show a Notice with the message taken from the given `error`
     ///
@@ -26,6 +26,6 @@ extension WPError {
 
     /// Dismiss the currently shown Notice if it was created using showNetworkingNotice()
     static func dismissNetworkingNotice() {
-        ActionDispatcher.dispatch(NoticeAction.dismiss)
+        ActionDispatcher.dispatch(NoticeAction.clearWithTag(noticeTag))
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -410,7 +410,7 @@ private extension QuickStartTourGuide {
         }
 
         currentSuggestion = nil
-        presenter.dismissCurrentNotice()
+        ActionDispatcher.dispatch(NoticeAction.dismiss)
     }
 
     func getNextStep() -> TourState? {
@@ -436,7 +436,6 @@ private extension QuickStartTourGuide {
             return
         }
 
-        presenter.dismissCurrentNotice()
         ActionDispatcher.dispatch(NoticeAction.empty)
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.noSuchElement])
     }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -405,7 +405,7 @@ private extension QuickStartTourGuide {
     }
 
     func dismissSuggestion() {
-        guard currentSuggestion != nil, let presenter = findNoticePresenter() else {
+        guard currentSuggestion != nil else {
             return
         }
 
@@ -427,15 +427,8 @@ private extension QuickStartTourGuide {
         recentlyTouredBlog = nil
     }
 
-    func findNoticePresenter() -> NoticePresenter? {
-        return (UIApplication.shared.delegate as? WordPressAppDelegate)?.noticePresenter
-    }
-
     func dismissCurrentNotice() {
-        guard let presenter = findNoticePresenter() else {
-            return
-        }
-
+        ActionDispatcher.dispatch(NoticeAction.dismiss)
         ActionDispatcher.dispatch(NoticeAction.empty)
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.noSuchElement])
     }

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -4,6 +4,7 @@ import UserNotifications
 import WordPressFlux
 
 class NoticePresenter: NSObject {
+    /// Used for tracking the currently displayed Notice and its corresponding view.
     private struct NoticeArtifact {
         let notice: Notice
         let containerView: NoticeContainerView?
@@ -42,6 +43,7 @@ class NoticePresenter: NSObject {
 
         super.init()
 
+        // Keep the storeReceipt to prevent the `onChange` subscription from being deactivated.
         storeReceipt = store.onChange { [weak self] in
             self?.onStoreChange()
         }
@@ -86,7 +88,7 @@ class NoticePresenter: NSObject {
     }
 
     private func onStoreChange() {
-        guard currentNoticeArtifact?.notice != store.nextNotice else {
+        guard currentNoticeArtifact?.notice != store.currentNotice else {
             return
         }
 
@@ -94,7 +96,7 @@ class NoticePresenter: NSObject {
 
         currentNoticeArtifact = nil
 
-        guard let notice = store.nextNotice else {
+        guard let notice = store.currentNotice else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -116,7 +116,7 @@ class NoticePresenter: NSObject {
 
         UNUserNotificationCenter.current().add(request, withCompletionHandler: { error in
             DispatchQueue.main.async {
-                self.dismiss()
+                ActionDispatcher.dispatch(NoticeAction.remove(notice))
             }
         })
     }
@@ -137,7 +137,7 @@ class NoticePresenter: NSObject {
         ])
 
         let dismiss = {
-            self.dismiss()
+            ActionDispatcher.dispatch(NoticeAction.remove(notice))
         }
         noticeView.dismissHandler = dismiss
 
@@ -192,10 +192,6 @@ class NoticePresenter: NSObject {
                 self?.window.isHidden = true
             }
         })
-    }
-
-    private func dismiss() {
-        ActionDispatcher.dispatch(NoticeAction.dismiss)
     }
 
     private func addNoticeContainerToPresentingViewController(_ noticeContainer: UIView) {

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -116,7 +116,7 @@ class NoticePresenter: NSObject {
 
         UNUserNotificationCenter.current().add(request, withCompletionHandler: { error in
             DispatchQueue.main.async {
-                ActionDispatcher.dispatch(NoticeAction.remove(notice))
+                ActionDispatcher.dispatch(NoticeAction.clear(notice))
             }
         })
     }
@@ -137,7 +137,7 @@ class NoticePresenter: NSObject {
         ])
 
         let dismiss = {
-            ActionDispatcher.dispatch(NoticeAction.remove(notice))
+            ActionDispatcher.dispatch(NoticeAction.clear(notice))
         }
         noticeView.dismissHandler = dismiss
 
@@ -170,14 +170,6 @@ class NoticePresenter: NSObject {
 
         currentNotice = nil
         currentContainer = nil
-    }
-
-    /// Dismiss the currently shown `Notice` if its `tag` is equal to the given `tag`.
-    private func dismissCurrentNotice(tagged tag: String) {
-        // It's named _nextNotice_ but it really is the _current_ Notice in NoticeStore.state
-        if store.nextNotice?.tag == tag {
-            dismissCurrentNotice()
-        }
     }
 
     private func dismiss(container: NoticeContainerView) {

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -3,6 +3,34 @@ import UIKit
 import UserNotifications
 import WordPressFlux
 
+/// Presents the views of Notices emitted by `NoticeStore`.
+///
+/// Notices are displayed in 2 ways based on the `UIApplication.state`.
+///
+/// ## Foreground
+///
+/// If the app is in the foreground, the Notice is shown as a snackbar-like view inside a separate
+/// `UIWindow`. This `UIWindow` is always on top of the main app's `UIWindow`.
+///
+/// Only one Notice view is displayed at a single time. Queued Notices will be displayed after
+/// the current Notice view is dismissed.
+///
+/// If the `Notice.style.isDismissable` is `true`, the Notice view will be dismissed after a few
+/// seconds. This is done by dispatching a `NoticeAction.clear` Action.
+///
+/// ## Background
+///
+/// If the app is in the background and the Notice has a `notificationInfo`, a push notification
+/// will be sent to the device. If there is no `notificationInfo`, the Notice will be ignored.
+///
+/// # Usage
+///
+/// The `NoticePresenter` only needs to be initialized once and kept in memory. After that, it
+/// is self-sufficient. You shouldn't need to interact with it directly. In order to display
+/// Notices, use `ActionDispatcher` with `NoticeAction` Actions.
+///
+/// - SeeAlso: `NoticeStore`
+/// - SeeAlso: `NoticeAction`
 class NoticePresenter: NSObject {
     /// Used for tracking the currently displayed Notice and its corresponding view.
     private struct NoticeArtifact {

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -12,9 +12,11 @@ class NoticePresenter: NSObject {
         }
         return view
     }
+
+    private var currentNotice: Notice?
     private var currentContainer: NoticeContainerView?
 
-    let generator = UINotificationFeedbackGenerator()
+    private let generator = UINotificationFeedbackGenerator()
 
     private var storeReceipt: Receipt?
 
@@ -98,6 +100,9 @@ class NoticePresenter: NSObject {
             return
         }
 
+        currentNotice = notice
+        currentContainer = nil
+
         let content = UNMutableNotificationContent(notice: notice)
         let request = UNNotificationRequest(identifier: notificationInfo.identifier,
                                             content: content,
@@ -118,8 +123,6 @@ class NoticePresenter: NSObject {
 
         let noticeContainerView = NoticeContainerView(noticeView: noticeView)
         addNoticeContainerToPresentingViewController(noticeContainerView)
-        currentContainer = noticeContainerView
-
         addBottomConstraintToNoticeContainer(noticeContainerView)
 
         NSLayoutConstraint.activate([
@@ -127,15 +130,13 @@ class NoticePresenter: NSObject {
             noticeContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
 
-        let fromState = offscreenState(for: noticeContainerView)
-
-        let toState = onscreenState(for: noticeContainerView)
-
         let dismiss = {
             self.dismiss(container: noticeContainerView)
         }
-
         noticeView.dismissHandler = dismiss
+
+        currentNotice = notice
+        currentContainer = noticeContainerView
 
         if let feedbackType = notice.feedbackType {
             generator.notificationOccurred(feedbackType)
@@ -143,6 +144,8 @@ class NoticePresenter: NSObject {
 
         window.isHidden = false
 
+        let fromState = offscreenState(for: noticeContainerView)
+        let toState = onscreenState(for: noticeContainerView)
         animatePresentation(fromState: fromState, toState: toState, completion: {
             // Quick Start notices don't get automatically dismissed
             guard notice.style.isDismissable else {
@@ -202,7 +205,9 @@ class NoticePresenter: NSObject {
             return
         }
 
+        currentNotice = nil
         currentContainer = nil
+
         self.animatePresentation(fromState: {}, toState: offscreenState(for: container), completion: { [weak self] in
             container.removeFromSuperview()
             self?.window.isHidden = true

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -117,7 +117,7 @@ class NoticePresenter: NSObject {
     /// Handle all changes in the `NoticeStore`.
     ///
     /// In here, we determine whether to show a Notice or dismiss the currently shown Notice based
-    /// on the value of `NoticeStore.currenNotice`.
+    /// on the value of `NoticeStore.currentNotice`.
     private func onStoreChange() {
         guard currentNoticeArtifact?.notice != store.currentNotice else {
             return

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -131,8 +131,8 @@ class NoticePresenter: NSObject {
             return
         }
 
-        if let artifact = present(notice) {
-            currentNoticePresentation = artifact
+        if let presentation = present(notice) {
+            currentNoticePresentation = presentation
         } else {
             // We were not able to show the `notice` so we will dispatch a .clear action. This
             // should prevent us from getting in a stuck state where `NoticeStore` thinks its

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -336,6 +336,7 @@
 		462F4E0A18369F0B0028D2F8 /* BlogDetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 462F4E0718369F0B0028D2F8 /* BlogDetailsViewController.m */; };
 		4645AFC51961E1FB005F7509 /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4645AFC41961E1FB005F7509 /* AppImages.xcassets */; };
 		4C8A715EBCE7E73AEE216293 /* Pods_WordPressShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */; };
+		572FB401223A806000933C76 /* NoticeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572FB400223A806000933C76 /* NoticeStoreTests.swift */; };
 		57D5812D2228526C002BAAD7 /* WPError+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D5812C2228526C002BAAD7 /* WPError+Swift.swift */; };
 		5903AE1B19B60A98009D5354 /* WPButtonForNavigationBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 5903AE1A19B60A98009D5354 /* WPButtonForNavigationBar.m */; };
 		590E873B1CB8205700D1B734 /* PostListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590E873A1CB8205700D1B734 /* PostListViewController.swift */; };
@@ -2192,6 +2193,7 @@
 		4F943DB9A7237917709622D5 /* Pods-WordPressNotificationContentExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationContentExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationContentExtension/Pods-WordPressNotificationContentExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		51A5F017948878F7E26979A0 /* Pods-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release.xcconfig"; sourceTree = "<group>"; };
 		556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPress.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		572FB400223A806000933C76 /* NoticeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStoreTests.swift; sourceTree = "<group>"; };
 		57D5812C2228526C002BAAD7 /* WPError+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPError+Swift.swift"; sourceTree = "<group>"; };
 		5903AE1A19B60A98009D5354 /* WPButtonForNavigationBar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPButtonForNavigationBar.m; sourceTree = "<group>"; usesTabs = 0; };
 		5903AE1C19B60AB9009D5354 /* WPButtonForNavigationBar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WPButtonForNavigationBar.h; sourceTree = "<group>"; usesTabs = 0; };
@@ -4806,6 +4808,22 @@
 			children = (
 			);
 			name = "Resources-iPad";
+			sourceTree = "<group>";
+		};
+		572FB3FE223A800500933C76 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				572FB3FF223A802900933C76 /* Stores */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		572FB3FF223A802900933C76 /* Stores */ = {
+			isa = PBXGroup;
+			children = (
+				572FB400223A806000933C76 /* NoticeStoreTests.swift */,
+			);
+			path = Stores;
 			sourceTree = "<group>";
 		};
 		59B48B601B99E0B0008EBB84 /* TestUtilities */ = {
@@ -7697,6 +7715,7 @@
 		E1239B7B176A2E0F00D37220 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				572FB3FE223A800500933C76 /* Classes */,
 				FF9A6E6F21F9359200D36D14 /* Gutenberg */,
 				7E442FC520F677A300DEACA5 /* ActivityLog */,
 				FF7691661EE06CF500713F4B /* Aztec */,
@@ -10707,6 +10726,7 @@
 				08A2AD7B1CCED8E500E84454 /* PostCategoryServiceTests.m in Sources */,
 				172D7825212D93B800D513F7 /* GiphyPageableTests.swift in Sources */,
 				D88A64A8208D9733008AE9BC /* ThumbnailCollectionTests.swift in Sources */,
+				572FB401223A806000933C76 /* NoticeStoreTests.swift in Sources */,
 				D816B8D12112D5960052CE4D /* DefaultNewsManagerTests.swift in Sources */,
 				748437EE1F1D4A7300E8DDAF /* RichContentFormatterTests.swift in Sources */,
 				D88A649E208D82D2008AE9BC /* XCTestCase+Wait.swift in Sources */,

--- a/WordPress/WordPressTest/Classes/Stores/NoticeStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/NoticeStoreTests.swift
@@ -150,4 +150,3 @@ class NoticeStoreTests: XCTestCase {
         dispatcher.dispatch(action)
     }
 }
-

--- a/WordPress/WordPressTest/Classes/Stores/NoticeStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/NoticeStoreTests.swift
@@ -1,0 +1,153 @@
+import WordPressFlux
+import XCTest
+
+@testable import WordPress
+
+class NoticeStoreTests: XCTestCase {
+    private var dispatcher: ActionDispatcher!
+    private var store: NoticeStore!
+
+    override func setUp() {
+        super.setUp()
+
+        dispatcher = ActionDispatcher()
+        store = NoticeStore(dispatcher: dispatcher)
+    }
+
+    override func tearDown() {
+        dispatcher = nil
+        store = nil
+
+        super.tearDown()
+    }
+
+    func testPostActionSetsTheNoticeAsTheCurrent() {
+        // Given
+        precondition(store.currentNotice == nil)
+        let notice = Notice(title: "Alpha")
+
+        // When
+        dispatch(.post(notice))
+
+        // Then
+        XCTAssertEqual(notice, store.currentNotice)
+    }
+
+    func testPostActionQueuesTheNoticeIfThereIsACurrentNotice() {
+        // Given
+        let alpha = Notice(title: "Alpha")
+        dispatch(.post(alpha))
+        precondition(store.currentNotice == alpha)
+
+        // When
+        dispatch(.post(Notice(title: "Bravo")))
+
+        // Then
+        XCTAssertEqual(alpha, store.currentNotice)
+    }
+
+    func testDismissActionSetsTheNextNoticeInTheQueueAsTheCurrent() {
+        // Given
+        let alpha = Notice(title: "Alpha")
+        let bravo = Notice(title: "Bravo")
+
+        dispatch(.post(alpha))
+        dispatch(.post(bravo))
+
+        precondition(store.currentNotice == alpha)
+
+        // When
+        dispatch(.dismiss)
+
+        // Then
+        XCTAssertEqual(bravo, store.currentNotice)
+    }
+
+    func testClearActionCanClearTheCurrentNotice() {
+        // Given
+        let alpha = Notice(title: "Alpha")
+        let bravo = Notice(title: "Bravo")
+
+        dispatch(.post(alpha))
+        dispatch(.post(bravo))
+
+        precondition(store.currentNotice == alpha)
+
+        // When
+        dispatch(.clear(alpha))
+
+        // Then
+        // Alpha was removed so the next in queue, Bravo, is set as the current
+        XCTAssertEqual(bravo, store.currentNotice)
+    }
+
+    func testClearActionCanRemoveANoticeInTheQueue() {
+        // Given
+        let alpha = Notice(title: "Alpha")
+        let bravo = Notice(title: "Bravo")
+
+        dispatch(.post(alpha))
+        dispatch(.post(bravo))
+
+        precondition(store.currentNotice == alpha)
+
+        // When
+        dispatch(.clear(bravo))
+        // Remove alpha
+        dispatch(.dismiss)
+
+        // Then
+        // Since Bravo was removed from the queue, there should be no current
+        XCTAssertNil(store.currentNotice)
+    }
+
+    func testClearWithTagActionRemovesNoticesWithTheMatchingTag() {
+        // Given
+        let tagToClear: Notice.Tag = "quae"
+        let alpha = Notice(title: "Alpha", tag: tagToClear)
+        let bravo = Notice(title: "Bravo")
+        let charlie = Notice(title: "Charlie", tag: tagToClear)
+
+        [alpha, bravo, charlie].forEach { dispatch(.post($0)) }
+
+        precondition(store.currentNotice == alpha)
+
+        // When
+        dispatch(.clearWithTag(tagToClear))
+
+        // Then
+        // Since Alpha was removed, Bravo is now the current Notice
+        XCTAssertEqual(bravo, store.currentNotice)
+
+        // Dismiss Bravo so that we can test that Charlie was removed too
+        dispatch(.dismiss)
+        XCTAssertNil(store.currentNotice)
+    }
+
+    func testEmptyActionClearsTheQueueButNotTheCurrentNotice() {
+        // Given
+        let alpha = Notice(title: "Alpha")
+        let bravo = Notice(title: "Bravo")
+        let charlie = Notice(title: "Charlie")
+
+        [alpha, bravo, charlie].forEach { dispatch(.post($0)) }
+
+        precondition(store.currentNotice == alpha)
+
+        // When
+        dispatch(.empty)
+
+        // Then
+        XCTAssertEqual(alpha, store.currentNotice)
+        // Dismiss Alpha so that we can test that everything else was removed
+        dispatch(.dismiss)
+        XCTAssertNil(store.currentNotice)
+    }
+
+    // MARK: - Helpers
+
+    private func dispatch(_ action: NoticeAction) {
+        dispatcher.dispatch(action)
+    }
+}
+

--- a/WordPress/WordPressTest/QueueTests.swift
+++ b/WordPress/WordPressTest/QueueTests.swift
@@ -78,4 +78,3 @@ class QueueTests: XCTestCase {
         XCTAssertNil(queue.pop())
     }
 }
-

--- a/WordPress/WordPressTest/QueueTests.swift
+++ b/WordPress/WordPressTest/QueueTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import WordPress
 
 class QueueTests: XCTestCase {
-    var queue = Queue<Int>()
+    private var queue = Queue<Int>()
 
     override func setUp() {
         super.setUp()
@@ -50,4 +50,32 @@ class QueueTests: XCTestCase {
         XCTAssertEqual(item4, 4)
         XCTAssertNil(item5)
     }
+
+    func testRemoveAllEmptiesTheQueue() {
+        // Given
+        queue.push(1)
+        queue.push(2)
+        queue.push(3)
+
+        // When
+        queue.removeAll()
+
+        // Then
+        XCTAssertNil(queue.pop())
+    }
+
+    func testRemoveAllRemovesElementsMatchingThePredicate() {
+        // Given
+        queue.push(1)
+        queue.push(2)
+        queue.push(3)
+
+        // When
+        queue.removeAll { $0 >= 2 }
+
+        // Then
+        XCTAssertEqual(queue.pop(), 1)
+        XCTAssertNil(queue.pop())
+    }
 }
+

--- a/WordPressFlux/WordPressFlux/Sources/Store.swift
+++ b/WordPressFlux/WordPressFlux/Sources/Store.swift
@@ -39,6 +39,7 @@ open class Store: Observable {
     /// Subclasses should implement this and deal with the Actions relevant to
     /// them.
     ///
+    /// This is always called on the main thread.
     open func onDispatch(_ action: Action) {
         // Subclasses should override this
     }


### PR DESCRIPTION
Closes #11175.

This changes the `Notice` dismissal architecture to more closely follow Flux. 

## Problem

To show a `Notice`, we would do this:

```swift
ActionDispatcher.dispatch(NoticeAction.post(notice))
```

The process flow looks like this:

![post](https://user-images.githubusercontent.com/198826/54390313-cc9e1a00-4667-11e9-884d-74bf332b367a.png)

To dismiss the `Notice`, we currently need the `NoticePresenter`:

```swift
let noticePresenter = findNoticePresenterFromAppDelegate()
noticePresenter?.dismissCurrentNotice()
```

And the flow looks like this:

![dismiss](https://user-images.githubusercontent.com/198826/54390261-a8dad400-4667-11e9-9abe-95b2752bdc54.png)

As you can see, it doesn't follow the same flow when we show a `Notice`. 

## Changes

This PR changes this so that to dismiss a `Notice`, we would only need the `ActionDispatcher`:

```swift
ActionDispatcher.dispatch(NoticeAction.dismiss)
```

And the flow looks the same as when showing a `Notice`:

![dismiss-new](https://user-images.githubusercontent.com/198826/54390210-8e085f80-4667-11e9-9a9e-fb6f1d1a4784.png)

## Testing

Testing for regression is recommended. Here are some places we use Notices:

- Quick Start 
- Offline messages described in #11171 
- Uploading a media and putting the app in the background

Unit tests were also added for `NoticeStore` and `Queue`.