### PR TITLE
Fix Notice and Empty View shown at the same time in Site → Pages/Posts

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -614,7 +614,7 @@ class AbstractPostListViewController: UIViewController,
         if appDelegate?.connectionAvailable == false {
             refreshResults()
             dismissAllNetworkErrorNotices()
-            presentNoNetworkAlert()
+            handleConnectionError()
             return
         }
 
@@ -625,10 +625,6 @@ class AbstractPostListViewController: UIViewController,
             // Update in the background
             syncItemsWithUserInteraction(false)
         }
-    }
-
-    func shouldPresentAlert() -> Bool {
-        return !connectionAvailable() && !contentIsEmpty() && isViewOnScreen()
     }
 
     @objc func syncItemsWithUserInteraction(_ userInteraction: Bool) {
@@ -796,7 +792,7 @@ class AbstractPostListViewController: UIViewController,
             let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")
             WPError.showNetworkingNotice(title: title, error: error)
         } else {
-            presentNoNetworkAlert()
+            handleConnectionError()
         }
     }
 
@@ -1145,6 +1141,10 @@ class AbstractPostListViewController: UIViewController,
 
     func noConnectionMessage() -> String {
         return ReachabilityUtils.noConnectionMessage()
+    }
+
+    func shouldPresentAlert() -> Bool {
+        return !connectionAvailable() && !contentIsEmpty() && isViewOnScreen()
     }
 }
 


### PR DESCRIPTION
Fixes #11310.

This fixes a bug in Site → Pages and Site → Posts where when there is no content and no internet connection, both the Notice and Empty View are shown at the same time.

| Before | After |
|--------|-------|
|  ![2019-03-20 11 40 57 2019-03-20 11_53_45](https://user-images.githubusercontent.com/198826/54786194-dc7ca780-4bed-11e9-8921-a1dc02e4edb5.gif) |  ![2019-03-20 11 44 04 2019-03-20 11_51_44](https://user-images.githubusercontent.com/198826/54786203-e1415b80-4bed-11e9-8232-ec678cedf410.gif) |

## Testing

Before starting, make sure that you have not loaded anything in Site → Pages and Site → Posts. You can use an empty site or delete the app from the device.

1. Turn off the internet connection on the device.
2. Navigate to Site → Pages and Site → Posts.

You should not see the Notice anymore but see the empty view.

