### PR TITLE
[Stats Refresh] Enable Today widget

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -90,16 +90,16 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 - (void)addStatsViewControllerToView
 {
+    if (self.presentingViewController == nil) {
+        UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Today", @"") style:UIBarButtonItemStylePlain target:self action:@selector(makeSiteTodayWidgetSite:)];
+        self.navigationItem.rightBarButtonItem = settingsButton;
+    }
+
     if ([Feature enabled:FeatureFlagStatsRefresh]) {
         [self addChildViewController:self.siteStatsDashboardVC];
         [self.view addSubview:self.siteStatsDashboardVC.view];
         [self.siteStatsDashboardVC didMoveToParentViewController:self];
     } else {
-        if (self.presentingViewController == nil) {
-            UIBarButtonItem *settingsButton = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Today", @"") style:UIBarButtonItemStylePlain target:self action:@selector(makeSiteTodayWidgetSite:)];
-            self.navigationItem.rightBarButtonItem = settingsButton;
-        }
-        
         [self addChildViewController:self.statsVC];
         [self.view addSubview:self.statsVC.view];
         self.statsVC.view.translatesAutoresizingMaskIntoConstraints = NO;
@@ -167,10 +167,18 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 - (void)saveSiteDetailsForTodayWidget
 {
     TodayExtensionService *service = [TodayExtensionService new];
-    [service configureTodayWidgetWithSiteID:self.statsVC.siteID
-                                   blogName:self.blog.settings.name
-                               siteTimeZone:self.statsVC.siteTimeZone
-                             andOAuth2Token:self.statsVC.oauth2Token];
+    
+    if ([Feature enabled:FeatureFlagStatsRefresh]) {
+        [service configureTodayWidgetWithSiteID:SiteStatsInformation.sharedInstance.siteID
+                                       blogName:self.blog.settings.name
+                                   siteTimeZone:SiteStatsInformation.sharedInstance.siteTimeZone
+                                 andOAuth2Token:SiteStatsInformation.sharedInstance.oauth2Token];
+    } else {
+        [service configureTodayWidgetWithSiteID:self.statsVC.siteID
+                                       blogName:self.blog.settings.name
+                                   siteTimeZone:self.statsVC.siteTimeZone
+                                 andOAuth2Token:self.statsVC.oauth2Token];
+    }
 }
 
 


### PR DESCRIPTION
Fixes #11126

This enables the existing Today widget for the new Stats.

To test:

---
- Go to Stats. 
- Verify `Today` appears on the navigation bar on the main view (i.e. for Insights and Periods).

---
This verifies the existing Today widget functionality.
- Select `Today`, then `Use this site`.
- Go to the device's notification center.
  - You may need to add the WordPress widget via Edit > Add Widgets.
- Verify the Stats widget appears and is using the selected site.

<img width="350" alt="stats_widget" src="https://user-images.githubusercontent.com/1816888/57105588-66895700-6ce8-11e9-965b-a151be8b3357.png">

