### PR TITLE
[Stats Refresh] Period Search Terms: fix displaying details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.xib
@@ -12,7 +12,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="200" id="KGk-i7-Jjw" customClass="DetailDataCell" customModule="WordPress" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="200" id="KGk-i7-Jjw" customClass="DetailDataCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="80"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -27,9 +27,13 @@ class SiteStatsDetailsViewModel: Observable {
     private var selectedPeriod: StatsPeriodUnit?
     private var postID: Int?
 
+    // MARK: - Init
+
     init(detailsDelegate: SiteStatsDetailsDelegate) {
         self.detailsDelegate = detailsDelegate
     }
+
+    // MARK: - Data Fetching
 
     func fetchDataFor(statSection: StatSection,
                       selectedDate: Date? = nil,
@@ -73,6 +77,8 @@ class SiteStatsDetailsViewModel: Observable {
         }
     }
 
+    // MARK: - Table Model
+
     func tableViewModel() -> ImmuTable {
 
         guard let statSection = statSection,
@@ -108,10 +114,9 @@ class SiteStatsDetailsViewModel: Observable {
             tableRows.append(contentsOf: postsAndPagesRows())
 
         case .periodSearchTerms:
-            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodSearchTerms.itemSubtitle,
-                                                     dataSubtitle: StatSection.periodSearchTerms.dataSubtitle,
-                                                     dataRows: searchTermsRows(),
-                                                     siteStatsDetailsDelegate: detailsDelegate))
+            tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: StatSection.periodSearchTerms.itemSubtitle,
+                                                     dataSubtitle: StatSection.periodSearchTerms.dataSubtitle))
+            tableRows.append(contentsOf: searchTermsRows())
         case .periodVideos:
             tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodVideos.itemSubtitle,
                                                      dataSubtitle: StatSection.periodVideos.dataSubtitle,
