### PR TITLE
Use editor published post event, instead of quick published post.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -131,7 +131,7 @@ public enum PostEditorAction {
         case .publish:
             return .editorPublishedPost
         case .publishNow:
-            return .editorQuickPublishedPost
+            return .editorPublishedPost
         case .update:
             return .editorUpdatedPost
         case .submitForReview:


### PR DESCRIPTION
This PR changes the stat sent when the Publish Now button is used on the editor. Instead of using the  `editorQuickPublishedPos`t event we now consolidate all publish actions on the editor with `editorPublishedPost`.

To test:
 - Start the open
 - Create a new post
 - Add some content
 - Save the post has draft
 - Exit editor
 - Open the post again
 - Tap on publish now
 - Check if event sent is `editorPublishedPost`. I checked this by putting a breakpoint on `PostEditor+Publish.swift` on the `publishPost` method

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
