### PR TITLE
[FIX] Application stuck after Notifications dialog block is called

### DIFF
--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -54,10 +54,12 @@ final class InteractiveNotificationsManager: NSObject {
         }
         let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.requestAuthorization(options: [.badge, .sound, .alert]) { (allowed, _)  in
-            if allowed {
-                WPAnalytics.track(.pushNotificationOSAlertAllowed)
-            } else {
-                WPAnalytics.track(.pushNotificationOSAlertDenied)
+            DispatchQueue.main.async {
+                if allowed {
+                    WPAnalytics.track(.pushNotificationOSAlertAllowed)
+                } else {
+                    WPAnalytics.track(.pushNotificationOSAlertDenied)
+                }
             }
             completion()
         }


### PR DESCRIPTION
Fix #11293 

The Analytics call is dispatched to the main thread avoiding the app being stuck while the dialog is dismissed.

## To test:
• Fully uninstall the app (just delete it out of the simulator).
• Reinstall the app and log in.
• When prompted to allow notifications, choose to allow them.
• The App should work normally and the Fancy Alert should be dismissed quickly.