@@ -251,6 +256,8 @@ class SiteStatsDetailsViewModel: Observable {
 
 private extension SiteStatsDetailsViewModel {
 
+    // MARK: - Store Queries
+
     func queryForInsightStatSection(_ statSection: StatSection) -> InsightQuery? {
         switch statSection {
         case .insightsFollowersWordPress, .insightsFollowersEmail:
@@ -292,6 +299,8 @@ private extension SiteStatsDetailsViewModel {
             return nil
         }
     }
+
+    // MARK: - Tabbed Cards
 
     func tabDataForFollowerType(_ followerType: StatSection) -> TabData {
         let tabTitle = followerType.tabTitle
@@ -359,6 +368,8 @@ private extension SiteStatsDetailsViewModel {
                        dataRows: rowItems)
     }
 
+    // MARK: - Tags and Categories
+
     func tagsAndCategoriesRows() -> [StatsTotalRowData] {
         guard let tagsAndCategories = insightsStore.getAllTagsAndCategories()?.topTagsAndCategories else {
             return []
@@ -378,17 +389,10 @@ private extension SiteStatsDetailsViewModel {
         }
     }
 
+    // MARK: - Posts and Pages
+
     func postsAndPagesRows() -> [DetailDataRow] {
-        let rowsData = postsAndPagesRowData()
-        var detailDataRows = [DetailDataRow]()
-
-        for (idx, rowData) in rowsData.enumerated() {
-            detailDataRows.append(DetailDataRow(rowData: rowData,
-                                                detailsDelegate: detailsDelegate,
-                                                hideSeparator: idx == rowsData.endIndex-1))
-        }
-
-        return detailDataRows
+        return dataRowsFor(postsAndPagesRowData())
     }
 
     func postsAndPagesRowData() -> [StatsTotalRowData] {
@@ -419,7 +423,13 @@ private extension SiteStatsDetailsViewModel {
         }
     }
 
-    func searchTermsRows() -> [StatsTotalRowData] {
+    // MARK: - Search Terms
+
+    func searchTermsRows() -> [DetailDataRow] {
+        return dataRowsFor(searchTermsRowData())
+    }
+
+    func searchTermsRowData() -> [StatsTotalRowData] {
         guard let searchTerms = periodStore.getTopSearchTerms() else {
             return []
         }
@@ -444,6 +454,8 @@ private extension SiteStatsDetailsViewModel {
         return mappedSearchTerms
     }
 
+    // MARK: - Videos
+
     func videosRows() -> [StatsTotalRowData] {
         return periodStore.getTopVideos()?.videos.map { StatsTotalRowData(name: $0.title,
                                                                           data: $0.playsCount.abbreviatedString(),
@@ -453,6 +465,8 @@ private extension SiteStatsDetailsViewModel {
                                                                           statSection: .periodVideos) }
             ?? []
     }
+
+    // MARK: - Clicks
 
     func clicksRows() -> [StatsTotalRowData] {
         return periodStore.getTopClicks()?.clicks.map { StatsTotalRowData(name: $0.title,
@@ -467,6 +481,8 @@ private extension SiteStatsDetailsViewModel {
             ?? []
     }
 
+    // MARK: - Authors
+
     func authorsRows() -> [StatsTotalRowData] {
         let authors = periodStore.getTopAuthors()?.topAuthors ?? []
 
@@ -478,6 +494,8 @@ private extension SiteStatsDetailsViewModel {
                                                childRows: $0.posts.map { StatsTotalRowData(name: $0.title, data: $0.viewsCount.abbreviatedString()) },
                                                statSection: .periodAuthors) }
     }
+
+    // MARK: - Referrers
 
     func referrersRows() -> [StatsTotalRowData] {
         let referrers = periodStore.getTopReferrers()?.referrers ?? []
@@ -495,6 +513,8 @@ private extension SiteStatsDetailsViewModel {
         return referrers.map { rowDataFromReferrer(referrer: $0) }
     }
 
+    // MARK: - Countries
+
     func countriesRows() -> [StatsTotalRowData] {
         return periodStore.getTopCountries()?.countries.map { StatsTotalRowData(name: $0.name,
                                                                                 data: $0.viewsCount.abbreviatedString(),
@@ -502,6 +522,8 @@ private extension SiteStatsDetailsViewModel {
                                                                                 statSection: .periodCountries) }
             ?? []
     }
+
+    // MARK: - Published
 
     func publishedRows() -> [StatsTotalRowData] {
         return periodStore.getTopPublished()?.publishedPosts.map { StatsTotalRowData(name: $0.title,
@@ -511,6 +533,8 @@ private extension SiteStatsDetailsViewModel {
                                                                                      statSection: .periodPublished) }
             ?? []
     }
+
+    // MARK: - Post Stats
 
     func postStatsRows(forAverages: Bool = false) -> [StatsTotalRowData] {
 
@@ -546,6 +570,20 @@ private extension SiteStatsDetailsViewModel {
         }
 
         return yearRows
+    }
+
+    // MARK: - Helpers
+
+    func dataRowsFor(_ rowsData: [StatsTotalRowData]) -> [DetailDataRow] {
+        var detailDataRows = [DetailDataRow]()
+
+        for (idx, rowData) in rowsData.enumerated() {
+            detailDataRows.append(DetailDataRow(rowData: rowData,
+                                                detailsDelegate: detailsDelegate,
+                                                hideSeparator: idx == rowsData.endIndex-1))
+        }
+
+        return detailDataRows
     }
 
 }


### PR DESCRIPTION
Ref #11360

This changes Period > Search Terms to use `UITableViewCell`s instead of one `UIStackView`.

Previously, all the data was stuffed into the stack view on the `TopTotalsCell` card. Now it only uses the `TopTotalsCell` card to show the "header" via `DetailSubtitlesHeaderRow`. The stack view is left empty. Instead, a `UITableViewCell` is added to the table for each data row via `q`. 

There should be no visual or functional changes, but showing the details view is _a lot_ faster. To note, there is still no loading view, so there may still be a blank view for a couple seconds for longer periods.

To test:
- Go to Stats > Period > Search Terms on a very active site (en.blog Years was particularly painful).
- Select `View more`.
- Verify the data appears relatively quickly.
- Verify selecting a row does nothing.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

<img width="400" alt="search_terms_details" src="https://user-images.githubusercontent.com/1816888/57422845-d8710d00-71ce-11e9-8819-d88b42c3d9b3.png">
