### PR TITLE
Check NRV visibility before modifying constraints

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 12.4
 -----
- 
+* Fixed crash when searching Free Photo Library.
+
 12.3
 -----
 * Images are now imported from TextBundle and TextPack files shared from other apps

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -328,6 +328,10 @@ private extension NoResultsViewController {
         imageView.isHidden = (hideImage == true) ? true : !accessoryView.isHidden
     }
 
+    func viewIsVisible() -> Bool {
+        return isViewLoaded && view.window != nil
+    }
+
     // MARK: - Configure for Title View Only
 
     func configureForTitleViewOnly() {
@@ -359,7 +363,8 @@ private extension NoResultsViewController {
 
     func configureTitleViewConstraints() {
 
-        guard displayTitleViewOnly == true else {
+        guard self.viewIsVisible(),
+            displayTitleViewOnly == true else {
             return
         }
 


### PR DESCRIPTION
Fixes #11387 

According to the Fabric logs, this crash seems to happen when searching the Free Photo Library. 
```
51 | 1556091505912 | 🔵 Tracked: stock_media_accessed
52 | 1556091512547 | 🔵 Tracked: stock_media_searched
53 | 1556091514021 | 🔵 Tracked: stock_media_searched
54 | 1556091515163 | 🔵 Tracked: stock_media_searched
55 | 1556091515401 | 🔵 Tracked: stock_media_searched
56 | 1556091520549 | 🔵 Tracked: stock_media_searched
57 | 1556091525780 | 🔵 Tracked: stock_media_searched
```

I was not able to reproduce the crash, but this sort of crash typically happens when the NRV isn't actually visible so it fails when setting the constraints according to the `view`. So I added a check to ensure the NRV is visible before setting the constraints. 🤞 this fixes it.

To test:
- Access the Free Photo Library.
- Perform searches that have no results.
- Verify it doesn't crash.

<img width="350" alt="no_results" src="https://user-images.githubusercontent.com/1816888/56698184-4afdcb00-66ae-11e9-9edc-9043c27bea2f.png">

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
