### PR TITLE
Allow WordPress.com API URLs to be overridden with a launch argument

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -146,7 +146,7 @@ target 'WordPress' do
     
     pod 'Gridicons', '~> 0.16'
 
-    pod 'WordPressAuthenticator', '~> 1.4.1'
+    pod 'WordPressAuthenticator', '~> 1.5.0-beta'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -174,7 +174,7 @@ PODS:
   - WordPress-Aztec-iOS (1.6.1)
   - WordPress-Editor-iOS (1.6.1):
     - WordPress-Aztec-iOS (= 1.6.1)
-  - WordPressAuthenticator (1.4.1):
+  - WordPressAuthenticator (1.5.0-beta.1):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (~> 3.5)
@@ -245,7 +245,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.6.1)
-  - WordPressAuthenticator (~> 1.4.1)
+  - WordPressAuthenticator (~> 1.5.0-beta)
   - WordPressKit (~> 4.1.0)
   - WordPressShared (~> 1.7.5)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, tag `1.2.1`)
@@ -382,7 +382,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-Aztec-iOS: fecf8f0b8f7711c54de727bd597e449386bea094
   WordPress-Editor-iOS: 8392c6acb0c8a155f5db3b1a6c85c3ef7631d3a1
-  WordPressAuthenticator: 1741b00c58c4e57a0505cbff32528c7a049b24e6
+  WordPressAuthenticator: 81f2c9832cc1e4345c67acab671e02580e3fa72e
   WordPressKit: 78208a27c24f4f6eaf6bcfdf0ed4978de3bd080a
   WordPressShared: 2389d30388fd89660aeb4ae26bd28484639db959
   WordPressUI: 6d9dc6d1920ea3626483588413848f456a26a48d
