### PR TITLE
Completed transition to coordinate period bar and chart interaction

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -29,15 +29,13 @@ extension StatsPeriodFilterDimension {
 final class PeriodChart {
 
     private let rawChartData: StatsSummaryTimeIntervalData
-    private let period: StatsPeriodUnit
     private var filterDimension: StatsPeriodFilterDimension
 
     private(set) var barChartData: [BarChartDataConvertible]
     private(set) var barChartStyling: [BarChartStyling]
 
-    init(data: StatsSummaryTimeIntervalData, period: StatsPeriodUnit, filterDimension: StatsPeriodFilterDimension = .views) {
+    init(data: StatsSummaryTimeIntervalData, filterDimension: StatsPeriodFilterDimension = .views) {
         rawChartData = data
-        self.period = period
         self.filterDimension = filterDimension
 
         let (data, styling) = PeriodChartDataTransformer.transform(data: data)

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartConfiguration.swift
@@ -1,0 +1,18 @@
+
+struct StatsBarChartConfiguration {
+    let data: BarChartDataConvertible
+    let styling: BarChartStyling
+    let analyticsGranularity: BarChartAnalyticsPropertyGranularityValue?
+    let delegate: StatsBarChartViewDelegate?
+    let indexToHighlight: Int?
+}
+
+extension StatsBarChartConfiguration {
+    init(data: BarChartDataConvertible, styling: BarChartStyling) {
+        self.init(data: data, styling: styling, analyticsGranularity: nil, delegate: nil, indexToHighlight: nil)
+    }
+
+    init(data: BarChartDataConvertible, styling: BarChartStyling, analyticsGranularity: BarChartAnalyticsPropertyGranularityValue?) {
+        self.init(data: data, styling: styling, analyticsGranularity: analyticsGranularity, delegate: nil, indexToHighlight: nil)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -246,7 +246,8 @@ private extension LatestPostSummaryCell {
         }
 
         let chart = PostChart(type: .latest, postViews: lastTwoWeeks)
-        let chartView = StatsBarChartView(data: chart, styling: chart.barChartStyling)
+        let configuration = StatsBarChartConfiguration(data: chart, styling: chart.barChartStyling)
+        let chartView = StatsBarChartView(configuration: configuration)
 
         resetChartContainerView()
         chartStackView.addArrangedSubview(chartView)
@@ -257,7 +258,5 @@ private extension LatestPostSummaryCell {
             chartView.topAnchor.constraint(equalTo: chartStackView.topAnchor),
             chartView.bottomAnchor.constraint(equalTo: chartStackView.bottomAnchor)
         ])
-
-        chartView.present()
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -70,12 +70,9 @@ class OverviewCell: UITableViewCell, NibLoadable {
     private var chartData: [BarChartDataConvertible] = []
     private var chartStyling: [BarChartStyling] = []
     private weak var statsBarChartViewDelegate: StatsBarChartViewDelegate?
+    private var chartHighlightIndex: Int?
 
-    private var period: StatsPeriodUnit? {
-        didSet {
-            configureChartView()
-        }
-    }
+    private var period: StatsPeriodUnit?
 
     // MARK: - Configure
 
@@ -84,13 +81,15 @@ class OverviewCell: UITableViewCell, NibLoadable {
         applyStyles()
     }
 
-    func configure(tabsData: [OverviewTabData], barChartData: [BarChartDataConvertible] = [], barChartStyling: [BarChartStyling] = [], period: StatsPeriodUnit? = nil, statsBarChartViewDelegate: StatsBarChartViewDelegate? = nil) {
+    func configure(tabsData: [OverviewTabData], barChartData: [BarChartDataConvertible] = [], barChartStyling: [BarChartStyling] = [], period: StatsPeriodUnit? = nil, statsBarChartViewDelegate: StatsBarChartViewDelegate? = nil, barChartHighlightIndex: Int? = nil) {
         self.tabsData = tabsData
         self.chartData = barChartData
         self.chartStyling = barChartStyling
-        self.statsBarChartViewDelegate = statsBarChartViewDelegate  // we set this first, as setting period has side effects
+        self.statsBarChartViewDelegate = statsBarChartViewDelegate
+        self.chartHighlightIndex = barChartHighlightIndex
         self.period = period
 
+        configureChartView()
         setupFilterBar()
         updateLabels()
     }
@@ -161,11 +160,8 @@ private extension OverviewCell {
             return
         }
 
-        let barChartData = chartData[filterSelectedIndex]
-        let barChartStyling = chartStyling[filterSelectedIndex]
-        let analyticsGranularity = period?.analyticsGranularity
-
-        let chartView = StatsBarChartView(data: barChartData, styling: barChartStyling, analyticsGranularity: analyticsGranularity, delegate: statsBarChartViewDelegate)
+        let configuration = StatsBarChartConfiguration(data: chartData[filterSelectedIndex], styling: chartStyling[filterSelectedIndex], analyticsGranularity: period?.analyticsGranularity, delegate: statsBarChartViewDelegate, indexToHighlight: chartHighlightIndex)
+        let chartView = StatsBarChartView(configuration: configuration)
 
         resetChartContainerView()
         chartContainerView.addSubview(chartView)
@@ -176,8 +172,6 @@ private extension OverviewCell {
             chartView.topAnchor.constraint(equalTo: chartContainerView.topAnchor),
             chartView.bottomAnchor.constraint(equalTo: chartContainerView.bottomAnchor)
         ])
-
-        chartView.present()
     }
 
     func resetChartContainerView() {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -79,7 +79,8 @@ class SiteStatsPeriodTableViewController: UITableViewController {
             return nil
         }
 
-        cell.configure(date: selectedDate, period: selectedPeriod, delegate: self)
+        let periodCount = 10
+        cell.configure(date: selectedDate, period: .day, delegate: self, expectedPeriodCount: periodCount)
         viewModel?.statsBarChartViewDelegate = cell
 
         return cell

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -13,6 +13,7 @@ class SiteStatsPeriodViewModel: Observable {
 
     private weak var periodDelegate: SiteStatsPeriodDelegate?
     private let store: StatsPeriodStore
+    private var currentDate = Date()
     private var lastRequestedDate: Date
     private var lastRequestedPeriod: StatsPeriodUnit
     private let periodReceipt: Receipt
@@ -79,7 +80,7 @@ class SiteStatsPeriodViewModel: Observable {
     // MARK: - Refresh Data
 
     func refreshPeriodOverviewData(withDate date: Date, forPeriod period: StatsPeriodUnit) {
-        ActionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: date, period: period, forceRefresh: true))
+        ActionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: currentDate, period: period, forceRefresh: true))
         self.lastRequestedDate = date
         self.lastRequestedPeriod = period
     }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -13,7 +13,6 @@ class SiteStatsPeriodViewModel: Observable {
 
     private weak var periodDelegate: SiteStatsPeriodDelegate?
     private let store: StatsPeriodStore
-    private var currentDate = Date()
     private var lastRequestedDate: Date
     private var lastRequestedPeriod: StatsPeriodUnit
     private let periodReceipt: Receipt
@@ -80,7 +79,7 @@ class SiteStatsPeriodViewModel: Observable {
     // MARK: - Refresh Data
 
     func refreshPeriodOverviewData(withDate date: Date, forPeriod period: StatsPeriodUnit) {
-        ActionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: currentDate, period: period, forceRefresh: true))
+        ActionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: date, period: period, forceRefresh: true))
         self.lastRequestedDate = date
         self.lastRequestedPeriod = period
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -24,9 +24,10 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable {
 
     // Limits how far back the date chooser can go.
     // Corresponds to the number of bars shown on the Overview chart.
-    private static let expectedPeriodCount = 14
+    static let defaultPeriodCount = 14
+    private var expectedPeriodCount = SiteStatsTableHeaderView.defaultPeriodCount
     private var backLimit: Int {
-        return -(SiteStatsTableHeaderView.expectedPeriodCount - 1)
+        return -(expectedPeriodCount - 1)
     }
 
     private lazy var calendar: Calendar = {
@@ -42,10 +43,11 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable {
         applyStyles()
     }
 
-    func configure(date: Date?, period: StatsPeriodUnit?, delegate: SiteStatsTableHeaderDelegate) {
+    func configure(date: Date?, period: StatsPeriodUnit?, delegate: SiteStatsTableHeaderDelegate, expectedPeriodCount: Int) {
         self.date = date
         self.period = period
         self.delegate = delegate
+        self.expectedPeriodCount = expectedPeriodCount
         dateLabel.text = displayDate()
         updateButtonStates()
     }
@@ -186,7 +188,7 @@ private extension SiteStatsTableHeaderView {
 
 extension SiteStatsTableHeaderView: StatsBarChartViewDelegate {
     func statsBarChartValueSelected(_ statsBarChartView: StatsBarChartView, entryIndex: Int, entryCount: Int) {
-        guard let period = period, entryCount > 0, entryCount <= SiteStatsTableHeaderView.expectedPeriodCount else {
+        guard let period = period, entryCount > 0, entryCount <= SiteStatsTableHeaderView.defaultPeriodCount else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -195,6 +195,7 @@ extension SiteStatsTableHeaderView: StatsBarChartViewDelegate {
         let currentDate = Date().normalizedDate()
 
         self.date = calendar.date(byAdding: period.calendarComponent, value: periodShift, to: currentDate)
+        delegate?.dateChangedTo(self.date)
         dateLabel.text = displayDate()
         updateButtonStates()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -43,7 +43,7 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable {
         applyStyles()
     }
 
-    func configure(date: Date?, period: StatsPeriodUnit?, delegate: SiteStatsTableHeaderDelegate, expectedPeriodCount: Int) {
+    func configure(date: Date?, period: StatsPeriodUnit?, delegate: SiteStatsTableHeaderDelegate, expectedPeriodCount: Int = SiteStatsTableHeaderView.defaultPeriodCount) {
         self.date = date
         self.period = period
         self.delegate = delegate

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -195,7 +195,6 @@ extension SiteStatsTableHeaderView: StatsBarChartViewDelegate {
         let currentDate = Date().normalizedDate()
 
         self.date = calendar.date(byAdding: period.calendarComponent, value: periodShift, to: currentDate)
-        delegate?.dateChangedTo(self.date)
         dateLabel.text = displayDate()
         updateButtonStates()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -52,8 +52,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
             return nil
         }
 
-        let periodCount = SiteStatsTableHeaderView.defaultPeriodCount
-        cell.configure(date: selectedDate, period: .day, delegate: self, expectedPeriodCount: periodCount)
+        cell.configure(date: selectedDate, period: .day, delegate: self)
         viewModel?.statsBarChartViewDelegate = cell
 
         return cell

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -52,7 +52,8 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
             return nil
         }
 
-        cell.configure(date: selectedDate, period: .day, delegate: self)
+        let periodCount = SiteStatsTableHeaderView.defaultPeriodCount
+        cell.configure(date: selectedDate, period: .day, delegate: self, expectedPeriodCount: periodCount)
         viewModel?.statsBarChartViewDelegate = cell
 
         return cell

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -118,7 +118,12 @@ private extension PostStatsViewModel {
 
         let chart = PostChart(postViews: lastTwoWeeks)
 
-        let row = OverviewRow(tabsData: [overviewData], chartData: [chart], chartStyling: [chart.barChartStyling], period: nil, statsBarChartViewDelegate: statsBarChartViewDelegate)
+        let selectedDateComponents = calendar.dateComponents([.year, .month, .day], from: selectedDate)
+        let indexToHighlight = lastTwoWeeks.lastIndex(where: {
+            $0.date == selectedDateComponents
+        })
+
+        let row = OverviewRow(tabsData: [overviewData], chartData: [chart], chartStyling: [chart.barChartStyling], period: nil, statsBarChartViewDelegate: statsBarChartViewDelegate, chartHighlightIndex: indexToHighlight)
         tableRows.append(row)
 
         return tableRows

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -290,6 +290,7 @@ struct OverviewRow: ImmuTableRow {
     let chartStyling: [BarChartStyling]
     let period: StatsPeriodUnit?
     weak var statsBarChartViewDelegate: StatsBarChartViewDelegate?
+    let chartHighlightIndex: Int?
 
     func configureCell(_ cell: UITableViewCell) {
 
@@ -297,7 +298,7 @@ struct OverviewRow: ImmuTableRow {
             return
         }
 
-        cell.configure(tabsData: tabsData, barChartData: chartData, barChartStyling: chartStyling, period: period, statsBarChartViewDelegate: statsBarChartViewDelegate)
+        cell.configure(tabsData: tabsData, barChartData: chartData, barChartStyling: chartStyling, period: period, statsBarChartViewDelegate: statsBarChartViewDelegate, barChartHighlightIndex: chartHighlightIndex)
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -550,6 +550,7 @@
 		733F36102126197800988727 /* WordPressNotificationContentExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 733F36032126197800988727 /* WordPressNotificationContentExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		7345EAC4212DD49400607EC9 /* CircularImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37EAAF4C1A11799A006D6306 /* CircularImageView.swift */; };
 		7358E6BF210BD318002323EB /* WordPressNotificationServiceExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 7358E6B8210BD318002323EB /* WordPressNotificationServiceExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		735A9681228E421F00461135 /* StatsBarChartConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 735A9680228E421F00461135 /* StatsBarChartConfiguration.swift */; };
 		7360018F20A265C7001E5E31 /* String+Files.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7360018E20A265C7001E5E31 /* String+Files.swift */; };
 		736584E6213752730029C9A4 /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		736584EB2137533A0029C9A4 /* NotificationContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736584E82137533A0029C9A4 /* NotificationContentView.swift */; };
@@ -1728,7 +1729,6 @@
 		FF00889F204E01AE007CCE66 /* MediaQuotaCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF00889E204E01AE007CCE66 /* MediaQuotaCell.swift */; };
 		FF0148E51DFABBC9001AD265 /* NSFileManager+FolderSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0148E41DFABBC9001AD265 /* NSFileManager+FolderSize.swift */; };
 		FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF0AAE091A150A560089841D /* WPProgressTableViewCell.m */; };
-
 		FF0D8146205809C8000EE505 /* PostCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0D8145205809C8000EE505 /* PostCoordinator.swift */; };
 		FF0F722C206E5345000DAAB5 /* PostService+RefreshStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0F722B206E5345000DAAB5 /* PostService+RefreshStatus.swift */; };
 		FF1933FF1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1933FE1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m */; };
@@ -2521,6 +2521,7 @@
 		7347407E2114C5EF007FDDFF /* WordPressNotificationServiceExtension-Internal.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = "WordPressNotificationServiceExtension-Internal.entitlements"; sourceTree = "<group>"; };
 		7347407F2114C5F0007FDDFF /* WordPressNotificationServiceExtension-Alpha.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = "WordPressNotificationServiceExtension-Alpha.entitlements"; sourceTree = "<group>"; };
 		7358E6B8210BD318002323EB /* WordPressNotificationServiceExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WordPressNotificationServiceExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		735A9680228E421F00461135 /* StatsBarChartConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsBarChartConfiguration.swift; sourceTree = "<group>"; };
 		7360018E20A265C7001E5E31 /* String+Files.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Files.swift"; sourceTree = "<group>"; };
 		736584E82137533A0029C9A4 /* NotificationContentView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationContentView.swift; sourceTree = "<group>"; };
 		736584EA2137533A0029C9A4 /* Tracks+ContentExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Tracks+ContentExtension.swift"; sourceTree = "<group>"; };
@@ -4488,7 +4489,7 @@
 			path = Networking;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				F14B5F6F208E648200439554 /* config */,
@@ -5599,6 +5600,7 @@
 				73FF7031221F469100541798 /* Charts+Support.swift */,
 				733195822284FE9F0007D904 /* PeriodChart.swift */,
 				73E4E375227A033A0007D752 /* PostChart.swift */,
+				735A9680228E421F00461135 /* StatsBarChartConfiguration.swift */,
 				73FF702F221F43CD00541798 /* StatsBarChartView.swift */,
 				73D86968223AF4040064920F /* StatsChartLegendView.swift */,
 			);
@@ -8934,7 +8936,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -10189,6 +10191,7 @@
 				B57B92BD1B73B08100DFF00B /* SeparatorsView.swift in Sources */,
 				E69BA1981BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m in Sources */,
 				7E4123C320F4097B00DF8486 /* FormattableContentStyles.swift in Sources */,
+				735A9681228E421F00461135 /* StatsBarChartConfiguration.swift in Sources */,
 				080C44A91CE14A9F00B3A02F /* MenuDetailsViewController.m in Sources */,
 				2FA6511B21F26A57009AA935 /* InlineErrorRetryTableViewCell.swift in Sources */,
 				08216FCF1CDBF96000304BA7 /* MenuItemSourceCell.m in Sources */,


### PR DESCRIPTION
### Description
Fixes #11671.

To test:
- Checkout the branch & confirm that existing tests pass.
- Navigate to Stats for a given site, and review the Post Stats & Period Charts presented. 
- Observe that navigating with the Period bar updates the chart, as well as the highlighted bar when applicable.
- Rinse & repeat for a couple of different periods, dimensions, device types & orientations, confirming no regressions in behavior or appearance.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

### Screenshots

_Period Chart (iPhone) :_

![11671c_iPhone_periodChart](https://user-images.githubusercontent.com/221062/57944571-4206b080-788c-11e9-9fc3-fef0002203a4.png)

_Post Stats Chart (iPhone) :_

![11671c_iPhone_postStats](https://user-images.githubusercontent.com/221062/57944572-4206b080-788c-11e9-85af-73600a6a04b7.png)

_Post Stats Chart (iPad)  :_

<img width="539" alt="11671c_iPad_02" src="https://user-images.githubusercontent.com/221062/57944923-50a19780-788d-11e9-9ab2-f5379d0a8f16.png">
