### PR TITLE
Fixes the right inset in SearchTextField when not in edit mode.

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -9,6 +9,7 @@ private final class SearchTextField: UITextField {
     // MARK: Properties
 
     private struct Constants {
+        static let defaultPadding   = CGFloat(16)
         static let iconDimension    = CGFloat(18)
         static let iconInset        = CGFloat(19)
         static let clearButtonInset = CGFloat(-9)
@@ -34,7 +35,7 @@ private final class SearchTextField: UITextField {
     }
 
     override func textRect(forBounds bounds: CGRect) -> CGRect {
-        let textInsets = UIEdgeInsets(top: 0, left: Constants.textInset, bottom: 0, right: 0)
+        let textInsets = UIEdgeInsets(top: 0, left: Constants.textInset, bottom: 0, right: Constants.defaultPadding)
         return bounds.inset(by: textInsets)
     }
 


### PR DESCRIPTION
## Description:

Fixes #11370 

The right inset of `SearchTextField` was zero.  This PR fixes that inset to add some spacing.

## Testing:

1. Go to the list of sites.
2. Tap + and create a WP.com site.
3. In step 3 of the Site Creation flow, type a really long text.
4. Select one of the suggestions below, so that the input field is no longer first responder.

Make sure the right margin of the input field is not sticking to the right border of the screen, and has a 16pt margin.