### PR TITLE
Removing "Tap to retry"

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * Better URL validation when logging in with a self hosted site.
 * Account Settings Primary Site now shows the site URL if the site has no name.
 * Implemented incremental improvements to accessibility experience across the app.
+* Updated error message when tag loading failed.
 
 12.3
 -----

--- a/WordPress/Classes/Utility/WPError+Swift.swift
+++ b/WordPress/Classes/Utility/WPError+Swift.swift
@@ -4,6 +4,7 @@ import WordPressFlux
 
 extension WPError {
     private static let noticeTag: Notice.Tag = "WPError.Networking"
+    private static let noticeErrorTag: Notice.Tag = "WPError.anyError"
 
     /// Show a Notice with the message taken from the given `error`
     ///
@@ -23,9 +24,25 @@ extension WPError {
                             tag: noticeTag)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
+    
+    static func showNotice(title: String, message: String? = nil, error: Error) {
+        if showWPComSigninIfErrorIsInvalidAuth(error) {
+            return
+        }
+
+        let notice = Notice(title: title,
+                            message: message ?? "",
+                            tag: noticeErrorTag)
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
+    }
+
 
     /// Dismiss the currently shown Notice if it was created using showNetworkingNotice()
     static func dismissNetworkingNotice() {
         ActionDispatcher.dispatch(NoticeAction.clearWithTag(noticeTag))
+    }
+    
+    static func dismissNotice() {
+        ActionDispatcher.dispatch(NoticeAction.clearWithTag(noticeErrorTag))
     }
 }

--- a/WordPress/Classes/Utility/WPError+Swift.swift
+++ b/WordPress/Classes/Utility/WPError+Swift.swift
@@ -4,7 +4,6 @@ import WordPressFlux
 
 extension WPError {
     private static let noticeTag: Notice.Tag = "WPError.Networking"
-    private static let noticeErrorTag: Notice.Tag = "WPError.anyError"
 
     /// Show a Notice with the message taken from the given `error`
     ///
@@ -24,25 +23,9 @@ extension WPError {
                             tag: noticeTag)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
-    
-    static func showNotice(title: String, message: String? = nil, error: Error) {
-        if showWPComSigninIfErrorIsInvalidAuth(error) {
-            return
-        }
-
-        let notice = Notice(title: title,
-                            message: message ?? "",
-                            tag: noticeErrorTag)
-        ActionDispatcher.dispatch(NoticeAction.post(notice))
-    }
-
 
     /// Dismiss the currently shown Notice if it was created using showNetworkingNotice()
     static func dismissNetworkingNotice() {
         ActionDispatcher.dispatch(NoticeAction.clearWithTag(noticeTag))
-    }
-    
-    static func dismissNotice() {
-        ActionDispatcher.dispatch(NoticeAction.clearWithTag(noticeErrorTag))
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -105,6 +105,7 @@ class PostTagPickerViewController: UIViewController {
         if originalTags != tags {
             onValueChanged?(tags.joined(separator: ", "))
         }
+        WPError.dismissNotice()
     }
 
     fileprivate func reloadTableData() {
@@ -141,6 +142,8 @@ private extension PostTagPickerViewController {
     func tagsFailedLoading(error: Error) {
         DDLogError("Error loading tags for \(String(describing: blog.url)): \(error)")
         dataSource = FailureDataSource()
+        WPError.showNotice(title: NSLocalizedString("Couldn't load tags.", comment: "Error message when tag loading failed"), error: error)
+        
     }
 }
 
@@ -340,7 +343,7 @@ private class FailureDataSource: NSObject, PostTagPickerDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: FailureDataSource.cellIdentifier, for: indexPath)
         WPStyleGuide.configureTableViewSuggestionCell(cell)
-        cell.textLabel?.text = NSLocalizedString("Couldn't load tags.", comment: "Error message when tag loading failed")
+        cell.textLabel?.text = ""
         return cell
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -332,17 +332,16 @@ private class FailureDataSource: NSObject, PostTagPickerDataSource {
     typealias Cell = UITableViewCell
 
     func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+        return 0
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 1
+        return 0
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: FailureDataSource.cellIdentifier, for: indexPath)
         WPStyleGuide.configureTableViewSuggestionCell(cell)
-        cell.textLabel?.text = ""
         return cell
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -143,7 +143,6 @@ private extension PostTagPickerViewController {
         DDLogError("Error loading tags for \(String(describing: blog.url)): \(error)")
         dataSource = FailureDataSource()
         WPError.showNetworkingNotice(title: NSLocalizedString("Couldn't load tags.", comment: "Error message when tag loading failed"), error: error as NSError)
-        
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -105,7 +105,7 @@ class PostTagPickerViewController: UIViewController {
         if originalTags != tags {
             onValueChanged?(tags.joined(separator: ", "))
         }
-        WPError.dismissNotice()
+        WPError.dismissNetworkingNotice()
     }
 
     fileprivate func reloadTableData() {
@@ -142,7 +142,7 @@ private extension PostTagPickerViewController {
     func tagsFailedLoading(error: Error) {
         DDLogError("Error loading tags for \(String(describing: blog.url)): \(error)")
         dataSource = FailureDataSource()
-        WPError.showNotice(title: NSLocalizedString("Couldn't load tags.", comment: "Error message when tag loading failed"), error: error)
+        WPError.showNetworkingNotice(title: NSLocalizedString("Couldn't load tags.", comment: "Error message when tag loading failed"), error: error as NSError)
         
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -340,7 +340,7 @@ private class FailureDataSource: NSObject, PostTagPickerDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: FailureDataSource.cellIdentifier, for: indexPath)
         WPStyleGuide.configureTableViewSuggestionCell(cell)
-        cell.textLabel?.text = NSLocalizedString("Couldn't load tags. Tap to retry.", comment: "Error message when tag loading failed")
+        cell.textLabel?.text = NSLocalizedString("Couldn't load tags.", comment: "Error message when tag loading failed")
         return cell
     }
 }


### PR DESCRIPTION
Fixes #11432 

Expected: When unable to load tags the bottom label will show "Couldn't load tags."
To test:
1. Be offline 
2. Go to post from the post list
3. Go to post settings
4. Go to tags
5. see that the label shows  "Couldn't load tags."

BEFORE:
![tags_label](https://user-images.githubusercontent.com/1335657/57257472-5e922580-700e-11e9-995e-8a32fb29153d.gif)

AFTER:
![tags_notice](https://user-images.githubusercontent.com/1335657/57257429-34d8fe80-700e-11e9-8767-0c00bef4441c.gif)



Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
