### PR TITLE
Bring back uniquing of StatsRecordValues

### DIFF
--- a/WordPress/Classes/Models/AllTimeStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/AllTimeStatsRecordValue+CoreDataClass.swift
@@ -5,7 +5,7 @@ import CoreData
 public class AllTimeStatsRecordValue: StatsRecordValue {
     public override func validateForInsert() throws {
         try super.validateForInsert()
-        try singleEntryTypeValidation()
+        try recordValueSingleValueValidation()
     }
 }
 

--- a/WordPress/Classes/Models/AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift
@@ -5,7 +5,7 @@ import CoreData
 public class AnnualAndMostPopularTimeStatsRecordValue: StatsRecordValue {
     public override func validateForInsert() throws {
         try super.validateForInsert()
-        try singleEntryTypeValidation()
+        try recordValueSingleValueValidation()
     }
 }
 

--- a/WordPress/Classes/Models/LastPostStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/LastPostStatsRecordValue+CoreDataClass.swift
@@ -12,7 +12,7 @@ public class LastPostStatsRecordValue: StatsRecordValue {
 
     public override func validateForInsert() throws {
         try super.validateForInsert()
-        try singleEntryTypeValidation()
+        try recordValueSingleValueValidation()
     }
 }
 

--- a/WordPress/Classes/Models/StatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StatsRecordValue+CoreDataClass.swift
@@ -8,6 +8,17 @@ public class StatsRecordValue: NSManagedObject {
         self.statsRecord = parent
         parent.addToValues(self)
     }
