### PR TITLE
[Stats Refresh] Period Countries: fix displaying details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
@@ -63,7 +63,7 @@ private extension CountriesCell {
 
     func setSubtitleVisibility() {
 
-        guard !forDetails else {
+        if forDetails {
             subtitleStackView.isHidden = false
             rowsStackView.isHidden = true
             return

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
@@ -18,6 +18,7 @@ class CountriesCell: UITableViewCell, NibLoadable {
     private weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
     private var dataRows = [StatsTotalRowData]()
     private typealias Style = WPStyleGuide.Stats
+    private var forDetails = false
 
     // MARK: - Configure
 
@@ -25,17 +26,21 @@ class CountriesCell: UITableViewCell, NibLoadable {
                    dataSubtitle: String,
                    dataRows: [StatsTotalRowData],
                    siteStatsPeriodDelegate: SiteStatsPeriodDelegate? = nil,
-                   limitRowsDisplayed: Bool = true) {
+                   limitRowsDisplayed: Bool = true,
+                   forDetails: Bool = false) {
         itemSubtitleLabel.text = itemSubtitle
         dataSubtitleLabel.text = dataSubtitle
         self.dataRows = dataRows
         self.siteStatsPeriodDelegate = siteStatsPeriodDelegate
+        self.forDetails = forDetails
 
+        if !forDetails {
         addRows(dataRows,
                 toStackView: rowsStackView,
                 forType: .period,
                 limitRowsDisplayed: limitRowsDisplayed,
                 viewMoreDelegate: self)
+        }
 
         setSubtitleVisibility()
         applyStyles()
@@ -58,6 +63,13 @@ private extension CountriesCell {
     }
 
     func setSubtitleVisibility() {
+
+        guard !forDetails else {
+            subtitleStackView.isHidden = false
+            rowsStackView.isHidden = true
+            return
+        }
+
         let showSubtitles = dataRows.count > 0
         subtitleStackView.isHidden = !showSubtitles
         rowsStackViewTopConstraint.isActive = !showSubtitles

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
@@ -26,7 +26,6 @@ class CountriesCell: UITableViewCell, NibLoadable {
                    dataSubtitle: String,
                    dataRows: [StatsTotalRowData],
                    siteStatsPeriodDelegate: SiteStatsPeriodDelegate? = nil,
-                   limitRowsDisplayed: Bool = true,
                    forDetails: Bool = false) {
         itemSubtitleLabel.text = itemSubtitle
         dataSubtitleLabel.text = dataSubtitle
@@ -38,7 +37,7 @@ class CountriesCell: UITableViewCell, NibLoadable {
         addRows(dataRows,
                 toStackView: rowsStackView,
                 forType: .period,
-                limitRowsDisplayed: limitRowsDisplayed,
+                limitRowsDisplayed: true,
                 viewMoreDelegate: self)
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -121,7 +121,7 @@ private extension SiteStatsDetailTableViewController {
                 DetailSubtitlesHeaderRow.self,
                 TabbedTotalsDetailStatsRow.self,
                 TopTotalsDetailStatsRow.self,
-                CountriesDetailStatsRow.self]
+                DetailSubtitlesCountriesHeaderRow.self]
     }
 
     func storeIsFetching(statSection: StatSection) -> Bool {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -137,9 +137,9 @@ class SiteStatsDetailsViewModel: Observable {
                                                      dataRows: referrersRows(),
                                                      siteStatsDetailsDelegate: detailsDelegate))
         case .periodCountries:
-            tableRows.append(CountriesDetailStatsRow(itemSubtitle: StatSection.periodCountries.itemSubtitle,
-                                                     dataSubtitle: StatSection.periodCountries.dataSubtitle,
-                                                     dataRows: countriesRows()))
+            tableRows.append(DetailSubtitlesCountriesHeaderRow(itemSubtitle: StatSection.periodCountries.itemSubtitle,
+                                                     dataSubtitle: StatSection.periodCountries.dataSubtitle))
+            tableRows.append(contentsOf: countriesRows())
         case .periodPublished:
             tableRows.append(contentsOf: publishedRows())
         case .postStatsMonthsYears:
@@ -517,7 +517,11 @@ private extension SiteStatsDetailsViewModel {
 
     // MARK: - Countries
 
-    func countriesRows() -> [StatsTotalRowData] {
+    func countriesRows() -> [DetailDataRow] {
+        return dataRowsFor(countriesRowData())
+    }
+
+    func countriesRowData() -> [StatsTotalRowData] {
         return periodStore.getTopCountries()?.countries.map { StatsTotalRowData(name: $0.name,
                                                                                 data: $0.viewsCount.abbreviatedString(),
                                                                                 icon: UIImage(named: $0.code),

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -112,7 +112,7 @@ private extension TopTotalsCell {
     ///
     func setSubtitleVisibility() {
 
-        guard !forDetails else {
+        if forDetails {
             subtitleStackView.isHidden = !subtitlesProvided
             rowsStackView.isHidden = true
             bottomSeparatorLine.isHidden = true

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -178,32 +178,6 @@ struct TopTotalsDetailStatsRow: ImmuTableRow {
     }
 }
 
-struct CountriesDetailStatsRow: ImmuTableRow {
-
-    typealias CellType = CountriesCell
-
-    static let cell: ImmuTableCell = {
-        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
-    }()
-
-    let itemSubtitle: String
-    let dataSubtitle: String
-    let dataRows: [StatsTotalRowData]
-    let action: ImmuTableAction? = nil
-
-    func configureCell(_ cell: UITableViewCell) {
-
-        guard let cell = cell as? CellType else {
-            return
-        }
-
-        cell.configure(itemSubtitle: itemSubtitle,
-                       dataSubtitle: dataSubtitle,
-                       dataRows: dataRows,
-                       limitRowsDisplayed: false)
-    }
-}
-
 struct TopTotalsInsightStatsRow: ImmuTableRow {
 
     typealias CellType = TopTotalsCell
@@ -492,6 +466,28 @@ struct DetailDataRow: ImmuTableRow {
 struct DetailSubtitlesHeaderRow: ImmuTableRow {
 
     typealias CellType = TopTotalsCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let itemSubtitle: String
+    let dataSubtitle: String
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(itemSubtitle: itemSubtitle, dataSubtitle: dataSubtitle, dataRows: [], forDetails: true)
+    }
+}
+
+struct DetailSubtitlesCountriesHeaderRow: ImmuTableRow {
+
+    typealias CellType = CountriesCell
 
     static let cell: ImmuTableCell = {
         return ImmuTableCell.nib(CellType.defaultNib, CellType.self)


### PR DESCRIPTION
Ref #11360

This changes Period > Countries to use `UITableViewCell`s instead of one `UIStackView`.

Previously, all the data was stuffed into the stack view on the `CountriesCell` card. Now it only uses the `CountriesCell` card to show the header via the new `DetailSubtitlesCountriesHeaderRow`. The stack view is left empty. Instead, a `UITableViewCell` is added to the table for each data row via `DetailDataRow`. 

There should be no visual or functional changes, but showing the details view is a lot faster. To note, there is still no loading view, so there may still be a blank view for a couple seconds for longer periods.

To test:
- Go to Stats > Period > Countries on a very active site.
- Select `View more`.
- Verify the data appears relatively quickly.
- Verify selecting a row does nothing.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

<img width="400" alt="countries_details" src="https://user-images.githubusercontent.com/1816888/57489439-47a03d00-7273-11e9-8f91-591ad150aab3.png">


