### PR TITLE
Update WordPressKit to 3.2.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -42,7 +42,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 3.2.0'
+    pod 'WordPressKit', '~> 3.2.1'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'ddf1292ff9df94550b8d30dd8f3c2e23be677a9c'
     #pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -42,7 +42,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 3.1.2'
+    pod 'WordPressKit', '~> 3.2.0'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'ddf1292ff9df94550b8d30dd8f3c2e23be677a9c'
     #pod 'WordPressKit', :path => '~/Developer/a8c/WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -199,9 +199,9 @@ PODS:
     - WordPressKit (~> 3.1)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-  - WordPressKit (3.2.0):
+  - WordPressKit (3.2.1):
     - Alamofire (~> 4.7.3)
-    - CocoaLumberjack (= 3.4.2)
+    - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.4)
@@ -257,7 +257,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.5.0)
   - WordPressAuthenticator (~> 1.2.0)
-  - WordPressKit (~> 3.2.0)
+  - WordPressKit (~> 3.2.1)
   - WordPressShared (= 1.7.2)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -395,7 +395,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 0cc6e513027dde1af209b8f41b6ed6961e181ae5
   WordPress-Editor-iOS: e25330010a9360e48bce6f264f62dff05230b31d
   WordPressAuthenticator: 9d33878c78115b8727dedd0915fb3b0ad3439c55
-  WordPressKit: fb20bc580b55c0dd34fcae869473819b4c90d4f0
+  WordPressKit: fbe41d08c1d3b9ec909e0fe82c09bddb143bc972
   WordPressShared: 63d57a4a07ad9f9a1ee5e8a7162e48fbb5192014
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
@@ -403,6 +403,6 @@ SPEC CHECKSUMS:
   yoga: 1fe535cf9b523600f42e2785b6ed56484a62b46d
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: 80ac6f4d1108fea55ee6670d0499c1ff74e7160a
+PODFILE CHECKSUM: 3586518adcfc022d62e2ef7e663e14758c1fd65f
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -199,9 +199,9 @@ PODS:
     - WordPressKit (~> 3.1)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-  - WordPressKit (3.1.2):
+  - WordPressKit (3.2.0):
     - Alamofire (~> 4.7.3)
-    - CocoaLumberjack (~> 3.4)
+    - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.4)
@@ -257,7 +257,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.5.0)
   - WordPressAuthenticator (~> 1.2.0)
-  - WordPressKit (~> 3.1.2)
+  - WordPressKit (~> 3.2.0)
   - WordPressShared (= 1.7.2)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -395,7 +395,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 0cc6e513027dde1af209b8f41b6ed6961e181ae5
   WordPress-Editor-iOS: e25330010a9360e48bce6f264f62dff05230b31d
   WordPressAuthenticator: 9d33878c78115b8727dedd0915fb3b0ad3439c55
-  WordPressKit: c431508391b18d5d5e622564c9f12ee9f8883eda
+  WordPressKit: fb20bc580b55c0dd34fcae869473819b4c90d4f0
   WordPressShared: 63d57a4a07ad9f9a1ee5e8a7162e48fbb5192014
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
@@ -403,6 +403,6 @@ SPEC CHECKSUMS:
   yoga: 1fe535cf9b523600f42e2785b6ed56484a62b46d
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
 
-PODFILE CHECKSUM: ee361d575f135bc1d4e0dc6783cefc0fb44caa5b
+PODFILE CHECKSUM: 80ac6f4d1108fea55ee6670d0499c1ff74e7160a
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
Update WordPressKit to 3.2.0

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
