### PR TITLE
Fix discard draft loosing all changes

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -236,8 +236,13 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     };
     void (^failureBlock)(NSError *error) = ^(NSError *error) {
         [self.managedObjectContext performBlock:^{
-            Post *postInContext = (Post *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
+            AbstractPost *postInContext = (AbstractPost *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
+                if ([postInContext isRevision]) {
+                    postInContext = postInContext.original;
+                    [postInContext applyRevision];
+                    [postInContext deleteRevision];
+                }
                 postInContext.remoteStatus = AbstractPostRemoteStatusFailed;
                 // If the post was not created on the server yet we convert the post to a local draft post with the current date.
                 if (!postInContext.hasRemote) {


### PR DESCRIPTION
When a post fails to save, it status was set to `AbstractPostRemoteStatusFailed` which should have
made `post.hasNeverAttemptedToUpload` return true hence return false in `shouldRemovePostOnDismiss` in `discardChanges()`.
https://github.com/wordpress-mobile/WordPress-iOS/blob/d05cb734d50c253e0bf67fc8415dbc90f7089eff/WordPress/Classes/ViewRelated/Post/PostEditor%2BPublish.swift#L239
The problem was that the remoteStatus property was not really being saved. In order to save those changes we are merging the revisions back into the base post.

Fixes #11435

To test:

**upload failed post with no changes**

1.Be offline
2.Create a new draft
3.Save draft (either through options menu or by exiting the editor and choosing "save draft")
4.rerun xcode
5.See the post with "failed upload" status
6.tap on post
7.Exist editor
8.Choose discard
*Expected - post is not be deleted.

**upload failed post with changes:**

1.Follow steps 1-6 above
2.Make changes to post
3.Exit editor
4.Choose discard
Expected - Changes made in step 2 will be discarded and the post is not be deleted.
Before:
![discard_offline_2](https://user-images.githubusercontent.com/1335657/58062639-db092600-7b2f-11e9-93aa-c5fc218bd732.gif)



After:
![discard_offline](https://user-images.githubusercontent.com/1335657/58062181-3afecd00-7b2e-11e9-94be-1635e3aecaf8.gif)


Update release notes:

 If there are user facing changes, I have added an item to RELEASE-NOTES.txt.