### PR TITLE
Site Creation: Make label taps focus their corresponding text fields

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -37,6 +37,7 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
         nameLabel.textColor = Const.Color.nameText
         nameLabel.font = WPStyleGuide.tableviewTextFont()
         nameLabel.numberOfLines = 0
+        nameLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(setValueTextFieldAsFirstResponder(_:))))
 
         valueTextField.textColor = Const.Color.valueText
         valueTextField.font = WPStyleGuide.tableviewTextFont()
@@ -62,6 +63,10 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
 
     @objc func textEditingDidEnd(textField: UITextField) {
         delegate?.inlineEditableNameValueCell?(self, valueTextFieldEditingDidEnd: textField)
+    }
+
+    @objc func setValueTextFieldAsFirstResponder(_ gesture: UITapGestureRecognizer) {
+        valueTextField.becomeFirstResponder()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -33,9 +33,11 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
     override func awakeFromNib() {
         super.awakeFromNib()
         selectionStyle = .none
+
         nameLabel.textColor = Const.Color.nameText
         nameLabel.font = WPStyleGuide.tableviewTextFont()
         nameLabel.numberOfLines = 0
+
         valueTextField.textColor = Const.Color.valueText
         valueTextField.font = WPStyleGuide.tableviewTextFont()
         valueTextField.borderStyle = .none
@@ -43,8 +45,6 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
                                  for: UIControl.Event.editingChanged)
         valueTextField.addTarget(self, action: #selector(textEditingDidEnd(textField:)),
                                  for: UIControl.Event.editingDidEnd)
-
-        accessoryType = .none
         if effectiveUserInterfaceLayoutDirection == .leftToRight {
             // swiftlint:disable:next inverse_text_alignment
             valueTextField.textAlignment = .right
@@ -52,6 +52,8 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
             // swiftlint:disable:next natural_text_alignment
             valueTextField.textAlignment = .left
         }
+
+        accessoryType = .none
     }
 
     @objc func textFieldDidChange(textField: UITextField) {

--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.xib
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.xib
@@ -19,7 +19,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="363" height="45.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JYy-XU-9v8">
+                    <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JYy-XU-9v8">
                         <rect key="frame" x="16" y="11" width="42" height="24"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>


### PR DESCRIPTION
Fixes #11356 

<img src="https://user-images.githubusercontent.com/198826/55425987-f482ee00-5540-11e9-8284-40f7278e43b1.gif" width="320"/>

## Testing 

Copied from #11356: 

1. Go to the list of sites.
2. Tap + and create a new WP.com site.
3. As you move forward in the process of creating a new site, try tapping in the title of cells that have an editable field.
