### PR TITLE
[Stats Refresh] Post Stats: show web view when post title tapped

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -224,7 +224,7 @@ private extension LatestPostSummaryCell {
 
         switch actionType {
         case .viewMore:
-            siteStatsInsightsDelegate?.showPostStats?(withPostTitle: postTitle)
+            siteStatsInsightsDelegate?.showPostStats?(postTitle: postTitle, postURL: lastPostInsight?.url)
         case .sharePost:
             guard let postID = lastPostInsight?.postID else {
                 return

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -37,7 +37,7 @@ enum InsightType: Int {
     @objc optional func tabbedTotalsCellUpdated()
     @objc optional func expandedRowUpdated(_ row: StatsTotalRow)
     @objc optional func viewMoreSelectedForStatSection(_ statSection: StatSection)
-    @objc optional func showPostStats(withPostTitle postTitle: String?)
+    @objc optional func showPostStats(postTitle: String?, postURL: URL?)
 }
 
 class SiteStatsInsightsTableViewController: UITableViewController {
@@ -237,9 +237,9 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         navigationController?.pushViewController(detailTableViewController, animated: true)
     }
 
-    func showPostStats(withPostTitle postTitle: String?) {
+    func showPostStats(postTitle: String?, postURL: URL?) {
         let postStatsTableViewController = PostStatsTableViewController.loadFromStoryboard()
-        postStatsTableViewController.configure(postTitle: postTitle)
+        postStatsTableViewController.configure(postTitle: postTitle, postURL: postURL)
         navigationController?.pushViewController(postStatsTableViewController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -182,7 +182,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
     func displayWebViewWithURL(_ url: URL) {
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
         let navController = UINavigationController.init(rootViewController: webViewController)
-        present(navController, animated: true, completion: nil)
+        present(navController, animated: true)
     }
 
     func showCreatePost() {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -186,7 +186,7 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
     func displayWebViewWithURL(_ url: URL) {
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
         let navController = UINavigationController.init(rootViewController: webViewController)
-        present(navController, animated: true, completion: nil)
+        present(navController, animated: true)
     }
 
     func displayMediaWithID(_ mediaID: NSNumber) {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -7,7 +7,7 @@ import WordPressFlux
     @objc optional func displayMediaWithID(_ mediaID: NSNumber)
     @objc optional func expandedRowUpdated(_ row: StatsTotalRow)
     @objc optional func viewMoreSelectedForStatSection(_ statSection: StatSection)
-    @objc optional func showPostStats(withPostTitle postTitle: String?)
+    @objc optional func showPostStats(withPostTitle postTitle: String?, postURL: URL?)
 }
 
 
@@ -222,9 +222,9 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
         navigationController?.pushViewController(detailTableViewController, animated: true)
     }
 
-    func showPostStats(withPostTitle postTitle: String?) {
+    func showPostStats(withPostTitle postTitle: String?, postURL: URL?) {
         let postStatsTableViewController = PostStatsTableViewController.loadFromStoryboard()
-        postStatsTableViewController.configure(postTitle: postTitle)
+        postStatsTableViewController.configure(postTitle: postTitle, postURL: postURL)
         navigationController?.pushViewController(postStatsTableViewController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -82,7 +82,7 @@ extension PostStatsTableViewController: PostStatsDelegate {
     func displayWebViewWithURL(_ url: URL) {
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
         let navController = UINavigationController.init(rootViewController: webViewController)
-        present(navController, animated: true, completion: nil)
+        present(navController, animated: true)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -32,8 +32,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
         initViewModel()
     }
 
-    // TODO: remove nil when fix Period Table VC
-    func configure(postTitle: String?, postURL: URL? = nil) {
+    func configure(postTitle: String?, postURL: URL?) {
         self.postTitle = postTitle
         self.postURL = postURL
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -1,5 +1,9 @@
 import UIKit
 
+@objc protocol PostStatsDelegate {
+    @objc optional func displayWebViewWithURL(_ url: URL)
+}
+
 class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
 
     // MARK: - StoryboardLoadable Protocol
@@ -9,6 +13,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
     // MARK: - Properties
 
     private var postTitle: String?
+    private var postURL: URL?
     private typealias Style = WPStyleGuide.Stats
     private var viewModel: PostStatsViewModel?
 
@@ -27,8 +32,10 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
         initViewModel()
     }
 
-    func configure(postTitle: String?) {
+    // TODO: remove nil when fix Period Table VC
+    func configure(postTitle: String?, postURL: URL? = nil) {
         self.postTitle = postTitle
+        self.postURL = postURL
     }
 }
 
@@ -37,7 +44,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
 private extension PostStatsTableViewController {
 
     func initViewModel() {
-        viewModel = PostStatsViewModel(postTitle: postTitle)
+        viewModel = PostStatsViewModel(postTitle: postTitle, postURL: postURL, postStatsDelegate: self)
         refreshTableView()
     }
 
@@ -65,6 +72,18 @@ private extension PostStatsTableViewController {
         // TODO: data fetching
 
         refreshControl?.endRefreshing()
+    }
+
+}
+
+// MARK: - PostStatsDelegate Methods
+
+extension PostStatsTableViewController: PostStatsDelegate {
+
+    func displayWebViewWithURL(_ url: URL) {
+        let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
+        let navController = UINavigationController.init(rootViewController: webViewController)
+        present(navController, animated: true, completion: nil)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
@@ -10,11 +10,17 @@ class PostStatsTitleCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var bottomSeparatorLine: UIView!
 
     private typealias Style = WPStyleGuide.Stats
+    private var postTitle: String?
+    private var postURL: URL?
+    private weak var postStatsDelegate: PostStatsDelegate?
 
     // MARK: - Configure
 
-    func configure(postTitle: String) {
-        postTitleLabel.text = postTitle
+    // nix ? on URL (?)
+    func configure(postTitle: String, postURL: URL?, postStatsDelegate: PostStatsDelegate? = nil) {
+        self.postTitle = postTitle
+        self.postURL = postURL
+        self.postStatsDelegate = postStatsDelegate
         applyStyles()
     }
 }
@@ -23,10 +29,25 @@ private extension PostStatsTitleCell {
 
     func applyStyles() {
         titleLabel.text = NSLocalizedString("Showing stats for:", comment: "Label on Post Stats view indicating which post the stats are for.")
+
         Style.configureLabelAsPostStatsTitle(titleLabel)
         Style.configureLabelAsPostTitle(postTitleLabel)
         Style.configureViewAsSeparator(topSeparatorLine)
         Style.configureViewAsSeparator(bottomSeparatorLine)
+
+        guard let postTitle = postTitle else {
+            return
+        }
+
+        postTitleLabel.attributedText = Style.highlightString(postTitle, inString: postTitle)
+    }
+
+    @IBAction func didTapPostTitle(_ sender: UIButton) {
+        guard let postURL = postURL else {
+            return
+        }
+
+        postStatsDelegate?.displayWebViewWithURL?(postURL)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
@@ -16,7 +16,6 @@ class PostStatsTitleCell: UITableViewCell, NibLoadable {
 
     // MARK: - Configure
 
-    // nix ? on URL (?)
     func configure(postTitle: String, postURL: URL?, postStatsDelegate: PostStatsDelegate? = nil) {
         self.postTitle = postTitle
         self.postURL = postURL

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -38,6 +38,13 @@
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q7F-mg-QOb" userLabel="Post Title Button">
+                        <rect key="frame" x="16" y="34" width="374" height="20.5"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <connections>
+                            <action selector="didTapPostTitle:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="DVU-yE-MhC"/>
+                        </connections>
+                    </button>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dJu-H6-3qo" userLabel="Bottom Separator Line">
                         <rect key="frame" x="0.0" y="70" width="406" height="0.5"/>
                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -53,10 +60,14 @@
                     <constraint firstAttribute="bottom" secondItem="IAo-11-r7k" secondAttribute="bottom" constant="16" id="OAe-F1-q3m"/>
                     <constraint firstAttribute="trailing" secondItem="dJu-H6-3qo" secondAttribute="trailing" id="QCn-b6-3ob"/>
                     <constraint firstItem="VQc-hL-Bbc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="TIp-2M-tkj"/>
+                    <constraint firstItem="q7F-mg-QOb" firstAttribute="bottom" secondItem="IAo-11-r7k" secondAttribute="bottom" id="Tom-tr-1Cc"/>
                     <constraint firstAttribute="trailing" secondItem="kpL-Db-PKI" secondAttribute="trailing" id="XhD-xV-KoQ"/>
+                    <constraint firstItem="q7F-mg-QOb" firstAttribute="top" secondItem="IAo-11-r7k" secondAttribute="top" id="Xpe-ec-0aG"/>
                     <constraint firstItem="IAo-11-r7k" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="Yni-Dp-MXW"/>
                     <constraint firstItem="IAo-11-r7k" firstAttribute="top" secondItem="VQc-hL-Bbc" secondAttribute="bottom" constant="2" id="Zcd-Qe-cRI"/>
+                    <constraint firstItem="q7F-mg-QOb" firstAttribute="trailing" secondItem="IAo-11-r7k" secondAttribute="trailing" id="eGe-Ux-cg8"/>
                     <constraint firstAttribute="trailing" secondItem="VQc-hL-Bbc" secondAttribute="trailing" constant="16" id="fB6-eP-9H9"/>
+                    <constraint firstItem="q7F-mg-QOb" firstAttribute="leading" secondItem="IAo-11-r7k" secondAttribute="leading" id="hxy-ew-stt"/>
                     <constraint firstAttribute="trailing" secondItem="IAo-11-r7k" secondAttribute="trailing" constant="16" id="kch-C9-JS2"/>
                     <constraint firstItem="dJu-H6-3qo" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="t4N-kv-EoQ"/>
                     <constraint firstItem="VQc-hL-Bbc" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="uNe-Lu-pCh"/>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -10,11 +10,15 @@ class PostStatsViewModel: Observable {
 
     let changeDispatcher = Dispatcher<Void>()
     private var postTitle: String?
+    private var postURL: URL?
+    private weak var postStatsDelegate: PostStatsDelegate?
 
     // MARK: - Init
 
-    init(postTitle: String?) {
+    init(postTitle: String?, postURL: URL?, postStatsDelegate: PostStatsDelegate) {
         self.postTitle = postTitle
+        self.postURL = postURL
+        self.postStatsDelegate = postStatsDelegate
     }
 
     // MARK: - Table View
@@ -42,7 +46,9 @@ private extension PostStatsViewModel {
     // MARK: - Create Table Rows
 
     func titleTableRow() -> ImmuTableRow {
-        return PostStatsTitleRow(postTitle: postTitle ?? NSLocalizedString("(No Title)", comment: "Empty Post Title"))
+        return PostStatsTitleRow(postTitle: postTitle ?? NSLocalizedString("(No Title)", comment: "Empty Post Title"),
+                                 postURL: postURL,
+                                 postStatsDelegate: postStatsDelegate)
     }
 
     func overviewTableRows() -> [ImmuTableRow] {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -242,7 +242,7 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
     func displayWebViewWithURL(_ url: URL) {
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
         let navController = UINavigationController.init(rootViewController: webViewController)
-        present(navController, animated: true, completion: nil)
+        present(navController, animated: true)
     }
 
     func expandedRowUpdated(_ row: StatsTotalRow) {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -5,7 +5,7 @@ import WordPressFlux
     @objc optional func tabbedTotalsCellUpdated()
     @objc optional func displayWebViewWithURL(_ url: URL)
     @objc optional func expandedRowUpdated(_ row: StatsTotalRow)
-    @objc optional func showPostStats(withPostTitle postTitle: String?)
+    @objc optional func showPostStats(withPostTitle postTitle: String?, postURL: URL?)
     @objc optional func displayMediaWithID(_ mediaID: NSNumber)
 }
 
@@ -250,9 +250,9 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
         StatsDataHelper.updatedExpandedState(forRow: row, inDetails: true)
     }
 
-    func showPostStats(withPostTitle postTitle: String?) {
+    func showPostStats(withPostTitle postTitle: String?, postURL: URL?) {
         let postStatsTableViewController = PostStatsTableViewController.loadFromStoryboard()
-        postStatsTableViewController.configure(postTitle: postTitle)
+        postStatsTableViewController.configure(postTitle: postTitle, postURL: postURL)
         navigationController?.pushViewController(postStatsTableViewController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -45,7 +45,7 @@ struct StatsTotalRowData {
     @objc optional func displayWebViewWithURL(_ url: URL)
     @objc optional func displayMediaWithID(_ mediaID: NSNumber)
     @objc optional func toggleChildRowsForRow(_ row: StatsTotalRow)
-    @objc optional func showPostStats(withPostTitle postTitle: String?)
+    @objc optional func showPostStats(withPostTitle postTitle: String?, postURL: URL?)
 }
 
 class StatsTotalRow: UIView, NibLoadable {
@@ -279,7 +279,7 @@ private extension StatsTotalRow {
         if let disclosureURL = rowData?.disclosureURL {
             if let statSection = rowData?.statSection,
                 statSection == .periodPostsAndPages {
-                delegate?.showPostStats?(withPostTitle: rowData?.name)
+                delegate?.showPostStats?(withPostTitle: rowData?.name, postURL: rowData?.disclosureURL)
             } else {
                 delegate?.displayWebViewWithURL?(disclosureURL)
             }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -289,7 +289,7 @@ extension TopTotalsCell: StatsTotalRowDelegate {
 
     func showPostStats(withPostTitle postTitle: String?, postURL: URL?) {
         siteStatsPeriodDelegate?.showPostStats?(withPostTitle: postTitle, postURL: postURL)
-        siteStatsDetailsDelegate?.showPostStats?(withPostTitle: postTitle)
+        siteStatsDetailsDelegate?.showPostStats?(withPostTitle: postTitle, postURL: postURL)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -287,8 +287,8 @@ extension TopTotalsCell: StatsTotalRowDelegate {
         siteStatsDetailsDelegate?.expandedRowUpdated?(row)
     }
 
-    func showPostStats(withPostTitle postTitle: String?) {
-        siteStatsPeriodDelegate?.showPostStats?(withPostTitle: postTitle)
+    func showPostStats(withPostTitle postTitle: String?, postURL: URL?) {
+        siteStatsPeriodDelegate?.showPostStats?(withPostTitle: postTitle, postURL: postURL)
         siteStatsDetailsDelegate?.showPostStats?(withPostTitle: postTitle)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -390,6 +390,8 @@ struct PostStatsTitleRow: ImmuTableRow {
     }()
 
     let postTitle: String
+    let postURL: URL?
+    weak var postStatsDelegate: PostStatsDelegate?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -398,7 +400,7 @@ struct PostStatsTitleRow: ImmuTableRow {
             return
         }
 
-        cell.configure(postTitle: postTitle)
+        cell.configure(postTitle: postTitle, postURL: postURL, postStatsDelegate: postStatsDelegate)
     }
 }
 


### PR DESCRIPTION
Fixes #11344 

When on Post Stats, tapping the post title will now open a web view for that post.

To test:
- Access Post Stats via:
  - Insights > Latest Post Summary > View more
  - Period > Posts and Pages > row selection
  - Period > Posts and Pages > View more > row selection
- Verify tapping in the post title area opens a web view for that post.

![post_title](https://user-images.githubusercontent.com/1816888/56382335-68c1c080-61d4-11e9-9ee5-2fdf38c5dbb0.png)



