### PR TITLE
Integrate domain registration flow to domain credit redemption

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+DomainCredit.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+DomainCredit.swift
@@ -18,10 +18,15 @@ extension BlogDetailsViewController {
     }
 
     @objc func showDomainCreditRedemption() {
-        // TODO-#11467 - subtask - integration with domain registration.
-        // Temporarily shows success screen before domain registration is integrated.
-        let domain = "lifeoftea.com"
-        presentDomainCreditRedemptionSuccess(domain: domain)
+        guard let site = JetpackSiteRef(blog: blog) else {
+            return
+        }
+        let controller = RegisterDomainSuggestionsViewController
+            .instance(site: site, domainPurchasedCallback: { [weak self] domain in
+                self?.presentDomainCreditRedemptionSuccess(domain: domain)
+            })
+        let navigationController = UINavigationController(rootViewController: controller)
+        present(navigationController, animated: true)
     }
 
     private func presentDomainCreditRedemptionSuccess(domain: String) {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+DomainCredit.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+DomainCredit.swift
@@ -26,7 +26,7 @@ extension BlogDetailsViewController {
             )
             let alertController = UIAlertController(
                 title: NSLocalizedString("Unable to register domain", comment: "Alert title when `JetpackSiteRef` cannot be initialized from a blog during domain credit redemption."),
-                message: NSLocalizedString("Something went wrong. Please try again.", comment: "Alert message when `JetpackSiteRef` cannot be initialized from a blog during domain credit redemption."),
+                message: NSLocalizedString("Something went wrong, please try again.", comment: "Alert message when `JetpackSiteRef` cannot be initialized from a blog during domain credit redemption."),
                 preferredStyle: .alert
             )
             alertController.addCancelActionWithTitle(cancelActionTitle, handler: nil)

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+DomainCredit.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+DomainCredit.swift
@@ -19,6 +19,18 @@ extension BlogDetailsViewController {
 
     @objc func showDomainCreditRedemption() {
         guard let site = JetpackSiteRef(blog: blog) else {
+            DDLogError("Error: couldn't initialize `JetpackSiteRef` from blog with ID: \(blog.dotComID?.intValue ?? 0)")
+            let cancelActionTitle = NSLocalizedString(
+                "OK",
+                comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt."
+            )
+            let alertController = UIAlertController(
+                title: NSLocalizedString("Unable to register domain", comment: "Alert title when `JetpackSiteRef` cannot be initialized from a blog during domain credit redemption."),
+                message: NSLocalizedString("Something went wrong. Please try again.", comment: "Alert message when `JetpackSiteRef` cannot be initialized from a blog during domain credit redemption."),
+                preferredStyle: .alert
+            )
+            alertController.addCancelActionWithTitle(cancelActionTitle, handler: nil)
+            present(alertController, animated: true, completion: nil)
             return
         }
         let controller = RegisterDomainSuggestionsViewController

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1098,11 +1098,16 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     if (row.showsSelectionState) {
         self.restorableSelectedIndexPath = indexPath;
-    } else if (![self splitViewControllerIsHorizontallyCompact]) {
-        // Reselect the previous row
-        [tableView selectRowAtIndexPath:self.restorableSelectedIndexPath
-                               animated:YES
-                         scrollPosition:UITableViewScrollPositionNone];
+    } else {
+        if ([self splitViewControllerIsHorizontallyCompact]) {
+            // Deselect current row when not in split view layout
+            [tableView deselectRowAtIndexPath:indexPath animated:YES];
+        } else {
+            // Reselect the previous row
+            [tableView selectRowAtIndexPath:self.restorableSelectedIndexPath
+                                   animated:YES
+                             scrollPosition:UITableViewScrollPositionNone];
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -179,6 +179,7 @@ class RegisterDomainDetailsViewController: NUXTableViewController {
         case .loading(let isLoading):
             if isLoading {
                 footerView.submitButton.isEnabled = false
+                SVProgressHUD.setDefaultMaskType(.clear)
                 SVProgressHUD.show()
             } else {
                 footerView.submitButton.isEnabled = true

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -171,9 +171,9 @@ class RegisterDomainDetailsViewController: NUXTableViewController {
         case .checkMarkRowsUpdated:
             tableView.reloadData()
         case .registerSucceeded(let domain):
-
-            viewModel.domainPurchasedCallback(domain)
-            dismiss(animated: true)
+            dismiss(animated: true) { [weak self] in
+                self?.viewModel.domainPurchasedCallback(domain)
+            }
         case .unexpectedError(let message):
             showAlert(message: message)
         case .loading(let isLoading):

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -57,8 +57,8 @@ class RegisterDomainDetailsViewController: NUXTableViewController {
         configureTableView()
         WPStyleGuide.configureColors(for: view, andTableView: tableView)
 
-        viewModel.onChange = { [unowned self] (change) in
-            self.handle(change: change)
+        viewModel.onChange = { [weak self] (change) in
+            self?.handle(change: change)
         }
 
         viewModel.prefill()

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsServiceProxy.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsServiceProxy.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+/// Protocol for cart response, empty because there are no external details.
+protocol CartResponseProtocol {}
+
+extension CartResponse: CartResponseProtocol {}
+
 /// A proxy for being able to use dependency injection for RegisterDomainDetailsViewModel
 /// especially for unittest mocking purposes
 protocol RegisterDomainDetailsServiceProxyProtocol {
@@ -22,10 +27,10 @@ protocol RegisterDomainDetailsServiceProxyProtocol {
     func createShoppingCart(siteID: Int,
                             domainSuggestion: DomainSuggestion,
                             privacyProtectionEnabled: Bool,
-                            success: @escaping (CartResponse) -> Void,
+                            success: @escaping (CartResponseProtocol) -> Void,
                             failure: @escaping (Error) -> Void)
 
-    func redeemCartUsingCredits(cart: CartResponse,
+    func redeemCartUsingCredits(cart: CartResponseProtocol,
                                 domainContactInformation: [String: String],
                                 success: @escaping () -> Void,
                                 failure: @escaping (Error) -> Void)
@@ -88,7 +93,7 @@ class RegisterDomainDetailsServiceProxy: RegisterDomainDetailsServiceProxyProtoc
     func createShoppingCart(siteID: Int,
                             domainSuggestion: DomainSuggestion,
                             privacyProtectionEnabled: Bool,
-                            success: @escaping (CartResponse) -> Void,
+                            success: @escaping (CartResponseProtocol) -> Void,
                             failure: @escaping (Error) -> Void) {
         transactionsServiceRemote.createShoppingCart(siteID: siteID,
                                                      domainSuggestion: domainSuggestion,
@@ -97,11 +102,14 @@ class RegisterDomainDetailsServiceProxy: RegisterDomainDetailsServiceProxyProtoc
                                                      failure: failure)
     }
 
-    func redeemCartUsingCredits(cart: CartResponse,
+    func redeemCartUsingCredits(cart: CartResponseProtocol,
                                 domainContactInformation: [String: String],
                                 success: @escaping () -> Void,
                                 failure: @escaping (Error) -> Void) {
-        transactionsServiceRemote.redeemCartUsingCredits(cart: cart,
+        guard let cartResponse = cart as? CartResponse else {
+            fatalError()
+        }
+        transactionsServiceRemote.redeemCartUsingCredits(cart: cartResponse,
                                                          domainContactInformation: domainContactInformation,
                                                          success: success,
                                                          failure: failure)

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 class RegisterDomainDetailsViewModel {
 
     typealias Localized = RegisterDomainDetails.Localized
@@ -188,7 +187,6 @@ class RegisterDomainDetailsViewModel {
                 self?.isLoading = false
                 return
             }
-
 
             WPAnalytics.track(.automatedTransferCustomDomainContactInfoValidated)
 
@@ -485,16 +483,16 @@ extension RegisterDomainDetailsViewModel {
                     return
                 }
 
-                strongSelf.isLoading = false
-
                 if response.success {
                     strongSelf.clearValidationErrors()
+                    strongSelf.onChange?(.remoteValidationFinished)
                     successCompletion()
                 } else {
+                    strongSelf.isLoading = false
                     WPAnalytics.track(.automatedTransferCustomDomainContactInfoValidationFailed)
                     strongSelf.updateValidationErrors(with: response.messages)
+                    strongSelf.onChange?(.remoteValidationFinished)
                 }
-                strongSelf.onChange?(.remoteValidationFinished)
         }) { [weak self] (error) in
             guard let strongSelf = self else {
                 return

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		027AC51D227896540033E56E /* DomainCreditEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027AC51C227896540033E56E /* DomainCreditEligibilityChecker.swift */; };
 		027AC5212278983F0033E56E /* DomainCreditEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027AC5202278983F0033E56E /* DomainCreditEligibilityTests.swift */; };
 		02AC3092226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02AC3091226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift */; };
+		02BE5CC02281B53F00E351BA /* RegisterDomainDetailsViewModelLoadingStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BE5CBF2281B53F00E351BA /* RegisterDomainDetailsViewModelLoadingStateTests.swift */; };
 		02BF30532271D7F000616558 /* DomainCreditRedemptionSuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BF30522271D7F000616558 /* DomainCreditRedemptionSuccessViewController.swift */; };
 		02D75D9922793EA2003FF09A /* BlogDetailsSectionFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D75D9822793EA2003FF09A /* BlogDetailsSectionFooterView.swift */; };
 		04936A8B3D936CD1FC4AB1EF /* Pods_WordPressNotificationContentExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6CC2CF274BA2F245C464D562 /* Pods_WordPressNotificationContentExtension.framework */; };
@@ -1879,6 +1880,7 @@
 		027AC51C227896540033E56E /* DomainCreditEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainCreditEligibilityChecker.swift; sourceTree = "<group>"; };
 		027AC5202278983F0033E56E /* DomainCreditEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainCreditEligibilityTests.swift; sourceTree = "<group>"; };
 		02AC3091226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+DomainCredit.swift"; sourceTree = "<group>"; };
+		02BE5CBF2281B53F00E351BA /* RegisterDomainDetailsViewModelLoadingStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterDomainDetailsViewModelLoadingStateTests.swift; sourceTree = "<group>"; };
 		02BF30522271D7F000616558 /* DomainCreditRedemptionSuccessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainCreditRedemptionSuccessViewController.swift; sourceTree = "<group>"; };
 		02D75D9822793EA2003FF09A /* BlogDetailsSectionFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDetailsSectionFooterView.swift; sourceTree = "<group>"; };
 		0807CB711CE670A800CDBDAC /* WPContentSearchHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WPContentSearchHelper.swift; sourceTree = "<group>"; };
@@ -4917,6 +4919,7 @@
 				436D55EF2115CB6800CEAA33 /* RegisterDomainDetailsSectionTests.swift */,
 				436D55F4211632B700CEAA33 /* RegisterDomainDetailsViewModelTests.swift */,
 				436D5654212209D600CEAA33 /* RegisterDomainDetailsServiceProxyMock.swift */,
+				02BE5CBF2281B53F00E351BA /* RegisterDomainDetailsViewModelLoadingStateTests.swift */,
 			);
 			name = RegisterDomain;
 			sourceTree = "<group>";
@@ -11057,6 +11060,7 @@
 				B566EC751B83867800278395 /* NSMutableAttributedStringTests.swift in Sources */,
 				E6B9B8AF1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift in Sources */,
 				40F50B82221310F000CBBB73 /* StatsTestCase.swift in Sources */,
+				02BE5CC02281B53F00E351BA /* RegisterDomainDetailsViewModelLoadingStateTests.swift in Sources */,
 				40EE948222132F5800CD264F /* PublicizeConectionStatsRecordValueTests.swift in Sources */,
 				02761EC4227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift in Sources */,
 				732A473D218787500015DA74 /* WPRichTextFormatterTests.swift in Sources */,

--- a/WordPress/WordPressTest/RegisterDomainDetailsServiceProxyMock.swift
+++ b/WordPress/WordPressTest/RegisterDomainDetailsServiceProxyMock.swift
@@ -1,6 +1,8 @@
 import Foundation
 @testable import WordPress
 
+fileprivate struct CartResponseMock: CartResponseProtocol {}
+
 class RegisterDomainDetailsServiceProxyMock: RegisterDomainDetailsServiceProxyProtocol {
 
     enum MockData {
@@ -20,11 +22,26 @@ class RegisterDomainDetailsServiceProxyMock: RegisterDomainDetailsServiceProxyPr
         static let postalCode = "12345"
     }
 
-    var success: Bool
-    var emptyPrefillData: Bool
+    private let validateDomainContactInformationSuccess: Bool
+    private let validateDomainContactInformationResponseSuccess: Bool
+    private let createShoppingCartSuccess: Bool
+    private let redeemCartUsingCreditsSuccess: Bool
+    private let changePrimaryDomainSuccess: Bool
 
-    init(success: Bool, emptyPrefillData: Bool = false) {
-        self.success = success
+    private let emptyPrefillData: Bool
+
+    init(validateDomainContactInformationSuccess: Bool = true,
+         validateDomainContactInformationResponseSuccess: Bool = true,
+         createShoppingCartSuccess: Bool = true,
+         emptyPrefillDataSuccess: Bool = true,
+         redeemCartUsingCreditsSuccess: Bool = true,
+         changePrimaryDomainSuccess: Bool = true,
+         emptyPrefillData: Bool = false) {
+        self.validateDomainContactInformationSuccess = validateDomainContactInformationSuccess
+        self.validateDomainContactInformationResponseSuccess = validateDomainContactInformationResponseSuccess
+        self.createShoppingCartSuccess = createShoppingCartSuccess
+        self.redeemCartUsingCreditsSuccess = redeemCartUsingCreditsSuccess
+        self.changePrimaryDomainSuccess = changePrimaryDomainSuccess
         self.emptyPrefillData = emptyPrefillData
     }
 
@@ -32,19 +49,19 @@ class RegisterDomainDetailsServiceProxyMock: RegisterDomainDetailsServiceProxyPr
                                           domainNames: [String],
                                           success: @escaping (ValidateDomainContactInformationResponse) -> Void,
                                           failure: @escaping (Error) -> Void) {
-        guard self.success else {
+        guard validateDomainContactInformationSuccess else {
             failure(NSError())
             return
         }
         var response = ValidateDomainContactInformationResponse()
-        response.success = true
+        response.success = validateDomainContactInformationResponseSuccess
         success(response)
 
     }
 
     func getDomainContactInformation(success: @escaping (DomainContactInformation) -> Void,
                                      failure: @escaping (Error) -> Void) {
-        guard self.success else {
+        guard validateDomainContactInformationSuccess else {
             failure(NSError())
             return
         }
@@ -69,7 +86,7 @@ class RegisterDomainDetailsServiceProxyMock: RegisterDomainDetailsServiceProxyPr
 
     func getSupportedCountries(success: @escaping ([Country]) -> Void,
                                failure: @escaping (Error) -> Void) {
-        guard self.success else {
+        guard validateDomainContactInformationSuccess else {
             failure(NSError())
             return
         }
@@ -85,7 +102,7 @@ class RegisterDomainDetailsServiceProxyMock: RegisterDomainDetailsServiceProxyPr
     func getStates(for countryCode: String,
                    success: @escaping ([State]) -> Void,
                    failure: @escaping (Error) -> Void) {
-        guard self.success else {
+        guard validateDomainContactInformationSuccess else {
             failure(NSError())
             return
         }
@@ -101,19 +118,35 @@ class RegisterDomainDetailsServiceProxyMock: RegisterDomainDetailsServiceProxyPr
     func createShoppingCart(siteID: Int,
                             domainSuggestion: DomainSuggestion,
                             privacyProtectionEnabled: Bool,
-                            success: @escaping (CartResponse) -> Void,
+                            success: @escaping (CartResponseProtocol) -> Void,
                             failure: @escaping (Error) -> Void) {
-        fatalError("not implemented")
+        guard createShoppingCartSuccess else {
+            failure(NSError())
+            return
+        }
+        let response = CartResponseMock()
+        success(response)
     }
 
-    func redeemCartUsingCredits(cart: CartResponse, domainContactInformation: [String: String], success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
-        fatalError("not implemented")
+    func redeemCartUsingCredits(cart: CartResponseProtocol,
+                                domainContactInformation: [String: String],
+                                success: @escaping () -> Void,
+                                failure: @escaping (Error) -> Void) {
+        guard redeemCartUsingCreditsSuccess else {
+            failure(NSError())
+            return
+        }
+        success()
     }
 
-    func changePrimaryDomain(siteID: Int, newDomain: String, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
-         fatalError("not implemented")
+    func changePrimaryDomain(siteID: Int,
+                             newDomain: String,
+                             success: @escaping () -> Void,
+                             failure: @escaping (Error) -> Void) {
+        guard changePrimaryDomainSuccess else {
+            failure(NSError())
+            return
+        }
+        success()
     }
-
-
-
 }

--- a/WordPress/WordPressTest/RegisterDomainDetailsViewModelLoadingStateTests.swift
+++ b/WordPress/WordPressTest/RegisterDomainDetailsViewModelLoadingStateTests.swift
@@ -1,0 +1,149 @@
+@testable import WordPress
+import XCTest
+
+class RegisterDomainDetailsViewModelLoadingStateTests: XCTestCase {
+    private var viewModel: RegisterDomainDetailsViewModel!
+
+    override func setUp() {
+        super.setUp()
+
+        let domainSuggestion = try! DomainSuggestion(json: ["domain_name": "" as AnyObject])
+        let site = JetpackSiteRef.mock(siteID: 9001, username: "test")
+        viewModel = RegisterDomainDetailsViewModel(site: site, domain: domainSuggestion) { _ in return }
+    }
+
+    func testLoadingStateWithContactInfoValidationFailure() {
+        let mockService = RegisterDomainDetailsServiceProxyMock(validateDomainContactInformationSuccess: false)
+        viewModel.registerDomainDetailsService = mockService
+
+        let waitExpectation = expectation(description: "Waiting for mock service")
+        viewModel.onChange = { [weak self] change in
+            switch change {
+            case .unexpectedError:
+                XCTAssert(self?.viewModel.isLoading == false)
+                waitExpectation.fulfill()
+                return
+            default:
+                break
+            }
+        }
+        viewModel.register()
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testLoadingStateWithContactInfoValidationResponseFailure() {
+        let mockService = RegisterDomainDetailsServiceProxyMock(validateDomainContactInformationSuccess: true,
+                                                                validateDomainContactInformationResponseSuccess: false)
+        viewModel.registerDomainDetailsService = mockService
+
+        let waitExpectation = expectation(description: "Waiting for mock service")
+        viewModel.onChange = { [weak self] change in
+            switch change {
+            case .remoteValidationFinished:
+                XCTAssert(self?.viewModel.isLoading == false)
+                waitExpectation.fulfill()
+                return
+            default:
+                break
+            }
+        }
+        viewModel.register()
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testLoadingStateWithContactInfoValidationResponseSuccess() {
+        let mockService = RegisterDomainDetailsServiceProxyMock(validateDomainContactInformationSuccess: true,
+                                                                validateDomainContactInformationResponseSuccess: true)
+        viewModel.registerDomainDetailsService = mockService
+
+        let waitExpectation = expectation(description: "Waiting for mock service")
+        viewModel.onChange = { [weak self] change in
+            switch change {
+            case .remoteValidationFinished:
+                XCTAssert(self?.viewModel.isLoading == true)
+                waitExpectation.fulfill()
+                return
+            default:
+                break
+            }
+        }
+        viewModel.register()
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testLoadingStateWithShoppingCartCreationFailure() {
+        let mockService = RegisterDomainDetailsServiceProxyMock(createShoppingCartSuccess: false)
+        viewModel.registerDomainDetailsService = mockService
+
+        let waitExpectation = expectation(description: "Waiting for mock service")
+        viewModel.onChange = { [weak self] change in
+            switch change {
+            case .prefillError:
+                XCTAssert(self?.viewModel.isLoading == false)
+                waitExpectation.fulfill()
+                return
+            default:
+                break
+            }
+        }
+        viewModel.register()
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testLoadingStateWithCartRedemptionUsingCreditsFailure() {
+        let mockService = RegisterDomainDetailsServiceProxyMock(redeemCartUsingCreditsSuccess: false)
+        viewModel.registerDomainDetailsService = mockService
+
+        let waitExpectation = expectation(description: "Waiting for mock service")
+        viewModel.onChange = { [weak self] change in
+            switch change {
+            case .prefillError:
+                XCTAssert(self?.viewModel.isLoading == false)
+                waitExpectation.fulfill()
+                return
+            default:
+                break
+            }
+        }
+        viewModel.register()
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testLoadingStateWithPrimaryDomainChangeFailure() {
+        let mockService = RegisterDomainDetailsServiceProxyMock(changePrimaryDomainSuccess: false)
+        viewModel.registerDomainDetailsService = mockService
+
+        let waitExpectation = expectation(description: "Waiting for mock service")
+        viewModel.onChange = { [weak self] change in
+            switch change {
+            case .prefillError:
+                XCTAssert(self?.viewModel.isLoading == false)
+                waitExpectation.fulfill()
+                return
+            default:
+                break
+            }
+        }
+        viewModel.register()
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+
+    func testLoadingStateWithRegistrationSuccess() {
+        let mockService = RegisterDomainDetailsServiceProxyMock()
+        viewModel.registerDomainDetailsService = mockService
+
+        let waitExpectation = expectation(description: "Waiting for mock service")
+        viewModel.onChange = { [weak self] change in
+            switch change {
+            case .registerSucceeded:
+                XCTAssert(self?.viewModel.isLoading == false)
+                waitExpectation.fulfill()
+                return
+            default:
+                break
+            }
+        }
+        viewModel.register()
+        waitForExpectations(timeout: 0.1, handler: nil)
+    }
+}

--- a/WordPress/WordPressTest/RegisterDomainDetailsViewModelTests.swift
+++ b/WordPress/WordPressTest/RegisterDomainDetailsViewModelTests.swift
@@ -1,7 +1,7 @@
 @testable import WordPress
 import XCTest
 
-private extension JetpackSiteRef {
+extension JetpackSiteRef {
     static func mock(siteID: Int, username: String) -> JetpackSiteRef {
         let payload: NSString = """
         {
@@ -15,7 +15,6 @@ private extension JetpackSiteRef {
     }
 }
 
-
 class RegisterDomainDetailsViewModelTests: XCTestCase {
     typealias Change = RegisterDomainDetailsViewModel.Change
     typealias CellIndex = RegisterDomainDetailsViewModel.CellIndex
@@ -27,7 +26,6 @@ class RegisterDomainDetailsViewModelTests: XCTestCase {
 
     var viewModel: RegisterDomainDetailsViewModel!
     var changeArray: [Change] = []
-
 
     override func setUp() {
         super.setUp()
@@ -46,7 +44,7 @@ class RegisterDomainDetailsViewModelTests: XCTestCase {
         let addressSection = viewModel.sections[SectionIndex.address.rawValue]
         let initialRowCount = addressSection.rows.count
 
-        viewModel.registerDomainDetailsService = RegisterDomainDetailsServiceProxyMock(success: true)
+        viewModel.registerDomainDetailsService = RegisterDomainDetailsServiceProxyMock()
 
         viewModel.enableAddAddressRow()
         XCTAssert(addressSection.rows[1] ==
@@ -68,7 +66,7 @@ class RegisterDomainDetailsViewModelTests: XCTestCase {
     func testReplaceAddAddressRow() {
         let addressSection = viewModel.sections[SectionIndex.address.rawValue]
         let initialRowCount = addressSection.rows.count
-        viewModel.registerDomainDetailsService = RegisterDomainDetailsServiceProxyMock(success: true)
+        viewModel.registerDomainDetailsService = RegisterDomainDetailsServiceProxyMock()
 
         viewModel.enableAddAddressRow()
         viewModel.replaceAddNewAddressLine()
@@ -107,7 +105,7 @@ class RegisterDomainDetailsViewModelTests: XCTestCase {
     func testAddAddressRowMaxLimit() {
         let addressSection = viewModel.sections[SectionIndex.address.rawValue]
         let initialRowCount = addressSection.rows.count
-        viewModel.registerDomainDetailsService = RegisterDomainDetailsServiceProxyMock(success: true)
+        viewModel.registerDomainDetailsService = RegisterDomainDetailsServiceProxyMock()
 
         viewModel.enableAddAddressRow()
         viewModel.replaceAddNewAddressLine()
@@ -136,7 +134,7 @@ class RegisterDomainDetailsViewModelTests: XCTestCase {
     }
 
     func testEnableSubmitValidation() {
-        viewModel.registerDomainDetailsService = RegisterDomainDetailsServiceProxyMock(success: true, emptyPrefillData: true)
+        viewModel.registerDomainDetailsService = RegisterDomainDetailsServiceProxyMock(emptyPrefillData: true)
 
         XCTAssert(viewModel.isValid(inContext: .clientSide) == false)
 
@@ -167,7 +165,7 @@ class RegisterDomainDetailsViewModelTests: XCTestCase {
     }
 
     func testPrefillData() {
-        viewModel.registerDomainDetailsService = RegisterDomainDetailsServiceProxyMock(success: true, emptyPrefillData: false)
+        viewModel.registerDomainDetailsService = RegisterDomainDetailsServiceProxyMock(emptyPrefillData: false)
 
         viewModel.prefill()
 


### PR DESCRIPTION
Refs. #11467 - subtask - Integrate the whole domain registration flow

Code changes:

* Integrated domain registration flow from domain credit redemption entry point.
* In `RegisterDomainDetailsViewController`, moved domain registration success callback from before view controller dismissal to dismissal's completion block. This change was made so that after domain registration UI is dismissed, new UI can be presented (otherwise presenting view controller is not visible in view hierarchy when success block is called).

To test:

- Prerequisites: have a site/blog with paid WordPress.com plan (e.g. Blogger plan) and its domain credit still available
- Go to a site dashboard where the site meets conditions in prerequisites, domain credit section should be shown
- Tap on "Register Domain" row
- Pick a `*.blog` domain (`.blog` has high purchase volume so that cancellation rate from testing has less effect on production domain service)
  - Note that the same domain cannot be purchased by the same user after cancellation, so make sure this testing domain is not what you might want to own with the WP.com account :)
- Fill out registration details (these will be saved for the next time)
- Submit domain registration, and wait for registration service to complete
  - One issue I noticed and fixed in this PR (same with Business account automated transfer): the spinner appears after submitting the form, and then disappears shortly while registration is still in progress (network spinner on).
  - An edge case crash fixed in this PR in https://github.com/wordpress-mobile/WordPress-iOS/pull/11613/commits/2de5bc062ca3ca600a007a5cb5c1884f40cc13be: while registration service is in progress, tapping "< Back" quickly and dismissing the domain registration modal used to crash due to retained `self`.
- Around the time an email on domain registration success is received, the domain registration modal should be dismissed and a congratulations screen is shown with the purchased domain
- After dismissing the congratulations screen, a snackbar should appear notifying further instructions in email. At the same time, domain credit UI should not be shown on site dashboard
- **[Important]** Cancel domain purchase shortly after testing in Account Profile --> Manage Purchases ([official FAQ](https://en.support.wordpress.com/manage-purchases/#FAQ-Cancelling))


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
