### PR TITLE
[Stats Refresh] Post Stats: add date selector

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -18,6 +18,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
     private var postTitle: String?
     private var postURL: URL?
     private var postID: Int?
+    private var selectedDate = Date()
     private typealias Style = WPStyleGuide.Stats
     private var viewModel: PostStatsViewModel?
     private let store = StoreContainer.shared.statsPeriod
@@ -35,6 +36,8 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
         refreshControl?.addTarget(self, action: #selector(userInitiatedRefresh), for: .valueChanged)
         Style.configureTable(tableView)
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
+        tableView.register(SiteStatsTableHeaderView.defaultNib,
+                           forHeaderFooterViewReuseIdentifier: SiteStatsTableHeaderView.defaultNibName)
         initViewModel()
     }
 
@@ -43,6 +46,21 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
         self.postTitle = postTitle
         self.postURL = postURL
     }
+
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: SiteStatsTableHeaderView.defaultNibName) as? SiteStatsTableHeaderView else {
+            return nil
+        }
+
+        cell.configure(date: selectedDate, period: .day, delegate: self)
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return SiteStatsTableHeaderView.height
+    }
+
 }
 
 // MARK: - Table Methods

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -86,7 +86,8 @@ private extension PostStatsTableViewController {
     }
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
-        return [CellHeaderRow.self,
+        return [PostStatsEmptyCellHeaderRow.self,
+                CellHeaderRow.self,
                 PostStatsTitleRow.self,
                 OverviewRow.self,
                 TopTotalsPostStatsRow.self,
@@ -151,6 +152,20 @@ extension PostStatsTableViewController: PostStatsDelegate {
         let detailTableViewController = SiteStatsDetailTableViewController.loadFromStoryboard()
         detailTableViewController.configure(statSection: statSection, postID: postID)
         navigationController?.pushViewController(detailTableViewController, animated: true)
+    }
+
+}
+
+// MARK: - SiteStatsTableHeaderDelegate Methods
+
+extension PostStatsTableViewController: SiteStatsTableHeaderDelegate {
+
+    func dateChangedTo(_ newDate: Date?) {
+        guard let newDate = newDate else {
+            return
+        }
+
+        selectedDate = newDate
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -73,7 +73,11 @@ private extension PostStatsTableViewController {
             return
         }
 
-        viewModel = PostStatsViewModel(postID: postID, postTitle: postTitle, postURL: postURL, postStatsDelegate: self)
+        viewModel = PostStatsViewModel(postID: postID,
+                                       selectedDate: selectedDate,
+                                       postTitle: postTitle,
+                                       postURL: postURL,
+                                       postStatsDelegate: self)
 
         changeReceipt = viewModel?.onChange { [weak self] in
             guard let store = self?.store,
@@ -115,7 +119,7 @@ private extension PostStatsTableViewController {
             return
         }
 
-        viewModel?.refreshPostStats(postID: postID)
+        viewModel?.refreshPostStats(postID: postID, selectedDate: selectedDate)
     }
 
     func applyTableUpdates() {
@@ -166,6 +170,7 @@ extension PostStatsTableViewController: SiteStatsTableHeaderDelegate {
         }
 
         selectedDate = newDate
+        refreshData()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
@@ -4,7 +4,6 @@ class PostStatsTitleCell: UITableViewCell, NibLoadable {
 
     // MARK: - Properties
 
-    @IBOutlet weak var topSeparatorLine: UIView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var postTitleLabel: UILabel!
     @IBOutlet weak var bottomSeparatorLine: UIView!
@@ -31,7 +30,6 @@ private extension PostStatsTitleCell {
 
         Style.configureLabelAsPostStatsTitle(titleLabel)
         Style.configureLabelAsPostTitle(postTitleLabel)
-        Style.configureViewAsSeparator(topSeparatorLine)
         Style.configureViewAsSeparator(bottomSeparatorLine)
 
         guard let postTitle = postTitle else {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.xib
@@ -19,13 +19,6 @@
                 <rect key="frame" x="0.0" y="0.0" width="406" height="70.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kpL-Db-PKI" userLabel="Top Separator Line">
-                        <rect key="frame" x="0.0" y="0.0" width="406" height="0.5"/>
-                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="0.5" id="beV-Kg-kx9"/>
-                        </constraints>
-                    </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Showing stats for:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VQc-hL-Bbc">
                         <rect key="frame" x="16" y="16" width="374" height="16"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
@@ -54,14 +47,11 @@
                     </view>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="kpL-Db-PKI" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="1GA-ej-kPX"/>
-                    <constraint firstItem="kpL-Db-PKI" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="2Ru-Rj-qeU"/>
                     <constraint firstAttribute="bottom" secondItem="dJu-H6-3qo" secondAttribute="bottom" id="MKS-QE-IDd"/>
                     <constraint firstAttribute="bottom" secondItem="IAo-11-r7k" secondAttribute="bottom" constant="16" id="OAe-F1-q3m"/>
                     <constraint firstAttribute="trailing" secondItem="dJu-H6-3qo" secondAttribute="trailing" id="QCn-b6-3ob"/>
                     <constraint firstItem="VQc-hL-Bbc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="TIp-2M-tkj"/>
                     <constraint firstItem="q7F-mg-QOb" firstAttribute="bottom" secondItem="IAo-11-r7k" secondAttribute="bottom" id="Tom-tr-1Cc"/>
-                    <constraint firstAttribute="trailing" secondItem="kpL-Db-PKI" secondAttribute="trailing" id="XhD-xV-KoQ"/>
                     <constraint firstItem="q7F-mg-QOb" firstAttribute="top" secondItem="IAo-11-r7k" secondAttribute="top" id="Xpe-ec-0aG"/>
                     <constraint firstItem="IAo-11-r7k" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="Yni-Dp-MXW"/>
                     <constraint firstItem="IAo-11-r7k" firstAttribute="top" secondItem="VQc-hL-Bbc" secondAttribute="bottom" constant="2" id="Zcd-Qe-cRI"/>
@@ -78,7 +68,6 @@
                 <outlet property="bottomSeparatorLine" destination="dJu-H6-3qo" id="9aa-at-qTn"/>
                 <outlet property="postTitleLabel" destination="IAo-11-r7k" id="Vq3-Qu-ku2"/>
                 <outlet property="titleLabel" destination="VQc-hL-Bbc" id="4KO-Om-16S"/>
-                <outlet property="topSeparatorLine" destination="kpL-Db-PKI" id="G6k-Xz-9tR"/>
             </connections>
             <point key="canvasLocation" x="68.799999999999997" y="174.96251874062969"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -10,6 +10,7 @@ class PostStatsViewModel: Observable {
 
     let changeDispatcher = Dispatcher<Void>()
 
+    private var selectedDate = Date()
     private var postID: Int?
     private var postTitle: String?
     private var postURL: URL?
@@ -43,9 +44,11 @@ class PostStatsViewModel: Observable {
     // MARK: - Init
 
     init(postID: Int,
+         selectedDate: Date,
          postTitle: String?,
          postURL: URL?,
          postStatsDelegate: PostStatsDelegate) {
+        self.selectedDate = selectedDate
         self.postID = postID
         self.postTitle = postTitle
         self.postURL = postURL
@@ -80,7 +83,8 @@ class PostStatsViewModel: Observable {
 
     // MARK: - Refresh Data
 
-    func refreshPostStats(postID: Int) {
+    func refreshPostStats(postID: Int, selectedDate: Date) {
+        self.selectedDate = selectedDate
         ActionDispatcher.dispatch(PeriodAction.refreshPostStats(postID: postID))
     }
 
@@ -102,16 +106,20 @@ private extension PostStatsViewModel {
         var tableRows = [ImmuTableRow]()
         tableRows.append(PostStatsEmptyCellHeaderRow())
 
-        // TODO: replace with real data
-        let data = OverviewTabData(tabTitle: StatSection.periodOverviewVisitors.tabTitle, tabData: 741, difference: 22222, differencePercent: 50)
+        let lastTwoWeeks = postStats?.lastTwoWeeks ?? []
+        let dayData = dayDataFrom(lastTwoWeeks)
+
+        let overviewData = OverviewTabData(tabTitle: StatSection.periodOverviewViews.tabTitle,
+                                           tabData: dayData.viewCount,
+                                           difference: dayData.difference,
+                                           differencePercent: dayData.percentage)
 
         // Introduced via #11062, to be replaced with real data via #11068
         let stubbedData = SelectedPostSummaryDataStub()
         let firstStubbedDateInterval = stubbedData.summaryData.first?.date.timeIntervalSince1970 ?? 0
         let styling = SelectedPostSummaryStyling(initialDateInterval: firstStubbedDateInterval)
 
-        let row = OverviewRow(tabsData: [data], chartData: [stubbedData], chartStyling: [styling], period: nil)
-        tableRows.append(row)
+        tableRows.append(OverviewRow(tabsData: [overviewData], chartData: [stubbedData], chartStyling: [styling], period: nil))
 
         return tableRows
     }
@@ -230,6 +238,34 @@ private extension PostStatsViewModel {
         }
 
         return weekDateFormatter.string(from: day)
+    }
+
+    // MARK: - Overview Helpers
+
+    func dayDataFrom(_ daysData: [StatsPostViews]) -> (viewCount: Int, difference: Int, percentage: Int) {
+        // Use date without time
+        let date = selectedDate.normalizedDate()
+        let matchingDay = daysData.first { calendar.date(from: $0.date) == date }
+
+        guard let currentDay = matchingDay else {
+            return (0, 0, 0)
+        }
+
+        let currentCount = currentDay.viewsCount
+
+        let previousDate = calendar.date(byAdding: .day, value: -1, to: date)
+        let previousDay = daysData.first { calendar.date(from: $0.date) == previousDate }
+        let previousCount = previousDay?.viewsCount ?? 0
+
+        let difference = currentCount - previousCount
+        var roundedPercentage = 0
+
+        if previousCount > 0 {
+            let percentage = (Float(difference) / Float(previousCount)) * 100
+            roundedPercentage = Int(round(percentage))
+        }
+
+        return (currentCount, difference, roundedPercentage)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -100,7 +100,7 @@ private extension PostStatsViewModel {
 
     func overviewTableRows() -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
-        tableRows.append(CellHeaderRow(title: ""))
+        tableRows.append(PostStatsEmptyCellHeaderRow())
 
         // TODO: replace with real data
         let data = OverviewTabData(tabTitle: StatSection.periodOverviewVisitors.tabTitle, tabData: 741, difference: 22222, differencePercent: 50)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -8,18 +8,24 @@ class StatsCellHeader: UITableViewCell, NibLoadable {
     @IBOutlet weak var headerLabel: UILabel!
     @IBOutlet weak var manageInsightButton: UIButton!
     @IBOutlet weak var stackViewTopConstraint: NSLayoutConstraint!
+    @IBOutlet weak var stackViewHeightConstraint: NSLayoutConstraint!
 
     private typealias Style = WPStyleGuide.Stats
     private var defaultStackViewTopConstraint: CGFloat = 0
+    private var defaultStackViewHeightConstraint: CGFloat = 0
+    private var adjustHeightForPostStats = false
+    private let emptyPostStatsHeight: CGFloat = 20
 
     // MARK: - Configure
 
     override func awakeFromNib() {
         defaultStackViewTopConstraint = stackViewTopConstraint.constant
+        defaultStackViewHeightConstraint = stackViewHeightConstraint.constant
     }
 
-    func configure(withTitle title: String) {
+    func configure(withTitle title: String, adjustHeightForPostStats: Bool = false) {
         headerLabel.text = title
+        self.adjustHeightForPostStats = adjustHeightForPostStats
         applyStyles()
     }
 
@@ -38,6 +44,9 @@ private extension StatsCellHeader {
     func updateStackView() {
         // Only show the top padding if there is actually a label.
         stackViewTopConstraint.constant = headerLabel.text == "" ? 0 : defaultStackViewTopConstraint
+
+        // Adjust the height if displaying on Post Stats with no title.
+        stackViewHeightConstraint.constant = adjustHeightForPostStats ? emptyPostStatsHeight : defaultStackViewHeightConstraint
     }
 
     func configureManageInsightButton() {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -54,6 +54,7 @@
             <connections>
                 <outlet property="headerLabel" destination="fZv-YC-hoV" id="iNM-se-RIs"/>
                 <outlet property="manageInsightButton" destination="Pmt-5q-3Mg" id="y2o-B3-h7B"/>
+                <outlet property="stackViewHeightConstraint" destination="zcu-iF-hUF" id="Dj4-IG-tje"/>
                 <outlet property="stackViewTopConstraint" destination="RWL-Fv-z9B" id="ywF-XN-ZM2"/>
             </connections>
             <point key="canvasLocation" x="336.80000000000001" y="-442.12893553223392"/>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -450,6 +450,26 @@ struct CellHeaderRow: ImmuTableRow {
     }
 }
 
+struct PostStatsEmptyCellHeaderRow: ImmuTableRow {
+
+    typealias CellType = StatsCellHeader
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(withTitle: "", adjustHeightForPostStats: true)
+    }
+}
+
 struct TableFooterRow: ImmuTableRow {
 
     typealias CellType = StatsTableFooter


### PR DESCRIPTION
Ref #11189

This adds the date selector to the Post Stats view.
- When the date is changed, the Views count, difference, and percentage update on the Overview card.
- Back button goes back by one day.
- Forward button goes forward by one day.

Behavior inherited from the date selector (i.e. this is not new, just reiterating the behavior):
- Forward button is disabled if the next day is beyond the current day.
- Back button is disabled if the next day is beyond the number of days shown on the Overview chart, which is 13.


To test:

- Access Post Stats via:
  - Insights > Latest Post Summary > View more
  - Period > Posts and Pages > row selection
  - Period > Posts and Pages > View more > row selection
- Change the date back and forward.
- Verify it performs as expected, and the overview data updates.

<img width="350" alt="post_stats" src="https://user-images.githubusercontent.com/1816888/57041004-57d66d80-6c1e-11e9-96e5-db6b5ff90747.png">

