### PR TITLE
Fix Notices sometimes shown behind the keyboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+12.5
+-----
+* Fixed Notices sometimes showing behind the keyboard
+
 12.4
 -----
 * You can now mark notifications as unread with just a swipe.

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -115,7 +115,7 @@ class NoticePresenter: NSObject {
             }
 
             UIView.animate(withDuration: durationValue.doubleValue, animations: {
-                currentContainer.bottomConstraint?.constant = self.onscreenNoticeContainerBottomConstraintConstant()
+                currentContainer.bottomConstraint?.constant = self.onscreenNoticeContainerBottomConstraintConstant
                 self.view.layoutIfNeeded()
             })
         }
@@ -130,7 +130,7 @@ class NoticePresenter: NSObject {
             }
 
             UIView.animate(withDuration: durationValue.doubleValue, animations: {
-                currentContainer.bottomConstraint?.constant = self.onscreenNoticeContainerBottomConstraintConstant()
+                currentContainer.bottomConstraint?.constant = self.onscreenNoticeContainerBottomConstraintConstant
                 self.view.layoutIfNeeded()
             })
         }
@@ -312,13 +312,13 @@ class NoticePresenter: NSObject {
             }
 
             noticeContainer.noticeView.alpha = WPAlphaFull
-            noticeContainer.bottomConstraint?.constant = self.onscreenNoticeContainerBottomConstraintConstant()
+            noticeContainer.bottomConstraint?.constant = self.onscreenNoticeContainerBottomConstraintConstant
 
             self.view.layoutIfNeeded()
         }
     }
 
-    private func onscreenNoticeContainerBottomConstraintConstant() -> CGFloat {
+    private var onscreenNoticeContainerBottomConstraintConstant: CGFloat {
         switch self.currentKeyboardPresentation {
         case .present(let keyboardHeight):
             return -keyboardHeight

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -57,7 +57,7 @@ class NoticePresenter: NSObject {
     private var storeReceipt: Receipt?
 
     private var currentNoticePresentation: NoticePresentation?
-    private var currentKeyboardPresentation = KeyboardPresentation(isPresent: false, height: 0)
+    private var currentKeyboardPresentation: KeyboardPresentation = .notPresent
 
     private init(store: NoticeStore) {
         self.store = store

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -37,6 +37,7 @@ class NoticePresenter: NSObject {
         let notice: Notice
         let containerView: NoticeContainerView?
     }
+    /// Used to determine if the keyboard is currently shown and what its height is.
     private struct KeyboardPresentation {
         let isPresent: Bool
         let height: CGFloat

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -103,14 +103,14 @@ class NoticePresenter: NSObject {
         NotificationCenter.default.addObserver(forName: UIResponder.keyboardWillShowNotification, object: nil, queue: nil) { [weak self] (notification) in
             guard let self = self,
                 let userInfo = notification.userInfo,
-                let keyboardFrameValue = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+                let keyboardFrameValue = userInfo[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue,
+                let durationValue = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber else {
                     return
             }
 
             self.currentKeyboardPresentation = .present(height: keyboardFrameValue.cgRectValue.size.height)
 
-            guard let currentContainer = self.currentNoticePresentation?.containerView,
-                let durationValue = userInfo[UIResponder.keyboardAnimationDurationUserInfoKey] as? NSNumber else {
+            guard let currentContainer = self.currentNoticePresentation?.containerView else {
                 return
             }
 


### PR DESCRIPTION
Fixes #11620.

I found that in `NoticePresenter`, we do watch for keyboard notifications and move the **existing** Notice up when it's shown. However, we don't check if there is a keyboard already present when showing a new Notice. This adds that check.

| Before | After |
|--------|-------|
| ![notice-before gifcask 2019-05-03 13_26_47](https://user-images.githubusercontent.com/198826/57160823-26d57480-6da7-11e9-9308-1231747f5b26.gif)|  ![notice-after](https://user-images.githubusercontent.com/198826/57160827-29d06500-6da7-11e9-93e0-049a269e4ba0.gif) |

## Testing

This can be tested in, but not limited to, these scenarios: 

### Post List

1. Navigate to Site → Blog Posts
2. Tap on the search box to trigger the keyboard
3. Go offline. 

The offline Notice should be shown (eventually) on top of the keyboard. If not, pull to refresh. Please see _Testing Notes_ below. 

### Tags

1. Add this line to the end of `PostTagPickerViewController.tagsFailedLoading`:
    ```swift
    WPError.showNetworkingNotice(title: "Error", error: error as NSError)    
    ```
2.  Edit a post from the post list
3. Navigate to the post settings
4. Go offline
5. Click on Tags

The Notice should be shown on top of the keyboard. 

### Testing Notes

If you're using the simulator, play around with hiding and showing the keyboard (CMD+K). 

Please note that offline message Notices sometimes take a while to be shown. I noticed that on simulators, our API requests tend to wait for a long time before responding with a timeout. After that, the Notice is shown.

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
