### PR TITLE
Modified Stats charts to update the period in response to bar selection

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -69,6 +69,7 @@ class OverviewCell: UITableViewCell, NibLoadable {
 
     private var chartData: [BarChartDataConvertible] = []
     private var chartStyling: [BarChartStyling] = []
+    private weak var statsBarChartViewDelegate: StatsBarChartViewDelegate?
 
     private var period: StatsPeriodUnit? {
         didSet {
@@ -85,10 +86,11 @@ class OverviewCell: UITableViewCell, NibLoadable {
         applyStyles()
     }
 
-    func configure(tabsData: [OverviewTabData], barChartData: [BarChartDataConvertible] = [], barChartStyling: [BarChartStyling] = [], period: StatsPeriodUnit? = nil) {
+    func configure(tabsData: [OverviewTabData], barChartData: [BarChartDataConvertible] = [], barChartStyling: [BarChartStyling] = [], period: StatsPeriodUnit? = nil, statsBarChartViewDelegate: StatsBarChartViewDelegate? = nil) {
         self.tabsData = tabsData
         self.chartData = barChartData
         self.chartStyling = barChartStyling
+        self.statsBarChartViewDelegate = statsBarChartViewDelegate  // we set this first, as setting period has side effects
         self.period = period
 
         setupFilterBar()
@@ -171,7 +173,7 @@ private extension OverviewCell {
         let barChartStyling = chartStyling[filterSelectedIndex]
         let analyticsGranularity = period?.analyticsGranularity
 
-        let chartView = StatsBarChartView(data: barChartData, styling: barChartStyling, analyticsGranularity: analyticsGranularity)
+        let chartView = StatsBarChartView(data: barChartData, styling: barChartStyling, analyticsGranularity: analyticsGranularity, delegate: statsBarChartViewDelegate)
 
         resetChartContainerView()
         chartContainerView.addSubview(chartView)

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -78,6 +78,7 @@ class SiteStatsPeriodTableViewController: UITableViewController {
         }
 
         cell.configure(date: selectedDate, period: selectedPeriod, delegate: self)
+        viewModel?.statsBarChartViewDelegate = cell
 
         return cell
     }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -17,6 +17,8 @@ class SiteStatsPeriodViewModel: Observable {
     private var changeReceipt: Receipt?
     private typealias Style = WPStyleGuide.Stats
 
+    weak var statsBarChartViewDelegate: StatsBarChartViewDelegate?
+
     // MARK: - Constructor
 
     init(store: StatsPeriodStore = StoreContainer.shared.statsPeriod,
@@ -111,7 +113,7 @@ private extension SiteStatsPeriodViewModel {
         }
 
         let row = OverviewRow(tabsData: [viewsTabData, visitorsTabData, likesTabData, commentsTabData],
-                              chartData: barChartData, chartStyling: barChartStyling, period: lastRequestedPeriod)
+                              chartData: barChartData, chartStyling: barChartStyling, period: lastRequestedPeriod, statsBarChartViewDelegate: statsBarChartViewDelegate)
         tableRows.append(row)
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -24,7 +24,10 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable {
 
     // Limits how far back the date chooser can go.
     // Corresponds to the number of bars shown on the Overview chart.
-    private let backLimit = -12
+    private static let expectedPeriodCount = 14
+    private var backLimit: Int {
+        return -(SiteStatsTableHeaderView.expectedPeriodCount - 1)
+    }
 
     private lazy var calendar: Calendar = {
         var cal = Calendar(identifier: .iso8601)
@@ -182,5 +185,18 @@ private extension SiteStatsTableHeaderView {
 }
 
 extension SiteStatsTableHeaderView: StatsBarChartViewDelegate {
-    func statsBarChartValueSelected(_ statsBarChartView: StatsBarChartView, entryIndex: Int, entryCount: Int) {}
+    func statsBarChartValueSelected(_ statsBarChartView: StatsBarChartView, entryIndex: Int, entryCount: Int) {
+        guard let period = period, entryCount > 0, entryCount <= SiteStatsTableHeaderView.expectedPeriodCount else {
+            return
+        }
+
+        let periodShift = -((entryCount - 1) - entryIndex)
+
+        let currentDate = Date().normalizedDate()
+
+        self.date = calendar.date(byAdding: period.calendarComponent, value: periodShift, to: currentDate)
+        delegate?.dateChangedTo(self.date)
+        dateLabel.text = displayDate()
+        updateButtonStates()
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -180,3 +180,7 @@ private extension SiteStatsTableHeaderView {
         return calendar.component(.year, from: date)
     }
 }
+
+extension SiteStatsTableHeaderView: StatsBarChartViewDelegate {
+    func statsBarChartValueSelected(_ statsBarChartView: StatsBarChartView, entryIndex: Int, entryCount: Int) {}
+}

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -53,6 +53,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
         }
 
         cell.configure(date: selectedDate, period: .day, delegate: self)
+        viewModel?.statsBarChartViewDelegate = cell
 
         return cell
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -41,6 +41,8 @@ class PostStatsViewModel: Observable {
 
     private let weekFormat = NSLocalizedString("%@ - %@, %@", comment: "Post Stats label for week date range. Ex: Mar 25 - Mar 31, 2019")
 
+    weak var statsBarChartViewDelegate: StatsBarChartViewDelegate?
+
     // MARK: - Init
 
     init(postID: Int,
@@ -116,7 +118,8 @@ private extension PostStatsViewModel {
 
         let chart = PostChart(postViews: lastTwoWeeks)
 
-        tableRows.append(OverviewRow(tabsData: [overviewData], chartData: [chart], chartStyling: [chart.barChartStyling], period: nil))
+        let row = OverviewRow(tabsData: [overviewData], chartData: [chart], chartStyling: [chart.barChartStyling], period: nil, statsBarChartViewDelegate: statsBarChartViewDelegate)
+        tableRows.append(row)
 
         return tableRows
     }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -289,6 +289,7 @@ struct OverviewRow: ImmuTableRow {
     let chartData: [BarChartDataConvertible]
     let chartStyling: [BarChartStyling]
     let period: StatsPeriodUnit?
+    weak var statsBarChartViewDelegate: StatsBarChartViewDelegate?
 
     func configureCell(_ cell: UITableViewCell) {
 
@@ -296,7 +297,7 @@ struct OverviewRow: ImmuTableRow {
             return
         }
 
-        cell.configure(tabsData: tabsData, barChartData: chartData, barChartStyling: chartStyling, period: period)
+        cell.configure(tabsData: tabsData, barChartData: chartData, barChartStyling: chartStyling, period: period, statsBarChartViewDelegate: statsBarChartViewDelegate)
     }
 }
 


### PR DESCRIPTION
Addresses another portion of #11671. Namely, it updates the period header view in response to taps on individual chart bars.

To test:
- Checkout the branch & confirm that existing tests pass.
- Navigate to Stats for a given site, and review the Post Stats & Period Charts presented. 
- Observe that tapping a different bar shifts the applicable period as expected.
- Rinse & repeat for a couple of different periods, dimensions, device types & orientations, confirming no regressions in behavior or appearance.
- _Caveat_ : the period chart still contains 10 bars, as noted in `p1557859877030800-slack-nde-stats-refresh`.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.