### PR TITLE
 Xcode 10.2 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,17 @@
 version: 2.1
 
 orbs:
-  ios: wordpress-mobile/ios@0.0.20
+  ios: wordpress-mobile/ios@0.0.25
 
 workflows:
   wordpress_ios:
     jobs:
       - ios/test:
           name: build_and_test
+          xcode-version: "10.2.0"
           workspace: WordPress.xcworkspace
           scheme: WordPress
           device: iPhone XS
-          ios-version: "12.1"
+          ios-version: "12.2"
           # If you want to reset the CircleCI cache, increment the number in the cache prefix below
           cache-prefix: dependency-cache-v1

--- a/Podfile
+++ b/Podfile
@@ -133,7 +133,7 @@ target 'WordPress' do
     #pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => 'f6332b67448a4e9c2661513cbb98fa5bb12b7c8f'
 
     pod 'NSURL+IDN', '0.3'
-    pod 'WPMediaPicker', '1.3.2'
+    pod 'WPMediaPicker', '1.3.3'
     pod 'Gridicons', '~> 0.16'
     ## while PR is in review:
     ## pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :commit => 'e546205cd2a992838837b0a4de502507b89b6e63'

--- a/Podfile
+++ b/Podfile
@@ -29,7 +29,7 @@ def aztec
     #pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'a916afc713e5d650f47fd03772022c01ca0ac8a8'
     #pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'a916afc713e5d650f47fd03772022c01ca0ac8a8'
     ##pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag => '1.5.0.beta.1'
-    pod 'WordPress-Editor-iOS', '1.5.2'
+    pod 'WordPress-Editor-iOS', '~> 1.6.0-beta'
 end
 
 def wordpress_ui
@@ -120,7 +120,7 @@ target 'WordPress' do
     pod 'MRProgress', '0.8.3'
     pod 'Starscream', '3.0.6'
     pod 'SVProgressHUD', '2.2.5'
-    pod 'ZendeskSDK', '2.2.0'
+    pod 'ZendeskSDK', '2.3.1'
     pod 'ZIPFoundation', '~> 0.9.8'
 
     ## Automattic libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -219,7 +219,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.2.0)
-  - WPMediaPicker (1.3.2)
+  - WPMediaPicker (1.3.3)
   - wpxmlrpc (0.8.4)
   - yoga (0.59.3.React)
   - ZendeskSDK (2.3.1):
@@ -270,7 +270,7 @@ DEPENDENCIES:
   - WordPressKit (~> 4.0.0-beta)
   - WordPressShared (~> 1.7.3)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
-  - WPMediaPicker (= 1.3.2)
+  - WPMediaPicker (= 1.3.3)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.2.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
   - ZendeskSDK (= 2.3.1)
   - ZIPFoundation (~> 0.9.8)
@@ -409,12 +409,12 @@ SPEC CHECKSUMS:
   WordPressKit: 1ddb164dcca4a03ed8e9bd7c6050a8deea1264e0
   WordPressShared: 0853172642668b0fbf5c8d56e743896ebf9aae01
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
-  WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
+  WPMediaPicker: 6d23120b16c0f66987fd98ec2b294864e1df03bf
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   yoga: 0cb6e1c4f763ba12d1c825f2d6f863da6614a2a4
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 172eb6068d8f1e864f1655fb65389b21a9732b2b
+PODFILE CHECKSUM: 36cf7950699299ed7f9a616e828f39058dd614d9
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -193,9 +193,9 @@ PODS:
   - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPress-Aztec-iOS (1.5.2)
-  - WordPress-Editor-iOS (1.5.2):
-    - WordPress-Aztec-iOS (= 1.5.2)
+  - WordPress-Aztec-iOS (1.6.0-beta.1)
+  - WordPress-Editor-iOS (1.6.0-beta.1):
+    - WordPress-Aztec-iOS (= 1.6.0-beta.1)
   - WordPressAuthenticator (1.4.0-beta.1):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
@@ -222,13 +222,13 @@ PODS:
   - WPMediaPicker (1.3.2)
   - wpxmlrpc (0.8.4)
   - yoga (0.59.3.React)
-  - ZendeskSDK (2.2.0):
-    - ZendeskSDK/Providers (= 2.2.0)
-    - ZendeskSDK/UI (= 2.2.0)
-  - ZendeskSDK/Core (2.2.0)
-  - ZendeskSDK/Providers (2.2.0):
+  - ZendeskSDK (2.3.1):
+    - ZendeskSDK/Providers (= 2.3.1)
+    - ZendeskSDK/UI (= 2.3.1)
+  - ZendeskSDK/Core (2.3.1)
+  - ZendeskSDK/Providers (2.3.1):
     - ZendeskSDK/Core
