### PR TITLE
[Stats Refresh] Post Stats: revive Recent Weeks headers

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -140,7 +140,7 @@
             return ItemSubtitles.country
         case .periodSearchTerms:
             return ItemSubtitles.searchTerm
-        case .postStatsMonthsYears, .postStatsAverageViews:
+        case .postStatsMonthsYears, .postStatsAverageViews, .postStatsRecentWeeks:
             return ItemSubtitles.period
         default:
             return ""
@@ -160,7 +160,8 @@
              .periodSearchTerms,
              .periodVideos,
              .postStatsMonthsYears,
-             .postStatsAverageViews:
+             .postStatsAverageViews,
+             .postStatsRecentWeeks:
             return DataSubtitles.views
         case .insightsPublicize:
             return DataSubtitles.followers


### PR DESCRIPTION
Ref #11189

This brings back the Recent Weeks column headers (`Period` and `Views`), which I broke with https://github.com/wordpress-mobile/WordPress-iOS/pull/11593. Woops.

To test:
- Go to Post Stats > Recent Weeks.
- Verify it has column headers once again.

<img width="350" alt="recent_weeks_headers" src="https://user-images.githubusercontent.com/1816888/57109594-1c59a300-6cf3-11e9-808e-daf6b853ba62.png">

