### PR TITLE
Account Settings Primary Site: show URL if site has no name

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * You can now mark notifications as unread with just a swipe.
 * Fixed crash when searching Free Photo Library.
 * Better URL validation when logging in with a self hosted site.
+* Account Settings Primary Site now shows the site URL if the site has no name.
 
 12.3
 -----

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -89,7 +89,7 @@ private class AccountSettingsController: SettingsController {
 
         // If the primary site has no name, then show the URL.
         var primarySiteName = settings.flatMap { service.primarySiteNameForSettings($0) }
-        primarySiteName = (primarySiteName == nil || primarySiteName == "") ? settings?.webAddress : primarySiteName
+        primarySiteName = (primarySiteName?.isEmpty ?? true) ? settings?.webAddress : primarySiteName
 
         let primarySite = EditableTextRow(
             title: NSLocalizedString("Primary Site", comment: "Primary Web Site"),

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -75,7 +75,6 @@ private class AccountSettingsController: SettingsController {
     // MARK: - Model mapping
 
     func mapViewModel(_ settings: AccountSettings?, service: AccountSettingsService, presenter: ImmuTablePresenter) -> ImmuTable {
-        let primarySiteName = settings.flatMap { service.primarySiteNameForSettings($0) }
 
         let username = TextRow(
             title: NSLocalizedString("Username", comment: "Account Settings Username label"),
@@ -87,6 +86,10 @@ private class AccountSettingsController: SettingsController {
             value: settings?.emailForDisplay ?? "",
             action: presenter.push(editEmailAddress(settings, service: service))
         )
+
+        // If the primary site has no name, then show the URL.
+        var primarySiteName = settings.flatMap { service.primarySiteNameForSettings($0) }
+        primarySiteName = (primarySiteName == nil || primarySiteName == "") ? settings?.webAddress : primarySiteName
 
         let primarySite = EditableTextRow(
             title: NSLocalizedString("Primary Site", comment: "Primary Web Site"),


### PR DESCRIPTION
Fixes #5884

In Account Settings > Primary Site, if the site has no name, the site URL will now be displayed.

To test:

---
- Remove the primary site Title. (site > Settings > Site Title)
- Go to Account Settings > Primary Site.
- Verify the URL is displayed.


---
- Give the primary site a Title.
- Go to Account Settings > Primary Site.
- Verify the Title is displayed.

---
Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
