### PR TITLE
[Stats Refresh] Period Posts and Pages: fix displaying details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -1,0 +1,44 @@
+import UIKit
+
+/// This cell type displays data rows for Site Stats Details (SiteStatsDetailTableViewController).
+/// Ex: Period Post and Pages.
+/// It adds a StatsTotalRow to the cell, and utilizes its functionality for row selection.
+/// If a row is selected, StatsTotalRowDelegate is informed to display the associated detail.
+///
+
+class DetailDataCell: UITableViewCell, NibLoadable {
+
+    // MARK: - Properties
+
+    private weak var detailsDelegate: SiteStatsDetailsDelegate?
+    private var rowData: StatsTotalRowData?
+
+    // MARK: - Configure
+
+    func configure(rowData: StatsTotalRowData,
+                   detailsDelegate: SiteStatsDetailsDelegate?,
+                   hideSeparator: Bool = false) {
+
+        self.rowData = rowData
+        self.detailsDelegate = detailsDelegate
+
+        let row = StatsTotalRow.loadFromNib()
+        row.configure(rowData: rowData, delegate: self)
+        row.showSeparator = !hideSeparator
+
+        contentView.addSubview(row)
+        row.translatesAutoresizingMaskIntoConstraints = false
+        contentView.pinSubviewToAllEdges(row)
+    }
+
+}
+
+// MARK: - StatsTotalRowDelegate
+
+extension DetailDataCell: StatsTotalRowDelegate {
+
+    func showPostStats(postID: Int, postTitle: String?, postURL: URL?) {
+        detailsDelegate?.showPostStats?(postID: postID, postTitle: postTitle, postURL: postURL)
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.xib
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="200" id="KGk-i7-Jjw" customClass="DetailDataCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="80"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="79.5"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <point key="canvasLocation" x="137.68115942028987" y="148.66071428571428"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -117,7 +117,9 @@ private extension SiteStatsDetailTableViewController {
     }
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
-        return [TabbedTotalsDetailStatsRow.self,
+        return [DetailDataRow.self,
+                DetailSubtitlesHeaderRow.self,
+                TabbedTotalsDetailStatsRow.self,
                 TopTotalsDetailStatsRow.self,
                 CountriesDetailStatsRow.self,
                 TopTotalsNoSubtitlesPeriodDetailStatsRow.self]

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -103,10 +103,10 @@ class SiteStatsDetailsViewModel: Observable {
                                                      dataRows: tagsAndCategoriesRows(),
                                                      siteStatsDetailsDelegate: detailsDelegate))
         case .periodPostsAndPages:
-            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodPostsAndPages.itemSubtitle,
-                                                     dataSubtitle: StatSection.periodPostsAndPages.dataSubtitle,
-                                                     dataRows: postsAndPagesRows(),
-                                                     siteStatsDetailsDelegate: detailsDelegate))
+            tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: StatSection.periodPostsAndPages.itemSubtitle,
+                                                      dataSubtitle: StatSection.periodPostsAndPages.dataSubtitle))
+            tableRows.append(contentsOf: postsAndPagesRows())
+
         case .periodSearchTerms:
             tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodSearchTerms.itemSubtitle,
                                                      dataSubtitle: StatSection.periodSearchTerms.dataSubtitle,
@@ -378,7 +378,20 @@ private extension SiteStatsDetailsViewModel {
         }
     }
 
