### PR TITLE
Use global env variables in fastlane deliver

### DIFF
--- a/Scripts/fastlane/Deliverfile
+++ b/Scripts/fastlane/Deliverfile
@@ -1,3 +1,6 @@
+require 'dotenv'
+Dotenv.load('~/.wpios-env.default')
+
 screenshots_path "./screenshots/"
 app_identifier "org.wordpress"
 


### PR DESCRIPTION
**To Test:**

If you already have an Fastlane environment configuration file, just run `bundle exec fastlane deliver--skip_binary_upload --skip_screenshots`. 

If you have `FASTLANE_USER` / `DELIVER_USER` and `FASTLANE_ITC_TEAM_ID` defined in there, the first prompt you should receive is to verify the HTML file. That's how you'll know it's working.