### PR TITLE
[Stats Refresh] Period Clicks: fix displaying details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -131,10 +131,9 @@ class SiteStatsDetailsViewModel: Observable {
                                                      dataSubtitle: StatSection.periodVideos.dataSubtitle))
             tableRows.append(contentsOf: videosRows())
         case .periodClicks:
-            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodClicks.itemSubtitle,
-                                                     dataSubtitle: StatSection.periodClicks.dataSubtitle,
-                                                     dataRows: clicksRows(),
-                                                     siteStatsDetailsDelegate: detailsDelegate))
+            tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: StatSection.periodClicks.itemSubtitle,
+                                                      dataSubtitle: StatSection.periodClicks.dataSubtitle))
+            tableRows.append(contentsOf: clicksRows())
         case .periodAuthors:
             tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodAuthors.itemSubtitle,
                                                      dataSubtitle: StatSection.periodAuthors.dataSubtitle,
@@ -487,17 +486,22 @@ private extension SiteStatsDetailsViewModel {
 
     // MARK: - Clicks
 
-    func clicksRows() -> [StatsTotalRowData] {
-        return periodStore.getTopClicks()?.clicks.map { StatsTotalRowData(name: $0.title,
-                                                                          data: $0.clicksCount.abbreviatedString(),
-                                                                          showDisclosure: true,
-                                                                          disclosureURL: $0.iconURL,
-                                                                          childRows: $0.children.map { StatsTotalRowData(name: $0.title,
-                                                                                                                         data: $0.clicksCount.abbreviatedString(),
-                                                                                                                         showDisclosure: true,
-                                                                                                                         disclosureURL: $0.clickedURL) },
-                                                                          statSection: .periodClicks) }
-            ?? []
+    func clicksRows() -> [DetailExpandableDataRow] {
+        return expandableDataRowsFor(clicksRowData(), forStat: .periodClicks)
+    }
+
+    func clicksRowData() -> [StatsTotalRowData] {
+        return periodStore.getTopClicks()?.clicks.map {
+            StatsTotalRowData(name: $0.title,
+                              data: $0.clicksCount.abbreviatedString(),
+                              showDisclosure: true,
+                              disclosureURL: $0.iconURL,
+                              childRows: $0.children.map { StatsTotalRowData(name: $0.title,
+                                                                             data: $0.clicksCount.abbreviatedString(),
+                                                                             showDisclosure: true,
+                                                                             disclosureURL: $0.clickedURL) },
+                              statSection: .periodClicks)
+            } ?? []
     }
 
     // MARK: - Authors
@@ -648,8 +652,8 @@ private extension SiteStatsDetailsViewModel {
                 let childRowsData = rowData.childRows ?? []
                 for (idx, childRowData) in childRowsData.enumerated() {
                     // If this is the last child row, toggle the full separator based on
-                    // the current and next parent expanded states.
-                    let hideFullSeparator = (idx == childRowsData.endIndex-1) ? (expanded && nextExpanded) : true
+                    // next parent's expanded state to prevent duplicate lines.
+                    let hideFullSeparator = (idx == childRowsData.endIndex-1) ? nextExpanded : true
 
                     detailDataRows.append(DetailExpandableDataRow(rowData: childRowData,
                                                                   detailsDelegate: detailsDelegate,


### PR DESCRIPTION
Ref #11360

This changes Period > Clicks to use `UITableViewCell`s instead of one `UIStackView`.

Previously, all the data was stuffed into the stack view on the `TopTotalsCell` card. Now it only uses the `TopTotalsCell` card to show the header via `DetailSubtitlesHeaderRow`. The stack view is left empty. Instead, a `UITableViewCell` is added to the table for each data row via `DetailExpandableDataRow`. 

There should be no visual or functional changes, but showing the details view is faster. To note, there is still no loading view, so there may still be a blank view for a couple seconds for longer periods.

Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

To test:

---
- Go to Stats > Period > Clicks on a very active site.
  - Tip: en.blog is a good one.
- Select `View more`.
- Verify the data appears relatively quickly.
- For a _non-expandable_ row, verify row selection shows a web view.

---
- For an expandable row, row selection shows all child rows.
- When a row is expanded:
  - The child label text color is light grey.
  - Child rows have no separator line between them.
  - There is a full width separator line above the parent row, and below the last child.
- Selecting a child row shows a web view.

<img width="400" alt="clicks_expanded" src="https://user-images.githubusercontent.com/1816888/57959160-aabb5080-78bf-11e9-88b5-f8657491d093.png">

