### PR TITLE
Improvements to signup epilogue accessibility

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -31,6 +31,34 @@ class SignupEpilogueCell: UITableViewCell {
 
         accessoryType = .none
         cellField.textContentType = nil
+        isAccessibilityElement = false
+    }
+
+    override var accessibilityLabel: String? {
+        get {
+            let emptyValue = NSLocalizedString("Empty", comment: "Accessibility value presented in the signup epilogue for an empty value.")
+            let secureTextValue = NSLocalizedString("Secure text", comment: "Accessibility value presented in the signup epilogue for a password value.")
+
+            let labelValue = cellLabel.text ?? emptyValue
+
+            let fieldValue: String
+            if let cellText = cellField.text, !cellText.isEmpty {
+                if cellType == .password {
+                    fieldValue = secureTextValue    // let's refrain from reading the password aloud
+                } else {
+                    fieldValue = cellText
+                }
+            } else {
+                fieldValue = emptyValue
+            }
+
+            let value = "\(labelValue), \(fieldValue)"
+
+            return value
+        }
+        set {
+            super.accessibilityLabel = accessibilityLabel
+        }
     }
 
     // MARK: - Public Methods
@@ -54,7 +82,12 @@ class SignupEpilogueCell: UITableViewCell {
 
     // MARK: - Private behavior
 
-    private func configureAccessibility(for cellType: EpilogueCellType) {}
+    private func configureAccessibility(for cellType: EpilogueCellType) {
+        if cellType == .username {
+            accessibilityTraits.insert(.button) // selection transitions to SignupUsernameViewController
+            isAccessibilityElement = true       // this assures double-tap properly captures cell selection
+        }
+    }
 
     private func configureAccessoryType(for cellType: EpilogueCellType) {
         if cellType == .username {

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -65,12 +65,17 @@ class SignupEpilogueCell: UITableViewCell {
     }
 
     private func configureTextContentTypeIfNeeded(for cellType: EpilogueCellType) {
-        if #available(iOS 12.0, *) {
-            if cellType == .password {
-                cellField.textContentType = .newPassword
-            } else {
-                cellField.textContentType = nil
-            }
+        guard #available(iOS 12, *) else {
+            return
+        }
+
+        switch cellType {
+        case .displayName:
+            cellField.textContentType = .name
+        case .username:
+            cellField.textContentType = .username
+        case .password:
+            cellField.textContentType = .newPassword
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -29,7 +29,6 @@ class SignupEpilogueCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
 
-        accessibilityTraits = super.accessibilityTraits
         accessoryType = .none
         cellField.textContentType = nil
     }
@@ -55,21 +54,7 @@ class SignupEpilogueCell: UITableViewCell {
 
     // MARK: - Private behavior
 
-    private func configureAccessibility(for cellType: EpilogueCellType) {
-        let labelText = cellLabel.text ?? ""
-        let fieldText = cellField.text ?? ""
-        let defaultAccessibilityLabel = "\(labelText), \(fieldText)"
-
-        switch cellType {
-        case .displayName:
-            accessibilityLabel = defaultAccessibilityLabel
-        case .username:
-            accessibilityLabel = defaultAccessibilityLabel
-            accessibilityTraits.insert(.button)     // selection transitions to SignupUsernameViewController
-        case .password:
-            accessibilityLabel = labelText          // let's refrain from reading the password aloud
-        }
-    }
+    private func configureAccessibility(for cellType: EpilogueCellType) {}
 
     private func configureAccessoryType(for cellType: EpilogueCellType) {
         if cellType == .username {

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -29,6 +29,7 @@ class SignupEpilogueCell: UITableViewCell {
     override func prepareForReuse() {
         super.prepareForReuse()
 
+        accessibilityTraits = super.accessibilityTraits
         accessoryType = .none
         cellField.textContentType = nil
     }
@@ -54,7 +55,21 @@ class SignupEpilogueCell: UITableViewCell {
 
     // MARK: - Private behavior
 
-    private func configureAccessibility(for cellType: EpilogueCellType) {}
+    private func configureAccessibility(for cellType: EpilogueCellType) {
+        let labelText = cellLabel.text ?? ""
+        let fieldText = cellField.text ?? ""
+        let defaultAccessibilityLabel = "\(labelText), \(fieldText)"
+
+        switch cellType {
+        case .displayName:
+            accessibilityLabel = defaultAccessibilityLabel
+        case .username:
+            accessibilityLabel = defaultAccessibilityLabel
+            accessibilityTraits.insert(.button)     // selection transitions to SignupUsernameViewController
+        case .password:
+            accessibilityLabel = labelText          // let's refrain from reading the password aloud
+        }
+    }
 
     private func configureAccessoryType(for cellType: EpilogueCellType) {
         if cellType == .username {

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -24,6 +24,15 @@ class SignupEpilogueCell: UITableViewCell {
     private var cellType: EpilogueCellType?
     open var delegate: SignupEpilogueCellDelegate?
 
+    // MARK: - UITableViewCell
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        accessoryType = .none
+        cellField.textContentType = nil
+    }
+
     // MARK: - Public Methods
 
     func configureCell(forType newCellType: EpilogueCellType,
@@ -38,12 +47,24 @@ class SignupEpilogueCell: UITableViewCell {
         cellField.isSecureTextEntry = (cellType == .password)
         selectionStyle = .none
 
+        configureAccessoryType(for: newCellType)
+        configureTextContentTypeIfNeeded(for: newCellType)
+        configureAccessibility(for: newCellType)
+    }
+
+    // MARK: - Private behavior
+
+    private func configureAccessibility(for cellType: EpilogueCellType) {}
+
+    private func configureAccessoryType(for cellType: EpilogueCellType) {
         if cellType == .username {
             accessoryType = .disclosureIndicator
         } else {
             accessoryType = .none
         }
+    }
 
+    private func configureTextContentTypeIfNeeded(for cellType: EpilogueCellType) {
         if #available(iOS 12.0, *) {
             if cellType == .password {
                 cellField.textContentType = .newPassword
@@ -52,7 +73,6 @@ class SignupEpilogueCell: UITableViewCell {
             }
         }
     }
-
 }
 
 
@@ -87,5 +107,4 @@ extension SignupEpilogueCell: UITextFieldDelegate {
         cellField.endEditing(true)
         return true
     }
-
 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -21,9 +21,6 @@
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IPK-b3-7Fi">
                         <rect key="frame" x="10" y="0.0" width="42" height="43.5"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <accessibility key="accessibilityConfiguration">
-                            <bool key="isElement" value="NO"/>
-                        </accessibility>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
@@ -50,9 +47,6 @@
                     <constraint firstItem="BeK-ke-PFi" firstAttribute="top" secondItem="j3X-VY-JUT" secondAttribute="top" id="qjh-pQ-X5J"/>
                 </constraints>
             </tableViewCellContentView>
-            <accessibility key="accessibilityConfiguration">
-                <bool key="isElement" value="YES"/>
-            </accessibility>
             <connections>
                 <outlet property="cellField" destination="BeK-ke-PFi" id="jXq-d3-n8z"/>
                 <outlet property="cellLabel" destination="IPK-b3-7Fi" id="zEA-to-D3Z"/>

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.xib
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -21,6 +21,9 @@
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IPK-b3-7Fi">
                         <rect key="frame" x="10" y="0.0" width="42" height="43.5"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <accessibility key="accessibilityConfiguration">
+                            <bool key="isElement" value="NO"/>
+                        </accessibility>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
@@ -47,6 +50,9 @@
                     <constraint firstItem="BeK-ke-PFi" firstAttribute="top" secondItem="j3X-VY-JUT" secondAttribute="top" id="qjh-pQ-X5J"/>
                 </constraints>
             </tableViewCellContentView>
+            <accessibility key="accessibilityConfiguration">
+                <bool key="isElement" value="YES"/>
+            </accessibility>
             <connections>
                 <outlet property="cellField" destination="BeK-ke-PFi" id="jXq-d3-n8z"/>
                 <outlet property="cellLabel" destination="IPK-b3-7Fi" id="zEA-to-D3Z"/>


### PR DESCRIPTION
Fixes #11490, via the following changes:

- Applied "extract method" refactoring* to the existing configuration of cell accessory view & text content type.
- Although there is a low likelihood of cell reuse on this table, implemented `prepareForReuse()` to reset existing cell configuration to "known, good" state.
- Disabled `isAccessibilityElement` of the cell's label, as its value is now read implicitly.
- Set `accessibilityTraits` of `username` cell configuration to reflect that it's a button. This is consistent with other parts of the app (e.g., `MyProfileViewController`) where the value is _not_ edited inline.
- Modified the cell's `accessibilityLabel` to read back contents of the label & the current text field value, as applicable (i.e., for `displayName` & `username` types, but _not_ the `password`).

In the future, it might be worthwhile to further specialize `SignupEpilogueCell` into separate cells for each particular type.

_*It can be argued that this is not really refactoring without tests to validate the behavior before & after the change._

To test:
- Checkout the branch, verify it builds, and that tests pass.
- Replicate the steps in the issue with VoiceOver, and verify that the desired accessibility behavior is observed.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.