### PR TITLE
Updating upload post method failure UI to show notice instead of a HUD

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressFlux
 
 extension PostEditor where Self: UIViewController {
 
@@ -318,10 +319,10 @@ extension PostEditor where Self: UIViewController {
         postEditorStateContext.updated(isBeingPublished: true)
 
         uploadPost() { [weak self] uploadedPost, error in
-            guard let strongSelf = self else {
+            guard let self = self else {
                 return
             }
-            strongSelf.postEditorStateContext.updated(isBeingPublished: false)
+            self.postEditorStateContext.updated(isBeingPublished: false)
             SVProgressHUD.dismiss()
 
             let generator = UINotificationFeedbackGenerator()
@@ -329,19 +330,20 @@ extension PostEditor where Self: UIViewController {
 
             if let error = error {
                 DDLogError("Error publishing post: \(error.localizedDescription)")
-
-                SVProgressHUD.showDismissibleError(withStatus: action.publishingErrorLabel)
+                SVProgressHUD.dismiss()
+                let model = PostNoticeViewModel(post: self.post)
+                ActionDispatcher.dispatch(NoticeAction.post(model.notice))
                 generator.notificationOccurred(.error)
             } else if let uploadedPost = uploadedPost {
-                strongSelf.post = uploadedPost
+                self.post = uploadedPost
 
                 generator.notificationOccurred(.success)
             }
 
             if dismissWhenDone {
-                strongSelf.dismissOrPopView()
+                self.dismissOrPopView()
             } else {
-                strongSelf.createRevisionOfPost()
+                self.createRevisionOfPost()
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -330,9 +330,8 @@ extension PostEditor where Self: UIViewController {
 
             if let error = error {
                 DDLogError("Error publishing post: \(error.localizedDescription)")
-                SVProgressHUD.dismiss()
-                let model = PostNoticeViewModel(post: self.post)
-                ActionDispatcher.dispatch(NoticeAction.post(model.notice))
+                let notice = Notice(title: action.publishingErrorLabel)
+                ActionDispatcher.dispatch(NoticeAction.post(notice))
                 generator.notificationOccurred(.error)
             } else if let uploadedPost = uploadedPost {
                 self.post = uploadedPost

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -187,6 +187,7 @@ extension PostEditor where Self: UIViewController {
     // MARK: - Close button handling
 
     func cancelEditing() {
+        ActionDispatcher.dispatch(NoticeAction.clearWithTag(uploadFailureNoticeTag))
         stopEditing()
 
         if post.canSave() {
@@ -330,8 +331,7 @@ extension PostEditor where Self: UIViewController {
 
             if let error = error {
                 DDLogError("Error publishing post: \(error.localizedDescription)")
-                let notice = Notice(title: action.publishingErrorLabel)
-                ActionDispatcher.dispatch(NoticeAction.post(notice))
+                ActionDispatcher.dispatch(NoticeAction.post(self.uploadFailureNotice))
                 generator.notificationOccurred(.error)
             } else if let uploadedPost = uploadedPost {
                 self.post = uploadedPost

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -127,11 +127,11 @@ extension PostEditor {
     var isSingleSiteMode: Bool {
         return currentBlogCount <= 1 || post.hasRemote()
     }
-    
+
     var uploadFailureNoticeTag: Notice.Tag {
         return "PostEditor.UploadFailed"
     }
-    
+
     var uploadFailureNotice: Notice {
         let action = self.postEditorStateContext.action
         return Notice(title: action.publishingErrorLabel, tag: uploadFailureNoticeTag)

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -127,5 +127,13 @@ extension PostEditor {
     var isSingleSiteMode: Bool {
         return currentBlogCount <= 1 || post.hasRemote()
     }
-
+    
+    var uploadFailureNoticeTag: Notice.Tag {
+        return "PostEditor.UploadFailed"
+    }
+    
+    var uploadFailureNotice: Notice {
+        let action = self.postEditorStateContext.action
+        return Notice(title: action.publishingErrorLabel, tag: uploadFailureNoticeTag)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -88,11 +88,11 @@ public enum PostEditorAction {
     var publishingErrorLabel: String {
         switch self {
         case .publish, .publishNow:
-            return NSLocalizedString("Error occurred\nduring publishing", comment: "Text displayed in HUD while a post is being published.")
+            return NSLocalizedString("Error occurred during publishing", comment: "Text displayed in notice while a post is being published.")
         case .schedule:
-            return NSLocalizedString("Error occurred\nduring scheduling", comment: "Text displayed in HUD while a post is being scheduled to be published.")
+            return NSLocalizedString("Error occurred during scheduling", comment: "Text displayed in notice while a post is being scheduled to be published.")
         case .save, .saveAsDraft, .submitForReview, .update:
-            return NSLocalizedString("Error occurred\nduring saving", comment: "Text displayed in HUD after attempting to save a draft post and an error occurred.")
+            return NSLocalizedString("Error occurred during saving", comment: "Text displayed in notice after attempting to save a draft post and an error occurred.")
         }
     }
 


### PR DESCRIPTION
For the sake of consistency like we do upon failure to upload when the user choose to update after closing the editor.

Fixes #11421

To test:
1. update published post
2. be offline
3. tap "Update" from the top right in the navigation
4. See notice message on failure to upload 

**Before**
![updating_ui_before_1](https://user-images.githubusercontent.com/1335657/57429918-d9ac3500-71e2-11e9-8aa4-12844b28a949.gif)

**After**
![updating_ui](https://user-images.githubusercontent.com/1335657/57429658-e0867800-71e1-11e9-9762-851ba58a3160.gif)

* Also updated strongSelf to self in this PR to fit  > Swift 4.0 

** Will update Release notes before merging 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
