### PR TITLE
Turn on domain credit feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 12.5
 -----
 * Fixed Notices sometimes showing behind the keyboard
+* Implemented Domain Credit feature
 
 12.4
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -17,7 +17,7 @@ enum FeatureFlag: Int {
         case .statsRefresh:
             return BuildConfiguration.current == .localDeveloper
         case .domainCredit:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         }
     }
 }


### PR DESCRIPTION
Refs. #11467 

Turned on domain credit feature flag!

To test:
- Prerequisite: have a site/blog with any paid WP.com plan (e.g. Blogger plan), with domain credit still available
- Go to "My Sites"
- Tap on the site in prerequisite
- Should see "Register Domain" row on the top of the site page below site name and URL. For all the other sites not with conditions in prerequisite, should not see this UI

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
