### PR TITLE
Fix layout issues:

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
+++ b/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.13.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="doV-5W-Rtg">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="doV-5W-Rtg">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.9"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -53,20 +53,20 @@
                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="bottom" secondItem="LBU-zb-iai" secondAttribute="bottom" id="6uy-tW-55g"/>
-                                <constraint firstItem="LBU-zb-iai" firstAttribute="leading" secondItem="pEF-oN-cih" secondAttribute="leading" id="9sh-kF-RQv"/>
+                                <constraint firstItem="LBU-zb-iai" firstAttribute="leading" secondItem="pEF-oN-cih" secondAttribute="leading" priority="999" id="9sh-kF-RQv"/>
                                 <constraint firstItem="LBU-zb-iai" firstAttribute="top" secondItem="pEF-oN-cih" secondAttribute="top" id="Ib2-7V-nPZ"/>
-                                <constraint firstAttribute="trailing" secondItem="LBU-zb-iai" secondAttribute="trailing" id="Zhl-Rn-WR6"/>
+                                <constraint firstAttribute="trailing" secondItem="LBU-zb-iai" secondAttribute="trailing" priority="999" id="Zhl-Rn-WR6"/>
                             </constraints>
                         </view>
                     </subviews>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
-                        <constraint firstItem="pEF-oN-cih" firstAttribute="leading" secondItem="Uvo-9e-l6I" secondAttribute="leading" identifier="FiltersLeading" id="0TE-M7-WfE"/>
-                        <constraint firstAttribute="trailing" secondItem="pEF-oN-cih" secondAttribute="trailing" identifier="FiltersTrailing" id="222-MX-igM"/>
-                        <constraint firstItem="ZnY-3K-upT" firstAttribute="leading" secondItem="Uvo-9e-l6I" secondAttribute="leading" identifier="RatingsLeading" id="27p-cV-siE"/>
+                        <constraint firstItem="pEF-oN-cih" firstAttribute="leading" secondItem="Uvo-9e-l6I" secondAttribute="leading" priority="999" identifier="FiltersLeading" id="0TE-M7-WfE"/>
+                        <constraint firstAttribute="trailing" secondItem="pEF-oN-cih" secondAttribute="trailing" priority="999" identifier="FiltersTrailing" id="222-MX-igM"/>
+                        <constraint firstItem="ZnY-3K-upT" firstAttribute="leading" secondItem="Uvo-9e-l6I" secondAttribute="leading" priority="999" identifier="RatingsLeading" id="27p-cV-siE"/>
                         <constraint firstItem="pEF-oN-cih" firstAttribute="top" secondItem="ZnY-3K-upT" secondAttribute="bottom" identifier="FiltersTop" id="MBK-Ez-h7B"/>
                         <constraint firstItem="ZnY-3K-upT" firstAttribute="top" secondItem="Uvo-9e-l6I" secondAttribute="top" priority="750" identifier="RatingsTop" id="SJu-PU-nzt"/>
-                        <constraint firstAttribute="trailing" secondItem="ZnY-3K-upT" secondAttribute="trailing" identifier="RatingsTrailing" id="b8L-0Q-JCB"/>
+                        <constraint firstAttribute="trailing" secondItem="ZnY-3K-upT" secondAttribute="trailing" priority="999" identifier="RatingsTrailing" id="b8L-0Q-JCB"/>
                         <constraint firstItem="pEF-oN-cih" firstAttribute="top" relation="greaterThanOrEqual" secondItem="Uvo-9e-l6I" secondAttribute="top" id="iOI-vG-EsO"/>
                         <constraint firstItem="pEF-oN-cih" firstAttribute="centerX" secondItem="Uvo-9e-l6I" secondAttribute="centerX" identifier="FiltersCenter" id="rGu-9k-JxJ"/>
                         <constraint firstAttribute="bottom" secondItem="pEF-oN-cih" secondAttribute="bottom" identifier="FiltersBottom" id="zwD-z0-d6i"/>


### PR DESCRIPTION
Fixing the below mentioned layout issues by setting the leading and trailing constraints priorities to 999 so there would be no ambiguity:

