### PR TITLE
Start draft with image

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -102,7 +102,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :commit => '47a9ebcb086dc72facaa4ec07d5a53d75f8e4106'
+    gutenberg :commit => '4c4e00a04453ef662f783606e93dee82eff65f5f'
 
     pod 'RNSVG', :git => 'https://github.com/wordpress-mobile/react-native-svg.git', :tag => '9.3.3-gb'
     pod 'react-native-keyboard-aware-scroll-view', :git => 'https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git', :tag => 'gb-v0.8.6'

--- a/Podfile
+++ b/Podfile
@@ -102,7 +102,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :commit => '4c4e00a04453ef662f783606e93dee82eff65f5f'
+    gutenberg :commit => 'f03630a82d9c0a91dc5441ef289cc5082a7587de'
 
     pod 'RNSVG', :git => 'https://github.com/wordpress-mobile/react-native-svg.git', :tag => '9.3.3-gb'
     pod 'react-native-keyboard-aware-scroll-view', :git => 'https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git', :tag => 'gb-v0.8.6'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -231,12 +231,12 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.4.2)
   - Crashlytics (= 3.12.0)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/47a9ebcb086dc72facaa4ec07d5a53d75f8e4106/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `47a9ebcb086dc72facaa4ec07d5a53d75f8e4106`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `4c4e00a04453ef662f783606e93dee82eff65f5f`)
   - HockeySDK (= 5.1.4)
   - MGSwipeTableCell (= 1.6.8)
   - MRProgress (= 0.8.3)
