### PR TITLE
[Stats Refresh] Post Stats: fix displaying details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -150,15 +150,13 @@ class SiteStatsDetailsViewModel: Observable {
         case .periodPublished:
             tableRows.append(contentsOf: publishedRows())
         case .postStatsMonthsYears:
-            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.postStatsMonthsYears.itemSubtitle,
-                                                     dataSubtitle: StatSection.postStatsMonthsYears.dataSubtitle,
-                                                     dataRows: postStatsRows(),
-                                                     siteStatsDetailsDelegate: detailsDelegate))
+            tableRows.append(DetailSubtitlesCountriesHeaderRow(itemSubtitle: StatSection.postStatsMonthsYears.itemSubtitle,
+                                                               dataSubtitle: StatSection.postStatsMonthsYears.dataSubtitle))
+            tableRows.append(contentsOf: postStatsRows())
         case .postStatsAverageViews:
-            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.postStatsAverageViews.itemSubtitle,
-                                                     dataSubtitle: StatSection.postStatsAverageViews.dataSubtitle,
-                                                     dataRows: postStatsRows(forAverages: true),
-                                                     siteStatsDetailsDelegate: detailsDelegate))
+            tableRows.append(DetailSubtitlesCountriesHeaderRow(itemSubtitle: StatSection.postStatsAverageViews.itemSubtitle,
+                                                               dataSubtitle: StatSection.postStatsAverageViews.dataSubtitle))
+            tableRows.append(contentsOf: postStatsRows(forAverages: true))
         default:
             break
         }
@@ -572,8 +570,12 @@ private extension SiteStatsDetailsViewModel {
 
     // MARK: - Post Stats
 
-    func postStatsRows(forAverages: Bool = false) -> [StatsTotalRowData] {
+    func postStatsRows(forAverages: Bool = false) -> [ImmuTableRow] {
+        return expandableDataRowsFor(postStatsRowData(forAverages: forAverages),
+                                     forStat: forAverages ? .postStatsAverageViews : .postStatsMonthsYears)
+    }
 
+    func postStatsRowData(forAverages: Bool) -> [StatsTotalRowData] {
         let postStats = periodStore.getPostStats()
 
         guard let yearsData = (forAverages ? postStats?.dailyAveragesPerMonth : postStats?.monthlyBreakdown),


### PR DESCRIPTION
Ref #11360

This changes Post Stats  _Months and Years_ and _Avg Views Per Day_ to use `UITableViewCell`s instead of one `UIStackView`.

Previously, all the data was stuffed into the stack view on the `TopTotalsCell` card. Now it only uses the `TopTotalsCell` card to show the header via `DetailSubtitlesHeaderRow`. The stack view is left empty. Instead, a `UITableViewCell` is added to the table for each data row via:
- `DetailExpandableRow` - for parent rows
- `DetailExpandableChildRow` - for child rows

There should be no visual or functional changes, but showing the details view is faster. To note, there is still no loading view, so there may still be a blank view for a couple seconds for longer periods.

Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

To test:

---
- For a site older than 6 years, Go to Stats > Period > Post and Pages > row selection.
  - Tip: en.blog Home Page is a good one.
  - Due to https://github.com/wordpress-mobile/WordPress-iOS/issues/11708, refresh the view to get correct data.
- For _Months and Years_ and _Avg Views Per Day_, select `View more`.
- Verify the data appears relatively quickly.
- For a _non-expandable_ row, verify row selection does nothing.

---
- For an expandable row, row selection shows all months in the year.
- When a row is expanded:
  - The child label text color is light grey.
  - Child rows have no separator line between them.
  - There is a full width separator line above the parent row, and below the last child.
- Selecting a child row does nothing.

<img width="400" alt="months_years" src="https://user-images.githubusercontent.com/1816888/57962791-afd8c980-78d8-11e9-9d40-49703087dcb5.png">

<img width="400" alt="avg_views" src="https://user-images.githubusercontent.com/1816888/57962792-b404e700-78d8-11e9-9a0f-23767419ae41.png">

