### PR TITLE
[Stats Refresh] Insights: fix getting most popular day

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -204,7 +204,7 @@ private extension SiteStatsInsightsViewModel {
         calendar.locale = Locale.autoupdatingCurrent
 
         // Back up mostPopularWeekday by 1 to get correct index for standaloneWeekdaySymbols.
-        mostPopularWeekday = mostPopularWeekday == 0 ? 6 : mostPopularWeekday - 1
+        mostPopularWeekday = mostPopularWeekday == 0 ? calendar.standaloneWeekdaySymbols.count - 1 : mostPopularWeekday - 1
         let dayString = calendar.standaloneWeekdaySymbols[mostPopularWeekday]
 
         guard let timeModifiedDate = calendar.date(bySettingHour: mostPopularHour, minute: 0, second: 0, of: Date()) else {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -193,28 +193,27 @@ private extension SiteStatsInsightsViewModel {
 
     func createMostPopularStatsRows() -> [StatsTotalRowData] {
         guard let mostPopularStats = store.getAnnualAndMostPopularTime(),
-                let mostPopularWeekday = mostPopularStats.mostPopularDayOfWeek.weekday,
-                let mostPopularHour = mostPopularStats.mostPopularHour.hour,
-                mostPopularStats.mostPopularDayOfWeekPercentage > 0
-         else {
+            var mostPopularWeekday = mostPopularStats.mostPopularDayOfWeek.weekday,
+            let mostPopularHour = mostPopularStats.mostPopularHour.hour,
+            mostPopularStats.mostPopularDayOfWeekPercentage > 0
+            else {
                 return []
         }
 
         var calendar = Calendar.init(identifier: .gregorian)
         calendar.locale = Locale.autoupdatingCurrent
 
-        let dayString = calendar.standaloneWeekdaySymbols[mostPopularWeekday - 1]
+        // Back up mostPopularWeekday by 1 to get correct index for standaloneWeekdaySymbols.
+        mostPopularWeekday = mostPopularWeekday == 0 ? 6 : mostPopularWeekday - 1
+        let dayString = calendar.standaloneWeekdaySymbols[mostPopularWeekday]
 
-        let nowWithChangedHour = calendar.date(bySettingHour: mostPopularHour, minute: 0, second: 0, of: Date())
+        guard let timeModifiedDate = calendar.date(bySettingHour: mostPopularHour, minute: 0, second: 0, of: Date()) else {
+            return []
+        }
 
         let timeFormatter = DateFormatter()
         timeFormatter.dateStyle = .none
         timeFormatter.timeStyle = .short
-
-        guard let timeModifiedDate = nowWithChangedHour else {
-
-            return []
-        }
 
         let timeString = timeFormatter.string(from: timeModifiedDate)
 
@@ -226,7 +225,7 @@ private extension SiteStatsInsightsViewModel {
                                   data: String(format: MostPopularStats.percentOfViews,
                                                mostPopularStats.mostPopularHourPercentage),
                                   icon: Style.imageForGridiconType(.time, withTint: .darkGrey))]
-        }
+    }
 
     func createTotalFollowersRows() -> [StatsTotalRowData] {
         var dataRows = [StatsTotalRowData]()


### PR DESCRIPTION
Fixes #n/a

When accessing Insights, if the raw `mostPopularWeekday` was 0, subtracting 1 from it would go 💥  when used as the index for `standaloneWeekdaySymbols`. This adds a check for that, and sets the index accordingly.

To test:
- On a site where the most popular day is the start of the week, go to Stats > Insights.
- Verify it doesn't crash.

Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
