### PR TITLE
Hiding header if there are no item in that section.

### DIFF
--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -575,9 +575,12 @@ public protocol ThemePresenter: class {
                 // since we need to keep a reference to them to update the counts
                 if sections[indexPath.section] == .customThemes {
                     customThemesHeader = (collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: ThemeBrowserViewController.reuseIdentifierForCustomThemesHeader, for: indexPath) as! ThemeBrowserSectionHeaderView)
+                    customThemesHeader?.isHidden = customThemeCount == 0
+
                     return customThemesHeader!
                 } else {
                     themesHeader = (collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: ThemeBrowserViewController.reuseIdentifierForCustomThemesHeader, for: indexPath) as! ThemeBrowserSectionHeaderView)
+                    themesHeader?.isHidden = themeCount == 0
                     return themesHeader!
                 }
             }


### PR DESCRIPTION
Fixes #11309 

To test:
1. Be offline
2. switch to site that has custom themes
3. make sure the labels  are not being displayed if the "no results view is presented"
Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
