### PR TITLE
Remove giphy FeatureFlag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -4,7 +4,6 @@
 enum FeatureFlag: Int {
     case exampleFeature
     case jetpackDisconnect
-    case giphy
     case automatedTransfersCustomDomain
     case revisions
     case statsRefresh
@@ -20,8 +19,6 @@ enum FeatureFlag: Int {
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .automatedTransfersCustomDomain:
-            return true
-        case .giphy:
             return true
         case .revisions:
             return true

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryMediaPickingCoordinator.swift
@@ -36,9 +36,7 @@ final class MediaLibraryMediaPickingCoordinator {
             menuAlert.addAction(freePhotoAction(origin: origin, blog: blog))
         }
 
-        if FeatureFlag.giphy.enabled {
-            menuAlert.addAction(giphyAction(origin: origin, blog: blog))
-        }
+        menuAlert.addAction(giphyAction(origin: origin, blog: blog))
 
         if #available(iOS 11.0, *) {
             menuAlert.addAction(otherAppsAction(origin: origin, blog: blog))

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
@@ -22,10 +22,7 @@ final class AztecMediaPickingCoordinator {
             alertController.addAction(freePhotoAction(origin: origin, blog: blog))
         }
 
-        if FeatureFlag.giphy.enabled {
-            alertController.addAction(giphyAction(origin: origin, blog: blog))
-        }
-
+        alertController.addAction(giphyAction(origin: origin, blog: blog))
         alertController.addAction(otherAppsAction(origin: origin, blog: blog))
         alertController.addAction(cancelAction())
 


### PR DESCRIPTION
Fixes #11509 - Part 2

To test:

Check that you can add images from Giphy in:
- [x] Aztec Text Editor
- [x] Media Library

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
