### PR TITLE
[Stats Refresh] Period Videos: fix displaying details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -37,6 +37,10 @@ class DetailDataCell: UITableViewCell, NibLoadable {
 
 extension DetailDataCell: StatsTotalRowDelegate {
 
+    func displayMediaWithID(_ mediaID: NSNumber) {
+        detailsDelegate?.displayMediaWithID?(mediaID)
+    }
+
     func displayWebViewWithURL(_ url: URL) {
         detailsDelegate?.displayWebViewWithURL?(url)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -118,10 +118,9 @@ class SiteStatsDetailsViewModel: Observable {
                                                      dataSubtitle: StatSection.periodSearchTerms.dataSubtitle))
             tableRows.append(contentsOf: searchTermsRows())
         case .periodVideos:
-            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodVideos.itemSubtitle,
-                                                     dataSubtitle: StatSection.periodVideos.dataSubtitle,
-                                                     dataRows: videosRows(),
-                                                     siteStatsDetailsDelegate: detailsDelegate))
+            tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: StatSection.periodVideos.itemSubtitle,
+                                                     dataSubtitle: StatSection.periodVideos.dataSubtitle))
+            tableRows.append(contentsOf: videosRows())
         case .periodClicks:
             tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodClicks.itemSubtitle,
                                                      dataSubtitle: StatSection.periodClicks.dataSubtitle,
@@ -455,7 +454,11 @@ private extension SiteStatsDetailsViewModel {
 
     // MARK: - Videos
 
-    func videosRows() -> [StatsTotalRowData] {
+    func videosRows() -> [DetailDataRow] {
+        return dataRowsFor(videosRowData())
+    }
+
+    func videosRowData() -> [StatsTotalRowData] {
         return periodStore.getTopVideos()?.videos.map { StatsTotalRowData(name: $0.title,
                                                                           data: $0.playsCount.abbreviatedString(),
                                                                           mediaID: $0.postID as NSNumber,


### PR DESCRIPTION
Ref #11360

This changes Period > Videos to use `UITableViewCell`s instead of one `UIStackView`.

Previously, all the data was stuffed into the stack view on the `TopTotalsCell` card. Now it only uses the `TopTotalsCell` card to show the header via `DetailSubtitlesHeaderRow`. The stack view is left empty. Instead, a `UITableViewCell` is added to the table for each data row via `DetailDataRow`. 

There should be no visual or functional changes, but showing the details view is a lot faster. To note, there is still no loading view, so there may still be a blank view for a couple seconds for longer periods.

To test:
- Go to Stats > Period > Videos on a very active site.
- Select `View more`.
- Verify the data appears relatively quickly.
- Verify selecting a row displays the media.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

<img width="400" alt="videos_details" src="https://user-images.githubusercontent.com/1816888/57487549-238e2d00-726e-11e9-8108-0c432983baff.png">

