### PR TITLE
Theme options picker: align with button

### DIFF
--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
@@ -225,17 +225,18 @@ open class ThemeBrowserCell: UICollectionViewCell {
             })
         }
 
+        let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel action title")
+        alertController.addCancelActionWithTitle(cancelTitle, handler: nil)
+
         alertController.modalPresentationStyle = .popover
+        alertController.presentFromRootViewController()
+
         if let popover = alertController.popoverPresentationController {
             popover.sourceView = actionButton
             popover.sourceRect = actionButton.bounds
             popover.permittedArrowDirections = .any
             popover.canOverlapSourceViewRect = true
-        } else {
-            let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel action title")
-            alertController.addCancelActionWithTitle(cancelTitle, handler: nil)
         }
-        alertController.presentFromRootViewController()
     }
 
 }


### PR DESCRIPTION
Fixes #11721

To test:
- Run the app on an iPad.
- Go to Themes.
- Tap the `...` button on a theme.
- Verify the menu appears aligned with the button tapped.
- Verify it works in both landscape and portrait.

![portrait](https://user-images.githubusercontent.com/1816888/58597207-24dec400-8234-11e9-8d2f-e78a19d765de.png)

![landscape](https://user-images.githubusercontent.com/1816888/58597213-28724b00-8234-11e9-862e-4c89a9e46582.png)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
