### PR TITLE
Updated reply and edit comment messaging experience

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 * Account Settings Primary Site now shows the site domain if the site has no name.
 * The app now launches a bit more quickly.
 * Added a list of third-party library acknowledgements.
-* Updated messaging experience for a reply failure and a comment edit failure.
+* Updated messaging experience for a reply upload result.
 
 12.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * Account Settings Primary Site now shows the site domain if the site has no name.
 * The app now launches a bit more quickly.
 * Added a list of third-party library acknowledgements.
+* Updated messaging experience for a reply failure and a comment edit failure.
 
 12.5
 -----

--- a/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
@@ -53,3 +53,13 @@ extension UIAlertController {
         copyAlertController?.presentFromRootViewController()
     }
 }
+
+@objc extension UIAlertController {
+    static func presentNotice(title: String) {
+        ActionDispatcher.dispatch(NoticeAction.post(Notice(title: title)))
+    }
+    
+    static func dismissNotice() {
+        ActionDispatcher.dispatch(NoticeAction.dismiss)
+    }
+}

--- a/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
@@ -53,13 +53,3 @@ extension UIAlertController {
         copyAlertController?.presentFromRootViewController()
     }
 }
-
-@objc extension UIAlertController {
-    static func presentNotice(title: String) {
-        ActionDispatcher.dispatch(NoticeAction.post(Notice(title: title)))
-    }
-
-    static func dismissNotice() {
-        ActionDispatcher.dispatch(NoticeAction.dismiss)
-    }
-}

--- a/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIAlertController+Helpers.swift
@@ -58,7 +58,7 @@ extension UIAlertController {
     static func presentNotice(title: String) {
         ActionDispatcher.dispatch(NoticeAction.post(Notice(title: title)))
     }
-    
+
     static func dismissNotice() {
         ActionDispatcher.dispatch(NoticeAction.dismiss)
     }

--- a/WordPress/Classes/Extensions/UIViewController+Notice.swift
+++ b/WordPress/Classes/Extensions/UIViewController+Notice.swift
@@ -33,3 +33,15 @@ extension UIViewController {
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 }
+
+@objc extension UIViewController {
+    
+    @objc func displayNotice(title: String, message: String? = nil) {
+        let notice = Notice(title: title, message: message)
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
+    }
+    
+    @objc func dismissNotice() {
+        ActionDispatcher.dispatch(NoticeAction.dismiss)
+    }
+}

--- a/WordPress/Classes/Extensions/UIViewController+Notice.swift
+++ b/WordPress/Classes/Extensions/UIViewController+Notice.swift
@@ -35,12 +35,11 @@ extension UIViewController {
 }
 
 @objc extension UIViewController {
-    
     @objc func displayNotice(title: String, message: String? = nil) {
         let notice = Notice(title: title, message: message)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
-    
+
     @objc func dismissNotice() {
         ActionDispatcher.dispatch(NoticeAction.dismiss)
     }

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -598,7 +598,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
                               NSString *message = NSLocalizedString(@"There has been an unexpected error while editing your comment",
                                                                     @"Error displayed if a comment fails to get updated");
                               
-                               [ReachabilityUtils showNoInternetConnectionNoticeWithMessage:message];
+                              [weakSelf displayNoticeWithTitle:message message:nil];
                           }];
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -197,7 +197,6 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     [super viewWillDisappear:animated];
 
     [self.keyboardManager stopListeningToKeyboardNotifications];
-    [UIAlertController dismissNotice];
 }
 
 #pragma mark - Fetching Post
@@ -597,8 +596,26 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
                           } failure:^(NSError *error) {
                               NSString *message = NSLocalizedString(@"There has been an unexpected error while editing your comment",
                                                                     @"Error displayed if a comment fails to get updated");
-                              [UIAlertController presentNoticeWithTitle:message];
                               
+                              UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil
+                                                                                                       message:message
+                                                                                                preferredStyle:UIAlertControllerStyleAlert];
+                              
+                              UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Verb, Cancel an action")
+                                                                                     style:UIAlertActionStyleCancel
+                                                                                   handler:^(UIAlertAction *action){
+                                                                                       [weakSelf.comment.managedObjectContext refreshObject:weakSelf.comment mergeChanges:false];
+                                                                                       [weakSelf reloadData];
+                                                                                   }];
+                              
+                              UIAlertAction *retryAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Try Again", @"Retry an action that failed")
+                                                                                    style:UIAlertActionStyleDestructive
+                                                                                  handler:^(UIAlertAction *action){
+                                                                                      [weakSelf updateCommentForNewContent:content];
+                                                                                  }];
+                              [alertController addAction:cancelAction];
+                              [alertController addAction:retryAction];
+                              [weakSelf presentViewController:alertController animated:YES completion:nil];
                           }];
 }
 
