### PR TITLE
[Stats Refresh] Enable internal testing

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -15,7 +15,7 @@ enum FeatureFlag: Int {
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .statsRefresh:
-            return BuildConfiguration.current == .localDeveloper
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cPrereleaseTesting]
         case .domainCredit:
             return BuildConfiguration.current == .localDeveloper
         }


### PR DESCRIPTION
Fixes #n/a

This enables Stats Refresh for internal testers.

To test:
Go to Stats. Verify the new Stats appears.
