### PR TITLE
Uploading draft and displaying remote preview

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 12.2
 -----
- 
+* Draft preview now shows the remote version of the post.
 12.1
 -----
 * Improve messages when updates to user account details fail because of server logic, for exanple email being used for another account.

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -8,7 +8,6 @@ import WordPressShared
 import MobileCoreServices
 import WordPressEditor
 import WPMediaPicker
-import SVProgressHUD
 import AVKit
 import MobileCoreServices
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -27,12 +27,17 @@ extension PostEditor where Self: UIViewController {
         if post.isDraft() && post.hasUnsavedChanges() {
             let context = ContextManager.sharedInstance().mainContext
             let postService = PostService(managedObjectContext: context)
+             let status = NSLocalizedString("Saving...", comment: "Text displayed in HUD while a post is being saved as a draft.")
+            SVProgressHUD.setDefaultMaskType(.clear)
+            SVProgressHUD.show(withStatus: status)
             postService.uploadPost(post, success: { [weak self] newPost in
                 self?.post = newPost
                 self?.createPostRevisionBeforePreview(completion: completion)
+                SVProgressHUD.dismiss()
                 }, failure: { error in
                     DDLogError("Error while trying to save post before preview: \(String(describing: error))")
                     completion()
+                    SVProgressHUD.dismiss()
             })
         } else {
            createPostRevisionBeforePreview(completion: completion)

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -14,7 +14,7 @@ extension PostEditor where Self: UIViewController {
         self.navigationController?.pushViewController(settingsViewController, animated: true)
     }
 
-    private func savePostBeforePreview(completion: @escaping () -> Void){
+    private func savePostBeforePreview(completion: @escaping (() -> Void)){
         let context = ContextManager.sharedInstance().mainContext
         let postService = PostService(managedObjectContext: context)
         if post.isDraft() {
@@ -29,7 +29,7 @@ extension PostEditor where Self: UIViewController {
             completion()
         }
     }
-        
+
     func displayPreview() {
         self.savePostBeforePreview() { [weak self] in
             guard let post = self?.post else {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -185,7 +185,7 @@ extension PostEditor where Self: UIViewController {
     func cancelEditing() {
         stopEditing()
 
-        if post.canSave() && !post.isDraft() {
+        if post.canSave() {
             showPostHasChangesAlert()
         } else {
             editorSession.end(outcome: .cancel)

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -185,7 +185,7 @@ extension PostEditor where Self: UIViewController {
     func cancelEditing() {
         stopEditing()
 
-        if post.canSave() && post.hasUnsavedChanges() {
+        if post.canSave() && !post.isDraft() {
             showPostHasChangesAlert()
         } else {
             editorSession.end(outcome: .cancel)


### PR DESCRIPTION
Here we go again.
After long discussions I've decided to tackle this in steps. This is the first step and it includes drafts only. It also uses an existing end point for uploading the post with API version 1.2.
If the post is a draft we are uploading it before the preview so it shows the remote version of the preview. 
This PR DOES NOT include a solution for a published post which currently shows the remote version on no changes and the local version when there are local changes.
A following PR will cover a published post.

Fixes #9286 
To test:
1. Create a new draft or edit an existing one
2. Preview the draft
3. See the remote preview
![draft_preview](https://user-images.githubusercontent.com/1335657/55205648-77f3b680-51b2-11e9-887c-83d4e7c9f2fe.gif)


Update release notes:
- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
