### PR TITLE
Fix Notices not being actionable after taking a photo

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -421,6 +421,7 @@ private extension NoticePresenter {
 
             super.init(frame: MaskView.calculateFrame(parent: parent, untouchableVC: untouchableViewController))
 
+            isUserInteractionEnabled = false
             translatesAutoresizingMaskIntoConstraints = false
             backgroundColor = .blue
 


### PR DESCRIPTION
Fixes #11391. 

## Findings

This was caused by the changes in #11319. It does not happen on WPiOS 12.0.

It looks like after the camera is dismissed, the mask (`MaskView`) can be interacted with. As @SergioEstevao found, it is also put in front of the `NoticeView`. I did not expect this because the mask shouldn't be part of the view hierarchy.

Aside from the mask preventing interaction with the `NoticeView`, it also prevents users from interacting with the view _behind_ it. This means that when Notices are shown, users cannot scroll around the Media Library or press any button. 

## Solution 

I opted to disable the user interaction for the `MaskView` when it is initialized. In retrospect, I wonder if I could have used a `CALayer` when I worked on #11319. 

## Testing 

Copied from #11391: 

1. Using a real device
2. Go to the Media Library on a Site
3. Tap on + on the top right
4. Select Take Photo or Video
5. Capture a Image
6. Add the image
7. After the image is uploaded a notification should show saying Image Uploaded - Write Post
8. Try to tap on Write Post.
9. Nothing happens
