### PR TITLE
Use page-specific Offline Notice messages

### DIFF
--- a/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
+++ b/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
@@ -43,10 +43,8 @@ extension ReachabilityUtils {
     ///
     /// We use a Snackbar instead of a literal Alert because, for internet connection errors,
     /// Alerts can be disruptive.
-    static func showNoInternetConnectionNotice() {
-        let notice = Notice(title: DefaultNoConnectionMessage.title,
-                            message: DefaultNoConnectionMessage.message,
-                            tag: DefaultNoConnectionMessage.tag)
+    static func showNoInternetConnectionNotice(message: String) {
+        let notice = Notice(title: "", message: message, tag: DefaultNoConnectionMessage.tag)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 

--- a/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
+++ b/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
@@ -44,6 +44,7 @@ extension ReachabilityUtils {
     /// We use a Snackbar instead of a literal Alert because, for internet connection errors,
     /// Alerts can be disruptive.
     static func showNoInternetConnectionNotice(message: String) {
+        // An empty title is intentional to only show a single regular font message.
         let notice = Notice(title: "", message: message, tag: DefaultNoConnectionMessage.tag)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }

--- a/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
+++ b/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
@@ -2,7 +2,7 @@ import Foundation
 import WordPressFlux
 
 extension ReachabilityUtils {
-    private enum NoConnectionMessage {
+    private enum DefaultNoConnectionMessage {
         static let title = NSLocalizedString("No Connection",
                 comment: "Title of error prompt when no internet connection is available.")
         static let message = noConnectionMessage()
@@ -14,7 +14,7 @@ extension ReachabilityUtils {
     ///
     @objc class func onAvailableInternetConnectionDo(_ action: () -> Void) {
         guard ReachabilityUtils.isInternetReachable() else {
-            WPError.showAlert(withTitle: NoConnectionMessage.title, message: NoConnectionMessage.message)
+            WPError.showAlert(withTitle: DefaultNoConnectionMessage.title, message: DefaultNoConnectionMessage.message)
             return
         }
         action()
@@ -44,14 +44,14 @@ extension ReachabilityUtils {
     /// We use a Snackbar instead of a literal Alert because, for internet connection errors,
     /// Alerts can be disruptive.
     static func showNoInternetConnectionNotice() {
-        let notice = Notice(title: NoConnectionMessage.title,
-                            message: NoConnectionMessage.message,
-                            tag: NoConnectionMessage.tag)
+        let notice = Notice(title: DefaultNoConnectionMessage.title,
+                            message: DefaultNoConnectionMessage.message,
+                            tag: DefaultNoConnectionMessage.tag)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
     /// Dismiss the currently shown Notice if it was created using showNoInternetConnectionNotice()
     static func dismissNoInternetConnectionNotice() {
-        ActionDispatcher.dispatch(NoticeAction.clearWithTag(NoConnectionMessage.tag))
+        ActionDispatcher.dispatch(NoticeAction.clearWithTag(DefaultNoConnectionMessage.tag))
     }
 }

--- a/WordPress/Classes/Utility/ReachabilityUtils.m
+++ b/WordPress/Classes/Utility/ReachabilityUtils.m
@@ -80,7 +80,7 @@ static ReachabilityAlert *__currentReachabilityAlert = nil;
 
 + (NSString *)noConnectionMessage
 {
-    return NSLocalizedString(@"The Internet connection appears to be offline.",
+    return NSLocalizedString(@"The internet connection appears to be offline.",
             @"Message of error prompt shown when a user tries to perform an action without an internet connection.");
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController+NetworkAware.swift
@@ -6,7 +6,8 @@ extension CommentsViewController: NetworkAwareUI {
     }
 
     @objc func noConnectionMessage() -> String {
-        return ReachabilityUtils.noConnectionMessage()
+        return NSLocalizedString("No internet connection. Some comments may be unavailable while offline.",
+                                 comment: "Error message shown when the user is browsing Site Comments without an internet connection.")
     }
 
     @objc func connectionAvailable() -> Bool {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -828,6 +828,11 @@ extension NotificationsViewController: NetworkAwareUI {
     func contentIsEmpty() -> Bool {
         return tableViewHandler.resultsController.isEmpty()
     }
+
+    func noConnectionMessage() -> String {
+        return NSLocalizedString("No internet connection. Some content may be unavailable while offline.",
+                                 comment: "Error message shown when the user is browsing Notifications without an internet connection.")
+    }
 }
 
 extension NotificationsViewController: NetworkStatusDelegate {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -808,6 +808,13 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     enum Animations {
         static let searchDismissDuration: TimeInterval = 0.3
     }
+
+    // MARK: - NetworkAwareUI
+
+    override func noConnectionMessage() -> String {
+        return NSLocalizedString("No internet connection. Some pages may be unavailable while offline.",
+                                 comment: "Error message shown when the user is browsing Site Pages without an internet connection.")
+    }
 }
 
 // MARK: - No Results Handling

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -28,7 +28,14 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
 }
 
 
-class AbstractPostListViewController: UIViewController, WPContentSyncHelperDelegate, UISearchControllerDelegate, UISearchResultsUpdating, WPTableViewHandlerDelegate {
+class AbstractPostListViewController: UIViewController,
+    WPContentSyncHelperDelegate,
+    UISearchControllerDelegate,
+    UISearchResultsUpdating,
+    WPTableViewHandlerDelegate,
+    // This protocol is not in an extension so that subclasses can override noConnectionMessage()
+    NetworkAwareUI {
+
     fileprivate static let postsControllerRefreshInterval = TimeInterval(300)
     fileprivate static let HTTPErrorCodeForbidden = Int(403)
     fileprivate static let postsFetchRequestBatchSize = Int(10)
@@ -1125,11 +1132,15 @@ class AbstractPostListViewController: UIViewController, WPContentSyncHelperDeleg
         resetTableViewContentOffset()
         searchHelper.searchUpdated(searchController.searchBar.text)
     }
-}
 
-extension AbstractPostListViewController: NetworkAwareUI {
+    // MARK: - NetworkAwareUI
+
     func contentIsEmpty() -> Bool {
         return tableViewHandler.resultsController.isEmpty()
+    }
+
+    func noConnectionMessage() -> String {
+        return ReachabilityUtils.noConnectionMessage()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -792,8 +792,12 @@ class AbstractPostListViewController: UIViewController,
 
         dismissAllNetworkErrorNotices()
 
-        let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
-        WPError.showNetworkingNotice(title: title, error: error)
+        if connectionAvailable() {
+            let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
+            WPError.showNetworkingNotice(title: title, error: error)
+        } else {
+            presentNoNetworkAlert()
+        }
     }
 
     @objc func promptForPassword() {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -792,11 +792,14 @@ class AbstractPostListViewController: UIViewController,
 
         dismissAllNetworkErrorNotices()
 
-        if connectionAvailable() {
+        // If there is no internet connection, we'll show the specific error message defined in
+        // `noConnectionMessage()` (overridden by subclasses). For everything else, we let
+        // `WPError.showNetworkingNotice` determine the user-friendly error message.
+        if !connectionAvailable() {
+            presentNoNetworkAlert()
+        } else {
             let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
             WPError.showNetworkingNotice(title: title, error: error)
-        } else {
-            presentNoNetworkAlert()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -579,11 +579,17 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
         tableViewTopConstraint.isActive = false
         filterTabBarBottomConstraint.isActive = true
-
     }
 
     enum Animations {
         static let searchDismissDuration: TimeInterval = 0.3
+    }
+
+    // MARK: - NetworkAwareUI
+
+    override func noConnectionMessage() -> String {
+        return NSLocalizedString("No internet connection. Some posts may be unavailable while offline.",
+                                 comment: "Error message shown when the user is browsing Site Posts without an internet connection.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1632,6 +1632,11 @@ extension ReaderStreamViewController: NetworkAwareUI {
     func contentIsEmpty() -> Bool {
         return content.contentCount == 0
     }
+
+    func noConnectionMessage() -> String {
+        return NSLocalizedString("No internet connection. Some content may be unavailable while offline.",
+                                 comment: "Error message shown when the user is browsing Reader without an internet connection.")
+    }
 }
 
 // MARK: - NetworkAwareUI NetworkStatusDelegate

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -32,7 +32,7 @@ extension NetworkAwareUI {
     }
 
     func presentNoNetworkAlert() {
-        ReachabilityUtils.showNoInternetConnectionNotice()
+        ReachabilityUtils.showNoInternetConnectionNotice(message: noConnectionMessage())
     }
 
     func dismissNoNetworkAlert() {


### PR DESCRIPTION
Closes #11034. 

This changes the Notices applied in #11171 to use messages that are specific to where they are shown.  The areas affected are:

- Reader
- Site → Comments
- Site → Blog Posts 
- Site → Pages 
- Notifications (pull-to-refresh only)

| Before | After |
|--------|-------|
|  ![2019-03-20 09 33 06](https://user-images.githubusercontent.com/198826/54697680-96431d80-4af3-11e9-933e-0657debdd3d9.png)      |  ![2019-03-20 09 25 19](https://user-images.githubusercontent.com/198826/54697703-a1964900-4af3-11e9-890c-24c148693625.png)    |
|  ![2019-03-20 09 32 49](https://user-images.githubusercontent.com/198826/54698432-ef5f8100-4af4-11e9-88b9-021c1a352ad1.png)      |   ![2019-03-20 09 43 53](https://user-images.githubusercontent.com/198826/54698458-f5556200-4af4-11e9-9a38-afad826a4f98.png)   |
| ![2019-03-20 09 32 15](https://user-images.githubusercontent.com/198826/54698576-26359700-4af5-11e9-8350-9e8921459d72.png) | ![2019-03-20 09 25 31](https://user-images.githubusercontent.com/198826/54698603-30579580-4af5-11e9-845f-f5cd07ed5431.png) |
| ![2019-03-20 09 32 00](https://user-images.githubusercontent.com/198826/54698695-567d3580-4af5-11e9-8a5c-c70900c027d6.png) | ![2019-03-20 09 25 50](https://user-images.githubusercontent.com/198826/54698711-60069d80-4af5-11e9-910f-0c2cfce2d3d0.png) |
| ![2019-03-20 09 33 13](https://user-images.githubusercontent.com/198826/54698740-6c8af600-4af5-11e9-986f-9139d42e2cc4.png) | ![2019-03-20 09 26 12](https://user-images.githubusercontent.com/198826/54698754-74e33100-4af5-11e9-8e88-ad709b1a3fa8.png) | 

## Testing

This can be tested by turning off the device's internet connection and navigating to the pages listed above. For some pages, the Notices are also shown when the device was online while opening the page and suddenly gets disconnected.