### PR TITLE
[Stats Refresh] Fix a reuse bug in Last Post Insight

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -53,10 +53,7 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        rowsStackView.arrangedSubviews.forEach {
-            rowsStackView.removeArrangedSubview($0)
-            $0.removeFromSuperview()
-        }
+        removeRowsFromStackView(rowsStackView)
     }
 
     func configure(withData lastPostInsight: StatsLastPostInsight?, andDelegate delegate: SiteStatsInsightsDelegate?) {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -51,6 +51,14 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable {
         applyStyles()
     }
 
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        rowsStackView.arrangedSubviews.forEach {
+            rowsStackView.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+    }
+
     func configure(withData lastPostInsight: StatsLastPostInsight?, andDelegate delegate: SiteStatsInsightsDelegate?) {
 
         siteStatsInsightsDelegate = delegate


### PR DESCRIPTION
Fixes #11474

This fixes a bug where the "Last Post Insight" would grow every time it's displayed on screen. 


To test:

Go to Stats Insights
Scroll around a bit making the "Last Post Insight" repeatedly appear on/off screen
Verify that the number of the rows stays constant