-    func postsAndPagesRows() -> [StatsTotalRowData] {
+    func postsAndPagesRows() -> [DetailDataRow] {
+        let rowsData = postsAndPagesRowData()
+        var detailDataRows = [DetailDataRow]()
+
+        for (idx, rowData) in rowsData.enumerated() {
+            detailDataRows.append(DetailDataRow(rowData: rowData,
+                                                detailsDelegate: detailsDelegate,
+                                                hideSeparator: idx == rowsData.endIndex-1))
+        }
+
+        return detailDataRows
+    }
+
+    func postsAndPagesRowData() -> [StatsTotalRowData] {
         let postsAndPages = periodStore.getTopPostsAndPages()?.topPosts ?? []
 
         return postsAndPages.map {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -24,6 +24,7 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var topSeparatorLine: UIView!
     @IBOutlet weak var bottomSeparatorLine: UIView!
 
+    private var forDetails = false
     private var limitRowsDisplayed = true
     private let maxChildRowsToDisplay = 10
     private var dataRows = [StatsTotalRowData]()
@@ -43,7 +44,8 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
                    siteStatsPeriodDelegate: SiteStatsPeriodDelegate? = nil,
                    siteStatsDetailsDelegate: SiteStatsDetailsDelegate? = nil,
                    postStatsDelegate: PostStatsDelegate? = nil,
-                   limitRowsDisplayed: Bool = true) {
+                   limitRowsDisplayed: Bool = true,
+                   forDetails: Bool = false) {
         itemSubtitleLabel.text = itemSubtitle
         dataSubtitleLabel.text = dataSubtitle
         subtitlesProvided = (itemSubtitle != nil && dataSubtitle != nil)
@@ -53,19 +55,20 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
         self.siteStatsDetailsDelegate = siteStatsDetailsDelegate
         self.postStatsDelegate = postStatsDelegate
         self.limitRowsDisplayed = limitRowsDisplayed
+        self.forDetails = forDetails
 
-        let statType: StatType = (siteStatsPeriodDelegate != nil) ? .period : .insights
+        if !forDetails {
+            addRows(dataRows,
+                    toStackView: rowsStackView,
+                    forType: siteStatsPeriodDelegate != nil ? .period : .insights,
+                    limitRowsDisplayed: limitRowsDisplayed,
+                    rowDelegate: self,
+                    viewMoreDelegate: self)
 
-        addRows(dataRows,
-                toStackView: rowsStackView,
-                forType: statType,
-                limitRowsDisplayed: limitRowsDisplayed,
-                rowDelegate: self,
-                viewMoreDelegate: self)
+            initChildRows()
+        }
 
         setSubtitleVisibility()
-        initChildRows()
-
         applyStyles()
     }
 
@@ -102,9 +105,20 @@ private extension TopTotalsCell {
         Style.configureViewAsSeparator(bottomSeparatorLine)
     }
 
-    /// Hide the subtitles if there is no data or Subtitles.
+    /// For Overview tables: Hide the subtitles if there is no data or subtitles.
+    /// For Details table:
+    /// - Hide the subtitles if none provided.
+    /// - Hide the stack view.
     ///
     func setSubtitleVisibility() {
+
+        guard !forDetails else {
+            subtitleStackView.isHidden = !subtitlesProvided
+            rowsStackView.isHidden = true
+            bottomSeparatorLine.isHidden = true
+            return
+        }
+
         let showSubtitles = dataRows.count > 0 && subtitlesProvided
         subtitleStackView.isHidden = !showSubtitles
         rowsStackViewTopConstraint.isActive = !showSubtitles

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -486,3 +486,51 @@ struct TableFooterRow: ImmuTableRow {
         // This method is needed to satisfy ImmuTableRow protocol requirements.
     }
 }
+
+// MARK: - Site Stats Detail Table cells
+
+struct DetailDataRow: ImmuTableRow {
+
+    typealias CellType = DetailDataCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let rowData: StatsTotalRowData
+    weak var detailsDelegate: SiteStatsDetailsDelegate?
+    let hideSeparator: Bool
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(rowData: rowData, detailsDelegate: detailsDelegate, hideSeparator: hideSeparator)
+
+    }
+}
+
+struct DetailSubtitlesHeaderRow: ImmuTableRow {
+
+    typealias CellType = TopTotalsCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let itemSubtitle: String
+    let dataSubtitle: String
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(itemSubtitle: itemSubtitle, dataSubtitle: dataSubtitle, dataRows: [], forDetails: true)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -979,6 +979,8 @@
 		9872CB30203B8A730066A293 /* SignupEpilogueTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9872CB2F203B8A730066A293 /* SignupEpilogueTableViewController.swift */; };
 		9874766F219630240080967F /* SiteStatsTableViewCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9874766E219630240080967F /* SiteStatsTableViewCells.swift */; };
 		9874767321963D330080967F /* SiteStatsInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9874767221963D320080967F /* SiteStatsInformation.swift */; };
