### PR TITLE
 Restored bottom-scroll analytics tracking for Stats screens

### DIFF
--- a/WordPress/Classes/Utility/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable.swift
@@ -235,12 +235,15 @@ public enum ImmuTableCell {
 ///
 open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDelegate {
     @objc unowned let target: UITableViewController
+    private weak var passthroughScrollViewDelegate: UIScrollViewDelegate?
 
     /// Initializes the handler with a target table view controller.
     /// - postcondition: After initialization, it becomse the data source and
     ///   delegate for the the target's table view.
-    @objc public init(takeOver target: UITableViewController) {
+    @objc public init(takeOver target: UITableViewController, with passthroughScrollViewDelegate: UIScrollViewDelegate? = nil) {
         self.target = target
+        self.passthroughScrollViewDelegate = passthroughScrollViewDelegate
+
         super.init()
 
         self.target.tableView.dataSource = self
@@ -259,7 +262,7 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
     /// Configure the handler to automatically deselect any cell after tapping it.
     @objc var automaticallyDeselectCells = false
 
-    // MARK: Table View Data Source
+    // MARK: UITableViewDataSource
 
     open func numberOfSections(in tableView: UITableView) -> Int {
         return viewModel.sections.count
@@ -286,7 +289,7 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
         return viewModel.sections[section].footerText
     }
 
-    // MARK: Table View Delegate
+    // MARK: UITableViewDelegate
 
     open func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         if target.responds(to: #selector(UITableViewDelegate.tableView(_:willSelectRowAt:))) {
@@ -363,6 +366,63 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
         return nil
     }
 
+    // MARK: UIScrollViewDelegate
+
+    open func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        passthroughScrollViewDelegate?.scrollViewDidScroll?(scrollView)
+    }
+
+    open func scrollViewDidZoom(_ scrollView: UIScrollView) {
+        passthroughScrollViewDelegate?.scrollViewDidZoom?(scrollView)
+    }
+
+    open func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        passthroughScrollViewDelegate?.scrollViewWillBeginDragging?(scrollView)
+    }
+
+    open func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        passthroughScrollViewDelegate?.scrollViewWillEndDragging?(scrollView, withVelocity: velocity, targetContentOffset: targetContentOffset)
+    }
+
+    open func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        passthroughScrollViewDelegate?.scrollViewDidEndDragging?(scrollView, willDecelerate: decelerate)
+    }
+
+    open func scrollViewWillBeginDecelerating(_ scrollView: UIScrollView) {
+        passthroughScrollViewDelegate?.scrollViewWillBeginDecelerating?(scrollView)
+    }
+
+    open func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        passthroughScrollViewDelegate?.scrollViewDidEndDecelerating?(scrollView)
+    }
+
+    open func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        passthroughScrollViewDelegate?.scrollViewDidEndScrollingAnimation?(scrollView)
+    }
+
+    open func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+        return passthroughScrollViewDelegate?.viewForZooming?(in: scrollView)
+    }
+
+    open func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
+        passthroughScrollViewDelegate?.scrollViewWillBeginZooming?(scrollView, with: view)
+    }
+
+    open func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
+        passthroughScrollViewDelegate?.scrollViewDidEndZooming?(scrollView, with: view, atScale: scale)
+    }
+
+    open func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
+        return passthroughScrollViewDelegate?.scrollViewShouldScrollToTop?(scrollView) ?? true
+    }
+
+    open func scrollViewDidScrollToTop(_ scrollView: UIScrollView) {
+        passthroughScrollViewDelegate?.scrollViewDidScrollToTop?(scrollView)
+    }
+
+    open func scrollViewDidChangeAdjustedContentInset(_ scrollView: UIScrollView) {
+        passthroughScrollViewDelegate?.scrollViewDidChangeAdjustedContentInset?(scrollView)
+    }
 }
 
 

