### PR TITLE
Send proper locale key to Activity remotes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,8 @@
 12.3
 -----
 * Resolved a crash that might occur during the new Site Creation flow.
- * Improved connectivity errors messaging in sharing screen.
+* Improved connectivity errors messaging in sharing screen.
+* Fixed an issue where some text in Activity Log would show up in a wrong language
 
 12.2
 -----

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -380,7 +380,7 @@ private extension ActivityStore {
             return nil
         }
 
-        let api = WordPressComRestApi(oAuthToken: token, userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyDefault)   // ActivityServiceRemote currently injects "locale", not "_locale"
+        let api = WordPressComRestApi(oAuthToken: token, userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
 
         return ActivityServiceRemote(wordPressComRestApi: api)
     }


### PR DESCRIPTION
Fixes #9818

I'm clearing up some old issues that were assigned to me, and this is a quick fix :)

This fixes a problem where Activity Log would have incorrectly translated labels coming from backend.

| old | new |
| --- | ---- |
| ![Simulator Screen Shot - iPhone Xs Max - 2019-04-17 at 01 10 10](https://user-images.githubusercontent.com/1594081/56249843-92cc9300-60ad-11e9-915d-530499dda391.png) | ![Simulator Screen Shot - iPhone Xs Max - 2019-04-17 at 01 08 21](https://user-images.githubusercontent.com/1594081/56249849-99f3a100-60ad-11e9-9832-1d9a31050d84.png)|


To test:
Change your device/simulator language to something non-english
Go to Activity Log
Verify that the text is localized properly

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.