### PR TITLE
[Stats Refresh] Period Published: add detail list view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -112,6 +112,7 @@ private extension SiteStatsDetailTableViewController {
         return [TabbedTotalsDetailStatsRow.self,
                 TopTotalsDetailStatsRow.self,
                 CountriesDetailStatsRow.self,
+                TopTotalsNoSubtitlesPeriodDetailStatsRow.self,
                 TableFooterRow.self]
     }
 
@@ -137,6 +138,8 @@ private extension SiteStatsDetailTableViewController {
             return periodStore.isFetchingReferrers
         case .periodCountries:
             return periodStore.isFetchingCountries
+        case .periodPublished:
+            return periodStore.isFetchingPublished
         default:
             return false
         }
@@ -182,6 +185,8 @@ private extension SiteStatsDetailTableViewController {
             viewModel?.refreshReferrers()
         case .periodCountries:
             viewModel?.refreshCountries()
+        case .periodPublished:
+            viewModel?.refreshPublished()
         default:
             refreshControl?.endRefreshing()
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -118,6 +118,9 @@ class SiteStatsDetailsViewModel: Observable {
             tableRows.append(CountriesDetailStatsRow(itemSubtitle: StatSection.periodCountries.itemSubtitle,
                                                      dataSubtitle: StatSection.periodCountries.dataSubtitle,
                                                      dataRows: countriesRows()))
+        case .periodPublished:
+            tableRows.append(TopTotalsNoSubtitlesPeriodDetailStatsRow(dataRows: publishedRows(),
+                                                                      siteStatsDetailsDelegate: detailsDelegate))
         default:
             break
         }
@@ -200,6 +203,14 @@ class SiteStatsDetailsViewModel: Observable {
         ActionDispatcher.dispatch(PeriodAction.refreshCountries(date: selectedDate, period: selectedPeriod))
     }
 
+    func refreshPublished() {
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return
+        }
+        ActionDispatcher.dispatch(PeriodAction.refreshPublished(date: selectedDate, period: selectedPeriod))
+    }
+
 }
 
 // MARK: - Private Extension
@@ -241,6 +252,8 @@ private extension SiteStatsDetailsViewModel {
             return .allReferrers(date: selectedDate, period: selectedPeriod)
         case .periodCountries:
             return .allCountries(date: selectedDate, period: selectedPeriod)
+        case .periodPublished:
+            return .allPublished(date: selectedDate, period: selectedPeriod)
         default:
             return nil
         }
@@ -414,6 +427,15 @@ private extension SiteStatsDetailsViewModel {
                                                                            data: $0.value.displayString(),
                                                                            countryIconURL: $0.iconURL,
                                                                            statSection: .periodCountries) }
+            ?? []
+    }
+
+    func publishedRows() -> [StatsTotalRowData] {
+        return periodStore.getAllPublished()?.map { StatsTotalRowData.init(name: $0.label,
+                                                                           data: "",
+                                                                           showDisclosure: true,
+                                                                           disclosureURL: StatsDataHelper.disclosureUrlForItem($0),
+                                                                           statSection: .periodPublished) }
             ?? []
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -206,6 +206,30 @@ struct CountriesDetailStatsRow: ImmuTableRow {
     }
 }
 
+struct TopTotalsNoSubtitlesPeriodDetailStatsRow: ImmuTableRow {
+
+    typealias CellType = TopTotalsCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let dataRows: [StatsTotalRowData]
+    let siteStatsDetailsDelegate: SiteStatsDetailsDelegate
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(dataRows: dataRows,
+                       siteStatsDetailsDelegate: siteStatsDetailsDelegate,
+                       limitRowsDisplayed: false)
+    }
+}
+
 struct TopTotalsInsightStatsRow: ImmuTableRow {
 
     typealias CellType = TopTotalsCell


### PR DESCRIPTION
Fixes #11280     

On the Period Published card, selecting `View more` will now show a full list of Published. The rows should look like they do on the Period Published card. Selecting a row will open a web view.

**NOTES:** 
- Currently, there is no API call to get the full list of Published. So for now, this displays the data fetched from the "top" Published API call used for the Period card. (cc @jklausa issue #11283 )
- Depending on the number of Published, it could take several seconds for the view to load. There is an outstanding issue to show a loading view (#11166).

To test:
- On a site with more than 6 Published, go to Period > Published > View more.
- Verify the view is as shown below.
- Verify selecting a row displays a web view.

![published_flow](https://user-images.githubusercontent.com/1816888/54392164-85665800-466c-11e9-892b-ccd92a06f4a3.png)