-  - ZendeskSDK/UI (2.2.0):
+  - ZendeskSDK/UI (2.3.1):
     - ZendeskSDK/Core
     - ZendeskSDK/Providers
   - ZIPFoundation (0.9.9)
@@ -265,14 +265,14 @@ DEPENDENCIES:
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
-  - WordPress-Editor-iOS (= 1.5.2)
+  - WordPress-Editor-iOS (~> 1.6.0-beta)
   - WordPressAuthenticator (~> 1.4.0-beta)
   - WordPressKit (~> 4.0.0-beta)
   - WordPressShared (~> 1.7.3)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.2.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
-  - ZendeskSDK (= 2.2.0)
+  - ZendeskSDK (= 2.3.1)
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
@@ -403,8 +403,8 @@ SPEC CHECKSUMS:
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPress-Aztec-iOS: 16339a831d5d605ba9300b3722b75ba78e53cf09
-  WordPress-Editor-iOS: b90649909f99c1d02cef2bb79c0641322b31fa52
+  WordPress-Aztec-iOS: 3b12eea844ff38b3b82c66f3ed5b01b0fc2f6327
+  WordPress-Editor-iOS: d3352429009ba5a75f6ae81deded7156b7a6ffb8
   WordPressAuthenticator: f0e30e8e555e33bea8e13e6f1245172d557a8ee4
   WordPressKit: 1ddb164dcca4a03ed8e9bd7c6050a8deea1264e0
   WordPressShared: 0853172642668b0fbf5c8d56e743896ebf9aae01
@@ -412,9 +412,9 @@ SPEC CHECKSUMS:
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   yoga: 0cb6e1c4f763ba12d1c825f2d6f863da6614a2a4
-  ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
+  ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 7466f8cf3ef2c83e65afe23ae3659aa3f78b7ed0
+PODFILE CHECKSUM: 172eb6068d8f1e864f1655fb65389b21a9732b2b
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Models/JetpackSiteRef.swift
+++ b/WordPress/Classes/Models/JetpackSiteRef.swift
@@ -23,8 +23,8 @@ struct JetpackSiteRef: Hashable, Codable {
         self.username = username
     }
 
