### PR TITLE
[Stats Refresh] remove extra space when 'No data' shown

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
@@ -74,7 +74,7 @@ private extension CountriesCell {
             return
         }
 
-        rowsStackViewTopConstraint.constant = dataRows.count > 0 ? subtitleHeight : 0
+        rowsStackViewTopConstraint.constant = !dataRows.isEmpty ? subtitleHeight : 0
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
@@ -10,11 +10,8 @@ class CountriesCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var itemSubtitleLabel: UILabel!
     @IBOutlet weak var dataSubtitleLabel: UILabel!
     @IBOutlet weak var bottomSeparatorLine: UIView!
-
-    // If the subtitles are not shown, this is active.
+    @IBOutlet weak var subtitlesStackViewTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var rowsStackViewTopConstraint: NSLayoutConstraint!
-    // If the subtitles are shown, this is active.
-    @IBOutlet weak var rowsStackViewTopConstraintWithSubtitles: NSLayoutConstraint!
 
     private weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
     private var dataRows = [StatsTotalRowData]()
@@ -70,17 +67,14 @@ private extension CountriesCell {
     }
 
     func setSubtitleVisibility() {
+        let subtitleHeight = subtitlesStackViewTopConstraint.constant * 2 + subtitleStackView.frame.height
 
         if forDetails {
-            subtitleStackView.isHidden = false
-            rowsStackView.isHidden = true
+            rowsStackViewTopConstraint.constant = subtitleHeight
             return
         }
 
-        let showSubtitles = dataRows.count > 0
-        subtitleStackView.isHidden = !showSubtitles
-        rowsStackViewTopConstraint.isActive = !showSubtitles
-        rowsStackViewTopConstraintWithSubtitles.isActive = showSubtitles
+        rowsStackViewTopConstraint.constant = dataRows.count > 0 ? subtitleHeight : 0
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.xib
@@ -61,7 +61,7 @@
                         </constraints>
                     </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="UCQ-gq-RrN" userLabel="Rows Stack View">
-                        <rect key="frame" x="0.0" y="30.5" width="355" height="386"/>
+                        <rect key="frame" x="0.0" y="0.5" width="355" height="416"/>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OxT-ul-sgW" userLabel="Top Seperator Line">
                         <rect key="frame" x="0.0" y="0.0" width="355" height="0.5"/>
@@ -84,9 +84,8 @@
                     <constraint firstItem="WGt-7n-PjC" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="7v5-dC-nT6"/>
                     <constraint firstAttribute="trailing" secondItem="WGt-7n-PjC" secondAttribute="trailing" constant="16" id="F8F-2p-b3J"/>
                     <constraint firstAttribute="trailing" secondItem="4PI-2u-gGF" secondAttribute="trailing" id="Fby-mi-9AI"/>
-                    <constraint firstItem="UCQ-gq-RrN" firstAttribute="top" secondItem="WGt-7n-PjC" secondAttribute="bottom" constant="7" id="ILe-TY-16f"/>
                     <constraint firstItem="OxT-ul-sgW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="IPs-GC-KBm"/>
-                    <constraint firstItem="UCQ-gq-RrN" firstAttribute="top" secondItem="OxT-ul-sgW" secondAttribute="bottom" priority="999" id="Usf-7v-7m6"/>
+                    <constraint firstItem="UCQ-gq-RrN" firstAttribute="top" secondItem="OxT-ul-sgW" secondAttribute="bottom" id="Usf-7v-7m6"/>
                     <constraint firstItem="OxT-ul-sgW" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="V1r-tT-mNL"/>
                     <constraint firstAttribute="bottom" secondItem="UCQ-gq-RrN" secondAttribute="bottom" id="WJD-J4-Jab"/>
                     <constraint firstAttribute="trailing" secondItem="UCQ-gq-RrN" secondAttribute="trailing" id="aFU-xt-Aie"/>
@@ -101,7 +100,6 @@
                 <variation key="default">
                     <mask key="constraints">
                         <exclude reference="05N-cC-wfk"/>
-                        <exclude reference="Usf-7v-7m6"/>
                     </mask>
                 </variation>
             </tableViewCellContentView>
@@ -112,8 +110,8 @@
                 <outlet property="itemSubtitleLabel" destination="5E0-WK-AUD" id="IUx-oV-aio"/>
                 <outlet property="rowsStackView" destination="UCQ-gq-RrN" id="Y2s-76-aAt"/>
                 <outlet property="rowsStackViewTopConstraint" destination="Usf-7v-7m6" id="Res-MH-gOh"/>
-                <outlet property="rowsStackViewTopConstraintWithSubtitles" destination="ILe-TY-16f" id="sbx-rC-13u"/>
                 <outlet property="subtitleStackView" destination="WGt-7n-PjC" id="5JN-Yn-YM9"/>
+                <outlet property="subtitlesStackViewTopConstraint" destination="u2O-MU-b7v" id="ya9-A4-B6Y"/>
                 <outlet property="topSeparatorLine" destination="OxT-ul-sgW" id="qjZ-f6-e57"/>
             </connections>
             <point key="canvasLocation" x="-263.19999999999999" y="204.64767616191907"/>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -15,12 +15,8 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var rowsStackView: UIStackView!
     @IBOutlet weak var itemSubtitleLabel: UILabel!
     @IBOutlet weak var dataSubtitleLabel: UILabel!
-
-    // If the subtitles are not shown, this is active.
+    @IBOutlet weak var subtitlesStackViewTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var rowsStackViewTopConstraint: NSLayoutConstraint!
-    // If the subtitles are shown, this is active.
-    @IBOutlet weak var rowsStackViewTopConstraintWithSubtitles: NSLayoutConstraint!
-
     @IBOutlet weak var topSeparatorLine: UIView!
     @IBOutlet weak var bottomSeparatorLine: UIView!
 
@@ -111,18 +107,16 @@ private extension TopTotalsCell {
     /// - Hide the stack view.
     ///
     func setSubtitleVisibility() {
+        let subtitleHeight = subtitlesStackViewTopConstraint.constant * 2 + subtitleStackView.frame.height
 
         if forDetails {
-            subtitleStackView.isHidden = !subtitlesProvided
-            rowsStackView.isHidden = true
             bottomSeparatorLine.isHidden = true
+            rowsStackViewTopConstraint.constant = subtitlesProvided ? subtitleHeight : 0
             return
         }
 
         let showSubtitles = dataRows.count > 0 && subtitlesProvided
-        subtitleStackView.isHidden = !showSubtitles
-        rowsStackViewTopConstraint.isActive = !showSubtitles
-        rowsStackViewTopConstraintWithSubtitles.isActive = showSubtitles
+        rowsStackViewTopConstraint.constant = showSubtitles ? subtitleHeight : 0
     }
 
     // MARK: - Child Row Handling

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -115,7 +115,7 @@ private extension TopTotalsCell {
             return
         }
 
-        let showSubtitles = dataRows.count > 0 && subtitlesProvided
+        let showSubtitles = !dataRows.isEmpty && subtitlesProvided
         rowsStackViewTopConstraint.constant = showSubtitles ? subtitleHeight : 0
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -40,7 +40,7 @@
                         </constraints>
                     </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="w2N-OJ-hIR">
-                        <rect key="frame" x="0.0" y="30" width="323" height="169.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="323" height="199.5"/>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cBd-Ut-Uch" userLabel="Top Seperator Line">
                         <rect key="frame" x="0.0" y="0.0" width="323" height="0.5"/>
@@ -62,7 +62,6 @@
                     <constraint firstItem="cBd-Ut-Uch" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="3tF-WR-xtY"/>
                     <constraint firstItem="Tyj-5B-MLc" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="7" id="3w8-O5-egA"/>
                     <constraint firstAttribute="bottom" secondItem="w2N-OJ-hIR" secondAttribute="bottom" id="42h-SA-4TJ"/>
-                    <constraint firstItem="w2N-OJ-hIR" firstAttribute="top" secondItem="Tyj-5B-MLc" secondAttribute="bottom" constant="7" id="EHT-9C-hjv"/>
                     <constraint firstItem="w2N-OJ-hIR" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="HgO-4i-Tfs"/>
                     <constraint firstAttribute="trailing" secondItem="w2N-OJ-hIR" secondAttribute="trailing" id="J0K-LT-LLo"/>
                     <constraint firstItem="cBd-Ut-Uch" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="MkM-w2-NRz"/>
@@ -71,13 +70,8 @@
                     <constraint firstAttribute="trailing" secondItem="cBd-Ut-Uch" secondAttribute="trailing" id="bwo-8W-tHL"/>
                     <constraint firstAttribute="bottom" secondItem="9px-XX-eCP" secondAttribute="bottom" id="e26-py-r2V"/>
                     <constraint firstItem="9px-XX-eCP" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="qfo-Hn-1HP"/>
-                    <constraint firstItem="w2N-OJ-hIR" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" priority="999" id="sza-97-qoA"/>
+                    <constraint firstItem="w2N-OJ-hIR" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="sza-97-qoA"/>
                 </constraints>
-                <variation key="default">
-                    <mask key="constraints">
-                        <exclude reference="sza-97-qoA"/>
-                    </mask>
-                </variation>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
@@ -86,8 +80,8 @@
                 <outlet property="itemSubtitleLabel" destination="vbE-CG-voj" id="eZl-wI-KfG"/>
                 <outlet property="rowsStackView" destination="w2N-OJ-hIR" id="5DU-xj-fcC"/>
                 <outlet property="rowsStackViewTopConstraint" destination="sza-97-qoA" id="s2p-EA-TTR"/>
-                <outlet property="rowsStackViewTopConstraintWithSubtitles" destination="EHT-9C-hjv" id="XOV-Qp-fub"/>
                 <outlet property="subtitleStackView" destination="Tyj-5B-MLc" id="Ddg-AW-G7w"/>
+                <outlet property="subtitlesStackViewTopConstraint" destination="3w8-O5-egA" id="Qsd-dr-iv9"/>
                 <outlet property="topSeparatorLine" destination="cBd-Ut-Uch" id="C1i-Zd-yPU"/>
             </connections>
             <point key="canvasLocation" x="55.200000000000003" y="17.991004497751124"/>


### PR DESCRIPTION
Fixes #11798

The problem stemmed from toggling two top constraints on the row stack view depending on if the subtitles are shown or not. This wasn't working very well when the cells were reused. Now there is only one top constraint, and is modified per subtitle visibility.

To test:

---
- On a site with no data, go to Stats.
- On Insights and Periods, verify when `No data...` is displayed there is no longer extra space above the label. Example:

<img width="400" alt="example" src="https://user-images.githubusercontent.com/1816888/58591840-6d8e8100-8224-11e9-97f0-d589c8bd5c22.png">

---
- Switch to a site with data, and go to Stats.
- For that stats that previously showed `No data...` verify the subtitles are shown correctly. Example:

<img width="400" alt="no_data" src="https://user-images.githubusercontent.com/1816888/58591782-48017780-8224-11e9-859c-dbc82d413375.png">

<img width="400" alt="data" src="https://user-images.githubusercontent.com/1816888/58591791-4f288580-8224-11e9-8737-7215879b2fa0.png">


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
