### PR TITLE
[Stats Refresh] Enable Stats Refresh for all.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -15,7 +15,7 @@ enum FeatureFlag: Int {
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .statsRefresh:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cPrereleaseTesting]
+            return true
         case .domainCredit:
             return true
         }


### PR DESCRIPTION
Fixes #n/a

This enables Stats Refresh for everyone.

To note, I won't merge this until we're 100% sure we're ready. But at least we'll have it ready to go.

To test:
Go to Stats. Verify the new Stats appears.