### PR TITLE
Improve SiteAssemblyServiceTests execution time

### DIFF
--- a/WordPress/Classes/Services/SiteAssembly.swift
+++ b/WordPress/Classes/Services/SiteAssembly.swift
@@ -73,7 +73,7 @@ final class MockSiteAssemblyService: NSObject, SiteAssemblyService {
         self.statusChangeHandler = changeHandler
         currentStatus = .inProgress
 
-        let contrivedDelay = DispatchTimeInterval.seconds(3)
+        let contrivedDelay = DispatchTimeInterval.milliseconds(50)
         let dispatchDelay = DispatchTime.now() + contrivedDelay
         DispatchQueue.main.asyncAfter(deadline: dispatchDelay) { [weak self] in
             guard let self = self else {

--- a/WordPress/WordPressTest/SiteCreation/SiteAssemblyServiceTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteAssemblyServiceTests.swift
@@ -71,7 +71,7 @@ class SiteAssemblyServiceTests: XCTestCase {
             }
         }
 
-        wait(for: [inProgressExpectation, successExpectation], timeout: 10, enforceOrder: true)
+        wait(for: [inProgressExpectation, successExpectation], timeout: 3, enforceOrder: true)
     }
 
     func testSiteAssemblyService_StatusPostRequest__WhenMockingError_IsFailure() {
@@ -91,6 +91,6 @@ class SiteAssemblyServiceTests: XCTestCase {
             }
         }
 
-        wait(for: [inProgressExpectation, failureExpectation], timeout: 10, enforceOrder: true)
+        wait(for: [inProgressExpectation, failureExpectation], timeout: 3, enforceOrder: true)
     }
 }


### PR DESCRIPTION
Hi @stevebaranski! I'm hoping to get your feedback on this. 

The two `testSiteAssemblyService_StatusPostRequest_*` are being reported as the slowest tests in CI. I found that there's a deliberate delay in `MockSiteAssemblyService.createSite()` when it is executed. Is there a reason for this long delay? I checked #10609 but couldn't find any discussion around that. Do you think what I proposed here, 50 ms, is good enough for the test? 

## Testing

Run `SiteAssemblyServiceTests` and check that it still passes.

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
