### PR TITLE
Make Stats Followers/Tags and Categories detail views use the new API.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -42,9 +42,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.0.0-beta'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '5d13f1513a630be3c0d3f31a09b20468c807a26d'
-    #pod 'WordPressKit', :path => '~/Developer/WordPressKit-iOS'
+    #pod 'WordPressKit', '~> 4.0.0-beta'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/tags-and-categories-limit'
+    #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 
 def shared_with_all_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -208,7 +208,7 @@ PODS:
     - WordPressKit (~> 4.0.0-beta)
     - WordPressShared (~> 1.4)
     - WordPressUI (~> 1.0)
-  - WordPressKit (4.0.0-beta.2):
+  - WordPressKit (4.0.0-beta.3):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -267,7 +267,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (= 1.5.2)
   - WordPressAuthenticator (~> 1.4.0-beta)
-  - WordPressKit (~> 4.0.0-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/tags-and-categories-limit`)
   - WordPressShared (~> 1.7.3)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.0`)
   - WPMediaPicker (= 1.3.2)
@@ -313,7 +313,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
     - WPMediaPicker
     - wpxmlrpc
@@ -339,6 +338,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.2.0
+  WordPressKit:
+    :branch: feature/tags-and-categories-limit
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -358,6 +360,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.2.0
+  WordPressKit:
+    :commit: 33d4d01806a54cf0cfc953a65b6c1e9cb46c5185
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
     :tag: 1.2.0
@@ -406,7 +411,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 16339a831d5d605ba9300b3722b75ba78e53cf09
   WordPress-Editor-iOS: b90649909f99c1d02cef2bb79c0641322b31fa52
   WordPressAuthenticator: f0e30e8e555e33bea8e13e6f1245172d557a8ee4
-  WordPressKit: e9fcb4af6bbb31554a3dde1eb8df09ef0eabcafb
+  WordPressKit: caf0c55f704778c18ec6ab0914ed8eeeef7dc2d7
   WordPressShared: 0853172642668b0fbf5c8d56e743896ebf9aae01
   WordPressUI: 44fe43a9c5c504dfd534286e39e1ce6ebcd69ff5
   WPMediaPicker: e50edd8f30f5d87288840941ef3ff9cd11860937
@@ -415,6 +420,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: 44ee00338dd718495f0364369420ae11b389c878
   ZIPFoundation: b1f07e4409baf1641f3fe5948b2a1c3f5c500cb1
 
-PODFILE CHECKSUM: 176ea891062eda934b6266e8a10df7bf6339e072
+PODFILE CHECKSUM: 8bc725da9481587f84248cae6b89c0d79d9535b9
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -469,7 +469,10 @@ private extension StatsInsightsStore {
 
         state.fetchingAllCommentsInsight = true
 
-        api.getInsight(limit: 100) {(allComments: StatsCommentsInsight?, error) in
+        // The API doesn't work when we specify `0` here, like most of the other endpoints do, unfortunately...
+        // 1000 was chosen as an arbitraily large number that should be "big enough" for all of our users
+        // but I'm open to increasing it.
+        api.getInsight(limit: 1000) {(allComments: StatsCommentsInsight?, error) in
             if error != nil {
                 DDLogInfo("Error fetching all comments: \(String(describing: error?.localizedDescription))")
             }
@@ -486,10 +489,8 @@ private extension StatsInsightsStore {
 
         let api = apiService(for: siteID)
 
-        // The API doesn't work when we specify `0` here, like most of the other endpoints do, unfortunately...
-        // 100 was chosen as an arbitraily large number that should be "big enough" for all of our users
-        // but I'm open to increasing it.
-        api.getInsight(limit: 100) { (allTagsAndCategories: StatsTagsAndCategoriesInsight?, error) in
+        // See the comment about the limit in the method above.
+        api.getInsight(limit: 1000) { (allTagsAndCategories: StatsTagsAndCategoriesInsight?, error) in
             if error != nil {
                 DDLogInfo("Error fetching all tags and categories: \(String(describing: error?.localizedDescription))")
             }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -290,10 +290,7 @@ private extension SiteStatsDetailsViewModel {
     }
 
     func tabDataForCommentType(_ commentType: StatSection) -> TabData {
-
-        // TODO: replace this Store call to get actual Authors and Posts comments
-        // when the api supports it.
-        let commentsInsight = insightsStore.getTopCommentsInsight()
+        let commentsInsight = insightsStore.getAllCommentsInsight()
 
         var rowItems: [StatsTotalRowData] = []
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -259,26 +259,26 @@ private extension SiteStatsDetailsViewModel {
 
     func tabDataForFollowerType(_ followerType: StatSection) -> TabData {
         let tabTitle = followerType.tabTitle
-        var followers: [StatsItem]?
+        var followers: [StatsFollower] = []
         var totalFollowers: Int?
 
         switch followerType {
         case .insightsFollowersWordPress:
-            followers = insightsStore.getAllDotComFollowers()
+            followers = insightsStore.getAllDotComFollowers()?.topDotComFollowers ?? []
             totalFollowers = insightsStore.getDotComFollowers()?.dotComFollowersCount
         case .insightsFollowersEmail:
-            followers = insightsStore.getAllEmailFollowers()
-            totalFollowers = insightsStore.getEmailFollowers()?.emailFollowersCount
+            followers = insightsStore.getAllEmailFollowers()?.topEmailFollowers ?? []
+            totalFollowers = insightsStore.getAllEmailFollowers()?.emailFollowersCount
         default:
             break
         }
 
         let totalCount = String(format: followerType.totalFollowers, (totalFollowers ?? 0).abbreviatedString())
 
-        let followersData = followers?.compactMap {
-            return StatsTotalRowData(name: $0.label,
-                                     data: $0.value,
-                                     userIconURL: $0.iconURL,
+        let followersData = followers.compactMap {
+            return StatsTotalRowData(name: $0.name,
+                                     data: $0.subscribedDate.relativeStringInPast(),
+                                     userIconURL: $0.avatarURL,
                                      statSection: followerType)
         }
 
@@ -286,7 +286,7 @@ private extension SiteStatsDetailsViewModel {
                        itemSubtitle: followerType.itemSubtitle,
                        dataSubtitle: followerType.dataSubtitle,
                        totalCount: totalCount,
-                       dataRows: followersData ?? [])
+                       dataRows: followersData)
     }
 
     func tabDataForCommentType(_ commentType: StatSection) -> TabData {


### PR DESCRIPTION
Fixes #11238 and #11182

This updates the StatsInsightStore to use the new API endpoints for fetching data for detail views of Followers/Tags and Categories/Comments.

To test:
* Build this branch
* Go to Stats
* Go to detail view for Followers for a highly-followed site
* Verify that more than 10 datapoints appears 
* Go back
* Go to detail view for Tags And Categories
* Verify that up to 100 datapoints appear