-    var hashValue: Int {
-        return "\(username)-\(siteID)".hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine("\(username)-\(siteID)")
     }
 
     static func ==(lhs: JetpackSiteRef, rhs: JetpackSiteRef) -> Bool {

--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -16,18 +16,18 @@ enum InsightAction: Action {
     case receivedTodaysStats(_ todaysStats: StatsTodayInsight?)
     case receivedPostingActivity(_ postingActivity: StatsPostingStreakInsight?)
     case receivedTagsAndCategories(_ tagsAndCategories: StatsTagsAndCategoriesInsight?)
-    case refreshInsights()
+    case refreshInsights
 
     // Insights details
     case receivedAllDotComFollowers(_ allDotComFollowers: StatsDotComFollowersInsight?)
     case receivedAllEmailFollowers(_ allDotComFollowers: StatsEmailFollowersInsight?)
-    case refreshFollowers()
+    case refreshFollowers
 
     case receivedAllCommentsInsight(_ commentsInsight: StatsCommentsInsight?)
-    case refreshComments()
+    case refreshComments
 
     case receivedAllTagsAndCategories(_ allTagsAndCategories: StatsTagsAndCategoriesInsight?)
-    case refreshTagsAndCategories()
+    case refreshTagsAndCategories
 }
 
 enum InsightQuery {

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Media.swift
@@ -8,7 +8,7 @@ public extension WPAppAnalytics {
     ///     - selectionMethod: The Media's method of selection.
     /// - Returns: Dictionary
     ///
-    public class func properties(for media: Media, selectionMethod: MediaSelectionMethod) -> [String: Any] {
+    class func properties(for media: Media, selectionMethod: MediaSelectionMethod) -> [String: Any] {
         var properties = WPAppAnalytics.properties(for: media)
         properties[MediaOriginKey] = String(describing: selectionMethod)
         return properties
@@ -19,7 +19,7 @@ public extension WPAppAnalytics {
      - parameter media: the Media object
      - returns: Dictionary
      */
-    @objc public class func properties(for media: Media) -> Dictionary<String, Any> {
+    @objc class func properties(for media: Media) -> Dictionary<String, Any> {
         var properties = [String: Any]()
         properties[MediaProperties.mime] = media.mimeType()
         if let fileExtension = media.fileExtension(), !fileExtension.isEmpty {

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -60,7 +60,7 @@ extension NSManagedObjectContext {
         do {
             result = try count(for: request)
         } catch {
-            DDLogError("Error counting objects [\(T.entityName)]: \(error)")
+            DDLogError("Error counting objects [\(String(describing: T.entityName))]: \(error)")
             assertionFailure()
         }
 
@@ -113,7 +113,7 @@ extension NSManagedObjectContext {
         do {
             result = try existingObject(with: objectID) as? T
         } catch {
-            DDLogError("Error loading Object [\(T.entityName)]")
+            DDLogError("Error loading Object [\(String(describing: T.entityName))]")
         }
 
         return result
@@ -140,7 +140,7 @@ extension NSManagedObjectContext {
         do {
             objects = try fetch(request) as? [T]
         } catch {
-            DDLogError("Error loading Objects [\(T.entityName)")
+            DDLogError("Error loading Objects [\(String(describing: T.entityName))")
             assertionFailure()
         }
 

--- a/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableContentRange.swift
@@ -32,7 +32,7 @@ extension FormattableContentRange {
 }
 
 public extension FormattableContentRange where Self: LinkContentRange {
-    public func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) -> Shift {
+    func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) -> Shift {
         let shiftedRange = rangeShifted(by: shift)
 
         apply(styles, to: string, at: shiftedRange)

--- a/WordPress/Classes/Utility/FormattableContent/FormattableMediaContent.swift
+++ b/WordPress/Classes/Utility/FormattableContent/FormattableMediaContent.swift
@@ -62,7 +62,7 @@ extension FormattableMediaItem {
 public extension FormattableMediaItem {
     /// Known kinds of Media Entities
     ///
-    public enum Kind: String {
+    enum Kind: String {
         case image              = "image"
         case badge              = "badge"
     }

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteSettingsViewController+SiteManagement.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/SiteSettingsViewController+SiteManagement.swift
@@ -9,7 +9,7 @@ public extension SiteSettingsViewController {
 
     /// Presents confirmation alert for Export Content
     ///
-    @objc public func confirmExportContent() {
+    @objc func confirmExportContent() {
         tableView.deselectSelectedRowWithAnimation(true)
 
         WPAppAnalytics.track(.siteSettingsExportSiteAccessed, with: self.blog)
@@ -72,7 +72,7 @@ public extension SiteSettingsViewController {
 
     /// Requests site purchases to determine whether site is deletable
     ///
-    @objc public func checkSiteDeletable() {
+    @objc func checkSiteDeletable() {
         tableView.deselectSelectedRowWithAnimation(true)
 
         let status = NSLocalizedString("Checking purchases…", comment: "Overlay message displayed while checking if site has premium purchases")

--- a/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.h
+++ b/WordPress/Classes/ViewRelated/Cells/PostFeaturedImageCell.h
@@ -4,9 +4,9 @@
 @class PostFeaturedImageCell;
 
 @protocol PostFeaturedImageCellDelegate <NSObject>
-- (void)postFeatureImageCellDidFinishLoadingImage:(PostFeaturedImageCell *)cell;
-- (void)postFeatureImageCell:(PostFeaturedImageCell *)cell didFinishLoadingAnimatedImageWithData:(NSData *)animationData;
-- (void)postFeatureImageCell:(PostFeaturedImageCell *)cell didFinishLoadingImageWithError:(NSError *)error;
+- (void)postFeatureImageCellDidFinishLoadingImage:(nonnull PostFeaturedImageCell *)cell;
+- (void)postFeatureImageCell:(nonnull PostFeaturedImageCell *)cell didFinishLoadingAnimatedImageWithData:(nullable NSData *)animationData;
+- (void)postFeatureImageCell:(nonnull PostFeaturedImageCell *)cell didFinishLoadingImageWithError:(nullable NSError *)error;
 @end
 
 @interface PostFeaturedImageCell : WPTableViewCell

--- a/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CachedAnimatedImageView.swift
@@ -155,14 +155,9 @@ public class CachedAnimatedImageView: UIImageView, GIFAnimatable {
     }
 
     public func addLoadingIndicator(_ loadingIndicator: ActivityIndicatorType, style: LoadingIndicatorStyle) {
-        guard let loadingView = loadingIndicator as? UIView else {
-            assertionFailure("Loading indicator must be a UIView subclass")
-            return
-        }
-
         removeCustomLoadingIndicator()
         customLoadingIndicator = loadingIndicator
-        addCustomLoadingIndicator(loadingView, style: style)
+        addCustomLoadingIndicator(loadingIndicator, style: style)
     }
 
     // MARK: - Private methods
@@ -228,7 +223,7 @@ public class CachedAnimatedImageView: UIImageView, GIFAnimatable {
     // MARK: Loading indicator
 
     private func removeCustomLoadingIndicator() {
-        if let oldLoadingIndicator = customLoadingIndicator as? UIView {
+        if let oldLoadingIndicator = customLoadingIndicator {
             oldLoadingIndicator.removeFromSuperview()
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/DomainSuggestionsTableViewController.swift
@@ -285,7 +285,7 @@ extension DomainSuggestionsTableViewController {
         }
         styledDomain.addAttribute(.foregroundColor,
                                   value: WPStyleGuide.darkGrey(),
-                                  range: NSMakeRange(0, dotPosition.encodedOffset))
+                                  range: NSMakeRange(0, dotPosition.utf16Offset(in: domain)))
         return styledDomain
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -160,9 +160,7 @@ private extension SignupEpilogueViewController {
             }
         } else {
             if !changesMade {
-                defer {
-                    WordPressAuthenticator.track(.signupEpilogueUnchanged, properties: tracksProperties())
-                }
+                WordPressAuthenticator.track(.signupEpilogueUnchanged, properties: tracksProperties())
             }
             self.refreshAccountDetails() {
                 SVProgressHUD.dismiss()

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -66,9 +66,7 @@ class SignupUsernameTableViewController: NUXTableViewController {
         let service = AccountSettingsService(userID: account.userID.intValue, api: api)
         service.suggestUsernames(base: searchTerm) { [weak self] (newSuggestions) in
             if newSuggestions.count == 0 {
-                defer {
-                    WordPressAuthenticator.track(.signupEpilogueUsernameSuggestionsFailed)
-                }
+                WordPressAuthenticator.track(.signupEpilogueUsernameSuggestionsFailed)
             }
             self?.isSearching = false
             SVProgressHUD.dismiss()

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateView.swift
@@ -264,15 +264,15 @@ final class ErrorStateView: UIView {
 
 @objc
 private extension ErrorStateView {
-    func contactSupportTapped() {
+    @objc func contactSupportTapped() {
         configuration.contactSupportActionHandler?()
     }
 
-    func dismissTapped() {
+    @objc func dismissTapped() {
         configuration.dismissalActionHandler?()
     }
 
-    func retryTapped() {
+    @objc func retryTapped() {
         configuration.retryActionHandler?()
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -27,7 +27,7 @@ class SiteStatsInsightsViewModel: Observable {
         self.store = store
 
         insightsReceipt = store.query(.insights)
-        store.actionDispatcher.dispatch(InsightAction.refreshInsights())
+        store.actionDispatcher.dispatch(InsightAction.refreshInsights)
 
         changeReceipt = store.onChange { [weak self] in
             self?.emitChange()
@@ -95,7 +95,7 @@ class SiteStatsInsightsViewModel: Observable {
     // MARK: - Refresh Data
 
     func refreshInsights() {
-        ActionDispatcher.dispatch(InsightAction.refreshInsights())
+        ActionDispatcher.dispatch(InsightAction.refreshInsights)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -134,15 +134,15 @@ class SiteStatsDetailsViewModel: Observable {
     // MARK: - Refresh Data
 
     func refreshFollowers() {
-        ActionDispatcher.dispatch(InsightAction.refreshFollowers())
+        ActionDispatcher.dispatch(InsightAction.refreshFollowers)
     }
 
     func refreshComments() {
-        ActionDispatcher.dispatch(InsightAction.refreshComments())
+        ActionDispatcher.dispatch(InsightAction.refreshComments)
     }
 
     func refreshTagsAndCategories() {
-        ActionDispatcher.dispatch(InsightAction.refreshTagsAndCategories())
+        ActionDispatcher.dispatch(InsightAction.refreshTagsAndCategories)
     }
 
     func refreshPostsAndPages() {

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/NSAttributedString+WPRichText.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/NSAttributedString+WPRichText.swift
@@ -17,7 +17,7 @@ public extension NSAttributedString {
     ///
     /// - Returns: NSAttributedString Optional
     ///
-    public class func attributedStringFromHTMLString(
+    class func attributedStringFromHTMLString(
         _ string: String,
         defaultAttributes: [NSAttributedString.Key: Any]?) throws -> NSAttributedString? {
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -8892,13 +8892,9 @@
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "WordPress" */;
 			compatibilityVersion = "Xcode 8.0";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
 				en,
 				es,
 				it,
@@ -9336,9 +9332,9 @@
 				"${BUILT_PRODUCTS_DIR}/WordPressShared/WordPressShared.framework",
 				"${BUILT_PRODUCTS_DIR}/WordPressUI/WordPressUI.framework",
 				"${BUILT_PRODUCTS_DIR}/ZIPFoundation/ZIPFoundation.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/4.2/ZendeskCoreSDK.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/4.2/ZendeskProviderSDK.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/4.2/ZendeskSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0/ZendeskCoreSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0/ZendeskProviderSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0/ZendeskSDK.framework",
 				"${BUILT_PRODUCTS_DIR}/glog/glog.framework",
 				"${BUILT_PRODUCTS_DIR}/lottie-ios/Lottie.framework",
 				"${BUILT_PRODUCTS_DIR}/react-native-keyboard-aware-scroll-view/react_native_keyboard_aware_scroll_view.framework",
@@ -9496,7 +9492,7 @@
 				"${PODS_ROOT}/Target Support Files/Pods-WordPress/Pods-WordPress-resources.sh",
 				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/WordPressAuthenticator/WordPressAuthenticator.bundle",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/4.2/ZendeskSDKStrings.bundle",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0/ZendeskSDKStrings.bundle",
 				"${PODS_CONFIGURATION_BUILD_DIR}/HockeySDK/HockeySDKResources.bundle",
 			);
 			name = "[CP] Copy Pods Resources";
@@ -11528,12 +11524,7 @@
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = PZYM8XX95Q;
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/Classes\"",
-					"$(SRCROOT)",
-					"$(PROJECT_DIR)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
@@ -11599,12 +11590,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/Classes\"",
-					"$(SRCROOT)",
-					"$(PROJECT_DIR)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -12448,12 +12434,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/Classes\"",
-					"$(SRCROOT)",
-					"$(PROJECT_DIR)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -12928,12 +12909,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEFINES_MODULE = YES;
 				ENABLE_BITCODE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/Classes\"",
-					"$(SRCROOT)",
-					"$(PROJECT_DIR)",
-				);
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/OCLint.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/OCLint.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Alpha.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Alpha.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Internal.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Internal.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressScreenshotGeneration.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressScreenshotGeneration.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressShareExtension.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressShareExtension.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressTodayWidget.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressTodayWidget.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -533,7 +533,7 @@ fileprivate extension AppExtensionsService {
         }
     }
 
-    fileprivate func mediaService(siteID: Int, api: WordPressComRestApi) -> MediaServiceRemoteREST {
+    func mediaService(siteID: Int, api: WordPressComRestApi) -> MediaServiceRemoteREST {
         return MediaServiceRemoteREST(wordPressComRestApi: api, siteID: NSNumber(value: siteID))
     }
 }

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -773,7 +773,7 @@ fileprivate extension ShareModularViewController {
         }
     }
 
-    fileprivate func prepareForPublishing() {
+    func prepareForPublishing() {
         // We are preemptively logging the Tracks posted event here because if handled in a completion handler,
         // there is a good chance iOS will invalidate that network call and the event is never received server-side.
         // See https://github.com/wordpress-mobile/WordPress-iOS/issues/9789 for more details.

--- a/WordPress/WordPressShareExtension/ShareSegueHandler.swift
+++ b/WordPress/WordPressShareExtension/ShareSegueHandler.swift
@@ -6,7 +6,7 @@ protocol ShareSegueHandler {
 }
 
 extension ShareSegueHandler where Self: ShareExtensionAbstractViewController {
-    func performSegue(withIdentifier identifier: SegueIdentifier, sender: AnyObject?) {
+    func performSegue(withIdentifier identifier: ShareExtensionAbstractViewController.SegueIdentifier, sender: AnyObject?) {
         performSegue(withIdentifier: identifier.rawValue, sender: sender)
     }
 }

--- a/WordPress/WordPressShareExtension/ShareTagsPickerViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareTagsPickerViewController.swift
@@ -353,7 +353,7 @@ fileprivate extension ShareTagsPickerViewController {
         presentationController.resetViewUsingKeyboardFrame(keyboardFrame)
     }
 
-    fileprivate func reloadTableData() {
+    func reloadTableData() {
         tableView.reloadData()
         textViewContainer.layer.shadowOpacity = tableView.isEmpty ? 0 : 0.5
     }

--- a/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
+++ b/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
@@ -220,7 +220,7 @@ class MediaProgressCoordinatorTests: XCTestCase {
         XCTAssertTrue(mediaProgressCoordinator.mediaGlobalProgress!.totalUnitCount == Int64(1), "There should 1 item")
 
         let progress = Progress.discreteProgress(totalUnitCount: 1)
-        mediaProgressCoordinator.track(progress: progress, of: makeTestMedia(), withIdentifier: "\(index)")
+        mediaProgressCoordinator.track(progress: progress, of: makeTestMedia(), withIdentifier: "\(String(describing: index))")
 
         XCTAssertTrue(mediaProgressCoordinator.isRunning)
 

--- a/WordPressComStatsiOS/WordPressComStatsiOS.xcodeproj/project.pbxproj
+++ b/WordPressComStatsiOS/WordPressComStatsiOS.xcodeproj/project.pbxproj
@@ -1477,7 +1477,7 @@
 		931CFFBF1EBCB016005E6BB4 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1020;
 				ORGANIZATIONNAME = "Automattic Inc.";
 				TargetAttributes = {
 					931CFFC71EBCB016005E6BB4 = {
@@ -1494,10 +1494,11 @@
 			};
 			buildConfigurationList = 931CFFC21EBCB016005E6BB4 /* Build configuration list for PBXProject "WordPressComStatsiOS" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 931CFFBE1EBCB016005E6BB4;
 			productRefGroup = 931CFFC91EBCB016005E6BB4 /* Products */;
@@ -1998,6 +1999,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -2059,6 +2061,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -2191,6 +2194,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -2284,6 +2288,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";

--- a/WordPressComStatsiOS/WordPressComStatsiOS.xcodeproj/xcshareddata/xcschemes/WordPressComStatsiOS.xcscheme
+++ b/WordPressComStatsiOS/WordPressComStatsiOS.xcodeproj/xcshareddata/xcschemes/WordPressComStatsiOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPressFlux/WordPressFlux.xcodeproj/project.pbxproj
+++ b/WordPressFlux/WordPressFlux.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = E12F96DF1FBC67AC00329E2E;
 			productRefGroup = E12F96EA1FBC67AC00329E2E /* Products */;

--- a/WordPressFlux/WordPressFlux.xcodeproj/xcshareddata/xcschemes/WordPressFlux.xcscheme
+++ b/WordPressFlux/WordPressFlux.xcodeproj/xcshareddata/xcschemes/WordPressFlux.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/WordPressFlux/WordPressFlux/Sources/Dispatcher.swift
+++ b/WordPressFlux/WordPressFlux/Sources/Dispatcher.swift
@@ -3,8 +3,8 @@
 public struct DispatchToken: Hashable, Equatable {
     private let uuid = UUID()
 
-    public var hashValue: Int {
-        return uuid.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(uuid)
     }
 
     public static func ==(lhs: DispatchToken, rhs: DispatchToken) -> Bool {


### PR DESCRIPTION
This fixes compatibility with Xcode 10.2 by updating Aztec, updating Zendesk and fixing the new Xcode warnings/errors.

Related pull requests and issues:

- CocoaPods update: https://github.com/wordpress-mobile/WordPress-iOS/pull/11442.
- WordPressAutenticator: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/67, https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/68, https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/70
- WordPressKit: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/140
- Aztec: https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1167
- CircleCI Orb: https://github.com/wordpress-mobile/circleci-orbs/pull/21
- Zendesk SDK: https://github.com/zendesk/zendesk_sdk_ios/issues/480.
- WooCommerce: https://github.com/woocommerce/woocommerce-ios/pull/868

Still to do:

- [x] Fix remaining warnings and errors (there still Zendesk deprecations that I have not touched).
- [x] Fix crash on launch (`objc[8731]: Swift class extensions and categories on Swift classes are not allowed to have +load methods`). This is caused by https://github.com/facebook/react-native/issues/24139. To fix we will need to upgrade to RN 0.59.3.
- [x] Use release or beta versions of WordPressKit and WordPressAutenticator.
- [x] Fix the crashes caused by building Aztec on Xcode 10.2 (done in https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1167).

**Note:** Due to the Zendesk SDK update this breaks compatibility with Xcode 10.1. We should merge this very carefully with plenty of notice.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
