### PR TITLE
Update WebKitViewController to show notice When offline instead of showing alert

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
   - FormatterKit/TimeIntervalFormatter (1.8.2):
     - FormatterKit/Resources
   - Gifu (3.2.0)
-  - GiphyCoreSDK (1.4.1)
+  - GiphyCoreSDK (1.4.2)
   - glog (0.3.4)
   - GoogleSignIn (4.1.2):
     - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
@@ -376,7 +376,7 @@ SPEC CHECKSUMS:
   Folly: de497beb10f102453a1afa9edbf8cf8a251890de
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   Gifu: 7bcb6427457d85e0b4dff5a84ec5947ac19a93ea
-  GiphyCoreSDK: 147a492c2477e9ddb20f8dd3a4489e3ea3c05e38
+  GiphyCoreSDK: 1a89e03e55dc6b636b9d40fde76107867dbb9da5
   glog: 1de0bb937dccdc981596d3b5825ebfb765017ded
   GoogleSignIn: d9ef55b10f0aa401a5de2747f59b725e4b9732ac
   GoogleToolboxForMac: ff31605b7d66400dcec09bed5861689aebadda4d

--- a/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
+++ b/WordPress/Classes/Utility/ReachabilityUtils+OnlineActions.swift
@@ -43,14 +43,14 @@ extension ReachabilityUtils {
     ///
     /// We use a Snackbar instead of a literal Alert because, for internet connection errors,
     /// Alerts can be disruptive.
-    static func showNoInternetConnectionNotice(message: String) {
+    @objc static func showNoInternetConnectionNotice(message: String = noConnectionMessage()) {
         // An empty title is intentional to only show a single regular font message.
         let notice = Notice(title: "", message: message, tag: DefaultNoConnectionMessage.tag)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
     /// Dismiss the currently shown Notice if it was created using showNoInternetConnectionNotice()
-    static func dismissNoInternetConnectionNotice() {
+    @objc static func dismissNoInternetConnectionNotice() {
         ActionDispatcher.dispatch(NoticeAction.clearWithTag(DefaultNoConnectionMessage.tag))
     }
 }

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -318,6 +318,7 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
 
 - (IBAction)dismiss
 {
+    [ReachabilityUtils dismissNoInternetConnectionNotice];
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
@@ -440,7 +441,7 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
 - (void)displayLoadError:(NSError *)error
 {
     if (![ReachabilityUtils isInternetReachable]) {
-        [ReachabilityUtils showAlertNoInternetConnection];
+        [ReachabilityUtils showNoInternetConnectionNoticeWithMessage: ReachabilityUtils.noConnectionMessage];
         [self reloadWhenConnectionRestored];
     } else {
         [WPError showAlertWithTitle: NSLocalizedString(@"Error", @"Generic error alert title") message: error.localizedDescription];

--- a/WordPress/Classes/Utility/WPWebViewController.m
+++ b/WordPress/Classes/Utility/WPWebViewController.m
@@ -140,6 +140,12 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
     }
 }
 
+-(void)viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+    [ReachabilityUtils dismissNoInternetConnectionNotice];
+}
+
 - (void)applyModalStyleIfNeeded
 {
     // Proceed only if this Modal, and it's the only view in the stack.
@@ -318,7 +324,6 @@ static NSInteger const WPWebViewErrorPluginHandledLoad = 204;
 
 - (IBAction)dismiss
 {
-    [ReachabilityUtils dismissNoInternetConnectionNotice];
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -120,6 +120,7 @@ class WebKitViewController: UIViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         stopWaitingForConnectionRestored()
+        ReachabilityUtils.dismissNoInternetConnectionNotice()
     }
 
     @objc func loadWebViewRequest() {
@@ -412,7 +413,7 @@ extension WebKitViewController: WKUIDelegate {
         }
 
         if !ReachabilityUtils.isInternetReachable() {
-            ReachabilityUtils.showAlertNoInternetConnection()
+            ReachabilityUtils.showNoInternetConnectionNotice(message: ReachabilityUtils.noConnectionMessage())
             reloadWhenConnectionRestored()
         } else {
             WPError.showAlert(withTitle: NSLocalizedString("Error", comment: "Generic error alert title"), message: error.localizedDescription)

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -413,7 +413,7 @@ extension WebKitViewController: WKUIDelegate {
         }
 
         if !ReachabilityUtils.isInternetReachable() {
-            ReachabilityUtils.showNoInternetConnectionNotice(message: ReachabilityUtils.noConnectionMessage())
+            ReachabilityUtils.showNoInternetConnectionNotice()
             reloadWhenConnectionRestored()
         } else {
             WPError.showAlert(withTitle: NSLocalizedString("Error", comment: "Generic error alert title"), message: error.localizedDescription)


### PR DESCRIPTION
This is only for os 11.0 as we are showing WebKitViewController for os > 11.0 but for lesser versions we show WPWebViewController that doesn't seem to be able to adopt the new notice (as it is a struct WPWebViewController is obj-c)

Fixes #11313 

To test:
1. Be offline
2. Go to "View Site"
3. See snack bar (if os > 11.0)

![Simulator Screen Shot - iPhone 8 - 2019-04-09 at 19 53 58](https://user-images.githubusercontent.com/1335657/55848407-a69e5500-5b01-11e9-914b-df2388d54c50.png)

* Unfortunately my device has updated to 12.2 and I am currently unable to test this on the device (still no support for xcode 10.2) so this is only tested in simulator  

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