+		987535632282682D001661B4 /* DetailDataCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 987535612282682D001661B4 /* DetailDataCell.swift */; };
+		987535642282682D001661B4 /* DetailDataCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 987535622282682D001661B4 /* DetailDataCell.xib */; };
 		98797DBC222F434500128C21 /* OverviewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98797DBA222F434500128C21 /* OverviewCell.swift */; };
 		98797DBD222F434500128C21 /* OverviewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98797DBB222F434500128C21 /* OverviewCell.xib */; };
 		988056032183CCE50083B643 /* SiteStatsInsightsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988056022183CCE50083B643 /* SiteStatsInsightsTableViewController.swift */; };
@@ -2993,6 +2995,8 @@
 		9872CB2F203B8A730066A293 /* SignupEpilogueTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupEpilogueTableViewController.swift; sourceTree = "<group>"; };
 		9874766E219630240080967F /* SiteStatsTableViewCells.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsTableViewCells.swift; sourceTree = "<group>"; };
 		9874767221963D320080967F /* SiteStatsInformation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsInformation.swift; sourceTree = "<group>"; };
+		987535612282682D001661B4 /* DetailDataCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailDataCell.swift; sourceTree = "<group>"; };
+		987535622282682D001661B4 /* DetailDataCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DetailDataCell.xib; sourceTree = "<group>"; };
 		98797DBA222F434500128C21 /* OverviewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverviewCell.swift; sourceTree = "<group>"; };
 		98797DBB222F434500128C21 /* OverviewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = OverviewCell.xib; sourceTree = "<group>"; };
 		988056022183CCE50083B643 /* SiteStatsInsightsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStatsInsightsTableViewController.swift; sourceTree = "<group>"; };
@@ -6469,6 +6473,8 @@
 				98467A42221CD74D00DF51AE /* SiteStatsDetailTableViewController.storyboard */,
 				98467A3E221CD48500DF51AE /* SiteStatsDetailTableViewController.swift */,
 				9829162E2224BC1C008736C0 /* SiteStatsDetailsViewModel.swift */,
+				987535612282682D001661B4 /* DetailDataCell.swift */,
+				987535622282682D001661B4 /* DetailDataCell.xib */,
 			);
 			path = "Stats Detail";
 			sourceTree = "<group>";
@@ -9092,6 +9098,7 @@
 				98812967219CE42A0075FF33 /* StatsTotalRow.xib in Resources */,
 				98B3FA8621C05BF000148DD4 /* ViewMoreRow.xib in Resources */,
 				D865722F2186F96D0023A99C /* SiteSegmentsWizardContent.xib in Resources */,
+				987535642282682D001661B4 /* DetailDataCell.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9951,6 +9958,7 @@
 				D8071631203DA23700B32FD9 /* Accessible.swift in Sources */,
 				9826AE9021B5D3CD00C851FA /* PostingActivityCell.swift in Sources */,
 				98077B5A2075561800109F95 /* SupportTableViewController.swift in Sources */,
+				987535632282682D001661B4 /* DetailDataCell.swift in Sources */,
 				E17E67031FA22C93009BDC9A /* PluginViewModel.swift in Sources */,
 				7059CD210F332B6500A0660B /* WPCategoryTree.m in Sources */,
 				B5E167F419C08D18009535AA /* NSCalendar+Helpers.swift in Sources */,


### PR DESCRIPTION
Ref #11360

This is the first step in fixing #11360. Which is - instead of adding all the data to one `UIStackView`, use `UITableViewCell`s instead. This change fixes Period > Posts and Pages in that manner.

Previously, all the data was stuffed into the stack view on the `TopTotalsCell` card. Which didn't work out so well with a lot of data. 

Now it only uses the `TopTotalsCell` card to show the "header" via the new `DetailSubtitlesHeaderRow`. The stack view is left empty. Instead, a `UITableViewCell` is added to the table for each data row via the new `DetailDataRow`. 

There should be no visual or functional changes, but showing the details view is _a lot_ faster. To note, there is still no loading view, so there may still be a blank view for a couple seconds for longer periods.

Side note: The constraint warnings are not to do with the details view, but are from the Reader and News Card, and are present on `develop` as well.

To test:
- Go to Stats > Period > Posts and Pages on a very active site (like en.blog or Hogwarts).
- Select `View more`.
- Verify the data appears relatively quickly.
- Verify selecting a row displays the Post Stats view.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.



<img width="400" alt="pandp_details" src="https://user-images.githubusercontent.com/1816888/57420178-a0b09800-71c3-11e9-92ef-9d3213ba71c0.png">

