### PR TITLE
Fix my_site_tab_accessed tracking

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -21,13 +21,22 @@ extension WPTabBarController {
 
     /// Count the current tab as "accessed" in analytics.
     ///
-    /// We want to call this on:
+    /// We want to call this when:
     ///
     /// - The app has been placed in the foreground
     /// - The app was just launched and we restored the previously selected tab
     ///   (in `decodeRestorableStateWithCoder`)
     /// - The user selected a different tab
     @objc func trackAccessStatForTabIndex(_ tabIndex: Int) {
+        // Since this ViewController is a singleton, it can be active **behind** the login view.
+        // The `isViewonScreen()` prevents us from tracking this.
+        //
+        // The `presentedViewController` check is to avoid tracking while a modal dialog is shown
+        // and the app is placed in the background and back to foreground.
+        guard isViewOnScreen(), presentedViewController == nil else {
+            return
+        }
+
         guard let tabType = WPTabType(rawValue: UInt(tabIndex)),
             let stat = WPTabBarController.tabIndexToStatMap[tabType] else {
                 return

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -8,7 +8,7 @@ extension WPTabBarController {
         .me: .meTabAccessed
     ]
 
-    @objc func startObserversForTracking() {
+    @objc func startObserversForTabAccessStatTracking() {
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(trackAccessStatForCurrentlySelectedTab),
                                                name: UIApplication.willEnterForegroundNotification,

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -10,15 +10,23 @@ extension WPTabBarController {
 
     @objc func startObserversForTracking() {
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(trackEventsForAppForeground(_:)),
+                                               selector: #selector(trackAccessStatForCurrentlySelectedTabIndex),
                                                name: UIApplication.willEnterForegroundNotification,
                                                object: nil)
     }
 
-    @objc func trackEventsForAppForeground(_ notification: Notification) {
+    /// Count the current `selectedIndex` as "accessed" in analytics.
+    ///
+    /// We want to call this on:
+    ///
+    /// - The app has been placed in the foreground
+    /// - The app was just launched and we restored the previously selected tab
+    ///   (in `decodeRestorableStateWithCoder`)
+    /// - The user selected a different tab
+    @objc func trackAccessStatForCurrentlySelectedTabIndex() {
         guard let tabType = WPTabType(rawValue: UInt(selectedIndex)),
             let stat = WPTabBarController.tabIndexToStatMap[tabType] else {
-            return
+                return
         }
 
         WPAppAnalytics.track(stat)

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -1,0 +1,26 @@
+
+// MARK: - Tracking
+
+extension WPTabBarController {
+    private static let tabIndexToStatMap: [WPTabType: WPAnalyticsStat] = [
+        .mySites: .mySitesTabAccessed,
+        .reader: .readerAccessed,
+        .me: .meTabAccessed
+    ]
+
+    @objc func startObserversForTracking() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(trackEventsForAppForeground(_:)),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil)
+    }
+
+    @objc func trackEventsForAppForeground(_ notification: Notification) {
+        guard let tabType = WPTabType(rawValue: UInt(selectedIndex)),
+            let stat = WPTabBarController.tabIndexToStatMap[tabType] else {
+            return
+        }
+
+        WPAppAnalytics.track(stat)
+    }
+}

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -10,12 +10,16 @@ extension WPTabBarController {
 
     @objc func startObserversForTracking() {
         NotificationCenter.default.addObserver(self,
-                                               selector: #selector(trackAccessStatForCurrentlySelectedTabIndex),
+                                               selector: #selector(trackAccessStatForCurrentlySelectedTab),
                                                name: UIApplication.willEnterForegroundNotification,
                                                object: nil)
     }
 
-    /// Count the current `selectedIndex` as "accessed" in analytics.
+    @objc func trackAccessStatForCurrentlySelectedTab() {
+        trackAccessStatForTabIndex(selectedIndex)
+    }
+
+    /// Count the current tab as "accessed" in analytics.
     ///
     /// We want to call this on:
     ///
@@ -23,8 +27,8 @@ extension WPTabBarController {
     /// - The app was just launched and we restored the previously selected tab
     ///   (in `decodeRestorableStateWithCoder`)
     /// - The user selected a different tab
-    @objc func trackAccessStatForCurrentlySelectedTabIndex() {
-        guard let tabType = WPTabType(rawValue: UInt(selectedIndex)),
+    @objc func trackAccessStatForTabIndex(_ tabIndex: Int) {
+        guard let tabType = WPTabType(rawValue: UInt(tabIndex)),
             let stat = WPTabBarController.tabIndexToStatMap[tabType] else {
                 return
         }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -20,14 +20,30 @@ extension WPTabBarController {
     }
 
     @objc func startObserversForTabAccessStatTracking() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(trackAccessStatForCurrentlySelectedTabOnEnterForeground),
-                                               name: UIApplication.willEnterForegroundNotification,
-                                               object: nil)
+        let nc = NotificationCenter.default
+        nc.addObserver(self,
+                       selector: #selector(trackAccessStatForCurrentlySelectedTabOnEnterForeground),
+                       name: UIApplication.willEnterForegroundNotification,
+                       object: nil)
+        nc.addObserver(self,
+                       selector: #selector(resetViewDidAppearTrackingFlagAfterWPComAccountChange(_:)),
+                       name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged,
+                       object: nil)
     }
 
     @objc func trackAccessStatForCurrentlySelectedTabOnEnterForeground() {
         trackAccessStatForTabIndex(selectedIndex)
+    }
+
+    /// Reset `hasTrackedTabAccessOnViewDidAppear` if the user has logged out.
+    ///
+    /// This allows us to track tab access on `-viewDidLoad` when the user logs back in again.
+    @objc func resetViewDidAppearTrackingFlagAfterWPComAccountChange(_ notification: NSNotification) {
+        guard notification.object == nil else {
+            return
+        }
+
+        hasTrackedTabAccessOnViewDidAppear = false
     }
 
     /// Track tab access on viewDidAppear but only once.

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -21,12 +21,13 @@ extension WPTabBarController {
 
     /// Count the current tab as "accessed" in analytics.
     ///
-    /// We want to call this when:
+    /// We want to call this when the user is logged in and:
     ///
     /// - The app has been placed in the foreground
     /// - The app was just launched and we restored the previously selected tab
     ///   (in `decodeRestorableStateWithCoder`)
     /// - The user selected a different tab
+    /// - After logging in (and this VC is shown)
     @objc func trackAccessStatForTabIndex(_ tabIndex: Int) {
         // Since this ViewController is a singleton, it can be active **behind** the login view.
         // The `isViewonScreen()` prevents us from tracking this.

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -181,8 +181,9 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (void)decodeRestorableStateWithCoder:(NSCoder *)coder
 {
     self.selectedIndex = [coder decodeIntegerForKey:WPTabBarSelectedIndexKey];
-    [self trackAccessStatForCurrentlySelectedTabIndex];
     [super decodeRestorableStateWithCoder:coder];
+
+    [self trackAccessStatForCurrentlySelectedTab];
 }
 
 #pragma mark - Tab Bar Items
@@ -815,22 +816,17 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     if (newIndex != tabBarController.selectedIndex) {
         switch (newIndex) {
             case WPTabMySites: {
-                [WPAppAnalytics track:WPAnalyticsStatMySitesTabAccessed];
                 [self bypassBlogListViewControllerIfNecessary];
                 break;
             }
             case WPTabReader: {
-                [WPAppAnalytics track:WPAnalyticsStatReaderAccessed];
                 [self alertQuickStartThatReaderWasTapped];
-                break;
-            }
-            case WPTabMe: {
-                [WPAppAnalytics track:WPAnalyticsStatMeTabAccessed];
                 break;
             }
             default: break;
         }
 
+        [self trackAccessStatForTabIndex:newIndex];
         [self alertQuickStartThatOtherTabWasTapped];
     } else {
         // If the current view controller is selected already and it's at its root then scroll to the top

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -182,8 +182,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 {
     self.selectedIndex = [coder decodeIntegerForKey:WPTabBarSelectedIndexKey];
     [super decodeRestorableStateWithCoder:coder];
-
-    [self trackAccessStatForCurrentlySelectedTab];
 }
 
 #pragma mark - Tab Bar Items
@@ -980,6 +978,12 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     [super viewDidAppear:animated];
     [self updateNotificationBadgeVisibility];
     [self startWatchingQuickTours];
+
+    // Since this ViewController is a singleton, we expect -viewDidAppear to only be launched
+    // once in the lifetime of the app. We trigger a "tab access" event here instead of `-init`
+    // and `-decodeRestorableStateWithCoder` to give a chance for the login VC to be shown. If
+    // the login VC is shown, this tracking method will not do anything -- and that's what we want.
+    [self trackAccessStatForCurrentlySelectedTab];
 }
 
 - (void)viewDidLayoutSubviews

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -824,7 +824,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
             default: break;
         }
 
-        [self trackAccessStatForTabIndex:newIndex];
+        [self trackTabAccessForTabIndex:newIndex];
         [self alertQuickStartThatOtherTabWasTapped];
     } else {
         // If the current view controller is selected already and it's at its root then scroll to the top
@@ -970,7 +970,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    [self startObserversForTabAccessStatTracking];
+    [self startObserversForTabAccessTracking];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -979,7 +979,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     [self updateNotificationBadgeVisibility];
     [self startWatchingQuickTours];
 
-    [self trackAccessStatForCurrentlySelectedTabOnViewDidAppear];
+    [self trackTabAccessOnViewDidAppear];
 }
 
 - (void)viewDidLayoutSubviews

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -181,6 +181,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 - (void)decodeRestorableStateWithCoder:(NSCoder *)coder
 {
     self.selectedIndex = [coder decodeIntegerForKey:WPTabBarSelectedIndexKey];
+    [self trackAccessStatForCurrentlySelectedTabIndex];
     [super decodeRestorableStateWithCoder:coder];
 }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -979,11 +979,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     [self updateNotificationBadgeVisibility];
     [self startWatchingQuickTours];
 
-    // Since this ViewController is a singleton, we expect -viewDidAppear to only be launched
-    // once in the lifetime of the app. We trigger a "tab access" event here instead of `-init`
-    // and `-decodeRestorableStateWithCoder` to give a chance for the login VC to be shown. If
-    // the login VC is shown, this tracking method will not do anything -- and that's what we want.
-    [self trackAccessStatForCurrentlySelectedTab];
+    [self trackAccessStatForCurrentlySelectedTabOnViewDidAppear];
 }
 
 - (void)viewDidLayoutSubviews

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -970,7 +970,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    [self startObserversForTracking];
+    [self startObserversForTabAccessStatTracking];
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -973,6 +973,11 @@ static CGFloat const WPTabBarIconSize = 32.0f;
 
 #pragma mark - Handling Layout
 
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    [self startObserversForTracking];
+}
+
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -170,29 +170,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     [[UIApplication sharedApplication] removeObserver:self forKeyPath:WPApplicationIconBadgeNumberKeyPath];
 }
 
-- (void)setSelectedIndex:(NSUInteger)selectedIndex
-{
-    [super setSelectedIndex:selectedIndex];
-
-    // Bumping the stat in this method works for cases where the selected tab is
-    // set in response to other feature behavior (e.g. a notifications), and
-    // when set via state restoration.
-    switch (selectedIndex) {
-        case WPTabMe:
-            [WPAppAnalytics track:WPAnalyticsStatMeTabAccessed];
-            break;
-        case WPTabMySites:
-            [WPAppAnalytics track:WPAnalyticsStatMySitesTabAccessed];
-            break;
-        case WPTabReader:
-            [WPAppAnalytics track:WPAnalyticsStatReaderAccessed];
-            break;
-
-        default:
-            break;
-    }
-}
-
 #pragma mark - UIViewControllerRestoration methods
 
 - (void)encodeRestorableStateWithCoder:(NSCoder *)coder

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -406,6 +406,7 @@
 		4645AFC51961E1FB005F7509 /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4645AFC41961E1FB005F7509 /* AppImages.xcassets */; };
 		4C8A715EBCE7E73AEE216293 /* Pods_WordPressShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */; };
 		572FB401223A806000933C76 /* NoticeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572FB400223A806000933C76 /* NoticeStoreTests.swift */; };
+		57BAD50C225CCE1A006139EC /* WPTabBarController+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BAD50B225CCE1A006139EC /* WPTabBarController+Swift.swift */; };
 		57D5812D2228526C002BAAD7 /* WPError+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D5812C2228526C002BAAD7 /* WPError+Swift.swift */; };
 		5903AE1B19B60A98009D5354 /* WPButtonForNavigationBar.m in Sources */ = {isa = PBXBuildFile; fileRef = 5903AE1A19B60A98009D5354 /* WPButtonForNavigationBar.m */; };
 		590E873B1CB8205700D1B734 /* PostListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 590E873A1CB8205700D1B734 /* PostListViewController.swift */; };
