### PR TITLE
Site Creation: Always add a space for the checkmark when selecting domains

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
@@ -2,16 +2,38 @@ import UIKit
 import WordPressKit
 
 final class AddressCell: UITableViewCell, ModelSettableCell {
-    @IBOutlet weak var title: UILabel!
+    /// A manually computed width of the accessory view (checkmark) when it is shown.
+    private static let checkmarkAccessoryViewWidth: CGFloat = 39
 
     private struct TextStyleAttributes {
         static let defaults: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular), .foregroundColor: WPStyleGuide.grey()]
         static let customName: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular), .foregroundColor: WPStyleGuide.darkGrey()]
     }
 
+    /// Used for recomputing the trailing constraint constant of `title`.
+    private var originalTitleTrailingConstraintConstant: CGFloat!
+
+    @IBOutlet weak var title: UILabel!
+    @IBOutlet weak var titleTrailingConstraint: NSLayoutConstraint! {
+        didSet {
+            originalTitleTrailingConstraintConstant = titleTrailingConstraint.constant
+        }
+    }
+
     var model: DomainSuggestion? {
         didSet {
             title.attributedText = processName(model?.domainName)
+        }
+    }
+
+    override var accessoryType: UITableViewCell.AccessoryType {
+        didSet {
+            // Recompute the constraint of the title to always have an empty space for the
+            // checkmark even if it is not shown.
+            let isChecked = accessoryType == .checkmark
+
+            titleTrailingConstraint.constant = originalTitleTrailingConstraintConstant
+                + (isChecked ? 0 : AddressCell.checkmarkAccessoryViewWidth)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.xib
@@ -39,6 +39,7 @@
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="title" destination="hQm-TV-IDW" id="B0v-92-6ti"/>
+                <outlet property="titleTrailingConstraint" destination="pJe-WK-HF0" id="2gJ-Uy-POc"/>
             </connections>
             <point key="canvasLocation" x="137.59999999999999" y="130.43478260869566"/>
         </tableViewCell>


### PR DESCRIPTION
Fixes #11369 

## Findings

The current behavior is the default behavior of iOS. The cell's `contentView` will always be resized when the checkmark is shown. 

![2019-04-01 14-11-48 2019-04-01 14_13_57](https://user-images.githubusercontent.com/198826/55356724-a5798200-5488-11e9-9e3b-a3e391bd8a13.gif)

## Solution 

This PR adds custom width calculation for the label's trailing constraint so that it will add or subtract the width of the checkmark when the checkmark is hidden or shown. 

| |  |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/198826/55357295-e7ef8e80-5489-11e9-8ff8-8897445d3d57.gif) |  ![2019-04-01 14-32-02 2019-04-01 14_32_59](https://user-images.githubusercontent.com/198826/55357827-3baea780-548b-11e9-9281-76601eb75d8b.gif)  |

### Concerns

My problem with this solution is the hardcoded `39` value for the checkmark width. This was manually taken from Xcode's UI debugger. I could not find a way to preemptively acquire this value during runtime. 

The hardcoded value does not seem to be a problem even if the device is using a large font size. 

## Testing 

From #11369:

1. Go to the list of sites.
2. Tap + and add a new WP.com site.
3. In step 3 of the Site Creation flow, enter a really long domain name.
4. Check the list of suggestions.

## Out of Scope

If the domain is initially long, the first render of the domains list shows cells that do not span multiple lines. We can fix that in a separate PR. 