### PR TITLE
Only display confirmation alert for unpublished posts

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -109,12 +109,15 @@ extension PostEditor where Self: UIViewController {
             self.present(controller, animated: true, completion: nil)
         }
 
-        if action.isAsync {
-            if !UserDefaults.standard.asyncPromoWasDisplayed {
-                promoBlock()
-            } else {
-                displayPublishConfirmationAlert(for: action, onPublish: publishBlock)
-            }
+
+        if action.isAsync &&
+            !UserDefaults.standard.asyncPromoWasDisplayed {
+            promoBlock()
+        } else if action.isAsync,
+            let postStatus = self.post.status,
+            ![.publish, .publishPrivate].contains(postStatus) {
+            // Only display confirmation alert for unpublished posts
+            displayPublishConfirmationAlert(for: action, onPublish: publishBlock)
         } else {
             publishBlock()
         }


### PR DESCRIPTION
Fixes #11242 

To test:

First replicate the issue following the instructions in the original ticket.
Then checkout this branch, and check the following scenarios:

- [x] Publishing a post from the top right button displays the Publish action sheet.
- [x] Closing the editor with an unpublished post displays the Save Draft action sheet.
- [x] Updating a published post from the top right button doesn't display an action sheet, the user remains in the editor.
- [x] Closing the editor with unsaved changes on a published post displays the option the Update Post action sheet.

Reset UserDefaults and check that when you first publish a post you get the AsyncPromo alert:
 - [x] Publishing from the top right button.
 - [x] Closing the editor with unsaved changes on a published post.

@rachelmcr do the testing steps sound good?

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.