### PR TITLE
[Stats Refresh] Period Published: fix displaying details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -37,6 +37,10 @@ class DetailDataCell: UITableViewCell, NibLoadable {
 
 extension DetailDataCell: StatsTotalRowDelegate {
 
+    func displayWebViewWithURL(_ url: URL) {
+        detailsDelegate?.displayWebViewWithURL?(url)
+    }
+
     func showPostStats(postID: Int, postTitle: String?, postURL: URL?) {
         detailsDelegate?.showPostStats?(postID: postID, postTitle: postTitle, postURL: postURL)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -121,8 +121,7 @@ private extension SiteStatsDetailTableViewController {
                 DetailSubtitlesHeaderRow.self,
                 TabbedTotalsDetailStatsRow.self,
                 TopTotalsDetailStatsRow.self,
-                CountriesDetailStatsRow.self,
-                TopTotalsNoSubtitlesPeriodDetailStatsRow.self]
+                CountriesDetailStatsRow.self]
     }
 
     func storeIsFetching(statSection: StatSection) -> Bool {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -142,8 +142,7 @@ class SiteStatsDetailsViewModel: Observable {
                                                      dataSubtitle: StatSection.periodCountries.dataSubtitle,
                                                      dataRows: countriesRows()))
         case .periodPublished:
-            tableRows.append(TopTotalsNoSubtitlesPeriodDetailStatsRow(dataRows: publishedRows(),
-                                                                      siteStatsDetailsDelegate: detailsDelegate))
+            tableRows.append(contentsOf: publishedRows())
         case .postStatsMonthsYears:
             tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.postStatsMonthsYears.itemSubtitle,
                                                      dataSubtitle: StatSection.postStatsMonthsYears.dataSubtitle,
@@ -525,7 +524,11 @@ private extension SiteStatsDetailsViewModel {
 
     // MARK: - Published
 
-    func publishedRows() -> [StatsTotalRowData] {
+    func publishedRows() -> [DetailDataRow] {
+        return dataRowsFor(publishedRowData())
+    }
+
+    func publishedRowData() -> [StatsTotalRowData] {
         return periodStore.getTopPublished()?.publishedPosts.map { StatsTotalRowData(name: $0.title,
                                                                                      data: "",
                                                                                      showDisclosure: true,

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -204,30 +204,6 @@ struct CountriesDetailStatsRow: ImmuTableRow {
     }
 }
 
-struct TopTotalsNoSubtitlesPeriodDetailStatsRow: ImmuTableRow {
-
-    typealias CellType = TopTotalsCell
-
-    static let cell: ImmuTableCell = {
-        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
-    }()
-
-    let dataRows: [StatsTotalRowData]
-    weak var siteStatsDetailsDelegate: SiteStatsDetailsDelegate?
-    let action: ImmuTableAction? = nil
-
-    func configureCell(_ cell: UITableViewCell) {
-
-        guard let cell = cell as? CellType else {
-            return
-        }
-
-        cell.configure(dataRows: dataRows,
-                       siteStatsDetailsDelegate: siteStatsDetailsDelegate,
-                       limitRowsDisplayed: false)
-    }
-}
-
 struct TopTotalsInsightStatsRow: ImmuTableRow {
 
     typealias CellType = TopTotalsCell


### PR DESCRIPTION
Ref #11360

This changes Period > Published to use `UITableViewCell`s instead of one `UIStackView`.

Previously, all the data was stuffed into the stack view on the `TopTotalsCell` card. Now it no longer uses the `TopTotalsCell`. Instead, a `UITableViewCell` is added to the table for each data row via `DetailDataRow`. 

There should be no visual or functional changes, but showing the details view is _a lot_ faster. To note, there is still no loading view, so there may still be a blank view for a couple seconds for longer periods.

To test:
- Go to Stats > Period > Published on a very active site.
- Select `View more`.
- Verify the data appears relatively quickly.
- Verify selecting a row opens a web view.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

<img width="400" alt="published_details" src="https://user-images.githubusercontent.com/1816888/57485574-44a04f00-7269-11e9-8206-871fb4627920.png">

