### PR TITLE
[Stats Refresh] Avoid reload stats overview when browsing back from a stats detail

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -96,6 +96,7 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
     }
 
     func refreshInsights() {
+        addViewModelListeners()
         viewModel?.refreshInsights()
     }
 }
@@ -107,13 +108,25 @@ private extension SiteStatsInsightsTableViewController {
     func initViewModel() {
         viewModel = SiteStatsInsightsViewModel(insightsToShow: insightsToShow, insightsDelegate: self, insightsStore: insightsStore, periodStore: periodStore)
 
+        addViewModelListeners()
+    }
+
+    func addViewModelListeners() {
+        if insightsChangeReceipt != nil {
+            return
+        }
+
         insightsChangeReceipt = viewModel?.onChange { [weak self] in
             guard let store = self?.insightsStore,
                 !store.isFetchingOverview else {
-                return
+                    return
             }
             self?.refreshTableView()
         }
+    }
+
+    func removeViewModelListeners() {
+        insightsChangeReceipt = nil
     }
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
@@ -278,12 +291,16 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
             return
         }
 
+        removeViewModelListeners()
+
         let detailTableViewController = SiteStatsDetailTableViewController.loadFromStoryboard()
         detailTableViewController.configure(statSection: statSection)
         navigationController?.pushViewController(detailTableViewController, animated: true)
     }
 
     func showPostStats(postID: Int, postTitle: String?, postURL: URL?) {
+        removeViewModelListeners()
+
         let postStatsTableViewController = PostStatsTableViewController.loadFromStoryboard()
         postStatsTableViewController.configure(postID: postID, postTitle: postTitle, postURL: postURL)
         navigationController?.pushViewController(postStatsTableViewController, animated: true)
@@ -297,6 +314,7 @@ extension SiteStatsInsightsTableViewController: NoResultsViewControllerDelegate 
                         accessoryView: NoResultsViewController.loadingAccessoryView()) { noResults in
                             noResults.hideImageView(false)
         }
+        addViewModelListeners()
         refreshInsights()
     }
 }


### PR DESCRIPTION
Fixes #11815 

This PR fixes in part #11815 (part has been fixed in #11805). Browsing back from a Stats Detail Screen changes the data in the current Stats overview. This is caused by the a receipt being deallocated, which triggers the query update function emitting the change trough all the observers. Having a shared instance of the stats stores makes the overview updated even if is not necessary.

## Fix
I decided then to remove the view model listeners when is not necessary, and add those again when it's required. This avoids the overview being reloaded when it's not necessary.

## To test:
• Select a Site with a big bunch of data, to have the _View More_ row in Insights and Periods
• Select Stats and test this behaviour with Insights and any Period
• Tap on a _View More_ row to display a Stats detail
• Navigate back to check the overview is not reloaded
• Pull down or change tab to reload an overview

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
