### PR TITLE
Change the fetching of summary data to fetch data for 14 periods at once

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,8 +43,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    #pod 'WordPressKit', '~> 4.1.1'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'bug/allow-specifying-limit-for-summary-queries'
+    pod 'WordPressKit', '~> 4.1-beta'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'bug/allow-specifying-limit-for-summary-queries'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -42,8 +42,8 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.1.1'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    #pod 'WordPressKit', '~> 4.1.1'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'bug/allow-specifying-limit-for-summary-queries'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -252,7 +252,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.6.3)
   - WordPressAuthenticator (~> 1.5.0)
-  - WordPressKit (~> 4.1.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `bug/allow-specifying-limit-for-summary-queries`)
   - WordPressShared (~> 1.8.1-beta)
   - WordPressUI (~> 1.3.0)
   - WPMediaPicker (~> 1.4.1)
@@ -392,7 +392,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 2b33d54cc2dd3f02bc5aad49810f955d0726dd4e
   WordPress-Editor-iOS: b5f2a352dc2b68b1a622ba83bdc716b7e346d556
   WordPressAuthenticator: 958545e13b06d39d064d96b2cfdd92c250fe6ead
-  WordPressKit: 188a1825d2bffdfa5e63bc3da836b0f4281637d9
+  WordPressKit: 841679f76215ec001dc37dca1f0ec71c0aa5a7b7
   WordPressShared: bf57cce7391f67ed3d128f6d733536191e04dcf8
   WordPressUI: f63d7852dea29a3d08a87ec19a3af938215123ba
   WPMediaPicker: 8cff8dff846f3440c0c6d088c12240ab85570ee5
@@ -401,6 +401,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: ea018dd99cbb66c03a94cc81ffa01361c2596d5a
+PODFILE CHECKSUM: ca7f46e9d10789962c072cacde793e5b39f4878d
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -252,7 +252,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.6.3)
   - WordPressAuthenticator (~> 1.5.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `bug/allow-specifying-limit-for-summary-queries`)
+  - WordPressKit (~> 4.1-beta)
   - WordPressShared (~> 1.8.1-beta)
   - WordPressUI (~> 1.3.0)
   - WPMediaPicker (~> 1.4.1)
@@ -297,6 +297,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressShared
     - WordPressUI
     - WPMediaPicker
@@ -325,9 +326,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.5.1
-  WordPressKit:
-    :branch: bug/allow-specifying-limit-for-summary-queries
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.5.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -344,9 +342,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.5.1
-  WordPressKit:
-    :commit: 63e0ad21a4924a37c4b52a54994619bc10a15221
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -401,6 +396,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: ca7f46e9d10789962c072cacde793e5b39f4878d
+PODFILE CHECKSUM: 5e98b2b9d05c0cd7a378a974b3b0dff6e69e63b7
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -191,12 +191,12 @@ PODS:
     - WordPressKit (~> 4.1.1-beta)
     - WordPressShared (~> 1.8.0-beta)
     - WordPressUI (~> 1.0)
-  - WordPressKit (4.1.1):
+  - WordPressKit (4.1.2-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 1.1.4)
-    - WordPressShared (~> 1.8.0)
+    - WordPressShared (~> 1.8.0-beta)
     - wpxmlrpc (= 0.8.4)
   - WordPressShared (1.8.0):
     - CocoaLumberjack (~> 3.4)
@@ -252,7 +252,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.6.3)
   - WordPressAuthenticator (~> 1.5.0)
-  - WordPressKit (~> 4.1.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `bug/allow-specifying-limit-for-summary-queries`)
   - WordPressShared (~> 1.8.0)
   - WordPressUI (~> 1.3.0)
   - WPMediaPicker (~> 1.4.1)
@@ -297,7 +297,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
     - WordPressUI
     - WPMediaPicker
@@ -326,6 +325,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.5.1
+  WordPressKit:
+    :branch: bug/allow-specifying-limit-for-summary-queries
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.5.1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -342,6 +344,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.5.1
+  WordPressKit:
+    :commit: 63e0ad21a4924a37c4b52a54994619bc10a15221
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -387,7 +392,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 2b33d54cc2dd3f02bc5aad49810f955d0726dd4e
   WordPress-Editor-iOS: b5f2a352dc2b68b1a622ba83bdc716b7e346d556
   WordPressAuthenticator: 958545e13b06d39d064d96b2cfdd92c250fe6ead
-  WordPressKit: 188a1825d2bffdfa5e63bc3da836b0f4281637d9
+  WordPressKit: 841679f76215ec001dc37dca1f0ec71c0aa5a7b7
   WordPressShared: 619ef07ecc8dfdf284c0105a8f5df201fab59426
   WordPressUI: f63d7852dea29a3d08a87ec19a3af938215123ba
   WPMediaPicker: 8cff8dff846f3440c0c6d088c12240ab85570ee5
@@ -396,6 +401,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 1dd64c87489d1786220b23362ff38684051fc381
+PODFILE CHECKSUM: e82b53c622013f53fd5d9b77e7dcae15d4fb6f42
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -318,7 +318,7 @@ private extension StatsPeriodStore {
 
         fetchingOverviewListener?(true, false)
 
-        statsRemote.getData(for: period, endingOn: date) { (summary: StatsSummaryTimeIntervalData?, error: Error?) in
+        statsRemote.getData(for: period, endingOn: date, limit: 14) { (summary: StatsSummaryTimeIntervalData?, error: Error?) in
             if error != nil {
                 DDLogInfo("Error fetching summary: \(String(describing: error?.localizedDescription))")
             }


### PR DESCRIPTION
This is the WPiOS counterpoint to https://github.com/wordpress-mobile/WordPressKit-iOS/pull/159 — which was brought up in Slack a while ago.

It also should speed up the performance of fetching Summaries a bit, but a more comprehensive solution is coming soon.