### PR TITLE
[Stats Refresh] Insights Annual Site Stats: round averages

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -356,11 +356,11 @@ private extension SiteStatsInsightsViewModel {
 
         // Averages rows
         let averageCommentsRow = StatsTotalRowData(name: AnnualSiteStats.commentsPerPost,
-                                                   data: annualInsights.annualInsightsAverageCommentsCount.abbreviatedString())
+                                                   data: Int(round(annualInsights.annualInsightsAverageCommentsCount)).abbreviatedString())
         let averageLikesRow = StatsTotalRowData(name: AnnualSiteStats.likesPerPost,
-                                                data: annualInsights.annualInsightsAverageLikesCount.abbreviatedString())
+                                                data: Int(round(annualInsights.annualInsightsAverageLikesCount)).abbreviatedString())
         let averageWordsRow = StatsTotalRowData(name: AnnualSiteStats.wordsPerPost,
-                                                data: annualInsights.annualInsightsAverageWordsCount.abbreviatedString())
+                                                data: Int(round(annualInsights.annualInsightsAverageWordsCount)).abbreviatedString())
         let averageDataRows = [averageCommentsRow, averageLikesRow, averageWordsRow]
 
         return AnnualSiteStatsRow(totalPostsRowData: totalPostsRowData,


### PR DESCRIPTION
Fixes #11546

This rounds the Annual Site Stats averages and displays them as whole numbers.

To test:
- Go to Stats > Insights > Annual Site Stats.
- Verify the Averages no longer have decimal values.

<img width="350" alt="averages" src="https://user-images.githubusercontent.com/1816888/57052589-8f0c4500-6c45-11e9-94bb-599d5b86c219.png">