### PR TITLE
Issues/improve reader comments performance

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -38,6 +38,8 @@ class ReaderCommentCell: UITableViewCell {
 
     @objc var comment: Comment?
 
+    @objc var attributedString: NSAttributedString?
+
     @objc var showReply: Bool {
         get {
             if let comment = comment, let post = comment.post as? ReaderPost {
@@ -118,8 +120,9 @@ class ReaderCommentCell: UITableViewCell {
     // MARK: - Configuration
 
 
-    @objc func configureCell(comment: Comment) {
+    @objc func configureCell(comment: Comment, attributedString: NSAttributedString) {
         self.comment = comment
+        self.attributedString = attributedString
 
         configureAvatar()
         configureAuthorButton()
@@ -175,14 +178,14 @@ class ReaderCommentCell: UITableViewCell {
 
 
     @objc func configureText() {
-        guard let comment = comment else {
+        guard let comment = comment, let attributedString = attributedString else {
             return
         }
 
         textView.isPrivate = comment.isPrivateContent()
         // Use `content` vs `contentForDisplay`. Hierarchcial comments are already
         // correctly formatted during the sync process.
-        textView.content = comment.content
+        textView.attributedText = attributedString
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -56,6 +56,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 @property (nonatomic) BOOL needsRefreshTableViewAfterScrolling;
 @property (nonatomic) BOOL failedToFetchComments;
 @property (nonatomic) BOOL deviceIsRotating;
+@property (nonatomic, strong) NSCache *cachedAttributedStrings;
 
 @end
 
@@ -322,6 +323,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
 
     self.estimatedRowHeights = [[NSCache alloc] init];
+    self.cachedAttributedStrings = [[NSCache alloc] init];
 }
 
 - (void)configureTableViewHandler
@@ -705,7 +707,32 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 {
     [self.tableViewHandler refreshTableView];
     [self refreshNoResultsView];
+    [self.managedObjectContext performBlock:^{
+        [self updateCachedContent];
+    }];
+
 }
+
+
+- (void)updateCachedContent
+{
+    NSArray *comments = self.tableViewHandler.resultsController.fetchedObjects;
+    for(Comment *comment in comments) {
+        [self cacheContentForComment:comment];
+    }
+}
+
+
+- (NSAttributedString *)cacheContentForComment:(Comment *)comment
+{
+    NSAttributedString *attrStr = [self.cachedAttributedStrings objectForKey:comment.commentID];
+    if (!attrStr) {
+        attrStr = [WPRichContentView formattedAttributedStringForString: comment.content];
+        [self.cachedAttributedStrings setObject:attrStr forKey:comment.commentID];
+    }
+    return attrStr;
+}
+
 
 #pragma mark - Actions
 
@@ -909,7 +936,8 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
         return;
     }
 
-    [cell configureCellWithComment:comment];
+    NSAttributedString *attrStr = [self cacheContentForComment:comment];
+    [cell configureCellWithComment:comment attributedString:attrStr];
 }
 
 - (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -78,6 +78,10 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     private let readerLinkRouter = UniversalLinkRouter(routes: UniversalLinkRouter.ReaderRoutes)
 
+    private let topMarginAttachment = NSTextAttachment()
+
+    private let bottomMarginAttachment = NSTextAttachment()
+
     @objc var currentPreferredStatusBarStyle = UIStatusBarStyle.lightContent {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
@@ -431,9 +435,25 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     /// Updates the bounds of the placeholder top and bottom text attachments so
     /// there is enough vertical space for the text header and footer views.
     fileprivate func updateTextViewMargins() {
-        textView.topMargin = textHeaderStackView.frame.height
-        textView.bottomMargin = textFooterStackView.frame.height
+        updateTopMargin()
+        updateBottomMargin()
         textFooterTopConstraint.constant = textFooterYOffset()
+    }
+
+    fileprivate func updateTopMargin() {
+        var bounds = topMarginAttachment.bounds
+        bounds.size.height = max(1, textHeaderStackView.frame.height)
+        bounds.size.width = textView.textContainer.size.width
+        topMarginAttachment.bounds = bounds
+        textView.ensureLayoutForAttachment(topMarginAttachment)
+    }
+
+    fileprivate func updateBottomMargin() {
+        var bounds = bottomMarginAttachment.bounds
+        bounds.size.height = max(1, textFooterStackView.frame.height)
+        bounds.size.width = textView.textContainer.size.width
+        bottomMarginAttachment.bounds = bounds
+        textView.ensureLayoutForAttachment(bottomMarginAttachment)
     }
 
 
@@ -670,13 +690,35 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         }
     }
 
-
     fileprivate func configureRichText() {
         guard let post = post else {
             return
         }
         textView.isPrivate = post.isPrivate()
         textView.content = post.contentForDisplay()
+
+        // TODO: Get attributed string
+        // Modify the attributed string. Add top and bottom embeds
+        // Ensure formatting for embeds.
+        // Assign attributed string to textView.
+        // Besure that embed bounds are updated.
+        let attrStr = WPRichContentView.formattedAttributedStringForString(post.contentForDisplay())
+        let mAttrStr = NSMutableAttributedString(attributedString: attrStr)
+
+        // Ensure the starting paragraph style is applied to the topMarginAttachment else the
+        // first paragraph might not have the correct line height.
+        var paraStyle = NSParagraphStyle.default
+        if attrStr.length > 0 {
+            if let pstyle = attrStr.attribute(.paragraphStyle, at: 0, effectiveRange: nil) as? NSParagraphStyle {
+                paraStyle = pstyle
+            }
+        }
+
+        mAttrStr.insert(NSAttributedString(attachment: topMarginAttachment), at: 0)
+        mAttrStr.addAttributes([.paragraphStyle: paraStyle], range: NSRange(location: 0, length: 1))
+        mAttrStr.append(NSAttributedString(attachment: bottomMarginAttachment))
+
+        textView.attributedText = mAttrStr
 
         updateTextViewMargins()
     }

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -60,7 +60,7 @@ class WPRichContentView: UITextView {
     }
 
 
-    class func formattedAttributedStringForString(_ string: String) -> NSAttributedString {
+    @objc class func formattedAttributedStringForString(_ string: String) -> NSAttributedString {
         let style = "<style>" +
             "body { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; line-height:1.6; color: #2e4453; }" +
             "blockquote { color:#4f748e; } " +


### PR DESCRIPTION
For hack week I wanted to try to improve the performance of the reader's comments view controller.  Scrolling the view seemed a little janky at times and when I profiled the controller the Time Profiler showed > 25% of time was spent building the attributed strings we show in each comment cell.  This seemed like a good candidate for improvement and led to this  PR. 

In this PR we do some refactoring to allow us to cache the attributed strings we show in the reader comments view controller rather than creating them on demand every time a cell is configured.   It was necessary to first implement a small refactor of the WPRichContentView to move logic specific to margin handling into the ReaderPostDetailController where its actually used.  Once done, ReaderCommentsViewController and ReaderCommentCell could be refactored to implement a new caching strategy.  Of note is the use of NSCache for storing attributed strings both for thread safety and for its memory handling behavior.

With these changes the Time Profiler is showing me time spent is down to ~15%. 

To test:
If you like, find a reader post with lots of comments and first examine its performance by profiling with the Time Profiler instrument. 
Switch to this patch.
Confirm reader comments load as expected. 
Scrolling should be smoother than it was previously tho this may be subjective and vary in its amount based on the comments being viewed. 
Compare its performance in the Time Profiler again and confirm that less time is spent building attributed strings. 

@stevebaranski Could I trouble you for a review of this one? 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
