### PR TITLE
[Stats Refresh] Disable internal testing

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -15,7 +15,7 @@ enum FeatureFlag: Int {
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .statsRefresh:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cPrereleaseTesting]
+            return BuildConfiguration.current == .localDeveloper
         case .domainCredit:
             return BuildConfiguration.current == .localDeveloper
         }


### PR DESCRIPTION
Fixes #n/a

We've decided Stats Refresh is not yet worthy of internal testing. Disabling that FeatureFlag.

To test:
Run the app. Verify new Stats still shows for development.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
