### PR TITLE
[Stats Refresh] Post Stats: add Avg Views Per Day

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -146,9 +146,9 @@ private extension PostStatsViewModel {
     }
 
     func yearsDataRows(forAverages: Bool = false) -> [StatsTotalRowData] {
-        let yearsData = (forAverages ? postStats?.dailyAveragesPerMonth : postStats?.monthlyBreakdown) ?? []
 
-        guard let maxYear = maxYearFrom(yearsData: yearsData) else {
+        guard let yearsData = (forAverages ? postStats?.dailyAveragesPerMonth : postStats?.monthlyBreakdown),
+            let maxYear = maxYearFrom(yearsData: yearsData) else {
             return []
         }
 
@@ -159,7 +159,13 @@ private extension PostStatsViewModel {
         for year in (minYear...maxYear).reversed() {
             let months = monthsFrom(yearsData: yearsData, forYear: year)
             let yearTotalViews = totalViewsFrom(monthsData: months)
-            let rowValue = forAverages ? (yearTotalViews / months.count) : yearTotalViews
+
+            let rowValue: Int = {
+                if forAverages {
+                    return months.count > 0 ? (yearTotalViews / months.count) : 0
+                }
+                return yearTotalViews
+            }()
 
             if rowValue > 0 {
                 yearRows.append(StatsTotalRowData(name: String(year),


### PR DESCRIPTION
Ref #11189

This adds the 'Avg Views Per Day' card to the Post Stats view. 
- It shows average views for the last 6 years. 
- If there are more than 6 years, `View more` will be added.
  - NOTE: `View more` doesn't do anything just yet. Coming soon.
- Expanding a year shows the average views for each month in the year.

To test:
- Tip: en.blog > Home Page has views for several years.
- Access Post Stats via:
  - Insights > Latest Post Summary > View more
  - Period > Posts and Pages > row selection
  - Period > Posts and Pages > View more > row selection
- Verify 'Avg Views Per Day' appears, and each year expands to show all months in the year.

<img width="350" alt="views_init" src="https://user-images.githubusercontent.com/1816888/56935819-e1682d00-6ab0-11e9-9d18-b96899bddbbf.png">

<img width="350" alt="views_partial_year" src="https://user-images.githubusercontent.com/1816888/56935824-e6c57780-6ab0-11e9-96e3-9cc79ce64b04.png">

<img width="350" alt="views_full_year" src="https://user-images.githubusercontent.com/1816888/56935825-eaf19500-6ab0-11e9-9f2f-014bfdaab130.png">
