### PR TITLE
Fix discard draft loosing all changes

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -39,7 +39,7 @@ PODS:
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.1)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.1)"
   - Gridicons (0.18)
-  - GTMSessionFetcher/Core (1.2.1)
+  - GTMSessionFetcher/Core (1.2.2)
   - Gutenberg (1.5.1):
     - React/Core (= 0.59.3)
     - React/CxxBridge (= 0.59.3)
@@ -179,7 +179,7 @@ PODS:
   - WordPress-Aztec-iOS (1.6.3)
   - WordPress-Editor-iOS (1.6.3):
     - WordPress-Aztec-iOS (= 1.6.3)
-  - WordPressAuthenticator (1.5.0-beta.4):
+  - WordPressAuthenticator (1.5.0):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (~> 3.5)
@@ -191,18 +191,18 @@ PODS:
     - WordPressKit (~> 4.1.1-beta)
     - WordPressShared (~> 1.8.0-beta)
     - WordPressUI (~> 1.0)
-  - WordPressKit (4.1.1-beta.2):
+  - WordPressKit (4.1.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 1.1.4)
-    - WordPressShared (~> 1.8.0-beta)
+    - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
-  - WordPressShared (1.8.0-beta.1):
+  - WordPressShared (1.8.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
-  - WordPressUI (1.3.0-beta.1)
-  - WPMediaPicker (1.4.1-beta.2)
+  - WordPressUI (1.3.0)
+  - WPMediaPicker (1.4.1)
   - wpxmlrpc (0.8.4)
   - yoga (0.59.3.React)
   - ZendeskSDK (2.3.1):
@@ -251,11 +251,11 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.6.3)
-  - WordPressAuthenticator (~> 1.5.0-beta)
-  - WordPressKit (~> 4.1.1-beta)
-  - WordPressShared (~> 1.8.0-beta)
-  - WordPressUI (~> 1.3.0-beta)
-  - WPMediaPicker (~> 1.4.1-beta)
+  - WordPressAuthenticator (~> 1.5.0)
+  - WordPressKit (~> 4.1.1)
+  - WordPressShared (~> 1.8.0)
+  - WordPressUI (~> 1.3.0)
+  - WPMediaPicker (~> 1.4.1)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.5.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
   - ZendeskSDK (= 2.3.1)
   - ZIPFoundation (~> 0.9.8)
@@ -361,7 +361,7 @@ SPEC CHECKSUMS:
   GoogleSignIn: 7ff245e1a7b26d379099d3243a562f5747e23d39
   GoogleToolboxForMac: b3553629623a3b1bff17f555e736cd5a6d95ad55
   Gridicons: 04261236382e9c62c62c9a104f2f532c1bdf6a78
-  GTMSessionFetcher: 32aeca0aa144acea523e1c8e053089dec2cb98ca
+  GTMSessionFetcher: 61bb0f61a4cb560030f1222021178008a5727a23
   Gutenberg: 9594aa8c1b07acd3e9401d5e7252b6d3cfc32290
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
   lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
@@ -386,16 +386,16 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-Aztec-iOS: 2b33d54cc2dd3f02bc5aad49810f955d0726dd4e
   WordPress-Editor-iOS: b5f2a352dc2b68b1a622ba83bdc716b7e346d556
-  WordPressAuthenticator: 2abd159bf1757f118ddf10e3b5ab5483fb5bf4ea
-  WordPressKit: 18480c8de3ab69ce8e4ad979dbe138b1421cf3f1
-  WordPressShared: c77c0fc4840d5694a1a684f8c541224dfdb147f2
-  WordPressUI: 0370acdee9a3ab8452a99d229b10479855430ee9
-  WPMediaPicker: bc8379006ac60297167e17d92bb466fc0d636ce8
+  WordPressAuthenticator: 958545e13b06d39d064d96b2cfdd92c250fe6ead
+  WordPressKit: 188a1825d2bffdfa5e63bc3da836b0f4281637d9
+  WordPressShared: 619ef07ecc8dfdf284c0105a8f5df201fab59426
+  WordPressUI: f63d7852dea29a3d08a87ec19a3af938215123ba
+  WPMediaPicker: 8cff8dff846f3440c0c6d088c12240ab85570ee5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   yoga: 0cb6e1c4f763ba12d1c825f2d6f863da6614a2a4
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 449ee4e7ea3e871803ee48726b7b5fedbdec0e8d
+PODFILE CHECKSUM: 1dd64c87489d1786220b23362ff38684051fc381
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -236,8 +236,13 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     };
     void (^failureBlock)(NSError *error) = ^(NSError *error) {
         [self.managedObjectContext performBlock:^{
-            Post *postInContext = (Post *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
+            AbstractPost *postInContext = (AbstractPost *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
+                if ([postInContext isRevision]) {
+                    postInContext = postInContext.original;
+                    [postInContext applyRevision];
+                    [postInContext deleteRevision];
+                }
                 postInContext.remoteStatus = AbstractPostRemoteStatusFailed;
                 // If the post was not created on the server yet we convert the post to a local draft post with the current date.
                 if (!postInContext.hasRemote) {


### PR DESCRIPTION
When a post fails to save, it status was set to AbstractPostRemoteStatusFailed which should have
made post.hasNeverAttemptedToUpload return true hence return false in shouldRemovePostOnDismiss in discardChanges().
The problem was that the remoteStatus property was not really being saved. In order to save those change
we are merging the revisions back into the base post

Fixes #11435 

To test:

**upload failed post with no changes**
1. Be offline
2. Create a new draft
3. Save draft (either through options menu or by exiting the editor and choosing "save draft")
4. rerun xcode
5. See the post with "failed upload" status
6. tap on post
7. Exist editor
8. Choose discard
*Expected - post is not be deleted.

**upload failed post with changes**:
1. Follow steps 1-6 above
2. Make changes to post
3. Exit editor
4. Choose discard
Expected - Changes made in step 2 will be discarded and the post is not be deleted.

Before:
![discard_offline_1](https://user-images.githubusercontent.com/1335657/58061601-ae530f80-7b2b-11e9-9902-57494446c176.gif)

After:
![discard_offline](https://user-images.githubusercontent.com/1335657/58061606-b9a63b00-7b2b-11e9-9c0c-e4379fb7c99a.gif)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
