### PR TITLE
Check domain credit eligibility

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -17,7 +17,7 @@ enum FeatureFlag: Int {
         case .statsRefresh:
             return BuildConfiguration.current == .localDeveloper
         case .domainCredit:
-            return false
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -600,7 +600,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)configureTableViewData
 {
     NSMutableArray *marr = [NSMutableArray array];
-    if ([Feature enabled:FeatureFlagDomainCredit]) {
+    if ([DomainCreditEligibilityChecker canRedeemDomainCreditWithBlog:self.blog
+                                                      isFeatureFlagOn:[Feature enabled:FeatureFlagDomainCredit]]) {
         [marr addObject:[self domainCreditSectionViewModel]];
     }
     if ([self shouldShowQuickStartChecklist]) {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -600,8 +600,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)configureTableViewData
 {
     NSMutableArray *marr = [NSMutableArray array];
-    if ([DomainCreditEligibilityChecker canRedeemDomainCreditWithBlog:self.blog
-                                                      isFeatureFlagOn:[Feature enabled:FeatureFlagDomainCredit]]) {
+    if ([Feature enabled:FeatureFlagDomainCredit] && [DomainCreditEligibilityChecker canRedeemDomainCreditWithBlog:self.blog]) {
         [marr addObject:[self domainCreditSectionViewModel]];
     }
     if ([self shouldShowQuickStartChecklist]) {

--- a/WordPress/Classes/ViewRelated/Blog/DomainCredit/DomainCreditEligibilityChecker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DomainCredit/DomainCreditEligibilityChecker.swift
@@ -1,8 +1,5 @@
 class DomainCreditEligibilityChecker: NSObject {
-    @objc static func canRedeemDomainCredit(blog: Blog, isFeatureFlagOn: Bool) -> Bool {
-        guard isFeatureFlagOn else {
-            return false
-        }
+    @objc static func canRedeemDomainCredit(blog: Blog) -> Bool {
         let isHostedAtWPCom = blog.isHostedAtWPcom
         let hasDomainCredit = blog.hasDomainCredit
         let hasWPComDomain = blog.url?.matches(regex: "wordpress\\.com\\/?$").isEmpty == false

--- a/WordPress/Classes/ViewRelated/Blog/DomainCredit/DomainCreditEligibilityChecker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DomainCredit/DomainCreditEligibilityChecker.swift
@@ -1,0 +1,11 @@
+class DomainCreditEligibilityChecker: NSObject {
+    @objc static func canRedeemDomainCredit(blog: Blog, isFeatureFlagOn: Bool) -> Bool {
+        guard isFeatureFlagOn else {
+            return false
+        }
+        let isHostedAtWPCom = blog.isHostedAtWPcom
+        let hasDomainCredit = blog.hasDomainCredit
+        let hasWPComDomain = blog.url?.matches(regex: "wordpress\\.com\\/?$").isEmpty == false
+        return isHostedAtWPCom && hasDomainCredit && hasWPComDomain
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		02761EC02270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EBF2270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift */; };
 		02761EC222700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EC122700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift */; };
 		02761EC4227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EC3227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift */; };
+		027AC51D227896540033E56E /* DomainCreditEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027AC51C227896540033E56E /* DomainCreditEligibilityChecker.swift */; };
+		027AC5212278983F0033E56E /* DomainCreditEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027AC5202278983F0033E56E /* DomainCreditEligibilityTests.swift */; };
 		02AC3092226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AC3091226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift */; };
 		02BF30532271D7F000616558 /* DomainCreditRedemptionSuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BF30522271D7F000616558 /* DomainCreditRedemptionSuccessViewController.swift */; };
 		04936A8B3D936CD1FC4AB1EF /* Pods_WordPressNotificationContentExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6CC2CF274BA2F245C464D562 /* Pods_WordPressNotificationContentExtension.framework */; };
@@ -1871,6 +1873,8 @@
 		02761EBF2270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+SectionHelpers.swift"; sourceTree = "<group>"; };
 		02761EC122700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDetailsSubsectionToSectionCategoryTests.swift; sourceTree = "<group>"; };
 		02761EC3227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDetailsSectionIndexTests.swift; sourceTree = "<group>"; };
