### PR TITLE
Share Extension: Remove the restriction on number of images shared

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 12.6
 -----
+* Removed the limit of number of photos that can be shared from other apps
 
 12.5
 -----

--- a/WordPress/WordPressDraftActionExtension/Info-Alpha.plist
+++ b/WordPress/WordPressDraftActionExtension/Info-Alpha.plist
@@ -45,7 +45,7 @@
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.tiff"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.compuserve.gif"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.bmp"
-                ).@count &lt; 3
+                ).@count &gt;= 1
                 OR
                 SUBQUERY(
                 $extensionItem.attachments,

--- a/WordPress/WordPressDraftActionExtension/Info-Internal.plist
+++ b/WordPress/WordPressDraftActionExtension/Info-Internal.plist
@@ -45,7 +45,7 @@
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.tiff"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.compuserve.gif"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.bmp"
-                ).@count &lt; 3
+                ).@count &gt;= 1
                 OR
                 SUBQUERY(
                 $extensionItem.attachments,

--- a/WordPress/WordPressDraftActionExtension/Info.plist
+++ b/WordPress/WordPressDraftActionExtension/Info.plist
@@ -45,7 +45,7 @@
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO &quot;public.tiff&quot;
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO &quot;com.compuserve.gif&quot;
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO &quot;com.microsoft.bmp&quot;
-                ).@count &lt; 3
+                ).@count &gt;= 1
                 OR
                 SUBQUERY(
                 $extensionItem.attachments,

--- a/WordPress/WordPressShareExtension/Info-Alpha.plist
+++ b/WordPress/WordPressShareExtension/Info-Alpha.plist
@@ -47,7 +47,7 @@
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.tiff"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.compuserve.gif"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.bmp"
-                ).@count &lt; 3
+                ).@count &gt;= 1
                 OR
                 SUBQUERY(
                 $extensionItem.attachments,

--- a/WordPress/WordPressShareExtension/Info-Internal.plist
+++ b/WordPress/WordPressShareExtension/Info-Internal.plist
@@ -47,7 +47,7 @@
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.tiff"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.compuserve.gif"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.bmp"
-                ).@count &lt; 3
+                ).@count &gt;= 1
                 OR
                 SUBQUERY(
                 $extensionItem.attachments,

--- a/WordPress/WordPressShareExtension/Info.plist
+++ b/WordPress/WordPressShareExtension/Info.plist
@@ -45,7 +45,7 @@
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.tiff"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.compuserve.gif"
                 || ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "com.microsoft.bmp"
-                ).@count &lt; 3
+                ).@count &gt;= 1
                 OR
                 SUBQUERY(
                 $extensionItem.attachments,


### PR DESCRIPTION
Refs #9335

Improvements in #11626 and #11740 should now allow a large number of images to be shared without any memory issues or broken image URLs. I made an [example post](https://natesnotesandnovels.wordpress.com/2019/05/20/lots-oimages/) with fifteen images.

To test:
- Build, and share more than three images with the share extension(s)
- Publish
- Ensure the post has all the images

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.