### PR TITLE
Resolved a defect where in limited cases a chart would not refresh with new data

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -73,9 +73,7 @@ class OverviewCell: UITableViewCell, NibLoadable {
 
     private var period: StatsPeriodUnit? {
         didSet {
-            if chartContainerView.subviews.isEmpty || oldValue != period {
-                configureChartView()
-            }
+            configureChartView()
         }
     }
 


### PR DESCRIPTION
Fixes an issue where the Post Stats chart presented stale data. 

As discussed via Slack, this issue is most apparent when navigating from _Posts and Pages_ to _Post Stats_ for a given post. Currently the data on the subsequent screen does update unless a pull-to-refresh gesture is performed. The chart, however, was _not_ refreshed in response to pull-to-refresh.

Now the chart updates via pull-to-refresh along with the other screen content.

To test:
- Checkout the branch and confirm that existing tests pass.
- Replicate the scenario above, and confirm that it updates as expected.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
