### PR TITLE
Testing: Use site address login for UI tests

### DIFF
--- a/.configure
+++ b/.configure
@@ -1,6 +1,6 @@
 {
   "branch": "master",
-  "pinned_hash": "3778694c751b396867d2e2265ebd0dbab76a4221",
+  "pinned_hash": "4f89780c8d2e3cfc5f0d4c7f0f5dc4abc4e786b3",
   "files_to_copy": [
 
   ],

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -13351,7 +13351,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TEST_TARGET_NAME = WordPress;
 			};
 			name = Debug;
@@ -13391,7 +13391,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TEST_TARGET_NAME = WordPress;
 			};
 			name = Release;
@@ -13431,7 +13431,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TEST_TARGET_NAME = WordPress;
 			};
 			name = "Release-Internal";
@@ -13471,7 +13471,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.WordPressUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TEST_TARGET_NAME = WordPress;
 			};
 			name = "Release-Alpha";

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -2,13 +2,13 @@ import XCTest
 
 class LoginFlow {
 
-    static func login(email: String, password: String) -> MySiteScreen {
+    static func login(siteUrl: String, username: String, password: String) -> MySiteScreen {
         logoutIfNeeded()
 
         return WelcomeScreen().login()
-            .proceedWith(email: email)
-            .proceedWithPassword()
-            .proceedWith(password: password)
+            .goToSiteAddressLogin()
+            .proceedWith(siteUrl: siteUrl)
+            .proceedWith(username: username, password: password)
             .continueWithSelectedSite()
             .dismissNotificationAlertIfNeeded()
     }

--- a/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
@@ -13,7 +13,7 @@ class EditorAztecTests: XCTestCase {
         app.activate()
 
         editorScreen = LoginFlow
-            .login(email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+            .login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, username: WPUITestCredentials.testWPcomUsername, password: WPUITestCredentials.testWPcomPassword)
             .tabBar.gotoEditorScreen()
     }
 

--- a/WordPress/WordPressUITests/Tests/EditorTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorTests.swift
@@ -13,7 +13,7 @@ class EditorTests: XCTestCase {
         app.activate()
 
         editorScreen = LoginFlow
-            .login(email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+            .login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, username: WPUITestCredentials.testWPcomUsername, password: WPUITestCredentials.testWPcomPassword)
             .tabBar
             .gotoEditorScreen()
     }

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -14,7 +14,7 @@ class MainNavigationTests: XCTestCase {
         app.activate()
 
         mySiteScreen = LoginFlow
-            .login(email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+            .login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, username: WPUITestCredentials.testWPcomUsername, password: WPUITestCredentials.testWPcomPassword)
     }
 
     override func tearDown() {

--- a/WordPress/WordPressUITests/WPUITestCredentials-Template.swift
+++ b/WordPress/WordPressUITests/WPUITestCredentials-Template.swift
@@ -3,6 +3,7 @@
 // you can read more here: https://github.com/wordpress-mobile/WordPress-iOS#setup-credentials
 struct WPUITestCredentials {
     static let testWPcomUserEmail: String = <# Your WordPress.com Account Email #>
+    static let testWPcomUsername: String = <# Your WordPress.com Account Username #>
     static let testWPcomPassword: String = <# Your WordPress.com Account Password #>
     static let testWPcomSiteAddress: String =  <# Your WordPress.com Site Address #>
     static let selfHostedUsername: String = <# Your Self Hosted Account Username #>


### PR DESCRIPTION
Fixes #11599 

The UI tests now use the site address login (with username/password) for all tests except LoginTests, which explicitly test different login flows.

To test:

* Pull the latest mobile secrets. (Your `WPUITestCredentials.swift` file will need to include `testWPcomUsername` with the WordPress.com test account's username.)
* Start the simulator with the device set to English.
* Run the tests under `EditorAztecTests`, `EditorTests`, and `MainNavigationTests` in the WordPressUITests target and confirm that they log in successfully using the site address login option.

Note that the test under `EditorTests` may fail after login but there's a fix for that in https://github.com/wordpress-mobile/WordPress-iOS/pull/11315.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
