### PR TITLE
Use Environment.current.wordPressComApiBase when initializing WPStatsService

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -131,7 +131,8 @@ struct DefaultContentCoordinator: ContentCoordinator {
         return WPStatsService(siteId: blog.dotComID,
                               siteTimeZone: blogService.timeZone(for: blog),
                               oauth2Token: blog.authToken,
-                              andCacheExpirationInterval: expirationTime)
+                              andCacheExpirationInterval: expirationTime,
+                              apiBaseUrlString: Environment.current.wordPressComApiBase)
     }
 
     private func newStatsViewController() -> StatsViewAllTableViewController {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+Stats.swift
@@ -1,0 +1,11 @@
+import WordPressComStatsiOS
+
+extension BlogDetailsViewController {
+    @objc func statsService(siteId: NSNumber, siteTimeZone: TimeZone, oauth2Token: String, cacheExpirationInterval: TimeInterval) -> WPStatsService {
+        return WPStatsService(siteId: siteId,
+                              siteTimeZone: siteTimeZone,
+                              oauth2Token: oauth2Token,
+                              andCacheExpirationInterval: cacheExpirationInterval,
+                              apiBaseUrlString: Environment.current.wordPressComApiBase)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1197,7 +1197,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     NSString *oauthToken = self.blog.authToken;
 
     if (oauthToken) {
-        self.statsService = [[WPStatsService alloc] initWithSiteId:self.blog.dotComID siteTimeZone:[self.blogService timeZoneForBlog:self.blog] oauth2Token:oauthToken andCacheExpirationInterval:5 * 60];
+        self.statsService = [self statsServiceWithSiteId:self.blog.dotComID siteTimeZone:[self.blogService timeZoneForBlog:self.blog] oauth2Token:oauthToken cacheExpirationInterval:5 * 60];
         [self.statsService retrieveInsightsStatsWithAllTimeStatsCompletionHandler:nil insightsCompletionHandler:nil todaySummaryCompletionHandler:nil latestPostSummaryCompletionHandler:nil commentsAuthorCompletionHandler:nil commentsPostsCompletionHandler:nil tagsCategoriesCompletionHandler:nil followersDotComCompletionHandler:nil followersEmailCompletionHandler:nil publicizeCompletionHandler:nil streakCompletionHandler:nil progressBlock:nil andOverallCompletionHandler:nil];
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -459,7 +459,11 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
         viewController.postID = apost.postID
         viewController.postTitle = apost.titleForDisplay()
-        viewController.statsService = WPStatsService(siteId: blog.dotComID, siteTimeZone: service.timeZone(for: blog), oauth2Token: blog.authToken, andCacheExpirationInterval: type(of: self).statsCacheInterval)
+        viewController.statsService = WPStatsService(siteId: blog.dotComID,
+                                                     siteTimeZone: service.timeZone(for: blog),
+                                                     oauth2Token: blog.authToken,
+                                                     andCacheExpirationInterval: type(of: self).statsCacheInterval,
+                                                     apiBaseUrlString: Environment.current.wordPressComApiBase)
 
         navigationController?.pushViewController(viewController, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
@@ -29,7 +29,8 @@ import WordPressComStatsiOS
         return WPStatsService.init(siteId: siteID,
                                    siteTimeZone: siteTimeZone,
                                    oauth2Token: oauth2Token,
-                                   andCacheExpirationInterval: SiteStatsInformation.cacheExpirationInterval)
+                                   andCacheExpirationInterval: SiteStatsInformation.cacheExpirationInterval,
+                                   apiBaseUrlString: Environment.current.wordPressComApiBase)
     }
 
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		17F7C24922770B68002E5C2E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17F7C24822770B68002E5C2E /* main.swift */; };
 		17FCA6811FD84B4600DBA9C8 /* NoticeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */; };
 		1A433B1D2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */; };
+		1AE0F2AE2296EDD4000BDD7F /* BlogDetailsViewController+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE0F2AD2296EDD4000BDD7F /* BlogDetailsViewController+Stats.swift */; };
 		1D36FCB53C05724865D41F7A /* Pods_WordPress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */; };
@@ -2087,6 +2088,7 @@
 		17F7C24822770B68002E5C2E /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStore.swift; sourceTree = "<group>"; };
 		1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComRestApi+Defaults.swift"; sourceTree = "<group>"; };
