### PR TITLE
[Stats Refresh] StatsPeriodStore: make use of the new API

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -42,8 +42,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 3.2.beta'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/time-interval-initializers'
+    #pod 'WordPressKit', '~> 3.2.beta'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/fix-parsing-for-empty-data-sets'
     #pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -199,9 +199,9 @@ PODS:
     - WordPressKit (~> 3.1)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-  - WordPressKit (3.2.0-beta.4):
+  - WordPressKit (3.2.2.beta-2):
     - Alamofire (~> 4.7.3)
-    - CocoaLumberjack (= 3.4.2)
+    - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.4)
@@ -257,7 +257,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.5.0.beta.2)
   - WordPressAuthenticator (~> 1.2.beta)
-  - WordPressKit (~> 3.2.beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/fix-parsing-for-empty-data-sets`)
   - WordPressShared (= 1.7.2)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -299,7 +299,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -327,6 +326,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :commit: 08a09629cc0adb7709b86f15bb3c43e8c69efd64
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressKit:
+    :branch: feature/fix-parsing-for-empty-data-sets
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -349,6 +351,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :commit: 08a09629cc0adb7709b86f15bb3c43e8c69efd64
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
+  WordPressKit:
+    :commit: 390675d35dfcf54fcb5e309e322f878983baa9c9
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -395,7 +400,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: a5f4702060e505c30ed8cf56fd246b9db91f3342
   WordPress-Editor-iOS: 79825aa356194f41987d79a15436f2788ad778e0
   WordPressAuthenticator: 4ab8ae42935718c7fe930c480367b43fe0376aa7
-  WordPressKit: 53ccac9ebba604414727add53e87f46f79d426e3
+  WordPressKit: f146ca94a5580e02da63072cdb90817322f6e4c4
   WordPressShared: 63d57a4a07ad9f9a1ee5e8a7162e48fbb5192014
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
@@ -403,6 +408,6 @@ SPEC CHECKSUMS:
   yoga: 1fe535cf9b523600f42e2785b6ed56484a62b46d
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: c53816078e3bff1710575a6414180ccaa093d25d
+PODFILE CHECKSUM: 564c423bd5a2a8149f262ee8008990c0b3ff25d5
 
 COCOAPODS: 1.5.3

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -169,10 +169,8 @@ class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
             refreshPublished(date: date, period: period)
         }
 
-        if isFetchingOverview {
-            DDLogInfo("Stats: Fetching overview in progress.")
-        } else {
-            DDLogInfo("Stats: Fetching overview finisheda.")
+        if !isFetchingOverview {
+            DDLogInfo("Stats: All fetching operations finished.")
         }
     }
 

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -168,6 +168,12 @@ class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
         case .refreshPublished(let date, let period):
             refreshPublished(date: date, period: period)
         }
+
+        if isFetchingOverview {
+            DDLogInfo("Stats: Fetching overview in progress.")
+        } else {
+            DDLogInfo("Stats: Fetching overview finisheda.")
+        }
     }
 
     override func queriesChanged() {

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -239,16 +239,6 @@ private extension StatsPeriodStore {
 
         setAllAsFetchingOverview()
 
-        statsRemote.getData(for: period, endingOn: date) { (summary: StatsSummaryTimeIntervalData?, error: Error?) in
-            if error != nil {
-                DDLogInfo("Error fetching summary: \(String(describing: error?.localizedDescription))")
-            }
-
-            DDLogInfo("Stats: Finished fetching summary.")
-
-            self.actionDispatcher.dispatch(PeriodAction.receivedSummary(summary))
-        }
-
         statsRemote.getData(for: period, endingOn: date) { (posts: StatsTopPostsTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogInfo("Error fetching posts: \(String(describing: error?.localizedDescription))")
@@ -664,7 +654,6 @@ private extension StatsPeriodStore {
     }
 
     func setAllAsFetchingOverview() {
-        state.fetchingSummary = true
         state.fetchingPostsAndPages = true
         state.fetchingReferrers = true
         state.fetchingClicks = true

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -123,59 +123,6 @@ class StatsDataHelper {
                                    disclosureURL: $0.url)
         }
     }
-
-    // MARK: - Child Rows Support
-
-    class func childRowsForClicks(_ item: StatsItem) -> [StatsTotalRowData] {
-
-        guard let children = item.children as? [StatsItem] else {
-            return [StatsTotalRowData]()
-        }
-
-        return children.map { StatsTotalRowData.init(name: $0.label,
-                                                     data: $0.value.displayString(),
-                                                     showDisclosure: true,
-                                                     disclosureURL: StatsDataHelper.disclosureUrlForItem($0)) }
-    }
-
-    class func childRowsForAuthor(_ item: StatsItem) -> [StatsTotalRowData] {
-
-        guard let children = item.children as? [StatsItem] else {
-            return [StatsTotalRowData]()
-        }
-
-        return children.map { StatsTotalRowData.init(name: $0.label,
-                                                     data: $0.value.displayString()) }
-    }
-
-    class func childRowsForReferrers(_ item: StatsItem) -> [StatsTotalRowData] {
-
-        var childRows = [StatsTotalRowData]()
-
-        guard let children = item.children as? [StatsItem] else {
-            return childRows
-        }
-
-        children.forEach { child in
-            var childsChildrenRows = [StatsTotalRowData]()
-            if let childsChildren = child.children as? [StatsItem] {
-                childsChildrenRows = childsChildren.map { StatsTotalRowData.init(name: $0.label,
-                                                                                 data: $0.value.displayString(),
-                                                                                 showDisclosure: true,
-                                                                                 disclosureURL: StatsDataHelper.disclosureUrlForItem($0)) }
-            }
-
-            childRows.append(StatsTotalRowData.init(name: child.label,
-                                                    data: child.value.displayString(),
-                                                    showDisclosure: true,
-                                                    disclosureURL: StatsDataHelper.disclosureUrlForItem(child),
-                                                    childRows: childsChildrenRows,
-                                                    statSection: .periodReferrers))
-        }
-
-        return childRows
-    }
-
 }
 
 /// These methods format stat Strings for display and usage.

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -138,14 +138,19 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func referrersDataRows() -> [StatsTotalRowData] {
-        return store.getTopReferrers()?.referrers.map { StatsTotalRowData(name: $0.title,
-                                                                          data: $0.viewsCount.abbreviatedString(),
-                                                                          socialIconURL: $0.iconURL,
-                                                                          showDisclosure: true,
-                                                                          disclosureURL: $0.url,
-                                                                          childRows: [], // FIXME
-                                                                          statSection: .periodReferrers) }
-            ?? []
+        let referrers = store.getTopReferrers()?.referrers ?? []
+
+        func rowDataFromReferrer(referrer: StatsReferrer) -> StatsTotalRowData {
+            return StatsTotalRowData(name: referrer.title,
+                                     data: referrer.viewsCount.abbreviatedString(),
+                                     socialIconURL: referrer.iconURL,
+                                     showDisclosure: true,
+                                     disclosureURL: referrer.url,
+                                     childRows: referrer.children.map { rowDataFromReferrer(referrer: $0) },
+                                     statSection: .periodReferrers)
+        }
+
+        return referrers.map { rowDataFromReferrer(referrer: $0) }
     }
 
     func clicksTableRows() -> [ImmuTableRow] {
@@ -165,7 +170,11 @@ private extension SiteStatsPeriodViewModel {
                                                                     userIconURL: $0.iconURL,
                                                                     showDisclosure: true,
                                                                     disclosureURL: $0.clickedURL,
-                                                                    childRows: [], //TODO FIXME
+                                                                    childRows: $0.children.map { StatsTotalRowData(name: $0.title,
+                                                                                                                   data: $0.clicksCount.abbreviatedString(),
+                                                                                                                   showDisclosure: true,
+                                                                                                                   disclosureURL: $0.clickedURL)
+            },
                                                                     statSection: .periodClicks) }
             ?? []
     }
@@ -190,7 +199,7 @@ private extension SiteStatsPeriodViewModel {
                                                dataBarPercent: Float($0.viewsCount) / Float(authors.first!.viewsCount),
                                                userIconURL: $0.iconURL,
                                                showDisclosure: true,
-                                               childRows: [], // TODO FIXME
+                                               childRows: $0.posts.map { StatsTotalRowData(name: $0.title, data: $0.viewsCount.abbreviatedString()) },
                                                statSection: .periodAuthors)
         }
     }
@@ -209,7 +218,7 @@ private extension SiteStatsPeriodViewModel {
     func countriesDataRows() -> [StatsTotalRowData] {
         return store.getTopCountries()?.countries.map { StatsTotalRowData(name: $0.name,
                                                                           data: $0.viewsCount.abbreviatedString(),
-                                                                          countryIconURL: nil, //FIXME TODO
+                                                                          countryIconURL: nil, // TODO Move this from WPStatsiOS.
                                                                           statSection: .periodCountries) }
             ?? []
     }
@@ -276,7 +285,7 @@ private extension SiteStatsPeriodViewModel {
     func videosDataRows() -> [StatsTotalRowData] {
         return store.getTopVideos()?.videos.map { StatsTotalRowData(name: $0.title,
                                                                     data: $0.playsCount.abbreviatedString(),
-                                                                    mediaID: 0, //TODO FIXIT,
+                                                                    mediaID: 0, //TODO Currently backend only returns URLs, not IDs.
                                                                     icon: Style.imageForGridiconType(.video),
                                                                     showDisclosure: true,
                                                                     statSection: .periodVideos) }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -100,7 +100,7 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func postsAndPagesDataRows() -> [StatsTotalRowData] {
-        let postsAndPages = store.getTopPostsAndPages()?.topPosts ?? []
+        let postsAndPages = store.getTopPostsAndPages()?.topPosts.prefix(10) ?? []
 
         return postsAndPages.map {
             let icon: UIImage?
@@ -138,7 +138,7 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func referrersDataRows() -> [StatsTotalRowData] {
-        let referrers = store.getTopReferrers()?.referrers ?? []
+        let referrers = store.getTopReferrers()?.referrers.prefix(10) ?? []
 
         func rowDataFromReferrer(referrer: StatsReferrer) -> StatsTotalRowData {
             return StatsTotalRowData(name: referrer.title,
@@ -165,17 +165,17 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func clicksDataRows() -> [StatsTotalRowData] {
-        return store.getTopClicks()?.clicks.map { StatsTotalRowData(name: $0.title,
-                                                                    data: $0.clicksCount.abbreviatedString(),
-                                                                    userIconURL: $0.iconURL,
-                                                                    showDisclosure: true,
-                                                                    disclosureURL: $0.clickedURL,
-                                                                    childRows: $0.children.map { StatsTotalRowData(name: $0.title,
-                                                                                                                   data: $0.clicksCount.abbreviatedString(),
-                                                                                                                   showDisclosure: true,
-                                                                                                                   disclosureURL: $0.clickedURL)
+        return store.getTopClicks()?.clicks.prefix(10).map { StatsTotalRowData(name: $0.title,
+                                                                               data: $0.clicksCount.abbreviatedString(),
+                                                                               userIconURL: $0.iconURL,
+                                                                               showDisclosure: true,
+                                                                               disclosureURL: $0.clickedURL,
+                                                                               childRows: $0.children.map { StatsTotalRowData(name: $0.title,
+                                                                                                                              data: $0.clicksCount.abbreviatedString(),
+                                                                                                                              showDisclosure: true,
+                                                                                                                              disclosureURL: $0.clickedURL)
             },
-                                                                    statSection: .periodClicks) }
+                                                                               statSection: .periodClicks) }
             ?? []
     }
 
@@ -191,7 +191,7 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func authorsDataRows() -> [StatsTotalRowData] {
-        let authors = store.getTopAuthors()?.topAuthors ?? []
+        let authors = store.getTopAuthors()?.topAuthors.prefix(10) ?? []
 
 
         return authors.map { StatsTotalRowData(name: $0.name,
@@ -216,10 +216,10 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func countriesDataRows() -> [StatsTotalRowData] {
-        return store.getTopCountries()?.countries.map { StatsTotalRowData(name: $0.name,
-                                                                          data: $0.viewsCount.abbreviatedString(),
-                                                                          countryIconURL: nil, // TODO Move this from WPStatsiOS.
-                                                                          statSection: .periodCountries) }
+        return store.getTopCountries()?.countries.prefix(10).map { StatsTotalRowData(name: $0.name,
+                                                                                     data: $0.viewsCount.abbreviatedString(),
+                                                                                     countryIconURL: nil, // TODO Move this from WPStatsiOS.
+                                                                                     statSection: .periodCountries) }
             ?? []
     }
 
@@ -239,9 +239,9 @@ private extension SiteStatsPeriodViewModel {
             return []
         }
 
-        var mappedSearchTerms = searchTerms.searchTerms.map { StatsTotalRowData(name: $0.term,
-                                                                                data: $0.viewsCount.abbreviatedString(),
-                                                                                statSection: .periodSearchTerms) }
+        var mappedSearchTerms = searchTerms.searchTerms.prefix(10).map { StatsTotalRowData(name: $0.term,
+                                                                                           data: $0.viewsCount.abbreviatedString(),
+                                                                                           statSection: .periodSearchTerms) }
 
         let unknownSearchTerm = StatsTotalRowData(name: NSLocalizedString("Unknown search terms",
                                                                           comment: "Search Terms label for 'unknown search terms'."),
@@ -263,7 +263,7 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func publishedDataRows() -> [StatsTotalRowData] {
-        return store.getTopPublished()?.publishedPosts.map { StatsTotalRowData.init(name: $0.title,
+        return store.getTopPublished()?.publishedPosts.prefix(10).map { StatsTotalRowData.init(name: $0.title,
                                                                                     data: "",
                                                                                     showDisclosure: true,
                                                                                     disclosureURL: $0.postURL,
@@ -283,12 +283,12 @@ private extension SiteStatsPeriodViewModel {
     }
 
     func videosDataRows() -> [StatsTotalRowData] {
-        return store.getTopVideos()?.videos.map { StatsTotalRowData(name: $0.title,
-                                                                    data: $0.playsCount.abbreviatedString(),
-                                                                    mediaID: 0, //TODO Currently backend only returns URLs, not IDs.
-                                                                    icon: Style.imageForGridiconType(.video),
-                                                                    showDisclosure: true,
-                                                                    statSection: .periodVideos) }
+        return store.getTopVideos()?.videos.prefix(10).map { StatsTotalRowData(name: $0.title,
+                                                                               data: $0.playsCount.abbreviatedString(),
+                                                                               mediaID: 0, //TODO Currently backend only returns URLs, not IDs.
+                                                                               icon: Style.imageForGridiconType(.video),
+                                                                               showDisclosure: true,
+                                                                               statSection: .periodVideos) }
             ?? []
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -242,12 +242,17 @@ private extension SiteStatsPeriodViewModel {
                                                                                            data: $0.viewsCount.abbreviatedString(),
                                                                                            statSection: .periodSearchTerms) }
 
-        let unknownSearchTerm = StatsTotalRowData(name: NSLocalizedString("Unknown search terms",
-                                                                          comment: "Search Terms label for 'unknown search terms'."),
-                                                  data: searchTerms.hiddenSearchTermsCount.abbreviatedString(),
-                                                  statSection: .periodSearchTerms)
+        if !mappedSearchTerms.isEmpty && searchTerms.hiddenSearchTermsCount > 0 {
+            // We want to insert the "Unknown search terms" item only if there's anything to show in the first place — if the
+            // section is empty, it doesn't make sense to insert it here.
 
-        mappedSearchTerms.insert(unknownSearchTerm, at: 0)
+            let unknownSearchTerm = StatsTotalRowData(name: NSLocalizedString("Unknown search terms",
+                                                                              comment: "Search Terms label for 'unknown search terms'."),
+                                                      data: searchTerms.hiddenSearchTermsCount.abbreviatedString(),
+                                                      statSection: .periodSearchTerms)
+
+            mappedSearchTerms.insert(unknownSearchTerm, at: 0)
+        }
 
         return mappedSearchTerms
     }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -167,7 +167,6 @@ private extension SiteStatsPeriodViewModel {
     func clicksDataRows() -> [StatsTotalRowData] {
         return store.getTopClicks()?.clicks.prefix(10).map { StatsTotalRowData(name: $0.title,
                                                                                data: $0.clicksCount.abbreviatedString(),
-                                                                               userIconURL: $0.iconURL,
                                                                                showDisclosure: true,
                                                                                disclosureURL: $0.clickedURL,
                                                                                childRows: $0.children.map { StatsTotalRowData(name: $0.title,

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -284,7 +284,7 @@ private extension SiteStatsPeriodViewModel {
     func videosDataRows() -> [StatsTotalRowData] {
         return store.getTopVideos()?.videos.prefix(10).map { StatsTotalRowData(name: $0.title,
                                                                                data: $0.playsCount.abbreviatedString(),
-                                                                               mediaID: 0, //TODO Currently backend only returns URLs, not IDs.
+                                                                               mediaID: $0.postID as NSNumber,
                                                                                icon: Style.imageForGridiconType(.video),
                                                                                showDisclosure: true,
                                                                                statSection: .periodVideos) }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -394,7 +394,7 @@ private extension SiteStatsDetailsViewModel {
                                                                         data: $0.value.displayString(),
                                                                         showDisclosure: true,
                                                                         disclosureURL: StatsDataHelper.disclosureUrlForItem($0),
-                                                                        childRows: StatsDataHelper.childRowsForClicks($0),
+                                                                        childRows: [], //TODO FIXME StatsDataHelper.childRowsForClicks($0),
                                                                         statSection: .periodClicks) }
             ?? []
     }
@@ -406,7 +406,7 @@ private extension SiteStatsDetailsViewModel {
                                                      dataBarPercent: StatsDataHelper.dataBarPercentForRow($0, relativeToRow: authors?.first),
                                                      userIconURL: $0.iconURL,
                                                      showDisclosure: true,
-                                                     childRows: StatsDataHelper.childRowsForAuthor($0),
+                                                     childRows: [], // TODO FIXME StatsDataHelper.childRowsForAuthor($0),
                                                      statSection: .periodAuthors) }
             ?? []
     }
@@ -417,7 +417,7 @@ private extension SiteStatsDetailsViewModel {
                                                                            socialIconURL: $0.iconURL,
                                                                            showDisclosure: true,
                                                                            disclosureURL: StatsDataHelper.disclosureUrlForItem($0),
-                                                                           childRows: StatsDataHelper.childRowsForReferrers($0),
+                                                                           childRows: [], // TODO FIXME StatsDataHelper.childRowsForReferrers($0),
                                                                            statSection: .periodReferrers) }
             ?? []
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -375,10 +375,28 @@ private extension SiteStatsDetailsViewModel {
     }
 
     func searchTermsRows() -> [StatsTotalRowData] {
-        return periodStore.getTopSearchTerms()?.searchTerms.map { StatsTotalRowData(name: $0.term,
-                                                                                    data: $0.viewsCount.abbreviatedString(),
-                                                                                    statSection: .periodSearchTerms) }
-            ?? []
+        guard let searchTerms = periodStore.getTopSearchTerms() else {
+            return []
+        }
+
+
+        var mappedSearchTerms = searchTerms.searchTerms.map { StatsTotalRowData(name: $0.term,
+                                                                                data: $0.viewsCount.abbreviatedString(),
+                                                                                statSection: .periodSearchTerms) }
+
+        if !mappedSearchTerms.isEmpty && searchTerms.hiddenSearchTermsCount > 0 {
+            // We want to insert the "Unknown search terms" item only if there's anything to show in the first place — if the
+            // section is empty, it doesn't make sense to insert it here.
+
+            let unknownSearchTerm = StatsTotalRowData(name: NSLocalizedString("Unknown search terms",
+                                                                              comment: "Search Terms label for 'unknown search terms'."),
+                                                      data: searchTerms.hiddenSearchTermsCount.abbreviatedString(),
+                                                      statSection: .periodSearchTerms)
+
+            mappedSearchTerms.insert(unknownSearchTerm, at: 0)
+        }
+
+        return mappedSearchTerms
     }
 
     func videosRows() -> [StatsTotalRowData] {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -384,7 +384,7 @@ private extension SiteStatsDetailsViewModel {
     func videosRows() -> [StatsTotalRowData] {
         return periodStore.getTopVideos()?.videos.map { StatsTotalRowData(name: $0.title,
                                                                           data: $0.playsCount.abbreviatedString(),
-                                                                          mediaID: 0, // TODO FIXME Add this from WPKit
+                                                                          mediaID: $0.postID as NSNumber,
                                                                           icon: Style.imageForGridiconType(.video),
                                                                           showDisclosure: true,
                                                                           statSection: .periodVideos) }


### PR DESCRIPTION
This switches StatsPeriodStore to the new `StatsServiceRemoteV2` based API, also updating the appropriate ViewModels.

I found two more changes (grr.....) I'll need to make to the data model when working on this — 
* `Videos` endpoint doesn't return a media `ID`, just a URL
* we need to move the country-flag icons from WPStatsiOS module to WPiOS. This was outside of scope for this PR so I decided to leave it broken for now.

To test:

* Go to Stats
* Look at Period-type data
* Verify everything still works! (modulo the two broken things above)