### PR TITLE
[Stats Refresh] Post Stats: abbreviate Recent Weeks values.

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/Double+Stats.swift
@@ -53,7 +53,7 @@ extension Double {
         }
     }
 
-    func formatWithCommas() -> String {
+    private func formatWithCommas() -> String {
         return numberFormatter.string(for: self) ?? ""
     }
 
@@ -74,9 +74,5 @@ extension Float {
 extension Int {
     func abbreviatedString(forHeroNumber: Bool = false) -> String {
         return Double(self).abbreviatedString(forHeroNumber: forHeroNumber)
-    }
-
-    func formatWithCommas() -> String {
-        return Double(self).formatWithCommas()
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -193,7 +193,7 @@ private extension PostStatsViewModel {
 
         return recentWeeks.reversed().prefix(StatsDataHelper.maxRowsToDisplay).map {
             StatsTotalRowData(name: displayWeek(startDay: $0.startDay, endDay: $0.endDay),
-                              data: $0.totalViewsCount.formatWithCommas(),
+                              data: $0.totalViewsCount.abbreviatedString(),
                               showDisclosure: true,
                               childRows: childRowsForWeek($0),
                               statSection: .postStatsRecentWeeks)
@@ -205,7 +205,7 @@ private extension PostStatsViewModel {
     func childRowsForWeek(_ week: StatsWeeklyBreakdown) -> [StatsTotalRowData] {
         return week.days.reversed().map {
             StatsTotalRowData(name: displayDay(forDate: $0.date),
-                              data: $0.viewsCount.formatWithCommas())
+                              data: $0.viewsCount.abbreviatedString())
         }
     }
 


### PR DESCRIPTION
Ref #11189

This abbreviates the Recent Weeks values in Post Stats starting at 10,000.

To test:
- Go to Stats > Period > Posts and Pages.
- Select one with a lot of views.
  - Tip: en.blog Home Page is a good one.
- Verify the numbers are abbreviated.
  - NOTE: I don't have a site where a _day_ has high enough views to abbreviate, but it uses the same logic.

Before:

<img width="350" alt="recent_weeks_no_abbrev" src="https://user-images.githubusercontent.com/1816888/57108419-e961e000-6cef-11e9-97e7-3243c0d2f4c4.png">

After:
<img width="350" alt="recent_weeks_abbrev" src="https://user-images.githubusercontent.com/1816888/57108422-ed8dfd80-6cef-11e9-8e86-5e6218fcfef2.png">
