### PR TITLE
[Stats Refresh] Add missing separator lines

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SimpleTotalsCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -37,7 +37,7 @@
                         </subviews>
                     </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="w2N-OJ-hIR">
-                        <rect key="frame" x="0.0" y="0.0" width="323" height="199.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="323" height="199"/>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cBd-Ut-Uch" userLabel="Top Seperator Line">
                         <rect key="frame" x="0.0" y="0.0" width="323" height="0.5"/>
@@ -58,7 +58,6 @@
                     <constraint firstItem="Tyj-5B-MLc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="04p-Eh-3C7"/>
                     <constraint firstItem="cBd-Ut-Uch" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="3tF-WR-xtY"/>
                     <constraint firstItem="Tyj-5B-MLc" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="7" id="3w8-O5-egA"/>
-                    <constraint firstAttribute="bottom" secondItem="w2N-OJ-hIR" secondAttribute="bottom" id="42h-SA-4TJ"/>
                     <constraint firstItem="w2N-OJ-hIR" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="HgO-4i-Tfs"/>
                     <constraint firstAttribute="trailing" secondItem="w2N-OJ-hIR" secondAttribute="trailing" id="J0K-LT-LLo"/>
                     <constraint firstItem="cBd-Ut-Uch" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="MkM-w2-NRz"/>
@@ -66,6 +65,7 @@
                     <constraint firstAttribute="trailing" secondItem="Tyj-5B-MLc" secondAttribute="trailing" constant="16" id="XOL-9m-28D"/>
                     <constraint firstAttribute="trailing" secondItem="cBd-Ut-Uch" secondAttribute="trailing" id="bwo-8W-tHL"/>
                     <constraint firstAttribute="bottom" secondItem="9px-XX-eCP" secondAttribute="bottom" id="e26-py-r2V"/>
