### PR TITLE
 Transitioned selected post chart to leverage actual data

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
@@ -53,7 +53,11 @@ protocol BarChartStyling {
 /// Transforms a given data set for consumption by BarChartView in the Charts framework.
 ///
 protocol BarChartDataConvertible {
+
+    /// Describe the chart for VoiceOver usage
     var accessibilityDescription: String { get }
+
+    /// Adapts the original data format for consumption by the Charts framework.
     var barChartData: BarChartData { get }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
@@ -15,12 +15,12 @@ class PostChart {
     let barChartStyling: BarChartStyling
 
     init(postViews: [StatsPostViews]) {
-        self.rawPostViews = postViews
+        rawPostViews = postViews
 
         let (data, styling) = PostChartDataTransformer.transform(postViews: postViews)
 
-        self.transformedPostData = data
-        self.barChartStyling = styling
+        transformedPostData = data
+        barChartStyling = styling
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
@@ -1,0 +1,112 @@
+
+import Foundation
+
+import Charts
+
+// MARK: - PostChart
+
+class PostChart {
+
+    private static let chartDescription = NSLocalizedString("Bar Chart depicting visitors for this post", comment: "This description is used to set the accessibility label for the chart in the Post Stats view.")
+
+    private let rawPostViews: [StatsPostViews]
+    private let transformedPostData: BarChartData
+
+    let barChartStyling: BarChartStyling
+
+    init(postViews: [StatsPostViews]) {
+        self.rawPostViews = postViews
+
+        let (data, styling) = PostChartDataTransformer.transform(postViews: postViews)
+
+        self.transformedPostData = data
+        self.barChartStyling = styling
+    }
+}
+
+// MARK: - BarChartDataConvertible
+
+extension PostChart: BarChartDataConvertible {
+    var accessibilityDescription: String {
+        return PostChart.chartDescription
+    }
+
+    var barChartData: BarChartData {
+        return transformedPostData
+    }
+}
+
+// MARK: - PostChartDataTransformer
+
+private extension StatsPostViews {
+    var postDateTimeInterval: TimeInterval? {
+        let calendar = Calendar.autoupdatingCurrent
+
+        if !date.isValidDate(in: calendar) {
+            debugPrint("Invalid date components: \(date)")
+            return nil
+        }
+
+        let theDate = Calendar.autoupdatingCurrent.date(from: date)
+        return theDate?.timeIntervalSince1970
+    }
+}
+
+class PostChartDataTransformer {
+    static func transform(postViews: [StatsPostViews]) -> (barChartData: BarChartData, barChartStyling: BarChartStyling) {
+        let data = postViews
+
+        let firstDateInterval: TimeInterval
+        let lastDateInterval: TimeInterval
+        let effectiveWidth: Double
+
+        if data.isEmpty {
+            firstDateInterval = 0
+            lastDateInterval = 0
+            effectiveWidth = 1
+        } else {
+            firstDateInterval = data.first?.postDateTimeInterval ?? 0
+            lastDateInterval = data.last?.postDateTimeInterval ?? 0
+
+            let range = lastDateInterval - firstDateInterval
+
+            let effectiveBars = Double(Double(data.count) * 1.2)
+
+            effectiveWidth = range / effectiveBars
+        }
+
+        var entries = [BarChartDataEntry]()
+        for datum in data {
+            let dateInterval = datum.postDateTimeInterval ?? 0
+            let offset = dateInterval - firstDateInterval
+
+            let x = offset
+            let y = Double(datum.viewsCount)
+            let entry = BarChartDataEntry(x: x, y: y)
+
+            entries.append(entry)
+        }
+
+        let chartData = BarChartData(entries: entries)
+        chartData.barWidth = effectiveWidth
+
+        let xAxisFormatter: IAxisValueFormatter = HorizontalAxisFormatter(initialDateInterval: firstDateInterval)
+        let styling = PostChartStyling(xAxisValueFormatter: xAxisFormatter)
+
+        return (chartData, styling)
+    }
+}
+
+// MARK: - PostChartStyling
+
+private struct PostChartStyling: BarChartStyling {
+    let primaryBarColor: UIColor                    = WPStyleGuide.wordPressBlue()
+    let secondaryBarColor: UIColor?                 = nil
+    let primaryHighlightColor: UIColor?             = WPStyleGuide.jazzyOrange()
+    let secondaryHighlightColor: UIColor?           = nil
+    let labelColor: UIColor                         = WPStyleGuide.grey()
+    let legendTitle: String?                        = nil
+    let lineColor: UIColor                          = WPStyleGuide.greyLighten30()
+    let xAxisValueFormatter: IAxisValueFormatter
+    let yAxisValueFormatter: IAxisValueFormatter    = VerticalAxisFormatter()
+}

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
@@ -43,7 +43,6 @@ private extension StatsPostViews {
         let calendar = Calendar.autoupdatingCurrent
 
         if !date.isValidDate(in: calendar) {
-            debugPrint("Invalid date components: \(date)")
             return nil
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PostSummaryDataStub.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Stubs/PostSummaryDataStub.swift
@@ -39,15 +39,6 @@ class LatestPostSummaryDataStub: PostSummaryDataStub {
     }
 }
 
-// MARK: - SelectedPostSummaryDataStub
-
-class SelectedPostSummaryDataStub: PostSummaryDataStub {
-    init() {
-        let chartDescription = "Bar Chart depicting Visitors for the Selected Post"  // NB: we don't localize stub data
-        super.init(fileName: "selectedPost_data", description: chartDescription)
-    }
-}
-
 // MARK: - BarChartDataConvertible
 
 extension PostSummaryDataStub: BarChartDataConvertible {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -114,12 +114,9 @@ private extension PostStatsViewModel {
                                            difference: dayData.difference,
                                            differencePercent: dayData.percentage)
 
-        // Introduced via #11062, to be replaced with real data via #11068
-        let stubbedData = SelectedPostSummaryDataStub()
-        let firstStubbedDateInterval = stubbedData.summaryData.first?.date.timeIntervalSince1970 ?? 0
-        let styling = SelectedPostSummaryStyling(initialDateInterval: firstStubbedDateInterval)
+        let chart = PostChart(postViews: lastTwoWeeks)
 
-        tableRows.append(OverviewRow(tabsData: [overviewData], chartData: [stubbedData], chartStyling: [styling], period: nil))
+        tableRows.append(OverviewRow(tabsData: [overviewData], chartData: [chart], chartStyling: [chart.barChartStyling], period: nil))
 
         return tableRows
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -592,6 +592,7 @@
 		73E3238B212CE0D7001B735C /* Noticons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E6B42CBE1D9DA6270043E228 /* Noticons.ttf */; };
 		73E40D8921238BF50012ABA6 /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
 		73E40D8C21238C520012ABA6 /* Tracks+ServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E40D8B21238C520012ABA6 /* Tracks+ServiceExtension.swift */; };
+		73E4E376227A033A0007D752 /* PostChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E4E375227A033A0007D752 /* PostChart.swift */; };
 		73E8E591212CD5DD000B26A5 /* NSParagraphStyle+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B587797119B799D800E57C5A /* NSParagraphStyle+Helpers.swift */; };
 		73E8E592212CD635000B26A5 /* UIImage+Assets.swift in Sources */ = {isa = PBXBuildFile; fileRef = B58C4EC9207C5E1900E32E4D /* UIImage+Assets.swift */; };
 		73EDC70A212E5D6700E5E3ED /* RemoteNotificationStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73EDC709212E5D6700E5E3ED /* RemoteNotificationStyles.swift */; };
@@ -2548,6 +2549,7 @@
 		73D5AC672126236600ADDDD2 /* Info-Internal.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-Internal.plist"; sourceTree = "<group>"; };
 		73D86968223AF4040064920F /* StatsChartLegendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsChartLegendView.swift; sourceTree = "<group>"; };
 		73E40D8B21238C520012ABA6 /* Tracks+ServiceExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Tracks+ServiceExtension.swift"; sourceTree = "<group>"; };
+		73E4E375227A033A0007D752 /* PostChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostChart.swift; sourceTree = "<group>"; };
 		73EDC709212E5D6700E5E3ED /* RemoteNotificationStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationStyles.swift; sourceTree = "<group>"; };
 		73F6DD41212BA54700CE447D /* RichNotificationContentFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichNotificationContentFormatter.swift; sourceTree = "<group>"; };
 		73F6DD43212C714F00CE447D /* RichNotificationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichNotificationViewModel.swift; sourceTree = "<group>"; };
@@ -5572,6 +5574,7 @@
 				73F76E1D222851E300FDDAD2 /* Charts+AxisFormatters.swift */,
 				73FF7033221F4AE200541798 /* Charts+Styling.swift */,
 				73FF7031221F469100541798 /* Charts+Support.swift */,
+				73E4E375227A033A0007D752 /* PostChart.swift */,
 				73FF702F221F43CD00541798 /* StatsBarChartView.swift */,
 				73D86968223AF4040064920F /* StatsChartLegendView.swift */,
 			);
@@ -10015,6 +10018,7 @@
 				E125443C12BF5A7200D87A0A /* WordPress.xcdatamodeld in Sources */,
 				B574CE111B5D8F8600A84FFD /* WPStyleGuide+AlertView.swift in Sources */,
 				731E88C921C9A10B0055C014 /* ErrorStateViewConfiguration.swift in Sources */,
+				73E4E376227A033A0007D752 /* PostChart.swift in Sources */,
 				43290D04215C28D800F6B398 /* Blog+QuickStart.swift in Sources */,
 				D82253E5219956540014D0E2 /* AddressCell.swift in Sources */,
 				FF1FD0242091268900186384 /* URL+LinkNormalization.swift in Sources */,


### PR DESCRIPTION
Fixes #11068.

To test:

- Checkout the branch & confirm that existing tests pass.
- View stats for a selected post (1 of 3 ways).
- Observe the chart. There should be no aesthetic differences from #11173, but the chart should now be populated with live data (see below image).

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

<img width="511" alt="11068a" src="https://user-images.githubusercontent.com/221062/57050207-531ab500-6c30-11e9-82f0-7d37a316e3ef.png">