@@ -2315,6 +2316,7 @@
 		51A5F017948878F7E26979A0 /* Pods-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPress/Pods-WordPress.release.xcconfig"; sourceTree = "<group>"; };
 		556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPress.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		572FB400223A806000933C76 /* NoticeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStoreTests.swift; sourceTree = "<group>"; };
+		57BAD50B225CCE1A006139EC /* WPTabBarController+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPTabBarController+Swift.swift"; sourceTree = "<group>"; };
 		57D5812C2228526C002BAAD7 /* WPError+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPError+Swift.swift"; sourceTree = "<group>"; };
 		5903AE1A19B60A98009D5354 /* WPButtonForNavigationBar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPButtonForNavigationBar.m; sourceTree = "<group>"; usesTabs = 0; };
 		5903AE1C19B60AB9009D5354 /* WPButtonForNavigationBar.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WPButtonForNavigationBar.h; sourceTree = "<group>"; usesTabs = 0; };
@@ -6182,6 +6184,7 @@
 				17A28DC2205001A900EA6D9E /* FilterBar.swift */,
 				D8B9B58E204F4EA1003C6042 /* NetworkAware.swift */,
 				43DDFE8B21715ADD008BE72F /* WPTabBarController+QuickStart.swift */,
+				57BAD50B225CCE1A006139EC /* WPTabBarController+Swift.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -10482,6 +10485,7 @@
 				E14977181C0DC0770057CD60 /* MediaSizeSliderCell.swift in Sources */,
 				7E987F562108017B00CAFB88 /* NotificationContentRouter.swift in Sources */,
 				177076211EA206C000705A4A /* PlayIconView.swift in Sources */,
