### PR TITLE
Domains Search: Filter an exact match to the top of the list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * Redesigned Notices
 * Changed offline error messages to be less disruptive.
 * Resolved a defect in the new Site Creation flow where the site preview address bar could be edited.
+* Made it easier to find a domain for your new site, by moving the best match to the top of the search results.
  
 11.9
 ------

--- a/WordPress/Classes/Services/DomainsService.swift
+++ b/WordPress/Classes/Services/DomainsService.swift
@@ -28,16 +28,16 @@ struct DomainsService {
         remote.getDomainSuggestions(base: base,
                                     domainSuggestionType: domainSuggestionType,
                                     success: { suggestions in
-            let filteredSuggestions = self.filterSuggestions(suggestions, forBase: base)
-            success(filteredSuggestions)
+            let sorted = self.sortedSuggestions(suggestions, forBase: base)
+            success(sorted)
         }) { error in
             failure(error)
         }
     }
 
     // If any of the suggestions matches the base exactly,
-    // then filter that suggestion up to the top of the list.
-    fileprivate func filterSuggestions(_ suggestions: [DomainSuggestion], forBase base: String) -> [DomainSuggestion] {
+    // then sort that suggestion up to the top of the list.
+    fileprivate func sortedSuggestions(_ suggestions: [DomainSuggestion], forBase base: String) -> [DomainSuggestion] {
         let normalizedBase = base.lowercased().replacingMatches(of: " ", with: "")
 
         var filteredSuggestions = suggestions

--- a/WordPress/Classes/Services/DomainsService.swift
+++ b/WordPress/Classes/Services/DomainsService.swift
@@ -28,10 +28,25 @@ struct DomainsService {
         remote.getDomainSuggestions(base: base,
                                     domainSuggestionType: domainSuggestionType,
                                     success: { suggestions in
-            success(suggestions)
+            let filteredSuggestions = self.filterSuggestions(suggestions, forBase: base)
+            success(filteredSuggestions)
         }) { error in
             failure(error)
         }
+    }
+
+    // If any of the suggestions matches the base exactly,
+    // then filter that suggestion up to the top of the list.
+    fileprivate func filterSuggestions(_ suggestions: [DomainSuggestion], forBase base: String) -> [DomainSuggestion] {
+        let normalizedBase = base.lowercased().replacingMatches(of: " ", with: "")
+
+        var filteredSuggestions = suggestions
+        if let matchedSuggestionIndex = suggestions.firstIndex(where: { $0.subdomain == base || $0.subdomain == normalizedBase }) {
+            let matchedSuggestion = filteredSuggestions.remove(at: matchedSuggestionIndex)
+            filteredSuggestions.insert(matchedSuggestion, at: 0)
+        }
+
+        return filteredSuggestions
     }
 
     fileprivate func mergeDomains(_ domains: [Domain], forSite siteID: Int) {


### PR DESCRIPTION
Fixes #10530.

During a domains search, if any of the domain's subdomains exactly matches the user's query, filter it to the top of the list.

![domain-search](https://user-images.githubusercontent.com/4780/54461938-f9385b80-4765-11e9-827a-9b572826d3c8.gif)

**To test:**

* Build and run, log in, and tap + on the site list view.
* Tap Create a new Wordpress.com Site
* Chose a type of site and enter a category
* Enter a title that might produce an exact available domain match – perhaps include some numbers. Tap Next.
* On the domains search screen, the initial results should populate. Hopefully there should be an exact match for your search, and it should be at the top of the list.
* Enter a new domain search query, again something that matches an available domain. Check that the exact match shows at the top of the list.
* Check that existing tests pass.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.