### PR TITLE
Turns off the status bar on launch to prevent W logo squish

### DIFF
--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -108,6 +108,8 @@
 	<true/>
 	<key>UIRequiresFullScreen</key>
 	<false/>
+	<key>UIStatusBarHidden</key>
+	<true/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleBlackOpaque</string>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
Fixes #8231

I simply turned off the status bar upon launch to prevent the logo from being squished. No amount of autolayout constraints fixed this for some reason. Common solution online is to disable the status bar on launch which it should be anyway.

![Simulator Screen Shot - iPhone 8 - 2019-03-29 at 08 13 32](https://user-images.githubusercontent.com/373903/55236315-a5b21d00-51fd-11e9-890c-46b9176d5658.png)

To test:
Put a breakpoint in the App Delegate in didFinishLaunching and double check the simulator doesn't show the squished logo.

Make sure all the screens in the app don't look janky with the status bar turned off on launch. So far everything looks okay.

