### PR TITLE
Fix post categories not saved bug

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -41,8 +41,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    #pod 'WordPressKit', '~> 3.1.1'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'ddf1292ff9df94550b8d30dd8f3c2e23be677a9c'
+    pod 'WordPressKit', '~> 3.1.2'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'ddf1292ff9df94550b8d30dd8f3c2e23be677a9c'
     #pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -41,8 +41,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 3.1.1'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/invalid-token'
+    #pod 'WordPressKit', '~> 3.1.1'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'ddf1292ff9df94550b8d30dd8f3c2e23be677a9c'
     #pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -191,7 +191,7 @@ PODS:
     - WordPressKit (~> 3.1.1)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-  - WordPressKit (3.1.1):
+  - WordPressKit (3.1.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -249,7 +249,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.4)
   - WordPressAuthenticator (~> 1.1.11)
-  - WordPressKit (~> 3.1.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `ddf1292ff9df94550b8d30dd8f3c2e23be677a9c`)
   - WordPressShared (= 1.7.2)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -291,7 +291,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -319,6 +318,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.1.0
+  WordPressKit:
+    :commit: ddf1292ff9df94550b8d30dd8f3c2e23be677a9c
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -341,6 +343,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.1.0
+  WordPressKit:
+    :commit: ddf1292ff9df94550b8d30dd8f3c2e23be677a9c
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -387,7 +392,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: b4a1fac03f617eea9882336bf64f122cbc60e727
   WordPress-Editor-iOS: 9787d07b2362457952fb74e4f09fa63bbf22cf14
   WordPressAuthenticator: 50e1119773a78fde89c39da83d2e503eceb971b7
-  WordPressKit: 9af12361492d12c6c5512d3d7de594aa415ad670
+  WordPressKit: c431508391b18d5d5e622564c9f12ee9f8883eda
   WordPressShared: 63d57a4a07ad9f9a1ee5e8a7162e48fbb5192014
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
@@ -395,6 +400,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 032952b6504c3e925c36ced3f2a0b7f24f086b3b
+PODFILE CHECKSUM: 26ecae33fa48d48ec37b7ab5473a7aba9cdaf9fc
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -249,7 +249,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.4.4)
   - WordPressAuthenticator (~> 1.1.11)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `ddf1292ff9df94550b8d30dd8f3c2e23be677a9c`)
+  - WordPressKit (~> 3.1.2)
   - WordPressShared (= 1.7.2)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -291,6 +291,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -318,9 +319,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.1.0
-  WordPressKit:
-    :commit: ddf1292ff9df94550b8d30dd8f3c2e23be677a9c
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -343,9 +341,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.1.0
-  WordPressKit:
-    :commit: ddf1292ff9df94550b8d30dd8f3c2e23be677a9c
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -400,6 +395,6 @@ SPEC CHECKSUMS:
   yoga: f37b1edbd68be803f1dc4d57d40d8a5b277d8e2c
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 26ecae33fa48d48ec37b7ab5473a7aba9cdaf9fc
+PODFILE CHECKSUM: e30821e8072b6bcb3f6e82ca6b0d3132220dbd64
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Fixes #11302 

This PR address the issue that post categories weren't being saved.
The work on the main app just updates the reference to a new version of WordPressKit that provides the fix. You can see the related PR here: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/126

Note: After the review I will update the WordPressKit hash to use a proper version. 

To test:

1. Start a new post and enter a title and text.
2. Open Post Settings.
3. Open Categories.
4. Select a category other than the default.
5. Go back to Post Settings and confirm you see your selected category.
6. Go back to the editor and save or publish the post.
7. Reopen the post and view the Post Settings.
8. Check that correct category is set.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
