### PR TITLE
[Stats Refresh] Stats Detail lists / Post Stats loading view

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -19,14 +19,14 @@ enum InsightAction: Action {
     case refreshInsights
 
     // Insights details
-    case receivedAllDotComFollowers(_ allDotComFollowers: StatsDotComFollowersInsight?)
-    case receivedAllEmailFollowers(_ allDotComFollowers: StatsEmailFollowersInsight?)
+    case receivedAllDotComFollowers(_ allDotComFollowers: StatsDotComFollowersInsight?, _ error: Error?)
+    case receivedAllEmailFollowers(_ allDotComFollowers: StatsEmailFollowersInsight?, _ error: Error?)
     case refreshFollowers
 
-    case receivedAllCommentsInsight(_ commentsInsight: StatsCommentsInsight?)
+    case receivedAllCommentsInsight(_ commentsInsight: StatsCommentsInsight?, _ error: Error?)
     case refreshComments
 
-    case receivedAllTagsAndCategories(_ allTagsAndCategories: StatsTagsAndCategoriesInsight?)
+    case receivedAllTagsAndCategories(_ allTagsAndCategories: StatsTagsAndCategoriesInsight?, _ error: Error?)
     case refreshTagsAndCategories
 }
 
@@ -85,15 +85,19 @@ struct InsightStoreState {
 
     var allDotComFollowers: StatsDotComFollowersInsight?
     var fetchingAllDotComFollowers = false
+    var fetchingAllDotComFollowersHasFailed = false
 
     var allEmailFollowers: StatsEmailFollowersInsight?
     var fetchingAllEmailFollowers = false
+    var fetchingAllEmailFollowersHasFailed = false
 
     var allCommentsInsight: StatsCommentsInsight?
     var fetchingAllCommentsInsight = false
+    var fetchingAllCommentsInsightHasFailed = false
 
     var allTagsAndCategories: StatsTagsAndCategoriesInsight?
     var fetchingAllTagsAndCategories = false
+    var fetchingAllTagsAndCategoriesHasFailed = false
 }
 
 class StatsInsightsStore: QueryStore<InsightStoreState, InsightQuery> {
@@ -131,18 +135,18 @@ class StatsInsightsStore: QueryStore<InsightStoreState, InsightQuery> {
             receivedTagsAndCategories(tagsAndCategories, error)
         case .refreshInsights:
             refreshInsights()
-        case .receivedAllDotComFollowers(let allDotComFollowers):
-            receivedAllDotComFollowers(allDotComFollowers)
-        case .receivedAllEmailFollowers(let allEmailFollowers):
-            receivedAllEmailFollowers(allEmailFollowers)
+        case .receivedAllDotComFollowers(let allDotComFollowers, let error):
+            receivedAllDotComFollowers(allDotComFollowers, error)
+        case .receivedAllEmailFollowers(let allEmailFollowers, let error):
+            receivedAllEmailFollowers(allEmailFollowers, error)
         case .refreshFollowers:
             refreshFollowers()
-        case .receivedAllCommentsInsight(let allComments):
-            receivedAllCommentsInsight(allComments)
+        case .receivedAllCommentsInsight(let allComments, let error):
+            receivedAllCommentsInsight(allComments, error)
         case .refreshComments:
             refreshComments()
-        case .receivedAllTagsAndCategories(let allTagsAndCategories):
-            receivedAllTagsAndCategories(allTagsAndCategories)
+        case .receivedAllTagsAndCategories(let allTagsAndCategories, let error):
+            receivedAllTagsAndCategories(allTagsAndCategories, error)
         case .refreshTagsAndCategories:
             refreshTagsAndCategories()
         }
@@ -473,14 +477,14 @@ private extension StatsInsightsStore {
             if error != nil {
                 DDLogInfo("Error fetching dotCom Followers: \(String(describing: error?.localizedDescription))")
             }
-            self.actionDispatcher.dispatch(InsightAction.receivedAllDotComFollowers(dotComFollowers))
+            self.actionDispatcher.dispatch(InsightAction.receivedAllDotComFollowers(dotComFollowers, error))
         }
 
           api.getInsight(limit: 100) { (emailFollowers: StatsEmailFollowersInsight?, error) in
             if error != nil {
                 DDLogInfo("Error fetching email Followers: \(String(describing: error?.localizedDescription))")
             }
-            self.actionDispatcher.dispatch(InsightAction.receivedAllEmailFollowers(emailFollowers))
+            self.actionDispatcher.dispatch(InsightAction.receivedAllEmailFollowers(emailFollowers, error))
         }
     }
 
