### PR TITLE
Fix Notices showing anywhere but the bottom on iPad devices

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -70,6 +70,14 @@ class NoticePresenter: NSObject {
 
         super.init()
 
+        // Make the window key and visible at first but hide it on the next UI loop. If this is not
+        // done, the window is not automatically resized when the device is rotated. This issue
+        // only happens on iPad devices.
+        window.makeKeyAndVisible()
+        DispatchQueue.main.async {
+            self.window.isHidden = true
+        }
+
         // Keep the storeReceipt to prevent the `onChange` subscription from being deactivated.
         storeReceipt = store.onChange { [weak self] in
             self?.onStoreChange()

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -70,10 +70,10 @@ class NoticePresenter: NSObject {
 
         super.init()
 
-        // Make the window key and visible at first but hide it on the next UI loop. If this is not
-        // done, the window is not automatically resized when the device is rotated. This issue
+        // Keep the window visible but hide it on the next run loop. If we hide it immediately,
+        // the window is not automatically resized when the device is rotated. This issue
         // only happens on iPad devices.
-        window.makeKeyAndVisible()
+        window.isHidden = false
         DispatchQueue.main.async { [weak self] in
             self?.window.isHidden = true
         }

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -72,7 +72,7 @@ class NoticePresenter: NSObject {
 
         // Keep the window visible but hide it on the next run loop. If we hide it immediately,
         // the window is not automatically resized when the device is rotated. This issue
-        // only happens on iPad devices.
+        // only happens on iPad simulators.
         window.isHidden = false
         DispatchQueue.main.async { [weak self] in
             self?.window.isHidden = true

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -74,8 +74,8 @@ class NoticePresenter: NSObject {
         // done, the window is not automatically resized when the device is rotated. This issue
         // only happens on iPad devices.
         window.makeKeyAndVisible()
-        DispatchQueue.main.async {
-            self.window.isHidden = true
+        DispatchQueue.main.async { [weak self] in
+            self?.window.isHidden = true
         }
 
         // Keep the storeReceipt to prevent the `onChange` subscription from being deactivated.

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -442,7 +442,15 @@ private extension NoticePresenter {
         }
 
         @objc func updateFrame(notification: Notification) {
-            frame = MaskView.calculateFrame(parent: parentView, untouchableVC: untouchableVC)
+            // Update the `frame` on the next run loop. When this Notification event handler is
+            // called, the `self.parentView` still has the frame from the previous orientation.
+            // Running this routine after the current run loop ensures we have the correct frame.
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else {
+                    return
+                }
+                self.frame = MaskView.calculateFrame(parent: self.parentView, untouchableVC: self.untouchableVC)
+            }
         }
 
         private static func calculateFrame(parent: UIView,


### PR DESCRIPTION
Fixes #11325. 

The bug seems to consistently happen when you launch the app, show a `Notice`, and then rotate the device.

| Starting Orientation | After Rotating |
|--------|-------|
  |      <img width="1455" alt="develop-before-rotate" src="https://user-images.githubusercontent.com/198826/54955986-83c24d00-4f14-11e9-9f43-967e0d746db9.png"> | <img width="1087" alt="develop-after-rotate" src="https://user-images.githubusercontent.com/198826/54955985-83c24d00-4f14-11e9-8021-cec34f7825a1.png"> |

## The Problem

Based on my tests, the `UntouchableViewController.view` never gets automatically resized when the device is rotated. The first orientation that the app is launched in will determine the size of the `view`.

This only happens on iPad devices. For iPhone, the `view` seems to be rotated correctly. 

## The Solution

Based on @nheagy's advice, this is a regression. We hunted for the cause and found that this started happening in 4cac38f8. It looks like the auto-resizing gets disabled when the `window` is not visible after it is initialized. This PR restores that. It will still be hidden but on the next UI loop. 

The `MaskView` got affected with the fix so the `MaskView` `frame` update had to be fixed as well.

## Testing

To reproduce the bug:

1. iPad only: Start the app on landscape
2. Go to Site → Pages
3. Turn off the internet connection
4. The offline error Notice will be shown.
5. Rotate the device.
6. Pull to refresh the page.
7. The offline error Notice is not shown.

Please also play around with showing the Notice while on portrait. 