### PR TITLE
Reader: Guard against ensuring layout when there are no attachments.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachmentManager.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachmentManager.swift
@@ -73,6 +73,10 @@ import UIKit
                 attachmentsAndRanges.append((attachment, range))
         })
 
+        guard attachmentsAndRanges.count > 0 else {
+            return
+        }
+
         // Invalidate the layout wherever attachments are
         let combinedRange = attachmentsAndRanges.reduce(NSRange(location: 0, length: Int.max)) {
             $0.union($1.1)


### PR DESCRIPTION
Fixes #10745 

This has been a very stubborn bug.  Starting the other day we began the same crash reported in #10745, #11145, and #11692 [showing up in Sentry](https://sentry.io/organizations/a8c/issues/1024577016/?referrer=github_integration).  Previous patches improved things yet something is still triggering the crash.  

This time around, when I was able to reproduce the crash I noticed via the stack trace and some debugging that `WPTextAttachmentManager layoutAttachmentViews` was calling ` layoutManager.ensureLayout(for: textView.textContainer)` ([here](https://github.com/wordpress-mobile/WordPress-iOS/blob/12.4.0.2/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachmentManager.swift#L82)) even when there were no attachments. Two things about this: 
1) its wasted work when there are no attachment views to deal with
2) this seems to always be the last WordPress code executed in the stack trace. Everything else is the SDK.

It seems reasonable that we can at least reduce the occurrences of the crash by guarding against zero attachments before ensuring layout.  The exact cause of the crash remains illusive 😠.  I did find an old thread where [a person claimed](https://stackoverflow.com/questions/20103352/range-related-exception-when-subclassing-nstextstorage-on-mavericks#comment31396613_20544379) an Apple engineer attributed it to a sdk bug but I didn't find the radar. I'm tempted to agree regardless.

This patch adds a guard to check for zero attachments as described above. I've been testing it on physical iPhone 6s against five of the example posts in this thread plus three other test posts I've used in the past.  With out the patch I can occasionally trigger the glitch by scrolling the comment list but its infrequent and difficult to reproduce.  With the patch I have not been able to trigger the glitch at all. 

To test:
Use the five example posts from the original issue for testing. For easy reference they are:
- p73Wbz-ja-p2
- p9OQAC-6B-p2
- pb6Nl-cWd-p2
- p9aQEi-x2-p2
- https://justmakeitadouble.wordpress.com/2019/04/11/to-jess/

For extra credit, confirm you can trigger the glitch by scrolling the Reader comments list for one of the five example posts. The easiest way to do this is to like these posts and access them from your Reader > Likes feed.
Switch to this branch and repeat the test for each post.  Try scrolling back and forth the full list multiple times for each post. Confirm there isn't a crash, or if there is it is at least exceedingly difficult to reproduce. 


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
