### PR TITLE
Improved accessibility of Quick Start checklist header

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.swift
@@ -1,7 +1,6 @@
 import Gridicons
 
 class QuickStartChecklistHeader: UIView {
-
     var collapseListener: ((Bool) -> Void)?
     var collapse: Bool = false {
         didSet {
@@ -88,7 +87,7 @@ extension QuickStartChecklistHeader: Accessible {
 
         // From an accessibility perspective, this view is essentially monolithic, so we configure it accordingly
         isAccessibilityElement = true
-        accessibilityTraits = [ .header, .button ]
+        accessibilityTraits = [.header, .button]
 
         updateCollapseHeaderAccessibility()
     }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.swift
@@ -16,29 +16,13 @@ class QuickStartChecklistHeader: UIView {
                 self?.bottomStroke.alpha = CGFloat(alpha)
                 self?.chevronView.transform = CGAffineTransform(rotationAngle: rotate)
             })
-
-            let hintToken: String
-            if collapse {
-                hintToken = NSLocalizedString("Collapses", comment: "This token is used with ~ to format the accessibility hint to reflect the expanded and collapsed state of the list.")
-            } else {
-                hintToken = NSLocalizedString("Expands", comment: "This token is used with ~ to format the accessibility hint to reflect the expanded and collapsed state of the list.")
-            }
-
-            let accessibilityFormat = NSLocalizedString("%@ the list of completed tasks.", comment: "Accessibility hint for the list of completed tasks presented during Quick Start.")
-            let localizedAccessibilityHint = String(format: accessibilityFormat, hintToken)
-
-            accessibilityHint = localizedAccessibilityHint
+            updateCollapseHeaderAccessibility()
         }
     }
     var count: Int = 0 {
         didSet {
             titleLabel.text = String(format: Constant.title, count)
-
-            // Admittedly pluralization support could be improved here. See also: `paaHJt-c3-p2`
-            let accessibilityFormat = NSLocalizedString("%i completed tasks, toggling expands & contracts the list of these tasks", comment: "Accessibility description for the list of completed tasks presented during Quick Start.")
-            let localizedAccessibilityDescription = String(format: accessibilityFormat, arguments: [count])
-
-            accessibilityLabel = localizedAccessibilityDescription
+            updateCollapseHeaderAccessibility()
         }
     }
 
