### PR TITLE
[Stats Refresh] Post Stats: add Months and Years

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -200,7 +200,7 @@ private extension PostStatsViewModel {
     func childRowsForYear(_ months: [StatsPostViews]) -> [StatsTotalRowData] {
         return months.map {
             StatsTotalRowData(name: displayMonth(forDate: $0.date),
-                              data: $0.viewsCount.formatWithCommas())
+                              data: $0.viewsCount.abbreviatedString())
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -38,6 +38,11 @@ class PostStatsViewModel: Observable {
         return df
     }()
 
+    private lazy var monthFormatter: DateFormatter = {
+        let df = DateFormatter()
+        df.setLocalizedDateFormatFromTemplate("MMM")
+        return df
+    }()
 
     private struct Constants {
         static let maxRowsToDisplay = 6
@@ -47,6 +52,7 @@ class PostStatsViewModel: Observable {
         static let recentWeeks = NSLocalizedString("Recent Weeks", comment: "Post Stats recent weeks header.")
         static let views = NSLocalizedString("Views", comment: "Label for number of views.")
         static let period = NSLocalizedString("Period", comment: "Label for date periods.")
+        static let monthsAndYears = NSLocalizedString("Months and Years", comment: "Post Stats months and years header.")
     }
 
     // MARK: - Init
@@ -76,6 +82,7 @@ class PostStatsViewModel: Observable {
 
         tableRows.append(titleTableRow())
         tableRows.append(contentsOf: overviewTableRows())
+        tableRows.append(contentsOf: yearsTableRows())
         tableRows.append(contentsOf: recentWeeksTableRows())
         tableRows.append(TableFooterRow())
 
@@ -123,6 +130,47 @@ private extension PostStatsViewModel {
         return tableRows
     }
 
+    func yearsTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+
+        tableRows.append(CellHeaderRow(title: Constants.monthsAndYears))
+        tableRows.append(TopTotalsPostStatsRow(itemSubtitle: Constants.period,
+                                               dataSubtitle: Constants.views,
+                                               dataRows: yearsDataRows(),
+                                               limitRowsDisplayed: true,
+                                               postStatsDelegate: postStatsDelegate))
+
+        return tableRows
+    }
+
+    func yearsDataRows() -> [StatsTotalRowData] {
+
+        guard let monthlyBreakdown = postStats?.monthlyBreakdown,
+            let maxYear = (monthlyBreakdown.max(by: { $0.date.year! < $1.date.year! }))?.date.year else {
+                return []
+        }
+
+        let minYear = maxYear - Constants.maxRowsToDisplay
+        var yearRows = [StatsTotalRowData]()
+
+        // Create Year rows in descending order
+        for year in (minYear...maxYear).reversed() {
+            // Get months for year, in descending order
+            let months = (monthlyBreakdown.filter({ $0.date.year == year })).sorted(by: { $0.date.month! > $1.date.month! })
+            // Sum months views for the year
+            let yearTotalViews = months.map({$0.viewsCount}).reduce(0, +)
+
+            if yearTotalViews > 0 {
+                yearRows.append(StatsTotalRowData(name: String(year),
+                                                  data: yearTotalViews.abbreviatedString(),
+                                                  showDisclosure: true,
+                                                  childRows: childRowsForYear(months)))
+            }
+        }
+
+        return yearRows
+    }
+
     func recentWeeksTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
 
@@ -145,6 +193,23 @@ private extension PostStatsViewModel {
                               showDisclosure: true,
                               childRows: childRowsForWeek($0))
         }
+    }
+
+    // MARK: - Months & Years Helpers
+
+    func childRowsForYear(_ months: [StatsPostViews]) -> [StatsTotalRowData] {
+        return months.map {
+            StatsTotalRowData(name: displayMonth(forDate: $0.date),
+                              data: $0.viewsCount.formatWithCommas())
+        }
+    }
+
+    func displayMonth(forDate date: DateComponents) -> String {
+        guard let month = calendar.date(from: date) else {
+            return ""
+        }
+
+        return monthFormatter.string(from: month)
     }
 
     // MARK: - Recent Weeks Helpers

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -149,7 +149,15 @@ private extension TopTotalsCell {
         // store that on the row (for possible removal later),
         // and add the child view to the row stack view.
 
-        let numberOfRowsToAdd = childRows.count > maxChildRowsToDisplay ? maxChildRowsToDisplay : childRows.count
+        let numberOfRowsToAdd: Int = {
+            // If this is on Post Stats, don't limit the number of child rows
+            // as it needs to show a year's worth of data.
+            if postStatsDelegate != nil {
+                return childRows.count
+            }
+            return childRows.count > maxChildRowsToDisplay ? maxChildRowsToDisplay : childRows.count
+        }()
+
         let containingStackView = stackViewContainingRow(row)
         let childRowsView = StatsChildRowsView.loadFromNib()
 


### PR DESCRIPTION
Ref #11189

This adds the 'Months and Years' card to the Post Stats view. 
- It shows total views for the last 6 years. 
- If there are more than 6 years, `View more` will be added.
  - NOTE: `View more` doesn't do anything just yet. Coming soon.
- Expanding a year shows the total views for each month in the year.

To test:
- Tip: en.blog > Home Page has views for several years.
- Access Post Stats via:
  - Insights > Latest Post Summary > View more
  - Period > Posts and Pages > row selection
  - Period > Posts and Pages > View more > row selection
- Verify 'Months and Years' appears, and each year expands to show all months in the year.

<img width="350" alt="moyr_init" src="https://user-images.githubusercontent.com/1816888/56931245-9a703c80-6a9c-11e9-8d6e-569242d0eeae.png">

<img width="350" alt="moyr_partial_year" src="https://user-images.githubusercontent.com/1816888/56931252-a0661d80-6a9c-11e9-9076-d95771fb8735.png">

<img width="350" alt="moyr_full_year" src="https://user-images.githubusercontent.com/1816888/56931254-a3f9a480-6a9c-11e9-8bd9-e95fe3cea9f4.png">
