### PR TITLE
[Stats Refresh] Insights tabbed cards: fix displaying details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/UITableViewCell+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/UITableViewCell+Stats.swift
@@ -13,14 +13,13 @@ extension UITableViewCell {
                  toStackView rowsStackView: UIStackView,
                  forType statType: StatType,
                  limitRowsDisplayed: Bool = true,
-                 forDetailsList: Bool = false,
                  rowDelegate: StatsTotalRowDelegate? = nil,
                  viewMoreDelegate: ViewMoreRowDelegate? = nil) {
 
         let numberOfDataRows = dataRows.count
 
         guard numberOfDataRows > 0 else {
-            if !forDetailsList {
+            if limitRowsDisplayed {
                 let row = StatsNoDataRow.loadFromNib()
                 row.configure(forType: statType)
                 rowsStackView.addArrangedSubview(row)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -56,7 +56,7 @@ class TabbedTotalsCell: UITableViewCell, NibLoadable {
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     private weak var siteStatsDetailsDelegate: SiteStatsDetailsDelegate?
     private var showTotalCount = false
-    private var limitRowsDisplayed = true
+    private var forDetails = false
 
     // MARK: - Configure
 
@@ -65,13 +65,13 @@ class TabbedTotalsCell: UITableViewCell, NibLoadable {
                    siteStatsDetailsDelegate: SiteStatsDetailsDelegate? = nil,
                    showTotalCount: Bool,
                    selectedIndex: Int = 0,
-                   limitRowsDisplayed: Bool = true) {
+                   forDetails: Bool = false) {
         self.tabsData = tabsData
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
         self.siteStatsDetailsDelegate = siteStatsDetailsDelegate
         self.showTotalCount = showTotalCount
-        self.limitRowsDisplayed = limitRowsDisplayed
-        bottomSeparatorLine.isHidden = !limitRowsDisplayed
+        self.forDetails = forDetails
+        bottomSeparatorLine.isHidden = forDetails
         setupFilterBar(selectedIndex: selectedIndex)
         addRowsForSelectedFilter()
         configureSubtitles()
@@ -114,14 +114,18 @@ private extension TabbedTotalsCell {
     }
 
     func toggleNoResults() {
+
+        guard forDetails else {
+            return
+        }
+
         noResultsViewController.removeFromView()
 
-        let showNoResults = tabsData[filterTabBar.selectedIndex].dataRows.isEmpty && !limitRowsDisplayed
+        let showNoResults = tabsData[filterTabBar.selectedIndex].dataRows.isEmpty
         noResultsView.isHidden = !showNoResults
 
-        guard showNoResults,
-            let superview = superview else {
-                return
+        guard showNoResults, let superview = superview else {
+            return
         }
 
         noResultsViewController.view.frame = noResultsView.bounds
@@ -130,17 +134,16 @@ private extension TabbedTotalsCell {
     }
 
     func addRowsForSelectedFilter() {
-        toggleNoResults()
 
-        guard noResultsView.isHidden else {
+        if forDetails {
+            toggleNoResults()
             return
         }
 
         addRows(tabsData[filterTabBar.selectedIndex].dataRows,
                 toStackView: rowsStackView,
                 forType: .insights,
-                limitRowsDisplayed: limitRowsDisplayed,
-                forDetailsList: !limitRowsDisplayed,
+                limitRowsDisplayed: true,
                 rowDelegate: self,
                 viewMoreDelegate: self)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -119,7 +119,7 @@ private extension SiteStatsDetailTableViewController {
     func tableRowTypes() -> [ImmuTableRow.Type] {
         return [DetailDataRow.self,
                 DetailSubtitlesHeaderRow.self,
-                TabbedTotalsDetailStatsRow.self,
+                DetailSubtitlesTabbedHeaderRow.self,
                 TopTotalsDetailStatsRow.self,
                 DetailSubtitlesCountriesHeaderRow.self]
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -91,18 +91,28 @@ class SiteStatsDetailsViewModel: Observable {
         switch statSection {
         case .insightsFollowersWordPress, .insightsFollowersEmail:
             let selectedIndex = statSection == .insightsFollowersWordPress ? 0 : 1
-            tableRows.append(TabbedTotalsDetailStatsRow(tabsData: [tabDataForFollowerType(.insightsFollowersWordPress),
-                                                                   tabDataForFollowerType(.insightsFollowersEmail)],
-                                                        siteStatsDetailsDelegate: detailsDelegate,
-                                                        showTotalCount: true,
-                                                        selectedIndex: selectedIndex))
+            let wpTabData = tabDataForFollowerType(.insightsFollowersWordPress)
+            let emailTabData = tabDataForFollowerType(.insightsFollowersEmail)
+
+            tableRows.append(DetailSubtitlesTabbedHeaderRow(tabsData: [wpTabData, emailTabData],
+                                                            siteStatsDetailsDelegate: detailsDelegate,
+                                                            showTotalCount: true,
+                                                            selectedIndex: selectedIndex))
+
+            let dataRows = statSection == .insightsFollowersWordPress ? wpTabData.dataRows : emailTabData.dataRows
+            tableRows.append(contentsOf: tabbedRowsFrom(dataRows))
         case .insightsCommentsAuthors, .insightsCommentsPosts:
             let selectedIndex = statSection == .insightsCommentsAuthors ? 0 : 1
-            tableRows.append(TabbedTotalsDetailStatsRow(tabsData: [tabDataForCommentType(.insightsCommentsAuthors),
-                                                                   tabDataForCommentType(.insightsCommentsPosts)],
-                                                        siteStatsDetailsDelegate: detailsDelegate,
-                                                        showTotalCount: false,
-                                                        selectedIndex: selectedIndex))
+            let authorsTabData = tabDataForCommentType(.insightsCommentsAuthors)
+            let postsTabData = tabDataForCommentType(.insightsCommentsPosts)
+
+            tableRows.append(DetailSubtitlesTabbedHeaderRow(tabsData: [authorsTabData, postsTabData],
+                                                            siteStatsDetailsDelegate: detailsDelegate,
+                                                            showTotalCount: false,
+                                                            selectedIndex: selectedIndex))
+
+            let dataRows = statSection == .insightsCommentsAuthors ? authorsTabData.dataRows : postsTabData.dataRows
+            tableRows.append(contentsOf: tabbedRowsFrom(dataRows))
         case .insightsTagsAndCategories:
             tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.insightsTagsAndCategories.itemSubtitle,
                                                      dataSubtitle: StatSection.insightsTagsAndCategories.dataSubtitle,
@@ -299,6 +309,10 @@ private extension SiteStatsDetailsViewModel {
     }
 
     // MARK: - Tabbed Cards
+
+    func tabbedRowsFrom(_ commentsRowData: [StatsTotalRowData]) -> [DetailDataRow] {
+        return dataRowsFor(commentsRowData)
+    }
 
     func tabDataForFollowerType(_ followerType: StatSection) -> TabData {
         let tabTitle = followerType.tabTitle

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -122,34 +122,6 @@ struct TabbedTotalsStatsRow: ImmuTableRow {
     }
 }
 
-struct TabbedTotalsDetailStatsRow: ImmuTableRow {
-
-    typealias CellType = TabbedTotalsCell
-
-    static let cell: ImmuTableCell = {
-        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
-    }()
-
-    let tabsData: [TabData]
-    weak var siteStatsDetailsDelegate: SiteStatsDetailsDelegate?
-    let showTotalCount: Bool
-    let selectedIndex: Int
-    let action: ImmuTableAction? = nil
-
-    func configureCell(_ cell: UITableViewCell) {
-
-        guard let cell = cell as? CellType else {
-            return
-        }
-
-        cell.configure(tabsData: tabsData,
-                       siteStatsDetailsDelegate: siteStatsDetailsDelegate,
-                       showTotalCount: showTotalCount,
-                       selectedIndex: selectedIndex,
-                       limitRowsDisplayed: false)
-    }
-}
-
 struct TopTotalsDetailStatsRow: ImmuTableRow {
 
     typealias CellType = TopTotalsCell
@@ -504,5 +476,33 @@ struct DetailSubtitlesCountriesHeaderRow: ImmuTableRow {
         }
 
         cell.configure(itemSubtitle: itemSubtitle, dataSubtitle: dataSubtitle, dataRows: [], forDetails: true)
+    }
+}
+
+struct DetailSubtitlesTabbedHeaderRow: ImmuTableRow {
+
+    typealias CellType = TabbedTotalsCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let tabsData: [TabData]
+    weak var siteStatsDetailsDelegate: SiteStatsDetailsDelegate?
+    let showTotalCount: Bool
+    let selectedIndex: Int
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(tabsData: tabsData,
+                       siteStatsDetailsDelegate: siteStatsDetailsDelegate,
+                       showTotalCount: showTotalCount,
+                       selectedIndex: selectedIndex,
+                       forDetails: true)
     }
 }


### PR DESCRIPTION
Ref #11360

This changes the Insights tabbed cards, Comments and Followers, to use `UITableViewCell`s instead of one `UIStackView`.

Previously, all the data was stuffed into the stack view on the `TabbedTotalsCell` card. Now it only uses the `TabbedTotalsCell` card to show the header via the new `DetailSubtitlesTabbedHeaderRow`. The stack view is left empty. Instead, a `UITableViewCell` is added to the table for each data row via `DetailDataRow`. 

There should be no visual or functional changes, but showing the details view is a lot faster. To note, there is still no loading view, so there may still be a blank view for a couple seconds for longer periods.

To test:

---
- Go to Stats > Insights > Comments on a very active site.
- Select `View more`.
- Verify the data appears relatively quickly.
- Verify selecting an Author row does nothing.
- Verify selecting a Post/Page row shows a web view.
- Verify selecting the filter tabs updates the data accordingly.

![comments](https://user-images.githubusercontent.com/1816888/57558286-51d93e80-733a-11e9-9671-3a193f5c9d61.png)

---
- Go to Stats > Insights > Followers on a very active site.
- Select `View more`.
- Verify the data appears relatively quickly.
- Verify selecting a row does nothing.
- Verify selecting the filter tabs updates the data accordingly.

![followers](https://user-images.githubusercontent.com/1816888/57558338-8b11ae80-733a-11e9-862f-51395c75bcf1.png)

---
Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

