### PR TITLE
Site Creation: Domain suggestions are no longer laid out behind the checkmark.

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.xib
@@ -34,7 +34,7 @@
             <constraints>
                 <constraint firstItem="hQm-TV-IDW" firstAttribute="leading" secondItem="njF-e1-oar" secondAttribute="leading" constant="16" id="QB9-fd-Zsn"/>
                 <constraint firstItem="hQm-TV-IDW" firstAttribute="centerY" secondItem="njF-e1-oar" secondAttribute="centerY" id="eud-Yr-hp5"/>
-                <constraint firstItem="njF-e1-oar" firstAttribute="trailing" secondItem="hQm-TV-IDW" secondAttribute="trailing" constant="16" id="pJe-WK-HF0"/>
+                <constraint firstItem="H2p-sc-9uM" firstAttribute="trailing" secondItem="hQm-TV-IDW" secondAttribute="trailing" constant="16" id="pJe-WK-HF0"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>


### PR DESCRIPTION
## Description:

Fixes #11335 

This PR resolves an issue that was causing text to be laid out behind the selected cell's checkmark icon, in the domains suggestion screen in our Site Creation flow.

![checkmark](https://user-images.githubusercontent.com/1836005/55099973-7e453e00-509f-11e9-9019-70ef0f415c25.gif)

## Testing:

1. Go to the list of sites.
2. Tap the + icon and create a new wp.com site.
3. In the domain suggestion step, type a really long text.
4. Select one of the suggestions and make sure text is no longer laid out behind the checkmark icon.