### PR TITLE
Fix crash on login with password

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -468,7 +468,7 @@ extension WordPressAppDelegate {
         navigationAppearance.shadowImage = WPStyleGuide.navigationBarShadowImage()
         navigationAppearance.barStyle = WPStyleGuide.navigationBarBarStyle()
 
-        UISegmentedControl.appearance().setTitleTextAttributes( [NSAttributedString.Key.font: WPStyleGuide.regularTextFont], for: .normal)
+        UISegmentedControl.appearance().setTitleTextAttributes( [NSAttributedString.Key.font: WPStyleGuide.regularTextFont()], for: .normal)
         UIToolbar.appearance().barTintColor = WPStyleGuide.wordPressBlue()
         UISwitch.appearance().onTintColor = WPStyleGuide.wordPressBlue()
         UITabBarItem.appearance().setTitleTextAttributes([NSAttributedString.Key.foregroundColor: WPStyleGuide.grey()], for: .normal)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/11595

To test:
Open login screen, enter your mail address, tap next
Choose enter your password instead
Enter your password and tap next
Application shouldn't crash

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