@@ -617,13 +634,44 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 {
     NSString *successMessage = NSLocalizedString(@"Reply Sent!", @"The app successfully sent a comment");
     
+    __typeof(self) __weak weakSelf = self;
+    
     void (^successBlock)(void) = ^void() {
         [SVProgressHUD showDismissibleSuccessWithStatus:successMessage];
     };
     
     void (^failureBlock)(NSError *error) = ^void(NSError *error) {
-        NSString *message = NSLocalizedString(@"There has been an unexpected error while sending your reply", nil);
-        [UIAlertController presentNoticeWithTitle:message];
+        NSUInteger lastIndex = content.length == 0 ? 0 : content.length - 1;
+        NSUInteger composedCharacterIndex = NSMaxRange([content rangeOfComposedCharacterSequenceAtIndex:MIN(lastIndex, 140)]);
+        // 140 is a somewhat arbitraily chosen number (old tweet length) — should be enough to let people know what
+        // comment failed to show, but not too long to display.
+
+        NSString *replyExcerpt = [content substringToIndex:composedCharacterIndex];
+
+        NSString *message = [NSString stringWithFormat:NSLocalizedString(@"There has been an unexpected error while sending your reply: \n\"%@\"", nil), replyExcerpt];
+        if (composedCharacterIndex < lastIndex) {
+            NSMutableString *mutString = message.mutableCopy;
+            [mutString insertString:@"…" atIndex:(message.length - 2)];
+
+            message = mutString.copy;
+        }
+        
+        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil
+                                                                                 message:message
+                                                                          preferredStyle:UIAlertControllerStyleAlert];
+        
+        UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Verb, Cancel an action")
+                                                               style:UIAlertActionStyleCancel
+                                                             handler:^(UIAlertAction *action){}];
+        
+        UIAlertAction *retryAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Try Again", @"Retry an action that failed")
+                                                              style:UIAlertActionStyleDestructive
+                                                            handler:^(UIAlertAction *action){
+                                                                [weakSelf sendReplyWithNewContent:content];
+                                                            }];
+        [alertController addAction:cancelAction];
+        [alertController addAction:retryAction];
+        [weakSelf presentViewController:alertController animated:YES completion:nil];
     };
     
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -598,6 +598,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
                               NSString *message = NSLocalizedString(@"There has been an unexpected error while editing your comment",
                                                                     @"Error displayed if a comment fails to get updated");
                               [UIAlertController presentNoticeWithTitle:message];
+                              
                           }];
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -197,6 +197,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     [super viewWillDisappear:animated];
 
     [self.keyboardManager stopListeningToKeyboardNotifications];
+    [UIAlertController dismissNotice];
 }
 
 #pragma mark - Fetching Post
@@ -596,26 +597,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
                           } failure:^(NSError *error) {
                               NSString *message = NSLocalizedString(@"There has been an unexpected error while editing your comment",
                                                                     @"Error displayed if a comment fails to get updated");
-                              
-                              UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil
-                                                                                                       message:message
-                                                                                                preferredStyle:UIAlertControllerStyleAlert];
-                              
-                              UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Verb, Cancel an action")
-                                                                                     style:UIAlertActionStyleCancel
-                                                                                   handler:^(UIAlertAction *action){
-                                                                                       [weakSelf.comment.managedObjectContext refreshObject:weakSelf.comment mergeChanges:false];
-                                                                                       [weakSelf reloadData];
-                                                                                   }];
-                              
-                              UIAlertAction *retryAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Try Again", @"Retry an action that failed")
-                                                                                    style:UIAlertActionStyleDestructive
-                                                                                  handler:^(UIAlertAction *action){
-                                                                                      [weakSelf updateCommentForNewContent:content];
-                                                                                  }];
-                              [alertController addAction:cancelAction];
-                              [alertController addAction:retryAction];
-                              [weakSelf presentViewController:alertController animated:YES completion:nil];
+                              [UIAlertController presentNoticeWithTitle:message];
                           }];
 }
 
