### PR TITLE
[Stats Refresh] Posts Stats - Display correct data 

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -145,8 +145,8 @@ struct PeriodStoreState {
 
     // Post Stats
 
-    var postStats: [Int: StatsPostDetails?] = [:]
-    var fetchingPostStats: [Int: Bool] = [:]
+    var postStats = Dictionary<Int, StatsPostDetails?>()
+    var fetchingPostStats = Dictionary<Int, Bool>()
 }
 
 class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -145,8 +145,8 @@ struct PeriodStoreState {
 
     // Post Stats
 
-    var postStats = Dictionary<Int, StatsPostDetails?>()
-    var fetchingPostStats = Dictionary<Int, Bool>()
+    var postStats = [Int: StatsPostDetails?]()
+    var fetchingPostStats = [Int: Bool]()
 }
 
 class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -27,7 +27,7 @@ enum PeriodAction: Action {
     case refreshCountries(date: Date, period: StatsPeriodUnit)
 
     // Post Stats
-    case receivedPostStats(_ postStats: StatsPostDetails?)
+    case receivedPostStats(_ postStats: StatsPostDetails?, _ postId: Int)
     case refreshPostStats(postID: Int)
 }
 
@@ -145,8 +145,8 @@ struct PeriodStoreState {
 
     // Post Stats
 
-    var postStats: StatsPostDetails?
-    var fetchingPostStats = false
+    var postStats: [Int: StatsPostDetails?] = [:]
+    var fetchingPostStats: [Int: Bool] = [:]
 }
 
 class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
@@ -202,8 +202,8 @@ class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
             refreshCountries(date: date, period: period)
         case .refreshPublished(let date, let period):
             refreshPublished(date: date, period: period)
-        case .receivedPostStats(let postStats):
-            receivedPostStats(postStats)
+        case .receivedPostStats(let postStats, let postId):
+            receivedPostStats(postStats, postId)
         case .refreshPostStats(let postID):
             refreshPostStats(postID: postID)
         }
@@ -290,7 +290,7 @@ private extension StatsPeriodStore {
                     fetchAllPublished(date: query.date, period: query.period)
                 }
             case .postStats:
-                if shouldFetchPostStats() {
+                if shouldFetchPostStats(for: query.postID) {
                     fetchPostStats(postID: query.postID)
                 }
             }
@@ -688,19 +688,19 @@ private extension StatsPeriodStore {
                 return
         }
 
-        state.fetchingPostStats = true
+        state.fetchingPostStats[postID] = true
 
         statsRemote.getDetails(forPostID: postID) { (postStats: StatsPostDetails?, error: Error?) in
             if error != nil {
                 DDLogInfo("Error fetching Post Stats: \(String(describing: error?.localizedDescription))")
             }
             DDLogInfo("Stats: Finished fetching post stats.")
-            self.actionDispatcher.dispatch(PeriodAction.receivedPostStats(postStats))
+            self.actionDispatcher.dispatch(PeriodAction.receivedPostStats(postStats, postID))
         }
     }
 
     func refreshPostStats(postID: Int) {
-        state.fetchingPostStats = false
+        state.fetchingPostStats[postID] = false
         cancelQueries()
         fetchPostStats(postID: postID)
     }
@@ -806,13 +806,10 @@ private extension StatsPeriodStore {
         }
     }
 
