### PR TITLE
Implement Stats Refresh analytics events

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,13 +13,14 @@ plugin 'cocoapods-repo-update'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.8.0'
+    #pod 'WordPressShared', '~> 1.8.0'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'
+    # pod 'WordPressShared', :git => 	# 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'
+	pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> 'e2b0b5d'
 end
 
 def aztec

--- a/Podfile
+++ b/Podfile
@@ -20,7 +20,7 @@ def wordpress_shared
 
     ## while PR is in review:
     # pod 'WordPressShared', :git => 	# 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'
-	pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> 'e2b0b5d'
+	pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> 'a903525'
 end
 
 def aztec

--- a/Podfile
+++ b/Podfile
@@ -13,14 +13,14 @@ plugin 'cocoapods-repo-update'
 ##
 def wordpress_shared
     ## for production:
-    #pod 'WordPressShared', '~> 1.8.0'
+    pod 'WordPressShared', '~> 1.8.1-beta'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
     # pod 'WordPressShared', :git => 	# 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/support-swift-5'
-	pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> 'a903525'
+	#pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> 'a903525'
 end
 
 def aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -253,7 +253,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.6.3)
   - WordPressAuthenticator (~> 1.5.0)
   - WordPressKit (~> 4.1.1)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `a903525`)
+  - WordPressShared (~> 1.8.1-beta)
   - WordPressUI (~> 1.3.0)
   - WPMediaPicker (~> 1.4.1)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.5.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -298,6 +298,7 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -325,9 +326,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.5.1
-  WordPressShared:
-    :commit: a903525
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.5.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -344,9 +342,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.5.1
-  WordPressShared:
-    :commit: a903525
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -401,6 +396,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 4928671d2c867a54c232ce2cf44930e424675de3
+PODFILE CHECKSUM: ea018dd99cbb66c03a94cc81ffa01361c2596d5a
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -253,7 +253,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.6.3)
   - WordPressAuthenticator (~> 1.5.0)
   - WordPressKit (~> 4.1.1)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `e2b0b5d`)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `a903525`)
   - WordPressUI (~> 1.3.0)
   - WPMediaPicker (~> 1.4.1)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.5.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -326,7 +326,7 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.5.1
   WordPressShared:
-    :commit: e2b0b5d
+    :commit: a903525
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.5.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
@@ -345,7 +345,7 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.5.1
   WordPressShared:
-    :commit: e2b0b5d
+    :commit: a903525
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 444280d520cb0a5350a8986f1f446a71179d781b
+PODFILE CHECKSUM: 4928671d2c867a54c232ce2cf44930e424675de3
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -198,7 +198,7 @@ PODS:
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
-  - WordPressShared (1.8.0):
+  - WordPressShared (1.8.1-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.3.0)
@@ -253,7 +253,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.6.3)
   - WordPressAuthenticator (~> 1.5.0)
   - WordPressKit (~> 4.1.1)
-  - WordPressShared (~> 1.8.0)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `e2b0b5d`)
   - WordPressUI (~> 1.3.0)
   - WPMediaPicker (~> 1.4.1)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.5.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -298,7 +298,6 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -326,6 +325,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.5.1
+  WordPressShared:
+    :commit: e2b0b5d
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.5.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -342,6 +344,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.5.1
+  WordPressShared:
+    :commit: e2b0b5d
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -388,7 +393,7 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: b5f2a352dc2b68b1a622ba83bdc716b7e346d556
   WordPressAuthenticator: 958545e13b06d39d064d96b2cfdd92c250fe6ead
   WordPressKit: 188a1825d2bffdfa5e63bc3da836b0f4281637d9
-  WordPressShared: 619ef07ecc8dfdf284c0105a8f5df201fab59426
+  WordPressShared: bf57cce7391f67ed3d128f6d733536191e04dcf8
   WordPressUI: f63d7852dea29a3d08a87ec19a3af938215123ba
   WPMediaPicker: 8cff8dff846f3440c0c6d088c12240ab85570ee5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -396,6 +401,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 1dd64c87489d1786220b23362ff38684051fc381
+PODFILE CHECKSUM: 444280d520cb0a5350a8986f1f446a71179d781b
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1618,8 +1618,41 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatStatsInsightsAccessed:
             eventName = @"stats_insights_accessed";
             break;
