### PR TITLE
Modified vertical axis to include just five labels

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -18,14 +18,16 @@ class StatsBarChartView: BarChartView {
     // MARK: Properties
 
     private struct Constants {
-        static let intrinsicHeight      = CGFloat(170)      // height via Zeplin
-        static let highlightAlpha       = CGFloat(1)
-        static let markerAlpha          = CGFloat(0.2)
-        static let presentationDelay    = TimeInterval(0.01)
-        static let rotationDelay        = TimeInterval(0.35)
-        static let topOffsetSansLegend  = CGFloat(5)
-        static let topOffsetWithLegend  = CGFloat(16)
-        static let trailingOffset       = CGFloat(20)
+        static let intrinsicHeight          = CGFloat(170)      // height via Zeplin
+        static let highlightAlpha           = CGFloat(1)
+        static let horizontalAxisLabelCount = 2
+        static let markerAlpha              = CGFloat(0.2)
+        static let presentationDelay        = TimeInterval(0.01)
+        static let rotationDelay            = TimeInterval(0.35)
+        static let topOffsetSansLegend      = CGFloat(5)
+        static let topOffsetWithLegend      = CGFloat(16)
+        static let trailingOffset           = CGFloat(20)
+        static let verticalAxisLabelCount   = 5
     }
 
     /// This adapts the data set for presentation by the Charts framework.
@@ -254,7 +256,7 @@ private extension StatsBarChartView {
         xAxis.drawLabelsEnabled = true
         xAxis.labelPosition = .bottom
         xAxis.labelTextColor = styling.labelColor
-        xAxis.setLabelCount(2, force: true)
+        xAxis.setLabelCount(Constants.horizontalAxisLabelCount, force: true)
         xAxis.valueFormatter = styling.xAxisValueFormatter
     }
 
@@ -268,7 +270,7 @@ private extension StatsBarChartView {
         yAxis.drawZeroLineEnabled = true
         yAxis.gridColor = styling.lineColor
         yAxis.labelTextColor = styling.labelColor
-        yAxis.setLabelCount(6, force: true)
+        yAxis.setLabelCount(Constants.verticalAxisLabelCount, force: true)
         yAxis.valueFormatter = styling.yAxisValueFormatter
         yAxis.zeroLineColor = styling.lineColor
 


### PR DESCRIPTION
As [requested](https://github.com/wordpress-mobile/WordPress-iOS/pull/11672#issuecomment-492601849) by @SylvesterWilmott, this PR sets the number of vertical axis label count to be 5 instead of 6.

To test:
- Checkout the branch & confirm that existing tests pass.
- Review a few charts and confirm that you now see 5 labels on the vertical axis instead of 6.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

![a](https://user-images.githubusercontent.com/221062/57811344-d81cc880-771e-11e9-9850-0caa854acc3c.png)
![b](https://user-images.githubusercontent.com/221062/57811345-d8b55f00-771e-11e9-82c5-8a0377a3e05f.png)