+                    <constraint firstItem="9px-XX-eCP" firstAttribute="top" secondItem="w2N-OJ-hIR" secondAttribute="bottom" id="f44-Bu-iYm"/>
                     <constraint firstItem="w2N-OJ-hIR" firstAttribute="top" secondItem="Tyj-5B-MLc" secondAttribute="bottom" priority="999" constant="7" id="kke-sY-9lr"/>
                     <constraint firstItem="w2N-OJ-hIR" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="olb-Fp-tx9"/>
                     <constraint firstItem="9px-XX-eCP" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="qfo-Hn-1HP"/>

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -32,8 +32,8 @@ class TabbedTotalsCell: UITableViewCell, NibLoadable {
 
     // MARK: - Properties
 
+    @IBOutlet weak var topSeparatorLine: UIView!
     @IBOutlet weak var filterTabBar: FilterTabBar!
-
     @IBOutlet weak var labelsStackView: UIStackView!
     @IBOutlet weak var totalCountView: UIView!
     @IBOutlet weak var totalCountLabel: UILabel!
@@ -157,6 +157,7 @@ private extension TabbedTotalsCell {
     func applyStyles() {
         Style.configureCell(self)
         Style.configureLabelAsTotalCount(totalCountLabel)
+        Style.configureViewAsSeparator(topSeparatorLine)
         Style.configureViewAsSeparator(bottomSeparatorLine)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -87,6 +87,13 @@
                             </view>
                         </subviews>
                     </stackView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PYx-e4-dol" userLabel="Top Seperator Line">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="0.5"/>
+                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.5" id="J73-LT-vIp"/>
+                        </constraints>
+                    </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mrX-mq-7oM" userLabel="Bottom Seperator Line">
                         <rect key="frame" x="0.0" y="198" width="320" height="0.5"/>
                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -98,11 +105,14 @@
                 <constraints>
                     <constraint firstAttribute="bottom" secondItem="BCs-rZ-yvc" secondAttribute="bottom" priority="999" id="2Dz-Yh-HCh"/>
                     <constraint firstAttribute="trailing" secondItem="BCs-rZ-yvc" secondAttribute="trailing" id="8L6-FC-Egf"/>
+                    <constraint firstAttribute="trailing" secondItem="PYx-e4-dol" secondAttribute="trailing" id="EN8-EM-JoT"/>
+                    <constraint firstItem="PYx-e4-dol" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="FBv-xe-jdx"/>
                     <constraint firstAttribute="trailing" secondItem="mrX-mq-7oM" secondAttribute="trailing" id="IWD-do-mFR"/>
                     <constraint firstItem="BCs-rZ-yvc" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="MIS-Ey-ftw"/>
                     <constraint firstItem="BCs-rZ-yvc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="NEM-qd-ExS"/>
                     <constraint firstAttribute="bottom" secondItem="mrX-mq-7oM" secondAttribute="bottom" id="RLO-5A-KjF"/>
                     <constraint firstItem="mrX-mq-7oM" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="Vay-Je-2h0"/>
+                    <constraint firstItem="PYx-e4-dol" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="nph-m1-hrY"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -114,6 +124,7 @@
                 <outlet property="labelsStackView" destination="lNV-f4-WuQ" id="4Gk-Jp-fLW"/>
                 <outlet property="noResultsView" destination="Rq8-nV-ybk" id="h9y-ph-Bba"/>
                 <outlet property="rowsStackView" destination="EG5-87-rU0" id="pEz-Ra-CwP"/>
+                <outlet property="topSeparatorLine" destination="PYx-e4-dol" id="huV-t6-zJX"/>
                 <outlet property="totalCountLabel" destination="6MP-vc-NUk" id="CUM-kV-Ce1"/>
                 <outlet property="totalCountView" destination="rbk-YO-aQi" id="e58-g5-qcx"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
@@ -4,11 +4,12 @@ class CountriesCell: UITableViewCell, NibLoadable {
 
     // MARK: - Properties
 
-    @IBOutlet weak var separatorLine: UIView!
+    @IBOutlet weak var topSeparatorLine: UIView!
     @IBOutlet weak var subtitleStackView: UIStackView!
     @IBOutlet weak var rowsStackView: UIStackView!
     @IBOutlet weak var itemSubtitleLabel: UILabel!
     @IBOutlet weak var dataSubtitleLabel: UILabel!
+    @IBOutlet weak var bottomSeparatorLine: UIView!
 
     // If the subtitles are not shown, this is active.
     @IBOutlet weak var rowsStackViewTopConstraint: NSLayoutConstraint!
@@ -32,11 +33,12 @@ class CountriesCell: UITableViewCell, NibLoadable {
         self.dataRows = dataRows
         self.siteStatsPeriodDelegate = siteStatsPeriodDelegate
         self.forDetails = forDetails
+        bottomSeparatorLine.isHidden = forDetails
 
         // TODO: in xib when add map:
         // - unhide Map View
-        // - Separator Line: enable Top Space to Map View constraint
-        // - Separator Line: remove Top Space to Superview constraint
+        // - Top Separator Line: enable Top Space to Map View constraint
+        // - Top Separator Line: remove Top Space to Superview constraint
 
         if !forDetails {
         addRows(dataRows,
@@ -63,7 +65,8 @@ private extension CountriesCell {
         Style.configureCell(self)
         Style.configureLabelAsSubtitle(itemSubtitleLabel)
         Style.configureLabelAsSubtitle(dataSubtitleLabel)
-        Style.configureViewAsSeparator(separatorLine)
+        Style.configureViewAsSeparator(topSeparatorLine)
+        Style.configureViewAsSeparator(bottomSeparatorLine)
     }
 
     func setSubtitleVisibility() {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.xib
@@ -40,13 +40,6 @@
                             <constraint firstAttribute="trailing" secondItem="OsT-Jn-Nkl" secondAttribute="trailing" id="s9K-TQ-Nze"/>
                         </constraints>
                     </view>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OxT-ul-sgW" userLabel="Seperator Line">
-                        <rect key="frame" x="0.0" y="0.0" width="355" height="0.5"/>
-                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="0.5" id="tep-qB-gA1"/>
-                        </constraints>
-                    </view>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="WGt-7n-PjC" userLabel="Subtitles Stack View">
                         <rect key="frame" x="16" y="7.5" width="323" height="16"/>
                         <subviews>
@@ -70,12 +63,27 @@
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="UCQ-gq-RrN" userLabel="Rows Stack View">
                         <rect key="frame" x="0.0" y="30.5" width="355" height="386"/>
                     </stackView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OxT-ul-sgW" userLabel="Top Seperator Line">
+                        <rect key="frame" x="0.0" y="0.0" width="355" height="0.5"/>
+                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.5" id="tep-qB-gA1"/>
+                        </constraints>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4PI-2u-gGF" userLabel="Bottom Seperator Line">
+                        <rect key="frame" x="0.0" y="416" width="355" height="0.5"/>
+                        <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.5" id="RQD-WP-JN5"/>
+                        </constraints>
+                    </view>
                 </subviews>
                 <constraints>
                     <constraint firstItem="OxT-ul-sgW" firstAttribute="top" secondItem="X6O-ua-Hm7" secondAttribute="bottom" id="05N-cC-wfk"/>
                     <constraint firstItem="X6O-ua-Hm7" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="3j5-bC-lW0"/>
                     <constraint firstItem="WGt-7n-PjC" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="7v5-dC-nT6"/>
                     <constraint firstAttribute="trailing" secondItem="WGt-7n-PjC" secondAttribute="trailing" constant="16" id="F8F-2p-b3J"/>
+                    <constraint firstAttribute="trailing" secondItem="4PI-2u-gGF" secondAttribute="trailing" id="Fby-mi-9AI"/>
                     <constraint firstItem="UCQ-gq-RrN" firstAttribute="top" secondItem="WGt-7n-PjC" secondAttribute="bottom" constant="7" id="ILe-TY-16f"/>
                     <constraint firstItem="OxT-ul-sgW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="IPs-GC-KBm"/>
                     <constraint firstItem="UCQ-gq-RrN" firstAttribute="top" secondItem="OxT-ul-sgW" secondAttribute="bottom" priority="999" id="Usf-7v-7m6"/>
@@ -84,6 +92,8 @@
                     <constraint firstAttribute="trailing" secondItem="UCQ-gq-RrN" secondAttribute="trailing" id="aFU-xt-Aie"/>
                     <constraint firstAttribute="trailing" secondItem="OxT-ul-sgW" secondAttribute="trailing" id="lH1-IY-PBX"/>
                     <constraint firstAttribute="trailing" secondItem="X6O-ua-Hm7" secondAttribute="trailing" id="lQx-hE-jLN"/>
+                    <constraint firstAttribute="bottom" secondItem="4PI-2u-gGF" secondAttribute="bottom" id="mfY-aB-rjX"/>
+                    <constraint firstItem="4PI-2u-gGF" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="pPJ-5q-XT5"/>
                     <constraint firstItem="WGt-7n-PjC" firstAttribute="top" secondItem="OxT-ul-sgW" secondAttribute="bottom" constant="7" id="u2O-MU-b7v"/>
                     <constraint firstItem="X6O-ua-Hm7" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="vew-RU-HMw"/>
                     <constraint firstItem="UCQ-gq-RrN" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="zLz-hS-D9n"/>
@@ -97,13 +107,14 @@
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="bottomSeparatorLine" destination="4PI-2u-gGF" id="sVv-1n-kB5"/>
                 <outlet property="dataSubtitleLabel" destination="2jM-Bl-1PY" id="72z-f9-HCr"/>
                 <outlet property="itemSubtitleLabel" destination="5E0-WK-AUD" id="IUx-oV-aio"/>
                 <outlet property="rowsStackView" destination="UCQ-gq-RrN" id="Y2s-76-aAt"/>
                 <outlet property="rowsStackViewTopConstraint" destination="Usf-7v-7m6" id="Res-MH-gOh"/>
                 <outlet property="rowsStackViewTopConstraintWithSubtitles" destination="ILe-TY-16f" id="sbx-rC-13u"/>
-                <outlet property="separatorLine" destination="OxT-ul-sgW" id="Hp1-EA-174"/>
                 <outlet property="subtitleStackView" destination="WGt-7n-PjC" id="5JN-Yn-YM9"/>
+                <outlet property="topSeparatorLine" destination="OxT-ul-sgW" id="qjZ-f6-e57"/>
             </connections>
             <point key="canvasLocation" x="-263.19999999999999" y="204.64767616191907"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -658,9 +658,11 @@ private extension SiteStatsDetailsViewModel {
         var detailDataRows = [DetailDataRow]()
 
         for (idx, rowData) in rowsData.enumerated() {
+            let isLastRow = idx == rowsData.endIndex-1
             detailDataRows.append(DetailDataRow(rowData: rowData,
                                                 detailsDelegate: detailsDelegate,
-                                                hideSeparator: idx == rowsData.endIndex-1))
+                                                hideIndentedSeparator: isLastRow,
+                                                hideFullSeparator: !isLastRow))
         }
 
         return detailDataRows

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -174,6 +174,7 @@ class SiteStatsDetailsViewModel: Observable {
                                                      dataSubtitle: StatSection.periodCountries.dataSubtitle))
             tableRows.append(contentsOf: countriesRows())
         case .periodPublished:
+            tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: "", dataSubtitle: ""))
             tableRows.append(contentsOf: publishedRows())
         case .postStatsMonthsYears:
             tableRows.append(DetailSubtitlesCountriesHeaderRow(itemSubtitle: StatSection.postStatsMonthsYears.itemSubtitle,

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -423,7 +423,8 @@ struct DetailDataRow: ImmuTableRow {
 
     let rowData: StatsTotalRowData
     weak var detailsDelegate: SiteStatsDetailsDelegate?
-    let hideSeparator: Bool
+    let hideIndentedSeparator: Bool
+    let hideFullSeparator: Bool
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -432,7 +433,10 @@ struct DetailDataRow: ImmuTableRow {
             return
         }
 
-        cell.configure(rowData: rowData, detailsDelegate: detailsDelegate, hideIndentedSeparator: hideSeparator)
+        cell.configure(rowData: rowData,
+                       detailsDelegate: detailsDelegate,
+                       hideIndentedSeparator: hideIndentedSeparator,
+                       hideFullSeparator: hideFullSeparator)
     }
 }
 


### PR DESCRIPTION
Fixes #n/a

This adds some missing separator lines. Specifically:
- Insights _Comments_ and _Followers_ cards - top line on card
- Insights _Publicize_ card - bottom line on card
- Detail views for all non-expandable stats - bottom line on last row
- Insights _Countries_ card - bottom line on card
- Period _Published_ details - top line on first row

cc @SylvesterWilmott - so you know which ones I fixed.

To test:
- Go to the Stats listed above. Verify the lines appear as expected.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