@@ -500,7 +504,7 @@ private extension StatsInsightsStore {
             if error != nil {
                 DDLogInfo("Error fetching all comments: \(String(describing: error?.localizedDescription))")
             }
-            self.actionDispatcher.dispatch(InsightAction.receivedAllCommentsInsight(allComments))
+            self.actionDispatcher.dispatch(InsightAction.receivedAllCommentsInsight(allComments, error))
         }
     }
 
@@ -518,25 +522,27 @@ private extension StatsInsightsStore {
             if error != nil {
                 DDLogInfo("Error fetching all tags and categories: \(String(describing: error?.localizedDescription))")
             }
-            self.actionDispatcher.dispatch(InsightAction.receivedAllTagsAndCategories(allTagsAndCategories))
+            self.actionDispatcher.dispatch(InsightAction.receivedAllTagsAndCategories(allTagsAndCategories, error))
         }
     }
 
-    func receivedAllDotComFollowers(_ allDotComFollowers: StatsDotComFollowersInsight?) {
+    func receivedAllDotComFollowers(_ allDotComFollowers: StatsDotComFollowersInsight?, _ error: Error?) {
         transaction { state in
             if allDotComFollowers != nil {
                 state.allDotComFollowers = allDotComFollowers
             }
             state.fetchingAllDotComFollowers = false
+            state.fetchingAllDotComFollowersHasFailed = error != nil
         }
     }
 
-    func receivedAllEmailFollowers(_ allEmailFollowers: StatsEmailFollowersInsight?) {
+    func receivedAllEmailFollowers(_ allEmailFollowers: StatsEmailFollowersInsight?, _ error: Error?) {
         transaction { state in
             if allEmailFollowers != nil {
                 state.allEmailFollowers = allEmailFollowers
             }
             state.fetchingAllEmailFollowers = false
+            state.fetchingAllEmailFollowersHasFailed = error != nil
         }
     }
 
@@ -553,12 +559,13 @@ private extension StatsInsightsStore {
         return !isFetchingFollowers
     }
 
-    func receivedAllCommentsInsight(_ allCommentsInsight: StatsCommentsInsight?) {
+    func receivedAllCommentsInsight(_ allCommentsInsight: StatsCommentsInsight?, _ error: Error?) {
         transaction { state in
             if allCommentsInsight != nil {
                 state.allCommentsInsight = allCommentsInsight
             }
             state.fetchingAllCommentsInsight = false
+            state.fetchingAllCommentsInsightHasFailed = error != nil
         }
     }
 
@@ -575,12 +582,13 @@ private extension StatsInsightsStore {
         return !isFetchingComments
     }
 
-    func receivedAllTagsAndCategories(_ allTagsAndCategories: StatsTagsAndCategoriesInsight?) {
+    func receivedAllTagsAndCategories(_ allTagsAndCategories: StatsTagsAndCategoriesInsight?, _ error: Error?) {
         transaction { state in
             if allTagsAndCategories != nil {
                 state.allTagsAndCategories = allTagsAndCategories
             }
             state.fetchingAllTagsAndCategories = false
+            state.fetchingAllTagsAndCategoriesHasFailed = error != nil
         }
     }
 
@@ -754,6 +762,20 @@ extension StatsInsightsStore {
             state.fetchingPostingActivityHasFailed &&
             state.fetchingCommentsInsightHasFailed &&
             state.fetchingTagsAndCategoriesHasFailed
+    }
+
+    func fetchingFailed(for query: InsightQuery) -> Bool {
+        switch query {
+        case .insights:
+            return fetchingOverviewHasFailed
+        case .allFollowers:
+            return state.fetchingAllDotComFollowersHasFailed &&
+                state.fetchingAllEmailFollowersHasFailed
+        case .allComments:
+            return state.fetchingAllCommentsInsightHasFailed
+        case .allTagsAndCategories:
+            return state.fetchingAllTagsAndCategoriesHasFailed
+        }
     }
 
     var containsCachedData: Bool {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -132,7 +132,7 @@ private extension SiteStatsInsightsTableViewController {
 
         tableHandler.viewModel = viewModel.tableViewModel()
 
-        if insightsStore.fetchingOverviewHasFailed &&
+        if insightsStore.fetchingFailed(for: .insights) &&
             !insightsStore.containsCachedData {
             displayFailureViewIfNecessary()
         } else {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -51,7 +51,7 @@ class SiteStatsInsightsViewModel: Observable {
 
         var tableRows = [ImmuTableRow]()
 
-        if insightsStore.fetchingOverviewHasFailed &&
+        if insightsStore.fetchingFailed(for: .insights) &&
             !insightsStore.containsCachedData {
             return ImmuTable.Empty
         }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -64,7 +64,7 @@ class SiteStatsPeriodViewModel: Observable {
 
         if !store.containsCachedData &&
             (store.fetchingOverviewHasFailed || store.isFetchingOverview) {
-            return ImmuTable(sections: [])
+            return ImmuTable.Empty
         }
 
         tableRows.append(contentsOf: overviewTableRows())

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -39,6 +39,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
         tableView.register(SiteStatsTableHeaderView.defaultNib,
                            forHeaderFooterViewReuseIdentifier: SiteStatsTableHeaderView.defaultNibName)
         initViewModel()
+        displayLoadingViewIfNecessary()
     }
 
     func configure(postID: Int, postTitle: String?, postURL: URL?) {
@@ -108,6 +109,12 @@ private extension PostStatsTableViewController {
 
         tableHandler.viewModel = viewModel.tableViewModel()
         refreshControl?.endRefreshing()
+
+        if viewModel.fetchDataHasFailed() {
+            displayFailureViewIfNecessary()
+        } else {
+            hideNoResults()
+        }
     }
 
     @objc func userInitiatedRefresh() {
@@ -115,12 +122,17 @@ private extension PostStatsTableViewController {
         refreshData()
     }
 
-    func refreshData() {
-        guard let postID = postID else {
+    func refreshData(forceUpdate: Bool = false) {
+        guard let viewModel = viewModel,
+            let postID = postID else {
             return
         }
 
-        viewModel?.refreshPostStats(postID: postID, selectedDate: selectedDate)
+        viewModel.refreshPostStats(postID: postID, selectedDate: selectedDate)
+        if forceUpdate {
+            tableHandler.viewModel = viewModel.tableViewModel()
+        }
+        displayLoadingViewIfNecessary()
     }
 
     func applyTableUpdates() {
@@ -166,7 +178,60 @@ extension PostStatsTableViewController: SiteStatsTableHeaderDelegate {
         }
 
         selectedDate = newDate
-        refreshData()
+        refreshData(forceUpdate: true)
+    }
+}
+
+// MARK: - NoResultsViewHost
+
+extension PostStatsTableViewController: NoResultsViewHost {
+    private func displayLoadingViewIfNecessary() {
+        guard tableHandler.viewModel.sections.isEmpty else {
+            return
+        }
+
+        if noResultsViewController.view.superview != nil {
+            updateNoResults(title: NoResultConstants.successTitle,
+                            accessoryView: NoResultsViewController.loadingAccessoryView()) { [weak self] noResults in
+                                noResults.delegate = self
+                                noResults.hideImageView(false)
+            }
+            return
+        }
+
+        configureAndDisplayNoResults(on: tableView,
+                                     title: NoResultConstants.successTitle,
+                                     accessoryView: NoResultsViewController.loadingAccessoryView()) { [weak self] noResults in
+                                        noResults.delegate = self
+                                        noResults.hideImageView(false)
+        }
     }
 
+    private func displayFailureViewIfNecessary() {
+        guard tableHandler.viewModel.sections.isEmpty else {
+            return
+        }
+
+        updateNoResults(title: NoResultConstants.errorTitle,
+                        subtitle: NoResultConstants.errorSubtitle,
+                        buttonTitle: NoResultConstants.refreshButtonTitle) { [weak self] noResults in
+                            noResults.delegate = self
+                            noResults.hideImageView()
+        }
+    }
+
+    private enum NoResultConstants {
+        static let successTitle = NSLocalizedString("Loading Stats...", comment: "The loading view title displayed while the service is loading")
+        static let errorTitle = NSLocalizedString("Stats not loaded", comment: "The loading view title displayed when an error occurred")
+        static let errorSubtitle = NSLocalizedString("There was a problem loading your data, refresh your page to try again.", comment: "The loading view subtitle displayed when an error occurred")
+        static let refreshButtonTitle = NSLocalizedString("Refresh", comment: "The loading view button title displayed when an error occurred")
+    }
+}
+
+// MARK: - NoResultsViewControllerDelegate methods
+
+extension PostStatsTableViewController: NoResultsViewControllerDelegate {
+    func actionButtonPressed() {
+        refreshData()
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -66,6 +66,10 @@ class PostStatsViewModel: Observable {
     // MARK: - Table View
 
     func tableViewModel() -> ImmuTable {
+        if let postID = postID,
+            (store.fetchingFailed(for: .postStats(postID: postID)) || store.isFetchingPostStats(for: postID)) {
+            return ImmuTable.Empty
+        }
 
         postStats = store.getPostStats(for: postID)
         var tableRows = [ImmuTableRow]()
@@ -90,6 +94,12 @@ class PostStatsViewModel: Observable {
         ActionDispatcher.dispatch(PeriodAction.refreshPostStats(postID: postID))
     }
 
+    func fetchDataHasFailed() -> Bool {
+        if let postID = postID {
+            return store.fetchingFailed(for: .postStats(postID: postID))
+        }
+        return true
+    }
 }
 
 // MARK: - Private Extension

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -71,6 +71,7 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
         statType = StatSection.allInsights.contains(statSection) ? .insights : .period
         title = statSection.title
         initViewModel()
+        displayLoadingViewIfNecessary()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -166,6 +167,12 @@ private extension SiteStatsDetailTableViewController {
 
         tableHandler.viewModel = viewModel.tableViewModel()
         refreshControl?.endRefreshing()
+
+        if viewModel.fetchDataHasFailed() {
+            displayFailureViewIfNecessary()
+        } else {
+            hideNoResults()
+        }
     }
 
     @objc func refreshData() {
@@ -286,4 +293,57 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
         })
     }
 
+}
+
+// MARK: - NoResultsViewHost
+
+extension SiteStatsDetailTableViewController: NoResultsViewHost {
+    private func displayLoadingViewIfNecessary() {
+        guard tableHandler.viewModel.sections.isEmpty else {
+            return
+        }
+
+        if noResultsViewController.view.superview != nil {
+            return
+        }
+
+        configureAndDisplayNoResults(on: tableView,
+                                     title: NoResultConstants.successTitle,
+                                     accessoryView: NoResultsViewController.loadingAccessoryView()) { [weak self] noResults in
+                                        noResults.delegate = self
+                                        noResults.hideImageView(false)
+        }
+    }
+
+    private func displayFailureViewIfNecessary() {
+        guard tableHandler.viewModel.sections.isEmpty else {
+            return
+        }
+
+        updateNoResults(title: NoResultConstants.errorTitle,
+                        subtitle: NoResultConstants.errorSubtitle,
+                        buttonTitle: NoResultConstants.refreshButtonTitle) { [weak self] noResults in
+                            noResults.delegate = self
+                            noResults.hideImageView()
+        }
+    }
+
+    private enum NoResultConstants {
+        static let successTitle = NSLocalizedString("Loading Stats...", comment: "The loading view title displayed while the service is loading")
+        static let errorTitle = NSLocalizedString("Stats not loaded", comment: "The loading view title displayed when an error occurred")
+        static let errorSubtitle = NSLocalizedString("There was a problem loading your data, refresh your page to try again.", comment: "The loading view subtitle displayed when an error occurred")
+        static let refreshButtonTitle = NSLocalizedString("Refresh", comment: "The loading view button title displayed when an error occurred")
+    }
+}
+
+// MARK: - NoResultsViewControllerDelegate methods
+
+extension SiteStatsDetailTableViewController: NoResultsViewControllerDelegate {
+    func actionButtonPressed() {
+        updateNoResults(title: NoResultConstants.successTitle,
+                        accessoryView: NoResultsViewController.loadingAccessoryView()) { noResults in
+                            noResults.hideImageView(false)
+        }
+        refreshData()
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -77,13 +77,40 @@ class SiteStatsDetailsViewModel: Observable {
         }
     }
 
+    func fetchDataHasFailed() -> Bool {
+        guard let statSection = statSection else {
+            return true
+        }
+
+        switch statSection {
+        case let statSection where StatSection.allInsights.contains(statSection):
+            guard let storeQuery = queryForInsightStatSection(statSection) else {
+                return true
+            }
+            return insightsStore.fetchingFailed(for: storeQuery)
+        case let statSection where StatSection.allPeriods.contains(statSection):
+            guard let storeQuery = queryForPeriodStatSection(statSection) else {
+                return true
+            }
+            return periodStore.fetchingFailed(for: storeQuery)
+        default:
+            guard let postID = postID else {
+                return true
+            }
+            return periodStore.fetchingFailed(for: .postStats(postID: postID))
+        }
+    }
+
     // MARK: - Table Model
 
     func tableViewModel() -> ImmuTable {
-
         guard let statSection = statSection,
             let detailsDelegate = detailsDelegate else {
                 return ImmuTable.Empty
+        }
+
+        if fetchDataHasFailed() {
+            return ImmuTable.Empty
         }
 
         var tableRows = [ImmuTableRow]()


### PR DESCRIPTION
Fixes #11166 
Refs. #10840

This PR adds the loading view on any detail view controller, `SiteStatsDetailTableViewController` and `PostStatsTableViewController ` accessed by tapping on _View More_ from the Insights and Periods overviews.

## To test:
• From My Sites select a site and open its dashboard
• Select Stats to open the Stats section.
• Select one of the tab _Insights_, _Days_, _Weeks_, _Months_, _Years_.
• Scrolling the selected tab overview tap on any _View More_ to open the detail
• You should see the loading view

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
