### PR TITLE
Convert HEIC images to JPG in share extension

### DIFF
--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -405,7 +405,16 @@ private struct URLExtractor: TypeBasedExtensionContentExtractor {
             let assetURL = url.appendingPathComponent(fileName, isDirectory: false)
 
             switch assetURL.pathExtension.lowercased() {
-            case "jpg", "jpeg", "heic", "gif", "png":
+            case "heic":
+                autoreleasepool {
+                    if let file = fileWrapper.regularFileContents,
+                        let tmpImage = UIImage(data: file),
+                        let cachedURL = saveToSharedContainer(image: tmpImage) {
+                        cachedImages["assets/\(fileName)"] = ExtractedImage(url: cachedURL, insertionState: .requiresInsertion)
+
+                    }
+                }
+            case "jpg", "jpeg", "gif", "png":
                 if let cachedURL = saveToSharedContainer(wrapper: fileWrapper) {
                     cachedImages["assets/\(fileName)"] = ExtractedImage(url: cachedURL, insertionState: .requiresInsertion)
                 }


### PR DESCRIPTION
Fixes #11626 

This allows HEIC images in TextBundles to be uploaded as JPGs.

To test:
- Put a HEIC image in a note in Bear
- Share as a TextBundle to the WordPress app
- Publish
- Ensure the post appears with the image

Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

@SergioEstevao do you have time to review this for 12.3? Let me know if not, thanks! 👍 
