### PR TITLE
Implements Uploader protocol in MediaCoordinator and PostCoordinator.

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -5,11 +5,7 @@ import WordPressFlux
 /// items, independently of a specific view controller. It should be accessed
 /// via the `shared` singleton.
 ///
-class MediaCoordinator: NSObject, Uploader {
-    func resume() {
-    }
-
-
+class MediaCoordinator: NSObject {
     @objc static let shared = MediaCoordinator()
 
     private(set) var backgroundContext: NSManagedObjectContext = {
@@ -602,6 +598,22 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
 
         if mediaProgressCoordinator != mediaLibraryProgressCoordinator {
             removeCoordinator(mediaProgressCoordinator)
+        }
+    }
+}
+
+extension MediaCoordinator: Uploader {
+    func resume() {
+        let service = MediaService(managedObjectContext: mainContext)
+
+        service.getFailedMedia { [weak self] mediaArray in
+            guard let self = self else {
+                return
+            }
+
+            for media in mediaArray {
+                self.retryMedia(media)
+            }
         }
     }
 }

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -606,14 +606,12 @@ extension MediaCoordinator: Uploader {
     func resume() {
         let service = MediaService(managedObjectContext: mainContext)
 
-        service.getFailedMedia { [weak self] mediaArray in
+        service.getFailedMedia { [weak self] media in
             guard let self = self else {
                 return
             }
 
-            for media in mediaArray {
-                self.retryMedia(media)
-            }
+            media.forEach() { self.retryMedia($0) }
         }
     }
 }

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -37,6 +37,12 @@ typedef NS_ERROR_ENUM(MediaServiceErrorDomain, MediaServiceError) {
                  thumbnailCallback:(nullable void (^)(Media * __nonnull media, NSURL * __nonnull thumbnailURL))thumbnailCallback
                         completion:(nullable void (^)(Media * __nullable media, NSError * __nullable error))completion;
 
+/**
+ Get all Media that failed to upload.
+ 
+ @param result a block that will be invoked to return the requested media.
+ */
+- (void)getFailedMedia:(nonnull void (^)( NSArray<Media *>* _Nonnull media))result;
 
 /**
  Get the Media object from the server using the blog and the mediaID as the identifier of the resource

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -509,6 +509,24 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 
 #pragma mark - Getting media
 
+- (void)getFailedMedia:(void (^)( NSArray<Media *>* media))result {
+    [self.managedObjectContext performBlock:^{
+        NSString *entityName = NSStringFromClass([Media class]);
+        NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
+        
+        request.predicate = [NSPredicate predicateWithFormat:@"remoteStatusNumber == %d", MediaRemoteStatusFailed];
+        
+        NSError *error = nil;
+        NSArray *results = [self.managedObjectContext executeFetchRequest:request error:&error];
+        
+        if (!results) {
+            result(@[]);
+        } else {
+            result(results);
+        }
+    }];
+}
+
 - (void) getMediaWithID:(NSNumber *) mediaID inBlog:(Blog *) blog
                 success:(void (^)(Media *media))success
                 failure:(void (^)(NSError *error))failure

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -255,9 +255,7 @@ extension PostCoordinator: Uploader {
                 return
             }
 
-            for post in posts {
-                self.retrySave(of: post)
-            }
+            posts.forEach() { self.retrySave(of: $0 ) }
         }
     }
 }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -248,9 +248,16 @@ class PostCoordinator: NSObject {
 
 extension PostCoordinator: Uploader {
     func resume() {
-        // Resume the upload of all posts that are not synched.
-        //
-        // 1. Query posts with status == .failed
-        // 2. Call retrySave() for each post
+        let service = PostService(managedObjectContext: mainContext)
+
+        service.getFailedPosts { [weak self] posts in
+            guard let self = self else {
+                return
+            }
+
+            for post in posts {
+                self.retrySave(of: post)
+            }
+        }
     }
 }

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -44,6 +44,13 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
               failure:(void (^)(NSError *))failure;
 
 /**
+ Get all posts that failed to upload.
+ 
+ @param result a block that will be invoked to return the requested posts.
+ */
+- (void)getFailedPosts:(nonnull void (^)( NSArray<AbstractPost *>* _Nonnull posts))result;
+
+/**
  Sync an initial batch of posts from the specified blog.
  Please note that success and/or failure are called in the context of the
  NSManagedObjectContext supplied when the PostService was initialized, and may not

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -65,6 +65,26 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     return page;
 }
 
+
+- (void)getFailedPosts:(void (^)( NSArray<AbstractPost *>* posts))result {
+    [self.managedObjectContext performBlock:^{
+        NSString *entityName = NSStringFromClass([AbstractPost class]);
+        NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
+        
+        request.predicate = [NSPredicate predicateWithFormat:@"remoteStatusNumber == %d", AbstractPostRemoteStatusFailed];
+        
+        NSError *error = nil;
+        NSArray *results = [self.managedObjectContext executeFetchRequest:request error:&error];
+        
+        if (!results) {
+            result(@[]);
+        } else {
+            result(results);
+        }
+    }];
+}
+
+
 - (void)getPostWithID:(NSNumber *)postID
               forBlog:(Blog *)blog
               success:(void (^)(AbstractPost *post))success

--- a/WordPress/Classes/Uploads/UploadsManager.swift
+++ b/WordPress/Classes/Uploads/UploadsManager.swift
@@ -2,9 +2,12 @@ import Foundation
 
 /// Takes care of coordinating all uploaders used by the app.
 ///
-@objc
 class UploadsManager: NSObject {
     private let uploaders: [Uploader]
+
+    /// The reason why this property is lazy is that it's basically a closure with a self reference.
+    /// There's no easy way to initialize these, other than making them lazy (2019-06-01)
+    ///
     private lazy var reachabilityObserver: NSObjectProtocol = {
         return NotificationCenter.default.addObserver(forName: .reachabilityChanged, object: nil, queue: nil) { [weak self] notification in
 
@@ -31,6 +34,9 @@ class UploadsManager: NSObject {
         self.uploaders = uploaders
 
         super.init()
+
+        /// This just makes sure the reachabilityObserver property is initialized here.
+        _ = reachabilityObserver
     }
 
     deinit {
@@ -41,7 +47,6 @@ class UploadsManager: NSObject {
 
     /// Resumes all uploads handled by the uploaders.
     ///
-    @objc
     func resume() {
         for uploader in uploaders {
             uploader.resume()


### PR DESCRIPTION
Fixes #11785 
Fixes #11784 

Implements the Uploader protocol in both coordinator, and wires it so that it's triggered when the App is opened, when it comes to foreground, and when `Reachability` detects there's a connection.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

## Known Issues / Scope limitations:

Reachability isn't working very well, but from my investigation this is not related to my PR.  Reachability is simply failing to call the closures it should call.

I'll need to [investigate this separately](https://github.com/wordpress-mobile/WordPress-iOS/issues/11840#issuecomment-498194915), as it goes beyond the scope of this specific PR.

## Testing:

### Test 1:

1. Create a post with media while offline.
2. Put the app in the background.
3. Go back online.
4. Bring the app back to foreground.
5. Make sure the post is uploaded.

### Test 2:

1. Create a post with media while offline.
2. Close the App.
3. Go back online
4. Launch the app again.
5. Make sure the post is uploaded.