### PR TITLE
Transitioned to use custom chart legend

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -13,8 +13,9 @@ class StatsBarChartView: BarChartView {
         static let animationDuration    = TimeInterval(1)
         static let intrinsicHeight      = CGFloat(170)      // height via Zeplin
         static let highlightAlpha       = CGFloat(1)
+        static let legendOffset         = CGFloat(16)
         static let markerAlpha          = CGFloat(0.2)
-        static let offset               = CGFloat(20)
+        static let trailingOffset       = CGFloat(20)
     }
 
     /// This adapts the data set for presentation by the Charts framework.
@@ -177,7 +178,7 @@ class StatsBarChartView: BarChartView {
     private func configureChartViewBaseProperties() {
         dragDecelerationEnabled = false
 
-        extraRightOffset = Constants.offset
+        extraRightOffset = Constants.trailingOffset
 
         animate(yAxisDuration: Constants.animationDuration)
     }
@@ -191,6 +192,11 @@ class StatsBarChartView: BarChartView {
 
         let chartLegend = StatsChartLegendView(color: legendColor, title: legendTitle)
         addSubview(chartLegend)
+
+        NSLayoutConstraint.activate([
+            chartLegend.widthAnchor.constraint(equalTo: widthAnchor)
+        ])
+        extraTopOffset += chartLegend.intrinsicContentSize.height
 
         self.legendView = chartLegend
     }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -13,7 +13,6 @@ class StatsBarChartView: BarChartView {
         static let animationDuration    = TimeInterval(1)
         static let intrinsicHeight      = CGFloat(170)      // height via Zeplin
         static let highlightAlpha       = CGFloat(1)
-        static let legendOffset         = CGFloat(16)
         static let markerAlpha          = CGFloat(0.2)
         static let trailingOffset       = CGFloat(20)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -17,9 +17,17 @@ class StatsBarChartView: BarChartView {
         static let offset               = CGFloat(20)
     }
 
+    /// This adapts the data set for presentation by the Charts framework.
+    ///
     private let barChartData: BarChartDataConvertible
 
+    /// This influences the visual appearance of the chart to be rendered.
+    ///
     private let styling: BarChartStyling
+
+    /// When set, this stock `UIView` serves as a legend for the rendered chart.
+    ///
+    private var legendView: UIView?
 
     // MARK: StatsBarChartView
 
@@ -175,19 +183,16 @@ class StatsBarChartView: BarChartView {
     }
 
     private func configureLegendIfNeeded() {
-        guard let legendTitle = styling.legendTitle, let legendColor = styling.secondaryBarColor else {
-            legend.enabled = false
+        legend.enabled = false
+
+        guard let legendColor = styling.secondaryBarColor, let legendTitle = styling.legendTitle, legendView == nil else {
             return
         }
 
-        legend.enabled = true
-        legend.verticalAlignment = .top
+        let chartLegend = StatsChartLegendView(color: legendColor, title: legendTitle)
+        addSubview(chartLegend)
 
-        let entry = LegendEntry()
-        entry.label = legendTitle
-        entry.formColor = legendColor
-
-        legend.setCustom(entries: [entry])
+        self.legendView = chartLegend
     }
 
     private func configureXAxis() {

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsChartLegendView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsChartLegendView.swift
@@ -11,8 +11,8 @@ class StatsChartLegendView: UIView {
         static let capsuleCornerRadius  = CGFloat(2)
         static let capsuleHeight        = CGFloat(8)
         static let capsuleWidth         = CGFloat(16)
-        static let intrinsicHeight      = CGFloat(14)
-        static let intrinsicWidth       = CGFloat(120)
+        static let intrinsicHeight      = CGFloat(16)
+        static let intrinsicWidth       = CGFloat(72)
         static let spacing              = CGFloat(8)
     }
 
@@ -86,6 +86,7 @@ class StatsChartLegendView: UIView {
             capsule.centerYAnchor.constraint(equalTo: centerYAnchor),
             label.leadingAnchor.constraint(equalTo: capsule.trailingAnchor, constant: Constants.spacing),
             label.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
         ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsChartLegendView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsChartLegendView.swift
@@ -1,0 +1,91 @@
+
+import UIKit
+
+// MARK: StatsChartLegendView
+
+class StatsChartLegendView: UIView {
+
+    // MARK: Properties
+
+    private struct Constants {
+        static let capsuleCornerRadius  = CGFloat(2)
+        static let capsuleHeight        = CGFloat(8)
+        static let capsuleWidth         = CGFloat(16)
+        static let intrinsicHeight      = CGFloat(14)
+        static let intrinsicWidth       = CGFloat(120)
+        static let spacing              = CGFloat(8)
+    }
+
+    private let color: UIColor
+    private let title: String
+
+    private let capsule: UIView
+    private let label: UILabel
+
+    // MARK: StatsLegendView
+
+    init(color: UIColor, title: String) {
+        self.color = color
+        self.title = title
+
+        self.capsule = {
+            let view = UIView()
+
+            view.translatesAutoresizingMaskIntoConstraints = false
+            view.backgroundColor = color
+            view.layer.cornerRadius = Constants.capsuleCornerRadius
+
+            NSLayoutConstraint.activate([
+                view.widthAnchor.constraint(equalToConstant: Constants.capsuleWidth),
+                view.heightAnchor.constraint(equalToConstant: Constants.capsuleHeight)
+            ])
+
+            return view
+        }()
+
+        self.label = {
+            let label = UILabel()
+
+            label.translatesAutoresizingMaskIntoConstraints = false
+            label.numberOfLines = 0
+            label.preferredMaxLayoutWidth = Constants.intrinsicWidth - Constants.capsuleWidth
+
+            label.font = WPStyleGuide.fixedFont(for: .caption2)
+            label.textColor = WPStyleGuide.greyDarken20()
+            label.text = title
+
+            label.sizeToFit()
+
+            return label
+        }()
+
+        super.init(frame: .zero)
+
+        initialize()
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: Constants.intrinsicWidth, height: Constants.intrinsicHeight)
+    }
+
+    // MARK: Private behavior
+
+    private func initialize() {
+        translatesAutoresizingMaskIntoConstraints = false
+        backgroundColor = .white
+
+        addSubview(capsule)
+        addSubview(label)
+
+        NSLayoutConstraint.activate([
+            capsule.leadingAnchor.constraint(equalTo: leadingAnchor),
+            capsule.centerYAnchor.constraint(equalTo: centerYAnchor),
+            label.leadingAnchor.constraint(equalTo: capsule.trailingAnchor, constant: Constants.spacing),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -517,6 +517,7 @@
 		73CE3E0E21F7F9D3007C9C85 /* TableViewOffsetCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73CE3E0D21F7F9D3007C9C85 /* TableViewOffsetCoordinator.swift */; };
 		73D5AC63212622B200ADDDD2 /* NotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D5AC5C212622B200ADDDD2 /* NotificationViewController.swift */; };
 		73D5AC64212622B200ADDDD2 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 73D5AC5E212622B200ADDDD2 /* Localizable.strings */; };
+		73D86969223AF4040064920F /* StatsChartLegendView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73D86968223AF4040064920F /* StatsChartLegendView.swift */; };
 		73E32389212CD8B5001B735C /* NSAttributedString+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54866C91A0D7042004AC79D /* NSAttributedString+Helpers.swift */; };
 		73E3238B212CE0D7001B735C /* Noticons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E6B42CBE1D9DA6270043E228 /* Noticons.ttf */; };
 		73E40D8921238BF50012ABA6 /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
@@ -2432,6 +2433,7 @@
 		73D5AC60212622B200ADDDD2 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		73D5AC662126236600ADDDD2 /* Info-Alpha.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Alpha.plist"; sourceTree = "<group>"; };
 		73D5AC672126236600ADDDD2 /* Info-Internal.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Internal.plist"; sourceTree = "<group>"; };
+		73D86968223AF4040064920F /* StatsChartLegendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsChartLegendView.swift; sourceTree = "<group>"; };
 		73E40D8B21238C520012ABA6 /* Tracks+ServiceExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tracks+ServiceExtension.swift"; sourceTree = "<group>"; };
 		73EDC709212E5D6700E5E3ED /* RemoteNotificationStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationStyles.swift; sourceTree = "<group>"; };
 		73F6DD41212BA54700CE447D /* RichNotificationContentFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichNotificationContentFormatter.swift; sourceTree = "<group>"; };
@@ -5354,6 +5356,7 @@
 				73FF7033221F4AE200541798 /* Charts+Styling.swift */,
 				73FF7031221F469100541798 /* Charts+Support.swift */,
 				73FF702F221F43CD00541798 /* StatsBarChartView.swift */,
+				73D86968223AF4040064920F /* StatsChartLegendView.swift */,
 			);
 			path = Charts;
 			sourceTree = "<group>";
@@ -10390,6 +10393,7 @@
 				E6431DE71C4E892900FD8D90 /* SharingViewController.m in Sources */,
 				7E4123C820F417EF00DF8486 /* FormattableActivity.swift in Sources */,
 				9A162F2B21C2A21A00FDC035 /* RevisionPreviewTextViewManager.swift in Sources */,
+				73D86969223AF4040064920F /* StatsChartLegendView.swift in Sources */,
 				FF286C761DE70A4500383A62 /* NSURL+Exporters.swift in Sources */,
 				E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */,
 				436D55DF210F866900CEAA33 /* StoryboardLoadable.swift in Sources */,


### PR DESCRIPTION
Fixes #11266 and in doing so, updates the legend to more closely respect the specification in Zeplin.

To test:
- Checkout the branch, confirm that it builds & tests pass.
- For a site, navigate to Stats, and select a given period (i.e., Days, Weeks, Months, Years). The image should look like the exhibits below.
- Please note that at the moment, the chart is the same regardless of period or dimension (Views, Visitors, Likes, Comments).

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

_iPhone SE (Portrait)_
![11266_SE_portrait](https://user-images.githubusercontent.com/221062/54394938-9367a900-466b-11e9-822f-426694544770.png)

_iPhone SE (Landscape)_
![11266_SE_landscape](https://user-images.githubusercontent.com/221062/54394943-9793c680-466b-11e9-8bea-8027cf25f49c.png)
