### PR TITLE
Account Settings Primary Site: show domain if site has no title

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 12.6
 -----
+Account Settings Primary Site now shows the site domain if the site has no name.
 
 12.5
 -----

--- a/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/AccountSettingsViewController.swift
@@ -87,13 +87,17 @@ private class AccountSettingsController: SettingsController {
             action: presenter.push(editEmailAddress(settings, service: service))
         )
 
-        // If the primary site has no name, then show the URL.
-        var primarySiteName = settings.flatMap { service.primarySiteNameForSettings($0) }
-        primarySiteName = (primarySiteName?.isEmpty ?? true) ? settings?.webAddress : primarySiteName
+        var primarySiteName = settings.flatMap { service.primarySiteNameForSettings($0) } ?? ""
+
+        // If the primary site has no Site Title, then show the displayURL.
+        if primarySiteName.isEmpty {
+            let blogService = BlogService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+            primarySiteName = blogService.primaryBlog()?.displayURL as String? ?? ""
+        }
 
         let primarySite = EditableTextRow(
             title: NSLocalizedString("Primary Site", comment: "Primary Web Site"),
-            value: primarySiteName ?? "",
+            value: primarySiteName,
             action: presenter.present(insideNavigationController(editPrimarySite(settings, service: service)))
         )
 


### PR DESCRIPTION
Fixes #11716 (original issue #5884)

This changes the Account Settings > Primary Site to display the domain (instead of the web address) if the site has no title. I checked Calpyso to ensure I got the right one this time, and it does appear to show the domain.

cc @designsimply 

To test:

---
- Go to Account Settings > Primary Site.
- Select a site with no title, or remove the primary site title via Site Settings > Site Title.
- Verify the domain is displayed.

![no_title](https://user-images.githubusercontent.com/1816888/58521141-a8d37600-8178-11e9-8865-872630e92bb4.png)

---
- Go to Account Settings > Primary Site.
- Select a site with a title, or set the primary site title via Site Settings > Site Title.
- Verify the title is displayed.

![with_title](https://user-images.githubusercontent.com/1816888/58521156-b852bf00-8178-11e9-9822-5a27bd745064.png)

---
Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
