### PR TITLE
Keeping image overlay on Action sheet dismissal

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2972,6 +2972,7 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
         if let mediaAttachment = attachment as? MediaAttachment {
             self.resetMediaAttachmentOverlay(mediaAttachment)
             richTextView.refresh(mediaAttachment)
+            processMediaAttachments()
         }
     }
 


### PR DESCRIPTION
When tapping an overlay and dismissing the action sheet by touching the screen out of the image a gesture recognizer is fired which in turn
calls the deselect method from the editor so the attachment gets removed.
I added the method to reprocess the media attachment upon dismissal so in case there is still an error, the attachment will show.

Fixes #11428 

To test:
1. Create new post while offline
2. Select media to upload
3. Tap the media to activate the action sheet
4. Tap outside of the action sheet
5. Return or add characters to the editing space
6. Scroll up and down in the view -- see that the overlay is still displayed 

**Before**

![image_overlay1](https://user-images.githubusercontent.com/1335657/58149116-62c96000-7c16-11e9-9383-4e90cc298fc4.gif)

**After**
![image_overlay](https://user-images.githubusercontent.com/1335657/58149129-71177c00-7c16-11e9-91e8-bac83145839a.gif)



Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
