### PR TITLE
[Stats Refresh] Insights Posting Activity detail: correct layout on rotation

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityViewController.swift
@@ -34,6 +34,11 @@ class PostingActivityViewController: UIViewController, StoryboardLoadable {
         dayDataView.isHidden = true
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        collectionView.collectionViewLayout.invalidateLayout()
+    }
+
 }
 
 // MARK: - UICollectionViewDataSource


### PR DESCRIPTION
Fixes #11796 

To test:

NOTE: The problem didn't happen on every device, but I was able to repro it on the iPhone Xs simulator.

- Go to Insights _Posting Activity_ and select `View more`.
- Rotate the device to landscape and back.
- Verify the months layout properly.

![posting_activity_detail](https://user-images.githubusercontent.com/1816888/58515829-59367f80-8163-11e9-8e16-caf15d771d9b.gif)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