--- a/WordPress/Classes/Utility/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable.swift
@@ -57,7 +57,7 @@ public struct ImmuTable {
 
     /// This function exists for testing purposes
     /// - seealso: registerRows(_:tableView:)
-    internal static func registerRows(_ rows: [ImmuTableRow.Type], registrator: CellRegistrator) {
+    internal static func registerRows(_ rows: [ImmuTableRow.Type], registrator: CellRegistrar) {
         let registrables = rows.reduce([:]) {
             (classes, row) -> [String: ImmuTableCell] in
 
@@ -373,12 +373,12 @@ public typealias ImmuTableAction = (ImmuTableRow) -> Void
 
 // MARK: - Internal testing helpers
 
-protocol CellRegistrator {
+protocol CellRegistrar {
     func register(_ cell: ImmuTableCell, cellReuseIdentifier: String)
 }
 
 
-extension UITableView: CellRegistrator {
+extension UITableView: CellRegistrar {
     public func register(_ cell: ImmuTableCell, cellReuseIdentifier: String) {
         switch cell {
         case .nib(let nib, _):

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/BottomScrollAnalyticsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/BottomScrollAnalyticsTracker.swift
@@ -1,0 +1,36 @@
+
+import Foundation
+
+// MARK: - BottomScrollAnalyticsTracker
+
+final class BottomScrollAnalyticsTracker: NSObject {
+
+    private func captureAnalyticsEvent(_ event: WPAnalyticsStat) {
+        if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
+            WPAppAnalytics.track(event, withBlogID: blogIdentifier)
+        } else {
+            WPAppAnalytics.track(event)
+        }
+    }
+
+    private func trackScrollToBottomEvent() {
+        captureAnalyticsEvent(.statsScrolledToBottom)
+    }
+}
+
+// MARK: - UIScrollViewDelegate
+
+extension BottomScrollAnalyticsTracker: UIScrollViewDelegate {
+    func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+
+        let targetOffsetY = Int(targetContentOffset.pointee.y)
+
+        let scrollViewContentHeight = scrollView.contentSize.height
+        let visibleScrollViewHeight = scrollView.bounds.height
+        let effectiveScrollViewHeight = Int(scrollViewContentHeight - visibleScrollViewHeight)
+
+        if targetOffsetY >= effectiveScrollViewHeight {
+            trackScrollToBottomEvent()
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -68,8 +68,10 @@ class SiteStatsInsightsTableViewController: UITableViewController {
 
     private var viewModel: SiteStatsInsightsViewModel?
 
+    private let analyticsTracker = BottomScrollAnalyticsTracker()
+
     private lazy var tableHandler: ImmuTableViewHandler = {
-        return ImmuTableViewHandler(takeOver: self)
+        return ImmuTableViewHandler(takeOver: self, with: analyticsTracker)
     }()
 
     // MARK: - View

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -56,8 +56,10 @@ class SiteStatsPeriodTableViewController: UITableViewController {
 
     private var viewModel: SiteStatsPeriodViewModel?
 
+    private let analyticsTracker = BottomScrollAnalyticsTracker()
+
     private lazy var tableHandler: ImmuTableViewHandler = {
-        return ImmuTableViewHandler(takeOver: self)
+        return ImmuTableViewHandler(takeOver: self, with: analyticsTracker)
     }()
 
     // MARK: - View

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -509,6 +509,7 @@
 		7059CD210F332B6500A0660B /* WPCategoryTree.m in Sources */ = {isa = PBXBuildFile; fileRef = 7059CD200F332B6500A0660B /* WPCategoryTree.m */; };
 		730354BA21C867E500CD18C2 /* SiteCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730354B921C867E500CD18C2 /* SiteCreatorTests.swift */; };
 		7305138321C031FC006BD0A1 /* AssembledSiteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7305138221C031FC006BD0A1 /* AssembledSiteView.swift */; };
+		730D290F22976F1A0004BB1E /* BottomScrollAnalyticsTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730D290E22976F1A0004BB1E /* BottomScrollAnalyticsTracker.swift */; };
 		73178C2821BEE09300E37C9A /* SiteCreationDataCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73178C2221BEE09300E37C9A /* SiteCreationDataCoordinatorTests.swift */; };
 		73178C2921BEE09300E37C9A /* SiteSegmentsStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73178C2321BEE09300E37C9A /* SiteSegmentsStepTests.swift */; };
 		73178C2A21BEE09300E37C9A /* SiteSegmentsCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73178C2421BEE09300E37C9A /* SiteSegmentsCellTests.swift */; };
@@ -2489,6 +2490,7 @@
 		712D0A17BC83B9730BD7CCC0 /* Pods-WordPressDraftActionExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressDraftActionExtension.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressDraftActionExtension/Pods-WordPressDraftActionExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		730354B921C867E500CD18C2 /* SiteCreatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreatorTests.swift; sourceTree = "<group>"; };
 		7305138221C031FC006BD0A1 /* AssembledSiteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssembledSiteView.swift; sourceTree = "<group>"; };
+		730D290E22976F1A0004BB1E /* BottomScrollAnalyticsTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomScrollAnalyticsTracker.swift; sourceTree = "<group>"; };
 		73178C2221BEE09300E37C9A /* SiteCreationDataCoordinatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteCreationDataCoordinatorTests.swift; sourceTree = "<group>"; };
 		73178C2321BEE09300E37C9A /* SiteSegmentsStepTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteSegmentsStepTests.swift; sourceTree = "<group>"; };
 		73178C2421BEE09300E37C9A /* SiteSegmentsCellTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteSegmentsCellTests.swift; sourceTree = "<group>"; };
@@ -6554,6 +6556,7 @@
 		98747674219644E40080967F /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				730D290E22976F1A0004BB1E /* BottomScrollAnalyticsTracker.swift */,
 				9874767221963D320080967F /* SiteStatsInformation.swift */,
 				98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */,
 				98CAD295221B4ED1003E8F45 /* StatSection.swift */,
@@ -10708,6 +10711,7 @@
 				E6A338501BB0A70F00371587 /* ReaderGapMarkerCell.swift in Sources */,
 				98BDFF6B20D0732900C72C58 /* SupportTableViewController+Activity.swift in Sources */,
 				82FFBF4D1F434BDA00F4573F /* ThemeIdHelper.swift in Sources */,
+				730D290F22976F1A0004BB1E /* BottomScrollAnalyticsTracker.swift in Sources */,
 				E6311C431ECA017E00122529 /* UserProfile.swift in Sources */,
 				B5CABB171C0E382C0050AB9F /* PickerTableViewCell.swift in Sources */,
 				E13ACCD41EE5672100CCE985 /* PostEditor.swift in Sources */,

--- a/WordPress/WordPressTest/ImmuTableTest.swift
+++ b/WordPress/WordPressTest/ImmuTableTest.swift
@@ -67,7 +67,7 @@ struct TestWithNibImmuTableRow: ImmuTableRow {
     }
 }
 
-class MockTableView: CellRegistrator {
+class MockTableView: CellRegistrar {
     var registeredClasses = [(String, AnyClass)]()
     var registeredNibs = [(String, UINib)]()
     func register(_ cell: ImmuTableCell, cellReuseIdentifier identifier: String) {


### PR DESCRIPTION
Fixes an issue identified in #11769. Namely, the bottom-scroll event analytics tracking was temporarily removed. This PR is based off of that PR branch, and contains three net new commits that restore analytics logging.

To test:
- Check out the branch, confirm that it builds & existing tests pass.
- Review the code changes, and confirm that everything looks okay.
- As a user, launch the app on-device or in the Simulator, logged in with _Collect Information_ toggle enabled in _Me : App Settings : Privacy Settings_.
- Select a site and navigate to _Stats_.
- On both _Insights_ & a _Period_ screen (e.g., Days, Weeks, Months, Years), scroll to the bottom and observe the console.
- You should see a Tracks event logged : `stats_scrolled_to_bottom`.

Update release notes:

- [X] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.