### PR TITLE
Restored period bar visibility and set to use default period count

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -79,8 +79,7 @@ class SiteStatsPeriodTableViewController: UITableViewController {
             return nil
         }
 
-        let periodCount = 10
-        cell.configure(date: selectedDate, period: selectedPeriod, delegate: self, expectedPeriodCount: periodCount)
+        cell.configure(date: selectedDate, period: selectedPeriod, delegate: self)
         viewModel?.statsBarChartViewDelegate = cell
 
         return cell

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -8,12 +8,7 @@ class SiteStatsDashboardViewController: UIViewController {
     @IBOutlet weak var insightsContainerView: UIView!
     @IBOutlet weak var statsContainerView: UIView!
 
-    private var insightsTableViewController: SiteStatsInsightsTableViewController? {
-        didSet {
-            prepareTableViewForAnalytics(insightsTableViewController?.tableView)
-        }
-    }
-
+    private var insightsTableViewController: SiteStatsInsightsTableViewController?
     private var periodTableViewController: SiteStatsPeriodTableViewController?
 
     // MARK: - View
@@ -135,7 +130,6 @@ private extension SiteStatsDashboardViewController {
         periodTableViewController?.selectedDate = Date()
         let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
         periodTableViewController?.selectedPeriod = selectedPeriod
-        prepareTableViewForAnalytics(periodTableViewController?.tableView)
     }
 }
 
@@ -151,34 +145,8 @@ private extension SiteStatsDashboardViewController {
         }
     }
 
-    func prepareTableViewForAnalytics(_ tableView: UIScrollView?) {
-        tableView?.delegate = self
-    }
-
     func trackAccessEvent() {
         let event = currentSelectedPeriod.analyticsAccessEvent
         captureAnalyticsEvent(event)
-    }
-
-    func trackScrollToBottomEvent() {
-        captureAnalyticsEvent(.statsScrolledToBottom)
-    }
-}
-
-// MARK: - UIScrollViewDelegate
-
-extension SiteStatsDashboardViewController: UIScrollViewDelegate {
-
-    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
-
-        let targetOffsetY = Int(targetContentOffset.pointee.y)
-
-        let scrollViewContentHeight = scrollView.contentSize.height
-        let visibleScrollViewHeight = scrollView.bounds.height
-        let effectiveScrollViewHeight = Int(scrollViewContentHeight - visibleScrollViewHeight)
-
-        if targetOffsetY >= effectiveScrollViewHeight {
-            trackScrollToBottomEvent()
-        }
     }
 }


### PR DESCRIPTION
This PR addresses two issues:

1. It addresses a regression introduced via #11757, where the period bar was not visible on the Period screens. Regrettably, the implementation of the `UIScrollViewDelegate` to capture the "scroll to bottom" analytics event was hijacking `UITableViewDelegate` (which now conforms to `UIScrollViewDelegate`). Restoring the tracked event will be tackled in a subsequent PR.
1. Now that #11758 has been merged, this PR removes the workaround introduced via #11719 to allow the period bar and chart navigation to remain in sync for a longer horizon (i.e., 14 periods).

To test:
- Checkout the branch & confirm that existing tests pass.
- Navigate to Stats for a given site, and review the Period Charts presented. 
- Observe that navigating with the Period bar updates the chart, as well as the highlighted bar when applicable.
- Rinse & repeat for a couple of different periods, dimensions, device types & orientations, confirming no regressions in behavior or appearance.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

<img width="584" alt="Screen Shot 2019-05-23 at 3 43 50 PM" src="https://user-images.githubusercontent.com/221062/58291403-1d21aa00-7d72-11e9-9974-814ac3a28d9b.png">
