### PR TITLE
Reader: restore empty state button functionality

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 -----
 * Improve messages when updates to user account details fail because of server logic, for exanple email being used for another account.
 * Improved text import from other apps, such as Bear or Ulysses 🥰
+* Reader: fixed issue where empty state buttons were not functional.
 
 12.0
 -----

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -285,9 +285,10 @@ import WordPressFlux
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        coordinator.animate(alongsideTransition: { [weak self] _ in
-
-            self?.resultsStatusView.updateAccessoryViewsVisibility()
+        coordinator.animate(alongsideTransition: { _ in
+            if self.isShowingResultStatusView {
+                self.resultsStatusView.updateAccessoryViewsVisibility()
+            }
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1560,17 +1560,9 @@ private extension ReaderStreamViewController {
     func displayResultsStatus() {
         resultsStatusView.removeFromView()
         tableView.insertSubview(resultsStatusView.view, belowSubview: refreshControl)
-        layoutNoResultsStatus()
+        resultsStatusView.view.frame = tableView.frame
         resultsStatusView.didMove(toParent: tableViewController)
         footerView.isHidden = true
-    }
-
-    func layoutNoResultsStatus() {
-        resultsStatusView.view.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            resultsStatusView.view.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
-            resultsStatusView.view.centerYAnchor.constraint(equalTo: tableView.centerYAnchor)
-            ])
     }
 
     func hideResultsStatus() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -283,6 +283,13 @@ import WordPressFlux
         NotificationCenter.default.addObserver(self, selector: #selector(ReaderStreamViewController.handleContextDidSaveNotification(_:)), name: NSNotification.Name.NSManagedObjectContextDidSave, object: mainContext)
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        coordinator.animate(alongsideTransition: { [weak self] _ in
+
+            self?.resultsStatusView.updateAccessoryViewsVisibility()
+        })
+    }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
         return .lightContent


### PR DESCRIPTION
Fixes #11292 

This restores the button functionality in Reader Followed Sites and My Likes. It also restores hiding/showing the No Results image when the device is rotated.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.


To test:

---
- On a site that is not following any sites, go to Reader > Followed Sites. 
- Tap the `Manage Sites` button. 
- Verify the Manage view is displayed.

![manage_sites](https://user-images.githubusercontent.com/1816888/54717585-1b432c80-4b1e-11e9-9495-dcd8c3ecd8ca.png)

---
- On a site with no liked posts, go to Reader > My Likes. 
- Tap the `Go to Following` button. 
- Verify the Followed Sites view is displayed.

![likes](https://user-images.githubusercontent.com/1816888/54717710-75dc8880-4b1e-11e9-9ce5-b687e192e1d7.png)

---
- On an iPhone, with a No Results view displayed, rotate the device. 
- Verify the image hides in landscape and shows in portrait.

<img width="250" alt="portrait" src="https://user-images.githubusercontent.com/1816888/54717893-d7045c00-4b1e-11e9-95e8-bbd8817ce2a9.png">

<img width="500" alt="landscape" src="https://user-images.githubusercontent.com/1816888/54717895-db307980-4b1e-11e9-8539-9900fe08e916.png">


