### PR TITLE
[Stats Refresh] Period Authors: fix displaying details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -28,7 +28,8 @@ class DetailDataCell: UITableViewCell, NibLoadable {
                    hideIndentedSeparator: Bool = false,
                    hideFullSeparator: Bool = true,
                    expanded: Bool = false,
-                   isChildRow: Bool = false) {
+                   isChildRow: Bool = false,
+                   showChildRowImage: Bool = true) {
 
         Style.configureViewAsSeparator(bottomExpandedSeparatorLine)
 
@@ -50,6 +51,7 @@ class DetailDataCell: UITableViewCell, NibLoadable {
 
         if isChildRow {
             Style.configureLabelAsChildRowTitle(row.itemLabel)
+            row.imageView.isHidden = !showChildRowImage
         }
 
         dataView.addSubview(row)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -119,7 +119,8 @@ private extension SiteStatsDetailTableViewController {
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
         return [DetailDataRow.self,
-                DetailExpandableDataRow.self,
+                DetailExpandableRow.self,
+                DetailExpandableChildRow.self,
                 DetailSubtitlesHeaderRow.self,
                 DetailSubtitlesTabbedHeaderRow.self,
                 TopTotalsDetailStatsRow.self,

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -380,7 +380,7 @@ private extension SiteStatsDetailsViewModel {
 
     // MARK: - Tags and Categories
 
-    func tagsAndCategoriesRows() -> [DetailExpandableDataRow] {
+    func tagsAndCategoriesRows() -> [ImmuTableRow] {
         return expandableDataRowsFor(tagsAndCategoriesRowData(), forStat: .insightsTagsAndCategories)
     }
 
@@ -486,7 +486,7 @@ private extension SiteStatsDetailsViewModel {
 
     // MARK: - Clicks
 
-    func clicksRows() -> [DetailExpandableDataRow] {
+    func clicksRows() -> [ImmuTableRow] {
         return expandableDataRowsFor(clicksRowData(), forStat: .periodClicks)
     }
 
@@ -617,8 +617,8 @@ private extension SiteStatsDetailsViewModel {
         return detailDataRows
     }
 
-    func expandableDataRowsFor(_ rowsData: [StatsTotalRowData], forStat statSection: StatSection) -> [DetailExpandableDataRow] {
-        var detailDataRows = [DetailExpandableDataRow]()
+    func expandableDataRowsFor(_ rowsData: [StatsTotalRowData], forStat statSection: StatSection) -> [ImmuTableRow] {
+        var detailDataRows = [ImmuTableRow]()
 
         for (idx, rowData) in rowsData.enumerated() {
             let isLastRow = idx == rowsData.endIndex-1
@@ -640,12 +640,11 @@ private extension SiteStatsDetailsViewModel {
             let hideIndentedSeparator = expanded ? (expanded || isLastRow) : (nextExpanded || isLastRow)
 
             // Add current row
-            detailDataRows.append(DetailExpandableDataRow(rowData: rowData,
+            detailDataRows.append(DetailExpandableRow(rowData: rowData,
                                                           detailsDelegate: detailsDelegate,
                                                           hideIndentedSeparator: hideIndentedSeparator,
                                                           hideFullSeparator: !isLastRow,
-                                                          expanded: expanded,
-                                                          isChildRow: false))
+                                                          expanded: expanded))
 
             // Add child rows
             if expanded {
@@ -655,12 +654,15 @@ private extension SiteStatsDetailsViewModel {
                     // next parent's expanded state to prevent duplicate lines.
                     let hideFullSeparator = (idx == childRowsData.endIndex-1) ? nextExpanded : true
 
-                    detailDataRows.append(DetailExpandableDataRow(rowData: childRowData,
-                                                                  detailsDelegate: detailsDelegate,
-                                                                  hideIndentedSeparator: true,
-                                                                  hideFullSeparator: hideFullSeparator,
-                                                                  expanded: false,
-                                                                  isChildRow: true))
+                    // If the parent row has an icon, show the image view for the child
+                    // to make the child row appear "indented".
+                    let showImage = rowData.hasIcon
+
+                    detailDataRows.append(DetailExpandableChildRow(rowData: childRowData,
+                                                                   detailsDelegate: detailsDelegate,
+                                                                   hideIndentedSeparator: true,
+                                                                   hideFullSeparator: hideFullSeparator,
+                                                                   showImage: showImage))
                 }
             }
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -135,10 +135,9 @@ class SiteStatsDetailsViewModel: Observable {
                                                       dataSubtitle: StatSection.periodClicks.dataSubtitle))
             tableRows.append(contentsOf: clicksRows())
         case .periodAuthors:
-            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodAuthors.itemSubtitle,
-                                                     dataSubtitle: StatSection.periodAuthors.dataSubtitle,
-                                                     dataRows: authorsRows(),
-                                                     siteStatsDetailsDelegate: detailsDelegate))
+            tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: StatSection.periodAuthors.itemSubtitle,
+                                                      dataSubtitle: StatSection.periodAuthors.dataSubtitle))
+            tableRows.append(contentsOf: authorsRows())
         case .periodReferrers:
             tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,
                                                      dataSubtitle: StatSection.periodReferrers.dataSubtitle,
@@ -506,16 +505,22 @@ private extension SiteStatsDetailsViewModel {
 
     // MARK: - Authors
 
-    func authorsRows() -> [StatsTotalRowData] {
+    func authorsRows() -> [ImmuTableRow] {
+        return expandableDataRowsFor(authorsRowData(), forStat: .periodAuthors)
+    }
+
+    func authorsRowData() -> [StatsTotalRowData] {
         let authors = periodStore.getTopAuthors()?.topAuthors ?? []
 
-        return authors.map { StatsTotalRowData(name: $0.name,
-                                               data: $0.viewsCount.abbreviatedString(),
-                                               dataBarPercent: Float($0.viewsCount) / Float(authors.first!.viewsCount),
-                                               userIconURL: $0.iconURL,
-                                               showDisclosure: true,
-                                               childRows: $0.posts.map { StatsTotalRowData(name: $0.title, data: $0.viewsCount.abbreviatedString()) },
-                                               statSection: .periodAuthors) }
+        return authors.map {
+            StatsTotalRowData(name: $0.name,
+                              data: $0.viewsCount.abbreviatedString(),
+                              dataBarPercent: Float($0.viewsCount) / Float(authors.first!.viewsCount),
+                              userIconURL: $0.iconURL,
+                              showDisclosure: true,
+                              childRows: $0.posts.map { StatsTotalRowData(name: $0.title, data: $0.viewsCount.abbreviatedString()) },
+                              statSection: .periodAuthors)
+        }
     }
 
     // MARK: - Referrers

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -42,6 +42,10 @@ struct StatsTotalRowData {
         self.childRows = childRows
         self.statSection = statSection
     }
+
+    var hasIcon: Bool {
+        return self.icon != nil || self.socialIconURL != nil || self.userIconURL != nil
+    }
 }
 
 @objc protocol StatsTotalRowDelegate {
@@ -132,10 +136,7 @@ class StatsTotalRow: UIView, NibLoadable {
     }
 
     var hasIcon: Bool {
-        guard let rowData = rowData else {
-            return false
-        }
-        return rowData.icon != nil || rowData.socialIconURL != nil || rowData.userIconURL != nil
+        return rowData?.hasIcon ?? false
     }
 
     // MARK: - Configure

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -436,7 +436,7 @@ struct DetailDataRow: ImmuTableRow {
     }
 }
 
-struct DetailExpandableDataRow: ImmuTableRow {
+struct DetailExpandableRow: ImmuTableRow {
 
     typealias CellType = DetailDataCell
 
@@ -449,7 +449,6 @@ struct DetailExpandableDataRow: ImmuTableRow {
     let hideIndentedSeparator: Bool
     let hideFullSeparator: Bool
     let expanded: Bool
-    let isChildRow: Bool
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -462,9 +461,38 @@ struct DetailExpandableDataRow: ImmuTableRow {
                        detailsDelegate: detailsDelegate,
                        hideIndentedSeparator: hideIndentedSeparator,
                        hideFullSeparator: hideFullSeparator,
-                       expanded: expanded,
-                       isChildRow: isChildRow)
+                       expanded: expanded)
 
+    }
+}
+
+struct DetailExpandableChildRow: ImmuTableRow {
+
+    typealias CellType = DetailDataCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let rowData: StatsTotalRowData
+    weak var detailsDelegate: SiteStatsDetailsDelegate?
+    let hideIndentedSeparator: Bool
+    let hideFullSeparator: Bool
+    let showImage: Bool
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(rowData: rowData,
+                       detailsDelegate: detailsDelegate,
+                       hideIndentedSeparator: hideIndentedSeparator,
+                       hideFullSeparator: hideFullSeparator,
+                       isChildRow: true,
+                       showChildRowImage: showImage)
     }
 }
 


### PR DESCRIPTION
Ref #11360

This changes Period > Authors to use `UITableViewCell`s instead of one `UIStackView`.

Previously, all the data was stuffed into the stack view on the `TopTotalsCell` card. Now it only uses the `TopTotalsCell` card to show the header via `DetailSubtitlesHeaderRow`. The stack view is left empty. Instead, a `UITableViewCell` is added to the table for each data row via:
- `DetailExpandableRow` - for parent rows
- `DetailExpandableChildRow` - for child rows

There should be no visual or functional changes, but showing the details view is faster. To note, there is still no loading view, so there may still be a blank view for a couple seconds for longer periods.

Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

To test:

---
- Go to Stats > Period > Authors on a very active site.
- Select `View more`.
- Verify the data appears relatively quickly.
- For a _non-expandable_ row, verify row selection does nothing.

---
- For an expandable row, row selection shows all child rows.
- When a row is expanded:
  - The child label text color is light grey.
  - Child rows have no separator line between them.
  - There is a full width separator line above the parent row, and below the last child.
  - The child row is indented.
- Selecting a child row does nothing.

<img width="400" alt="authors_expanded" src="https://user-images.githubusercontent.com/1816888/57961745-1ad0d300-78ce-11e9-8988-261ccb8c8923.png">
