### PR TITLE
Share Extension: use first line of Markdown as title

### DIFF
--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -415,10 +415,10 @@ private struct URLExtractor: TypeBasedExtensionContentExtractor {
         }
 
         if bundleWrapper.type == kUTTypeMarkdown {
-            let mdText = bundleWrapper.text
+            if let formattedItem = handleMarkdown(md: bundleWrapper.text),
+                var html = formattedItem.importedText {
+                returnedItem = formattedItem
 
-            let converter = Down(markdownString: mdText)
-            if var html = try? converter.toHTML(.safe) {
                 for key in cachedImages.keys {
                     if let escapedKey = key.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) {
                         let searchKey = "src=\"\(escapedKey)\""


### PR DESCRIPTION
Fixes #11352 

This PR improves our Markdown import by turning the first line of an MD file into the title of the created post, if that first line is formatted as a heading. 

This substantially improves the experience of sharing items from Bear, which is launching in 12.3 so I have targeted that branch instead of `develop`.

![md-post-title](https://user-images.githubusercontent.com/517257/56675934-1835e180-6672-11e9-83e6-27197585c080.gif)


To test:
- Build to device
- In Bear or Ulysses, create a new note with a headline as the first line (this is default in Bear)
- Share that note as either MD file or a TextBundle, open in WP
- Ensure that the first line of the file has become the post's title

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.