### PR TITLE
Fix layout warning in NoteBlockCommentTableViewCell and MeHeaderView.

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/MeHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Me/MeHeaderView.m
@@ -119,13 +119,20 @@ const NSTimeInterval MeHeaderViewMinimumPressDuration = 0.001;
     [self.stackView addArrangedSubview:spaceView];
     [self.stackView addArrangedSubview:self.displayNameLabel];
     [self.stackView addArrangedSubview:self.usernameLabel];
-
+    NSLayoutConstraint *heightConstraint =  [self.gravatarImageView.heightAnchor constraintEqualToConstant:MeHeaderViewGravatarSize];
+    heightConstraint.priority = 999;
+    NSLayoutConstraint *spaceHeightConstraint =  [spaceView.heightAnchor constraintEqualToConstant:MeHeaderViewVerticalSpacing];
+    heightConstraint.priority = 999;
+    NSLayoutConstraint *stackViewTopConstraint =  [self.stackView.topAnchor constraintEqualToAnchor:self.topAnchor constant:MeHeaderViewVerticalSpacing];
+    stackViewTopConstraint.priority = 999;
+    NSLayoutConstraint *stackViewBottomConstraint =  [self.bottomAnchor constraintEqualToAnchor:self.stackView.bottomAnchor constant:MeHeaderViewVerticalSpacing];
+    stackViewBottomConstraint.priority = 999;
     NSArray *constraints = @[
-                             [self.gravatarImageView.heightAnchor constraintEqualToConstant:MeHeaderViewGravatarSize],
+                             heightConstraint,
                              [self.gravatarImageView.widthAnchor constraintEqualToConstant:MeHeaderViewGravatarSize],
-                             [spaceView.heightAnchor constraintEqualToConstant:MeHeaderViewVerticalSpacing],
-                             [self.stackView.topAnchor constraintEqualToAnchor:self.topAnchor constant:MeHeaderViewVerticalSpacing],
-                             [self.bottomAnchor constraintEqualToAnchor:self.stackView.bottomAnchor constant:MeHeaderViewVerticalSpacing],
+                             spaceHeightConstraint,
+                             stackViewTopConstraint,
+                             stackViewBottomConstraint,
                              [self.stackView.centerXAnchor constraintEqualToAnchor:self.centerXAnchor],
                              ];
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockCommentTableViewCell.xib
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -70,7 +69,7 @@
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailingMargin" relation="greaterThanOrEqual" secondItem="J2Y-Yo-5I1" secondAttribute="trailing" id="0rY-qi-Fsw"/>
-                    <constraint firstItem="rgQ-sb-b7a" firstAttribute="top" secondItem="B30-uC-0a3" secondAttribute="bottom" constant="5" id="6v9-jN-jDW"/>
+                    <constraint firstItem="rgQ-sb-b7a" firstAttribute="top" secondItem="B30-uC-0a3" secondAttribute="bottom" priority="999" constant="5" id="6v9-jN-jDW"/>
                     <constraint firstItem="J2Y-Yo-5I1" firstAttribute="top" secondItem="GbU-dc-vAM" secondAttribute="topMargin" constant="-2" id="BbX-mc-1hp"/>
                     <constraint firstAttribute="bottomMargin" secondItem="rgQ-sb-b7a" secondAttribute="bottom" id="EnP-lZ-Ym3"/>
                     <constraint firstItem="rgQ-sb-b7a" firstAttribute="leading" secondItem="GbU-dc-vAM" secondAttribute="leadingMargin" id="OG7-0A-RZJ"/>
@@ -89,6 +88,7 @@
                 <outlet property="textView" destination="rgQ-sb-b7a" id="kg8-w4-JH9"/>
                 <outlet property="titleLabel" destination="J2Y-Yo-5I1" id="ZAu-qL-HWO"/>
             </connections>
+            <point key="canvasLocation" x="20" y="9"/>
         </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
