### PR TITLE
Fixing SplitViewController warning:

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -353,9 +353,8 @@ static CGFloat const WPTabBarIconSize = 32.0f;
         _blogListSplitViewController = [WPSplitViewController new];
         _blogListSplitViewController.restorationIdentifier = WPBlogListSplitViewRestorationID;
         _blogListSplitViewController.presentsWithGesture = NO;
-        _blogListSplitViewController.wpPrimaryColumnWidth = WPSplitViewControllerPrimaryColumnWidthNarrow;
-
         [_blogListSplitViewController setInitialPrimaryViewController:self.blogListNavigationController];
+        _blogListSplitViewController.wpPrimaryColumnWidth = WPSplitViewControllerPrimaryColumnWidthNarrow;
 
         _blogListSplitViewController.dimsDetailViewControllerAutomatically = YES;
 
@@ -371,6 +370,7 @@ static CGFloat const WPTabBarIconSize = 32.0f;
         _readerSplitViewController = [WPSplitViewController new];
         _readerSplitViewController.restorationIdentifier = WPReaderSplitViewRestorationID;
         _readerSplitViewController.presentsWithGesture = NO;
+        [_readerSplitViewController setInitialPrimaryViewController:self.readerNavigationController];
         _readerSplitViewController.wpPrimaryColumnWidth = WPSplitViewControllerPrimaryColumnWidthNarrow;
         _readerSplitViewController.collapseMode = WPSplitViewControllerCollapseModeAlwaysKeepDetail;
 
@@ -383,8 +383,6 @@ static CGFloat const WPTabBarIconSize = 32.0f;
             [_readerSplitViewController setOverrideTraitCollection:[UITraitCollection traitCollectionWithHorizontalSizeClass:UIUserInterfaceSizeClassCompact]];
         }
 
-        [_readerSplitViewController setInitialPrimaryViewController:self.readerNavigationController];
-
         _readerSplitViewController.tabBarItem = self.readerNavigationController.tabBarItem;
     }
 
@@ -396,9 +394,8 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     if (!_meSplitViewController) {
         _meSplitViewController = [WPSplitViewController new];
         _meSplitViewController.restorationIdentifier = WPMeSplitViewRestorationID;
-        _meSplitViewController.wpPrimaryColumnWidth = WPSplitViewControllerPrimaryColumnWidthNarrow;
-
         [_meSplitViewController setInitialPrimaryViewController:self.meNavigationController];
+        _meSplitViewController.wpPrimaryColumnWidth = WPSplitViewControllerPrimaryColumnWidthNarrow;
 
         _meSplitViewController.tabBarItem = self.meNavigationController.tabBarItem;
     }
@@ -411,10 +408,9 @@ static CGFloat const WPTabBarIconSize = 32.0f;
     if (!_notificationsSplitViewController) {
         _notificationsSplitViewController = [WPSplitViewController new];
         _notificationsSplitViewController.restorationIdentifier = WPNotificationsSplitViewRestorationID;
+         [_notificationsSplitViewController setInitialPrimaryViewController:self.notificationsNavigationController];
         _notificationsSplitViewController.fullscreenDisplayEnabled = NO;
         _notificationsSplitViewController.wpPrimaryColumnWidth = WPSplitViewControllerPrimaryColumnWidthDefault;
-
-        [_notificationsSplitViewController setInitialPrimaryViewController:self.notificationsNavigationController];
 
         _notificationsSplitViewController.tabBarItem = self.notificationsNavigationController.tabBarItem;
     }


### PR DESCRIPTION
[Warning] Splitview controller is expected to have a view controller at index 0 before it's used!

Fixed by setting the primary view controller before setting up the width and other parameters.

To test:
1. Run the app on develop see the warning in the logs. 
2. Checkout this branch and run the app. See that the warning is gone. 
