### PR TITLE
Update blog details footer section with optional extra spacing between sections

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionFooterView.swift
@@ -9,7 +9,7 @@ class BlogDetailsSectionFooterView: UITableViewHeaderFooterView {
         titleLabel.textColor = WPStyleGuide.greyDarken10()
         return titleLabel
     }()
-    private let spacerView: UIView = UIView(frame: .zero)
+    private let spacerView = UIView(frame: .zero)
 
     override public init(reuseIdentifier: String?) {
         super.init(reuseIdentifier: reuseIdentifier)

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionFooterView.swift
@@ -1,0 +1,45 @@
+import UIKit
+
+class BlogDetailsSectionFooterView: UITableViewHeaderFooterView {
+    private let titleLabel: UILabel = {
+        let titleLabel = UILabel()
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.numberOfLines = 0
+        titleLabel.font = WPStyleGuide.tableviewSectionFooterFont()
+        titleLabel.textColor = WPStyleGuide.greyDarken10()
+        return titleLabel
+    }()
+    private let spacerView: UIView = UIView(frame: .zero)
+
+    override public init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        setupSubviews()
+    }
+
+    required public init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setupSubviews()
+    }
+
+    private func setupSubviews() {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, spacerView])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        contentView.addSubview(stackView)
+        NSLayoutConstraint.activate([
+            // Stack view.
+            stackView.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor, constant: 0),
+            stackView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor, constant: 0),
+            stackView.topAnchor.constraint(equalTo: contentView.readableContentGuide.topAnchor, constant: 0),
+            stackView.bottomAnchor.constraint(equalTo: contentView.readableContentGuide.bottomAnchor, constant: 0),
+            // Spacer view.
+            spacerView.heightAnchor.constraint(equalToConstant: 20),
+            ])
+        updateUI(title: nil, shouldShowExtraSpacing: false)
+    }
+
+    @objc func updateUI(title: String?, shouldShowExtraSpacing: Bool) {
+        titleLabel.text = title
+        spacerView.isHidden = !shouldShowExtraSpacing
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionFooterView.swift
@@ -28,10 +28,10 @@ class BlogDetailsSectionFooterView: UITableViewHeaderFooterView {
         contentView.addSubview(stackView)
         NSLayoutConstraint.activate([
             // Stack view.
-            stackView.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor, constant: 0),
-            stackView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor, constant: 0),
-            stackView.topAnchor.constraint(equalTo: contentView.readableContentGuide.topAnchor, constant: 0),
-            stackView.bottomAnchor.constraint(equalTo: contentView.readableContentGuide.bottomAnchor, constant: 0),
+            stackView.leadingAnchor.constraint(equalTo: contentView.readableContentGuide.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: contentView.readableContentGuide.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: contentView.readableContentGuide.topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: contentView.readableContentGuide.bottomAnchor),
             // Spacer view.
             spacerView.heightAnchor.constraint(equalToConstant: 20),
             ])

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -547,8 +547,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if (footerTitle != nil) {
         BlogDetailsSectionFooterView *footerView = (BlogDetailsSectionFooterView *)[tableView dequeueReusableHeaderFooterViewWithIdentifier:BlogDetailsSectionFooterIdentifier];
         // If the next section has title, gives extra spacing between two sections.
-        BOOL doesNextSectionHaveTitle = (self.tableSections.count > section + 1) ? (self.tableSections[section + 1].title != nil): NO;
-        [footerView updateUIWithTitle:footerTitle shouldShowExtraSpacing:doesNextSectionHaveTitle];
+        BOOL shouldShowExtraSpacing = (self.tableSections.count > section + 1) ? (self.tableSections[section + 1].title != nil): NO;
+        [footerView updateUIWithTitle:footerTitle shouldShowExtraSpacing:shouldShowExtraSpacing];
         return footerView;
     }
     if (@available(iOS 11, *)) {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -27,6 +27,7 @@ static NSString *const BlogDetailsRemoveSiteCellIdentifier = @"BlogDetailsRemove
 static NSString *const BlogDetailsSectionHeaderViewIdentifier = @"BlogDetailsSectionHeaderView";
 static NSString *const QuickStartHeaderViewNibName = @"BlogDetailsSectionHeaderView";
 static NSString *const QuickStartListTitleCellNibName = @"QuickStartListTitleCell";
+static NSString *const BlogDetailsSectionFooterIdentifier = @"BlogDetailsSectionFooterView";
 
 NSString * const WPBlogDetailsRestorationID = @"WPBlogDetailsID";
 NSString * const WPBlogDetailsBlogKey = @"WPBlogDetailsBlogKey";
@@ -279,6 +280,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self.tableView registerNib:qsHeaderViewNib forHeaderFooterViewReuseIdentifier:BlogDetailsSectionHeaderViewIdentifier];
     UINib *qsTitleCellNib = [UINib nibWithNibName:QuickStartListTitleCellNibName bundle:[NSBundle bundleForClass:[QuickStartListTitleCell class]]];
     [self.tableView registerNib:qsTitleCellNib forCellReuseIdentifier:[QuickStartListTitleCell reuseIdentifier]];
+    [self.tableView registerClass:[BlogDetailsSectionFooterView class] forHeaderFooterViewReuseIdentifier:BlogDetailsSectionFooterIdentifier];
 
     self.clearsSelectionOnViewWillAppear = NO;
 
