### PR TITLE
[Stats Refresh] Revert cache method

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -1007,14 +1007,14 @@ extension StatsPeriodStore {
     }
 
     var containsCachedData: Bool {
-        if state.summary != nil &&
-            state.topPostsAndPages != nil &&
-            state.topReferrers != nil &&
-            state.topClicks != nil &&
-            state.topPublished != nil &&
-            state.topAuthors != nil &&
-            state.topSearchTerms != nil &&
-            state.topCountries != nil &&
+        if state.summary != nil ||
+            state.topPostsAndPages != nil ||
+            state.topReferrers != nil ||
+            state.topClicks != nil ||
+            state.topPublished != nil ||
+            state.topAuthors != nil ||
+            state.topSearchTerms != nil ||
+            state.topCountries != nil ||
             state.topVideos != nil {
             return true
         }


### PR DESCRIPTION
Refs. #10380

This PR just has a small revert to the previous method to check if there's cached data. This because the new block used to bind the loading view and its implementation don't require any change to that method.

## To test:
• From My Sites select a site and open its dashboard
• Select Stats to open the Stats section.
• Select one of the tab period tab _Days, Weeks, Months, Years_.
• You should see the loading view
• The loading view should disappear as soon the data is loaded
• The loading view should appear only if there's no data cached
• You can also test it tapping on the stats bar or changing the period date

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
