### PR TITLE
Site Creation: first responder can now be resigned in the Domain Selection screen.

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TableViewOffsetCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TableViewOffsetCoordinator.swift
@@ -136,6 +136,7 @@ final class TableViewOffsetCoordinator {
 
     @objc
     private func keyboardWillHide(_ notification: Foundation.Notification) {
+        keyboardContentOffset = 0
         toolbarHasBeenAdjusted = false
         toolbarBottomConstraint?.constant = 0
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -4,7 +4,7 @@ import WordPressShared
 
 // MARK: - SearchTextField
 
-private final class SearchTextField: UITextField {
+final class SearchTextField: UITextField {
 
     // MARK: Properties
 
@@ -15,6 +15,14 @@ private final class SearchTextField: UITextField {
         static let clearButtonInset = CGFloat(-9)
         static let searchHeight     = CGFloat(44)
         static let textInset        = CGFloat(56)
+    }
+
+    // MARK: Becoming First Responder
+
+    var allowFirstResponderStatus: Bool = true
+
+    override var canBecomeFirstResponder: Bool {
+        return allowFirstResponderStatus
     }
 
     // MARK: UIView
@@ -108,7 +116,7 @@ final class TitleSubtitleTextfieldHeader: UIView {
         return returnValue
     }()
 
-    private(set) var textField: UITextField = SearchTextField()
+    private(set) var textField = SearchTextField()
 
     private lazy var stackView: UIStackView = {
 


### PR DESCRIPTION
### Description:

This PR addresses the issue reported in #11702 that makes it impossible for the search field in the Domain Selection screen to resign first responder.  It also unifies the search logic a bit.

Fixes #11702 

### Important:

There are more issues when going back and re-opening this screen that can cause the layout to look a bit broken.  From my research those issues are not related to the changes in this PR, and I'm planning to address them incrementally after this fix.

### Testing:

#### Path 1:

1. ...Go through the site creation flow
2. Go to step 3 of 3, and tap on the search field.
4. Go back one step
5. Press "Next"

Make sure the search field doesn't have first responder, and make sure the title and subtitle aren't hidden.