### PR TITLE
[Stats Refresh] Fix period displayed on date bar

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -80,7 +80,7 @@ class SiteStatsPeriodTableViewController: UITableViewController {
         }
 
         let periodCount = 10
-        cell.configure(date: selectedDate, period: .day, delegate: self, expectedPeriodCount: periodCount)
+        cell.configure(date: selectedDate, period: selectedPeriod, delegate: self, expectedPeriodCount: periodCount)
         viewModel?.statsBarChartViewDelegate = cell
 
         return cell


### PR DESCRIPTION
Fixes #11755

This reinstates the correct period displayed on the date bar. It broke with [this change](https://github.com/wordpress-mobile/WordPress-iOS/commit/f11a8e4c5f664efb34b23d32c0dab0e66dd5f2e0#diff-11eff2d79209874b44eb956bedeb5ecf), which I believe was just a copy/paste error. I've checked out the charts, and they look fine. But please give them a look to be sure.

To test:
- Go to Stats.
- Select Day, Week, Month, Year.
- Verify the period displayed on the date bar once again reflects the period selected.

<img width="350" alt="days" src="https://user-images.githubusercontent.com/1816888/55032427-75d50080-4fd6-11e9-9325-63189c621d12.png">

<img width="350" alt="weeks" src="https://user-images.githubusercontent.com/1816888/55032429-79688780-4fd6-11e9-96c2-33ffe6b56e7a.png">

<img width="350" alt="months" src="https://user-images.githubusercontent.com/1816888/55032443-7cfc0e80-4fd6-11e9-9b7c-9a8314611b5e.png">

<img width="350" alt="years" src="https://user-images.githubusercontent.com/1816888/55032448-808f9580-4fd6-11e9-908d-cb205a1d1e11.png">

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
