### PR TITLE
[NRV] Loading view is not animated in the reader stream

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1570,6 +1570,7 @@ private extension ReaderStreamViewController {
         tableView.insertSubview(resultsStatusView.view, belowSubview: refreshControl)
         resultsStatusView.view.frame = tableView.frame
         resultsStatusView.didMove(toParent: tableViewController)
+        resultsStatusView.updateView()
         footerView.isHidden = true
     }
 


### PR DESCRIPTION
Refs. #11643 

This PR fix the animation issue found in the `ReaderStreamViewController`. 

![nrv-animation](https://user-images.githubusercontent.com/912252/57298773-e8072d80-70ca-11e9-889e-60ddfd105c9f.gif)

## To test:
• Go to reader
• Back out to the screen with streams and tags 
• Add a new tag
• Tap that tag
• You should see the loading animation

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
