### PR TITLE
[Crash] NSRangeException in BlogDetailsViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -504,7 +504,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     _restorableSelectedIndexPath = restorableSelectedIndexPath;
 
-    if (restorableSelectedIndexPath != nil) {
+    if (restorableSelectedIndexPath != nil && restorableSelectedIndexPath.section < [self.tableSections count]) {
         BlogDetailsSection *section = [self.tableSections objectAtIndex:restorableSelectedIndexPath.section];
         self.selectedSectionCategory = section.category;
     }

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -506,7 +506,19 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     if (restorableSelectedIndexPath != nil && restorableSelectedIndexPath.section < [self.tableSections count]) {
         BlogDetailsSection *section = [self.tableSections objectAtIndex:restorableSelectedIndexPath.section];
-        self.selectedSectionCategory = section.category;
+        switch (section.category) {
+            case BlogDetailsSectionCategoryQuickStart:
+            case BlogDetailsSectionCategoryDomainCredit: {
+                self.selectedSectionCategory = BlogDetailsSectionCategoryGeneral;
+                NSUInteger section = [self findSectionIndexWithSections:self.tableSections category:self.selectedSectionCategory];
+                _restorableSelectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:section];
+            }
+                break;
+                
+            default:
+                self.selectedSectionCategory = section.category;
+                break;
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -514,7 +514,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                 _restorableSelectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:section];
             }
                 break;
-                
             default:
                 self.selectedSectionCategory = section.category;
                 break;

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -502,23 +502,24 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)setRestorableSelectedIndexPath:(NSIndexPath *)restorableSelectedIndexPath
 {
-    _restorableSelectedIndexPath = restorableSelectedIndexPath;
-
     if (restorableSelectedIndexPath != nil && restorableSelectedIndexPath.section < [self.tableSections count]) {
         BlogDetailsSection *section = [self.tableSections objectAtIndex:restorableSelectedIndexPath.section];
         switch (section.category) {
             case BlogDetailsSectionCategoryQuickStart:
             case BlogDetailsSectionCategoryDomainCredit: {
-                self.selectedSectionCategory = BlogDetailsSectionCategoryGeneral;
-                NSUInteger section = [self findSectionIndexWithSections:self.tableSections category:self.selectedSectionCategory];
-                _restorableSelectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:section];
+                _restorableSelectedIndexPath = nil;
             }
                 break;
-            default:
+            default: {
                 self.selectedSectionCategory = section.category;
+                _restorableSelectedIndexPath = restorableSelectedIndexPath;
+            }
                 break;
         }
+        return;
     }
+
+    _restorableSelectedIndexPath = nil;
 }
 
 - (SiteIconPickerPresenter *)siteIconPickerPresenter


### PR DESCRIPTION
Fixes #11819 

This fixes a crash I introduced in _12.4_. It happened when the `restorableSelectedIndexPath` decoded by `- (void)decodeRestorableStateWithCoder:(NSCoder *)coder` is out of bounds with the `tableSections`.

To fix that I check in the section index is out of bound or not.

I wasn't able to reproduce it, so I forced it setting different values to the `restorableSelectedIndexPath` property when `- (void)decodeRestorableStateWithCoder:(NSCoder *)coder` is called.

Like this:
```
- (void)decodeRestorableStateWithCoder:(NSCoder *)coder
{
//    NSIndexPath *indexPath = [coder decodeObjectForKey:WPBlogDetailsSelectedIndexPathKey];
//    if (indexPath) {
        self.restorableSelectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:999999];
//    }

    [super decodeRestorableStateWithCoder:coder];
}
```
