### PR TITLE
Fixing error message when saving draft while offline

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -332,7 +332,7 @@ extension PostEditor where Self: UIViewController {
 
             if let error = error {
                 DDLogError("Error publishing post: \(error.localizedDescription)")
-                ActionDispatcher.dispatch(NoticeAction.post(self.uploadFailureNotice))
+                ActionDispatcher.dispatch(NoticeAction.post(self.uploadFailureNotice(action: action)))
                 generator.notificationOccurred(.error)
             } else if let uploadedPost = uploadedPost {
                 self.post = uploadedPost

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -132,8 +132,7 @@ extension PostEditor {
         return "PostEditor.UploadFailed"
     }
 
-    var uploadFailureNotice: Notice {
-        let action = self.postEditorStateContext.action
+    func uploadFailureNotice(action: PostEditorAction) -> Notice {
         return Notice(title: action.publishingErrorLabel, tag: uploadFailureNoticeTag)
     }
 }


### PR DESCRIPTION
The error message we're showing depends on the action. Previously we were sending the primary action hence the label was wrong.
We are now passing the action to uploadFailureNotice

Fixes #11732 

To test:
1. Be offline
2. Start new post
3. Go to the option menu and choose "Save As Draft"
4. See the notice message says "Error Occurred while saving"

Before:
![draft_save_error](https://user-images.githubusercontent.com/1335657/58053702-29f19400-7b0d-11e9-857b-4207a50c57d2.gif)

After:
![draft_save_error_1](https://user-images.githubusercontent.com/1335657/58053784-64f3c780-7b0d-11e9-95f4-182400fcbe59.gif)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