+		027AC51C227896540033E56E /* DomainCreditEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainCreditEligibilityChecker.swift; sourceTree = "<group>"; };
+		027AC5202278983F0033E56E /* DomainCreditEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainCreditEligibilityTests.swift; sourceTree = "<group>"; };
 		02AC3091226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+DomainCredit.swift"; sourceTree = "<group>"; };
 		02BF30522271D7F000616558 /* DomainCreditRedemptionSuccessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainCreditRedemptionSuccessViewController.swift; sourceTree = "<group>"; };
 		0807CB711CE670A800CDBDAC /* WPContentSearchHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPContentSearchHelper.swift; sourceTree = "<group>"; };
@@ -4135,10 +4139,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		027AC51F2278982D0033E56E /* DomainCredit */ = {
+			isa = PBXGroup;
+			children = (
+				027AC5202278983F0033E56E /* DomainCreditEligibilityTests.swift */,
+			);
+			path = DomainCredit;
+			sourceTree = "<group>";
+		};
 		02BF30512271D76F00616558 /* DomainCredit */ = {
 			isa = PBXGroup;
 			children = (
 				02BF30522271D7F000616558 /* DomainCreditRedemptionSuccessViewController.swift */,
+				027AC51C227896540033E56E /* DomainCreditEligibilityChecker.swift */,
 			);
 			path = DomainCredit;
 			sourceTree = "<group>";
@@ -4449,7 +4462,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				F14B5F6F208E648200439554 /* config */,
@@ -7585,6 +7598,7 @@
 		BEC8A3FD1B4BAA08001CB8C3 /* Blog */ = {
 			isa = PBXGroup;
 			children = (
+				027AC51F2278982D0033E56E /* DomainCredit */,
 				BE1071FD1BC75FCF00906AFF /* Style */,
 				02761EC122700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift */,
 				02761EC3227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift */,
@@ -8449,7 +8463,6 @@
 		F928EDA1226140430030D451 /* Sentry */ = {
 			isa = PBXGroup;
 			children = (
-				F928EDA2226140620030D451 /* WPCrashLogging.swift */,
 			);
 			path = Sentry;
 			sourceTree = "<group>";
@@ -8879,7 +8892,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -10036,6 +10049,7 @@
 				E166FA1B1BB0656B00374B5B /* PeopleCellViewModel.swift in Sources */,
 				73CE3E0E21F7F9D3007C9C85 /* TableViewOffsetCoordinator.swift in Sources */,
 				436D56292117312700CEAA33 /* RegisterDomainDetailsViewController.swift in Sources */,
+				027AC51D227896540033E56E /* DomainCreditEligibilityChecker.swift in Sources */,
 				83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */,
 				91DCE84421A6A7840062F134 /* PostEditor+BlogPicker.swift in Sources */,
 				B56994451B7A7EF200FF26FA /* WPStyleGuide+Comments.swift in Sources */,
@@ -11049,6 +11063,7 @@
 				0879FC161E9301DD00E1EFC8 /* MediaTests.swift in Sources */,
 				B556EFCB1DCA374200728F93 /* DictionaryHelpersTests.swift in Sources */,
 				08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */,
+				027AC5212278983F0033E56E /* DomainCreditEligibilityTests.swift in Sources */,
 				E10F3DA11E5C2CE0008FAADA /* PostListFilterTests.swift in Sources */,
 				93EF094C19ED533500C89770 /* ContextManagerTests.swift in Sources */,
 				D800D87820999B6D00E7C7E5 /* LikedMenuItemCreatorTests.swift in Sources */,

--- a/WordPress/WordPressTest/DomainCredit/DomainCreditEligibilityTests.swift
+++ b/WordPress/WordPressTest/DomainCredit/DomainCreditEligibilityTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import WordPress
+
+class DomainCreditEligibilityTests: XCTestCase {
+    private var manager: TestContextManager!
+    private var mainContext: NSManagedObjectContext {
+        return manager.mainContext
+    }
+    
+    override func setUp() {
+        super.setUp()
+        manager = TestContextManager()
+    }
+    
+    func testDomainCreditEligibilityWithFeatureFlagOff() {
+        let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
+        blog.hasDomainCredit = true
+        blog.isHostedAtWPcom = true
+        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog, isFeatureFlagOn: false)
+        XCTAssertFalse(canRedeemDomainCredit)
+    }
+    
+    func testDomainCreditEligibilityOnBlogWithCustomDomain() {
+        let blog = ModelTestHelper.insertSelfHostedBlog(context: mainContext)
+        blog.hasDomainCredit = true
+        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog, isFeatureFlagOn: true)
+        XCTAssertFalse(canRedeemDomainCredit)
+    }
+    
+    func testDomainCreditEligibilityOnSelfHostedBlog() {
+        let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
+        blog.hasDomainCredit = true
+        blog.isHostedAtWPcom = false
+        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog, isFeatureFlagOn: true)
+        XCTAssertFalse(canRedeemDomainCredit)
+    }
+    
+    func testDomainCreditEligibilityOnEligibleBlog() {
+        let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
+        blog.hasDomainCredit = true
+        blog.isHostedAtWPcom = true
+        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog, isFeatureFlagOn: true)
+        XCTAssertTrue(canRedeemDomainCredit)
+    }
+}

