### PR TITLE
[Stats Refresh] Period stats: restart queries when period or date changes

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -410,6 +410,8 @@ private extension StatsPeriodStore {
             // Stop existing queries and start fresh.
             statsServiceRemote?.wordPressComRestApi.invalidateAndCancelTasks()
             setAllAsFetchingOverview(fetching: false)
+            // invalidateAndCancelTasks invalidates the SessionManager, 
+            // so we need to recreate it to run queries.
             initializeStatsRemote()
         }
 

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -120,6 +120,8 @@ struct PeriodStoreState {
 
 class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
 
+    private var statsServiceRemote: StatsServiceRemoteV2?
+
     init() {
         super.init(initialState: PeriodStoreState())
     }
@@ -723,15 +725,25 @@ private extension StatsPeriodStore {
     // MARK: - Helpers
 
     func statsRemote() -> StatsServiceRemoteV2? {
+
+        if statsServiceRemote == nil {
+            initializeStatsRemote()
+        }
+
+        return statsServiceRemote
+    }
+
+    func initializeStatsRemote() {
         guard
             let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue,
             let timeZone = SiteStatsInformation.sharedInstance.siteTimeZone
             else {
-                return nil
+                statsServiceRemote = nil
+                return
         }
 
         let wpApi = WordPressComRestApi(oAuthToken: SiteStatsInformation.sharedInstance.oauth2Token, userAgent: WPUserAgent.wordPress())
-        return StatsServiceRemoteV2(wordPressComRestApi: wpApi, siteID: siteID, siteTimezone: timeZone)
+        statsServiceRemote = StatsServiceRemoteV2(wordPressComRestApi: wpApi, siteID: siteID, siteTimezone: timeZone)
     }
 
     func shouldFetchOverview() -> Bool {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -27,7 +27,7 @@ class SiteStatsPeriodViewModel: Observable {
         self.store = store
         self.lastRequestedPeriod = selectedPeriod
         periodReceipt = store.query(.periods(date: selectedDate, period: selectedPeriod))
-        store.actionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: selectedDate, period: selectedPeriod))
+        store.actionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: selectedDate, period: selectedPeriod, forceRefresh: false))
 
         changeReceipt = store.onChange { [weak self] in
             self?.emitChange()
@@ -60,7 +60,7 @@ class SiteStatsPeriodViewModel: Observable {
     // MARK: - Refresh Data
 
     func refreshPeriodOverviewData(withDate date: Date, forPeriod period: StatsPeriodUnit) {
-        ActionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: date, period: period))
+        ActionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: date, period: period, forceRefresh: true))
         self.lastRequestedPeriod = period
     }
 }


### PR DESCRIPTION
Fixes #11353 

When a user performs any of these actions, the currently running queries will be cancelled and new queries run.
- Select another period.
- Select another date.
- Pull to refresh.
(Basically, any action that triggers `SiteStatsPeriodTableViewController.refreshData`.)

To test:
- Go to Stats > Period.
- Perform any of the above actions in quick succession.
- If any queries were still running, you'll see messages like this in the console:
`Error fetching posts: Optional("cancelled")`