+		1AE0F2AD2296EDD4000BDD7F /* BlogDetailsViewController+Stats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+Stats.swift"; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D6058910D05DD3D006BFB54 /* WordPress.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordPress.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2262D835FA89938EBF63EADF /* Pods-WordPressShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
@@ -6889,6 +6891,7 @@
 				02761EBF2270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift */,
 				02AC3091226FFFAA0018D23B /* BlogDetailsViewController+DomainCredit.swift */,
 				02D75D9822793EA2003FF09A /* BlogDetailsSectionFooterView.swift */,
+				1AE0F2AD2296EDD4000BDD7F /* BlogDetailsViewController+Stats.swift */,
 			);
 			path = Blog;
 			sourceTree = "<group>";
@@ -10238,6 +10241,7 @@
 				5D4E30D11AA4B41A000D9904 /* WPStyleGuide+Posts.m in Sources */,
 				5D17530F1A97D2CA0031A082 /* PostCardTableViewCell.m in Sources */,
 				7E4123CA20F4184200DF8486 /* ActivityContentGroup.swift in Sources */,
+				1AE0F2AE2296EDD4000BDD7F /* BlogDetailsViewController+Stats.swift in Sources */,
 				D818FFD72191566B000E5FEE /* VerticalsWizardContent.swift in Sources */,
 				08F8CD2F1EBD29440049D0C0 /* MediaImageExporter.swift in Sources */,
 				912347192213484300BD9F97 /* GutenbergViewController+InformativeDialog.swift in Sources */,

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -142,7 +142,11 @@ extension TodayViewController: NCWidgetProviding {
 
         tracks.trackExtensionAccessed()
 
-        let statsService: WPStatsService = WPStatsService(siteId: siteID, siteTimeZone: timeZone, oauth2Token: oauthToken, andCacheExpirationInterval: 0)
+        let statsService: WPStatsService = WPStatsService(siteId: siteID,
+                                                          siteTimeZone: timeZone,
+                                                          oauth2Token: oauthToken,
+                                                          andCacheExpirationInterval: 0,
+                                                          apiBaseUrlString: WordPressComRestApi.apiBaseURLString)
         statsService.retrieveTodayStats(completionHandler: { wpStatsSummary, error in
             DDLogInfo("Downloaded data in the Today widget")
 

--- a/WordPressComStatsiOS/WordPressComStatsiOS/Services/WPStatsService.h
+++ b/WordPressComStatsiOS/WordPressComStatsiOS/Services/WPStatsService.h
@@ -23,7 +23,8 @@ typedef void (^StatsStreakCompletion)(StatsStreak *streak, NSError *error);
 - (instancetype)initWithSiteId:(NSNumber *)siteId
                   siteTimeZone:(NSTimeZone *)timeZone
                    oauth2Token:(NSString *)oauth2Token
-    andCacheExpirationInterval:(NSTimeInterval)cacheExpirationInterval;
+    andCacheExpirationInterval:(NSTimeInterval)cacheExpirationInterval
+              apiBaseUrlString:(NSString *)apiBaseUrlString;
 
 - (void)retrieveAllStatsForDate:(NSDate *)date
                            unit:(StatsPeriodUnit)unit

--- a/WordPressComStatsiOS/WordPressComStatsiOS/Services/WPStatsService.m
+++ b/WordPressComStatsiOS/WordPressComStatsiOS/Services/WPStatsService.m
@@ -19,6 +19,7 @@ NSString *const TodayCacheKey = @"Today";
 @property (nonatomic, strong) NSNumber *siteId;
 @property (nonatomic, strong) NSString *oauth2Token;
 @property (nonatomic, strong) NSTimeZone *siteTimeZone;
+@property (nonatomic, strong) NSString *apiBaseUrlString;
 @property (nonatomic, strong) StatsEphemory *ephemory;
 @property (nonatomic, strong) StatsDateUtilities *dateUtilities;
 
@@ -39,11 +40,12 @@ NSString *const TodayCacheKey = @"Today";
     return self;
 }
 
-- (instancetype)initWithSiteId:(NSNumber *)siteId siteTimeZone:(NSTimeZone *)timeZone oauth2Token:(NSString *)oauth2Token andCacheExpirationInterval:(NSTimeInterval)cacheExpirationInterval
+- (instancetype)initWithSiteId:(NSNumber *)siteId siteTimeZone:(NSTimeZone *)timeZone oauth2Token:(NSString *)oauth2Token andCacheExpirationInterval:(NSTimeInterval)cacheExpirationInterval apiBaseUrlString:(NSString *)apiBaseUrlString
 {
     NSAssert(oauth2Token.length > 0, @"OAuth2 token must not be empty.");
     NSAssert(siteId != nil, @"Site ID must not be nil.");
     NSAssert(timeZone != nil, @"Timezone must not be nil.");
+    NSAssert(apiBaseUrlString != nil, @"Base Url must not be nil.");
 
     self = [super init];
     if (self) {
@@ -51,6 +53,7 @@ NSString *const TodayCacheKey = @"Today";
         _oauth2Token = oauth2Token;
         _siteTimeZone = timeZone ?: [NSTimeZone localTimeZone];
         _ephemory = [[StatsEphemory alloc] initWithExpiryInterval:cacheExpirationInterval];
+        _apiBaseUrlString = apiBaseUrlString;
     }
 
     return self;
@@ -493,7 +496,10 @@ NSString *const TodayCacheKey = @"Today";
 - (WPStatsServiceRemote *)remote
 {
     if (!_remote) {
-        _remote = [[WPStatsServiceRemote alloc] initWithOAuth2Token:self.oauth2Token siteId:self.siteId andSiteTimeZone:self.siteTimeZone];
+        _remote = [[WPStatsServiceRemote alloc] initWithOAuth2Token:self.oauth2Token
+                                                             siteId:self.siteId
+                                                    andSiteTimeZone:self.siteTimeZone
+                                                      baseUrlString:self.apiBaseUrlString];
     }
 
     return _remote;

--- a/WordPressComStatsiOS/WordPressComStatsiOS/UI/WPStatsViewController.m
+++ b/WordPressComStatsiOS/WordPressComStatsiOS/UI/WPStatsViewController.m
@@ -50,7 +50,7 @@
         self.statsTableViewController = tableVC;
         tableVC.statsDelegate = self.statsDelegate;
         tableVC.statsProgressViewDelegate = self;
-        tableVC.statsService = [[WPStatsService alloc] initWithSiteId:self.siteID siteTimeZone:self.siteTimeZone oauth2Token:self.oauth2Token andCacheExpirationInterval:5 * 60];
+        tableVC.statsService = [[WPStatsService alloc] initWithSiteId:self.siteID siteTimeZone:self.siteTimeZone oauth2Token:self.oauth2Token andCacheExpirationInterval:5 * 60 apiBaseUrlString:[WordPressComRestApi apiBaseURLString]];
     } else if ([segue.identifier isEqualToString:@"InsightsTableEmbed"]) {
         InsightsTableViewController *insightsTableViewController = (InsightsTableViewController *)segue.destinationViewController;
         self.insightsTableViewController = insightsTableViewController;
@@ -63,7 +63,7 @@
         }
         if (insightsTableViewController.statsService == nil)
         {
-            insightsTableViewController.statsService = [[WPStatsService alloc] initWithSiteId:self.siteID siteTimeZone:self.siteTimeZone oauth2Token:self.oauth2Token andCacheExpirationInterval:5 * 60];
+            insightsTableViewController.statsService = [[WPStatsService alloc] initWithSiteId:self.siteID siteTimeZone:self.siteTimeZone oauth2Token:self.oauth2Token andCacheExpirationInterval:5 * 60 apiBaseUrlString:[WordPressComRestApi apiBaseURLString]];
         }
     }
 }

--- a/WordPressComStatsiOS/WordPressComStatsiOSTests/WPStatsServiceTests.m
+++ b/WordPressComStatsiOS/WordPressComStatsiOSTests/WPStatsServiceTests.m
@@ -19,7 +19,7 @@
 - (void)setUp {
     [super setUp];
     
-    self.subject = [[WPStatsService alloc] initWithSiteId:@123456 siteTimeZone:[NSTimeZone localTimeZone] oauth2Token:@"token" andCacheExpirationInterval:50 * 6];
+    self.subject = [[WPStatsService alloc] initWithSiteId:@123456 siteTimeZone:[NSTimeZone localTimeZone] oauth2Token:@"token" andCacheExpirationInterval:50 * 6 apiBaseUrlString:[WordPressComRestApi apiBaseURLString]];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
This extends the changes made in https://github.com/wordpress-mobile/WordPress-iOS/pull/11655 to `WPStatsService`. Once this change is made it will be possible to point the stats service at a different URL. We'll use this for mocking purposes.

To test:

- Smoke test stats to make sure things look as they should.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
