### PR TITLE
TimeInterval persistence

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -179,6 +179,10 @@ private extension StatsInsightsStore {
     func processQueries() {
 
         guard !activeQueries.isEmpty else {
+            // This being empty means a VC just unregistered from observing data.
+            // Let's persist what we have an clear the in-memory store.
+            persistToCoreData()
+            state = InsightStoreState()
             return
         }
 
@@ -209,12 +213,12 @@ private extension StatsInsightsStore {
     func fetchInsights() {
 
         loadFromCache()
-        setAllAsFetchingOverview()
 
         guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue else {
             return
         }
 
+        setAllAsFetchingOverview()
         let api = apiService(for: siteID)
 
         api.getInsight { (lastPost: StatsLastPostInsight?, error) in

--- a/WordPress/Classes/Stores/StoreContainer.swift
+++ b/WordPress/Classes/Stores/StoreContainer.swift
@@ -10,6 +10,7 @@ class StoreContainer {
     @objc fileprivate func applicationWillResignActive() {
         try? plugin.persistState()
         statsInsights.persistToCoreData()
+        statsPeriod.persistToCoreData()
     }
 
     let plugin = PluginStore()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -51,7 +51,7 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
         applyStyles()
     }
 
-    func configure(withData lastPostInsight: StatsLastPostInsight?, andDelegate delegate: SiteStatsInsightsDelegate) {
+    func configure(withData lastPostInsight: StatsLastPostInsight?, andDelegate delegate: SiteStatsInsightsDelegate?) {
 
         siteStatsInsightsDelegate = delegate
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
@@ -22,7 +22,7 @@ class PostingActivityCell: UITableViewCell, NibLoadable {
         addLegend()
     }
 
-    func configure(withData monthsData: [[PostingStreakEvent]], andDelegate delegate: SiteStatsInsightsDelegate) {
+    func configure(withData monthsData: [[PostingStreakEvent]], andDelegate delegate: SiteStatsInsightsDelegate?) {
         siteStatsInsightsDelegate = delegate
         addMonths(monthsData: monthsData)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -10,7 +10,7 @@ class SiteStatsInsightsViewModel: Observable {
 
     let changeDispatcher = Dispatcher<Void>()
 
-    private let siteStatsInsightsDelegate: SiteStatsInsightsDelegate
+    private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     private let store: StatsInsightsStore
     private let insightsReceipt: Receipt
     private var changeReceipt: Receipt?

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -10,7 +10,7 @@ class SiteStatsPeriodViewModel: Observable {
 
     let changeDispatcher = Dispatcher<Void>()
 
-    private let periodDelegate: SiteStatsPeriodDelegate
+    private weak var periodDelegate: SiteStatsPeriodDelegate?
     private let store: StatsPeriodStore
     private let periodReceipt: Receipt
     private var changeReceipt: Receipt?

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -12,7 +12,7 @@ struct LatestPostSummaryRow: ImmuTableRow {
     }()
 
     let summaryData: StatsLastPostInsight?
-    let siteStatsInsightsDelegate: SiteStatsInsightsDelegate
+    weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -83,7 +83,7 @@ struct PostingActivityRow: ImmuTableRow {
     }()
 
     let monthsData: [[PostingStreakEvent]]
-    let siteStatsInsightsDelegate: SiteStatsInsightsDelegate
+    weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -105,7 +105,7 @@ struct TabbedTotalsStatsRow: ImmuTableRow {
     }()
 
     let tabsData: [TabData]
-    let siteStatsInsightsDelegate: SiteStatsInsightsDelegate
+    weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     let showTotalCount: Bool
     let action: ImmuTableAction? = nil
 
@@ -130,7 +130,7 @@ struct TabbedTotalsDetailStatsRow: ImmuTableRow {
     }()
 
     let tabsData: [TabData]
-    let siteStatsDetailsDelegate: SiteStatsDetailsDelegate
+    weak var siteStatsDetailsDelegate: SiteStatsDetailsDelegate?
     let showTotalCount: Bool
     let selectedIndex: Int
     let action: ImmuTableAction? = nil
@@ -160,7 +160,7 @@ struct TopTotalsDetailStatsRow: ImmuTableRow {
     let itemSubtitle: String
     let dataSubtitle: String
     let dataRows: [StatsTotalRowData]
-    let siteStatsDetailsDelegate: SiteStatsDetailsDelegate
+    weak var siteStatsDetailsDelegate: SiteStatsDetailsDelegate?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -215,7 +215,7 @@ struct TopTotalsNoSubtitlesPeriodDetailStatsRow: ImmuTableRow {
     }()
 
     let dataRows: [StatsTotalRowData]
-    let siteStatsDetailsDelegate: SiteStatsDetailsDelegate
+    weak var siteStatsDetailsDelegate: SiteStatsDetailsDelegate?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -241,7 +241,7 @@ struct TopTotalsInsightStatsRow: ImmuTableRow {
     let itemSubtitle: String
     let dataSubtitle: String
     let dataRows: [StatsTotalRowData]
-    let siteStatsInsightsDelegate: SiteStatsInsightsDelegate
+    weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -269,7 +269,7 @@ struct TopTotalsPeriodStatsRow: ImmuTableRow {
     let itemSubtitle: String
     let dataSubtitle: String
     let dataRows: [StatsTotalRowData]
-    let siteStatsPeriodDelegate: SiteStatsPeriodDelegate
+    weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -294,7 +294,7 @@ struct TopTotalsNoSubtitlesPeriodStatsRow: ImmuTableRow {
     }()
 
     let dataRows: [StatsTotalRowData]
-    let siteStatsPeriodDelegate: SiteStatsPeriodDelegate
+    weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -341,7 +341,7 @@ struct CountriesStatsRow: ImmuTableRow {
     let itemSubtitle: String
     let dataSubtitle: String
     let dataRows: [StatsTotalRowData]
-    let siteStatsPeriodDelegate: SiteStatsPeriodDelegate
+    weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {


### PR DESCRIPTION
Alright, last of the major ones!

This teaches `StatsPeriodStore` about Core Data objects. I snuck in few other fixes in here too — some fixes for memory leaks  and a fix for persistence of Insights.

To test:
Pre-requisite: Comment out lines 114-120 in `StatsViewController.m` to disable current offline-mode handling.

1. Launch the app.
1. Tap around Stats, jump across different tabs etc
1. Background the app
1. Kill the app
1. Kill your network connection
1. Open the app again
1. Verify that data for Stats shows up!
