### PR TITLE
Remove newsCard FeatureFlag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -4,7 +4,6 @@
 enum FeatureFlag: Int {
     case exampleFeature
     case jetpackDisconnect
-    case newsCard
     case giphy
     case automatedTransfersCustomDomain
     case revisions
@@ -21,8 +20,6 @@ enum FeatureFlag: Int {
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .automatedTransfersCustomDomain:
-            return true
-        case .newsCard:
             return true
         case .giphy:
             return true

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Helper.swift
@@ -32,24 +32,16 @@ extension ReaderStreamViewController {
     func headerWithNewsCardForStream(_ topic: ReaderAbstractTopic, isLoggedIn: Bool, container: UITableViewController) -> UIView? {
 
         let header = headerForStream(topic)
-        let configuredHeader = configure(header, topic: topic, isLoggedIn: isLoggedIn, delegate: self)
-
-        // Feature flag is not active
-        if !FeatureFlag.newsCard.enabled {
-            return configuredHeader
-        }
-
+        configure(header, topic: topic, isLoggedIn: isLoggedIn, delegate: self)
         let containerIdentifier = Identifier(value: topic.title)
 
         return news.newsCard(containerIdentifier: containerIdentifier, header: header, container: container, delegate: self)
     }
 
-    func configure(_ header: ReaderHeader?, topic: ReaderAbstractTopic, isLoggedIn: Bool, delegate: ReaderStreamHeaderDelegate) -> ReaderHeader? {
+    func configure(_ header: ReaderHeader?, topic: ReaderAbstractTopic, isLoggedIn: Bool, delegate: ReaderStreamHeaderDelegate) {
         header?.configureHeader(topic)
         header?.enableLoggedInFeatures(isLoggedIn)
         header?.delegate = delegate
-
-        return header
     }
 
     func headerForStream(_ topic: ReaderAbstractTopic) -> ReaderHeader? {


### PR DESCRIPTION
Fixes #11509 - Part 1

To test:
- Go to Reader on a clean install and check that the News Card is displayed.
- Go to Reader, and then to a specific feed and check that the header is properly configured.
- In general check that Reader headers look good.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.