### PR TITLE
Improved accessibility experience with the site creation flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -75,11 +75,10 @@ static NSInteger HideSearchMinSites = 3;
                                                                   target:nil
                                                                   action:nil];
     [self.navigationItem setBackBarButtonItem:backButton];
-    
-    self.addSiteButton = [[UIBarButtonItem alloc] initWithImage:[UIImage imageNamed:@"icon-post-add"]
-                                                                                    style:UIBarButtonItemStylePlain
-                                                                                   target:self
-                                                                                   action:@selector(addSite)];
+
+    self.addSiteButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd
+                                                                       target:self
+                                                                       action:@selector(addSite)];
 
     self.navigationItem.title = NSLocalizedString(@"My Sites", @"");
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
@@ -297,16 +297,28 @@ final class SiteAssemblyContentView: UIView {
     }
 
     private func layoutInProgress() {
-        UIView.animate(withDuration: Parameters.animationDuration, delay: 0, options: .curveEaseOut, animations: { [errorStateView, statusStackView] in
-            errorStateView?.alpha = 0
-            statusStackView.alpha = 1
+        UIView.animate(withDuration: Parameters.animationDuration, delay: 0, options: .curveEaseOut, animations: { [weak self] in
+            guard let self = self else {
+                return
+            }
+            self.errorStateView?.alpha = 0
+            self.statusStackView.alpha = 1
+            self.accessibilityElements = [ self.statusLabel ]
         })
     }
 
     private func layoutFailed() {
-        UIView.animate(withDuration: Parameters.animationDuration, delay: 0, options: .curveEaseOut, animations: { [errorStateView, statusStackView] in
-            errorStateView?.alpha = 1
-            statusStackView.alpha = 0
+        UIView.animate(withDuration: Parameters.animationDuration, delay: 0, options: .curveEaseOut, animations: { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            self.statusStackView.alpha = 0
+
+            if let errorView = self.errorStateView {
+                errorView.alpha = 1
+                self.accessibilityElements = [ errorView ]
+            }
         })
     }
 
@@ -339,6 +351,13 @@ final class SiteAssemblyContentView: UIView {
                                 }
 
                                 self.completionLabel.alpha = 1
+
+                                if let buttonView = self.buttonContainerView {
+                                    self.accessibilityElements = [ self.completionLabel, buttonView ]
+                                } else {
+                                    self.accessibilityElements = [ self.completionLabel ]
+                                }
+
                                 self.layoutIfNeeded()
                 })
         })

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
@@ -61,8 +61,6 @@ final class TitleSubtitleHeader: UIView {
         ])
 
         setStyles()
-
-        prepareForVoiceOver()
     }
 
     private func setStyles() {
@@ -107,11 +105,5 @@ extension TitleSubtitleHeader {
     func preferredContentSizeDidChange() {
         // Title needs to be forced to reset its style, otherwise the types do not change
         styleTitle()
-    }
-}
-
-extension TitleSubtitleHeader: Accessible {
-    func prepareForVoiceOver() {
-
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -168,8 +168,6 @@ final class TitleSubtitleTextfieldHeader: UIView {
 
 extension TitleSubtitleTextfieldHeader: Accessible {
     func prepareForVoiceOver() {
-        titleSubtitle.prepareForVoiceOver()
-
         prepareSearchFieldForVoiceOver()
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
@@ -47,6 +47,7 @@ final class SiteSegmentsCell: UITableViewCell, ModelSettableCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+
         styleBackground()
         styleTitle()
         styleSubtitle()
@@ -91,18 +92,5 @@ extension SiteSegmentsCell {
     func preferredContentSizeDidChange() {
         // Title needs to be forced to reset its style, otherwise the types do not change
         styleTitle()
-    }
-}
-
-extension SiteSegmentsCell: Accessible {
-    func prepareForVoiceOver() {
-        prepareIconForVoiceOver()
-    }
-
-    private func prepareIconForVoiceOver() {
-        let format = NSLocalizedString("Icon representing %@", comment: "Accessibility description for Site Segment icon. The %@ is a placeholder for the name of the kind of site. If the kind of site is unknown the phrase 'kind of site' is used.")
-        let site = model?.title ?? NSLocalizedString("Kind of site", comment: "Default accessibilty label for an unknown kind of site.")
-        icon.accessibilityLabel =  String(format: format, site )
-        icon.accessibilityTraits = .image
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
@@ -44,7 +44,7 @@ final class SiteSegmentsWizardContent: UIViewController {
         initCancelButton()
 
         prepareForVoiceOver()
-	WPAnalytics.track(.enhancedSiteCreationSegmentsViewed)
+        WPAnalytics.track(.enhancedSiteCreationSegmentsViewed)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -196,7 +196,7 @@ final class SiteSegmentsWizardContent: UIViewController {
             errorVC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             errorVC.view.topAnchor.constraint(equalTo: view.topAnchor),
             errorVC.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            ])
+        ])
         errorVC.didMove(toParent: self)
 
 
@@ -254,7 +254,6 @@ extension SiteSegmentsWizardContent: Accessible {
     }
 
     private func prepareTableForVoiceOver() {
-        table.accessibilityLabel = NSLocalizedString("The kinds of sites that can be created", comment: "Accessibility hint for list ")
-        table.accessibilityTraits = UIAccessibilityTraits.allowsDirectInteraction
+        table.accessibilityLabel = NSLocalizedString("The kinds of sites that can be created", comment: "Accessibility hint for list")
     }
 }


### PR DESCRIPTION
Fixes #11480 by applying the following changes:

- Removed the `accessibilityTraits` designation that was preventing navigation of the screen in question.
- Tidied up a few other accessibility considerations elsewhere in the site creation flow.
- Improved the accessibility of the _Add_ button that initiates this flow. Previously it only read "Button". Now it leverages the system description, which is (a) accessible; and (b) properly localized.

To test:
1. From _My Sites_ (i.e., `BlogListViewController`), enable VoiceOver and initiate the Site Creation flow by selecting _Add_ : _Create WordPress.com site_.
1. Observe that _Create Site_ presented subsequently (i.e., `SiteSegmentsWizardContent`) can now be navigated successfully.
1. All other screens in the flow are (and were) still navigable via VoiceOver.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

@etoledom or @diegoreymendez would one of you have time to review this?