### PR TITLE
[Stats Refresh] Insights Latest Post Summary: update design

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -11,6 +11,7 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
 
     @IBOutlet weak var summariesStackView: UIStackView!
     @IBOutlet weak var chartStackView: UIStackView!
+    @IBOutlet weak var rowsStackView: UIStackView!
     @IBOutlet weak var actionStackView: UIStackView!
 
     @IBOutlet weak var viewsLabel: UILabel!
@@ -119,6 +120,7 @@ private extension LatestPostSummaryCell {
         case .viewMore:
             toggleDataViews(hide: false)
             configureChartView()
+            addRows(createDataRows(), toStackView: rowsStackView, forType: .insights, limitRowsDisplayed: false)
             actionLabel.text = CellStrings.viewMore
         case .sharePost:
             toggleDataViews(hide: true)
@@ -166,6 +168,24 @@ private extension LatestPostSummaryCell {
         summaryString.append(summaryToAppend)
 
         return Style.highlightString(postTitle, inString: summaryString)
+    }
+
+    func createDataRows() -> [StatsTotalRowData] {
+        guard let lastPostInsight = lastPostInsight else {
+            return []
+        }
+
+        var dataRows = [StatsTotalRowData]()
+
+        dataRows.append(StatsTotalRowData.init(name: CellStrings.likes,
+                                               data: lastPostInsight.likesCount.abbreviatedString(),
+                                               icon: Style.imageForGridiconType(.star)))
+
+        dataRows.append(StatsTotalRowData.init(name: CellStrings.comments,
+                                               data: lastPostInsight.commentsCount.abbreviatedString(),
+                                               icon: Style.imageForGridiconType(.comment)))
+
+        return dataRows
     }
 
     // MARK: - Properties

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -9,17 +9,13 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var summaryLabel: UILabel!
     @IBOutlet weak var contentStackViewTopConstraint: NSLayoutConstraint!
 
-    @IBOutlet weak var summariesStackView: UIStackView!
+    @IBOutlet weak var viewsStackView: UIStackView!
     @IBOutlet weak var chartStackView: UIStackView!
     @IBOutlet weak var rowsStackView: UIStackView!
     @IBOutlet weak var actionStackView: UIStackView!
 
     @IBOutlet weak var viewsLabel: UILabel!
     @IBOutlet weak var viewsDataLabel: UILabel!
-    @IBOutlet weak var likesLabel: UILabel!
-    @IBOutlet weak var likesDataLabel: UILabel!
-    @IBOutlet weak var commentsLabel: UILabel!
-    @IBOutlet weak var commentsDataLabel: UILabel!
 
     @IBOutlet weak var actionLabel: UILabel!
     @IBOutlet weak var actionImageView: UIImageView!
@@ -66,9 +62,7 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
         }
 
         self.lastPostInsight = lastPostInsight
