### PR TITLE
[Jetpack Remote Install] Remove warnings and unnecessary code

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/Data/JetpackRemoteInstallViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/Data/JetpackRemoteInstallViewModel.swift
@@ -13,23 +13,3 @@ class JetpackRemoteInstallViewModel {
         state = .install
     }
 }
-
-#warning("This is for manual testing purpose only. Remove after this PR is merged.")
-extension JetpackRemoteInstallViewModel {
-    func testState(_ index: Int) {
-        switch index {
-        case 0:
-            state = .install
-        case 1:
-            state = .installing
-        case 2:
-            state = .success
-        case 3:
-            state = .failure(.unknown)
-        case 4:
-            state = .failure(.forbidden)
-        default:
-            break
-        }
-    }
-}

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
@@ -14,9 +14,6 @@ class JetpackRemoteInstallViewController: UIViewController {
     private let jetpackView = JetpackRemoteInstallView()
     private let viewModel: JetpackRemoteInstallViewModel
 
-    #warning("This is for manual testing purpose only. Remove after this PR is merged.")
-    @IBOutlet private var segmented: UISegmentedControl!
-
     init(blog: Blog, delegate: JetpackRemoteInstallDelegate?, promptType: JetpackLoginPromptType) {
         self.blog = blog
         self.delegate = delegate
@@ -58,11 +55,9 @@ private extension JetpackRemoteInstallViewController {
 
         jetpackView.delegate = self
         add(jetpackView)
+        jetpackView.view.frame = view.bounds
 
         jetpackView.toggleHidingImageView(for: traitCollection)
-
-        #warning("This is for manual testing purpose only. Remove after this PR is merged.")
-        view.bringSubviewToFront(segmented)
 
         viewModel.viewReady()
     }
@@ -113,12 +108,5 @@ extension JetpackRemoteInstallViewController: JetpackRemoteInstallViewDelegate {
 
     func customerSupportButtonDidTouch() {
         navigationController?.pushViewController(SupportTableViewController(), animated: true)
-    }
-}
-
-#warning("This is for manual testing purpose only")
-private extension JetpackRemoteInstallViewController {
-    @IBAction func stateChange(_ sender: UISegmentedControl) {
-        viewModel.testState(sender.selectedSegmentIndex)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.xib
@@ -12,7 +12,6 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="JetpackRemoteInstallViewController" customModule="WordPress" customModuleProvider="target">
             <connections>
-                <outlet property="segmented" destination="q47-qd-WE3" id="RpJ-cg-wI0"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
@@ -20,27 +19,7 @@
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
             <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-            <subviews>
-                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" apportionsSegmentWidthsByContent="YES" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="q47-qd-WE3">
-                    <rect key="frame" x="10" y="629" width="355" height="29"/>
-                    <segments>
-                        <segment title="Install"/>
-                        <segment title="Installations"/>
-                        <segment title="Success"/>
-                        <segment title="Failure"/>
-                        <segment title="Fallback"/>
-                    </segments>
-                    <connections>
-                        <action selector="stateChange:" destination="-1" eventType="valueChanged" id="fpz-v8-gTI"/>
-                    </connections>
-                </segmentedControl>
-            </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-            <constraints>
-                <constraint firstItem="q47-qd-WE3" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="6Uv-3O-dne"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="q47-qd-WE3" secondAttribute="bottom" constant="10" id="Zs5-J6-7qf"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="q47-qd-WE3" secondAttribute="trailing" constant="10" id="g02-x5-8z4"/>
-            </constraints>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
         </view>
     </objects>


### PR DESCRIPTION
Refs. #10277 

This PR remove the warnings used to mark some functions and vars used to manually test #11405 .
The warning had this message: `This is for manual testing purpose only. Remove after this PR is merged.`


**To test:**
- Build the app to check if all the 4 warnings have been deleted.