### PR TITLE
SiteCreation: Fix AddressCell height on first load

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
@@ -2,38 +2,16 @@ import UIKit
 import WordPressKit
 
 final class AddressCell: UITableViewCell, ModelSettableCell {
-    /// A manually computed width of the accessory view (checkmark) when it is shown.
-    private static let checkmarkAccessoryViewWidth: CGFloat = 39
-
     private struct TextStyleAttributes {
         static let defaults: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular), .foregroundColor: WPStyleGuide.grey()]
         static let customName: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular), .foregroundColor: WPStyleGuide.darkGrey()]
     }
 
-    /// Used for recomputing the trailing constraint constant of `title`.
-    private var originalTitleTrailingConstraintConstant: CGFloat!
-
     @IBOutlet weak var title: UILabel!
-    @IBOutlet weak var titleTrailingConstraint: NSLayoutConstraint! {
-        didSet {
-            originalTitleTrailingConstraintConstant = titleTrailingConstraint.constant
-        }
-    }
 
     var model: DomainSuggestion? {
         didSet {
             title.attributedText = processName(model?.domainName)
-        }
-    }
-
-    override var accessoryType: UITableViewCell.AccessoryType {
-        didSet {
-            // Recompute the constraint of the title to always have an empty space for the
-            // checkmark even if it is not shown.
-            let isChecked = accessoryType == .checkmark
-
-            titleTrailingConstraint.constant = originalTitleTrailingConstraintConstant
-                + (isChecked ? 0 : AddressCell.checkmarkAccessoryViewWidth)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.xib
@@ -20,7 +20,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hQm-TV-IDW">
-                        <rect key="frame" x="16" y="12" width="288" height="20"/>
+                        <rect key="frame" x="16" y="12" width="249" height="20"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -34,12 +34,11 @@
             <constraints>
                 <constraint firstItem="hQm-TV-IDW" firstAttribute="leading" secondItem="njF-e1-oar" secondAttribute="leading" constant="16" id="QB9-fd-Zsn"/>
                 <constraint firstItem="hQm-TV-IDW" firstAttribute="centerY" secondItem="njF-e1-oar" secondAttribute="centerY" id="eud-Yr-hp5"/>
-                <constraint firstItem="H2p-sc-9uM" firstAttribute="trailing" secondItem="hQm-TV-IDW" secondAttribute="trailing" constant="16" id="pJe-WK-HF0"/>
+                <constraint firstItem="njF-e1-oar" firstAttribute="trailing" secondItem="hQm-TV-IDW" secondAttribute="trailing" constant="55" id="pJe-WK-HF0"/>
             </constraints>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="title" destination="hQm-TV-IDW" id="B0v-92-6ti"/>
-                <outlet property="titleTrailingConstraint" destination="pJe-WK-HF0" id="2gJ-Uy-POc"/>
             </connections>
             <point key="canvasLocation" x="137.59999999999999" y="130.43478260869566"/>
         </tableViewCell>


### PR DESCRIPTION
Fixes #11396.

After some tests, I found that this started happening in 4e6049a. That is a legitimate fix for the checkbox hovering over the labels. However it seems to be causing some issues on the self-sizing `AddressCell`. The issue only happens on the first table reload. This reverts the change on that.

To fix the checkbox hovering over the labels, I reverted the change in 6c84f94 and opted to increase the trailing constraint constant of the title label to accommodate the checkbox. This now works because the trailing constraint is tied to the Safe Area instead of the cell's Content View.

| Before | After |
|--------|-------|
|![2019-04-04 06 24 53 2019-04-04 06_32_47](https://user-images.githubusercontent.com/198826/55555908-8b67bb80-56a3-11e9-9d2d-8cda699466e3.gif) |  ![2019-04-04 06 27 15 2019-04-04 06_34_11](https://user-images.githubusercontent.com/198826/55555979-af2b0180-56a3-11e9-901c-611582bfc947.gif) |

## Testing

1. Go to the list of sites.
2. Tap + and add a new WP.com site.
3. In Basic Information, enter a very long Site Title.
4. Press Next. Confirm the domain names are not truncated.

Please also do some regression testing: 

- Going back to the previous page and changing the domain name
- Searching for a domain name
- Making sure #11385 still works
