### PR TITLE
Fix Notices showing anywhere but the bottom on iPad devices

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 12.2
 -----
+* Fix Notices appearing anywhere but the bottom on iPad devices.
  
 12.1
 -----

--- a/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
@@ -25,7 +25,6 @@ class UntouchableViewController: UIViewController {
     }
 
     override func loadView() {
-        super.loadView()
         view = UntouchableView()
     }
 

--- a/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
@@ -64,6 +64,40 @@ class UntouchableViewController: UIViewController {
         }
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // For iPad devices and app configs where all orientations are supported, the view is
+        // never automatically resized when the device is rotated. So, in here, we manually
+        // resize the view whenever the device is rotated.
+        //
+        // More curiously, the `viewWillTransitionToSize:withTransitionCoordinator` is also never
+        // called in the ViewController.
+        //
+        // Another solution to avoid this is to remove the support for _Upside Down_ orientation
+        // in Info.plist. We probably do not want that though.
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            let nc = NotificationCenter.default
+            nc.addObserver(self, selector: #selector(updateFrame(notification:)),
+                           name: UIDevice.orientationDidChangeNotification, object: nil)
+        }
+    }
+
+    /// Update the frame of the view to match the current device's orientation.
+    @objc func updateFrame(notification: Notification) {
+        let currentSize = view.frame.size
+        let maxDimension = max(currentSize.width, currentSize.height)
+        let minDimension = min(currentSize.width, currentSize.height)
+
+        let isLandscape = UIDevice.current.orientation.isLandscape
+        let size = CGSize(
+            width: isLandscape ? maxDimension : minDimension,
+            height: isLandscape ? minDimension : maxDimension
+        )
+
+        view.frame = CGRect(origin: view.frame.origin, size: size)
+    }
+
     enum Constants {
         static let offsetWithoutTabbar: CGFloat = 50.0
     }

--- a/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/UntouchableWindow.swift
@@ -73,9 +73,6 @@ class UntouchableViewController: UIViewController {
         //
         // More curiously, the `viewWillTransitionToSize:withTransitionCoordinator` is also never
         // called in the ViewController.
-        //
-        // Another solution to avoid this is to remove the support for _Upside Down_ orientation
-        // in Info.plist. We probably do not want that though.
         if UIDevice.current.userInterfaceIdiom == .pad {
             let nc = NotificationCenter.default
             nc.addObserver(self, selector: #selector(updateFrame(notification:)),


### PR DESCRIPTION
Fixes #11325. 

The bug seems to consistently happen when you launch the app, show a `Notice`, and then rotate the device.

| Starting Orientation | After Rotating |
|--------|-------|
  |      <img width="1455" alt="develop-before-rotate" src="https://user-images.githubusercontent.com/198826/54955986-83c24d00-4f14-11e9-9f43-967e0d746db9.png"> | <img width="1087" alt="develop-after-rotate" src="https://user-images.githubusercontent.com/198826/54955985-83c24d00-4f14-11e9-8021-cec34f7825a1.png"> |

## The Problem

Based on my tests, the `UntouchableViewController.view` never gets automatically resized when the device is rotated. The first orientation that the app is launched in will determine the size of the `view`.

This only happens on iPad devices. For iPhone, the `view` seems to be rotated correctly. 

## Abandoned solution: Full screen size

Setting the `UntouchableWindow` to full screen size seems to fix the issue. 

```swift
        window = UntouchableWindow(frame: UIScreen.main.bounds)
```

However, the status bar style text color gets changed to black (`.default`) whenever a `Notice` is shown. We could fix this by overridding `preferredStatusBarStyle` in `UntouchableViewController` but I'm not sure if we'd like to have status bar style configurations everywhere. 

I haven't gotten really deep to this solution but if you think this is a better approach, then I can try it out again. 

## The solution I ended up with

In `UntouchableViewController`, we now manually resize the `view` when the device is rotated. We only do this for iPads.

## Testing

To reproduce the bug:

1. iPad only: Start the app on landscape
2. Go to Site → Pages
3. Turn off the internet connection
4. The offline error Notice will be shown.
5. Rotate the device.
6. Pull to refresh the page.
7. The offline error Notice is not shown.

Please also play around with showing the Notice while on portrait. 