@@ -105,5 +89,28 @@ extension QuickStartChecklistHeader: Accessible {
         // From an accessibility perspective, this view is essentially monolithic, so we configure it accordingly
         isAccessibilityElement = true
         accessibilityTraits = [ .header, .button ]
+
+        updateCollapseHeaderAccessibility()
+    }
+
+    func updateCollapseHeaderAccessibility() {
+
+        let accessibilityHintText: String
+        let accessibilityLabelFormat: String
+
+        if collapse {
+            accessibilityHintText = NSLocalizedString("Collapses the list of completed tasks.", comment: "Accessibility hint for the list of completed tasks presented during Quick Start.")
+
+            accessibilityLabelFormat = NSLocalizedString("Expanded, %i completed tasks, toggling collapses the list of these tasks", comment: "Accessibility description for the list of completed tasks presented during Quick Start. Parameter is a number representing the count of completed tasks.")
+        } else {
+            accessibilityHintText = NSLocalizedString("Expands the list of completed tasks.", comment: "Accessibility hint for the list of completed tasks presented during Quick Start.")
+
+            accessibilityLabelFormat = NSLocalizedString("Collapsed, %i completed tasks, toggling expands the list of these tasks", comment: "Accessibility description for the list of completed tasks presented during Quick Start. Parameter is a number representing the count of completed tasks.")
+        }
+
+        accessibilityHint = accessibilityHintText
+
+        let localizedAccessibilityDescription = String(format: accessibilityLabelFormat, arguments: [count])
+        accessibilityLabel = localizedAccessibilityDescription
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.swift
@@ -1,6 +1,7 @@
 import Gridicons
 
 class QuickStartChecklistHeader: UIView {
+
     var collapseListener: ((Bool) -> Void)?
     var collapse: Bool = false {
         didSet {
@@ -15,11 +16,29 @@ class QuickStartChecklistHeader: UIView {
                 self?.bottomStroke.alpha = CGFloat(alpha)
                 self?.chevronView.transform = CGAffineTransform(rotationAngle: rotate)
             })
+
+            let hintToken: String
+            if collapse {
+                hintToken = NSLocalizedString("Collapses", comment: "This token is used with ~ to format the accessibility hint to reflect the expanded and collapsed state of the list.")
+            } else {
+                hintToken = NSLocalizedString("Expands", comment: "This token is used with ~ to format the accessibility hint to reflect the expanded and collapsed state of the list.")
+            }
+
+            let accessibilityFormat = NSLocalizedString("%@ the list of completed tasks.", comment: "Accessibility hint for the list of completed tasks presented during Quick Start.")
+            let localizedAccessibilityHint = String(format: accessibilityFormat, hintToken)
+
+            accessibilityHint = localizedAccessibilityHint
         }
     }
     var count: Int = 0 {
         didSet {
             titleLabel.text = String(format: Constant.title, count)
+
+            // Admittedly pluralization support could be improved here. See also: `paaHJt-c3-p2`
+            let accessibilityFormat = NSLocalizedString("%i completed tasks, toggling expands & contracts the list of these tasks", comment: "Accessibility description for the list of completed tasks presented during Quick Start.")
+            let localizedAccessibilityDescription = String(format: accessibilityFormat, arguments: [count])
+
+            accessibilityLabel = localizedAccessibilityDescription
         }
     }
 
@@ -60,8 +79,31 @@ class QuickStartChecklistHeader: UIView {
     @IBAction private func headerDidTouch(_ sender: UIButton) {
         collapse.toggle()
     }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        prepareForVoiceOver()
+    }
 }
 
 private enum Constant {
     static let title = NSLocalizedString("Complete (%i)", comment: "The table view header title that displays the number of completed tasks")
+}
+
+// MARK: - Accessible
+
+extension QuickStartChecklistHeader: Accessible {
+    func prepareForVoiceOver() {
+        // Here we explicit configure the subviews, to prepare for the desired composite behavior
+        bottomStroke.isAccessibilityElement = false
+        contentView.isAccessibilityElement = false
+        titleLabel.isAccessibilityElement = false
+        chevronView.isAccessibilityElement = false
+
+        // Neither the top stroke nor the button (overlay) are outlets, so we configured them in the nib
+
+        // From an accessibility perspective, this view is essentially monolithic, so we configure it accordingly
+        isAccessibilityElement = true
+        accessibilityTraits = [ .header, .button ]
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -35,6 +35,9 @@
                         </view>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" layoutMarginsFollowReadableWidth="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xiK-ca-ccq">
                             <rect key="frame" x="16" y="12.5" width="303" height="19"/>
+                            <accessibility key="accessibilityConfiguration">
+                                <bool key="isElement" value="NO"/>
+                            </accessibility>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -48,6 +51,10 @@
                         </imageView>
                         <button opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yus-75-Z9J">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                            <accessibility key="accessibilityConfiguration">
+                                <accessibilityTraits key="traits" none="YES"/>
+                                <bool key="isElement" value="NO"/>
+                            </accessibility>
                             <connections>
                                 <action selector="headerDidTouch:" destination="iN0-l3-epB" eventType="touchUpInside" id="g6s-7J-Fwg"/>
                             </connections>


### PR DESCRIPTION
Fixes #11493. 

The `QuickStartChecklistHeader` is somewhat dynamic, so I devoted a bit of attention to updating the `accessibilityLabel` & `accessibilityHint` in conjunction with the view state.

_NB: It's probably best to review this in conjunction with #11578, as the same screen (and release notes entry) are impacted._

To test:
- Checkout the branch, verify it builds, and that tests pass.
- Replicate the steps in the issue with VoiceOver, and verify that the desired accessibility behavior is observed.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.