+
+    func recordValueSingleValueValidation() throws {
+        guard let parent = statsRecord else {
+            throw StatsCoreDataValidationError.noParentStatsRecord
+        }
+
+        let fr: NSFetchRequest<StatsRecordValue> = StatsRecordValue.fetchRequest()
+        fr.predicate = NSPredicate(format: "\(#keyPath(StatsRecordValue.statsRecord)) = %@", parent)
+
+        try singleEntryTypeValidation(with: fr)
+    }
 }
 
 protocol StatsRecordValueConvertible {

--- a/WordPress/Classes/Models/StreakInsightStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/StreakInsightStatsRecordValue+CoreDataClass.swift
@@ -5,7 +5,7 @@ import CoreData
 public class StreakInsightStatsRecordValue: StatsRecordValue {
     public override func validateForInsert() throws {
         try super.validateForInsert()
-        try singleEntryTypeValidation()
+        try recordValueSingleValueValidation()
     }
 }
 

--- a/WordPress/Classes/Models/TodayStatsRecordValue+CoreDataClass.swift
+++ b/WordPress/Classes/Models/TodayStatsRecordValue+CoreDataClass.swift
@@ -5,7 +5,7 @@ import CoreData
 public class TodayStatsRecordValue: StatsRecordValue {
     public override func validateForInsert() throws {
         try super.validateForInsert()
-        try singleEntryTypeValidation()
+        try recordValueSingleValueValidation()
     }
 }
 

--- a/WordPress/WordPressTest/AllTimeStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/AllTimeStatsRecordValueTests.swift
@@ -12,7 +12,7 @@ class AllTimeStatsRecordValueTests: StatsTestCase {
                                            visitorsCount: 9003,
                                            bestViewsPerDayCount: 9004)
 
-        let blog = defaultBlog()
+        let blog = defaultBlog
 
         _ = StatsRecord.record(from: insight, for: blog)
 

--- a/WordPress/WordPressTest/AnnualAndMostPopularTimeStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/AnnualAndMostPopularTimeStatsRecordValueTests.swift
@@ -25,7 +25,7 @@ class AnnualAndMostPopularTimeStatsRecordValueTests: StatsTestCase {
                                                            annualInsightsTotalImagesCount: 9005,
                                                            annualInsightsAverageImagesCount: 5.5)
 
-        let blog = defaultBlog()
+        let blog = defaultBlog
 
         _ = StatsRecord.record(from: insight, for: blog)
 

--- a/WordPress/WordPressTest/FollowersStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/FollowersStatsRecordValueTests.swift
@@ -94,7 +94,7 @@ class FollowersStatsRecordValueTests: StatsTestCase {
         let dotComInsight = StatsDotComFollowersInsight(dotComFollowersCount: 1, topDotComFollowers: [follower1])
         let mailInsight = StatsEmailFollowersInsight(emailFollowersCount: 2, topEmailFollowers: [follower1, follower2])
 
-        let blog = defaultBlog()
+        let blog = defaultBlog
 
         _ = StatsRecord.record(from: mailInsight, for: blog)
         _ = StatsRecord.record(from: dotComInsight, for: blog)

--- a/WordPress/WordPressTest/LastPostStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/LastPostStatsRecordValueTests.swift
@@ -103,7 +103,7 @@ class LastPostStatsRecordValueTests: StatsTestCase {
                                            viewsCount: 3,
                                            postID: 4)
 
-        let blog = defaultBlog()
+        let blog = defaultBlog
 
         _ = StatsRecord.record(from: insight, for: blog)
 
@@ -130,6 +130,7 @@ class LastPostStatsRecordValueTests: StatsTestCase {
         let record = LastPostStatsRecordValue(parent: parent)
         record.publishedDate = Date() as NSDate
         record.title = ""
+        record.postID = 9001
         return record
     }
 

--- a/WordPress/WordPressTest/LastPostStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/LastPostStatsRecordValueTests.swift
@@ -55,7 +55,6 @@ class LastPostStatsRecordValueTests: StatsTestCase {
         XCTAssertNoThrow(try mainContext.save())
     }
 
-    /*
     func testInsertingMultipleFails() {
         mainContext.reset()
 
@@ -76,7 +75,7 @@ class LastPostStatsRecordValueTests: StatsTestCase {
             XCTAssertEqual(underlyingErrors.first!.code, expectedErrorAsNSErrror.code)
             XCTAssert(true)
         }
-    }*/
+    }
 
     // MARK: - LastPost specific posts
 
@@ -131,7 +130,6 @@ class LastPostStatsRecordValueTests: StatsTestCase {
         let record = LastPostStatsRecordValue(parent: parent)
         record.publishedDate = Date() as NSDate
         record.title = ""
-        record.postID = 9001
         return record
     }
 

--- a/WordPress/WordPressTest/PublicizeConectionStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/PublicizeConectionStatsRecordValueTests.swift
@@ -58,7 +58,7 @@ class PublicizeConectionStatsRecordValueTests: StatsTestCase {
 
         let insight = StatsPublicizeInsight(publicizeServices: [connection1, connection2])
 
-        let blog = defaultBlog()
+        let blog = defaultBlog
 
         _ = StatsRecord.record(from: insight, for: blog)
 

--- a/WordPress/WordPressTest/StatsRecordTests.swift
+++ b/WordPress/WordPressTest/StatsRecordTests.swift
@@ -31,7 +31,6 @@ class StatsRecordTests: StatsTestCase {
         XCTAssertNoThrow(try mainContext.save())
     }
 
-    /*
     func testSingleElementValidation() {
         createStatsRecord(in: mainContext, type: .allTimeStatsInsight, date: Date())
         createStatsRecord(in: mainContext, type: .allTimeStatsInsight, date: Date())
@@ -50,7 +49,7 @@ class StatsRecordTests: StatsTestCase {
             XCTAssertEqual(underlyingErrors.first!.code, expectedErrorAsNSErrror.code)
             XCTAssert(true)
         }
-    }*/
+    }
 
     func testFetchingForToday() {
         createStatsRecord(in: mainContext, type: .blogVisitsSummary, date: Date())

--- a/WordPress/WordPressTest/StatsTestCase.swift
+++ b/WordPress/WordPressTest/StatsTestCase.swift
@@ -27,13 +27,14 @@ class StatsTestCase: XCTestCase {
         newRecord.type = type.rawValue
         newRecord.date = date as NSDate
         newRecord.period = period.rawValue
+        newRecord.blog = defaultBlog
 
         return newRecord
     }
 
-    func defaultBlog() -> Blog {
+    lazy var defaultBlog: Blog = {
         return ModelTestHelper.insertDotComBlog(context: mainContext)
-    }
+    }()
 
 
 }

--- a/WordPress/WordPressTest/StreakStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/StreakStatsRecordValueTests.swift
@@ -80,7 +80,7 @@ class StreakStatsRecordValueTests: StatsTestCase {
                                                       longestStreakLength: 15,
                                                       postingEvents: [postingEventWeekAgo, postingEventToday])
 
-        let blog = defaultBlog()
+        let blog = defaultBlog
 
         _ = StatsRecord.record(from: streakInsight, for: blog)
 

--- a/WordPress/WordPressTest/TagsCategoriesStatsRecordValueTests.swift
+++ b/WordPress/WordPressTest/TagsCategoriesStatsRecordValueTests.swift
@@ -149,7 +149,7 @@ class TagsCategoriesStatsRecordValueTests: StatsTestCase {
 
         let insight = StatsTagsAndCategoriesInsight(topTagsAndCategories: [folderInsight, standaloneTag])
 
-        let blog = defaultBlog()
+        let blog = defaultBlog
 
         _ = StatsRecord.record(from: insight, for: blog)
 

--- a/WordPress/WordPressTest/TodayStatsTests.swift
+++ b/WordPress/WordPressTest/TodayStatsTests.swift
@@ -3,7 +3,7 @@
 
 class TodayStatsTests: StatsTestCase {
 
-/*
+
     func testInsertingMultipleFails() {
         mainContext.reset()
 
@@ -32,7 +32,7 @@ class TodayStatsTests: StatsTestCase {
             XCTAssertEqual(underlyingErrors.first!.code, expectedErrorAsNSErrror.code)
             XCTAssert(true)
         }
-    }*/
+    }
 
     func testCoreDataConversion() {
         let insight = StatsTodayInsight(viewsCount: 9001, visitorsCount: 9002, likesCount: 9003, commentsCount: 9004)

--- a/WordPress/WordPressTest/TodayStatsTests.swift
+++ b/WordPress/WordPressTest/TodayStatsTests.swift
@@ -37,7 +37,7 @@ class TodayStatsTests: StatsTestCase {
     func testCoreDataConversion() {
         let insight = StatsTodayInsight(viewsCount: 9001, visitorsCount: 9002, likesCount: 9003, commentsCount: 9004)
 
-        let blog = defaultBlog()
+        let blog = defaultBlog
 
         _ = StatsRecord.record(from: insight, for: blog)
 


### PR DESCRIPTION
This fixes a temporary workaround that was in place in #11295 and fixes the uniquing logic for Core Data validation for Stats objects — bringing back the commented-out tests from the previous PR.

To test:
Verify that the tests pass.
