### PR TITLE
[Jetpack Remote Install] New copy for Jetpack installation success

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/State/JetpackRemoteInstallState.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/State/JetpackRemoteInstallState.swift
@@ -29,7 +29,7 @@ enum JetpackRemoteInstallState: Equatable {
             return NSLocalizedString("Jetpack could not be installed at this time.",
                                      comment: "The default Jetpack view message used when an error occurred")
         case .success:
-            return NSLocalizedString("You have Jetpack set up on your site. Congrats!",
+            return NSLocalizedString("Now that Jetpack is installed, we just need to get you set up. This will only take a minute.",
                                      comment: "The default Jetpack view message for the success state")
         }
     }
@@ -38,6 +38,8 @@ enum JetpackRemoteInstallState: Equatable {
         switch self {
         case .failure:
             return NSLocalizedString("Retry", comment: "The Jetpack view button title used when an error occurred")
+        case .success:
+            return NSLocalizedString("Set up", comment: "The Jetpack view button title for the success state")
         default:
             return NSLocalizedString("Continue", comment: "The default Jetpack view button title")
         }


### PR DESCRIPTION
Fixes #11525 

![Simulator Screen Shot - iPhone X - 2019-04-24 at 13 59 13](https://user-images.githubusercontent.com/912252/56663465-108c3200-669e-11e9-8c52-416b4a0dc6fa.png)

This PR fixes the copy on the JRI success screen 

## To test
• Add a self-hosted site with no Jetpack installed
• Open Stats from your site dashboard
• Click on Install Jetpack
• Complete all the steps to install Jetpack