### PR TITLE
Use safeManagedObjectID to retrieval media objects referenced in HTML.

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -334,7 +334,7 @@ class MediaCoordinator: NSObject {
     func media(withObjectID objectID: String) -> Media? {
         guard let storeCoordinator = mainContext.persistentStoreCoordinator,
             let url = URL(string: objectID),
-            let managedObjectID = storeCoordinator.managedObjectID(forURIRepresentation: url),
+            let managedObjectID = storeCoordinator.safeManagedObjectID(forURIRepresentation: url),
             let media = try? mainContext.existingObject(with: managedObjectID) as? Media else {
             return nil
         }

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -120,6 +120,7 @@
 #import "WPUserAgent.h"
 #import "WPAndDeviceMediaLibraryDataSource.h"
 #import "WPLogger.h"
+#import "WPException.h"
 
 
 // Pods

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -147,3 +147,27 @@ extension NSManagedObjectContext {
         return objects ?? []
     }
 }
+
+extension NSPersistentStoreCoordinator {
+
+    /// Retrieves an NSManagedObjectID in a safe way, so even if the URL is not in a valid CoreData format no exceptions will be throw.
+    ///
+    /// - Parameter uri: the core-data object uri representation
+    /// - Returns: a NSManagedObjectID if the uri is valid or nil if not.
+    ///
+    public func safeManagedObjectID(forURIRepresentation uri: URL) -> NSManagedObjectID? {
+        guard let host = uri.host, host == "x-coredata" else {
+            return nil
+        }
+        var result:NSManagedObjectID? = nil
+        do {
+            try WPException.objcTry {
+                result = self.managedObjectID(forURIRepresentation: uri)
+            }
+        } catch {
+            return nil
+        }
+        return result
+    }
+
+}

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -159,7 +159,7 @@ extension NSPersistentStoreCoordinator {
         guard let host = uri.host, host == "x-coredata" else {
             return nil
         }
-        var result:NSManagedObjectID? = nil
+        var result: NSManagedObjectID? = nil
         do {
             try WPException.objcTry {
                 result = self.managedObjectID(forURIRepresentation: uri)

--- a/WordPress/Classes/Utility/WPException.h
+++ b/WordPress/Classes/Utility/WPException.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WPException : NSObject
+
+/**
+ Exectues the provided block surrounded by a @try @catch block in objetive C. If an NSException is throw it's converted to an NSError
+
+ @param block the block to execute.
+ @param outError If an exception is raised this variable returns the an error that wraps the exception.
+ @return return true if no exception is raised and false otherwise.
+ */
++ (BOOL)objcTryBlock:(void (^)(void))block error:(NSError * __autoreleasing *)outError;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Utility/WPException.m
+++ b/WordPress/Classes/Utility/WPException.m
@@ -1,0 +1,22 @@
+#import "WPException.h"
+
+@implementation WPException
+
++ (BOOL)objcTryBlock:(void (^)(void))block error:(NSError * __autoreleasing *)outError;
+{
+    @try {
+        if (block) {
+            block();
+        }
+        return true;
+    } @catch (NSException *exception) {
+        if (outError) {
+            *outError = [NSError errorWithDomain:exception.name code:0 userInfo:exception.userInfo];
+        }
+        return false;
+    } @finally {
+
+    }
+}
+
+@end

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1774,6 +1774,7 @@
 		FFC6ADD41B56F295002F3C84 /* AboutViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC6ADD21B56F295002F3C84 /* AboutViewController.swift */; };
 		FFC6ADD51B56F295002F3C84 /* AboutViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FFC6ADD31B56F295002F3C84 /* AboutViewController.xib */; };
 		FFC6ADDA1B56F366002F3C84 /* LocalCoreDataService.m in Sources */ = {isa = PBXBuildFile; fileRef = FFC6ADD91B56F366002F3C84 /* LocalCoreDataService.m */; };
+		FFCB9F4B22A125BD0080A45F /* WPException.m in Sources */ = {isa = PBXBuildFile; fileRef = FFCB9F4A22A125BD0080A45F /* WPException.m */; };
 		FFD12D5E1FE1998D00F20A00 /* Progress+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD12D5D1FE1998D00F20A00 /* Progress+Helpers.swift */; };
 		FFDA7E501B8DF6E500B83C56 /* BlogSiteVisibilityHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FFDA7E4F1B8DF6E500B83C56 /* BlogSiteVisibilityHelper.m */; };
 		FFE3B2C71B2E651400E9F1E0 /* WPAndDeviceMediaLibraryDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = FFE3B2C61B2E651400E9F1E0 /* WPAndDeviceMediaLibraryDataSource.m */; };
