### PR TITLE
Share Extension: Improve text import from other apps

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 12.1
 -----
 * Improve messages when updates to user account details fail because of server logic, for exanple email being used for another account.
+* Improved text import from other apps, such as Bear or Ulysses 🥰
 
 12.0
 -----

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -34,7 +34,7 @@ struct ExtractedShare {
         }
 
         guard selectedText.isEmpty else {
-            return "<blockquote><p>\(selectedText)\(readOnText)</p></blockquote>"
+            return "<blockquote><p>\(selectedText.escapeHtmlNamedEntities())\(readOnText)</p></blockquote>"
         }
 
         if !description.isEmpty {

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -231,23 +231,30 @@ private struct URLExtractor: TypeBasedExtensionContentExtractor {
     let acceptedType = kUTTypeURL as String
 
     func convert(payload: URL) -> ExtractedItem? {
-//        guard !payload.isFileURL else {
-//            let contents = try? String(contentsOf: payload)
-//            return ExtractedItem(selectedText: contents, description: nil, url: nil, title: nil, image: nil)
-//        }
+        guard !payload.isFileURL else {
+            return processLocalFile(url: payload)
+        }
+
         var returnedItem = ExtractedItem()
         returnedItem.url = payload
 
-        if payload.isFileURL {
-            let html = try? String(contentsOf: payload) ?? ""
-            returnedItem.selectedText = html?.escapeHtmlNamedEntities()
+        return returnedItem
         }
 
-        return returnedItem
+    private func processLocalFile(url: URL) -> ExtractedItem? {
+        switch url.pathExtension {
+        case "text", "txt":
+            return handlePlainTextFile(url: url)
+        default:
+            return nil
+        }
     }
 
-    private func extractBodyContents(html: String) {
-        let bodyParts = html.components(separatedBy: "<body")
+    private func handlePlainTextFile(url: URL) -> ExtractedItem? {
+        var returnedItem = ExtractedItem()
+        let html = (try? String(contentsOf: url)) ?? ""
+        returnedItem.selectedText = html.escapeHtmlNamedEntities()
+        return returnedItem
     }
 }
 

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -30,7 +30,7 @@ struct ExtractedShare {
         //   * 4: No selected text, but we have a page title...use that.
         //   * Finally, default to a simple link if nothing else is found
         guard importedText.isEmpty else {
-            return "<p>\(importedText.escapeHtmlNamedEntities())</p>"
+            return importedText.escapeHtmlNamedEntities()
         }
 
         guard selectedText.isEmpty else {
@@ -205,7 +205,6 @@ private extension TypeBasedExtensionContentExtractor {
 
     func extract(context: NSExtensionContext, completion: @escaping ([ExtractedItem]) -> Void) {
         let itemProviders = context.itemProviders(ofType: acceptedType)
-        print(acceptedType)
         var results = [ExtractedItem]()
         guard itemProviders.count > 0 else {
             DispatchQueue.main.async {

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -144,21 +144,21 @@ private extension ShareExtractor {
             return
         }
         textExtractor.extract(context: extensionContext) { extractedItems in
-            guard extractedItems.count > 0 else {
+                guard extractedItems.count > 0 else {
                 completion(nil)
-                return
-            }
-            let combinedTitle = extractedItems.compactMap({ $0.title }).joined(separator: " ")
-            let combinedDescription = extractedItems.compactMap({ $0.description }).joined(separator: " ")
-            let combinedSelectedText = extractedItems.compactMap({ $0.selectedText }).joined(separator: "\n\n")
-            let urls = extractedItems.compactMap({ $0.url })
+                    return
+                }
+                let combinedTitle = extractedItems.compactMap({ $0.title }).joined(separator: " ")
+                let combinedDescription = extractedItems.compactMap({ $0.description }).joined(separator: " ")
+                let combinedSelectedText = extractedItems.compactMap({ $0.selectedText }).joined(separator: "\n\n")
+                let urls = extractedItems.compactMap({ $0.url })
 
-            completion(ExtractedItem(selectedText: combinedSelectedText,
-                                     description: combinedDescription,
-                                     url: urls.first,
-                                     title: combinedTitle,
-                                     image: nil))
-        }
+                completion(ExtractedItem(selectedText: combinedSelectedText,
+                                         description: combinedDescription,
+                                         url: urls.first,
+                                         title: combinedTitle,
+                                         image: nil))
+            }
     }
 
     func extractImages(completion: @escaping ([UIImage]?) -> Void) {
@@ -195,6 +195,7 @@ private extension TypeBasedExtensionContentExtractor {
 
     func extract(context: NSExtensionContext, completion: @escaping ([ExtractedItem]) -> Void) {
         let itemProviders = context.itemProviders(ofType: acceptedType)
+        print(acceptedType)
         var results = [ExtractedItem]()
         guard itemProviders.count > 0 else {
             DispatchQueue.main.async {
@@ -230,12 +231,23 @@ private struct URLExtractor: TypeBasedExtensionContentExtractor {
     let acceptedType = kUTTypeURL as String
 
     func convert(payload: URL) -> ExtractedItem? {
-        guard !payload.isFileURL else {
-            return nil
-        }
+//        guard !payload.isFileURL else {
+//            let contents = try? String(contentsOf: payload)
+//            return ExtractedItem(selectedText: contents, description: nil, url: nil, title: nil, image: nil)
+//        }
         var returnedItem = ExtractedItem()
         returnedItem.url = payload
+
+        if payload.isFileURL {
+            let html = try? String(contentsOf: payload) ?? ""
+            returnedItem.selectedText = html?.escapeHtmlNamedEntities()
+        }
+
         return returnedItem
+    }
+
+    private func extractBodyContents(html: String) {
+        let bodyParts = html.components(separatedBy: "<body")
     }
 }
 

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -152,23 +152,23 @@ private extension ShareExtractor {
             return
         }
         textExtractor.extract(context: extensionContext) { extractedItems in
-                guard extractedItems.count > 0 else {
+            guard extractedItems.count > 0 else {
                 completion(nil)
-                    return
-                }
-                let combinedTitle = extractedItems.compactMap({ $0.title }).joined(separator: " ")
-                let combinedDescription = extractedItems.compactMap({ $0.description }).joined(separator: " ")
-                let combinedSelectedText = extractedItems.compactMap({ $0.selectedText }).joined(separator: "\n\n")
-                let combinedImportedText = extractedItems.compactMap({ $0.importedText }).joined(separator: "\n\n")
-                let urls = extractedItems.compactMap({ $0.url })
-
-                completion(ExtractedItem(selectedText: combinedSelectedText,
-                                         importedText: combinedImportedText,
-                                         description: combinedDescription,
-                                         url: urls.first,
-                                         title: combinedTitle,
-                                         image: nil))
+                return
             }
+            let combinedTitle = extractedItems.compactMap({ $0.title }).joined(separator: " ")
+            let combinedDescription = extractedItems.compactMap({ $0.description }).joined(separator: " ")
+            let combinedSelectedText = extractedItems.compactMap({ $0.selectedText }).joined(separator: "\n\n")
+            let combinedImportedText = extractedItems.compactMap({ $0.importedText }).joined(separator: "\n\n")
+            let urls = extractedItems.compactMap({ $0.url })
+
+            completion(ExtractedItem(selectedText: combinedSelectedText,
+                                     importedText: combinedImportedText,
+                                     description: combinedDescription,
+                                     url: urls.first,
+                                     title: combinedTitle,
+                                     image: nil))
+        }
     }
 
     func extractImages(completion: @escaping ([UIImage]?) -> Void) {

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -9,11 +9,10 @@ struct ExtractedShare {
     var description: String
     var url: URL?
     var selectedText: String
+    var importedText: String
     var images: [UIImage]
 
     var combinedContentHTML: String {
-        var returnString: String
-
         var rawLink = ""
         var readOnText = ""
 
@@ -25,23 +24,26 @@ struct ExtractedShare {
         }
 
         // Build the returned string by doing the following:
-        //   * 1st check: Look for selected text, if it exists put it into a blockquote.
-        //   * 2nd check: No selected text, but we have a page description...use that.
-        //   * 3rd check: No selected text, but we have a page title...use that.
+        //   * 1: Look for imported text.
+        //   * 2: Look for selected text, if it exists put it into a blockquote.
+        //   * 3: No selected text, but we have a page description...use that.
+        //   * 4: No selected text, but we have a page title...use that.
         //   * Finally, default to a simple link if nothing else is found
-        if selectedText.isEmpty {
-            if !description.isEmpty {
-                returnString = "<p>\(description)\(readOnText)</p>"
-            } else if !title.isEmpty {
-                returnString = "<p>\(title)\(readOnText)</p>"
-            } else {
-                returnString = "<p>\(rawLink)</p>"
-            }
-        } else {
-            returnString = "<blockquote><p>\(selectedText)\(readOnText)</p></blockquote>"
+        guard importedText.isEmpty else {
+            return "<p>\(importedText.escapeHtmlNamedEntities())</p>"
         }
 
-        return returnString
+        guard selectedText.isEmpty else {
+            return "<blockquote><p>\(selectedText)\(readOnText)</p></blockquote>"
+        }
+
+        if !description.isEmpty {
+            return "<p>\(description)\(readOnText)</p>"
+        } else if !title.isEmpty {
+            return "<p>\(title)\(readOnText)</p>"
+        } else {
+            return "<p>\(rawLink)</p>"
+        }
     }
 }
 
@@ -66,6 +68,7 @@ struct ShareExtractor {
                 let title = extractedTextResults?.title ?? ""
                 let description = extractedTextResults?.description ?? ""
                 let selectedText = extractedTextResults?.selectedText ?? ""
+                let importedText = extractedTextResults?.importedText ?? ""
                 let url = extractedTextResults?.url
                 let returnedImages = images ?? [UIImage]()
 
@@ -73,6 +76,7 @@ struct ShareExtractor {
                                           description: description,
                                           url: url,
                                           selectedText: selectedText,
+                                          importedText: importedText,
                                           images: returnedImages))
             }
         }
@@ -99,6 +103,10 @@ private struct ExtractedItem {
     /// Any text that was selected
     ///
     var selectedText: String?
+
+    /// Text that was imported from another app
+    ///
+    var importedText: String?
 
     /// A description of the resource if available
     ///
@@ -151,9 +159,11 @@ private extension ShareExtractor {
                 let combinedTitle = extractedItems.compactMap({ $0.title }).joined(separator: " ")
                 let combinedDescription = extractedItems.compactMap({ $0.description }).joined(separator: " ")
                 let combinedSelectedText = extractedItems.compactMap({ $0.selectedText }).joined(separator: "\n\n")
+                let combinedImportedText = extractedItems.compactMap({ $0.importedText }).joined(separator: "\n\n")
                 let urls = extractedItems.compactMap({ $0.url })
 
                 completion(ExtractedItem(selectedText: combinedSelectedText,
+                                         importedText: combinedImportedText,
                                          description: combinedDescription,
                                          url: urls.first,
                                          title: combinedTitle,
@@ -239,7 +249,7 @@ private struct URLExtractor: TypeBasedExtensionContentExtractor {
         returnedItem.url = payload
 
         return returnedItem
-        }
+    }
 
     private func processLocalFile(url: URL) -> ExtractedItem? {
         switch url.pathExtension {
@@ -252,8 +262,8 @@ private struct URLExtractor: TypeBasedExtensionContentExtractor {
 
     private func handlePlainTextFile(url: URL) -> ExtractedItem? {
         var returnedItem = ExtractedItem()
-        let html = (try? String(contentsOf: url)) ?? ""
-        returnedItem.selectedText = html.escapeHtmlNamedEntities()
+        let rawText = (try? String(contentsOf: url)) ?? ""
+        returnedItem.importedText = rawText
         return returnedItem
     }
 }


### PR DESCRIPTION
Fixes #11222
Fixes #11270 

This fixes text import from other applications by treating text from shared files differently than from text shared directly (which will still be blockquoted). It also fixes the issue of shared text (both kinds) being treated like HTML, opening the possibility of nefarious HTML making it into the user's site.

![text import longer](https://user-images.githubusercontent.com/517257/54452336-2c50ff80-4712-11e9-8100-5fb3dfdde529.gif)

To test:
- Share text from bear using the export UI. See GIF. (cc: @trix180)
- Share text from Ulysses using text UI
- In both cases, ensure that the text appears in the body of the post without block quote
- Also trying sharing from other text editors you may have. Some may only share the text directly, not a file, and the blockquote will still appear
- Also, try sharing HTML source in another editor. Now that HTML should appear with escaped HTML entities.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.