### PR TITLE
Reader: Disable text editing in reader views.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -33,6 +33,7 @@ class ReaderCommentCell: UITableViewCell {
     private let textView: WPRichContentView = {
         let newTextView = WPRichContentView(frame: .zero, textContainer: nil)
         newTextView.isScrollEnabled = false
+        newTextView.isEditable = false
         newTextView.translatesAutoresizingMaskIntoConstraints = false
 
         return newTextView

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -63,6 +63,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         let textView = WPRichContentView(frame: .zero, textContainer: nil)
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.alpha = 0
+        textView.isEditable = false
 
         return textView
     }()


### PR DESCRIPTION
Refs #11401 

While re-testing a different issue I noticed that text in the reader detail and reader comments was editable.  It looks like we missed that storyboards and xibs had flagged the WPRichContentView as not editable when refactoring.  This is a quick patch to disable editing again. 

To test:
Confirm the bug by running `develop` and tapping into a reader comment or detail and typing some text. 
Run this patch and repeat the test.  Confirm you do not see a cursor and can not edit text. 

@diegoreymendez could you take a quick peek at this one? 