To test:
1. Run the app on develop.
2. put a break point on NotificationsViewController line 113 (setupFilterBar())
3. notice that once you over step that line there are 4 layout issues (search for  "Unable to simultaneously satisfy constraints")
4. checkout this branch
5. repeat steps 2-3 
6. see that there are no layout issues. 

Layout issues in log
```2019-04-23 18:51:14.557428-0700 WordPress[56492:2956353] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want.
	Try this:
		(1) look at each constraint and try to figure out which you don't expect;
		(2) find the code that added the unwanted constraint or constraints and fix it.
(
    "<NSLayoutConstraint:0x600003122170 H:|-(37)-[UILabel:0x7ffc59c4dfa0]   (active, names: '|':WordPress.AppFeedbackPromptView:0x7ffc59c4dd90 )>",
    "<NSLayoutConstraint:0x6000031220d0 UILabel:0x7ffc59c4dfa0.trailing == WordPress.AppFeedbackPromptView:0x7ffc59c4dd90.trailing - 37   (active)>",
    "<NSLayoutConstraint:0x600003133390 'RatingsLeading' H:|-(0)-[WordPress.AppFeedbackPromptView:0x7ffc59c4dd90]   (active, names: '|':UIView:0x7ffc59c4dbb0 )>",
    "<NSLayoutConstraint:0x600003131900 'RatingsTrailing' H:[WordPress.AppFeedbackPromptView:0x7ffc59c4dd90]-(0)-|   (active, names: '|':UIView:0x7ffc59c4dbb0 )>",
    "<NSLayoutConstraint:0x60000313dea0 'UIView-Encapsulated-Layout-Width' UIView:0x7ffc59c4dbb0.width == 0   (active)>"
)

Will attempt to recover by breaking constraint
<NSLayoutConstraint:0x6000031220d0 UILabel:0x7ffc59c4dfa0.trailing == WordPress.AppFeedbackPromptView:0x7ffc59c4dd90.trailing - 37   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
2019-04-23 18:51:14.560604-0700 WordPress[56492:2956353] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want.
	Try this:
		(1) look at each constraint and try to figure out which you don't expect;
		(2) find the code that added the unwanted constraint or constraints and fix it.
(
    "<NSLayoutConstraint:0x600003122260 UIStackView:0x7ffc59c4ec30.centerX == WordPress.AppFeedbackPromptView:0x7ffc59c4dd90.centerX   (active)>",
    "<NSLayoutConstraint:0x600003122300 yes-button.leading >= WordPress.AppFeedbackPromptView:0x7ffc59c4dd90.leading + 15   (active, names: yes-button:0x7ffc59c4e290 )>",
    "<NSLayoutConstraint:0x600003133390 'RatingsLeading' H:|-(0)-[WordPress.AppFeedbackPromptView:0x7ffc59c4dd90]   (active, names: '|':UIView:0x7ffc59c4dbb0 )>",
    "<NSLayoutConstraint:0x600003131900 'RatingsTrailing' H:[WordPress.AppFeedbackPromptView:0x7ffc59c4dd90]-(0)-|   (active, names: '|':UIView:0x7ffc59c4dbb0 )>",
    "<NSLayoutConstraint:0x600003129130 'UISV-canvas-connection' UIStackView:0x7ffc59c4ec30.leading == yes-button.leading   (active, names: yes-button:0x7ffc59c4e290 )>",
    "<NSLayoutConstraint:0x6000031291d0 'UISV-canvas-connection' H:[no-button]-(0)-|   (active, names: no-button:0x7ffc59c4e8f0, '|':UIStackView:0x7ffc59c4ec30 )>",
    "<NSLayoutConstraint:0x6000031292c0 'UISV-spacing' H:[yes-button]-(10)-[no-button]   (active, names: no-button:0x7ffc59c4e8f0, yes-button:0x7ffc59c4e290 )>",
    "<NSLayoutConstraint:0x60000313dea0 'UIView-Encapsulated-Layout-Width' UIView:0x7ffc59c4dbb0.width == 0   (active)>"
)

Will attempt to recover by breaking constraint
<NSLayoutConstraint:0x6000031292c0 'UISV-spacing' H:[yes-button]-(10)-[no-button]   (active, names: no-button:0x7ffc59c4e8f0, yes-button:0x7ffc59c4e290 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
2019-04-23 18:51:14.580570-0700 WordPress[56492:2956353] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want.
	Try this:
		(1) look at each constraint and try to figure out which you don't expect;
		(2) find the code that added the unwanted constraint or constraints and fix it.
(
    "<NSLayoutConstraint:0x600003122260 UIStackView:0x7ffc59c4ec30.centerX == WordPress.AppFeedbackPromptView:0x7ffc59c4dd90.centerX   (active)>",
    "<NSLayoutConstraint:0x600003122300 yes-button.leading >= WordPress.AppFeedbackPromptView:0x7ffc59c4dd90.leading + 15   (active, names: yes-button:0x7ffc59c4e290 )>",
    "<NSLayoutConstraint:0x600003133390 'RatingsLeading' H:|-(0)-[WordPress.AppFeedbackPromptView:0x7ffc59c4dd90]   (active, names: '|':UIView:0x7ffc59c4dbb0 )>",
    "<NSLayoutConstraint:0x600003131900 'RatingsTrailing' H:[WordPress.AppFeedbackPromptView:0x7ffc59c4dd90]-(0)-|   (active, names: '|':UIView:0x7ffc59c4dbb0 )>",
    "<NSLayoutConstraint:0x600003129130 'UISV-canvas-connection' UIStackView:0x7ffc59c4ec30.leading == yes-button.leading   (active, names: yes-button:0x7ffc59c4e290 )>",
    "<NSLayoutConstraint:0x60000313dea0 'UIView-Encapsulated-Layout-Width' UIView:0x7ffc59c4dbb0.width == 0   (active)>"
)

Will attempt to recover by breaking constraint
<NSLayoutConstraint:0x600003129130 'UISV-canvas-connection' UIStackView:0x7ffc59c4ec30.leading == yes-button.leading   (active, names: yes-button:0x7ffc59c4e290 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
2019-04-23 18:51:14.580989-0700 WordPress[56492:2956353] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want.
	Try this:
		(1) look at each constraint and try to figure out which you don't expect;
		(2) find the code that added the unwanted constraint or constraints and fix it.
(
    "<NSLayoutConstraint:0x600003122260 UIStackView:0x7ffc59c4ec30.centerX == WordPress.AppFeedbackPromptView:0x7ffc59c4dd90.centerX   (active)>",
    "<NSLayoutConstraint:0x600003122350 WordPress.AppFeedbackPromptView:0x7ffc59c4dd90.trailing >= no-button.trailing + 15   (active, names: no-button:0x7ffc59c4e8f0 )>",
    "<NSLayoutConstraint:0x600003133390 'RatingsLeading' H:|-(0)-[WordPress.AppFeedbackPromptView:0x7ffc59c4dd90]   (active, names: '|':UIView:0x7ffc59c4dbb0 )>",
    "<NSLayoutConstraint:0x600003131900 'RatingsTrailing' H:[WordPress.AppFeedbackPromptView:0x7ffc59c4dd90]-(0)-|   (active, names: '|':UIView:0x7ffc59c4dbb0 )>",
    "<NSLayoutConstraint:0x6000031291d0 'UISV-canvas-connection' H:[no-button]-(0)-|   (active, names: no-button:0x7ffc59c4e8f0, '|':UIStackView:0x7ffc59c4ec30 )>",
    "<NSLayoutConstraint:0x60000313dea0 'UIView-Encapsulated-Layout-Width' UIView:0x7ffc59c4dbb0.width == 0   (active)>"
)

Will attempt to recover by breaking constraint
<NSLayoutConstraint:0x6000031291d0 'UISV-canvas-connection' H:[no-button]-(0)-|   (active, names: no-button:0x7ffc59c4e8f0, '|':UIStackView:0x7ffc59c4ec30 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.```