### PR TITLE
[Stats Refresh] Period Overview card: populate with real data

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -272,6 +272,16 @@ private extension StatsPeriodStore {
 
         setAllAsFetchingOverview()
 
+        statsRemote.getData(for: period, endingOn: date) { (summary: StatsSummaryTimeIntervalData?, error: Error?) in
+            if error != nil {
+                DDLogInfo("Error fetching summary: \(String(describing: error?.localizedDescription))")
+            }
+
+            DDLogInfo("Stats: Finished fetching summary.")
+
+            self.actionDispatcher.dispatch(PeriodAction.receivedSummary(summary))
+        }
+
         statsRemote.getData(for: period, endingOn: date) { (posts: StatsTopPostsTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogInfo("Error fetching posts: \(String(describing: error?.localizedDescription))")
@@ -729,6 +739,7 @@ private extension StatsPeriodStore {
     }
 
     func setAllAsFetchingOverview() {
+        state.fetchingSummary = true
         state.fetchingPostsAndPages = true
         state.fetchingReferrers = true
         state.fetchingClicks = true


### PR DESCRIPTION
Fixes #11205 

This uses real summary data for the Period Overview card. To note, the chart still uses stub data.

**NOTE**: As noted on https://github.com/wordpress-mobile/WordPress-iOS/pull/11342#issuecomment-477330842, fetching summary data can take a _really_ long time, especially with longer Periods. Patience is a virtue.

To test:
- Go to Stats > Period.
- Verify the numbers populate real data.
- Verify the data updates when different periods are selected (D, W, M, Y).
- Verify the data updates when different dates are selected via the date bar.

<img width="350" alt="overview_data" src="https://user-images.githubusercontent.com/1816888/56318275-1a50eb00-611c-11e9-8042-1e6e0717d826.png">

