### PR TITLE
[Stats Refresh] Period Overview chart: show dashes for Likes value

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -111,6 +111,7 @@ struct PeriodStoreState {
     var summary: StatsSummaryTimeIntervalData?
     var fetchingSummary = false
     var fetchingSummaryHasFailed = false
+    var fetchingSummaryLikes = false
 
     var topPostsAndPages: StatsTopPostsTimeIntervalData?
     var fetchingPostsAndPages = false
@@ -759,6 +760,7 @@ private extension StatsPeriodStore {
                                                       summaryData: newSummaryData)
 
         transaction { state in
+            state.fetchingSummaryLikes = false
             state.summary = newSummary
         }
 
@@ -897,6 +899,7 @@ private extension StatsPeriodStore {
 
     func setAllAsFetchingOverview(fetching: Bool = true) {
         state.fetchingSummary = fetching
+        state.fetchingSummaryLikes = fetching
         state.fetchingPostsAndPages = fetching
         state.fetchingReferrers = fetching
         state.fetchingClicks = fetching
@@ -1002,6 +1005,10 @@ extension StatsPeriodStore {
             state.fetchingSearchTerms ||
             state.fetchingVideos ||
             state.fetchingCountries
+    }
+
+    var isFetchingSummaryLikes: Bool {
+        return state.fetchingSummaryLikes
     }
 
     var isFetchingPostsAndPages: Bool {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -3,12 +3,14 @@ import UIKit
 struct OverviewTabData: FilterTabBarItem {
     var tabTitle: String
     var tabData: Int
+    var tabDataStub: String?
     var difference: Int
     var differencePercent: Int
 
-    init(tabTitle: String, tabData: Int, difference: Int, differencePercent: Int) {
+    init(tabTitle: String, tabData: Int, tabDataStub: String? = nil, difference: Int, differencePercent: Int) {
         self.tabTitle = tabTitle
         self.tabData = tabData
+        self.tabDataStub = tabDataStub
         self.difference = difference
         self.differencePercent = differencePercent
     }
@@ -19,7 +21,14 @@ struct OverviewTabData: FilterTabBarItem {
         attributedTitle.addAttributes([.font: WPStyleGuide.Stats.overviewCardFilterTitleFont],
                                        range: NSMakeRange(0, attributedTitle.string.count))
 
-        let attributedData = NSMutableAttributedString(string: tabData.abbreviatedString())
+        let dataString: String = {
+            if let tabDataStub = tabDataStub {
+                return tabDataStub
+            }
+            return tabData.abbreviatedString()
+        }()
+
+        let attributedData = NSMutableAttributedString(string: dataString)
         attributedData.addAttributes([.font: WPStyleGuide.Stats.overviewCardFilterDataFont],
                                        range: NSMakeRange(0, attributedData.string.count))
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -134,9 +134,15 @@ private extension SiteStatsPeriodViewModel {
                                               difference: visitorsData.difference,
                                               differencePercent: visitorsData.percentage)
 
+
+        // If Summary Likes is still loading, show dashes (instead of 0)
+        // to indicate it's still loading.
+        let likesLoadingStub = store.isFetchingSummaryLikes ? "----" : nil
+
         let likesData = intervalData(summaryData: summaryData, summaryType: .likes)
         let likesTabData = OverviewTabData(tabTitle: StatSection.periodOverviewLikes.tabTitle,
                                            tabData: likesData.count,
+                                           tabDataStub: likesLoadingStub,
                                            difference: likesData.difference,
                                            differencePercent: likesData.percentage)
 


### PR DESCRIPTION
Ref #11841

Since Overview Likes takes longer to load than the other summary data, showing 0 while loading is misleading. This change shows dashes for Likes until the fetching is complete.

To test:
- On a very active site, go to Stats > Period.
- On the overview chart, verify the Likes value is dashes until the actual Likes value is fetched.
- If the query times out (which it frequently does for longer periods), the dashes will remain as an indicator Likes was not obtained.

<img width="400" alt="likes_stub" src="https://user-images.githubusercontent.com/1816888/58826526-1f032d00-85fe-11e9-838b-1ceccca88f68.png">

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
