### PR TITLE
Improved accessibility of bar chart views in Stats

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
@@ -53,6 +53,7 @@ protocol BarChartStyling {
 /// Transforms a given data set for consumption by BarChartView in the Charts framework.
 ///
 protocol BarChartDataConvertible {
+    var accessibilityDescription: String { get }
     var barChartData: BarChartData { get }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -178,7 +178,6 @@ class StatsBarChartView: BarChartView {
     }
 
     private func configureChartForSingleDataSet(_ dataSet: BarChartDataSet) {
-
         dataSet.colors = [ styling.primaryBarColor ]
         dataSet.drawValuesEnabled = false
 
@@ -194,7 +193,6 @@ class StatsBarChartView: BarChartView {
 
     private func configureChartViewBaseProperties() {
         dragDecelerationEnabled = false
-
         extraRightOffset = Constants.trailingOffset
 
         animate(yAxisDuration: Constants.animationDuration)
@@ -288,6 +286,7 @@ class StatsBarChartView: BarChartView {
         delegate = self
 
         applyStyling()
+        prepareForVoiceOver()
         configureAndPopulateData()
     }
 
@@ -315,5 +314,18 @@ extension StatsBarChartView: ChartViewDelegate {
         captureAnalyticsEvent()
         drawSecondaryHighlightIfNeeded(for: entry, with: highlight)
         drawChartMarker(for: entry)
+    }
+}
+
+// MARK: - Accessible
+
+extension StatsBarChartView: Accessible {
+    func prepareForVoiceOver() {
+        // ChartDataRendererBase creates a meaningful a11y description, relying on the chart description
+        guard let chartDescription = chartDescription else {
+            return
+        }
+        chartDescription.text = barChartData.accessibilityDescription
+        chartDescription.enabled = false    // disabling the description hides a corresponding label
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsChartLegendView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsChartLegendView.swift
@@ -88,5 +88,17 @@ class StatsChartLegendView: UIView {
             label.centerYAnchor.constraint(equalTo: centerYAnchor),
             label.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor)
         ])
+
+        prepareForVoiceOver()
+    }
+}
+
+// MARK: - Accessible
+
+extension StatsChartLegendView: Accessible {
+    func prepareForVoiceOver() {
+        // This is the default state for non-control views. We set it explicitly for clarity,
+        // choosing instead to rely on the default a11y support offered by Charts framework.
+        isAccessibilityElement = false
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PeriodDataStub.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PeriodDataStub.swift
@@ -30,6 +30,10 @@ class PeriodDataStub: DataStub<[PeriodDatum]> {
 class ViewsPeriodDataStub: PeriodDataStub {}
 
 extension ViewsPeriodDataStub: BarChartDataConvertible {
+    var accessibilityDescription: String {
+        return "Bar Chart depicting Views for selected period, Visitors superimposed"   // NB: we don't localize stub data
+    }
+
     var barChartData: BarChartData {
 
         let data = periodData
@@ -87,6 +91,10 @@ extension ViewsPeriodDataStub: BarChartDataConvertible {
 class VisitorsPeriodDataStub: PeriodDataStub {}
 
 extension VisitorsPeriodDataStub: BarChartDataConvertible {
+    var accessibilityDescription: String {
+        return "Bar Chart depicting Visitors for selected period"   // NB: we don't localize stub data
+    }
+
     var barChartData: BarChartData {
 
         let data = periodData
@@ -134,6 +142,10 @@ extension VisitorsPeriodDataStub: BarChartDataConvertible {
 class LikesPeriodDataStub: PeriodDataStub {}
 
 extension LikesPeriodDataStub: BarChartDataConvertible {
+    var accessibilityDescription: String {
+        return "Bar Chart depicting Likes for selected period"   // NB: we don't localize stub data
+    }
+
     var barChartData: BarChartData {
 
         let data = periodData
@@ -181,6 +193,10 @@ extension LikesPeriodDataStub: BarChartDataConvertible {
 class CommentsPeriodDataStub: PeriodDataStub {}
 
 extension CommentsPeriodDataStub: BarChartDataConvertible {
+    var accessibilityDescription: String {
+        return "Bar Chart depicting Comments for selected period"   // NB: we don't localize stub data
+    }
+
     var barChartData: BarChartData {
 
         let data = periodData

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PostSummaryDataStub.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PostSummaryDataStub.swift
@@ -18,7 +18,10 @@ struct PostSummaryDatum: Decodable {
 // MARK: - PostSummaryDataStub
 
 class PostSummaryDataStub: DataStub<[PostSummaryDatum]> {
-    init(fileName: String) {
+    private let postSummaryChartDescription: String
+
+    init(fileName: String, description: String) {
+        self.postSummaryChartDescription = description
         super.init([PostSummaryDatum].self, fileName: fileName)
     }
 
@@ -31,7 +34,8 @@ class PostSummaryDataStub: DataStub<[PostSummaryDatum]> {
 
 class LatestPostSummaryDataStub: PostSummaryDataStub {
     init() {
-        super.init(fileName: "latestPost_data")
+        let chartDescription = "Bar Chart depicting Views for the Latest Post"  // NB: we don't localize stub data
+        super.init(fileName: "latestPost_data", description: chartDescription)
     }
 }
 
@@ -39,13 +43,18 @@ class LatestPostSummaryDataStub: PostSummaryDataStub {
 
 class SelectedPostSummaryDataStub: PostSummaryDataStub {
     init() {
-        super.init(fileName: "selectedPost_data")
+        let chartDescription = "Bar Chart depicting Visitors for the Selected Post"  // NB: we don't localize stub data
+        super.init(fileName: "selectedPost_data", description: chartDescription)
     }
 }
 
 // MARK: - BarChartDataConvertible
 
 extension PostSummaryDataStub: BarChartDataConvertible {
+    var accessibilityDescription: String {
+        return postSummaryChartDescription
+    }
+
     var barChartData: BarChartData {
 
         let data = summaryData


### PR DESCRIPTION
Fixes #11065.

To test:
- Checkout the branch and confirm that existing tests pass.
- Whether manually with VoiceOver, or via the Xcode Accessibility Inspector, select the bar chart in each of the following: Insights / Latest Post, Insights / Selected Post, Period (DWMY) / Views | Visitors | Likes | Comments.
- "Drill down" further on the chart and confirm that each bar is read out with the date (x-axis), followed by the value backing the bar (e.g., visitor count).

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.