### PR TITLE
Site Creation: Improves the Domain Suggestion UI/UX

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressTableViewProvider.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressTableViewProvider.swift
@@ -10,6 +10,14 @@ final class WebAddressTableViewProvider: NSObject, TableViewProvider {
     /// The table view serviced by this provider
     private weak var tableView: UITableView?
 
+    /// Implicit suggestions are the base suggestions based on the site's name and info.
+    /// Whenever the user types something, this should be set to false.
+    var isShowingImplicitSuggestions = true {
+        didSet {
+            tableView?.reloadData()
+        }
+    }
+
     /// The underlying data represented by the provider
     var data: [DomainSuggestion] {
         didSet {
@@ -50,6 +58,10 @@ final class WebAddressTableViewProvider: NSObject, TableViewProvider {
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        guard isShowingImplicitSuggestions else {
+            return nil
+        }
+
         return NSLocalizedString("Suggestions", comment: "Suggested domains")
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -150,10 +150,12 @@ final class WebAddressWizardContent: UIViewController {
         tableViewOffsetCoordinator?.hideBottomToolbar()
 
         guard let validDataProvider = tableViewProvider as? WebAddressTableViewProvider else {
-            setupTableDataProvider()
+            setupTableDataProvider(isShowingImplicitSuggestions: true)
             return
         }
+
         validDataProvider.data = []
+        validDataProvider.isShowingImplicitSuggestions = true
         tableViewOffsetCoordinator?.resetTableOffsetIfNeeded()
     }
 
@@ -172,10 +174,14 @@ final class WebAddressWizardContent: UIViewController {
     }
 
     private func handleData(_ data: [DomainSuggestion]) {
+        let header = self.table.tableHeaderView as! TitleSubtitleTextfieldHeader
+        let isShowingImplicitSuggestions = header.textField.text!.isEmpty
+
         if let validDataProvider = tableViewProvider as? WebAddressTableViewProvider {
             validDataProvider.data = data
+            validDataProvider.isShowingImplicitSuggestions = isShowingImplicitSuggestions
         } else {
-            setupTableDataProvider(data)
+            setupTableDataProvider(data, isShowingImplicitSuggestions: isShowingImplicitSuggestions)
         }
 
         if data.isEmpty {
@@ -365,7 +371,7 @@ final class WebAddressWizardContent: UIViewController {
         ])
     }
 
-    private func setupTableDataProvider(_ data: [DomainSuggestion] = []) {
+    private func setupTableDataProvider(_ data: [DomainSuggestion] = [], isShowingImplicitSuggestions: Bool) {
         let handler: CellSelectionHandler = { [weak self] selectedIndexPath in
             guard let self = self, let provider = self.tableViewProvider as? WebAddressTableViewProvider else {
                 return
@@ -377,17 +383,29 @@ final class WebAddressWizardContent: UIViewController {
             self.tableViewOffsetCoordinator?.showBottomToolbar()
         }
 
-        self.tableViewProvider = WebAddressTableViewProvider(tableView: table, data: data, selectionHandler: handler)
+        let provider = WebAddressTableViewProvider(tableView: table, data: data, selectionHandler: handler)
+        provider.isShowingImplicitSuggestions = isShowingImplicitSuggestions
+
+        self.tableViewProvider = provider
+    }
+
+    private func query(from textField: UITextField?) -> String? {
+        guard let text = textField?.text,
+            !text.isEmpty else {
+                return siteCreator.information?.title
+        }
+
+        return text
     }
 
     @objc
     private func textChanged(sender: UITextField) {
-        guard let searchTerm = sender.text, searchTerm.isEmpty == false else {
+        guard let query = query(from: sender) else {
             clearContent()
             return
         }
 
-        performSearchIfNeeded(query: searchTerm)
+        performSearchIfNeeded(query: query)
         tableViewOffsetCoordinator?.adjustTableOffsetIfNeeded()
     }
 


### PR DESCRIPTION
## Description:

Fixes #11331 
Fixes #11332 

The "Suggestions" title label is now only shown for the implicit suggestions (the suggestions we provide before the user types anything).

The implicit suggestions are now shown again if the domain text field is emptied.

## Testing:

1. Enter the site creation flow for a WP.com site.
2. In step 3, make sure that initially you can see the "Suggestions" title, and a list of implicit suggestions (based off the site's title).
3. Type something and make sure "Suggestions" goes away.
4. Clean the field and make sure the initial state is shown again.
