### PR TITLE
[Stats Refresh] Hide stub Countries map view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
@@ -33,6 +33,11 @@ class CountriesCell: UITableViewCell, NibLoadable {
         self.siteStatsPeriodDelegate = siteStatsPeriodDelegate
         self.forDetails = forDetails
 
+        // TODO: in xib when add map:
+        // - unhide Map View
+        // - Separator Line: enable Top Space to Map View constraint
+        // - Separator Line: remove Top Space to Superview constraint
+
         if !forDetails {
         addRows(dataRows,
                 toStackView: rowsStackView,

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,7 +19,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="355" height="416.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X6O-ua-Hm7" userLabel="Map View">
+                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X6O-ua-Hm7" userLabel="Map View">
                         <rect key="frame" x="0.0" y="0.0" width="355" height="200"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Imagine a pretty map here" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OsT-Jn-Nkl" userLabel="Temporary Label">
@@ -41,14 +41,14 @@
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OxT-ul-sgW" userLabel="Seperator Line">
-                        <rect key="frame" x="0.0" y="200" width="355" height="0.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="355" height="0.5"/>
                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0.5" id="tep-qB-gA1"/>
                         </constraints>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="WGt-7n-PjC" userLabel="Subtitles Stack View">
-                        <rect key="frame" x="16" y="207.5" width="323" height="16"/>
+                        <rect key="frame" x="16" y="7.5" width="323" height="16"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5E0-WK-AUD">
                                 <rect key="frame" x="0.0" y="0.0" width="161.5" height="16"/>
@@ -68,7 +68,7 @@
                         </constraints>
                     </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="UCQ-gq-RrN" userLabel="Rows Stack View">
-                        <rect key="frame" x="0.0" y="230.5" width="355" height="186"/>
+                        <rect key="frame" x="0.0" y="30.5" width="355" height="386"/>
                     </stackView>
                 </subviews>
                 <constraints>
@@ -79,6 +79,7 @@
                     <constraint firstItem="UCQ-gq-RrN" firstAttribute="top" secondItem="WGt-7n-PjC" secondAttribute="bottom" constant="7" id="ILe-TY-16f"/>
                     <constraint firstItem="OxT-ul-sgW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="IPs-GC-KBm"/>
                     <constraint firstItem="UCQ-gq-RrN" firstAttribute="top" secondItem="OxT-ul-sgW" secondAttribute="bottom" priority="999" id="Usf-7v-7m6"/>
+                    <constraint firstItem="OxT-ul-sgW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="V1r-tT-mNL"/>
                     <constraint firstAttribute="bottom" secondItem="UCQ-gq-RrN" secondAttribute="bottom" id="WJD-J4-Jab"/>
                     <constraint firstAttribute="trailing" secondItem="UCQ-gq-RrN" secondAttribute="trailing" id="aFU-xt-Aie"/>
                     <constraint firstAttribute="trailing" secondItem="OxT-ul-sgW" secondAttribute="trailing" id="lH1-IY-PBX"/>
@@ -89,6 +90,7 @@
                 </constraints>
                 <variation key="default">
                     <mask key="constraints">
+                        <exclude reference="05N-cC-wfk"/>
                         <exclude reference="Usf-7v-7m6"/>
                     </mask>
                 </variation>


### PR DESCRIPTION
Fixes #n/a

This hides the stub map view on the Countries views.

To test:

---
- Go to Stats > Period > Countries.
- Verify the map view no longer appears.

<img width="400" alt="period_countries" src="https://user-images.githubusercontent.com/1816888/57656147-d2937700-7594-11e9-8164-ab99d2d2949b.png">

---
- Select `View more`.
- Verify the map view no longer appears.

<img width="400" alt="countries_detail" src="https://user-images.githubusercontent.com/1816888/57656176-e6d77400-7594-11e9-89a7-66e61f753169.png">



---
Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
