### PR TITLE
[Domain Credit] Fix "Register Domain" cell wrongly pre-selected

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -563,21 +563,25 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if (sectionIndex != NSNotFound && self.restorableSelectedIndexPath.section != sectionIndex) {
         BlogDetailsSection *section = [self.tableSections objectAtIndex:sectionIndex];
 
+        NSUInteger row = 0;
+        NSUInteger statsSectionIndex;
+        
         // For QuickStart and Use Domain cases we want to select the first row on the next available section
         switch (section.category) {
             case BlogDetailsSectionCategoryQuickStart:
             case BlogDetailsSectionCategoryDomainCredit: {
                 BlogDetailsSectionCategory category = [self sectionCategoryWithSubsection:BlogDetailsSubsectionStats];
-                NSUInteger statsSectionIndex = [self findSectionIndexWithSections:self.tableSections category:category];
-                self.restorableSelectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:statsSectionIndex];
+                statsSectionIndex = [self findSectionIndexWithSections:self.tableSections category:category];
             }
                 break;
             default: {
-                NSUInteger row = self.restorableSelectedIndexPath.row;
-                self.restorableSelectedIndexPath = [NSIndexPath indexPathForRow:row inSection:sectionIndex];
+                row = self.restorableSelectedIndexPath.row;
+                statsSectionIndex = sectionIndex;
             }
                 break;
         }
+
+        self.restorableSelectedIndexPath = [NSIndexPath indexPathForRow:row inSection:statsSectionIndex];
     }
 
     BOOL isValidIndexPath = self.restorableSelectedIndexPath.section < self.tableView.numberOfSections &&

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -573,9 +573,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                 sectionIndex = [self findSectionIndexWithSections:self.tableSections category:category];
             }
                 break;
-            default: {
+            default:
                 row = self.restorableSelectedIndexPath.row;
-            }
                 break;
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -564,24 +564,22 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         BlogDetailsSection *section = [self.tableSections objectAtIndex:sectionIndex];
 
         NSUInteger row = 0;
-        NSUInteger statsSectionIndex;
         
         // For QuickStart and Use Domain cases we want to select the first row on the next available section
         switch (section.category) {
             case BlogDetailsSectionCategoryQuickStart:
             case BlogDetailsSectionCategoryDomainCredit: {
                 BlogDetailsSectionCategory category = [self sectionCategoryWithSubsection:BlogDetailsSubsectionStats];
-                statsSectionIndex = [self findSectionIndexWithSections:self.tableSections category:category];
+                sectionIndex = [self findSectionIndexWithSections:self.tableSections category:category];
             }
                 break;
             default: {
                 row = self.restorableSelectedIndexPath.row;
-                statsSectionIndex = sectionIndex;
             }
                 break;
         }
 
-        self.restorableSelectedIndexPath = [NSIndexPath indexPathForRow:row inSection:statsSectionIndex];
+        self.restorableSelectedIndexPath = [NSIndexPath indexPathForRow:row inSection:sectionIndex];
     }
 
     BOOL isValidIndexPath = self.restorableSelectedIndexPath.section < self.tableView.numberOfSections &&

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -558,10 +558,26 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     // Check if the last selected category index needs to be updated after a dynamic section is activated and displayed.
     // QuickStart and Use Domain are dynamic section, which means they can be removed or hidden at any time.
-    NSUInteger section = [self findSectionIndexWithSections:self.tableSections category:self.selectedSectionCategory];
-    if (section != NSNotFound && self.restorableSelectedIndexPath.section != section) {
-        NSUInteger row = self.restorableSelectedIndexPath.row;
-        self.restorableSelectedIndexPath = [NSIndexPath indexPathForRow:row inSection:section];
+    NSUInteger sectionIndex = [self findSectionIndexWithSections:self.tableSections category:self.selectedSectionCategory];
+
+    if (sectionIndex != NSNotFound && self.restorableSelectedIndexPath.section != sectionIndex) {
+        BlogDetailsSection *section = [self.tableSections objectAtIndex:sectionIndex];
+
+        // For QuickStart and Use Domain cases we want to select the first row on the next available section
+        switch (section.category) {
+            case BlogDetailsSectionCategoryQuickStart:
+            case BlogDetailsSectionCategoryDomainCredit: {
+                BlogDetailsSectionCategory category = [self sectionCategoryWithSubsection:BlogDetailsSubsectionStats];
+                NSUInteger statsSectionIndex = [self findSectionIndexWithSections:self.tableSections category:category];
+                self.restorableSelectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:statsSectionIndex];
+            }
+                break;
+            default: {
+                NSUInteger row = self.restorableSelectedIndexPath.row;
+                self.restorableSelectedIndexPath = [NSIndexPath indexPathForRow:row inSection:sectionIndex];
+            }
+                break;
+        }
     }
 
     BOOL isValidIndexPath = self.restorableSelectedIndexPath.section < self.tableView.numberOfSections &&


### PR DESCRIPTION
Fixes #11772 

This PR fixes a problem with the iPad and the first section/row selected. Because _Quick Start_ and _Domain Credit_ are dynamic sections, we should never keep selected these rows.

## To test:
This test requires a site with a plan purchased
- Open the _My Sites_ section and select a site with the _Register Domain_ prompt.
- Force-close the app (completely close it, don’t just background it).
- Open the app again and now the _Register Domain_ cell is not selected.
- Tap on _Register Domain_ to to open it

Do the same test with a site with _Quick Start_ enabled

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
