### PR TITLE
Remove jetpackRemoteInstallation FeatureFlag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -10,7 +10,6 @@ enum FeatureFlag: Int {
     case statsRefresh
     case gutenberg
     case quickStartV2
-    case jetpackRemoteInstallation
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -30,8 +29,6 @@ enum FeatureFlag: Int {
         case .gutenberg:
             return true
         case .quickStartV2:
-            return true
-        case .jetpackRemoteInstallation:
             return true
         }
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
@@ -135,19 +135,12 @@ class JetpackLoginViewController: UIViewController {
         descriptionLabel.text = message
         descriptionLabel.sizeToFit()
 
-        let title = Feature.enabled(.jetpackRemoteInstallation) ? Constants.Buttons.jetpackInstallTitle : Constants.Buttons.jetpackSetupTitle
-        installJetpackButton.setTitle(title, for: .normal)
+        installJetpackButton.setTitle(Constants.Buttons.jetpackInstallTitle, for: .normal)
         installJetpackButton.isHidden = hasJetpack
         installJetpackButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 20, bottom: 12, right: 20)
 
         signinButton.setTitle(Constants.Buttons.loginTitle, for: .normal)
         signinButton.isHidden = !hasJetpack
-
-        guard Feature.enabled(.jetpackRemoteInstallation) else {
-            tacButton.isHidden = true
-            faqButton.isHidden = tacButton.isHidden
-            return
-        }
 
         let paragraph = NSMutableParagraphStyle(minLineHeight: WPStyleGuide.fontSizeForTextStyle(.footnote),
                                                 lineBreakMode: .byWordWrapping,
@@ -241,10 +234,6 @@ class JetpackLoginViewController: UIViewController {
     }
 
     @IBAction func didTouchInstallJetpackButton(_ sender: Any) {
-        guard Feature.enabled(.jetpackRemoteInstallation) else {
-            openInstallJetpackURL()
-            return
-        }
         openJetpackRemoteInstall()
     }
 
@@ -298,19 +287,13 @@ public enum JetpackLoginPromptType {
     }
 
     var message: String {
-        switch (self, Feature.enabled(.jetpackRemoteInstallation)) {
-        case (.stats, true):
+        switch (self) {
+        case .stats:
             return NSLocalizedString("To use stats on your site, you'll need to install the Jetpack plugin.",
                                         comment: "Message asking the user if they want to set up Jetpack from stats")
-        case (.stats, false):
-            return NSLocalizedString("To use Stats on your site, you'll need to install the Jetpack plugin.\n Would you like to set up Jetpack?",
-                                     comment: "Message asking the user if they want to set up Jetpack from stats")
-        case (.notifications, true):
+        case .notifications:
             return NSLocalizedString("To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin.",
                                         comment: "Message asking the user if they want to set up Jetpack from notifications")
-        case (.notifications, false):
-            return NSLocalizedString("To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin. Would you like to set up Jetpack?",
-                                     comment: "Message asking the user if they want to set up Jetpack from notifications")
         }
     }
 }
@@ -336,7 +319,6 @@ private enum Constants {
                                                                                                 comment: "Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break \n. Also there is a placeholder %@ which is: Terms and Conditions"), termsAndConditions)
         static let faqTitle = NSLocalizedString("Jetpack FAQ", comment: "Title of the button which opens the Jetpack FAQ page.")
         static let jetpackInstallTitle = NSLocalizedString("Install Jetpack", comment: "Title of a button for Jetpack Installation.")
-        static let jetpackSetupTitle = NSLocalizedString("Set up Jetpack", comment: "Title of a button for Jetpack Set up.")
         static let loginTitle = NSLocalizedString("Log in", comment: "Title of a button for signing in.")
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
@@ -287,7 +287,7 @@ public enum JetpackLoginPromptType {
     }
 
     var message: String {
-        switch (self) {
+        switch self {
         case .stats:
             return NSLocalizedString("To use stats on your site, you'll need to install the Jetpack plugin.",
                                         comment: "Message asking the user if they want to set up Jetpack from stats")


### PR DESCRIPTION
Fixes #11509 - Part 7

To test:

- On a self-hosted site, trigger a Jetpack install and check that everything works as expected.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