-    func receivedPostStats(_ postStats: StatsPostDetails?) {
+    func receivedPostStats(_ postStats: StatsPostDetails?, _ postId: Int) {
         transaction { state in
-            state.fetchingPostStats = false
-
-            if postStats != nil {
-                state.postStats = postStats
-            }
+            state.fetchingPostStats[postId] = false
+            state.postStats[postId] = postStats
         }
     }
 
@@ -895,10 +892,9 @@ private extension StatsPeriodStore {
         return !isFetchingPublished
     }
 
-    func shouldFetchPostStats() -> Bool {
-        return !isFetchingPostStats
+    func shouldFetchPostStats(for postId: Int?) -> Bool {
+        return !isFetchingPostStats(for: postId)
     }
-
 }
 
 // MARK: - Public Accessors
@@ -941,8 +937,11 @@ extension StatsPeriodStore {
         return state.topCountries
     }
 
-    func getPostStats() -> StatsPostDetails? {
-        return state.postStats
+    func getPostStats(for postId: Int?) -> StatsPostDetails? {
+        guard let postId = postId else {
+            return nil
+        }
+        return state.postStats[postId] ?? nil
     }
 
     var isFetchingOverview: Bool {
@@ -990,10 +989,6 @@ extension StatsPeriodStore {
         return state.fetchingPublished
     }
 
-    var isFetchingPostStats: Bool {
-        return state.fetchingPostStats
-    }
-
     var fetchingOverviewHasFailed: Bool {
         return state.fetchingSummaryHasFailed &&
             state.fetchingPostsAndPagesHasFailed &&
@@ -1020,5 +1015,12 @@ extension StatsPeriodStore {
         }
 
         return false
+    }
+
+    func isFetchingPostStats(for postId: Int?) -> Bool {
+        guard let postId = postId else {
+            return false
+        }
+        return state.fetchingPostStats[postId] ?? false
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -56,12 +56,14 @@ class SiteStatsInsightsViewModel: Observable {
             return ImmuTable.Empty
         }
 
+        let postId = insightsStore.getLastPostInsight()?.postID
+
         insightsToShow.forEach { insightType in
             switch insightType {
             case .latestPostSummary:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsLatestPostSummary.title))
                 tableRows.append(LatestPostSummaryRow(summaryData: insightsStore.getLastPostInsight(),
-                                                      chartData: periodStore.getPostStats(),
+                                                      chartData: periodStore.getPostStats(for: postId),
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
             case .allTimeStats:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsAllTime.title))

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -82,7 +82,7 @@ private extension PostStatsTableViewController {
 
         changeReceipt = viewModel?.onChange { [weak self] in
             guard let store = self?.store,
-                !store.isFetchingPostStats else {
+                !store.isFetchingPostStats(for: self?.postID) else {
                     return
             }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -67,7 +67,7 @@ class PostStatsViewModel: Observable {
 
     func tableViewModel() -> ImmuTable {
 
-        postStats = store.getPostStats()
+        postStats = store.getPostStats(for: postID)
         var tableRows = [ImmuTableRow]()
 
         tableRows.append(titleTableRow())

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -151,7 +151,7 @@ private extension SiteStatsDetailTableViewController {
         case .periodPublished:
             return periodStore.isFetchingPublished
         case .postStatsMonthsYears, .postStatsAverageViews:
-            return periodStore.isFetchingPostStats
+            return periodStore.isFetchingPostStats(for: postID)
         default:
             return false
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -565,7 +565,7 @@ private extension SiteStatsDetailsViewModel {
 
     func postStatsRows(forAverages: Bool = false) -> [StatsTotalRowData] {
 
-        let postStats = periodStore.getPostStats()
+        let postStats = periodStore.getPostStats(for: postID)
 
         guard let yearsData = (forAverages ? postStats?.dailyAveragesPerMonth : postStats?.monthlyBreakdown),
             let minYear = StatsDataHelper.minYearFrom(yearsData: yearsData),


### PR DESCRIPTION
Fixes #11708 

This PR fixed the problem we had about displaying the correct Posts Stats data. Post Stats initially shows stats for the Latest Post Summary post. Only after refreshing the view does it show the correct data.

## The Problem
The _Period Store_ with more than one _Period Query_ of the same type **_postStats(postID: Int_)** executes only the first active query of that type when _func queriesChanged()_ is called.

## Solution
Use Dictionaries over single values. This allows to store _StatsPostDetails_ keyed by post id (fix a possible override action) and set the fetching status per post id (fix the problem of skipping multiple period queries of the same type).

## To test:
• Go to Stats > Insights -> Latest Post Summary (accessed via Insights > LPS > View more)
• Go to Stats > Period > Posts and Pages > select a post (different from the post displayed by LPS).
• Now the data should be different 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
