### PR TITLE
[Fix] UIAlertController popover properties

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.swift
@@ -1,10 +1,10 @@
 import Gridicons
 
 class BlogDetailsSectionHeaderView: UITableViewHeaderFooterView {
-    typealias EllipsisCallback = () -> Void
+    typealias EllipsisCallback = (BlogDetailsSectionHeaderView) -> Void
     @IBOutlet private var titleLabel: UILabel?
 
-    @IBOutlet private var ellipsisButton: UIButton? {
+    @objc @IBOutlet private(set) var ellipsisButton: UIButton? {
         didSet {
             ellipsisButton?.setImage(Gridicon.iconOfType(.ellipsis).imageWithTintColor(WPStyleGuide.grey()), for: .normal)
         }
@@ -16,9 +16,9 @@ class BlogDetailsSectionHeaderView: UITableViewHeaderFooterView {
         }
     }
 
-    @objc var callback: EllipsisCallback?
+    @objc var ellipsisButtonDidTouch: EllipsisCallback?
 
     @IBAction func ellipsisTapped() {
-        callback?()
+        ellipsisButtonDidTouch?(self)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1110,33 +1110,41 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (UIView *)quickStartHeaderWithTitle:(NSString *)title
 {
+    __weak __typeof(self) weakSelf = self;
+    BlogDetailsSectionHeaderView *view = [self.tableView dequeueReusableHeaderFooterViewWithIdentifier:BlogDetailsSectionHeaderViewIdentifier];
+    [view setTitle:title];
+    view.ellipsisButtonDidTouch = ^(BlogDetailsSectionHeaderView *header) {
+        [weakSelf removeQuickStartSection:header];
+    };
+    return view;
+}
+
+- (void)removeQuickStartSection:(BlogDetailsSectionHeaderView *)view
+{
     NSString *removeTitle = NSLocalizedString(@"Remove Next Steps", @"Title for action that will remove the next steps/quick start menus.");
     NSString *removeMessage = NSLocalizedString(@"Removing Next Steps will hide all tours on this site. This action cannot be undone.", @"Explanation of what will happen if the user confirms this alert.");
     NSString *confirmationTitle = NSLocalizedString(@"Remove", @"Title for button that will confirm removing the next steps/quick start menus.");
     NSString *cancelTitle = NSLocalizedString(@"Cancel", @"Cancel button");
-
+    
     UIAlertController *removeConfirmation = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleAlert];
     [removeConfirmation addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * _Nonnull action) {
         [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonCancelTapped];
     }];
     [removeConfirmation addDefaultActionWithTitle:confirmationTitle handler:^(UIAlertAction * _Nonnull action) {
         [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonRemoveTapped];
-
+        
         [[QuickStartTourGuide find] removeFrom:self.blog];
     }];
-
+    
     UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    removeSheet.popoverPresentationController.sourceView = view;
+    removeSheet.popoverPresentationController.sourceRect = view.ellipsisButton.frame;
     [removeSheet addDestructiveActionWithTitle:removeTitle handler:^(UIAlertAction * _Nonnull action) {
         [self presentViewController:removeConfirmation animated:YES completion:nil];
     }];
     [removeSheet addCancelActionWithTitle:cancelTitle handler:nil];
-
-    BlogDetailsSectionHeaderView *view = [self.tableView dequeueReusableHeaderFooterViewWithIdentifier:BlogDetailsSectionHeaderViewIdentifier];
-    [view setTitle:title];
-    view.callback = ^{
-        [self presentViewController:removeSheet animated:YES completion:nil];
-    };
-    return view;
+    
+    [self presentViewController:removeSheet animated:YES completion:nil];
 }
 
 - (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section


### PR DESCRIPTION
Fixes #11383 

This PR fix a crash we have when an iPad user wants to remove the QuickStart section.
The UIAlertController was presented as _ UIAlertControllerStyleActionSheet_ without any popover property set.

## To test:
**iPad**
• Add a new site and enable QuickStart
• Click on the `•••` ellipsis button to display the alert and remove the QuickStart Action

**iPhone**
Replicate the same steps on an iPhone to check everything works correctly as before. 


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
