### PR TITLE
Site Creation: Fixes separator alignment in the basic information step.

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -15,11 +15,6 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
             static let nameText = WPStyleGuide.darkGrey()
             static let valueText = WPStyleGuide.greyDarken10()
         }
-
-        enum ValueTextFieldEdgeInset {
-            static let accessoryTypeDisclosure = UIEdgeInsets(top: 7, left: 0, bottom: 7, right: 0)
-            static let accessoryTypeNone = UIEdgeInsets(top: 7, left: 0, bottom: 7, right: 10)
-        }
     }
 
     @IBOutlet weak var nameValueWidthRatioConstraint: NSLayoutConstraint!
@@ -29,13 +24,8 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
 
     override var accessoryType: UITableViewCell.AccessoryType {
         didSet {
-            switch accessoryType {
-            case .disclosureIndicator:
-                valueTextField.contentInsets = Const.ValueTextFieldEdgeInset.accessoryTypeDisclosure
+            if accessoryType != .none {
                 valueTextField.isEnabled = false
-            default:
-                valueTextField.contentInsets = Const.ValueTextFieldEdgeInset.accessoryTypeNone
-                valueTextField.isEnabled = true
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.xib
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.xib
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,26 +19,14 @@
                 <rect key="frame" x="0.0" y="0.0" width="363" height="45.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7hQ-Qd-7gD">
-                        <rect key="frame" x="0.0" y="0.0" width="129" height="45.5"/>
-                        <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JYy-XU-9v8">
-                                <rect key="frame" x="16" y="12" width="110" height="21.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstItem="JYy-XU-9v8" firstAttribute="top" secondItem="7hQ-Qd-7gD" secondAttribute="top" constant="12" id="913-Cc-Y34"/>
-                            <constraint firstAttribute="bottom" secondItem="JYy-XU-9v8" secondAttribute="bottom" constant="12" id="9kF-3X-cxU"/>
-                            <constraint firstItem="JYy-XU-9v8" firstAttribute="leading" secondItem="7hQ-Qd-7gD" secondAttribute="leading" constant="16" id="fuZ-M4-BMo"/>
-                            <constraint firstAttribute="trailing" secondItem="JYy-XU-9v8" secondAttribute="trailing" constant="3" id="mQw-rR-jjL"/>
-                        </constraints>
-                    </view>
-                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="aoI-Bw-gsZ" customClass="LoginTextField" customModule="WordPressAuthenticator">
-                        <rect key="frame" x="129" y="0.0" width="234" height="45.5"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JYy-XU-9v8">
+                        <rect key="frame" x="16" y="11" width="42" height="24"/>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="aoI-Bw-gsZ" customClass="LoginTextField" customModule="WordPressAuthenticator">
+                        <rect key="frame" x="74" y="0.0" width="273" height="45.5"/>
                         <nil key="textColor"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <textInputTraits key="textInputTraits"/>
@@ -45,18 +34,17 @@
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="bottom" secondItem="aoI-Bw-gsZ" secondAttribute="bottom" id="6sO-Yu-79x"/>
-                    <constraint firstItem="aoI-Bw-gsZ" firstAttribute="leading" secondItem="7hQ-Qd-7gD" secondAttribute="trailing" id="7da-If-Hjk"/>
-                    <constraint firstItem="7hQ-Qd-7gD" firstAttribute="width" secondItem="aoI-Bw-gsZ" secondAttribute="width" multiplier="0.55" id="T1g-JA-BoX"/>
+                    <constraint firstAttribute="bottomMargin" secondItem="JYy-XU-9v8" secondAttribute="bottom" id="KOZ-fg-qjv"/>
+                    <constraint firstItem="JYy-XU-9v8" firstAttribute="top" secondItem="6tg-46-1kN" secondAttribute="topMargin" id="a2U-XA-tOS"/>
                     <constraint firstItem="aoI-Bw-gsZ" firstAttribute="top" secondItem="6tg-46-1kN" secondAttribute="top" id="cht-u8-Mxn"/>
-                    <constraint firstItem="7hQ-Qd-7gD" firstAttribute="leading" secondItem="6tg-46-1kN" secondAttribute="leading" id="jfM-h3-9Cc"/>
-                    <constraint firstAttribute="bottom" secondItem="7hQ-Qd-7gD" secondAttribute="bottom" id="kAm-Mb-ESq"/>
-                    <constraint firstItem="7hQ-Qd-7gD" firstAttribute="top" secondItem="6tg-46-1kN" secondAttribute="top" id="kuV-uc-XHs"/>
-                    <constraint firstAttribute="trailing" secondItem="aoI-Bw-gsZ" secondAttribute="trailing" id="kve-lr-n0n"/>
+                    <constraint firstItem="aoI-Bw-gsZ" firstAttribute="leading" secondItem="JYy-XU-9v8" secondAttribute="trailing" constant="16" id="cla-S8-ICD"/>
+                    <constraint firstItem="JYy-XU-9v8" firstAttribute="leading" secondItem="6tg-46-1kN" secondAttribute="leadingMargin" id="day-4w-sKL"/>
+                    <constraint firstAttribute="trailing" secondItem="aoI-Bw-gsZ" secondAttribute="trailing" constant="16" id="kve-lr-n0n"/>
                 </constraints>
             </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="zHS-Ix-07n"/>
             <connections>
                 <outlet property="nameLabel" destination="JYy-XU-9v8" id="a4R-Gn-u1p"/>
-                <outlet property="nameValueWidthRatioConstraint" destination="T1g-JA-BoX" id="dGd-Vx-zIt"/>
                 <outlet property="valueTextField" destination="aoI-Bw-gsZ" id="Fg1-LO-RHf"/>
             </connections>
             <point key="canvasLocation" x="-884.5" y="113"/>

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
@@ -23,7 +23,6 @@ final class SiteInformationWizardContent: UIViewController {
         static let footerVerticalMargin: CGFloat = 6.0
         static let footerHorizontalMargin: CGFloat = 16.0
         static let rowHeight: CGFloat = 44.0
-        static let separatorInset = UIEdgeInsets(top: 0, left: 64.0, bottom: 0, right: 0)
     }
 
     private let completion: SiteInformationCompletion
@@ -113,7 +112,6 @@ final class SiteInformationWizardContent: UIViewController {
     private func setupCellHeight() {
         table.rowHeight = UITableView.automaticDimension
         table.estimatedRowHeight = Constants.rowHeight
-        table.separatorInset = Constants.separatorInset
     }
 
     private func setupButtonWrapper() {

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.xib
@@ -34,7 +34,7 @@
             <constraints>
                 <constraint firstItem="hQm-TV-IDW" firstAttribute="leading" secondItem="njF-e1-oar" secondAttribute="leading" constant="16" id="QB9-fd-Zsn"/>
                 <constraint firstItem="hQm-TV-IDW" firstAttribute="centerY" secondItem="njF-e1-oar" secondAttribute="centerY" id="eud-Yr-hp5"/>
-                <constraint firstItem="njF-e1-oar" firstAttribute="trailing" secondItem="hQm-TV-IDW" secondAttribute="trailing" constant="16" id="pJe-WK-HF0"/>
+                <constraint firstItem="H2p-sc-9uM" firstAttribute="trailing" secondItem="hQm-TV-IDW" secondAttribute="trailing" constant="16" id="pJe-WK-HF0"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>


### PR DESCRIPTION
## Description:

Fixes #11333 

This also changes the layout of `InlineEditableNameValueCellDelegate` so that we no longer need to configure the insets.

## Screenshot:

<img width="243" alt="separatorAlignment" src="https://user-images.githubusercontent.com/1836005/55119409-879ace80-50d0-11e9-87b0-92433fc9b606.png">

## Testing:

### Site Creation Flow

1. In the posts list press + and add a new WP.com site.
2. Select the type of site you want.
3. Make sure that the separator shown in step 2 is aligned with the cell titles.

### Domain Registration Flow

1. Go to source file `PluginViewModel.swift`, line 186
2. Replace that line with `if true {`
3. Go to source file `Blog.m` method `supportsPluginManagement`
4. Make sure the method exits immediately with `return true;`
5. Launch the app and go to the mobile dashboard for any site
6. Tap on "Plugins"
7. Try to install any plugin
8. When the alert comes up telling you that you need a custom domain, tap on "Register Domain".
9. Make sure all cells look right.