@@ -392,6 +392,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 674917c5b711f57fc1c150d77d25b54a1dbb0ea1
+PODFILE CHECKSUM: da54bad3ed9be1182f04b95cee070904bd0c331c
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Models/WPAccount+RestApi.swift
+++ b/WordPress/Classes/Models/WPAccount+RestApi.swift
@@ -11,6 +11,6 @@ extension WPAccount {
         let userAgent = WPUserAgent.wordPress()
         let localeKey = WordPressComRestApi.LocaleKeyV2
 
-        return WordPressComRestApi(oAuthToken: token, userAgent: userAgent, localeKey: localeKey)
+        return WordPressComRestApi.defaultApi(oAuthToken: token, userAgent: userAgent, localeKey: localeKey)
     }
 }

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -137,8 +137,9 @@ static NSString * const WordPressComOAuthKeychainServiceName = @"public-api.word
     if (!_wordPressComRestApi) {
         if (self.authToken.length > 0) {
             __weak __typeof(self) weakSelf = self;
-            _wordPressComRestApi = [[WordPressComRestApi alloc] initWithOAuthToken:self.authToken
-                                                                         userAgent: [WPUserAgent wordPressUserAgent]];
+            _wordPressComRestApi = [WordPressComRestApi defaultApiWithOAuthToken:self.authToken
+                                                                       userAgent:[WPUserAgent wordPressUserAgent]
+                                                                       localeKey:[WordPressComRestApi LocaleKeyDefault]];
             [_wordPressComRestApi setInvalidTokenHandler:^{
                 [weakSelf setAuthToken:nil];
                 [WordPressAuthenticationManager showSigninForWPComFixingAuthToken];

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -298,7 +298,10 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 
 - (id<AccountServiceRemote>)remoteForAnonymous
 {
-    return [[AccountServiceRemoteREST alloc] initWithWordPressComRestApi:[AccountServiceRemoteREST anonymousWordPressComRestApiWithUserAgent:WPUserAgent.wordPressUserAgent]];
+    WordPressComRestApi *api = [WordPressComRestApi defaultApiWithOAuthToken:nil
+                                                                   userAgent:nil
+                                                                   localeKey:[WordPressComRestApi LocaleKeyDefault]];
+    return [[AccountServiceRemoteREST alloc] initWithWordPressComRestApi:api];
 }
 
 - (id<AccountServiceRemote>)remoteForAccount:(WPAccount *)account

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -1056,7 +1056,9 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     WordPressComRestApi *api = [defaultAccount wordPressComRestApi];
     //Sergio Estevao: Do we really want to do this? If the call going to be valid if no credential is available?
     if (![api hasCredentials]) {
-        api = [[WordPressComRestApi alloc] initWithOAuthToken:nil userAgent:[WPUserAgent wordPressUserAgent]];
+        api = [WordPressComRestApi defaultApiWithOAuthToken:nil
+                                                  userAgent:[WPUserAgent wordPressUserAgent]
+                                                  localeKey:[WordPressComRestApi LocaleKeyDefault]];
     }
     return api;
 }

--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -22,7 +22,7 @@ open class PlanService: LocalCoreDataService {
     @objc public func getWpcomPlans(_ success: @escaping () -> Void,
                           failure: @escaping (Error?) -> Void) {
 
-        let wpcomAPI = WordPressComRestApi(localeKey: WordPressComRestApi.LocaleKeyDefault) // locale, not _locale
+        let wpcomAPI = WordPressComRestApi.defaultApi(localeKey: WordPressComRestApi.LocaleKeyDefault) // locale, not _locale
         let remote = PlanServiceRemote(wordPressComRestApi: wpcomAPI)
         remote.getWpcomPlans({ plans in
 

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -602,7 +602,9 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
     WordPressComRestApi *api = [defaultAccount wordPressComRestApi];
     if (![api hasCredentials]) {
-        api = [[WordPressComRestApi alloc] initWithOAuthToken:nil userAgent:[WPUserAgent wordPressUserAgent]];
+        api = [WordPressComRestApi defaultApiWithOAuthToken:nil
+                                                  userAgent:[WPUserAgent wordPressUserAgent]
+                                                  localeKey:[WordPressComRestApi LocaleKeyDefault]];
     }
     return api;
 }

--- a/WordPress/Classes/Services/ReaderSiteSearchService.swift
+++ b/WordPress/Classes/Services/ReaderSiteSearchService.swift
@@ -18,7 +18,7 @@ typealias ReaderSiteSearchFailureBlock = (_ error: Error?) -> Void
             return api
         }
 
-        return WordPressComRestApi(oAuthToken: nil, userAgent: WPUserAgent.wordPress())
+        return WordPressComRestApi.defaultApi(oAuthToken: nil, userAgent: WPUserAgent.wordPress())
     }
 
     /// Performs a search for sites / feeds matching the specified query.

--- a/WordPress/Classes/Services/ReaderTopicService+Subscriptions.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+Subscriptions.swift
@@ -19,7 +19,7 @@ extension ReaderTopicService {
             return api
         }
 
-        return WordPressComRestApi(oAuthToken: nil, userAgent: WPUserAgent.wordPress())
+        return WordPressComRestApi.defaultApi(oAuthToken: nil, userAgent: WPUserAgent.wordPress())
     }
 
     private func fetchSiteTopic(with siteId: Int, _ failure: @escaping (ReaderTopicServiceError?) -> Void) -> ReaderSiteTopic? {

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -257,7 +257,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 {
     NSAssert([phrase length] > 0, @"A search phrase is required.");
 
-    WordPressComRestApi *api = [[WordPressComRestApi alloc] initWithOAuthToken:nil userAgent:[WPUserAgent wordPressUserAgent]];
+    WordPressComRestApi *api = [WordPressComRestApi defaultApiWithOAuthToken:nil userAgent:[WPUserAgent wordPressUserAgent] localeKey:[WordPressComRestApi LocaleKeyDefault]];
     ReaderPostServiceRemote *remote = [[ReaderPostServiceRemote alloc] initWithWordPressComRestApi:api];
 
     NSString *path = [remote endpointUrlForSearchPhrase:[phrase lowercaseString]];
@@ -636,7 +636,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     WPAccount *defaultAccount = [accountService defaultWordPressComAccount];
     WordPressComRestApi *api = [defaultAccount wordPressComRestApi];
     if (![api hasCredentials]) {
-        api = [[WordPressComRestApi alloc] initWithOAuthToken:nil userAgent:[WPUserAgent wordPressUserAgent]];
+        api = [WordPressComRestApi defaultApiWithOAuthToken:nil userAgent:[WPUserAgent wordPressUserAgent] localeKey:[WordPressComRestApi LocaleKeyDefault]];
     }
     return api;
 }

--- a/WordPress/Classes/Services/SiteAddressService.swift
+++ b/WordPress/Classes/Services/SiteAddressService.swift
@@ -54,7 +54,7 @@ final class DomainsServiceAdapter: LocalCoreDataService, SiteAddressService {
         if let wpcomApi = accountService.defaultWordPressComAccount()?.wordPressComRestApi {
             api = wpcomApi
         } else {
-            api = WordPressComRestApi(userAgent: WPUserAgent.wordPress())
+            api = WordPressComRestApi.defaultApi(userAgent: WPUserAgent.wordPress())
         }
         let remoteService = DomainsServiceRemote(wordPressComRestApi: api)
 

--- a/WordPress/Classes/Services/SiteAssemblyService.swift
+++ b/WordPress/Classes/Services/SiteAssemblyService.swift
@@ -37,7 +37,7 @@ final class EnhancedSiteCreationService: LocalCoreDataService, SiteAssemblyServi
         if let wpcomApi = accountService.defaultWordPressComAccount()?.wordPressComRestApi {
             api = wpcomApi
         } else {
-            api = WordPressComRestApi(userAgent: WPUserAgent.wordPress())
+            api = WordPressComRestApi.defaultApi(userAgent: WPUserAgent.wordPress())
         }
         self.remoteService = WordPressComServiceRemote(wordPressComRestApi: api)
 

--- a/WordPress/Classes/Services/ThemeService.m
+++ b/WordPress/Classes/Services/ThemeService.m
@@ -376,7 +376,7 @@ const NSInteger ThemeOrderTrailing = 9999;
     NSParameterAssert(page > 0);
     NSParameterAssert([category isKindOfClass:[NSString class]]);
     
-    WordPressComRestApi *api = [[WordPressComRestApi alloc] initWithOAuthToken:nil userAgent:nil];
+    WordPressComRestApi *api = [WordPressComRestApi defaultApiWithOAuthToken:nil userAgent:nil localeKey:[WordPressComRestApi LocaleKeyDefault]];
     ThemeServiceRemote *remote = [[ThemeServiceRemote alloc] initWithWordPressComRestApi:api];
     
     [remote getStartingThemesForCategory:category

--- a/WordPress/Classes/Stores/ActivityStore.swift
+++ b/WordPress/Classes/Stores/ActivityStore.swift
@@ -380,7 +380,7 @@ private extension ActivityStore {
             return nil
         }
 
-        let api = WordPressComRestApi(oAuthToken: token, userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
+        let api = WordPressComRestApi.defaultApi(oAuthToken: token, userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
 
         return ActivityServiceRemote(wordPressComRestApi: api)
     }
@@ -389,7 +389,7 @@ private extension ActivityStore {
         guard let token = CredentialsService().getOAuthToken(site: site) else {
             return nil
         }
-        let api = WordPressComRestApi(oAuthToken: token, userAgent: WPUserAgent.wordPress())
+        let api = WordPressComRestApi.defaultApi(oAuthToken: token, userAgent: WPUserAgent.wordPress())
 
         return ActivityServiceRemote_ApiVersion1_0(wordPressComRestApi: api)
     }

--- a/WordPress/Classes/Stores/PluginStore.swift
+++ b/WordPress/Classes/Stores/PluginStore.swift
@@ -734,7 +734,7 @@ private extension PluginStore {
     }
 
     func fetchFeaturedPlugins() {
-        let anonymousAPI = PluginServiceRemote.anonymousWordPressComRestApi(withUserAgent: WPUserAgent.wordPress())
+        let anonymousAPI = WordPressComRestApi.defaultApi(userAgent: WPUserAgent.wordPress())
         let remote = PluginServiceRemote(wordPressComRestApi: anonymousAPI)
 
         state.fetchingFeatured = true
@@ -800,7 +800,7 @@ private extension PluginStore {
         guard let token = CredentialsService().getOAuthToken(site: site) else {
             return nil
         }
-        let api = WordPressComRestApi(oAuthToken: token, userAgent: WPUserAgent.wordPress())
+        let api = WordPressComRestApi.defaultApi(oAuthToken: token, userAgent: WPUserAgent.wordPress())
 
         return PluginServiceRemote(wordPressComRestApi: api)
     }

--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -322,7 +322,7 @@ private extension StatsInsightsStore {
     }
 
     func apiService(`for` site: Int) -> StatsServiceRemoteV2 {
-        let api = WordPressComRestApi(oAuthToken: SiteStatsInformation.sharedInstance.oauth2Token, userAgent: WPUserAgent.wordPress())
+        let api = WordPressComRestApi.defaultApi(oAuthToken: SiteStatsInformation.sharedInstance.oauth2Token, userAgent: WPUserAgent.wordPress())
 
         return StatsServiceRemoteV2(wordPressComRestApi: api, siteID: site, siteTimezone: SiteStatsInformation.sharedInstance.siteTimeZone!)
     }

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -812,7 +812,7 @@ private extension StatsPeriodStore {
                 return
         }
 
-        let wpApi = WordPressComRestApi(oAuthToken: SiteStatsInformation.sharedInstance.oauth2Token, userAgent: WPUserAgent.wordPress())
+        let wpApi = WordPressComRestApi.defaultApi(oAuthToken: SiteStatsInformation.sharedInstance.oauth2Token, userAgent: WPUserAgent.wordPress())
         statsServiceRemote = StatsServiceRemoteV2(wordPressComRestApi: wpApi, siteID: siteID, siteTimezone: timeZone)
     }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -38,6 +38,9 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
 
+        // Configure WPCom API overrides
+        configureWordPressComApi()
+
         configureWordPressAuthenticator()
 
         configureReachability()
@@ -388,6 +391,12 @@ extension WordPressAppDelegate {
 
     @objc func setupNetworkActivityIndicator() {
         NetworkActivityIndicatorManager.shared.isEnabled = true
+    }
+
+    @objc func configureWordPressComApi() {
+        if let baseUrl = UserDefaults.standard.string(forKey: "wpcom-api-base-url") {
+            Environment.replaceEnvironment(wordPressComApiBase: baseUrl)
+        }
     }
 }
 

--- a/WordPress/Classes/Utility/Automated Transfer/AutomatedTransferHelper.swift
+++ b/WordPress/Classes/Utility/Automated Transfer/AutomatedTransferHelper.swift
@@ -18,7 +18,7 @@ class AutomatedTransferHelper {
             return nil
         }
 
-        let api = WordPressComRestApi(oAuthToken: token, userAgent: WPUserAgent.wordPress())
+        let api = WordPressComRestApi.defaultApi(oAuthToken: token, userAgent: WPUserAgent.wordPress())
         let automatedTransferService = AutomatedTransferService(wordPressComRestApi: api)
 
         self.site = site

--- a/WordPress/Classes/Utility/Environment/Environment.swift
+++ b/WordPress/Classes/Utility/Environment/Environment.swift
@@ -1,5 +1,6 @@
 
 import Foundation
+import WordPressKit
 
 /// A collection of global variables and singletons that the app wants access to.
 ///
@@ -12,6 +13,9 @@ struct Environment {
 
     /// A type to create derived context, save context, etc...
     let contextManager: ContextManagerType
+
+    /// The base url to use for WP.com api requests
+    let wordPressComApiBase: String
 
     /// The mainContext that has concurrency type NSMainQueueConcurrencyType and should be used
     /// for UI elements and fetched results controllers.
@@ -29,10 +33,12 @@ struct Environment {
 
     private init(
         appRatingUtility: AppRatingUtilityType = AppRatingUtility.shared,
-        contextManager: ContextManagerType = ContextManager.shared) {
+        contextManager: ContextManagerType = ContextManager.shared,
+        wordPressComApiBase: String = WordPressComRestApi.apiBaseURLString) {
 
         self.appRatingUtility = appRatingUtility
         self.contextManager = contextManager
+        self.wordPressComApiBase = wordPressComApiBase
     }
 }
 
@@ -42,11 +48,13 @@ extension Environment {
     @discardableResult
     static func replaceEnvironment(
         appRatingUtility: AppRatingUtilityType = Environment.current.appRatingUtility,
-        contextManager: ContextManagerType = Environment.current.contextManager) -> Environment {
+        contextManager: ContextManagerType = Environment.current.contextManager,
+        wordPressComApiBase: String = Environment.current.wordPressComApiBase) -> Environment {
 
         current = Environment(
             appRatingUtility: appRatingUtility,
-            contextManager: contextManager
+            contextManager: contextManager,
+            wordPressComApiBase: wordPressComApiBase
         )
         return current
     }

--- a/WordPress/Classes/Utility/Networking/WordPressComRestApi+Defaults.swift
+++ b/WordPress/Classes/Utility/Networking/WordPressComRestApi+Defaults.swift
@@ -1,0 +1,13 @@
+import Foundation
+import WordPressKit
+
+extension WordPressComRestApi {
+    @objc public static func defaultApi(oAuthToken: String? = nil,
+                                        userAgent: String? = nil,
+                                        localeKey: String = WordPressComRestApi.LocaleKeyDefault) -> WordPressComRestApi {
+        return WordPressComRestApi(oAuthToken: oAuthToken,
+                                   userAgent: userAgent,
+                                   localeKey: localeKey,
+                                   baseUrlString: Environment.current.wordPressComApiBase)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsServiceProxy.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewModel/RegisterDomainDetailsServiceProxy.swift
@@ -47,7 +47,7 @@ class RegisterDomainDetailsServiceProxy: RegisterDomainDetailsServiceProxyProtoc
 
     private lazy var restApi: WordPressComRestApi = {
         let accountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        return accountService.defaultWordPressComAccount()?.wordPressComRestApi ?? WordPressComRestApi(oAuthToken: "")
+        return accountService.defaultWordPressComAccount()?.wordPressComRestApi ?? WordPressComRestApi.defaultApi(oAuthToken: "")
     }()
 
     private lazy var domainsServiceRemote = {

--- a/WordPress/Classes/ViewRelated/NUX/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/DomainSuggestionsTableViewController.swift
@@ -110,7 +110,7 @@ class DomainSuggestionsTableViewController: NUXTableViewController {
         isSearching = true
 
         let accountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        let api = accountService.defaultWordPressComAccount()?.wordPressComRestApi ?? WordPressComRestApi(oAuthToken: "")
+        let api = accountService.defaultWordPressComAccount()?.wordPressComRestApi ?? WordPressComRestApi.defaultApi(oAuthToken: "")
 
         let service = DomainsService(managedObjectContext: ContextManager.sharedInstance().mainContext, remote: DomainsServiceRemote(wordPressComRestApi: api))
         SVProgressHUD.show(withStatus: NSLocalizedString("Loading domains", comment: "Shown while the app waits for the domain suggestions web service to return during the site creation process."))

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -24,6 +24,8 @@ class WordPressAuthenticationManager: NSObject {
                                                                 wpcomSecret: ApiCredentials.secret(),
                                                                 wpcomScheme: WPComScheme,
                                                                 wpcomTermsOfServiceURL: WPAutomatticTermsOfServiceURL,
+                                                                wpcomBaseURL: WordPressComOAuthClient.WordPressComOAuthDefaultApiBaseUrl,
+                                                                wpcomAPIBaseURL: Environment.current.wordPressComApiBase,
                                                                 googleLoginClientId: ApiCredentials.googleLoginClientId(),
                                                                 googleLoginServerClientId: ApiCredentials.googleLoginServerClientId(),
                                                                 googleLoginScheme: ApiCredentials.googleLoginSchemeId(),

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		17F67C56203D81430072001E /* PostCardStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F67C55203D81430072001E /* PostCardStatusViewModel.swift */; };
 		17F7C24922770B68002E5C2E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F7C24822770B68002E5C2E /* main.swift */; };
 		17FCA6811FD84B4600DBA9C8 /* NoticeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */; };
+		1A433B1D2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */; };
 		1D36FCB53C05724865D41F7A /* Pods_WordPress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */; };
@@ -1727,6 +1728,7 @@
 		FF00889F204E01AE007CCE66 /* MediaQuotaCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00889E204E01AE007CCE66 /* MediaQuotaCell.swift */; };
 		FF0148E51DFABBC9001AD265 /* NSFileManager+FolderSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0148E41DFABBC9001AD265 /* NSFileManager+FolderSize.swift */; };
 		FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF0AAE091A150A560089841D /* WPProgressTableViewCell.m */; };
+
 		FF0D8146205809C8000EE505 /* PostCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0D8145205809C8000EE505 /* PostCoordinator.swift */; };
 		FF0F722C206E5345000DAAB5 /* PostService+RefreshStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0F722B206E5345000DAAB5 /* PostService+RefreshStatus.swift */; };
 		FF1933FF1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1933FE1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m */; };
@@ -2084,6 +2086,7 @@
 		17F67C55203D81430072001E /* PostCardStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardStatusViewModel.swift; sourceTree = "<group>"; };
 		17F7C24822770B68002E5C2E /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStore.swift; sourceTree = "<group>"; };
+		1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComRestApi+Defaults.swift"; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D6058910D05DD3D006BFB54 /* WordPress.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordPress.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2262D835FA89938EBF63EADF /* Pods-WordPressShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
@@ -4477,7 +4480,15 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
+		1A433B1B2254CBC300AE7910 /* Networking */ = {
+			isa = PBXGroup;
+			children = (
+				1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */,
+			);
+			path = Networking;
+			sourceTree = "<group>";
+		};
+		29B97314FDCFA39411CA2CEA = {
 			isa = PBXGroup;
 			children = (
 				F14B5F6F208E648200439554 /* config */,
@@ -6111,6 +6122,7 @@
 		8584FDB4192437160019C02E /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				1A433B1B2254CBC300AE7910 /* Networking */,
 				40247E002120FE2300AE1C3C /* Automated Transfer */,
 				F198533821ADAA4E00DCDAE7 /* Editor */,
 				7E58879820FE8D8300DB6F80 /* Environment */,
@@ -8930,7 +8942,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
+			mainGroup = 29B97314FDCFA39411CA2CEA;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -9853,6 +9865,7 @@
 				D8160442209C1B0F00ABAFFA /* ReaderSaveForLaterAction.swift in Sources */,
 				E68580F61E0D91470090EE63 /* WPHorizontalRuleAttachment.swift in Sources */,
 				E12FE0741FA0CEE000F28710 /* ImmuTable+Optional.swift in Sources */,
+				1A433B1D2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift in Sources */,
 				7EFF208C20EADF68009C4699 /* FormattableCommentContent.swift in Sources */,
 				D8212CBF20AA7B7F008E8AE8 /* ReaderShowAttributionAction.swift in Sources */,
 				C58349C51806F95100B64089 /* IOS7CorrectedTextView.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -151,6 +151,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-wpcom-api-base-url http://localhost:8080/"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-debugJetpackConnectionFlow"
             isEnabled = "NO">
          </CommandLineArgument>


### PR DESCRIPTION
## Description

Currently, `https://public-api.wordpress.com` and similar urls are hardcoded everywhere that we use WordPressKit and WordPressAuthenticator. This makes it very difficult to mock out network requests for testing purposes without resorting to swizzling or similar hacks. Recent changes to those pods (see the PRs below) allow the URLs to be passed in while defaulting to the correct value.

Here is what I have done:

- Added `wordPressComApiBase` to `Environment`. It defaults to `public-api.wordpress.com` but can be overridden.
- In an extension, I have defined `WordPressComRestApi.defaultApi()` which can be used everywhere that we want an API instance. It uses the value from `Environment.current.wordPressComApiBase`.
- Added support for a `-wpcom-api-base-url` launch argument that overrides the API endpoint used.

In a subsequent PR, I will take advantage of this by adding mocking for our UI tests as I have done in https://github.com/wordpress-mobile/WordPress-Android/pull/9422.

Related PRs:

- WordPressKit: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/141
- WordPressAuthenticator: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/93

## Testing:

First, check that nothing is broken:

1. Build and run the app.
2. Do a smoke test, making sure things work as expected.

Now test that the URL injection works:

1. Enable the `-wpcom-api-base-url http://localhost:8080/` launch argument (WordPress -> Edit Scheme -> Run -> Arguments -> Check the box).
2. Build and run the app.
3. Now you will see from the logs that the app is trying (and failing) to reach `http://localhost:8080/` for the API requests. This is correct, as there is nothing running at `http://localhost:8080/`.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
