### PR TITLE
[Stats Refresh] always display Posting Activity months

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -655,13 +655,6 @@ extension StatsInsightsStore {
     ///
     func getMonthlyPostingActivityFor(date: Date) -> [PostingStreakEvent] {
 
-        guard
-            let postingEvents = state.postingActivity?.postingEvents,
-            postingEvents.count > 0
-            else {
-                return []
-        }
-
         let calendar = Calendar.autoupdatingCurrent
         let components = calendar.dateComponents([.month, .year], from: date)
 
@@ -671,6 +664,8 @@ extension StatsInsightsStore {
             else {
                 return []
         }
+
+        let postingEvents = state.postingActivity?.postingEvents ?? []
 
         // This gives a range of how many days there are in a given month...
         let rangeOfMonth = calendar.range(of: .day, in: .month, for: date) ?? 0..<0


### PR DESCRIPTION
Fixes #11747

For Insights _Posting Activity_, always show the months grids, even if there is no data.

To test:
- On a site with no Posting Activity, go to Insights _Posting Activity_.
- Verify the 3 months appear.
- Select `View more`.
- Verify all months appear.

<img width="350" alt="posting_activity_insights" src="https://user-images.githubusercontent.com/1816888/58273932-f56d1a80-7d4e-11e9-9ac8-59b1829a8d6e.png">

<img width="400" alt="posting_activity_details" src="https://user-images.githubusercontent.com/1816888/58273935-f8680b00-7d4e-11e9-9bdb-9508105ba0ba.png">


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
