### PR TITLE
[Domain Credit] Remove wp.com constrain

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/DomainCredit/DomainCreditEligibilityChecker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DomainCredit/DomainCreditEligibilityChecker.swift
@@ -1,8 +1,5 @@
 class DomainCreditEligibilityChecker: NSObject {
     @objc static func canRedeemDomainCredit(blog: Blog) -> Bool {
-        let isHostedAtWPCom = blog.isHostedAtWPcom
-        let hasDomainCredit = blog.hasDomainCredit
-        let hasWPComDomain = blog.url?.matches(regex: "wordpress\\.com\\/?$").isEmpty == false
-        return isHostedAtWPCom && hasDomainCredit && hasWPComDomain
+        return blog.isHostedAtWPcom && blog.hasDomainCredit
     }
 }


### PR DESCRIPTION
Fixes #11797

This PR enables the domain credit section for all the sites with a domain credit. The problem was in the `func canRedeemDomainCredit(blog: Blog) -> Bool` where we constrained the feature only for `wordpress.com` domains.

Hey @jklausa would you mind having a look?

## To test:
As @designsimply suggested:
• On the web, setup a new site using a free .blog domain such as `thetimeywimeykindof.family.blog`.
• On the web, add a Blogger Plan for that site.
• From the app, go to My Sites and look for the _Register Domain_ option.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
