### PR TITLE
[Develop] Fix warnings

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -983,7 +983,7 @@ private extension NotificationDetailsViewController {
     }
 
     func spamCommentWithBlock(_ block: FormattableCommentContent) {
-        guard let onDeletionRequestCallback = onDeletionRequestCallback else {
+        guard onDeletionRequestCallback != nil else {
             // callback probably missing due to state restoration. at least by
             // not crashing the user can tap the back button and try again
             return
@@ -1008,7 +1008,7 @@ private extension NotificationDetailsViewController {
     }
 
     func trashCommentWithBlock(_ block: FormattableCommentContent) {
-        guard let onDeletionRequestCallback = onDeletionRequestCallback else {
+        guard onDeletionRequestCallback != nil else {
             // callback probably missing due to state restoration. at least by
             // not crashing the user can tap the back button and try again
             return


### PR DESCRIPTION
Refs. #11592

This is a quick PR which removes 2 warnings in `NotificationDetailsViewController`.

## To test:
• Build the PR and check the warnings `Value 'onDeletionRequestCallback' was defined but never used;...` won't be displayed.
• To test everything is the same you can follow the same step as before described [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/11592)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