+        case WPAnalyticsStatStatsItemTappedAuthors:
+            eventName = @"stats_authors_view_post_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedClicks:
+            eventName = @"stats_clicks_item_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedLatestPostSummaryNewPost:
+            eventName = @"stats_latest_post_summary_add_new_post_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedLatestPostSummarySharePost:
+            eventName = @"stats_latest_post_summary_share_post_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedLatestPostSummaryPost:
+            eventName = @"stats_latest_post_summary_post_item_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedLatestPostSummaryViewPostDetails:
+            eventName = @"stats_latest_post_summary_view_post_details_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedPostsAndPages:
+            eventName = @"stats_posts_and_pages_item_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedSearchTerms:
+            eventName = @"stats_search_terms_item_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedTagsAndCategories:
+            eventName = @"stats_tags_and_categories_view_tag_tapped";
+            break;
+        case WPAnalyticsStatStatsItemTappedVideoTapped:
+            eventName = @"stats_video_plays_video_tapped";
+            break;
         case WPAnalyticsStatStatsOverviewBarChartTapped:
             eventName = @"stats_overview_bar_chart_tapped";
+            break;
+        case WPAnalyticsStatStatsOverviewTypeTapped:
+            eventName = @"stats_overview_type_tapped";
             break;
         case WPAnalyticsStatStatsPeriodDaysAccessed:
             eventName = @"stats_period_accessed";
@@ -1648,6 +1681,39 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             break;
         case WPAnalyticsStatStatsViewAllAccessed:
             eventName = @"stats_view_all_accessed";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedAuthors:
+            eventName = @"stats_authors_view_more_tapped";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedClicks:
+            eventName = @"stats_clicks_view_more_tapped";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedComments:
+            eventName = @"stats_comments_view_more_tapped";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedCountries:
+            eventName = @"stats_countries_view_more_tapped";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedFollowers:
+            eventName = @"stats_followers_view_more_tapped";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedPostsAndPages:
+            eventName = @"stats_posts_and_pages_view_more_tapped";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedPublicize:
+            eventName = @"stats_publicize_view_more_tapped";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedReferrers:
+            eventName = @"stats_referrers_view_more_tapped";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedSearchTerms:
+            eventName = @"stats_search_terms_view_more_tapped";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedTagsAndCategories:
+            eventName = @"stats_tags_and_categories_view_more_tapped";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedVideoPlays:
+            eventName = @"stats_video_plays_view_more_tapped";
             break;
         case WPAnalyticsStatStockMediaAccessed:
             eventName = @"stock_media_accessed";

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -207,6 +207,7 @@ private extension LatestPostSummaryCell {
             return
         }
 
+        WPAppAnalytics.track(.statsItemTappedLatestPostSummaryPost)
         siteStatsInsightsDelegate?.displayWebViewWithURL?(postURL)
     }
 
@@ -216,22 +217,27 @@ private extension LatestPostSummaryCell {
             return
         }
 
+        let event: WPAnalyticsStat
         switch actionType {
         case .viewMore:
             guard let postID = lastPostInsight?.postID else {
                 DDLogInfo("No postID available to show Post Stats.")
                 return
             }
+            event = .statsItemTappedLatestPostSummaryViewPostDetails
             siteStatsInsightsDelegate?.showPostStats?(postID: postID, postTitle: postTitle, postURL: lastPostInsight?.url)
         case .sharePost:
             guard let postID = lastPostInsight?.postID else {
                 DDLogInfo("No postID available to share post.")
                 return
             }
+            event = .statsItemTappedLatestPostSummarySharePost
             siteStatsInsightsDelegate?.showShareForPost?(postID: postID as NSNumber, fromView: actionStackView)
         case .createPost:
+            event = .statsItemTappedLatestPostSummaryNewPost
             siteStatsInsightsDelegate?.showCreatePost?()
         }
+        WPAppAnalytics.track(event)
     }
 
     // MARK: - Chart support

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -40,6 +40,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
                            forHeaderFooterViewReuseIdentifier: SiteStatsTableHeaderView.defaultNibName)
         initViewModel()
         displayLoadingViewIfNecessary()