-        viewsDataLabel.text = lastPostInsight.viewsCount.abbreviatedString()
-        likesDataLabel.text = lastPostInsight.likesCount.abbreviatedString()
-        commentsDataLabel.text = lastPostInsight.commentsCount.abbreviatedString()
+        viewsDataLabel.text = lastPostInsight.viewsCount.abbreviatedString(forHeroNumber: true)
 
         // If there is a post but 0 data, show Share Post option.
         if lastPostInsight.likesCount == 0 && lastPostInsight.viewsCount == 0 && lastPostInsight.commentsCount == 0 {
@@ -98,14 +92,6 @@ private extension LatestPostSummaryCell {
         viewsLabel.textColor = Style.defaultTextColor
         viewsDataLabel.textColor = Style.defaultTextColor
 
-        likesLabel.text = CellStrings.likes
-        likesLabel.textColor = Style.defaultTextColor
-        likesDataLabel.textColor = Style.defaultTextColor
-
-        commentsLabel.text = CellStrings.comments
-        commentsLabel.textColor = Style.defaultTextColor
-        commentsDataLabel.textColor = Style.defaultTextColor
-
         actionLabel.textColor = Style.actionTextColor
     }
 
@@ -134,12 +120,12 @@ private extension LatestPostSummaryCell {
     }
 
     func toggleDataViews(hide: Bool) {
-        summariesStackView.isHidden = hide
+        viewsStackView.isHidden = hide
         chartStackView.isHidden = hide
         disclosureImageView.isHidden = hide
         actionImageView.isHidden = !hide
         contentStackViewTopConstraint.constant = hide ? ContentStackViewTopConstraint.dataHidden
-                                                        : ContentStackViewTopConstraint.dataShown
+                                                      : ContentStackViewTopConstraint.dataShown
     }
 
     func setActionImageFor(action: ActionType) {
@@ -197,7 +183,7 @@ private extension LatestPostSummaryCell {
     }
 
     struct ContentStackViewTopConstraint {
-        static let dataShown = CGFloat(37)
+        static let dataShown = CGFloat(24)
         static let dataHidden = CGFloat(16)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.xib
@@ -35,64 +35,38 @@
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="bEY-vj-O3h" userLabel="Content Stack View">
                         <rect key="frame" x="0.0" y="91" width="375" height="303.5"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="irr-i0-AM0" userLabel="Summaries Stack View">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="51.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="irr-i0-AM0" userLabel="Views Stack View">
+                                <rect key="frame" x="16" y="0.0" width="343" height="50"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="wux-rC-UyT" userLabel="Views Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="114.5" height="51.5"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GRi-20-ac2">
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="50"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L5K-Wp-mW9" userLabel="Views Label">
-                                                <rect key="frame" x="0.0" y="0.0" width="36" height="16"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="40,000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GLF-sc-SL2" userLabel="Views Data Label">
+                                                <rect key="frame" x="0.0" y="0.0" width="100.5" height="50"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Efd-SW-O9K" userLabel="Views Data">
-                                                <rect key="frame" x="0.0" y="20" width="12" height="31.5"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ioe-GD-QRv" userLabel="Views Label">
+                                                <rect key="frame" x="108.5" y="24.5" width="45.5" height="20.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="5Lu-bf-dhz" userLabel="Likes Stack View">
-                                        <rect key="frame" x="130.5" y="0.0" width="114" height="51.5"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Likes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-AB-ffn" userLabel="Likes Label">
-                                                <rect key="frame" x="41.5" y="0.0" width="31.5" height="16"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eSJ-ds-3G4" userLabel="Likes Data">
-                                                <rect key="frame" x="51" y="20" width="12" height="31.5"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="INN-7n-UXp" userLabel="Comments Stack View">
-                                        <rect key="frame" x="260.5" y="0.0" width="114.5" height="51.5"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jLy-hA-LxG" userLabel="Comments Label">
-                                                <rect key="frame" x="24.5" y="0.0" width="65.5" height="16"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ke4-L3-2a5" userLabel="Comments Data">
-                                                <rect key="frame" x="51.5" y="20" width="12" height="31.5"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstItem="GLF-sc-SL2" firstAttribute="leading" secondItem="GRi-20-ac2" secondAttribute="leading" id="6DY-VA-8WB"/>
+                                            <constraint firstItem="ioe-GD-QRv" firstAttribute="leading" secondItem="GLF-sc-SL2" secondAttribute="trailing" constant="8" id="Mqa-xa-dGu"/>
+                                            <constraint firstAttribute="bottom" secondItem="GLF-sc-SL2" secondAttribute="bottom" id="UJ5-qv-ZRp"/>
+                                            <constraint firstItem="GLF-sc-SL2" firstAttribute="top" secondItem="GRi-20-ac2" secondAttribute="top" id="xFW-FO-cJS"/>
+                                            <constraint firstItem="ioe-GD-QRv" firstAttribute="bottom" secondItem="GLF-sc-SL2" secondAttribute="bottom" constant="-5" id="xZw-5T-XZI"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="dVi-l5-zbj" userLabel="Chart Stack View">
-                                <rect key="frame" x="16" y="66.5" width="343" height="128"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="dVi-l5-zbj" userLabel="Chart Stack View">
+                                <rect key="frame" x="16" y="65" width="343" height="129.5"/>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="BoB-0m-Daq" userLabel="Bottom Stack View">
                                 <rect key="frame" x="0.0" y="209.5" width="375" height="94"/>
@@ -143,8 +117,10 @@
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="BoB-0m-Daq" secondAttribute="trailing" id="4YA-iY-eOu"/>
                             <constraint firstItem="BoB-0m-Daq" firstAttribute="leading" secondItem="bEY-vj-O3h" secondAttribute="leading" id="Ef2-Bo-VQb"/>
+                            <constraint firstAttribute="trailing" secondItem="irr-i0-AM0" secondAttribute="trailing" constant="16" id="Gyk-oi-Z6b"/>
                             <constraint firstItem="dVi-l5-zbj" firstAttribute="leading" secondItem="bEY-vj-O3h" secondAttribute="leading" constant="16" id="X70-QR-Oxz"/>
                             <constraint firstAttribute="trailing" secondItem="dVi-l5-zbj" secondAttribute="trailing" constant="16" id="kuA-hL-x7l"/>
+                            <constraint firstItem="irr-i0-AM0" firstAttribute="leading" secondItem="bEY-vj-O3h" secondAttribute="leading" constant="16" id="xpf-9u-a0Z"/>
                         </constraints>
                     </stackView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3OP-qA-To0" userLabel="Action Button">
@@ -201,18 +177,14 @@
                 <outlet property="actionStackView" destination="dj8-5c-J6O" id="gkV-Yq-6bI"/>
                 <outlet property="bottomSeparatorLine" destination="ogd-ft-cmW" id="lTW-ff-ahD"/>
                 <outlet property="chartStackView" destination="dVi-l5-zbj" id="kyV-EI-lLg"/>
-                <outlet property="commentsDataLabel" destination="Ke4-L3-2a5" id="Mi7-wx-efz"/>
-                <outlet property="commentsLabel" destination="jLy-hA-LxG" id="jxu-pA-4Xa"/>
                 <outlet property="contentStackViewTopConstraint" destination="9Vd-ny-SGg" id="60x-Z3-6cn"/>
                 <outlet property="disclosureImageView" destination="NUJ-mV-eYK" id="Feu-jf-QlE"/>
-                <outlet property="likesDataLabel" destination="eSJ-ds-3G4" id="g1g-h2-qD5"/>
-                <outlet property="likesLabel" destination="UBX-AB-ffn" id="kcJ-sh-Lsa"/>
                 <outlet property="rowsStackView" destination="SgZ-KL-6tA" id="xbT-pC-okw"/>
-                <outlet property="summariesStackView" destination="irr-i0-AM0" id="uUi-Wo-PAU"/>
                 <outlet property="summaryLabel" destination="MnQ-57-h8x" id="0Qb-wb-77F"/>
                 <outlet property="topSeparatorLine" destination="JSW-bj-szW" id="KgK-Mb-YQM"/>
-                <outlet property="viewsDataLabel" destination="Efd-SW-O9K" id="CL6-zS-XtJ"/>
-                <outlet property="viewsLabel" destination="L5K-Wp-mW9" id="gpt-1m-oBt"/>
+                <outlet property="viewsDataLabel" destination="GLF-sc-SL2" id="rcy-lz-6Jd"/>
+                <outlet property="viewsLabel" destination="ioe-GD-QRv" id="RId-CY-R6b"/>
+                <outlet property="viewsStackView" destination="irr-i0-AM0" id="m6U-vc-M7T"/>
             </connections>
             <point key="canvasLocation" x="-44" y="157.87106446776613"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.xib
@@ -12,11 +12,11 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="580" id="KGk-i7-Jjw" customClass="LatestPostSummaryCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="330"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="687" id="KGk-i7-Jjw" customClass="LatestPostSummaryCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="395"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="375" height="329.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="375" height="394.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It's been 999 months since Your Post was published. Here's how the post performed so far." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MnQ-57-h8x" userLabel="Summary Label">
@@ -33,22 +33,22 @@
                         </connections>
                     </button>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="bEY-vj-O3h" userLabel="Content Stack View">
-                        <rect key="frame" x="16" y="91" width="343" height="238.5"/>
+                        <rect key="frame" x="0.0" y="91" width="375" height="303.5"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="irr-i0-AM0" userLabel="Summaries Stack View">
-                                <rect key="frame" x="0.0" y="0.0" width="343" height="51.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="51.5"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="wux-rC-UyT" userLabel="Views Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="103.5" height="51.5"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="wux-rC-UyT" userLabel="Views Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="114.5" height="51.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="L5K-Wp-mW9" userLabel="Views Label">
-                                                <rect key="frame" x="34" y="0.0" width="36" height="16"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="36" height="16"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Efd-SW-O9K" userLabel="Views Data">
-                                                <rect key="frame" x="46" y="20" width="12" height="31.5"/>
+                                                <rect key="frame" x="0.0" y="20" width="12" height="31.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -56,16 +56,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="5Lu-bf-dhz" userLabel="Likes Stack View">
-                                        <rect key="frame" x="119.5" y="0.0" width="104" height="51.5"/>
+                                        <rect key="frame" x="130.5" y="0.0" width="114" height="51.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Likes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-AB-ffn" userLabel="Likes Label">
-                                                <rect key="frame" x="36.5" y="0.0" width="31.5" height="16"/>
+                                                <rect key="frame" x="41.5" y="0.0" width="31.5" height="16"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eSJ-ds-3G4" userLabel="Likes Data">
-                                                <rect key="frame" x="46" y="20" width="12" height="31.5"/>
+                                                <rect key="frame" x="51" y="20" width="12" height="31.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -73,16 +73,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="INN-7n-UXp" userLabel="Comments Stack View">
-                                        <rect key="frame" x="239.5" y="0.0" width="103.5" height="51.5"/>
+                                        <rect key="frame" x="260.5" y="0.0" width="114.5" height="51.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jLy-hA-LxG" userLabel="Comments Label">
-                                                <rect key="frame" x="19" y="0.0" width="65.5" height="16"/>
+                                                <rect key="frame" x="24.5" y="0.0" width="65.5" height="16"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ke4-L3-2a5" userLabel="Comments Data">
-                                                <rect key="frame" x="45.5" y="20" width="12" height="31.5"/>
+                                                <rect key="frame" x="51.5" y="20" width="12" height="31.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -91,41 +91,64 @@
                                     </stackView>
                                 </subviews>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="dVi-l5-zbj" userLabel="Chart Stack View">
-                                <rect key="frame" x="0.0" y="66.5" width="343" height="113"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="dVi-l5-zbj" userLabel="Chart Stack View">
+                                <rect key="frame" x="16" y="66.5" width="343" height="128"/>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="dj8-5c-J6O" userLabel="Action Stack View">
-                                <rect key="frame" x="0.0" y="194.5" width="343" height="44"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="BoB-0m-Daq" userLabel="Bottom Stack View">
+                                <rect key="frame" x="0.0" y="209.5" width="375" height="94"/>
                                 <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OZB-d7-5Vo" userLabel="Action Icon Image">
-                                        <rect key="frame" x="0.0" y="10" width="24" height="24"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="SgZ-KL-6tA" userLabel="Rows Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="24" id="Ltv-y1-Dw5"/>
-                                            <constraint firstAttribute="height" constant="24" id="cek-yN-0vF"/>
+                                            <constraint firstAttribute="height" constant="50" placeholder="YES" id="Drn-0e-m7y"/>
                                         </constraints>
-                                    </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View more" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xet-wC-hmj" userLabel="Action Label">
-                                        <rect key="frame" x="40" y="12" width="279" height="20.5"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="disclosure-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="NUJ-mV-eYK" userLabel="Disclosure Image">
-                                        <rect key="frame" x="335" y="15.5" width="8" height="13"/>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="dj8-5c-J6O" userLabel="Action Stack View">
+                                        <rect key="frame" x="16" y="50" width="343" height="44"/>
+                                        <subviews>
+                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OZB-d7-5Vo" userLabel="Action Icon Image">
+                                                <rect key="frame" x="0.0" y="10" width="24" height="24"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="24" id="Ltv-y1-Dw5"/>
+                                                    <constraint firstAttribute="height" constant="24" id="cek-yN-0vF"/>
+                                                </constraints>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View more" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xet-wC-hmj" userLabel="Action Label">
+                                                <rect key="frame" x="40" y="12" width="279" height="20.5"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="disclosure-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="NUJ-mV-eYK" userLabel="Disclosure Image">
+                                                <rect key="frame" x="335" y="15.5" width="8" height="13"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="8" id="AYx-EH-X3W"/>
+                                                    <constraint firstAttribute="height" constant="13" id="AZH-gy-7Ym"/>
+                                                </constraints>
+                                            </imageView>
+                                        </subviews>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="8" id="AYx-EH-X3W"/>
-                                            <constraint firstAttribute="height" constant="13" id="AZH-gy-7Ym"/>
+                                            <constraint firstAttribute="height" constant="44" id="LDT-2j-RkH"/>
                                         </constraints>
-                                    </imageView>
+                                    </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="44" id="LDT-2j-RkH"/>
+                                    <constraint firstItem="SgZ-KL-6tA" firstAttribute="leading" secondItem="BoB-0m-Daq" secondAttribute="leading" id="JPl-Fi-L7M"/>
+                                    <constraint firstItem="dj8-5c-J6O" firstAttribute="leading" secondItem="BoB-0m-Daq" secondAttribute="leading" constant="16" id="NoN-2X-b6R"/>
+                                    <constraint firstAttribute="trailing" secondItem="dj8-5c-J6O" secondAttribute="trailing" constant="16" id="cW9-eg-w99"/>
+                                    <constraint firstAttribute="trailing" secondItem="SgZ-KL-6tA" secondAttribute="trailing" id="kVT-UJ-S0F"/>
                                 </constraints>
                             </stackView>
                         </subviews>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="BoB-0m-Daq" secondAttribute="trailing" id="4YA-iY-eOu"/>
+                            <constraint firstItem="BoB-0m-Daq" firstAttribute="leading" secondItem="bEY-vj-O3h" secondAttribute="leading" id="Ef2-Bo-VQb"/>
+                            <constraint firstItem="dVi-l5-zbj" firstAttribute="leading" secondItem="bEY-vj-O3h" secondAttribute="leading" constant="16" id="X70-QR-Oxz"/>
+                            <constraint firstAttribute="trailing" secondItem="dVi-l5-zbj" secondAttribute="trailing" constant="16" id="kuA-hL-x7l"/>
+                        </constraints>
                     </stackView>
                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3OP-qA-To0" userLabel="Action Button">
-                        <rect key="frame" x="16" y="285.5" width="343" height="44"/>
+                        <rect key="frame" x="0.0" y="350.5" width="375" height="44"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <connections>
                             <action selector="didTapActionButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="crC-F5-hoa"/>
@@ -139,7 +162,7 @@
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ogd-ft-cmW" userLabel="Bottom Seperator Line">
-                        <rect key="frame" x="0.0" y="329" width="375" height="0.5"/>
+                        <rect key="frame" x="0.0" y="394" width="375" height="0.5"/>
                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0.5" id="DlC-nH-qYA"/>
@@ -149,20 +172,20 @@
                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
                     <constraint firstAttribute="bottom" secondItem="bEY-vj-O3h" secondAttribute="bottom" id="1Xk-xj-7sr"/>
+                    <constraint firstItem="3OP-qA-To0" firstAttribute="top" secondItem="dj8-5c-J6O" secondAttribute="top" id="4t3-45-aUP"/>
                     <constraint firstItem="yj9-fI-q4P" firstAttribute="trailing" secondItem="MnQ-57-h8x" secondAttribute="trailing" id="6m6-uF-zFb"/>
+                    <constraint firstItem="3OP-qA-To0" firstAttribute="bottom" secondItem="dj8-5c-J6O" secondAttribute="bottom" id="7yh-c8-7Sp"/>
                     <constraint firstItem="bEY-vj-O3h" firstAttribute="top" secondItem="MnQ-57-h8x" secondAttribute="bottom" constant="37" id="9Vd-ny-SGg"/>
                     <constraint firstAttribute="trailing" secondItem="MnQ-57-h8x" secondAttribute="trailing" constant="16" id="EoB-PV-pQf"/>
-                    <constraint firstItem="3OP-qA-To0" firstAttribute="bottom" secondItem="dj8-5c-J6O" secondAttribute="bottom" id="G6C-Pl-MJz"/>
                     <constraint firstItem="JSW-bj-szW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="GSo-Tf-T4G"/>
-                    <constraint firstItem="3OP-qA-To0" firstAttribute="trailing" secondItem="dj8-5c-J6O" secondAttribute="trailing" id="HVd-qt-bfv"/>
-                    <constraint firstItem="3OP-qA-To0" firstAttribute="top" secondItem="dj8-5c-J6O" secondAttribute="top" id="HmM-nj-qBP"/>
                     <constraint firstItem="MnQ-57-h8x" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="I5y-dW-v1A"/>
-                    <constraint firstItem="bEY-vj-O3h" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="I7j-LS-Nx7"/>
+                    <constraint firstItem="bEY-vj-O3h" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="I7j-LS-Nx7"/>
                     <constraint firstItem="yj9-fI-q4P" firstAttribute="bottom" secondItem="MnQ-57-h8x" secondAttribute="bottom" id="L8m-Ex-6C4"/>
-                    <constraint firstAttribute="trailing" secondItem="bEY-vj-O3h" secondAttribute="trailing" constant="16" id="PL4-wc-ElT"/>
-                    <constraint firstItem="3OP-qA-To0" firstAttribute="leading" secondItem="dj8-5c-J6O" secondAttribute="leading" id="TzG-h9-5jU"/>
+                    <constraint firstAttribute="trailing" secondItem="bEY-vj-O3h" secondAttribute="trailing" id="PL4-wc-ElT"/>
                     <constraint firstItem="JSW-bj-szW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="Ugq-GK-MgF"/>
+                    <constraint firstItem="3OP-qA-To0" firstAttribute="trailing" secondItem="BoB-0m-Daq" secondAttribute="trailing" id="Vq4-uY-Kc2"/>
                     <constraint firstItem="yj9-fI-q4P" firstAttribute="leading" secondItem="MnQ-57-h8x" secondAttribute="leading" id="XBq-Q5-JzZ"/>
+                    <constraint firstItem="3OP-qA-To0" firstAttribute="leading" secondItem="BoB-0m-Daq" secondAttribute="leading" id="XTr-Rs-NDZ"/>
                     <constraint firstItem="yj9-fI-q4P" firstAttribute="top" secondItem="MnQ-57-h8x" secondAttribute="top" id="ZnV-2L-TM5"/>
                     <constraint firstAttribute="trailing" secondItem="ogd-ft-cmW" secondAttribute="trailing" id="pYN-iK-2gB"/>
                     <constraint firstItem="ogd-ft-cmW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="qnq-J6-gS6"/>
@@ -184,13 +207,14 @@
                 <outlet property="disclosureImageView" destination="NUJ-mV-eYK" id="Feu-jf-QlE"/>
                 <outlet property="likesDataLabel" destination="eSJ-ds-3G4" id="g1g-h2-qD5"/>
                 <outlet property="likesLabel" destination="UBX-AB-ffn" id="kcJ-sh-Lsa"/>
+                <outlet property="rowsStackView" destination="SgZ-KL-6tA" id="xbT-pC-okw"/>
                 <outlet property="summariesStackView" destination="irr-i0-AM0" id="uUi-Wo-PAU"/>
                 <outlet property="summaryLabel" destination="MnQ-57-h8x" id="0Qb-wb-77F"/>
                 <outlet property="topSeparatorLine" destination="JSW-bj-szW" id="KgK-Mb-YQM"/>
                 <outlet property="viewsDataLabel" destination="Efd-SW-O9K" id="CL6-zS-XtJ"/>
                 <outlet property="viewsLabel" destination="L5K-Wp-mW9" id="gpt-1m-oBt"/>
             </connections>
-            <point key="canvasLocation" x="-44" y="109.74512743628186"/>
+            <point key="canvasLocation" x="-44" y="157.87106446776613"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -168,7 +168,7 @@ private extension OverviewCell {
         ])
     }
 
-    private enum ChartBottomMargin {
+    enum ChartBottomMargin {
         static let filterTabBarShown = CGFloat(16)
         static let filterTabBarHidden = CGFloat(24)
     }


### PR DESCRIPTION
Fixes #11284

This updates Insights Latest Post Summary to match the new design:
- Move “views” to top and use full number
- Move “likes” and “comments” to bottom as table rows
- The Views number now abbreviates after 99,999.

To test:

---
- On a site that has a post with views/comments/likes, go to Insights > Latest Post Summary.
- Verify the view is now:

<img width="375" alt="lps" src="https://user-images.githubusercontent.com/1816888/54459400-37188e00-472c-11e9-8793-60fe5a5da0aa.png">

---
- On a site that has a post with no views/comments/likes, go to Insights > Latest Post Summary.
- Verify the view is still: (the point being there should be no change here)

<img width="350" alt="no_data" src="https://user-images.githubusercontent.com/1816888/54459301-ef920200-472b-11e9-9c5f-b8b9aea01c47.png">

---
- On a site with a more than 99,999 views, go to Insights > Latest Post Summary.
- Verify the number is abbreviated.
  - Note: to test this, in `LatestPostSummaryCell:configure`, you can modify the value used in this line:
`viewsDataLabel.text = lastPostInsight.viewsCount.abbreviatedString(forHeroNumber: true)`

<img width="350" alt="abbr" src="https://user-images.githubusercontent.com/1816888/54459654-e6edfb80-472c-11e9-8892-cbd4d1225e7d.png">