@@ -634,44 +616,13 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 {
     NSString *successMessage = NSLocalizedString(@"Reply Sent!", @"The app successfully sent a comment");
     
-    __typeof(self) __weak weakSelf = self;
-    
     void (^successBlock)(void) = ^void() {
         [SVProgressHUD showDismissibleSuccessWithStatus:successMessage];
     };
     
     void (^failureBlock)(NSError *error) = ^void(NSError *error) {
-        NSUInteger lastIndex = content.length == 0 ? 0 : content.length - 1;
-        NSUInteger composedCharacterIndex = NSMaxRange([content rangeOfComposedCharacterSequenceAtIndex:MIN(lastIndex, 140)]);
-        // 140 is a somewhat arbitraily chosen number (old tweet length) — should be enough to let people know what
-        // comment failed to show, but not too long to display.
-
-        NSString *replyExcerpt = [content substringToIndex:composedCharacterIndex];
-
-        NSString *message = [NSString stringWithFormat:NSLocalizedString(@"There has been an unexpected error while sending your reply: \n\"%@\"", nil), replyExcerpt];
-        if (composedCharacterIndex < lastIndex) {
-            NSMutableString *mutString = message.mutableCopy;
-            [mutString insertString:@"…" atIndex:(message.length - 2)];
-
-            message = mutString.copy;
-        }
-        
-        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil
-                                                                                 message:message
-                                                                          preferredStyle:UIAlertControllerStyleAlert];
-        
-        UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Cancel", @"Verb, Cancel an action")
-                                                               style:UIAlertActionStyleCancel
-                                                             handler:^(UIAlertAction *action){}];
-        
-        UIAlertAction *retryAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Try Again", @"Retry an action that failed")
-                                                              style:UIAlertActionStyleDestructive
-                                                            handler:^(UIAlertAction *action){
-                                                                [weakSelf sendReplyWithNewContent:content];
-                                                            }];
-        [alertController addAction:cancelAction];
-        [alertController addAction:retryAction];
-        [weakSelf presentViewController:alertController animated:YES completion:nil];
+        NSString *message = NSLocalizedString(@"There has been an unexpected error while sending your reply", nil);
+        [UIAlertController presentNoticeWithTitle:message];
     };
     
     NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1085,7 +1085,7 @@ private extension NotificationDetailsViewController {
     }
 
     func displayReplyError(with block: FormattableCommentContent, content: String) {
-        let message = NSLocalizedString("There has been an unexpected error while sending your reply", comment: "Reply Failure Message");
+        let message = NSLocalizedString("There has been an unexpected error while sending your reply", comment: "Reply Failure Message")
         displayNotice(title: message)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -161,6 +161,7 @@ class NotificationDetailsViewController: UIViewController {
         keyboardManager?.stopListeningToKeyboardNotifications()
         tearDownNotificationListeners()
         storeNotificationReplyIfNeeded()
+        dismissNotice()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -1044,7 +1045,7 @@ private extension NotificationDetailsViewController {
         let actionContext = ActionContext(block: block, content: content) { [weak self] (request, success) in
             if success {
                 let message = NSLocalizedString("Reply Sent!", comment: "The app successfully sent a comment")
-                SVProgressHUD.showDismissibleSuccess(withStatus: message)
+                self?.displayNotice(title: message)
             } else {
                 generator.notificationOccurred(.error)
                 self?.displayReplyError(with: block, content: content)
@@ -1084,23 +1085,8 @@ private extension NotificationDetailsViewController {
     }
 
     func displayReplyError(with block: FormattableCommentContent, content: String) {
-        var message     = String(format: NSLocalizedString("There has been an unexpected error while sending your reply: \n\"%@\"",
-                                            comment: "Reply Failure Message"), String(content.prefix(140)))
-        let cancelTitle = NSLocalizedString("Cancel", comment: "Cancels an Action")
-        let retryTitle  = NSLocalizedString("Try Again", comment: "Retries sending a reply")
-
-        if content.count >= 140 {
-            message.insert("…", at: message.index(message.endIndex, offsetBy: -1))
-        }
-
-        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        alertController.addCancelActionWithTitle(cancelTitle)
-        alertController.addDefaultActionWithTitle(retryTitle) { action in
-            self.replyCommentWithBlock(block, content: content)
-        }
-
-        // Note: This viewController might not be visible anymore
-        alertController.presentFromRootViewController()
+        let message = NSLocalizedString("There has been an unexpected error while sending your reply", comment: "Reply Failure Message");
+        displayNotice(title: message)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -165,6 +165,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
+    [self dismissNotice];
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-result"
@@ -753,6 +754,8 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
     void (^successBlock)(void) = ^void() {
         [generator notificationOccurred:UINotificationFeedbackTypeSuccess];
+        NSString *successMessage = NSLocalizedString(@"Reply Sent!", @"The app successfully sent a comment");
+        [weakSelf displayNoticeWithTitle:successMessage message:nil];
 
         [weakSelf trackReplyToComment];
         [weakSelf.tableView deselectSelectedRowWithAnimation:YES];
@@ -762,35 +765,10 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     };
 
     void (^failureBlock)(NSError *error) = ^void(NSError *error) {
-        NSUInteger lastIndex = content.length == 0 ? 0 : content.length - 1;
-        NSUInteger composedCharacterIndex = NSMaxRange([content rangeOfComposedCharacterSequenceAtIndex:MIN(lastIndex, 140)]);
-        // 140 is a somewhat arbitraily chosen number (old tweet length) — should be enough to let people know what
-        // comment failed to show, but not too long to display.
-
-        NSString *replyExcerpt = [content substringToIndex:composedCharacterIndex];
-
-        NSString *alertMessage = [NSString stringWithFormat:NSLocalizedString(@"There has been an unexpected error while sending your reply: \n\"%@\"", nil), replyExcerpt];
-        if (composedCharacterIndex < lastIndex) {
-            NSMutableString *mutString = alertMessage.mutableCopy;
-            [mutString insertString:@"…" atIndex:(alertMessage.length - 2)];
-
-            alertMessage = mutString.copy;
-        }
-
         DDLogError(@"Error sending reply: %@", error);
-
         [generator notificationOccurred:UINotificationFeedbackTypeError];
-
-        NSString *alertCancel = NSLocalizedString(@"Cancel", @"Verb. A button label. Tapping the button dismisses a prompt.");
-        NSString *alertTryAgain = NSLocalizedString(@"Try Again", @"A button label. Tapping the re-tries an action that previously failed.");
-        UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil
-                                                                                 message:alertMessage
-                                                                          preferredStyle:UIAlertControllerStyleAlert];
-        [alertController addCancelActionWithTitle:alertCancel handler:nil];
-        [alertController addActionWithTitle:alertTryAgain style:UIAlertActionStyleDefault handler:^(UIAlertAction *action) {
-            [weakSelf sendReplyWithNewContent:content];
-        }];
-        [alertController presentFromRootViewController];
+        NSString *message = NSLocalizedString(@"There has been an unexpected error while sending your reply", "Reply Failure Message");
+        [weakSelf displayNoticeWithTitle:message message:nil];
 
         [weakSelf refreshTableViewAndNoResultsView];
     };


### PR DESCRIPTION
This PR only updates the experience of messaging the failure in uploading an edit to a comment or a reply to a comment and does not deal with the reported failure to upload the comment completely.

Instead of showing an alert with confusing options to try again (which didn't do anything) or to cancel (which dismissed the alert)
We are showing a snack bar to fit the behavior of this type of failure in other parts of the app. w

Hopefully the failed upload of the comment/reply can be automatically triggered in the future with the upcoming addition of the upload manager

Fixes #11307 

To test:
1. Turn on Network Link Conditioner with 100% loss
2. Go to comments
3. reply to a comment

* See the snack bar with a message saying "There has been an unexpected error while sending your reply"

Before:
![reply_old](https://user-images.githubusercontent.com/1335657/58605849-3634ca00-824e-11e9-973f-f4864e5b1a3c.gif)

After:
![reply_new](https://user-images.githubusercontent.com/1335657/58605855-3c2aab00-824e-11e9-899c-fa1e2108a8c0.gif)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
