### PR TITLE
Sharing screen to show snack bar instead of alert when offline

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 12.3
 -----
 * Resolved a crash that might occur during the new Site Creation flow.
+ * Improved connectivity errors messaging in sharing screen.
 
 12.2
 -----

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -6,7 +6,6 @@
 #import "WordPress-Swift.h"
 #import <WordPressUI/UIImage+Util.h>
 #import <WordPressShared/WPTableViewCell.h>
-#import <Reachability/Reachability.h>
 
 typedef NS_ENUM(NSInteger, SharingSectionIdentifier){
     SharingPublicizeServices = 0,
@@ -20,7 +19,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 @property (nonatomic, strong, readonly) Blog *blog;
 @property (nonatomic, strong) NSArray *publicizeServices;
-@property (nonatomic, strong, readwrite) Reachability *reachability;
 
 @end
 
@@ -44,7 +42,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     self.navigationItem.title = NSLocalizedString(@"Sharing", @"Title for blog detail sharing screen.");
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
-    [self setupReachability];
     [self syncServices];
 }
 
@@ -59,11 +56,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 {
     [super viewWillDisappear:animated];
     [ReachabilityUtils dismissNoInternetConnectionNotice];
-}
-
--(void) dealloc
-{
-    [self.reachability stopNotifier];
 }
 
 - (void)refreshPublicizers
@@ -259,21 +251,10 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     [self syncPublicizeServices];
     
 }
-- (void)setupReachability
-{
-    self.reachability = [Reachability reachabilityForInternetConnection];
-    [self.reachability startNotifier];
-}
 
 -(void)showConnectionError
 {
-//    NSString *title = NSLocalizedString(@"No Connection", @"Title of error prompt when no internet connection is available.");
-//    NSString *message = NSLocalizedString(@"The Internet connection appears to be offline.", @"Error message shown when a media upload fails because the user isn't connected to the internet.");
-//    dispatch_async(dispatch_get_main_queue(), ^{
-//        [WPError showAlertWithTitle:title message:message];
-//    });
-    
-     [ReachabilityUtils showNoInternetConnectionNoticeWithMessage: ReachabilityUtils.noConnectionMessage];
+    [ReachabilityUtils showNoInternetConnectionNoticeWithMessage: ReachabilityUtils.noConnectionMessage];
 }
 
 - (void)syncPublicizeServices
@@ -283,7 +264,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     [sharingService syncPublicizeServicesForBlog:self.blog success:^{
         [weakSelf syncConnections];
     } failure:^(NSError *error) {
-        if (!weakSelf.reachability.isReachable) {
+        if (!ReachabilityUtils.isInternetReachable) {
             [weakSelf showConnectionError];
         } else {
             [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Publicize service synchronization failed", @"Message to show when Publicize service synchronization failed")];
@@ -299,7 +280,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     [sharingService syncPublicizeConnectionsForBlog:self.blog success:^{
         [weakSelf refreshPublicizers];
     } failure:^(NSError *error) {
-        if (!weakSelf.reachability.isReachable) {
+        if (!ReachabilityUtils.isInternetReachable) {
             [weakSelf showConnectionError];
         } else {
             [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Publicize connection synchronization failed", @"Message to show when Publicize connection synchronization failed")];

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -55,6 +55,12 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     [self.tableView reloadData];
 }
 
+-(void)viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+    [ReachabilityUtils dismissNoInternetConnectionNotice];
+}
+
 -(void) dealloc
 {
     [self.reachability stopNotifier];
@@ -261,11 +267,13 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 -(void)showConnectionError
 {
-    NSString *title = NSLocalizedString(@"No Connection", @"Title of error prompt when no internet connection is available.");
-    NSString *message = NSLocalizedString(@"The Internet connection appears to be offline.", @"Error message shown when a media upload fails because the user isn't connected to the internet.");
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [WPError showAlertWithTitle:title message:message];
-    });
+//    NSString *title = NSLocalizedString(@"No Connection", @"Title of error prompt when no internet connection is available.");
+//    NSString *message = NSLocalizedString(@"The Internet connection appears to be offline.", @"Error message shown when a media upload fails because the user isn't connected to the internet.");
+//    dispatch_async(dispatch_get_main_queue(), ^{
+//        [WPError showAlertWithTitle:title message:message];
+//    });
+    
+     [ReachabilityUtils showNoInternetConnectionNoticeWithMessage: ReachabilityUtils.noConnectionMessage];
 }
 
 - (void)syncPublicizeServices


### PR DESCRIPTION
Fixes #11311 
[this PR should be merged before](https://github.com/wordpress-mobile/WordPress-iOS/issues/11312)

To test:
1. Be offline
2. go to sharing 
3. see snack bar.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
