### PR TITLE
Revert removeView method

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -179,7 +179,9 @@ import Reachability
     /// Public method to remove No Results View from parent view.
     ///
     @objc func removeFromView() {
-        remove()
+        willMove(toParent: nil)
+        view.removeFromSuperview()
+        removeFromParent()
     }
 
     /// Public method to show a 'Dismiss' button in the navigation bar in place of the 'Back' button.


### PR DESCRIPTION
This PR fix a problem @diegoreymendez reported me on Slack.
The loading view we display with the `NoResultsViewController` is not removed properly.
I reverted the `removeFromView()` method without using the UIViewController helper.


## To test:
• Open the reader and fetch the posts.
• Or open the posts of a followed site from the reader
• Or go to reader, back out to the screen with streams and tags. Add a new tag. Tap that tag.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