+				57BAD50C225CCE1A006139EC /* WPTabBarController+Swift.swift in Sources */,
 				E1468DE71E794A4D0044D80F /* LanguageSelectorViewController.swift in Sources */,
 				E14694071F3459E2004052C8 /* PluginListViewController.swift in Sources */,
 				FF0D8146205809C8000EE505 /* PostCoordinator.swift in Sources */,


### PR DESCRIPTION
Closes #11395 

## Findings

After some investigation, I found that the `my_site_tab_accessed` event is counted:

1. On app start (`WPTabBarController.init`)
2. On `WPTabBarController.decodeRestorableStateWithCoder`
3. When the user selects the _My Sites_ tab
4. On first launch of the app (user is not logged in)
5. After log out and moving the app to the background and then foreground again. 

The first and second causes the event to be counted *twice*.

Related: paCBwp-54-p2.

## Solution 

This adds a more elaborate mechanism for tracking the event. Most of them are encapsulated in the new file, `WPTabBarController+Swift.swift`. The event is now counted on these scenarios only:

- Logged in: The app has been placed in the foreground
- Logged in: The app was just launched and we restored the previously selected tab
- Logged in: The user selected a different tab
- Not logged in: After logging in (and this VC is shown)

## Testing

Please test that the event is only counted on the scenarios above. 

## Release Notes

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
