### PR TITLE
[Stats Refresh] Post Stats: fix Post Title display issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
@@ -9,15 +9,14 @@ class PostStatsTitleCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var bottomSeparatorLine: UIView!
 
     private typealias Style = WPStyleGuide.Stats
-    private var postTitle: String?
     private var postURL: URL?
     private weak var postStatsDelegate: PostStatsDelegate?
 
     // MARK: - Configure
 
     func configure(postTitle: String, postURL: URL?, postStatsDelegate: PostStatsDelegate? = nil) {
-        self.postTitle = postTitle
         self.postURL = postURL
+        postTitleLabel.text = postTitle
         self.postStatsDelegate = postStatsDelegate
         applyStyles()
     }
@@ -31,12 +30,6 @@ private extension PostStatsTitleCell {
         Style.configureLabelAsPostStatsTitle(titleLabel)
         Style.configureLabelAsPostTitle(postTitleLabel)
         Style.configureViewAsSeparator(bottomSeparatorLine)
-
-        guard let postTitle = postTitle else {
-            return
-        }
-
-        postTitleLabel.attributedText = Style.highlightString(postTitle, inString: postTitle)
     }
 
     @IBAction func didTapPostTitle(_ sender: UIButton) {


### PR DESCRIPTION
Fixes #11618

This addresses the problems noted in #11618 regarding the Post Title displayed in the title card, namely:
- The Post Title is now dark grey
- The font is NotoSerif-Bold
- The spacing between the `Showing stats for` label and the Post Title is now consistent regardless of the post title length.

The problems stemmed from [this](https://github.com/wordpress-mobile/WordPress-iOS/pull/11499) change, where I got...creative, and made the Post Title look like that on Latest Post Summary since it's now clickable.

The fix was simply to remove the `postTitleLabel.attributedText`, thus allowing the original formatting to shine through.

To test:
- Go to Post Stats, and verify the three points noted above.

<img width="463" alt="single_line_title" src="https://user-images.githubusercontent.com/1816888/57112370-f20ce300-6cfc-11e9-842c-e597799b9d90.png">

<img width="463" alt="multi_line_title" src="https://user-images.githubusercontent.com/1816888/57112374-f5a06a00-6cfc-11e9-9d34-4f0286e4f4b6.png">


