### PR TITLE
Fixes warnings regarding deprecated api.

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -83,7 +83,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
 
         title = NSLocalizedString("Media", comment: "Title for Media Library section of the app.")
 
-        automaticallyAdjustsScrollViewInsets = false
+        collectionView?.contentInsetAdjustmentBehavior = .never
 
         registerChangeObserver()
         registerUploadCoordinatorObserver()

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -83,8 +83,6 @@ class MediaLibraryViewController: WPMediaPickerViewController {
 
         title = NSLocalizedString("Media", comment: "Title for Media Library section of the app.")
 
-        collectionView?.contentInsetAdjustmentBehavior = .never
-
         registerChangeObserver()
         registerUploadCoordinatorObserver()
 

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemEditingViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemEditingViewController.m
@@ -89,7 +89,6 @@ typedef NS_ENUM(NSUInteger, MenuItemEditingViewControllerContentLayout) {
 {
     [super viewDidLoad];
 
-    self.automaticallyAdjustsScrollViewInsets = NO;
     self.view.backgroundColor = [UIColor whiteColor];
 
     self.headerView.item = self.item;


### PR DESCRIPTION
Fixes a couple of warnings about calling deprecated API : `automaticallyAdjustsScrollViewInsets`. 

In `MenuItemEditingViewController.m` the call is simply removed as it doesn't appear its needed.
In `MediaLibraryViewController.swift` the call is replaced with the recommended substitute.

To test:
Note how the UI looks, paying particular attention to the scroll views, on the following two screens:
- My Sites > Site > Menus > Select a Menu > Tap to Edit one of the menu's items. 
- My Sites > Site > Media
Check on an iPad and on an iPhone.  Bonus for also checking on the XS Max.

Apply the patch and check the screens again.  There should be no noticeable difference.
Note that there is some preexisting unrelated UI wonkiness with Menus. :(  I'll open issues for these when I get time.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
