### PR TITLE
Fix Notice animating over the tab bar

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -199,6 +199,8 @@ class NoticePresenter: NSObject {
 
         window.isHidden = false
 
+        view.mask = createMaskView()
+
         let fromState = offscreenState(for: noticeContainerView)
         let toState = onscreenState(for: noticeContainerView)
         animatePresentation(fromState: fromState, toState: toState, completion: {
@@ -221,6 +223,24 @@ class NoticePresenter: NSObject {
         let constraint = container.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         container.bottomConstraint = constraint
         constraint.isActive = true
+    }
+
+    /// Create a mask view for `self.view`.
+    ///
+    /// The mask will prevent any `NoticeView` from showing on top of a tab bar.
+    private func createMaskView() -> UIView {
+        assert(!window.isHidden, "The window must be visible so we can get non-zero view.bounds")
+
+        let mask = UIView(frame: CGRect(
+            x: 0,
+            y: 0,
+            width: view.bounds.width,
+            height: view.bounds.height - self.window.untouchableViewController.offsetOnscreen
+        ))
+        mask.translatesAutoresizingMaskIntoConstraints = false
+        mask.backgroundColor = .blue
+
+        return mask
     }
 
     // MARK: - Dismissal

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -76,11 +76,14 @@ class NoticePresenter: NSObject {
         }
 
         listenToKeyboardEvents()
+        listenToOrientationChangeEvents()
     }
 
     override convenience init() {
         self.init(store: StoreContainer.shared.notice)
     }
+
+    // MARK: - Events
 
     private func listenToKeyboardEvents() {
         NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: nil) { [weak self] (notification) in
@@ -111,6 +114,20 @@ class NoticePresenter: NSObject {
                 currentContainer.bottomConstraint?.constant = -self.window.untouchableViewController.offsetOnscreen
                 self.view.layoutIfNeeded()
             })
+        }
+    }
+
+    /// Adjust the current Notice so it will always be in the correct y-position after the
+    /// device is rotated.
+    private func listenToOrientationChangeEvents() {
+        let nc = NotificationCenter.default
+        nc.addObserver(forName: UIDevice.orientationDidChangeNotification, object: nil, queue: nil) { [weak self] _ in
+            guard let self = self,
+                let containerView = self.currentNoticePresentation?.containerView else {
+                    return
+            }
+
+            containerView.bottomConstraint?.constant = -self.window.untouchableViewController.offsetOnscreen
         }
     }
 


### PR DESCRIPTION
This fixes the bug where Notices animate on top of the tab bar. Also included is a fix for the Notice's y-position when the device is rotated. I had to fix this one because with the first fix, the Notice gets cut off from the screen and the bug becomes more obvious. 

## Animation Fix

| Before | After |
|--------|-------|
| ![2019-03-21 16 04 43 2019-03-21 16_28_16](https://user-images.githubusercontent.com/198826/54789001-ba3b5780-4bf6-11e9-85be-7effec6599b8.gif) |![2019-03-21 16 03 41 2019-03-21 16_27_06](https://user-images.githubusercontent.com/198826/54789014-c3c4bf80-4bf6-11e9-9f37-2ac275de5d00.gif) |

This fix was done by adding a mask (`MaskView`) on the main `view`:

<img src="https://user-images.githubusercontent.com/198826/54789211-52394100-4bf7-11e9-92a1-503917e4b5fe.gif" width="320" />

The blue background is where the Notice will only be visible. 

## Rotation Fix

The rotation bug is shown below. Notice that in _Before_, after rotating, the Notice is covering the tab bar. 

| Before | After |
|--------|-------|
| ![2019-03-21 16 38 43 2019-03-21 16_43_06](https://user-images.githubusercontent.com/198826/54789661-cfb18100-4bf8-11e9-9a7e-a2a8dd3bfe74.gif) | ![2019-03-21 16 39 19 2019-03-21 16_44_35](https://user-images.githubusercontent.com/198826/54789667-d8a25280-4bf8-11e9-8c22-de2922b42107.gif) |

## Testing

Testing for regression is recommended. Here are some places we use Notices:

- Quick Start
- Offline messages described in #11171
- Uploading a media and putting the app in the background


