### PR TITLE
Improve Sentry tags

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+Swift.swift
@@ -38,11 +38,7 @@ extension WordPressAppDelegate {
     }
 
     @objc func configureCrashLogging() {
-        #if DEBUG
-            return
-        #else
-            WPCrashLogging.start()
-        #endif
+        WPCrashLogging.start()
     }
 
     @objc func configureHockeySDK() {

--- a/WordPress/Classes/Utility/BuildInformation/BuildConfiguration.swift
+++ b/WordPress/Classes/Utility/BuildInformation/BuildConfiguration.swift
@@ -1,4 +1,4 @@
-enum BuildConfiguration {
+enum BuildConfiguration: String {
     /// Development build, usually run from Xcode
     case localDeveloper
 

--- a/WordPress/Classes/Utility/Sentry/WPCrashLogging.swift
+++ b/WordPress/Classes/Utility/Sentry/WPCrashLogging.swift
@@ -27,17 +27,28 @@ class WPCrashLogging {
             Client.shared?.beforeSerializeEvent = sharedInstance.beforeSerializeEvent
             Client.shared?.shouldSendEvent = sharedInstance.shouldSendEvent
 
+            // Apply Sentry Tags
+            Client.shared?.releaseName = sharedInstance.releaseName
+            Client.shared?.environment = sharedInstance.buildType
+
+            // Do user tracking
+            sharedInstance.applyUserTrackingPreferences()
+
         } catch let error {
             print("\(error)")
         }
     }
 
     func beforeSerializeEvent(_ event: Event) {
-        event.extra = ["b": "c"]
+        event.tags?["locale"] = NSLocale.current.languageCode
     }
 
     func shouldSendEvent(_ event: Event?) -> Bool {
+        #if DEBUG
+        return false
+        #else
         return !userHasOptedOut
+        #endif
     }
 
     var userHasOptedOut: Bool = false
@@ -84,9 +95,6 @@ extension WPCrashLogging {
         else {
             disableUserTracking()
         }
-
-        Client.shared?.releaseName = releaseName
-        Client.shared?.environment = buildType
     }
 
     func enableUserTracking() {
@@ -106,8 +114,8 @@ extension WPCrashLogging {
             "display_name": displayName,
             "user_id": userID,
             "number_of_blogs": blogService.blogCountForAllAccounts(),
-            "logged_in": defaultAccount == nil,
-            "connected_to_dotcom": defaultAccount == nil,
+            "logged_in": defaultAccount != nil,
+            "connected_to_dotcom": defaultAccount != nil,
         ]
 
         Client.shared?.user = user
@@ -117,14 +125,11 @@ extension WPCrashLogging {
         Client.shared?.clearContext()
     }
 
-    var releaseName: String {
-        let bundleVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as! String
-        let buildNumber = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as! String
-
-        return "\(bundleVersion) (\(buildNumber)"
+    fileprivate var releaseName: String {
+        return Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as! String
     }
 
-    var buildType: String {
-        return Mirror(reflecting: BuildConfiguration.current).children.first?.label ?? "unknown"
+    fileprivate var buildType: String {
+        return BuildConfiguration.current.rawValue
     }
 }


### PR DESCRIPTION
- Simplifies calling crash logging
- Fixes Sentry environment tag
- Simplifies the release name
- Adds the locale as a Sentry tag
- Fixes `logged_in` and `connected_to_dotcom` variables to be correct

**To Test:**

See `2d0c52b8f4f642e5a3e75d53cd163d44-sentry` and note the fixed tags.