### PR TITLE
[Stats Refresh] Insights Most Popular Time: change icon color to grey

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -242,11 +242,11 @@ private extension SiteStatsInsightsViewModel {
         return [StatsTotalRowData(name: dayString,
                                   data: String(format: MostPopularStats.percentOfViews,
                                                mostPopularStats.mostPopularDayOfWeekPercentage),
-                                  icon: Style.imageForGridiconType(.calendar, withTint: .darkGrey)),
+                                  icon: Style.imageForGridiconType(.calendar)),
                 StatsTotalRowData(name: timeString.replacingOccurrences(of: ":00", with: ""),
                                   data: String(format: MostPopularStats.percentOfViews,
                                                mostPopularStats.mostPopularHourPercentage),
-                                  icon: Style.imageForGridiconType(.time, withTint: .darkGrey))]
+                                  icon: Style.imageForGridiconType(.time))]
     }
 
     func createTotalFollowersRows() -> [StatsTotalRowData] {


### PR DESCRIPTION
Fixes #11792 

To test:
- Go to Insights Most Popular Time.
- Verify the icons color is now grey (matching other gridicons color)

<img width="400" alt="most_popular" src="https://user-images.githubusercontent.com/1816888/58508009-3fd80800-8150-11e9-99cc-dbd508622f20.png">


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