Fix layout issues in NoteBlockCommentTableViewCell:

 [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x6000018c79d0 WordPress.CircularImageView:0x7fdf7ecac590.height == 32   (active)>",
    "<NSLayoutConstraint:0x600001890b40 WordPress.CircularImageView:0x7fdf7ecac590.top == UITableViewCellContentView:0x7fdf7ecac3a0.topMargin   (active)>",
    "<NSLayoutConstraint:0x600001890cd0 V:[WordPress.CircularImageView:0x7fdf7ecac590]-(5)-[WordPress.RichTextView:0x7fdf7ecad1e0]   (active)>",
    "<NSLayoutConstraint:0x600001890d20 UITableViewCellContentView:0x7fdf7ecac3a0.bottomMargin == WordPress.RichTextView:0x7fdf7ecad1e0.bottom   (active)>",
    "<NSLayoutConstraint:0x600001890fa0 'UIView-bottomMargin-guide-constraint' V:[UILayoutGuide:0x6000002cd880'UIViewLayoutMarginsGuide']-(8)-|   (active, names: '|':UITableViewCellContentView:0x7fdf7ecac3a0 )>",
    "<NSLayoutConstraint:0x60000189d0e0 'UIView-Encapsulated-Layout-Height' UITableViewCellContentView:0x7fdf7ecac3a0.height == 44   (active)>",
    "<NSLayoutConstraint:0x600001890f00 'UIView-topMargin-guide-constraint' V:|-(8)-[UILayoutGuide:0x6000002cd880'UIViewLayoutMarginsGuide']   (active, names: '|':UITableViewCellContentView:0x7fdf7ecac3a0 )>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x6000018c79d0 WordPress.CircularImageView:0x7fdf7ecac590.height == 32   (active)>

Fix layout issues in MeHeaderView:

Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x600002753de0 UIImageView:0x7fc00fc1a5c0.height == 64   (active)>",
    "<NSLayoutConstraint:0x60000276c4b0 UIView:0x7fc00fc220b0.height == 10   (active)>",
    "<NSLayoutConstraint:0x60000277ebc0 V:|-(10)-[UIStackView:0x7fc00fc21820]   (active, names: '|':MeHeaderView:0x7fc00fb14b80 )>",
    "<NSLayoutConstraint:0x60000277ec10 V:[UIStackView:0x7fc00fc21820]-(10)-|   (active, names: '|':MeHeaderView:0x7fc00fb14b80 )>",
    "<NSLayoutConstraint:0x60000249c0a0 'UISV-canvas-connection' UIStackView:0x7fc00fc21820.top == UIImageView:0x7fc00fc1a5c0.top   (active)>",
    "<NSLayoutConstraint:0x60000249c0f0 'UISV-canvas-connection' V:[UILabel:0x7fc00fc204c0'@yaelirub']-(0)-|   (active, names: '|':UIStackView:0x7fc00fc21820 )>",
    "<NSLayoutConstraint:0x60000249c140 'UISV-spacing' V:[UIImageView:0x7fc00fc1a5c0]-(0)-[UIView:0x7fc00fc220b0]   (active)>",
    "<NSLayoutConstraint:0x60000249c190 'UISV-spacing' V:[UIView:0x7fc00fc220b0]-(0)-[UILabel:0x7fc00fc1a960'yaelirub']   (active)>",
    "<NSLayoutConstraint:0x60000249c1e0 'UISV-spacing' V:[UILabel:0x7fc00fc1a960'yaelirub']-(0)-[UILabel:0x7fc00fc204c0'@yaelirub']   (active)>",
    "<NSLayoutConstraint:0x60000249cb90 'UIView-Encapsulated-Layout-Height' MeHeaderView:0x7fc00fb14b80.height == 0   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x600002753de0 UIImageView:0x7fc00fc1a5c0.height == 64   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
2019-04-25 12:08:14.691130-0700 WordPress[5135:4104349] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x60000276c4b0 UIView:0x7fc00fc220b0.height == 10   (active)>",
    "<NSLayoutConstraint:0x60000277ebc0 V:|-(10)-[UIStackView:0x7fc00fc21820]   (active, names: '|':MeHeaderView:0x7fc00fb14b80 )>",
    "<NSLayoutConstraint:0x60000277ec10 V:[UIStackView:0x7fc00fc21820]-(10)-|   (active, names: '|':MeHeaderView:0x7fc00fb14b80 )>",
    "<NSLayoutConstraint:0x60000249c0a0 'UISV-canvas-connection' UIStackView:0x7fc00fc21820.top == UIImageView:0x7fc00fc1a5c0.top   (active)>",
    "<NSLayoutConstraint:0x60000249c0f0 'UISV-canvas-connection' V:[UILabel:0x7fc00fc204c0'@yaelirub']-(0)-|   (active, names: '|':UIStackView:0x7fc00fc21820 )>",
    "<NSLayoutConstraint:0x60000249c140 'UISV-spacing' V:[UIImageView:0x7fc00fc1a5c0]-(0)-[UIView:0x7fc00fc220b0]   (active)>",
    "<NSLayoutConstraint:0x60000249c190 'UISV-spacing' V:[UIView:0x7fc00fc220b0]-(0)-[UILabel:0x7fc00fc1a960'yaelirub']   (active)>",
    "<NSLayoutConstraint:0x60000249c1e0 'UISV-spacing' V:[UILabel:0x7fc00fc1a960'yaelirub']-(0)-[UILabel:0x7fc00fc204c0'@yaelirub']   (active)>",
    "<NSLayoutConstraint:0x60000249cb90 'UIView-Encapsulated-Layout-Height' MeHeaderView:0x7fc00fb14b80.height == 0   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x60000276c4b0 UIView:0x7fc00fc220b0.height == 10   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
2019-04-25 12:08:14.692975-0700 WordPress[5135:4104349] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x60000277ebc0 V:|-(10)-[UIStackView:0x7fc00fc21820]   (active, names: '|':MeHeaderView:0x7fc00fb14b80 )>",
    "<NSLayoutConstraint:0x60000277ec10 V:[UIStackView:0x7fc00fc21820]-(10)-|   (active, names: '|':MeHeaderView:0x7fc00fb14b80 )>",
    "<NSLayoutConstraint:0x60000249c0a0 'UISV-canvas-connection' UIStackView:0x7fc00fc21820.top == UIImageView:0x7fc00fc1a5c0.top   (active)>",
    "<NSLayoutConstraint:0x60000249c0f0 'UISV-canvas-connection' V:[UILabel:0x7fc00fc204c0'@yaelirub']-(0)-|   (active, names: '|':UIStackView:0x7fc00fc21820 )>",
    "<NSLayoutConstraint:0x60000249c140 'UISV-spacing' V:[UIImageView:0x7fc00fc1a5c0]-(0)-[UIView:0x7fc00fc220b0]   (active)>",
    "<NSLayoutConstraint:0x60000249c190 'UISV-spacing' V:[UIView:0x7fc00fc220b0]-(0)-[UILabel:0x7fc00fc1a960'yaelirub']   (active)>",
    "<NSLayoutConstraint:0x60000249c1e0 'UISV-spacing' V:[UILabel:0x7fc00fc1a960'yaelirub']-(0)-[UILabel:0x7fc00fc204c0'@yaelirub']   (active)>",
    "<NSLayoutConstraint:0x60000249cb90 'UIView-Encapsulated-Layout-Height' MeHeaderView:0x7fc00fb14b80.height == 0   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x60000249c1e0 'UISV-spacing' V:[UILabel:0x7fc00fc1a960'yaelirub']-(0)-[UILabel:0x7fc00fc204c0'@yaelirub']   (active)>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.
2019-04-25 12:08:14.693464-0700 WordPress[5135:4104349] [LayoutConstraints] Unable to simultaneously satisfy constraints.
	Probably at least one of the constraints in the following list is one you don't want. 
	Try this: 
		(1) look at each constraint and try to figure out which you don't expect; 
		(2) find the code that added the unwanted constraint or constraints and fix it. 
(
    "<NSLayoutConstraint:0x60000277ebc0 V:|-(10)-[UIStackView:0x7fc00fc21820]   (active, names: '|':MeHeaderView:0x7fc00fb14b80 )>",
    "<NSLayoutConstraint:0x60000277ec10 V:[UIStackView:0x7fc00fc21820]-(10)-|   (active, names: '|':MeHeaderView:0x7fc00fb14b80 )>",
    "<NSLayoutConstraint:0x60000249cb90 'UIView-Encapsulated-Layout-Height' MeHeaderView:0x7fc00fb14b80.height == 0   (active)>"
)

Will attempt to recover by breaking constraint 
<NSLayoutConstraint:0x60000277ec10 V:[UIStackView:0x7fc00fc21820]-(10)-|   (active, names: '|':MeHeaderView:0x7fc00fb14b80 )>

Make a symbolic breakpoint at UIViewAlertForUnsatisfiableConstraints to catch this in the debugger.
The methods in the UIConstraintBasedLayoutDebugging category on UIView listed in <UIKitCore/UIView.h> may also be helpful.

To Test:
Notifications:
1. Go to notification tab
2. tap on a notification that has text (image, author name, details tag with time stamp and text)
3. See the warning mentioned above in log 

MeHeaderView:
1. Go to me tab
2. see the layout warnings mentioned above

*checkout this branch and repeat the steps above. see that the warnings are gone.


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