+        trackAccessEvent()
     }
 
     func configure(postID: Int, postTitle: String?, postURL: URL?) {
@@ -89,6 +90,20 @@ private extension PostStatsTableViewController {
 
             self?.refreshTableView()
         }
+    }
+
+    func trackAccessEvent() {
+        var properties = [AnyHashable: Any]()
+
+        if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
+            properties["blog_id"] = blogIdentifier
+        }
+
+        if let postIdentifier = postID {
+            properties["post_id"] = postIdentifier
+        }
+
+        WPAppAnalytics.track(.statsSinglePostAccessed, withProperties: properties)
     }
 
     func tableRowTypes() -> [ImmuTableRow.Type] {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -269,6 +269,10 @@ private extension StatsTotalRow {
 
     @IBAction func didTapDisclosureButton(_ sender: UIButton) {
 
+        if let statSection = rowData?.statSection {
+            captureAnalyticsEventsFor(statSection)
+        }
+
         if let mediaID = rowData?.mediaID {
             delegate?.displayMediaWithID?(mediaID)
             return
@@ -297,4 +301,39 @@ private extension StatsTotalRow {
         DDLogInfo("Stat row selection action not supported.")
     }
 
+    func captureAnalyticsEventsFor(_ statSection: StatSection) {
+        guard let event = statSection.analyticsItemTappedEvent else {
+            return
+        }
+
+        if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
+            WPAppAnalytics.track(event, withBlogID: blogIdentifier)
+        } else {
+            WPAppAnalytics.track(event)
+        }
+    }
+
+}
+
+// MARK: - Analytics support
+
+private extension StatSection {
+    var analyticsItemTappedEvent: WPAnalyticsStat? {
+        switch self {
+        case .periodAuthors, .insightsCommentsAuthors:
+            return .statsItemTappedAuthors
+        case .periodClicks:
+            return .statsItemTappedClicks
+        case .periodPostsAndPages:
+            return .statsItemTappedPostsAndPages
+        case .periodSearchTerms:
+            return .statsItemTappedSearchTerms
+        case .insightsTagsAndCategories:
+            return .statsItemTappedTagsAndCategories
+        case .periodVideos:
+            return .statsItemTappedVideoTapped
+        default:
+            return nil
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
@@ -37,7 +37,57 @@ private extension ViewMoreRow {
             return
         }
 
+        captureAnalyticsEventsFor(statSection)
         delegate?.viewMoreSelectedForStatSection(statSection)
     }
 
+    func captureAnalyticsEventsFor(_ statSection: StatSection) {
+        let legacyEvent: WPAnalyticsStat = .statsViewAllAccessed
+        captureAnalyticsEvent(legacyEvent)
+
+        if let modernEvent = statSection.analyticsViewMoreEvent {
+            captureAnalyticsEvent(modernEvent)
+        }
+    }
+
+    func captureAnalyticsEvent(_ event: WPAnalyticsStat) {
+        if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
+            WPAppAnalytics.track(event, withBlogID: blogIdentifier)
+        } else {
+            WPAppAnalytics.track(event)
+        }
+    }
+}
+
+// MARK: - Analytics support
+
+private extension StatSection {
+    var analyticsViewMoreEvent: WPAnalyticsStat? {
+        switch self {
+        case .periodAuthors, .insightsCommentsAuthors:
+            return .statsViewMoreTappedAuthors
+        case .periodClicks:
+            return .statsViewMoreTappedClicks
+        case .periodOverviewComments:
+            return .statsViewMoreTappedComments
+        case .periodCountries:
+            return .statsViewMoreTappedCountries
+        case .insightsFollowerTotals, .insightsFollowersEmail, .insightsFollowersWordPress:
+            return .statsViewMoreTappedFollowers
+        case .periodPostsAndPages:
+            return .statsViewMoreTappedPostsAndPages
+        case .insightsPublicize:
+            return .statsViewMoreTappedPublicize
+        case .periodReferrers:
+            return .statsViewMoreTappedReferrers
+        case .periodSearchTerms:
+            return .statsViewMoreTappedSearchTerms
+        case .insightsTagsAndCategories:
+            return .statsViewMoreTappedTagsAndCategories
+        case .periodVideos:
+            return .statsViewMoreTappedVideoPlays
+        default:
+            return nil
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -60,6 +60,16 @@ private extension SiteStatsDashboardViewController {
             case .years: return NSLocalizedString("Years", comment: "Title of Years stats filter.")
             }
         }
+
+        var analyticsAccessEvent: WPAnalyticsStat {
+            switch self {
+            case .insights: return .statsInsightsAccessed
+            case .days:     return .statsPeriodDaysAccessed
+            case .weeks:    return .statsPeriodWeeksAccessed
+            case .months:   return .statsPeriodMonthsAccessed
+            case .years:    return .statsPeriodYearsAccessed
+            }
+        }
     }
 
     var currentSelectedPeriod: StatsPeriodType {
@@ -72,6 +82,7 @@ private extension SiteStatsDashboardViewController {
             setContainerViewVisibility()
             updatePeriodView()
             saveSelectedPeriodToUserDefaults()
+            trackAccessEvent()
         }
     }
 
@@ -119,5 +130,20 @@ private extension SiteStatsDashboardViewController {
         periodTableViewController?.selectedDate = Date()
         let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
         periodTableViewController?.selectedPeriod = selectedPeriod
+    }
+}
+
+// MARK: - Tracks Support
+
+private extension SiteStatsDashboardViewController {
+
+    func trackAccessEvent() {
+        let event = currentSelectedPeriod.analyticsAccessEvent
+
+        if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
+            WPAppAnalytics.track(event, withBlogID: blogIdentifier)
+        } else {
+            WPAppAnalytics.track(event)
+        }
     }
 }


### PR DESCRIPTION
### Summary
Fixes #11730.

To test:
- Checkout the branch and confirm that existing tests pass, including those in `WPAnalyticsTrackerAutomatticTracksTests`.
- Review the code changes, and confirm that everything looks square.
- As a user, launch the app on-device or in the Simulator, logged in with _Collect Information_ toggle enabled in _Me : App Settings : Privacy Settings_.
- Step through the Stats functionality, taking note that these events are logged* as expected.

It's probably easiest to validate events in one of the following two ways:
1. The event and properties are logged to the console [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m#L72-L76).
1. You can search for the events in post via _Tracks Live View_. Once the events are captured, be sure they are sent across the wire. This is easiest to accomplish by backgrounding the app, initiated [here](https://github.com/Automattic/Automattic-Tracks-iOS/blob/develop/Automattic-Tracks-iOS/TracksService.m#L269).

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

### Discussion
Absent explicit requirements, it took some time & energy to distill the specific changes that needed to be made. For this reason, I've chosen to chronicle my approach below. Please advise if I missed something!

1. Examined the Android implementation of analytics; the PRs for these changes are noted in the issue.
1. Defined the net new events in `WPAnalytics.h` (see `WordPressShared`).
1. Absorbed these new events in WPiOS, ensuring that `WPAnalytics.m` prescribes `eventName` properties that match the aforementioned Android implementation.
1. Implemented the events below:

#### "Legacy" Events
- `WPAnalyticsStatStatsInsightsAccessed`
- `WPAnalyticsStatStatsPeriodDaysAccessed`
- `WPAnalyticsStatStatsPeriodWeeksAccessed`
- `WPAnalyticsStatStatsPeriodMonthsAccessed`
- `WPAnalyticsStatStatsPeriodYearsAccessed`
- `WPAnalyticsStatStatsScrolledToBottom`
- `WPAnalyticsStatStatsSinglePostAccessed`

#### _Latest Post Summary_ Events
- `WPAnalyticsStatStatsItemTappedLatestPostSummaryNewPost`
- `WPAnalyticsStatStatsItemTappedLatestPostSummaryPost`
- `WPAnalyticsStatStatsItemTappedLatestPostSummarySharePost`
- `WPAnalyticsStatStatsItemTappedLatestPostSummaryViewPostDetails`

#### _View More_ Events
- `WPAnalyticsStatStatsViewAllAccessed` (legacy event)
- `WPAnalyticsStatStatsViewMoreTappedAuthors`
- `WPAnalyticsStatStatsViewMoreTappedClicks`
- `WPAnalyticsStatStatsViewMoreTappedComments`
- `WPAnalyticsStatStatsViewMoreTappedCountries`
- `WPAnalyticsStatStatsViewMoreTappedFollowers`
- `WPAnalyticsStatStatsViewMoreTappedLatestPostSummary`
- `WPAnalyticsStatStatsViewMoreTappedPostsAndPages`
- `WPAnalyticsStatStatsViewMoreTappedPublicize`
- `WPAnalyticsStatStatsViewMoreTappedReferrers`
- `WPAnalyticsStatStatsViewMoreTappedSearchTerms`
- `WPAnalyticsStatStatsViewMoreTappedTagsAndCategories`
- `WPAnalyticsStatStatsViewMoreTappedVideoPlays`

#### Additional Row Selection Events
- `WPAnalyticsStatStatsItemTappedAuthors`
- `WPAnalyticsStatStatsItemTappedClicks`
- `WPAnalyticsStatStatsItemTappedPostsAndPages`
- `WPAnalyticsStatStatsItemTappedSearchTerms`
- `WPAnalyticsStatStatsItemTappedSummaryPost`
- `WPAnalyticsStatStatsItemTappedTagsAndCategories`
- `WPAnalyticsStatStatsItemTappedVideoPlays`

The following events required no changes:
- `WPAnalyticsStatStatsAccessed`, still implemented in `BlogDetailsViewController`.
- `WPAnalyticsStatStatsOverviewBarChartTapped`, implemented [previously](https://github.com/wordpress-mobile/WordPress-iOS/pull/11372).

The following event(s) appear to be obsolete, and can be removed via #10975:
- `WPAnalyticsStatStatsTappedBarChart`