### PR TITLE
Add defensive check for crash in plugins

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListViewController.swift
@@ -95,8 +95,12 @@ class PluginListViewController: UITableViewController, ImmuTablePresenter {
         case .replace:
             tableView.reloadData()
         case .selective(let changedRows):
-            let indexPaths = changedRows.map({ IndexPath(row: $0, section: 0) })
-            tableView.reloadRows(at: indexPaths, with: .none)
+            if tableView.numberOfRows(inSection: 0) == changedRows.count {
+                let indexPaths = changedRows.map { IndexPath(row: $0, section: 0) }
+                tableView.reloadRows(at: indexPaths, with: .none)
+            } else {
+                tableView.reloadData()
+            }
         }
         setupRefreshControl()
         updateNoResults()


### PR DESCRIPTION
Fixes #11386

To test:
I couldn't make the crash reproduce, so this is a best-effort guess for a fix/workaround. Hopefully we'll see less crashers for this after this is released!

