### PR TITLE
Remove blocking interaction when trying to delete a post when offline

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -509,7 +509,8 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
     func cell(_ cell: UITableViewCell, handleTrashPost post: AbstractPost) {
         guard ReachabilityUtils.isInternetReachable() else {
-            ReachabilityUtils.showNoInternetConnectionNotice()
+            let offlineMessage = NSLocalizedString("Unable to trash posts while offline. Please try again later.", comment: "Message that appears when a user tries to trash a post while their device is offline.")
+            ReachabilityUtils.showNoInternetConnectionNotice(message: offlineMessage)
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -508,32 +508,36 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func cell(_ cell: UITableViewCell, handleTrashPost post: AbstractPost) {
-        ReachabilityUtils.onAvailableInternetConnectionDo {
-            let cancelText: String
-            let deleteText: String
-            let messageText: String
-            let titleText: String
-
-            if post.status == .trash {
-                cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
-                deleteText = NSLocalizedString("Delete Permanently", comment: "Delete option in the confirmation alert when deleting a post from the trash.")
-                titleText = NSLocalizedString("Delete Permanently?", comment: "Title of the confirmation alert when deleting a post from the trash.")
-                messageText = NSLocalizedString("Are you sure you want to permanently delete this post?", comment: "Message of the confirmation alert when deleting a post from the trash.")
-            } else {
-                cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
-                deleteText = NSLocalizedString("Move to Trash", comment: "Trash option in the trash confirmation alert.")
-                titleText = NSLocalizedString("Trash this post?", comment: "Title of the trash confirmation alert.")
-                messageText = NSLocalizedString("Are you sure you want to trash this post?", comment: "Message of the trash confirmation alert.")
-            }
-
-            let alertController = UIAlertController(title: titleText, message: messageText, preferredStyle: .alert)
-
-            alertController.addCancelActionWithTitle(cancelText)
-            alertController.addDestructiveActionWithTitle(deleteText) { [weak self] action in
-                self?.deletePost(post)
-            }
-            alertController.presentFromRootViewController()
+        guard ReachabilityUtils.isInternetReachable() else {
+            ReachabilityUtils.showNoInternetConnectionNotice()
+            return
         }
+
+        let cancelText: String
+        let deleteText: String
+        let messageText: String
+        let titleText: String
+
+        if post.status == .trash {
+            cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
+            deleteText = NSLocalizedString("Delete Permanently", comment: "Delete option in the confirmation alert when deleting a post from the trash.")
+            titleText = NSLocalizedString("Delete Permanently?", comment: "Title of the confirmation alert when deleting a post from the trash.")
+            messageText = NSLocalizedString("Are you sure you want to permanently delete this post?", comment: "Message of the confirmation alert when deleting a post from the trash.")
+        } else {
+            cancelText = NSLocalizedString("Cancel", comment: "Cancels an Action")
+            deleteText = NSLocalizedString("Move to Trash", comment: "Trash option in the trash confirmation alert.")
+            titleText = NSLocalizedString("Trash this post?", comment: "Title of the trash confirmation alert.")
+            messageText = NSLocalizedString("Are you sure you want to trash this post?", comment: "Message of the trash confirmation alert.")
+        }
+
+        let alertController = UIAlertController(title: titleText, message: messageText, preferredStyle: .alert)
+
+        alertController.addCancelActionWithTitle(cancelText)
+        alertController.addDestructiveActionWithTitle(deleteText) { [weak self] action in
+            self?.deletePost(post)
+        }
+        alertController.presentFromRootViewController()
+
     }
 
     func cell(_ cell: UITableViewCell, handleRestore post: AbstractPost) {


### PR DESCRIPTION
"Fixes" (not really though) #11425

This is the smallest possible thing to do in #11425, while I'm still investigating/working on actually making sure the post will get deleted offline.

For now we just swap the modal pop-up about internet being offline, for the new Notice.

To test:
Go to Post list
Go offline
Try to delete a post
Verify that you see a neat new Notice, and not a modal letting you know about the device being offline


