### PR TITLE
Notifications: Mark as unread

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 12.4
 -----
+* You can now mark notifications as unread with just a swipe.
 * Fixed crash when searching Free Photo Library.
 * Better URL validation when logging in with a self hosted site.
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -691,6 +691,14 @@ private extension NotificationsViewController {
 
         NotificationSyncMediator()?.markAsRead(note)
     }
+
+    func markAsUnread(note: Notification) {
+        guard note.read else {
+            return
+        }
+
+        NotificationSyncMediator()?.markAsUnread(note)
+    }
 }
 
 
@@ -952,7 +960,7 @@ extension NotificationsViewController: WPTableViewHandlerDelegate {
     }
 
     @objc func configureCellActions(_ cell: NoteTableViewCell, note: Notification) {
-        // Let "Mark as Read" expand
+        // Let "Mark as Read / Unread" expand
         let leadingExpansionButton = 0
 
         // Don't expand "Trash"
@@ -1011,15 +1019,19 @@ extension NotificationsViewController: WPTableViewHandlerDelegate {
 //
 private extension NotificationsViewController {
     func leadingButtons(note: Notification) -> [MGSwipeButton] {
-        guard !note.read else {
-            return []
-        }
+        let isRead = note.read
+
+        let title = isRead ? NSLocalizedString("Mark Unread", comment: "Marks a notification as unread") : NSLocalizedString("Mark Read", comment: "Marks a notification as unread")
 
         return [
-            MGSwipeButton(title: NSLocalizedString("Mark Read", comment: "Marks a notification as read"),
+            MGSwipeButton(title: title,
                           backgroundColor: WPStyleGuide.greyDarken20(),
                           callback: { _ in
-                            self.markAsRead(note: note)
+                            if isRead {
+                                self.markAsUnread(note: note)
+                            } else {
+                                self.markAsRead(note: note)
+                            }
                             return true
             })
         ]


### PR DESCRIPTION
This PR adds the ability to mark notifications as unread. Swipe left-to-right on a read notification to mark unread.

![mark-unread](https://user-images.githubusercontent.com/4780/56813623-444d9000-6835-11e9-8423-6b5c62420a80.gif)

**To test:**

* Build and run and go to your Notifications
* Swipe left-to-right on a read notification and check it becomes unread
* Ensure you can still swipe on unread notifications to mark them read
* Open the same WPCom account in a browser and check the state is reflected there. Note that you may need to reload the page to see your changes on the app take effect.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.