### PR TITLE
Zendesk: update API methods

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -117,8 +117,7 @@ extension NSNotification.Name {
         helpCenterConfig.groupIds = [Constants.mobileCategoryID as NSNumber]
         helpCenterConfig.labels = [Constants.articleLabel]
 
-        let helpCenterController = HelpCenterUi.buildHelpCenterOverview(withConfigs: [helpCenterConfig])
-        helpCenterController.uiDelegate = self
+        let helpCenterController = HelpCenterUi.buildHelpCenterOverviewUi(withConfigs: [helpCenterConfig])
         ZendeskUtils.showZendeskView(helpCenterController)
     }
 


### PR DESCRIPTION
Fixes #11477 

This updates the Zendesk API methods that were deprecated in v2.3. Visibly, there should be no changes, so these tests are just to make sure the new methods work as expected.

To test:

---
- Build the app. 
- Verify there are no Zendesk deprecation warnings.

---
The updated methods center around showing/hiding the `Contact Us` option from these views:

1. WordPress Help Center > right nav bar button.
<img width="350" alt="help_center_nav" src="https://user-images.githubusercontent.com/1816888/56534699-6e424200-6517-11e9-8bf2-20d2f4eb3bb9.png">
2. Help Center search > no results > link on no results view.
<img width="350" alt="search_no_results" src="https://user-images.githubusercontent.com/1816888/56534824-a9dd0c00-6517-11e9-9a89-011d13a20f71.png">
3. Help Center > select an Article > right nav bar button.
<img width="350" alt="article_nav" src="https://user-images.githubusercontent.com/1816888/56534973-f9bbd300-6517-11e9-96a2-93e7c83a012d.png">

If your `Contact Email` is set, you _will_ see these options. If your `Contact Email` is not set, you _will not_ see these options.

So, to test:
- Go to Me > Help & Support.
- With Contact Email set, go to the 3 views and verify the Contact options appear.
- With no email set, go to the 3 views and verify the Contact options do not appear.
  - NOTE: to clear your Contact Email, re-install the app to clear User Defaults.

