### PR TITLE
[Stats] Don't fetch insights/period data by default, only on manual refreshes

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -189,9 +189,7 @@ private extension StatsInsightsStore {
         activeQueries.forEach { query in
             switch query {
             case .insights:
-                if shouldFetchOverview() {
-                    fetchInsights()
-                }
+                loadFromCache()
             case .allFollowers:
                 if shouldFetchFollowers() {
                     fetchAllFollowers()

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -217,9 +217,7 @@ private extension StatsPeriodStore {
         activeQueries.forEach { query in
             switch query {
             case .periods:
-                if shouldFetchOverview() {
-                    fetchPeriodOverviewData(date: query.date, period: query.period)
-                }
+                loadFromCache(date: query.date, period: query.period)
             case .allPostsAndPages:
                 if shouldFetchPostsAndPages() {
                     fetchAllPostsAndPages(date: query.date, period: query.period)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -25,7 +25,9 @@ class SiteStatsInsightsViewModel: Observable {
         self.siteStatsInsightsDelegate = insightsDelegate
         self.insightsToShow = insightsToShow
         self.store = store
+
         insightsReceipt = store.query(.insights)
+        store.actionDispatcher.dispatch(InsightAction.refreshInsights())
 
         changeReceipt = store.onChange { [weak self] in
             self?.emitChange()

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -27,6 +27,7 @@ class SiteStatsPeriodViewModel: Observable {
         self.store = store
         self.lastRequestedPeriod = selectedPeriod
         periodReceipt = store.query(.periods(date: selectedDate, period: selectedPeriod))
+        store.actionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: selectedDate, period: selectedPeriod))
 
         changeReceipt = store.onChange { [weak self] in
             self?.emitChange()


### PR DESCRIPTION
Fixes #11359.

After banging my head against this for a better part of three days, and writing 200+ lines of code to do this in a clever way, in a fit of frustration I decided to try the dumbest possible thing... and it worked. I swear to god, trying to be too clever will be the end of me...

Both `Insight`/`Period` `Store`s now no longer run network operations when you ask them for the most generic datasets: `PeriodQuery.periods(date:_, period:  _)` in case of `PeriodStore` and `InsightQuery.insights` in case of `InsightQuery`. 

Now, asking for those only fetches data from the Core Data store and in order to trigger the network requests for these you need to manually dispatch  a `PeriodAction.refreshPeriodOverviewData(date: _, period: _)` or `InsightAction.refreshInsights()`, respectively.

To test:

Go to stats
Verify that the data loads correctly (also in cases where you didn't have any stored data for a specific blog/time period)
Go to Periods
Go into a detail view
Observing console output, verify that only data for that specific detail view is fetched from the network, and not all data for that period
