### PR TITLE
[Stats Refresh] Insights Tags & Categories: fix displaying details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -53,7 +53,7 @@ class SiteStatsInsightsViewModel: Observable {
 
         if insightsStore.fetchingOverviewHasFailed &&
             !insightsStore.containsCachedData {
-            return ImmuTable(sections: [])
+            return ImmuTable.Empty
         }
 
         insightsToShow.forEach { insightType in

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -10,25 +10,52 @@ class DetailDataCell: UITableViewCell, NibLoadable {
 
     // MARK: - Properties
 
+    @IBOutlet weak var dataView: UIView!
+
+    // Line shown at the bottom of the view, spanning the entire width.
+    // It is shown on the last child row of an expanded row.
+    // Used to indicate the bottom of the expanded rows section. Hidden by default.
+    @IBOutlet weak var bottomExpandedSeparatorLine: UIView!
+
     private weak var detailsDelegate: SiteStatsDetailsDelegate?
     private var rowData: StatsTotalRowData?
+    private typealias Style = WPStyleGuide.Stats
 
     // MARK: - Configure
 
     func configure(rowData: StatsTotalRowData,
                    detailsDelegate: SiteStatsDetailsDelegate?,
-                   hideSeparator: Bool = false) {
+                   hideSeparator: Bool = false,
+                   expanded: Bool = false,
+                   isChildRow: Bool = false) {
+
+        Style.configureViewAsSeparator(bottomExpandedSeparatorLine)
 
         self.rowData = rowData
         self.detailsDelegate = detailsDelegate
 
         let row = StatsTotalRow.loadFromNib()
         row.configure(rowData: rowData, delegate: self)
-        row.showSeparator = !hideSeparator
 
-        contentView.addSubview(row)
+        // If the row is expanded, the separators are set accordingly.
+        row.expanded = expanded
+
+        // If not expanded, then update showSeparator.
+        if !expanded {
+            row.showSeparator = !hideSeparator
+        }
+
+        // If this is a child row, don't show the StatsTotalRow bottom separator (i.e. the indented line).
+        // Instead, toggle this cell's full width separator line.
+        if isChildRow {
+            row.showSeparator = false
+            bottomExpandedSeparatorLine.isHidden = hideSeparator
+            Style.configureLabelAsChildRowTitle(row.itemLabel)
+        }
+
+        dataView.addSubview(row)
         row.translatesAutoresizingMaskIntoConstraints = false
-        contentView.pinSubviewToAllEdges(row)
+        dataView.pinSubviewToAllEdges(row)
     }
 
 }
@@ -47,6 +74,10 @@ extension DetailDataCell: StatsTotalRowDelegate {
 
     func showPostStats(postID: Int, postTitle: String?, postURL: URL?) {
         detailsDelegate?.showPostStats?(postID: postID, postTitle: postTitle, postURL: postURL)
+    }
+
+    func toggleChildRowsForRow(_ row: StatsTotalRow) {
+        detailsDelegate?.toggleChildRowsForRow?(row)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -25,7 +25,8 @@ class DetailDataCell: UITableViewCell, NibLoadable {
 
     func configure(rowData: StatsTotalRowData,
                    detailsDelegate: SiteStatsDetailsDelegate?,
-                   hideSeparator: Bool = false,
+                   hideIndentedSeparator: Bool = false,
+                   hideFullSeparator: Bool = true,
                    expanded: Bool = false,
                    isChildRow: Bool = false) {
 
@@ -37,19 +38,18 @@ class DetailDataCell: UITableViewCell, NibLoadable {
         let row = StatsTotalRow.loadFromNib()
         row.configure(rowData: rowData, delegate: self)
 
+        bottomExpandedSeparatorLine.isHidden = hideFullSeparator
+
         if expanded {
-            // If the row is expanded, the separators are set accordingly.
+            // If the row is expanded, the row's separators are set accordingly.
             row.expanded = expanded
         }
         else {
-            // If this is a child row, don't show the the indented separator.
-            // Instead, toggle this cell's full width separator line.
-            row.showSeparator = isChildRow ? false : !hideSeparator
-            bottomExpandedSeparatorLine.isHidden = isChildRow ? hideSeparator : true
+            row.showSeparator = !hideIndentedSeparator
+        }
 
-            if isChildRow {
-                Style.configureLabelAsChildRowTitle(row.itemLabel)
-            }
+        if isChildRow {
+            Style.configureLabelAsChildRowTitle(row.itemLabel)
         }
 
         dataView.addSubview(row)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -37,20 +37,19 @@ class DetailDataCell: UITableViewCell, NibLoadable {
         let row = StatsTotalRow.loadFromNib()
         row.configure(rowData: rowData, delegate: self)
 
-        // If the row is expanded, the separators are set accordingly.
-        row.expanded = expanded
-
-        // If not expanded, then update showSeparator.
-        if !expanded {
-            row.showSeparator = !hideSeparator
+        if expanded {
+            // If the row is expanded, the separators are set accordingly.
+            row.expanded = expanded
         }
+        else {
+            // If this is a child row, don't show the the indented separator.
+            // Instead, toggle this cell's full width separator line.
+            row.showSeparator = isChildRow ? false : !hideSeparator
+            bottomExpandedSeparatorLine.isHidden = isChildRow ? hideSeparator : true
 
-        // If this is a child row, don't show the StatsTotalRow bottom separator (i.e. the indented line).
-        // Instead, toggle this cell's full width separator line.
-        if isChildRow {
-            row.showSeparator = false
-            bottomExpandedSeparatorLine.isHidden = hideSeparator
-            Style.configureLabelAsChildRowTitle(row.itemLabel)
+            if isChildRow {
+                Style.configureLabelAsChildRowTitle(row.itemLabel)
+            }
         }
 
         dataView.addSubview(row)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.xib
@@ -18,8 +18,34 @@
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="79.5"/>
                 <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="57l-83-U4z" userLabel="Data View">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="79.5"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </view>
+                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MAl-vu-Juo" userLabel="Bottom Expanded Seperator Line">
+                        <rect key="frame" x="0.0" y="79" width="320" height="0.5"/>
+                        <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.5" id="5K4-TZ-yII"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="MAl-vu-Juo" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="1Ms-MM-uVE"/>
+                    <constraint firstItem="57l-83-U4z" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="Sdm-Mm-lAn"/>
+                    <constraint firstAttribute="bottom" secondItem="57l-83-U4z" secondAttribute="bottom" id="Uif-DD-W66"/>
+                    <constraint firstAttribute="bottom" secondItem="MAl-vu-Juo" secondAttribute="bottom" id="X1b-BN-Oks"/>
+                    <constraint firstAttribute="trailing" secondItem="MAl-vu-Juo" secondAttribute="trailing" id="ZPh-HZ-HBn"/>
+                    <constraint firstAttribute="trailing" secondItem="57l-83-U4z" secondAttribute="trailing" id="ciO-5G-KvA"/>
+                    <constraint firstItem="57l-83-U4z" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="gtV-UJ-UnW"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="bottomExpandedSeparatorLine" destination="MAl-vu-Juo" id="flF-L8-hvk"/>
+                <outlet property="dataView" destination="57l-83-U4z" id="E09-sp-p9L"/>
+            </connections>
             <point key="canvasLocation" x="137.68115942028987" y="148.66071428571428"/>
         </tableViewCell>
     </objects>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -5,6 +5,7 @@ import WordPressFlux
     @objc optional func tabbedTotalsCellUpdated()
     @objc optional func displayWebViewWithURL(_ url: URL)
     @objc optional func expandedRowUpdated(_ row: StatsTotalRow)
+    @objc optional func toggleChildRowsForRow(_ row: StatsTotalRow)
     @objc optional func showPostStats(postID: Int, postTitle: String?, postURL: URL?)
     @objc optional func displayMediaWithID(_ mediaID: NSNumber)
 }
@@ -118,6 +119,7 @@ private extension SiteStatsDetailTableViewController {
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
         return [DetailDataRow.self,
+                DetailExpandableDataRow.self,
                 DetailSubtitlesHeaderRow.self,
                 DetailSubtitlesTabbedHeaderRow.self,
                 TopTotalsDetailStatsRow.self,
@@ -261,6 +263,11 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
     func expandedRowUpdated(_ row: StatsTotalRow) {
         applyTableUpdates()
         StatsDataHelper.updatedExpandedState(forRow: row, inDetails: true)
+    }
+
+    func toggleChildRowsForRow(_ row: StatsTotalRow) {
+        StatsDataHelper.updatedExpandedState(forRow: row, inDetails: true)
+        refreshTableView()
     }
 
     func showPostStats(postID: Int, postTitle: String?, postURL: URL?) {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -114,10 +114,9 @@ class SiteStatsDetailsViewModel: Observable {
             let dataRows = statSection == .insightsCommentsAuthors ? authorsTabData.dataRows : postsTabData.dataRows
             tableRows.append(contentsOf: tabbedRowsFrom(dataRows))
         case .insightsTagsAndCategories:
-            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.insightsTagsAndCategories.itemSubtitle,
-                                                     dataSubtitle: StatSection.insightsTagsAndCategories.dataSubtitle,
-                                                     dataRows: tagsAndCategoriesRows(),
-                                                     siteStatsDetailsDelegate: detailsDelegate))
+            tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: StatSection.insightsTagsAndCategories.itemSubtitle,
+                                                      dataSubtitle: StatSection.insightsTagsAndCategories.dataSubtitle))
+            tableRows.append(contentsOf: tagsAndCategoriesRows())
         case .periodPostsAndPages:
             tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: StatSection.periodPostsAndPages.itemSubtitle,
                                                       dataSubtitle: StatSection.periodPostsAndPages.dataSubtitle))
@@ -382,7 +381,11 @@ private extension SiteStatsDetailsViewModel {
 
     // MARK: - Tags and Categories
 
-    func tagsAndCategoriesRows() -> [StatsTotalRowData] {
+    func tagsAndCategoriesRows() -> [DetailExpandableDataRow] {
+        return expandableDataRowsFor(tagsAndCategoriesRowData(), forStat: .insightsTagsAndCategories)
+    }
+
+    func tagsAndCategoriesRowData() -> [StatsTotalRowData] {
         guard let tagsAndCategories = insightsStore.getAllTagsAndCategories()?.topTagsAndCategories else {
             return []
         }
@@ -605,6 +608,53 @@ private extension SiteStatsDetailsViewModel {
             detailDataRows.append(DetailDataRow(rowData: rowData,
                                                 detailsDelegate: detailsDelegate,
                                                 hideSeparator: idx == rowsData.endIndex-1))
+        }
+
+        return detailDataRows
+    }
+
+    func expandableDataRowsFor(_ rowsData: [StatsTotalRowData], forStat statSection: StatSection) -> [DetailExpandableDataRow] {
+        var detailDataRows = [DetailExpandableDataRow]()
+
+        for (idx, rowData) in rowsData.enumerated() {
+            let expanded = StatsDataHelper.expandedRowLabelsDetails[statSection]?.contains(rowData.name) ?? false
+            let isLastRow = idx == rowsData.endIndex-1
+
+            // Toggle the indented separator line based on expanded states.
+            let hideSeparator: Bool = {
+                if expanded {
+                    return expanded || isLastRow
+                }
+
+                // If the current row is not expanded, hide the separator if the next row is.
+                var nextExpanded = false
+                let nextIndex = idx + 1
+                if nextIndex < rowsData.count {
+                    let nextRow = rowsData[nextIndex]
+                    nextExpanded = StatsDataHelper.expandedRowLabelsDetails[statSection]?.contains(nextRow.name) ?? false
+                }
+
+                return nextExpanded || isLastRow
+            }()
+
+            // Add current row
+            detailDataRows.append(DetailExpandableDataRow(rowData: rowData,
+                                                          detailsDelegate: detailsDelegate,
+                                                          hideSeparator: hideSeparator,
+                                                          expanded: expanded,
+                                                          isChildRow: false))
+
+            // Add child rows
+            if expanded {
+                let childRowsData = rowData.childRows ?? []
+                for (idx, childRowData) in childRowsData.enumerated() {
+                    detailDataRows.append(DetailExpandableDataRow(rowData: childRowData,
+                                                                  detailsDelegate: detailsDelegate,
+                                                                  hideSeparator: idx < childRowsData.endIndex-1,
+                                                                  expanded: false,
+                                                                  isChildRow: true))
+                }
+            }
         }
 
         return detailDataRows

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -83,7 +83,7 @@ class SiteStatsDetailsViewModel: Observable {
 
         guard let statSection = statSection,
             let detailsDelegate = detailsDelegate else {
-                return ImmuTable(sections: [])
+                return ImmuTable.Empty
         }
 
         var tableRows = [ImmuTableRow]()

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -639,7 +639,7 @@ private extension SiteStatsDetailsViewModel {
             detailDataRows.append(DetailExpandableDataRow(rowData: rowData,
                                                           detailsDelegate: detailsDelegate,
                                                           hideIndentedSeparator: hideIndentedSeparator,
-                                                          hideFullSeparator: true,
+                                                          hideFullSeparator: !isLastRow,
                                                           expanded: expanded,
                                                           isChildRow: false))
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -430,8 +430,7 @@ struct DetailDataRow: ImmuTableRow {
             return
         }
 
-        cell.configure(rowData: rowData, detailsDelegate: detailsDelegate, hideSeparator: hideSeparator)
-
+        cell.configure(rowData: rowData, detailsDelegate: detailsDelegate, hideIndentedSeparator: hideSeparator)
     }
 }
 
@@ -445,7 +444,8 @@ struct DetailExpandableDataRow: ImmuTableRow {
 
     let rowData: StatsTotalRowData
     weak var detailsDelegate: SiteStatsDetailsDelegate?
-    let hideSeparator: Bool
+    let hideIndentedSeparator: Bool
+    let hideFullSeparator: Bool
     let expanded: Bool
     let isChildRow: Bool
     let action: ImmuTableAction? = nil
@@ -456,7 +456,12 @@ struct DetailExpandableDataRow: ImmuTableRow {
             return
         }
 
-        cell.configure(rowData: rowData, detailsDelegate: detailsDelegate, hideSeparator: hideSeparator, expanded: expanded, isChildRow: isChildRow)
+        cell.configure(rowData: rowData,
+                       detailsDelegate: detailsDelegate,
+                       hideIndentedSeparator: hideIndentedSeparator,
+                       hideFullSeparator: hideFullSeparator,
+                       expanded: expanded,
+                       isChildRow: isChildRow)
 
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -435,6 +435,32 @@ struct DetailDataRow: ImmuTableRow {
     }
 }
 
+struct DetailExpandableDataRow: ImmuTableRow {
+
+    typealias CellType = DetailDataCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let rowData: StatsTotalRowData
+    weak var detailsDelegate: SiteStatsDetailsDelegate?
+    let hideSeparator: Bool
+    let expanded: Bool
+    let isChildRow: Bool
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(rowData: rowData, detailsDelegate: detailsDelegate, hideSeparator: hideSeparator, expanded: expanded, isChildRow: isChildRow)
+
+    }
+}
+
 struct DetailSubtitlesHeaderRow: ImmuTableRow {
 
     typealias CellType = TopTotalsCell


### PR DESCRIPTION
Ref #11360

This changes Insights > Tags and Categories to use `UITableViewCell`s instead of one `UIStackView`.

Previously, all the data was stuffed into the stack view on the `TopTotalsCell` card. Now it only uses the `TopTotalsCell` card to show the header via `DetailSubtitlesHeaderRow`. The stack view is left empty. Instead, a `UITableViewCell` is added to the table for each data row via the new `DetailExpandableDataRow`. 

There should be no visual or functional changes, but showing the details view is faster. To note, there is still no loading view, so there may still be a blank view for a couple seconds for longer periods.

Known Issues:
- When a row is expanded/collapsed, _all_ the rows' arrows update. I don't _think_ this is new as I've seen it before, but it's pretty obvious now. I'll address that separately.
- With all these "replace stack views with table cells" PRs, it's introduce a new problem where the details table isn't actually being refreshed, it's being duplicated, displaying on top of itself. (It's painfully obvious when trying to Debug View Hierarchy in Xcode.) Woops. Since I broke it long before now, and it's a problem with the details table itself, I'll fix that separately as well.

Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

To test:

---
- Go to Stats > Insights > Tags and Categories on a very active site.
  - Tip: Hogwarts has several expandable tags/categories.
- Select `View more`.
- Verify the data appears relatively quickly.
- For a _non-expandable_ row, verify row selection shows a web view.

---
- For an expandable row, row selection shows _all_ child rows.
  - Previously, child rows on Details were limited to 10. This was a bug that has now been addressed.
- When a row is expanded:
  - The child label text color is light grey.
  - Child rows have no separator line between them.
  - There is a full width separator line above the parent row, and below the last child.
- Selecting a child row shows a web view.




![tags_cats](https://user-images.githubusercontent.com/1816888/57817851-969c1580-773e-11e9-9894-5ecae5f0bda2.png)