@@ -247,11 +247,11 @@ DEPENDENCIES:
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/47a9ebcb086dc72facaa4ec07d5a53d75f8e4106/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
+  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
   - react-native-keyboard-aware-scroll-view (from `https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git`, tag `gb-v0.8.6`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/47a9ebcb086dc72facaa4ec07d5a53d75f8e4106/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `9.3.3-gb`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `47a9ebcb086dc72facaa4ec07d5a53d75f8e4106`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `4c4e00a04453ef662f783606e93dee82eff65f5f`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -261,7 +261,7 @@ DEPENDENCIES:
   - WordPressShared (= 1.7.2)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
-  - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/47a9ebcb086dc72facaa4ec07d5a53d75f8e4106/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
+  - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
   - ZendeskSDK (= 2.2.0)
 
 SPEC REPOS:
@@ -310,35 +310,35 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.3.2
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/47a9ebcb086dc72facaa4ec07d5a53d75f8e4106/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: 47a9ebcb086dc72facaa4ec07d5a53d75f8e4106
+    :commit: 4c4e00a04453ef662f783606e93dee82eff65f5f
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/47a9ebcb086dc72facaa4ec07d5a53d75f8e4106/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   react-native-keyboard-aware-scroll-view:
     :git: https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git
     :tag: gb-v0.8.6
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/47a9ebcb086dc72facaa4ec07d5a53d75f8e4106/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
   RNSVG:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 9.3.3-gb
   RNTAztecView:
-    :commit: 47a9ebcb086dc72facaa4ec07d5a53d75f8e4106
+    :commit: 4c4e00a04453ef662f783606e93dee82eff65f5f
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
   yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/47a9ebcb086dc72facaa4ec07d5a53d75f8e4106/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.3.2
   Gutenberg:
-    :commit: 47a9ebcb086dc72facaa4ec07d5a53d75f8e4106
+    :commit: 4c4e00a04453ef662f783606e93dee82eff65f5f
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   react-native-keyboard-aware-scroll-view:
     :git: https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git
@@ -347,7 +347,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 9.3.3-gb
   RNTAztecView:
-    :commit: 47a9ebcb086dc72facaa4ec07d5a53d75f8e4106
+    :commit: 4c4e00a04453ef662f783606e93dee82eff65f5f
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -403,6 +403,6 @@ SPEC CHECKSUMS:
   yoga: 1fe535cf9b523600f42e2785b6ed56484a62b46d
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: aaf5370a003b7430d7d041a2f7c08256d7e27ae5
+PODFILE CHECKSUM: 972837e42e8639f420d4f4316f929afa386f51b8
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -231,12 +231,12 @@ DEPENDENCIES:
   - Charts (~> 3.2.2)
   - CocoaLumberjack (= 3.4.2)
   - Crashlytics (= 3.12.0)
-  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
+  - Folly (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f03630a82d9c0a91dc5441ef289cc5082a7587de/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json`)
   - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - Gifu (= 3.2.0)
   - GiphyCoreSDK (~> 1.4.0)
   - Gridicons (~> 0.16)
-  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `4c4e00a04453ef662f783606e93dee82eff65f5f`)
+  - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `f03630a82d9c0a91dc5441ef289cc5082a7587de`)
   - HockeySDK (= 5.1.4)
   - MGSwipeTableCell (= 1.6.8)
   - MRProgress (= 0.8.3)
@@ -247,11 +247,11 @@ DEPENDENCIES:
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - Reachability (= 3.2)
-  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
+  - React (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f03630a82d9c0a91dc5441ef289cc5082a7587de/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json`)
   - react-native-keyboard-aware-scroll-view (from `https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git`, tag `gb-v0.8.6`)
-  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
+  - react-native-safe-area (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f03630a82d9c0a91dc5441ef289cc5082a7587de/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json`)
   - RNSVG (from `https://github.com/wordpress-mobile/react-native-svg.git`, tag `9.3.3-gb`)
-  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `4c4e00a04453ef662f783606e93dee82eff65f5f`)
+  - RNTAztecView (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, commit `f03630a82d9c0a91dc5441ef289cc5082a7587de`)
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
@@ -261,7 +261,7 @@ DEPENDENCIES:
   - WordPressShared (= 1.7.2)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
-  - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
+  - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f03630a82d9c0a91dc5441ef289cc5082a7587de/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
   - ZendeskSDK (= 2.2.0)
 
 SPEC REPOS:
@@ -310,35 +310,35 @@ EXTERNAL SOURCES:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.3.2
   Folly:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f03630a82d9c0a91dc5441ef289cc5082a7587de/react-native-gutenberg-bridge/third-party-podspecs/Folly.podspec.json
   Gutenberg:
-    :commit: 4c4e00a04453ef662f783606e93dee82eff65f5f
+    :commit: f03630a82d9c0a91dc5441ef289cc5082a7587de
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   React:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f03630a82d9c0a91dc5441ef289cc5082a7587de/react-native-gutenberg-bridge/third-party-podspecs/React.podspec.json
   react-native-keyboard-aware-scroll-view:
     :git: https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git
     :tag: gb-v0.8.6
   react-native-safe-area:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f03630a82d9c0a91dc5441ef289cc5082a7587de/react-native-gutenberg-bridge/third-party-podspecs/react-native-safe-area.podspec.json
   RNSVG:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 9.3.3-gb
   RNTAztecView:
-    :commit: 4c4e00a04453ef662f783606e93dee82eff65f5f
+    :commit: f03630a82d9c0a91dc5441ef289cc5082a7587de
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
   yoga:
-    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/4c4e00a04453ef662f783606e93dee82eff65f5f/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
+    :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/f03630a82d9c0a91dc5441ef289cc5082a7587de/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
 CHECKOUT OPTIONS:
   Automattic-Tracks-iOS:
     :git: https://github.com/Automattic/Automattic-Tracks-iOS.git
     :tag: 0.3.2
   Gutenberg:
-    :commit: 4c4e00a04453ef662f783606e93dee82eff65f5f
+    :commit: f03630a82d9c0a91dc5441ef289cc5082a7587de
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   react-native-keyboard-aware-scroll-view:
     :git: https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git
@@ -347,7 +347,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/react-native-svg.git
     :tag: 9.3.3-gb
   RNTAztecView:
-    :commit: 4c4e00a04453ef662f783606e93dee82eff65f5f
+    :commit: f03630a82d9c0a91dc5441ef289cc5082a7587de
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -403,6 +403,6 @@ SPEC CHECKSUMS:
   yoga: 1fe535cf9b523600f42e2785b6ed56484a62b46d
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 972837e42e8639f420d4f4316f929afa386f51b8
+PODFILE CHECKSUM: f00c6ca718434c79ca47a152cc63af725f37a6e1
 
 COCOAPODS: 1.5.3

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 ```<video alt="Another video with bunnies">
 <source src="https://videos.files.wordpress.com/kUJmAcSf/bbb_sunflower_1080p_30fps_normal.mp4" type="video/mp4">
 </video>```
+* Block editor now supports the creation of posts with pre-inserted photos and the the 3touch action of starting a post with photo.
 
 12.1
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -105,6 +105,7 @@ class GutenbergViewController: UIViewController, PostEditor {
     }
 
     private func showMediaSelectionOnStart() {
+        isOpenedDirectlyForPhotoPost = false
         mediaPickerHelper.presentMediaPickerFullScreen(animated: true,
                                                        dataSourceType: .device,
                                                        callback: {(asset) in
@@ -250,9 +251,6 @@ class GutenbergViewController: UIViewController, PostEditor {
 
         gutenberg.delegate = self
         showInformativeDialogIfNecessary()
-        if isOpenedDirectlyForPhotoPost {
-            showMediaSelectionOnStart()
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -485,6 +483,10 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             isFirstGutenbergLayout = false
         }
         if isFirstGutenbergLayout {
+            insertPrePopulatedMedia()
+            if isOpenedDirectlyForPhotoPost {
+                showMediaSelectionOnStart()
+            }
             focusTitleIfNeeded()
         }
     }
@@ -494,7 +496,6 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         if !editorSession.started {
             editorSession.start(hasUnsupportedBlocks: hasUnsupportedBlocks)
         }
-        insertPrePopulatedMedia()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -104,6 +104,24 @@ class GutenbergViewController: UIViewController, PostEditor {
         mediaToInsertOnPost = []
     }
 
+    private func showMediaSelectionOnStart() {
+        mediaPickerHelper.presentMediaPickerFullScreen(animated: true,
+                                                       dataSourceType: .device,
+                                                       callback: {(asset) in
+                                                        guard let phAsset = asset as? PHAsset else {
+                                                            return
+                                                        }
+                                                        self.mediaInserterHelper.insertFromDevice(asset: phAsset, callback: { (mediaID, mediaURL) in
+                                                            guard let mediaID = mediaID,
+                                                                let mediaURLString = mediaURL,
+                                                                let mediaURL = URL(string: mediaURLString) else {
+                                                                return
+                                                            }
+                                                            self.gutenberg.appendMedia(id: mediaID, url: mediaURL)
+                                                        })
+        })
+    }
+
     // MARK: - Auto save post
 
     static let autoSaveInterval: TimeInterval = 5
@@ -232,6 +250,9 @@ class GutenbergViewController: UIViewController, PostEditor {
 
         gutenberg.delegate = self
         showInformativeDialogIfNecessary()
+        if isOpenedDirectlyForPhotoPost {
+            showMediaSelectionOnStart()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -84,9 +84,33 @@ class GutenbergViewController: UIViewController, PostEditor {
         return mediaInserterHelper.cancelUploadOfAllMedia()
     }
 
+    var mediaToInsertOnPost = [Media]()
+
+    func prepopulateMediaItems(_ media: [Media]) {
+        mediaToInsertOnPost = media
+    }
+
+    private func insertPrePopulatedMedia() {
+        for media in mediaToInsertOnPost {
+            guard
+                media.mediaType == .image, // just images for now
+                let mediaID = media.mediaID?.int32Value,
+                let mediaURLString = media.remoteURL,
+                let mediaURL = URL(string: mediaURLString) else {
+                    continue
+            }
+            gutenberg.appendMedia(id: mediaID, url: mediaURL)
+        }
+        mediaToInsertOnPost = []
+    }
+
+    // MARK: - Auto save post
+
     static let autoSaveInterval: TimeInterval = 5
 
     var autoSaveTimer: Timer?
+
+    // MARK: - Set content
 
     func setTitle(_ title: String) {
         guard gutenberg.isLoaded else {
@@ -449,6 +473,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         if !editorSession.started {
             editorSession.start(hasUnsupportedBlocks: hasUnsupportedBlocks)
         }
+        insertPrePopulatedMedia()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -132,6 +132,8 @@ class EditPostViewController: UIViewController {
 
     private func showEditor(_ editor: EditorViewController) {
         editor.isOpenedDirectlyForPhotoPost = openWithMediaPicker
+        // only open the media picker once.
+        openWithMediaPicker = false
         editor.onClose = { [weak self, weak editor] changesSaved, showPostEpilogue in
             guard let strongSelf = self else {
                 editor?.dismiss(animated: true) {}

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -156,9 +156,8 @@ class EditPostViewController: UIViewController {
         postPost.present(navController, animated: !showImmediately) {
             generator.impactOccurred()
 
-            if let insertedMedia = self.insertedMedia,
-                let aztec = editor as? AztecPostViewController {
-                aztec.prepopulateMediaItems(insertedMedia)
+            if let insertedMedia = self.insertedMedia {
+                editor.prepopulateMediaItems(insertedMedia)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -33,6 +33,12 @@ protocol PostEditor: class, UIViewControllerTransitioningDelegate {
     ///
     var isOpenedDirectlyForPhotoPost: Bool { get set }
 
+    /// Media items to be inserted on the post after creation
+    ///
+    /// - Parameter media: the media items to add
+    ///
+    func prepopulateMediaItems(_ media: [Media])
+
     /// Boolean indicating whether the post should be removed whenever the changes are discarded, or not.
     ///
     var shouldRemovePostOnDismiss: Bool { get }


### PR DESCRIPTION
Fixes #11246 

This PR implements the necessary calls to allow Gutenberg to start a post with images pre-inserted or with the media picker started.

To test:

Scenario 1:
 - Make sure you have the Gutenberg editor activated
 - Open the Media Library of a site
 - Add one or more media items using the + button
 - When the uploads are finished and a notification informs you of that, press on the option "Write Post".
 - Check that Gutenberg editor opens and the image are pre-inserted on the post.

Scenario 2:
 - Go to the home screen on a device with force touch
 - Force touch on the WordPress app icon
 - Select the option New Photo Post
 - Check that the Gutenberg editor is open and a media picker is presented.
 - After the media is selected check if the media is added to the post and uploaded correctly.

Update release notes:

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
