### PR TITLE
[Stats Refresh] empty "simple" stat cards now show `No data yet` label

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/UITableViewCell+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/UITableViewCell+Stats.swift
@@ -19,11 +19,9 @@ extension UITableViewCell {
         let numberOfDataRows = dataRows.count
 
         guard numberOfDataRows > 0 else {
-            if limitRowsDisplayed {
-                let row = StatsNoDataRow.loadFromNib()
-                row.configure(forType: statType)
-                rowsStackView.addArrangedSubview(row)
-            }
+            let row = StatsNoDataRow.loadFromNib()
+            row.configure(forType: statType)
+            rowsStackView.addArrangedSubview(row)
             return
         }
 


### PR DESCRIPTION
Fixes #11746

When I first added support for details views, in `addRows` I added a check for `limitRowsDisplayed` before adding a `StatsNoDataRow` (since details doesn't limit rows). Clearly I didn't realize I broke `SimpleTotalsCell`s, which don't limit rows either. However, since details rows are added differently now, I've simply removed that check.

To test:
- On a site with very little/no data, go to Insights.
- Verify the following stats show `No data yet` instead of just being blank when there is no data.
  - Today's Stats
  - All Time Stats
  - Most Popular Time
  - Total Followers
  - Publicize

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
