### PR TITLE
Site Creation: Change example.wordpress.com to example.com in the placeholder URL

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 * Draft preview now shows the remote version of the post.
 * Initial support for importing TextBundle and TextPack from other apps.
 * Support for lists in Gutenberg posts.
-
+* Change example.wordpress.com to example.com in the placeholder URL when adding a self-hosted site
 12.1
 -----
 * Improve messages when updates to user account details fail because of server logic, for exanple email being used for another account.

--- a/WordPress/WordPressTest/ModelTestHelper.swift
+++ b/WordPress/WordPressTest/ModelTestHelper.swift
@@ -13,8 +13,8 @@ class ModelTestHelper: NSObject {
     @objc
     class func insertDotComBlog(context: NSManagedObjectContext) -> Blog {
         let blog = Blog.init(context: context)
-        blog.url = "https://example.wordpress.com/"
-        blog.xmlrpc = "https://example.wordpress.com/xmlrpc.php"
+        blog.url = "https://example.com/"
+        blog.xmlrpc = "https://example.com/xmlrpc.php"
         blog.account = insertAccount(context: context)
         return blog
     }


### PR DESCRIPTION
deleted wordpress out of example URL

Fixes #11286

To test:

Update release notes:

- [ X ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