@@ -540,6 +542,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section {
+    BlogDetailsSection *detailSection = self.tableSections[section];
+    NSString *footerTitle = detailSection.footerTitle;
+    if (footerTitle != nil) {
+        BlogDetailsSectionFooterView *footerView = (BlogDetailsSectionFooterView *)[tableView dequeueReusableHeaderFooterViewWithIdentifier:BlogDetailsSectionFooterIdentifier];
+        // If the next section has title, gives extra spacing between two sections.
+        BOOL doesNextSectionHaveTitle = (self.tableSections.count > section + 1) ? (self.tableSections[section + 1].title != nil): NO;
+        [footerView updateUIWithTitle:footerTitle shouldShowExtraSpacing:doesNextSectionHaveTitle];
+        return footerView;
+    }
     if (@available(iOS 11, *)) {
         return nil;
     } else {
@@ -550,17 +561,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         view.frame = CGRectMake(0, 0, 100.0, BlogDetailBottomPaddingForQuickStartNotices);
         return view;
     }
-}
-    
-- (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
-{
-    BlogDetailsSection *detailSection = [self.tableSections objectAtIndex:section];
-    return detailSection.footerTitle;
-}
-
-- (void)tableView:(UITableView *)tableView willDisplayFooterView:(UIView *)view forSection:(NSInteger)section
-{
-    [WPStyleGuide configureTableViewSectionFooter:view];
 }
 
 #pragma mark - Data Model setup

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		02761EC4227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EC3227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift */; };
 		02AC3092226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AC3091226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift */; };
 		02BF30532271D7F000616558 /* DomainCreditRedemptionSuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BF30522271D7F000616558 /* DomainCreditRedemptionSuccessViewController.swift */; };
+		02D75D9922793EA2003FF09A /* BlogDetailsSectionFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D75D9822793EA2003FF09A /* BlogDetailsSectionFooterView.swift */; };
 		04936A8B3D936CD1FC4AB1EF /* Pods_WordPressNotificationContentExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6CC2CF274BA2F245C464D562 /* Pods_WordPressNotificationContentExtension.framework */; };
 		0807CB721CE670A800CDBDAC /* WPContentSearchHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0807CB711CE670A800CDBDAC /* WPContentSearchHelper.swift */; };
 		080C44A91CE14A9F00B3A02F /* MenuDetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 080C449E1CE14A9F00B3A02F /* MenuDetailsViewController.m */; };
@@ -1873,6 +1874,7 @@
 		02761EC3227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDetailsSectionIndexTests.swift; sourceTree = "<group>"; };
 		02AC3091226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+DomainCredit.swift"; sourceTree = "<group>"; };
 		02BF30522271D7F000616558 /* DomainCreditRedemptionSuccessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainCreditRedemptionSuccessViewController.swift; sourceTree = "<group>"; };
+		02D75D9822793EA2003FF09A /* BlogDetailsSectionFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDetailsSectionFooterView.swift; sourceTree = "<group>"; };
 		0807CB711CE670A800CDBDAC /* WPContentSearchHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPContentSearchHelper.swift; sourceTree = "<group>"; };
 		080C449D1CE14A9F00B3A02F /* MenuDetailsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuDetailsViewController.h; sourceTree = "<group>"; };
 		080C449E1CE14A9F00B3A02F /* MenuDetailsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuDetailsViewController.m; sourceTree = "<group>"; };
@@ -6857,6 +6859,7 @@
 				4349BFF6221205740084F200 /* BlogDetailsSectionHeaderView.swift */,
 				02761EBF2270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift */,
 				02AC3091226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift */,
+				02D75D9822793EA2003FF09A /* BlogDetailsSectionFooterView.swift */,
 			);
 			path = Blog;
 			sourceTree = "<group>";
@@ -10157,6 +10160,7 @@
 				E14B40FF1C58B93F005046F6 /* SettingsCommon.swift in Sources */,
 				B50C0C661EF42B6400372C65 /* FormatBarItemProviders.swift in Sources */,
 				439F4F352196537500F8D0C7 /* RevisionDiffViewController.swift in Sources */,
+				02D75D9922793EA2003FF09A /* BlogDetailsSectionFooterView.swift in Sources */,
 				432A5AE021F9222A00603959 /* QuickStartListTitleCell.swift in Sources */,
 				E137B1661F8B77D4006AC7FC /* WebNavigationDelegate.swift in Sources */,
 				937D9A0F19F83812007B9D5F /* WordPress-22-23.xcmappingmodel in Sources */,


### PR DESCRIPTION
Refs. #11467 - subtask - [design polish] Add extra 20pt spacing after footer if the next section has title

* Created `BlogDetailsSectionFooterView` that contains a title label and a spacer view (20px height) in a vertical stack view. Configuration method updates the title text, and whether the spacer view is shown.
* In `BlogDetailsViewController`, replaced default footer title setup with `BlogDetailsSectionFooterView`, and set to show extra spacing when the next section has no-empty title.

To test:
- Turn on Domain Credit UI by returning true in `DomainCreditEligibilityChecker.canRedeemDomainCredit`
- Go to a site
- Turn `QuickStart` on (if not already on, can return true in `BlogDetailsViewController`'s `shouldShowQuickStartChecklist`)
  - There should be comfortable spacing (more than 20px) between the end of Domain Credit footer title and the the title of QuickStart ("NEXT STEPS")
- Turn `QuickStart` off (if not already off, can return false in `BlogDetailsViewController`'s `shouldShowQuickStartChecklist`)
  - There should be similar spacing between the end of Domain Credit footer title and the the beginning of the next section

Example screenshots:

next section without title | next section with title
--- | ---
![Simulator Screen Shot - iPhone SE - 2019-05-01 at 23 05 50](https://user-images.githubusercontent.com/1945542/57024604-96444a80-6c67-11e9-87ea-f337d520e16a.png) | ![Simulator Screen Shot - iPhone SE - 2019-05-01 at 23 08 54](https://user-images.githubusercontent.com/1945542/57024608-96dce100-6c67-11e9-8203-9e7e025680a7.png)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
