### PR TITLE
[Stats Refresh] placeholder while loading icon

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -167,6 +167,7 @@ extension WPStyleGuide {
         static let actionTextColor = WPStyleGuide.wordPressBlue()
         static let summaryTextColor = WPStyleGuide.darkGrey()
         static let substringHighlightTextColor = WPStyleGuide.wordPressBlue()
+        static let iconLoadingBackgroundColor = WPStyleGuide.greyLighten20()
 
         static let subTitleFont = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .medium)
         static let summaryFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -211,14 +211,18 @@ private extension StatsTotalRow {
         }
 
         if let iconURL = rowData.socialIconURL {
+            // Show a grey box with rounded corners until image is loaded.
+            imageView.backgroundColor = Style.iconLoadingBackgroundColor
+            imageView.layer.cornerRadius = 4.0
             downloadImageFrom(iconURL)
         }
 
         if let iconURL = rowData.userIconURL {
+            // Show user icon as a circle.
             imageView.layer.cornerRadius = imageSize * 0.5
             imageView.clipsToBounds = true
 
-            // Use placeholder image until real image is loaded.
+            // Use placeholder image until image is loaded.
             imageView.image = Style.gravatarPlaceholderImage()
 
             downloadImageFrom(iconURL)
@@ -255,6 +259,7 @@ private extension StatsTotalRow {
     func downloadImageFrom(_ iconURL: URL) {
         WPImageSource.shared()?.downloadImage(for: iconURL, withSuccess: { image in
             self.imageView.image = image
+            self.imageView.backgroundColor = .clear
         }, failure: { error in
             DDLogInfo("Error downloading image: \(String(describing: error?.localizedDescription)). From URL: \(iconURL).")
             self.imageView.isHidden = true


### PR DESCRIPTION
Fixes #11744

To test:
- On a slow network, go to either Period _Referrers_ or Insights _Publicize_.
  - These are the only two that are downloaded and aren't user icons.
- Until the icon is loaded, verify a grey box is shown.
- Once the icon is loaded, verify the icon appears.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

![loading icon](https://user-images.githubusercontent.com/1816888/58139834-d14bf500-7bf9-11e9-8f26-634817e2ce70.png)