### PR TITLE
Add support for updating chart in response to period dimension selection

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
@@ -65,13 +65,44 @@ class VerticalAxisFormatter: IAxisValueFormatter {
     // MARK: IAxisValueFormatter
 
     func stringForValue(_ value: Double, axis: AxisBase?) -> String {
-        let number = NSNumber(value: value/1000)
-        let value = formatter.string(from: number) ?? ""
+        let threshold = Double(1000)
 
-        // This is, admittedly NOT locale-sensitive formatting approach.
-        // It is slated to be improved via #11143.
-        let formattedValue = "\(value)k"
+        let formattedValue: String
+        if value > threshold {
+            let numericValue = NSNumber(value: value/threshold)
+            let rawFormattedValue = formatter.string(from: numericValue) ?? "\(numericValue)"
+
+            // This is, admittedly NOT locale-sensitive formatting approach. It will be improved via #11143.
+            formattedValue = "\(rawFormattedValue)k"
+        } else {
+            let numericValue = NSNumber(value: value)
+            formattedValue = formatter.string(from: numericValue) ?? "\(value)"
+        }
 
         return formattedValue
+
+        // Take 1
+//        let number = NSNumber(value: value/1000)
+//        let value = formatter.string(from: number) ?? ""
+//
+//        // This is, admittedly NOT locale-sensitive formatting approach.
+//        // It is slated to be improved via #11143.
+//        let formattedValue = "\(value)k"
+//
+//        return formattedValue
+
+        // Take 2
+//        let formattedValue: String
+//        let threshold = Double(1000)
+//        if value > threshold {
+//            // This is, admittedly NOT locale-sensitive formatting approach. It will be improved via #11143.
+//            let scaledValue = NSNumber(value: value/threshold)
+//            let rawFormattedValue = formatter.string(from: scaledValue) ?? ""
+//            formattedValue = "\(rawFormattedValue)k"
+//        } else {
+//            formattedValue = formatter.string(from: value) ?? "\(value)"
+//        }
+//
+//        return formattedValue
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
@@ -80,29 +80,5 @@ class VerticalAxisFormatter: IAxisValueFormatter {
         }
 
         return formattedValue
-
-        // Take 1
-//        let number = NSNumber(value: value/1000)
-//        let value = formatter.string(from: number) ?? ""
-//
-//        // This is, admittedly NOT locale-sensitive formatting approach.
-//        // It is slated to be improved via #11143.
-//        let formattedValue = "\(value)k"
-//
-//        return formattedValue
-
-        // Take 2
-//        let formattedValue: String
-//        let threshold = Double(1000)
-//        if value > threshold {
-//            // This is, admittedly NOT locale-sensitive formatting approach. It will be improved via #11143.
-//            let scaledValue = NSNumber(value: value/threshold)
-//            let rawFormattedValue = formatter.string(from: scaledValue) ?? ""
-//            formattedValue = "\(rawFormattedValue)k"
-//        } else {
-//            formattedValue = formatter.string(from: value) ?? "\(value)"
-//        }
-//
-//        return formattedValue
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Styling.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Styling.swift
@@ -3,9 +3,9 @@ import Foundation
 
 import Charts
 
-// MARK: - PeriodPerformanceStyling
+// MARK: - ViewsPeriodPerformanceStyling
 
-class PeriodPerformanceStyling: BarChartStyling {
+class ViewsPeriodPerformanceStyling: BarChartStyling {
 
     let primaryBarColor: UIColor
     let secondaryBarColor: UIColor?

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Styling.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Styling.swift
@@ -32,6 +32,35 @@ class ViewsPeriodPerformanceStyling: BarChartStyling {
     }
 }
 
+// MARK: - DefaultPeriodPerformanceStyling
+
+class DefaultPeriodPerformanceStyling: BarChartStyling {
+
+    let primaryBarColor: UIColor
+    let secondaryBarColor: UIColor?
+    let primaryHighlightColor: UIColor?
+    let secondaryHighlightColor: UIColor?
+    let labelColor: UIColor
+    let legendTitle: String?
+    let lineColor: UIColor
+    let xAxisValueFormatter: IAxisValueFormatter
+    let yAxisValueFormatter: IAxisValueFormatter
+
+    init(initialDateInterval: TimeInterval, highlightColor: UIColor? = nil) {
+        let xAxisFormatter = HorizontalAxisFormatter(initialDateInterval: initialDateInterval)
+
+        self.primaryBarColor            = WPStyleGuide.wordPressBlue()
+        self.secondaryBarColor          = WPStyleGuide.darkBlue()
+        self.primaryHighlightColor      = WPStyleGuide.jazzyOrange()
+        self.secondaryHighlightColor    = highlightColor
+        self.labelColor                 = WPStyleGuide.grey()
+        self.legendTitle                = nil
+        self.lineColor                  = WPStyleGuide.greyLighten30()
+        self.xAxisValueFormatter        = xAxisFormatter
+        self.yAxisValueFormatter        = VerticalAxisFormatter()
+    }
+}
+
 // MARK: - PostSummaryStyling
 
 class PostSummaryStyling: BarChartStyling {

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -241,6 +241,7 @@ class StatsBarChartView: BarChartView {
 
     private func drawSecondaryHighlightIfNeeded(for primaryEntry: ChartDataEntry, with primaryHighlight: Highlight) {
         guard let chartData = data, chartData.dataSets.count > 1 else {
+            highlightValues([primaryHighlight])
             return
         }
 
@@ -277,8 +278,8 @@ class StatsBarChartView: BarChartView {
 
         let postRotationDelay = DispatchTime.now() + TimeInterval(0.35)
         DispatchQueue.main.asyncAfter(deadline: postRotationDelay) {
-            self.drawChartMarker(for: entry)
             self.drawSecondaryHighlightIfNeeded(for: entry, with: highlight)
+            self.drawChartMarker(for: entry)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -14,6 +14,7 @@ class StatsBarChartView: BarChartView {
         static let intrinsicHeight      = CGFloat(170)      // height via Zeplin
         static let highlightAlpha       = CGFloat(1)
         static let markerAlpha          = CGFloat(0.2)
+        static let topOffsetSansLegend  = CGFloat(5)
         static let trailingOffset       = CGFloat(20)
     }
 
@@ -195,7 +196,7 @@ class StatsBarChartView: BarChartView {
         NSLayoutConstraint.activate([
             chartLegend.widthAnchor.constraint(equalTo: widthAnchor)
         ])
-        extraTopOffset += chartLegend.intrinsicContentSize.height
+        extraTopOffset = chartLegend.intrinsicContentSize.height
 
         self.legendView = chartLegend
     }
@@ -214,13 +215,17 @@ class StatsBarChartView: BarChartView {
     private func configureYAxis() {
         let yAxis = leftAxis
 
-        xAxis.axisLineColor = styling.lineColor
+        yAxis.axisLineColor = styling.lineColor
         yAxis.gridColor = styling.lineColor
         yAxis.drawAxisLineEnabled = false
         yAxis.drawLabelsEnabled = true
         yAxis.drawZeroLineEnabled = true
         yAxis.labelTextColor = styling.labelColor
         yAxis.valueFormatter = styling.yAxisValueFormatter
+
+        // This adjustment is intended to prevent clipping observed with some labels
+        // Potentially relevant : https://github.com/danielgindi/Charts/issues/992
+        extraTopOffset = Constants.topOffsetSansLegend
     }
 
     private func drawChartMarker(for entry: ChartDataEntry) {

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PeriodDataStub.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PeriodDataStub.swift
@@ -25,9 +25,11 @@ class PeriodDataStub: DataStub<[PeriodDatum]> {
     }
 }
 
-// MARK: - BarChartDataConvertible
+// MARK: - ViewsPeriodDataStub
 
-extension PeriodDataStub: BarChartDataConvertible {
+class ViewsPeriodDataStub: PeriodDataStub {}
+
+extension ViewsPeriodDataStub: BarChartDataConvertible {
     var barChartData: BarChartData {
 
         let data = periodData

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PeriodDataStub.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PeriodDataStub.swift
@@ -81,3 +81,144 @@ extension ViewsPeriodDataStub: BarChartDataConvertible {
         return chartData
     }
 }
+
+// MARK: - VisitorsPeriodDataStub
+
+class VisitorsPeriodDataStub: PeriodDataStub {}
+
+extension VisitorsPeriodDataStub: BarChartDataConvertible {
+    var barChartData: BarChartData {
+
+        let data = periodData
+
+        // Our stub data is ordered
+        let firstDateInterval: TimeInterval
+        let lastDateInterval: TimeInterval
+        let effectiveWidth: Double
+
+        if data.isEmpty {
+            firstDateInterval = 0
+            lastDateInterval = 0
+            effectiveWidth = 1
+        } else {
+            firstDateInterval = data.first!.date.timeIntervalSince1970
+            lastDateInterval = data.last!.date.timeIntervalSince1970
+
+            let range = lastDateInterval - firstDateInterval
+
+            let effectiveBars = Double(Double(data.count) * 1.2)
+
+            effectiveWidth = range / effectiveBars
+        }
+
+        var entries = [BarChartDataEntry]()
+        for datum in data {
+            let dateInterval = datum.date.timeIntervalSince1970
+            let offset = dateInterval - firstDateInterval
+
+            let x = offset
+            let y = Double(datum.visitorCount)
+            let entry = BarChartDataEntry(x: x, y: y)
+            entries.append(entry)
+        }
+
+        let chartData = BarChartData(entries: entries)
+        chartData.barWidth = effectiveWidth
+
+        return chartData
+    }
+}
+
+// MARK: - LikesPeriodDataStub
+
+class LikesPeriodDataStub: PeriodDataStub {}
+
+extension LikesPeriodDataStub: BarChartDataConvertible {
+    var barChartData: BarChartData {
+
+        let data = periodData
+
+        // Our stub data is ordered
+        let firstDateInterval: TimeInterval
+        let lastDateInterval: TimeInterval
+        let effectiveWidth: Double
+
+        if data.isEmpty {
+            firstDateInterval = 0
+            lastDateInterval = 0
+            effectiveWidth = 1
+        } else {
+            firstDateInterval = data.first!.date.timeIntervalSince1970
+            lastDateInterval = data.last!.date.timeIntervalSince1970
+
+            let range = lastDateInterval - firstDateInterval
+
+            let effectiveBars = Double(Double(data.count) * 1.2)
+
+            effectiveWidth = range / effectiveBars
+        }
+
+        var entries = [BarChartDataEntry]()
+        for datum in data {
+            let dateInterval = datum.date.timeIntervalSince1970
+            let offset = dateInterval - firstDateInterval
+
+            let x = offset
+            let y = Double(datum.likeCount)
+            let entry = BarChartDataEntry(x: x, y: y)
+            entries.append(entry)
+        }
+
+        let chartData = BarChartData(entries: entries)
+        chartData.barWidth = effectiveWidth
+
+        return chartData
+    }
+}
+
+// MARK: - CommentsPeriodDataStub
+
+class CommentsPeriodDataStub: PeriodDataStub {}
+
+extension CommentsPeriodDataStub: BarChartDataConvertible {
+    var barChartData: BarChartData {
+
+        let data = periodData
+
+        // Our stub data is ordered
+        let firstDateInterval: TimeInterval
+        let lastDateInterval: TimeInterval
+        let effectiveWidth: Double
+
+        if data.isEmpty {
+            firstDateInterval = 0
+            lastDateInterval = 0
+            effectiveWidth = 1
+        } else {
+            firstDateInterval = data.first!.date.timeIntervalSince1970
+            lastDateInterval = data.last!.date.timeIntervalSince1970
+
+            let range = lastDateInterval - firstDateInterval
+
+            let effectiveBars = Double(Double(data.count) * 1.2)
+
+            effectiveWidth = range / effectiveBars
+        }
+
+        var entries = [BarChartDataEntry]()
+        for datum in data {
+            let dateInterval = datum.date.timeIntervalSince1970
+            let offset = dateInterval - firstDateInterval
+
+            let x = offset
+            let y = Double(datum.commentCount)
+            let entry = BarChartDataEntry(x: x, y: y)
+            entries.append(entry)
+        }
+
+        let chartData = BarChartData(entries: entries)
+        chartData.barWidth = effectiveWidth
+
+        return chartData
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/period_data.json
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/period_data.json
@@ -38,7 +38,7 @@
         "date": "2019-02-24",
         "viewCount": 8400,
         "visitorCount": 6700,
-        "likeCount": 67,
+        "likeCount": 64,
         "commentCount": 6
     },
     {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -67,6 +67,7 @@ class OverviewCell: UITableViewCell, NibLoadable {
     private typealias Style = WPStyleGuide.Stats
     private var tabsData = [OverviewTabData]()
 
+    private(set) var chartSelectedIndex = -1
     private(set) var chartData: [BarChartDataConvertible] = []
     private(set) var chartStyling: [BarChartStyling] = []
 
@@ -138,7 +139,7 @@ private extension OverviewCell {
     }
 
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
-        // TODO: update chart - configureChartView() - via #11064
+        configureChartViewIfNeeded()
         updateLabels()
     }
 
@@ -153,8 +154,17 @@ private extension OverviewCell {
     // MARK: Chart support
 
     func configureChartViewIfNeeded() {
-        guard chartContainerView.subviews.isEmpty, let barChartData = chartData.first, let barChartStyling = chartStyling.first else {
+        let filterSelectedIndex = filterTabBar.selectedIndex
+
+        guard filterSelectedIndex != chartSelectedIndex, chartData.count > filterSelectedIndex, chartStyling.count > filterSelectedIndex else {
             return
+        }
+
+        let barChartData = chartData[filterSelectedIndex]
+        let barChartStyling = chartStyling[filterSelectedIndex]
+
+        for subview in chartContainerView.subviews {
+            subview.removeFromSuperview()
         }
 
         let chartView = StatsBarChartView(data: barChartData, styling: barChartStyling)
@@ -166,6 +176,8 @@ private extension OverviewCell {
             chartView.topAnchor.constraint(equalTo: chartContainerView.topAnchor),
             chartView.bottomAnchor.constraint(equalTo: chartContainerView.bottomAnchor)
         ])
+
+        self.chartSelectedIndex = filterSelectedIndex
     }
 
     enum ChartBottomMargin {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -67,8 +67,8 @@ class OverviewCell: UITableViewCell, NibLoadable {
     private typealias Style = WPStyleGuide.Stats
     private var tabsData = [OverviewTabData]()
 
-    private(set) var chartData: BarChartDataConvertible?
-    private(set) var chartStyling: BarChartStyling?
+    private(set) var chartData: [BarChartDataConvertible] = []
+    private(set) var chartStyling: [BarChartStyling] = []
 
     // MARK: - Configure
 
@@ -77,7 +77,7 @@ class OverviewCell: UITableViewCell, NibLoadable {
         applyStyles()
     }
 
-    func configure(tabsData: [OverviewTabData], barChartData: BarChartDataConvertible? = nil, barChartStyling: BarChartStyling? = nil) {
+    func configure(tabsData: [OverviewTabData], barChartData: [BarChartDataConvertible] = [], barChartStyling: [BarChartStyling] = []) {
         self.tabsData = tabsData
         self.chartData = barChartData
         self.chartStyling = barChartStyling
@@ -153,7 +153,7 @@ private extension OverviewCell {
     // MARK: Chart support
 
     func configureChartViewIfNeeded() {
-        guard chartContainerView.subviews.isEmpty, let barChartData = chartData, let barChartStyling = chartStyling else {
+        guard chartContainerView.subviews.isEmpty, let barChartData = chartData.first, let barChartStyling = chartStyling.first else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -82,7 +82,7 @@ private extension SiteStatsPeriodViewModel {
         let firstStubbedDateInterval = stubbedData.periodData.first?.date.timeIntervalSince1970 ?? 0
         let styling = PeriodPerformanceStyling(initialDateInterval: firstStubbedDateInterval)
 
-        let row = OverviewRow(tabsData: [one, two, three, four], chartData: stubbedData, chartStyling: styling)
+        let row = OverviewRow(tabsData: [one, two, three, four], chartData: [stubbedData], chartStyling: [styling])
         tableRows.append(row)
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -78,11 +78,11 @@ private extension SiteStatsPeriodViewModel {
         let four = OverviewTabData(tabTitle: StatSection.periodOverviewComments.tabTitle, tabData: 987654321, difference: -258547987, differencePercent: -125999)
 
         // Introduced via #11063, to be replaced with real data via #11069
-        let stubbedData = PeriodDataStub()
-        let firstStubbedDateInterval = stubbedData.periodData.first?.date.timeIntervalSince1970 ?? 0
-        let styling = PeriodPerformanceStyling(initialDateInterval: firstStubbedDateInterval)
+        let viewsPeriodStub = ViewsPeriodDataStub()
+        let viewsPeriodStubDateInterval = viewsPeriodStub.periodData.first?.date.timeIntervalSince1970 ?? 0
+        let viewsStyling = ViewsPeriodPerformanceStyling(initialDateInterval: viewsPeriodStubDateInterval)
 
-        let row = OverviewRow(tabsData: [one, two, three, four], chartData: [stubbedData], chartStyling: [styling])
+        let row = OverviewRow(tabsData: [one, two, three, four], chartData: [viewsPeriodStub], chartStyling: [viewsStyling])
         tableRows.append(row)
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -82,7 +82,33 @@ private extension SiteStatsPeriodViewModel {
         let viewsPeriodStubDateInterval = viewsPeriodStub.periodData.first?.date.timeIntervalSince1970 ?? 0
         let viewsStyling = ViewsPeriodPerformanceStyling(initialDateInterval: viewsPeriodStubDateInterval)
 
-        let row = OverviewRow(tabsData: [one, two, three, four], chartData: [viewsPeriodStub], chartStyling: [viewsStyling])
+        let visitorsPeriodStub = VisitorsPeriodDataStub()
+        let visitorsPeriodStubDateInterval = viewsPeriodStub.periodData.first?.date.timeIntervalSince1970 ?? 0
+        let visitorsStyling = DefaultPeriodPerformanceStyling(initialDateInterval: visitorsPeriodStubDateInterval)
+
+        let likesPeriodStub = LikesPeriodDataStub()
+        let likesPeriodStubDateInterval = likesPeriodStub.periodData.first?.date.timeIntervalSince1970 ?? 0
+        let likesStyling = DefaultPeriodPerformanceStyling(initialDateInterval: likesPeriodStubDateInterval)
+
+        let commentsPeriodStub = CommentsPeriodDataStub()
+        let commentsPeriodStubDateInterval = commentsPeriodStub.periodData.first?.date.timeIntervalSince1970 ?? 0
+        let commentsStyling = DefaultPeriodPerformanceStyling(initialDateInterval: commentsPeriodStubDateInterval)
+
+        let chartData: [BarChartDataConvertible] = [
+            viewsPeriodStub,
+            visitorsPeriodStub,
+            likesPeriodStub,
+            commentsPeriodStub
+        ]
+
+        let chartStyling: [BarChartStyling] = [
+            viewsStyling,
+            visitorsStyling,
+            likesStyling,
+            commentsStyling
+        ]
+
+        let row = OverviewRow(tabsData: [one, two, three, four], chartData: chartData, chartStyling: chartStyling)
         tableRows.append(row)
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -57,7 +57,7 @@ private extension PostStatsViewModel {
         let firstStubbedDateInterval = stubbedData.summaryData.first?.date.timeIntervalSince1970 ?? 0
         let styling = SelectedPostSummaryStyling(initialDateInterval: firstStubbedDateInterval)
 
-        let row = OverviewRow(tabsData: [data], chartData: stubbedData, chartStyling: styling)
+        let row = OverviewRow(tabsData: [data], chartData: [stubbedData], chartStyling: [styling])
         tableRows.append(row)
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -367,8 +367,8 @@ struct OverviewRow: ImmuTableRow {
 
     let tabsData: [OverviewTabData]
     let action: ImmuTableAction? = nil
-    let chartData: BarChartDataConvertible
-    let chartStyling: BarChartStyling
+    let chartData: [BarChartDataConvertible]
+    let chartStyling: [BarChartStyling]
 
     func configureCell(_ cell: UITableViewCell) {
 


### PR DESCRIPTION
Fixes #11064.

To test:

- Checkout the branch, confirm that it builds & tests pass.
- For a site, navigate to Stats, and select a given period. Then select a period dimension (Views, Visitors, Likes, Comments.
- Please note that at the moment, the chart is the same regardless of period (i.e., Days, Weeks, Months, Years).
- Please also note that the fabricated numbers do not match the magnitude of the values in the stubbed JSON data.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

![11064a_views_portrait](https://user-images.githubusercontent.com/221062/55040944-f6502d00-4fe7-11e9-8f18-b39a3b8f9fea.png)

![11064b_visitors_landscape](https://user-images.githubusercontent.com/221062/55040945-f6502d00-4fe7-11e9-926c-3ff0460f7166.png)

![11064c_likes_landscape](https://user-images.githubusercontent.com/221062/55040946-f6502d00-4fe7-11e9-8344-389946cbc3e7.png)

![11064d_comments_portrait](https://user-images.githubusercontent.com/221062/55040947-f6502d00-4fe7-11e9-874a-190776911e8e.png)
