### PR TITLE
[Stats Refresh] Period Authors: fix expanded row height

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -205,9 +205,18 @@ private extension StatsTotalRow {
         }
 
         let imageSize = rowData.statSection?.imageSize ?? StatSection.defaultImageSize
-        imageWidthConstraint.constant = imageSize
 
-        imageView.isHidden = !hasIcon
+        // If the parent row has an icon and this row does not,
+        // show the image view to make this row appear "indented" by the icon width.
+        if let parentRow = parentRow, parentRow.hasIcon, !hasIcon {
+            imageView.isHidden = false
+            imageWidthConstraint.constant = parentRow.imageWidthConstraint.constant
+            imageHeightConstraint.constant = 1
+        } else {
+            imageView.isHidden = !hasIcon
+            imageWidthConstraint.constant = imageSize
+            imageHeightConstraint.constant = imageSize
+        }
 
         if let icon = rowData.icon {
             imageView.image = icon

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -92,13 +92,11 @@ class StatsTotalRow: UIView, NibLoadable {
     private typealias Style = WPStyleGuide.Stats
     private weak var delegate: StatsTotalRowDelegate?
     private var forDetails = false
+    private(set) weak var parentRow: StatsTotalRow?
 
     // This view is modified by the containing cell, to show/hide
     // child rows when a parent row is selected.
     weak var childRowsView: StatsChildRowsView?
-
-    // This is set by the containing cell when child rows are added.
-    weak var parentRow: StatsTotalRow?
 
     var showSeparator = true {
         didSet {
@@ -143,10 +141,14 @@ class StatsTotalRow: UIView, NibLoadable {
 
     // MARK: - Configure
 
-    func configure(rowData: StatsTotalRowData, delegate: StatsTotalRowDelegate? = nil, forDetails: Bool = false) {
+    func configure(rowData: StatsTotalRowData,
+                   delegate: StatsTotalRowDelegate? = nil,
+                   forDetails: Bool = false,
+                   parentRow: StatsTotalRow? = nil) {
         self.rowData = rowData
         self.delegate = delegate
         self.forDetails = forDetails
+        self.parentRow = parentRow
 
         configureExpandedState()
         configureIcon()

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -71,6 +71,7 @@ class StatsTotalRow: UIView, NibLoadable {
 
     @IBOutlet weak var imageView: UIImageView!
     @IBOutlet weak var imageWidthConstraint: NSLayoutConstraint!
+    @IBOutlet weak var imageHeightConstraint: NSLayoutConstraint!
 
     @IBOutlet weak var itemLabel: UILabel!
     @IBOutlet weak var itemDetailLabel: UILabel!

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.xib
@@ -26,7 +26,7 @@
                                     <rect key="frame" x="0.0" y="15" width="28" height="28"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="28" id="Sez-wA-eee"/>
-                                        <constraint firstAttribute="width" secondItem="il5-2Z-QId" secondAttribute="height" multiplier="1:1" id="Xff-jJ-dhu"/>
+                                        <constraint firstAttribute="height" constant="28" id="vQc-8f-D53"/>
                                     </constraints>
                                 </imageView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="U2I-mF-Pab" userLabel="Label Stack View">
@@ -150,6 +150,7 @@
                 <outlet property="dataLabel" destination="Ivc-26-vsM" id="wbJ-ri-8Rh"/>
                 <outlet property="disclosureButton" destination="KoQ-BR-jDc" id="qah-fR-XpV"/>
                 <outlet property="disclosureImageView" destination="zUJ-W9-Eeb" id="RPm-XV-KAU"/>
+                <outlet property="imageHeightConstraint" destination="vQc-8f-D53" id="T9W-c3-pP3"/>
                 <outlet property="imageView" destination="il5-2Z-QId" id="G0o-g7-BBY"/>
                 <outlet property="imageWidthConstraint" destination="Sez-wA-eee" id="PXQ-kQ-vRU"/>
                 <outlet property="itemDetailLabel" destination="AYo-jW-XP6" id="KlK-Zw-PCH"/>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -182,12 +182,6 @@ private extension TopTotalsCell {
                 Style.configureLabelAsChildRowTitle(childRow.itemLabel)
             }
 
-            // If the parent row has an icon, show the image view for the child
-            // to make the child row appear "indented".
-            // If the parent does not have an icon, don't indent the child row.
-            childRow.imageView.isHidden = row.imageView.isHidden
-            childRow.imageWidthConstraint.constant = row.imageWidthConstraint.constant
-
             childRowsView.rowsStackView.addArrangedSubview(childRow)
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -173,9 +173,8 @@ private extension TopTotalsCell {
             let childRowData = childRows[childRowsIndex]
             let childRow = StatsTotalRow.loadFromNib()
 
-            childRow.configure(rowData: childRowData, delegate: self)
+            childRow.configure(rowData: childRowData, delegate: self, parentRow: row)
             childRow.showSeparator = false
-            childRow.parentRow = row
 
             // If this child is just a child, then change the label color.
             // If this child is also a parent, then leave the color as default.


### PR DESCRIPTION
Fixes #11800 

In order for the child row to appear indented, the icon image view is actually shown, just with no image. The side effect of this was the child row height was affected by the image view height.

To avoid this, if there is no image, the image height is now set to 1. The width is still the parent image width.

To note, this only fixes the overview card. I've created #11824 to fix the detail view.

To test:
- Go to Stats > Period > Authors.
- Expand an Author.
- Verify the child row height is 44.

<img width="450" alt="expanded_author" src="https://user-images.githubusercontent.com/1816888/58671598-70f73a80-8300-11e9-9d3b-91263d0fd0b4.png">

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
