### PR TITLE
Fixing layout issue in AppFeedbackPromptView

### DIFF
--- a/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
+++ b/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
@@ -107,7 +107,6 @@ class AppFeedbackPromptView: UIView {
 
     func setupConstraints() {
         addConstraints([
-            label.centerXAnchor.constraint(equalTo: centerXAnchor),
             label.topAnchor.constraint(equalTo: topAnchor, constant: LayoutConstants.basePadding),
             label.bottomAnchor.constraint(equalTo: buttonStack.topAnchor, constant: -LayoutConstants.basePadding),
             label.heightAnchor.constraint(greaterThanOrEqualToConstant: LayoutConstants.labelMinimumHeight),


### PR DESCRIPTION
Fixes #11510 
Removing centering of the label, as NSLayoutConstraint does, to resolve this issue.

To test:
1. Run the app on develop and see the issue in the log
2. checkout this branch and run the app. See that the issue doesn't appear in log 

I tested this in English and Hebrew with big and small fonts.
![Simulator Screen Shot - iPhone 8 - 2019-04-22 at 14 46 12](https://user-images.githubusercontent.com/1335657/56535434-8c587400-6510-11e9-9632-a10d73182769.png)
![Simulator Screen Shot - iPhone 8 - 2019-04-22 at 14 49 30](https://user-images.githubusercontent.com/1335657/56535444-911d2800-6510-11e9-8711-f852af483baa.png)
![Simulator Screen Shot - iPhone 8 - 2019-04-22 at 14 51 30](https://user-images.githubusercontent.com/1335657/56535460-98dccc80-6510-11e9-8f84-4c0570edb70c.png)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
