### PR TITLE
[Stats Refresh] correct Posting Activity data

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -292,9 +292,9 @@ private extension StatsInsightsStore {
             self.actionDispatcher.dispatch(InsightAction.receivedTagsAndCategories(tagsAndCategoriesInsight, error))
         }
 
-        api.getInsight { (streak: StatsPostingStreakInsight?, error) in
+        api.getInsight(limit: 5000) { (streak: StatsPostingStreakInsight?, error) in
             if error != nil {
-                DDLogInfo("Error fetching tags and categories insight: \(String(describing: error?.localizedDescription))")
+                DDLogInfo("Error fetching posting activity insight: \(String(describing: error?.localizedDescription))")
             }
 
             self.actionDispatcher.dispatch(InsightAction.receivedPostingActivity(streak, error))


### PR DESCRIPTION
Fixes #11763

So, the `limit` parameter bit us again. An unspecified limit defaults to 10. `limit: 0` doesn't return all. `StatsPostingStreakInsight.queryProperties` uses 5000, so I set the `limit` to 5000. And voila, we have a year's worth of data once again.

To test:
- Go to Stats > Insights > Posting Activity for an active site.
  - Tip: Hogwarts is a good one.
- Select `View more`. 
  - The Insights card and details view use the same data, so verifying details should do it.
- Compare the data with Calypso (https://wordpress.com/stats/insights/<site_url>).


Calypso for Hogwarts:
<img width="742" alt="calypso" src="https://user-images.githubusercontent.com/1816888/58271726-f8194100-7d49-11e9-92b0-fe095d07edb3.png">

Insights card:
<img width="400" alt="insights" src="https://user-images.githubusercontent.com/1816888/58271739-ffd8e580-7d49-11e9-9a54-8726ce1a6dc1.png">

Details:
<img width="450" alt="details" src="https://user-images.githubusercontent.com/1816888/58271753-06675d00-7d4a-11e9-9c2c-c61c15d656be.png">



Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