@@ -4003,6 +4004,8 @@
 		FFC6ADD31B56F295002F3C84 /* AboutViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = AboutViewController.xib; sourceTree = "<group>"; };
 		FFC6ADD91B56F366002F3C84 /* LocalCoreDataService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LocalCoreDataService.m; sourceTree = "<group>"; };
 		FFC6ADE11B56F58B002F3C84 /* WordPress 36.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 36.xcdatamodel"; sourceTree = "<group>"; };
+		FFCB9F4922A125BD0080A45F /* WPException.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WPException.h; sourceTree = "<group>"; };
+		FFCB9F4A22A125BD0080A45F /* WPException.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WPException.m; sourceTree = "<group>"; };
 		FFD12D5D1FE1998D00F20A00 /* Progress+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Progress+Helpers.swift"; sourceTree = "<group>"; };
 		FFDA7E4E1B8DF6E500B83C56 /* BlogSiteVisibilityHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlogSiteVisibilityHelper.h; sourceTree = "<group>"; };
 		FFDA7E4F1B8DF6E500B83C56 /* BlogSiteVisibilityHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogSiteVisibilityHelper.m; sourceTree = "<group>"; };
@@ -6176,6 +6179,8 @@
 				85B125431B02937E008A3D95 /* UIAlertControllerProxy.h */,
 				85B125441B02937E008A3D95 /* UIAlertControllerProxy.m */,
 				7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */,
+				FFCB9F4922A125BD0080A45F /* WPException.h */,
+				FFCB9F4A22A125BD0080A45F /* WPException.m */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -10605,6 +10610,7 @@
 				B5EEDB971C91F10400676B2B /* Blog+Interface.swift in Sources */,
 				5D839AA8187F0D6B00811F4A /* PostFeaturedImageCell.m in Sources */,
 				171909E4206CFFCD0054DF0B /* FancyAlertViewController+Async.swift in Sources */,
+				FFCB9F4B22A125BD0080A45F /* WPException.m in Sources */,
 				E14DF70620C922F200959BA9 /* NotificationCenter+ObserveOnce.swift in Sources */,
 				E125F1E41E8E595E00320B67 /* SharePost.swift in Sources */,
 				B56FEB791CD8E13C00E621F9 /* RoleViewController.swift in Sources */,

--- a/WordPress/WordPressTest/CoreDataHelperTests.swift
+++ b/WordPress/WordPressTest/CoreDataHelperTests.swift
@@ -176,6 +176,23 @@ class CoreDataHelperTests: XCTestCase {
         XCTAssertEqual(retrieved!.key, "YEAH!")
         XCTAssertEqual(retrieved!.value, 42)
     }
+
+    /// Verifies that safeManagedObjectID never runs into exceptions and always returns nil
+    ///
+    func testSafeManagedObjectIDRetrievalUsingURI() {
+        insertDummyEntities(10)
+        guard let psc = context.persistentStoreCoordinator,
+            let uriGood = URL(string: "x-coredata://ABDASDBASD/a.png"),
+            let uriBad1 = URL(string: "ABDASDBASD/a.png"),
+            let uriBad2 = URL(string: "x-coredata://ABDASDBASD") else {
+                return
+        }
+
+
+        XCTAssertNil(psc.safeManagedObjectID(forURIRepresentation: uriGood))
+        XCTAssertNil(psc.safeManagedObjectID(forURIRepresentation: uriBad1))
+        XCTAssertNil(psc.safeManagedObjectID(forURIRepresentation: uriBad2))
+    }
 }
 
 


### PR DESCRIPTION
Fixes #11609 

This PR changes the MediaCoordinator to use a safeManagedObjectID function to retrieval media objects referenced in HTML.

This avoid that malformed CoreData URI crashing Aztec when opening posts.

To test:
 - Create a new post using Aztec
 - Switch to HTML mode
 - Copy/Paste the HTML referred in #11609 
 - Switch to visual mode
 - Make sure the app doesn't crash.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
