### PR TITLE
[Stats Refresh] Period Referrers: fix displaying details view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -209,6 +209,24 @@
         }
     }
 
+    // MARK: - Image Size Accessor
+
+    static let defaultImageSize = CGFloat(24)
+
+    var imageSize: CGFloat {
+        switch self {
+        case .insightsPublicize, .periodReferrers:
+            return ImageSizes.socialImage
+        case .insightsCommentsAuthors,
+             .insightsFollowersWordPress,
+             .insightsFollowersEmail,
+             .periodAuthors:
+            return ImageSizes.userImage
+        default:
+            return ImageSizes.defaultImage
+        }
+    }
+
     // MARK: String Structs
 
     struct InsightsHeaders {
@@ -279,4 +297,13 @@
     }
 
     static let noPostTitle = NSLocalizedString("(No Title)", comment: "Empty Post Title")
+
+    // MARK: - Image Sizes
+
+    struct ImageSizes {
+        static let defaultImage = StatSection.defaultImageSize
+        static let socialImage = CGFloat(20)
+        static let userImage = CGFloat(28)
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -257,15 +257,15 @@ private extension SiteStatsPeriodViewModel {
         let referrers = store.getTopReferrers()?.referrers.prefix(10) ?? []
 
         func rowDataFromReferrer(referrer: StatsReferrer) -> StatsTotalRowData {
-            let icon: UIImage?
-            let iconURL: URL?
+            var icon: UIImage? = nil
+            var iconURL: URL? = nil
 
             switch referrer.iconURL?.lastPathComponent {
             case "search-engine.png":
                 icon = Style.imageForGridiconType(.search)
-                iconURL = nil
+            case nil:
+                icon = Style.imageForGridiconType(.globe)
             default:
-                icon = nil
                 iconURL = referrer.iconURL
             }
 
@@ -320,7 +320,6 @@ private extension SiteStatsPeriodViewModel {
 
     func authorsDataRows() -> [StatsTotalRowData] {
         let authors = store.getTopAuthors()?.topAuthors.prefix(10) ?? []
-
 
         return authors.map { StatsTotalRowData(name: $0.name,
                                                data: $0.viewsCount.abbreviatedString(),

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -37,7 +37,7 @@ class DetailDataCell: UITableViewCell, NibLoadable {
         self.detailsDelegate = detailsDelegate
 
         let row = StatsTotalRow.loadFromNib()
-        row.configure(rowData: rowData, delegate: self)
+        row.configure(rowData: rowData, delegate: self, forDetails: true)
 
         bottomExpandedSeparatorLine.isHidden = hideFullSeparator
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -4,7 +4,6 @@ import WordPressFlux
 @objc protocol SiteStatsDetailsDelegate {
     @objc optional func tabbedTotalsCellUpdated()
     @objc optional func displayWebViewWithURL(_ url: URL)
-    @objc optional func expandedRowUpdated(_ row: StatsTotalRow)
     @objc optional func toggleChildRowsForRow(_ row: StatsTotalRow)
     @objc optional func showPostStats(postID: Int, postTitle: String?, postURL: URL?)
     @objc optional func displayMediaWithID(_ mediaID: NSNumber)
@@ -253,11 +252,6 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
         let webViewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
         let navController = UINavigationController.init(rootViewController: webViewController)
         present(navController, animated: true)
-    }
-
-    func expandedRowUpdated(_ row: StatsTotalRow) {
-        applyTableUpdates()
-        StatsDataHelper.updatedExpandedState(forRow: row, inDetails: true)
     }
 
     func toggleChildRowsForRow(_ row: StatsTotalRow) {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -527,15 +527,15 @@ private extension SiteStatsDetailsViewModel {
         let referrers = periodStore.getTopReferrers()?.referrers ?? []
 
         func rowDataFromReferrer(referrer: StatsReferrer) -> StatsTotalRowData {
-            let icon: UIImage?
-            let iconURL: URL?
+            var icon: UIImage? = nil
+            var iconURL: URL? = nil
 
             switch referrer.iconURL?.lastPathComponent {
             case "search-engine.png":
                 icon = Style.imageForGridiconType(.search)
-                iconURL = nil
+            case nil:
+                icon = Style.imageForGridiconType(.globe)
             default:
-                icon = nil
                 iconURL = referrer.iconURL
             }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -378,7 +378,7 @@ private extension SiteStatsDetailsViewModel {
     // MARK: - Tags and Categories
 
     func tagsAndCategoriesRows() -> [ImmuTableRow] {
-        return expandableDataRowsFor(tagsAndCategoriesRowData(), forStat: .insightsTagsAndCategories)
+        return expandableDataRowsFor(tagsAndCategoriesRowData())
     }
 
     func tagsAndCategoriesRowData() -> [StatsTotalRowData] {
@@ -484,7 +484,7 @@ private extension SiteStatsDetailsViewModel {
     // MARK: - Clicks
 
     func clicksRows() -> [ImmuTableRow] {
-        return expandableDataRowsFor(clicksRowData(), forStat: .periodClicks)
+        return expandableDataRowsFor(clicksRowData())
     }
 
     func clicksRowData() -> [StatsTotalRowData] {
@@ -504,7 +504,7 @@ private extension SiteStatsDetailsViewModel {
     // MARK: - Authors
 
     func authorsRows() -> [ImmuTableRow] {
-        return expandableDataRowsFor(authorsRowData(), forStat: .periodAuthors)
+        return expandableDataRowsFor(authorsRowData())
     }
 
     func authorsRowData() -> [StatsTotalRowData] {
@@ -584,8 +584,7 @@ private extension SiteStatsDetailsViewModel {
     // MARK: - Post Stats
 
     func postStatsRows(forAverages: Bool = false) -> [ImmuTableRow] {
-        return expandableDataRowsFor(postStatsRowData(forAverages: forAverages),
-                                     forStat: forAverages ? .postStatsAverageViews : .postStatsMonthsYears)
+        return expandableDataRowsFor(postStatsRowData(forAverages: forAverages))
     }
 
     func postStatsRowData(forAverages: Bool) -> [StatsTotalRowData] {
@@ -637,8 +636,12 @@ private extension SiteStatsDetailsViewModel {
         return detailDataRows
     }
 
-    func expandableDataRowsFor(_ rowsData: [StatsTotalRowData], forStat statSection: StatSection) -> [ImmuTableRow] {
+    func expandableDataRowsFor(_ rowsData: [StatsTotalRowData]) -> [ImmuTableRow] {
         var detailDataRows = [ImmuTableRow]()
+
+        guard let statSection = rowsData.first?.statSection else {
+            return []
+        }
 
         for (idx, rowData) in rowsData.enumerated() {
             let isLastRow = idx == rowsData.endIndex-1

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -139,10 +139,9 @@ class SiteStatsDetailsViewModel: Observable {
                                                       dataSubtitle: StatSection.periodAuthors.dataSubtitle))
             tableRows.append(contentsOf: authorsRows())
         case .periodReferrers:
-            tableRows.append(TopTotalsDetailStatsRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,
-                                                     dataSubtitle: StatSection.periodReferrers.dataSubtitle,
-                                                     dataRows: referrersRows(),
-                                                     siteStatsDetailsDelegate: detailsDelegate))
+            tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,
+                                                      dataSubtitle: StatSection.periodReferrers.dataSubtitle))
+            tableRows.append(contentsOf: referrersRows())
         case .periodCountries:
             tableRows.append(DetailSubtitlesCountriesHeaderRow(itemSubtitle: StatSection.periodCountries.itemSubtitle,
                                                      dataSubtitle: StatSection.periodCountries.dataSubtitle))
@@ -523,7 +522,11 @@ private extension SiteStatsDetailsViewModel {
 
     // MARK: - Referrers
 
-    func referrersRows() -> [StatsTotalRowData] {
+    func referrersRows() -> [ImmuTableRow] {
+        return expandableDataRowsFor(referrersRowData())
+    }
+
+    func referrersRowData() -> [StatsTotalRowData] {
         let referrers = periodStore.getTopReferrers()?.referrers ?? []
 
         func rowDataFromReferrer(referrer: StatsReferrer) -> StatsTotalRowData {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -199,21 +199,21 @@ private extension StatsTotalRow {
             return
         }
 
+        let imageSize = rowData.statSection?.imageSize ?? StatSection.defaultImageSize
+        imageWidthConstraint.constant = imageSize
+
         imageView.isHidden = !hasIcon
 
         if let icon = rowData.icon {
-            imageWidthConstraint.constant = Constants.defaultImageSize
             imageView.image = icon
         }
 
         if let iconURL = rowData.socialIconURL {
-            imageWidthConstraint.constant = Constants.socialImageSize
             downloadImageFrom(iconURL)
         }
 
         if let iconURL = rowData.userIconURL {
-            imageWidthConstraint.constant = Constants.userImageSize
-            imageView.layer.cornerRadius = Constants.userImageSize * 0.5
+            imageView.layer.cornerRadius = imageSize * 0.5
             imageView.clipsToBounds = true
 
             // Use placeholder image until real image is loaded.
@@ -260,9 +260,6 @@ private extension StatsTotalRow {
     }
 
     struct Constants {
-        static let defaultImageSize = CGFloat(24)
-        static let socialImageSize = CGFloat(20)
-        static let userImageSize = CGFloat(28)
         static let disclosureImageUp = CGFloat.pi * 1.5
         static let disclosureImageDown = CGFloat.pi / 2
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -90,6 +90,7 @@ class StatsTotalRow: UIView, NibLoadable {
     private var dataBarMaxTrailing: Float = 0.0
     private typealias Style = WPStyleGuide.Stats
     private weak var delegate: StatsTotalRowDelegate?
+    private var forDetails = false
 
     // This view is modified by the containing cell, to show/hide
     // child rows when a parent row is selected.
@@ -141,9 +142,10 @@ class StatsTotalRow: UIView, NibLoadable {
 
     // MARK: - Configure
 
-    func configure(rowData: StatsTotalRowData, delegate: StatsTotalRowDelegate? = nil) {
+    func configure(rowData: StatsTotalRowData, delegate: StatsTotalRowDelegate? = nil, forDetails: Bool = false) {
         self.rowData = rowData
         self.delegate = delegate
+        self.forDetails = forDetails
 
         configureExpandedState()
         configureIcon()
@@ -183,14 +185,14 @@ private extension StatsTotalRow {
     }
 
     func configureExpandedState() {
-
         guard let name = rowData?.name,
         let statSection = rowData?.statSection else {
             expanded = false
             return
         }
 
-        expanded = StatsDataHelper.expandedRowLabels[statSection]?.contains(name) ?? false
+        let expandedLabels = forDetails ? StatsDataHelper.expandedRowLabelsDetails : StatsDataHelper.expandedRowLabels
+        expanded = expandedLabels[statSection]?.contains(name) ?? false
     }
 
     func configureIcon() {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -309,7 +309,6 @@ extension TopTotalsCell: StatsTotalRowDelegate {
         toggleSeparatorsAroundRow(row)
         siteStatsInsightsDelegate?.expandedRowUpdated?(row)
         siteStatsPeriodDelegate?.expandedRowUpdated?(row)
-        siteStatsDetailsDelegate?.expandedRowUpdated?(row)
         postStatsDelegate?.expandedRowUpdated?(row)
     }
 


### PR DESCRIPTION
Ref #11360, #11080

This changes Period > Referrers to use `UITableViewCell`s instead of one `UIStackView`.

Previously, all the data was stuffed into the stack view on the `TopTotalsCell` card. Now it only uses the `TopTotalsCell` card to show the header via `DetailSubtitlesHeaderRow`. The stack view is left empty. Instead, a `UITableViewCell` is added to the table for each data row via:
- `DetailExpandableRow` - for parent rows
- `DetailExpandableChildRow` - for child rows

And, because Referrers `Search Engines` rows can be expanded twice, "grandchild" rows are now supported.

This also addresses two other issues:
From #11080 - When no icon is available then show `gridicons-globe`.
From https://github.com/wordpress-mobile/WordPress-iOS/pull/11674#issuecomment-491386360 - fix `gridicons-search` icon size.

Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

To test:

---
- Go to Stats > Period > Referrers.
- For any Referrers that don't have an icon, verify the globe icon is displayed.

---
- Select `View more`.
- Verify the data appears relatively quickly.
- For any Referrers that don't have an icon, verify the globe icon is displayed.
- For a _non-expandable_ row, verify row selection shows a web view.

---
- For an expandable row, row selection shows all child rows.
- When a row is expanded:
  - The child label text color is light grey.
  - Child rows have no separator line between them.
  - There is a full width separator line above the parent row, and below the last child.
- Selecting a child row shows a web view.

<img width="400" alt="expanded" src="https://user-images.githubusercontent.com/1816888/58127985-e150de00-7bd3-11e9-8a9e-395412c0c4a0.png">

---
- For the `Search Engines` row: (tip: en.blog has this row)
  - Row selection shows all child rows.
  - If a child row is expandable, it looks like a parent row, i.e. text color is dark grey, and the chevron is pointed down.
  - When a child row is expanded, it exhibits the same behavior has listed above (`For an expandable row...`).

<img width="400" alt="search_engines_init" src="https://user-images.githubusercontent.com/1816888/58128145-30970e80-7bd4-11e9-8137-192e6532b33b.png">


<img width="400" alt="search_engines_expanded" src="https://user-images.githubusercontent.com/1816888/58128048-02b1ca00-7bd4-11e9-9265-f5fdb0da575d.png">



