### PR TITLE
Reader: Enforce max image size to prevent OOM errors due to gigantic images

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -271,16 +271,29 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
     /// Returns the CGSize instance for the given `WPTextAttachment`
     ///
     fileprivate func sizeForAttachment(_ attachment: WPTextAttachment) -> CGSize {
-        let width: CGFloat
+        var width: CGFloat = maxDisplaySize.width
         if attachment.width > 0 && attachment.width != .greatestFiniteMagnitude {
             width = attachment.width
-        } else {
-            width = textContainer.size.width
         }
 
-        let height: CGFloat = attachment.height > 0 ? attachment.height : maxDisplaySize.height
+        var height: CGFloat = maxDisplaySize.height
+        if attachment.height > 0 {
+            height = attachment.height
+        }
 
-        return CGSize(width: width, height: height)
+        let r = width / height
+
+        // Enforce max dimensions
+        if width > maxDisplaySize.width {
+            width = maxDisplaySize.width
+            height = width / r
+        }
+        if height > maxDisplaySize.height {
+            height = maxDisplaySize.height
+            width = height * r
+        }
+
+        return CGSize(width: ceil(width), height: ceil(height))
     }
 
     /// Returns the view to use for an image attachment.


### PR DESCRIPTION
Yesterday I was trying to view a post in the reader and the app was being shut down and spring board restarted on my iPhone X.  Investigating, I discovered the images in the post were quite large, over 10,000x8,000 pixels which was this being scaled up to over 30,000x25,000 (x3 for the iPhone X retina display).  Memory pressure from trying to process the image was apparently yielding an OOM error.
<img width="1502" alt="Screen Shot 2019-04-26 at 9 07 38 AM" src="https://user-images.githubusercontent.com/1435271/56820393-67fedf00-6811-11e9-84ae-f317ccfc3496.png">
To resolve the issue, this patch limits the maximum size for an image shown in the reader. 

To test:
Use this post to test: paKIRI-1c-p2
- Confirm the bug on a device by viewing the post in the reader.  Liking the post then viewing your My Likes feed is an easy way.  You can also check the post in the simulator.  The app probably won't crash but the post will not scroll smoothly while the images are being loaded.
- Run the patch and confirm that: 
1. The app does not crash or get ejected from memory. 
2. Scrolling is smooth. 

@etoledom could I trouble you with this one? 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