--- a/WordPress/WordPressTest/DomainCredit/DomainCreditEligibilityTests.swift
+++ b/WordPress/WordPressTest/DomainCredit/DomainCreditEligibilityTests.swift
@@ -12,18 +12,10 @@ class DomainCreditEligibilityTests: XCTestCase {
         manager = TestContextManager()
     }
 
-    func testDomainCreditEligibilityWithFeatureFlagOff() {
-        let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
-        blog.hasDomainCredit = true
-        blog.isHostedAtWPcom = true
-        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog, isFeatureFlagOn: false)
-        XCTAssertFalse(canRedeemDomainCredit)
-    }
-
     func testDomainCreditEligibilityOnBlogWithCustomDomain() {
         let blog = ModelTestHelper.insertSelfHostedBlog(context: mainContext)
         blog.hasDomainCredit = true
-        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog, isFeatureFlagOn: true)
+        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog)
         XCTAssertFalse(canRedeemDomainCredit)
     }
 
@@ -31,7 +23,7 @@ class DomainCreditEligibilityTests: XCTestCase {
         let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
         blog.hasDomainCredit = true
         blog.isHostedAtWPcom = false
-        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog, isFeatureFlagOn: true)
+        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog)
         XCTAssertFalse(canRedeemDomainCredit)
     }
 
@@ -39,7 +31,7 @@ class DomainCreditEligibilityTests: XCTestCase {
         let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
         blog.hasDomainCredit = true
         blog.isHostedAtWPcom = true
-        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog, isFeatureFlagOn: true)
+        let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog)
         XCTAssertTrue(canRedeemDomainCredit)
     }
 }

--- a/WordPress/WordPressTest/DomainCredit/DomainCreditEligibilityTests.swift
+++ b/WordPress/WordPressTest/DomainCredit/DomainCreditEligibilityTests.swift
@@ -6,12 +6,12 @@ class DomainCreditEligibilityTests: XCTestCase {
     private var mainContext: NSManagedObjectContext {
         return manager.mainContext
     }
-    
+
     override func setUp() {
         super.setUp()
         manager = TestContextManager()
     }
-    
+
     func testDomainCreditEligibilityWithFeatureFlagOff() {
         let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
         blog.hasDomainCredit = true
@@ -19,14 +19,14 @@ class DomainCreditEligibilityTests: XCTestCase {
         let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog, isFeatureFlagOn: false)
         XCTAssertFalse(canRedeemDomainCredit)
     }
-    
+
     func testDomainCreditEligibilityOnBlogWithCustomDomain() {
         let blog = ModelTestHelper.insertSelfHostedBlog(context: mainContext)
         blog.hasDomainCredit = true
         let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog, isFeatureFlagOn: true)
         XCTAssertFalse(canRedeemDomainCredit)
     }
-    
+
     func testDomainCreditEligibilityOnSelfHostedBlog() {
         let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
         blog.hasDomainCredit = true
@@ -34,7 +34,7 @@ class DomainCreditEligibilityTests: XCTestCase {
         let canRedeemDomainCredit = DomainCreditEligibilityChecker.canRedeemDomainCredit(blog: blog, isFeatureFlagOn: true)
         XCTAssertFalse(canRedeemDomainCredit)
     }
-    
+
     func testDomainCreditEligibilityOnEligibleBlog() {
         let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
         blog.hasDomainCredit = true


### PR DESCRIPTION
Refs. #11467 - subtask - determine whether domain credit can be redeemed

Code changes:

- Updated `domainCredit` feature flag to be on under local development.
- Created helper `DomainCreditEligibilityChecker` to check whether a site is eligible for domain credit, given feature flag is on. A site is eligible if:
  - Site is not self-hosted
  - Site has `*.wordpress.com` domain
  - Site has domain credit (with a paid WP.com plan and not redeemed yet)
- On site dashboard, used `DomainCreditEligibilityChecker` helper method to check for domain credit eligibility and showed domain credit section if eligible.

To test:

- Prerequisites: try having at least one site of the following:
  - Self-hosted site
  - Site created by others
  - Site that already has a custom domain (not `*.wordpress.com`)
  - WP.com site, on a free plan
  - WP.com site, on any paid plan and domain credit has not been redeemed
- Go to "My Sites"
- Tap into each site in prerequisites, check under site name:
  - Self-hosted site: should **not** see domain credit UI
  - Site created by others: should **not** see domain credit UI
  - Site that already has a custom domain: should **not** see domain credit UI
  - WP.com site, on a free plan: should **not** see domain credit UI
  - WP.com site, on any paid plan: should see domain credit UI

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
