### PR TITLE
Fix broken images in posts created by the share extensions

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * Implemented Domain Credit feature
 * Implemented auto saving a post on preview  
 * The app now launches a bit more quickly.
+* Fixed broken images in posts created by the share extension.
 
 12.4
 -----

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -349,9 +349,11 @@ extension AppExtensionsService {
                     if let remoteMediaID = remoteMedia.mediaID?.int64Value,
                         let remoteMediaURLString = remoteMedia.url?.absoluteString,
                         let localFileName = mediaUploadOp.fileName,
-                        let remoteFileName = remoteMedia.file {
+                        let remoteFileName = remoteMedia.file,
+                        let localFileNoExt = URL(string: localFileName)?.deletingPathExtension().lastPathComponent {
 
-                        if localFileName.lowercased().trim() == remoteFileName.lowercased().trim() {
+                        // sometimes the remote file name has been altered, such as `localfile.jpg` becoming `localfile-1.jpg`
+                        if remoteFileName.lowercased().trim().contains(localFileNoExt.lowercased()) {
                             mediaUploadOp.remoteURL = remoteMediaURLString
                             mediaUploadOp.remoteMediaID = remoteMediaID
                             mediaUploadOp.currentStatus = .complete

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -277,12 +277,10 @@ private extension TypeBasedExtensionContentExtractor {
 
     func saveToSharedContainer(image: UIImage) -> URL? {
         guard let encodedMedia = image.resizeWithMaximumSize(maximumImageSize).JPEGEncoded(),
-            let mediaDirectory = ShareMediaFileManager.shared.mediaUploadDirectoryURL else {
+            let fullPath = tempPath(for: "jpg") else {
                 return nil
         }
 
-        let fileName = "image_\(UUID().uuidString).jpg"
-        let fullPath = mediaDirectory.appendingPathComponent(fileName)
         do {
             try encodedMedia.write(to: fullPath, options: [.atomic])
         } catch {
@@ -293,14 +291,11 @@ private extension TypeBasedExtensionContentExtractor {
     }
 
     func saveToSharedContainer(wrapper: FileWrapper) -> URL? {
-        guard let mediaDirectory = ShareMediaFileManager.shared.mediaUploadDirectoryURL,
-            let wrappedFileName = wrapper.filename?.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-            let wrappedURL = URL(string: wrappedFileName) else {
+        guard let wrappedFileName = wrapper.filename?.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+            let wrappedURL = URL(string: wrappedFileName),
+            let newPath = tempPath(for: wrappedURL.pathExtension) else {
                 return nil
         }
-        let ext = wrappedURL.pathExtension
-        let fileName = "image_\(UUID().uuidString).\(ext)"
-        let newPath = mediaDirectory.appendingPathComponent(fileName)
 
         do {
             try wrapper.write(to: newPath, options: [], originalContentsURL: nil)
@@ -313,12 +308,9 @@ private extension TypeBasedExtensionContentExtractor {
     }
 
     func copyToSharedContainer(url: URL) -> URL? {
-        guard let mediaDirectory = ShareMediaFileManager.shared.mediaUploadDirectoryURL else {
+        guard let newPath = tempPath(for: url.lastPathComponent) else {
             return nil
         }
-        let ext = url.lastPathComponent
-        let fileName = "image_\(UUID().uuidString).\(ext)"
-        let newPath = mediaDirectory.appendingPathComponent(fileName)
 
         do {
             try FileManager.default.copyItem(at: url, to: newPath)
@@ -328,6 +320,15 @@ private extension TypeBasedExtensionContentExtractor {
         }
 
         return newPath
+    }
+
+    private func tempPath(for ext: String) -> URL? {
+        guard let mediaDirectory = ShareMediaFileManager.shared.mediaUploadDirectoryURL else {
+            return nil
+        }
+
+        let fileName = "image_\(UUID().uuidString).\(ext)".lowercased()
+        return mediaDirectory.appendingPathComponent(fileName)
     }
 }
 

--- a/WordPress/WordPressShareExtension/SharedCoreDataStack.swift
+++ b/WordPress/WordPressShareExtension/SharedCoreDataStack.swift
@@ -163,8 +163,12 @@ extension SharedCoreDataStack {
     /// - Returns: MediaUploadOperation or nil
     ///
     func fetchMediaUploadOp(for fileName: String, with sessionID: String) -> MediaUploadOperation? {
+        guard let fileNameWithoutExtension = URL(string: fileName)?.deletingPathExtension().lastPathComponent else {
+            return nil
+        }
+
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: "MediaUploadOperation")
-        request.predicate = NSPredicate(format: "(fileName == %@ AND backgroundSessionIdentifier == %@)", fileName, sessionID)
+        request.predicate = NSPredicate(format: "(fileName BEGINSWITH %@ AND backgroundSessionIdentifier == %@)", fileNameWithoutExtension.lowercased(), sessionID)
         request.fetchLimit = 1
         guard let results = (try? managedContext.fetch(request)) as? [MediaUploadOperation] else {
             return nil


### PR DESCRIPTION
Fixes #9118 
Replaces #11581

This fixes the problems with the share extension creating posts with broken images.

## To test:
- Share two images to the share extension, and publish
- Ensure both images are visible in the post
- Share a TextBundle that includes one or two images (from Bear, likely)
- Ensure the images work there, too

## Discussion

My first attempt to solve this, #11581, changed `AppExtensionsService.swift` to solve the possibility that the server had altered the name of the file, returning a filename that wouldn't match to our local file. However, I had failed to notice that `SharedCoreDataStack.swift` has the same issues, and also lacked the accounting for case changes that `AppExtensionsService` already had.

The app extension uploads images in a background session. It returns in one of two places: in the callback in `AppExtensionsService` if the upload is fast, or in `ShareExtensionSessionManager` via `WordPressAppDelegate` in the main app.

I've identified three reasons for the filename to change:
1. The filename changes case. It seems totally consistent for the server to return the filename as lowercase. When #11500 changed all temporary files created by the app extension to be `UUID`s it basically guaranteed that anytime the task completion was handled by `ShareExtensionSessionManager` the post would have broken images.
2. The extension changes. `PNG`s become `JPG` for example.
3. The server adds a counter to the filename. These seems to happen in some cases where the upload fails and is re-attempted. `myimg.jpg` becomes `myimg-1.jpg`, for example.


## Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.