### PR TITLE
Fix crash in NotificationDetailsViewController after state restoration

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -983,7 +983,11 @@ private extension NotificationDetailsViewController {
     }
 
     func spamCommentWithBlock(_ block: FormattableCommentContent) {
-        precondition(onDeletionRequestCallback != nil)
+        guard let onDeletionRequestCallback = onDeletionRequestCallback else {
+            // callback probably missing due to state restoration. at least by
+            // not crashing the user can tap the back button and try again
+            return
+        }
 
         guard let spamAction = block.action(id: MarkAsSpamAction.actionIdentifier()) else {
             return
@@ -1004,7 +1008,11 @@ private extension NotificationDetailsViewController {
     }
 
     func trashCommentWithBlock(_ block: FormattableCommentContent) {
-        precondition(onDeletionRequestCallback != nil)
+        guard let onDeletionRequestCallback = onDeletionRequestCallback else {
+            // callback probably missing due to state restoration. at least by
+            // not crashing the user can tap the back button and try again
+            return
+        }
 
         guard let trashAction = block.action(id: TrashCommentAction.actionIdentifier()) else {
             return

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -243,6 +243,20 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         }
     }
 
+    override func applicationFinishedRestoringState() {
+        super.applicationFinishedRestoringState()
+
+        guard let navigationControllers = navigationController?.children else {
+            return
+        }
+
+        for case let detailVC as NotificationDetailsViewController in navigationControllers {
+            if detailVC.onDeletionRequestCallback == nil, let note = detailVC.note {
+                configureDetailsViewController(detailVC, withNote: note)
+            }
+        }
+    }
+
     // MARK: - UITableView Methods
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {


### PR DESCRIPTION
Fixes #7287

### To reproduce the crash (before applying this change)
1. View a comment notification
2. Background the app (it will save state)
3. Kill the app and relaunch it
4. It should return to showing the same detail view for the same comment
5. Tap "Trash"
6. _Crash_

### To test this fix:
1. Repeat the steps above and ensure the app no longer crashes
2. Ensure that the Trash and Spam buttons now work in this situation

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

@aerych you ok with this one? If not I'll find someone else 😀 