### PR TITLE
Draft missing from post list

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -328,10 +328,6 @@ class AztecPostViewController: UIViewController, PostEditor {
     ///
     fileprivate var activeMediaRequests = [ImageDownloader.Task]()
 
-    /// Boolean indicating whether the post should be removed whenever the changes are discarded, or not.
-    ///
-    fileprivate(set) var shouldRemovePostOnDismiss = false
-
     /// Media Library Data Source
     ///
     lazy var mediaLibraryDataSource: MediaLibraryPickerDataSource = {
@@ -438,7 +434,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         self.editorSession = editorSession ?? PostEditorAnalyticsSession(editor: .classic, post: post)
 
         super.init(nibName: nil, bundle: nil)
-        self.shouldRemovePostOnDismiss = post.hasNeverAttemptedToUpload() && !post.isLocalRevision
 
         PostCoordinator.shared.cancelAnyPendingSaveOf(post: post)
         addObservers(toPost: post)
@@ -3310,7 +3305,6 @@ extension AztecPostViewController {
     struct Restoration {
         static let restorationIdentifier    = "AztecPostViewController"
         static let postIdentifierKey        = AbstractPost.classNameWithoutNamespaces()
-        static let shouldRemovePostKey      = "shouldRemovePostOnDismiss"
     }
 
     struct MediaUploadingCancelAlert {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -59,9 +59,6 @@ class GutenbergViewController: UIViewController, PostEditor {
 
     var isOpenedDirectlyForPhotoPost: Bool = false
 
-
-    var shouldRemovePostOnDismiss: Bool = false
-
     // MARK: - Editor Media actions
 
     var isUploadingMedia: Bool {
@@ -216,7 +213,6 @@ class GutenbergViewController: UIViewController, PostEditor {
 
         self.replaceEditor = replaceEditor
         verificationPromptHelper = AztecVerificationPromptHelper(account: self.post.blog.account)
-        shouldRemovePostOnDismiss = post.hasNeverAttemptedToUpload() && !post.isLocalRevision
         self.editorSession = editorSession ?? PostEditorAnalyticsSession(editor: .gutenberg, post: post)
 
         super.init(nibName: nil, bundle: nil)

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -232,8 +232,9 @@ extension PostEditor where Self: UIViewController {
 
         post = originalPost
         post.deleteRevision()
+        let shouldRemovePostOnDismiss = post.hasNeverAttemptedToUpload() && !post.isLocalRevision
 
-        if post.hasNeverAttemptedToUpload() && !post.isLocalRevision {
+        if shouldRemovePostOnDismiss {
             post.remove()
             postDeleted = true
         } else if shouldCreateDummyRevision {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -232,7 +232,7 @@ extension PostEditor where Self: UIViewController {
         post = originalPost
         post.deleteRevision()
 
-        if shouldRemovePostOnDismiss {
+        if post.hasNeverAttemptedToUpload() && !post.isLocalRevision {
             post.remove()
         } else if shouldCreateDummyRevision {
             post.createRevision()

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -192,14 +192,13 @@ extension PostEditor where Self: UIViewController {
             showPostHasChangesAlert()
         } else {
             editorSession.end(outcome: .cancel)
-            discardChangesAndUpdateGUI()
+            discardUnsavedChangesAndUpdateGUI()
         }
     }
 
-    func discardChangesAndUpdateGUI() {
+    func discardUnsavedChangesAndUpdateGUI() {
         discardChanges()
-
-        dismissOrPopView(didSave: false)
+        dismissOrPopView()
     }
 
     func discardChanges() {
@@ -283,7 +282,7 @@ extension PostEditor where Self: UIViewController {
         // Button: Discard
         alertController.addDestructiveActionWithTitle(discardTitle) { _ in
             self.editorSession.end(outcome: .discard)
-            self.discardChangesAndUpdateGUI()
+            self.discardUnsavedChangesAndUpdateGUI()
         }
 
         alertController.popoverPresentationController?.barButtonItem = navigationBarManager.closeBarButtonItem
@@ -334,7 +333,7 @@ extension PostEditor where Self: UIViewController {
             }
 
             if dismissWhenDone {
-                strongSelf.dismissOrPopView(didSave: true)
+                strongSelf.dismissOrPopView()
             } else {
                 strongSelf.createRevisionOfPost()
             }
@@ -352,7 +351,7 @@ extension PostEditor where Self: UIViewController {
 
         PostCoordinator.shared.save(post: post)
 
-        dismissOrPopView(didSave: true, shouldShowPostEpilogue: false)
+        dismissOrPopView()
 
         self.postEditorStateContext.updated(isBeingPublished: false)
     }
@@ -374,13 +373,13 @@ extension PostEditor where Self: UIViewController {
         }
     }
 
-    func dismissOrPopView(didSave: Bool, shouldShowPostEpilogue: Bool = true) {
+    func dismissOrPopView() {
         stopEditing()
 
         WPAppAnalytics.track(.editorClosed, withProperties: [WPAppAnalyticsKeyEditorSource: analyticsEditorSource], with: post)
 
         if let onClose = onClose {
-            onClose(didSave, shouldShowPostEpilogue)
+            onClose(true, false)
         } else if isModal() {
             presentingViewController?.dismiss(animated: true, completion: nil)
         } else {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -39,10 +39,6 @@ protocol PostEditor: class, UIViewControllerTransitioningDelegate {
     ///
     func prepopulateMediaItems(_ media: [Media])
 
-    /// Boolean indicating whether the post should be removed whenever the changes are discarded, or not.
-    ///
-    var shouldRemovePostOnDismiss: Bool { get }
-
     /// Cancels all ongoing uploads
     ///
     ///TODO: We won't need this once media uploading is extracted to PostEditorUtil


### PR DESCRIPTION
**Fixes** #8916 

**To test:**

1. Go to the posts list
2. Display the drafts list
3. Open the editor to create a new Post
4. Save it as a Draft from the top right three dots menu
5. Close the editor from the cross on the top left and to go back to the Draft list
6. The newly created post should be there

Also test: publishing a new post from the draft list, from the published list, scheduling posts, etc. Basically we need to run through all the publishing scenarios to make sure nothing is broken.

Notes:

There were two issues at play here:
 - The `shouldRemovePostOnDismiss` property was being calculated during the ViewController initialization, which was incorrect because the post status could change later on.
- When closing the editor from the top left cross, and assumption that there were no changes was made, and this is not correct since the post could've been previously saved via the right three dots menu. Basically when we close the editor we can't assume no changes were made unless the post was created and deleted/discarded.

I've made the minimum amount of changes that fix the bug, however there's a lot of dead code on `PostEditor+Publish`, and logic around PostPost that should be cleaned up in a subsequent PR.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.