### PR TITLE
[Stats Refresh] Period Videos: fix video selection

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -16,8 +16,6 @@ class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoada
 
     // MARK: - Properties
 
-    private let siteID = SiteStatsInformation.sharedInstance.siteID
-
     private lazy var mainContext: NSManagedObjectContext = {
         return ContextManager.sharedInstance().mainContext
     }()
@@ -275,7 +273,7 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
 
     func displayMediaWithID(_ mediaID: NSNumber) {
 
-        guard let siteID = siteID,
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID,
             let blog = blogService.blog(byBlogId: siteID) else {
                 DDLogInfo("Unable to get blog when trying to show media from Stats.")
                 return

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -34,7 +34,6 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
     }()
 
     private var postID: Int?
-    private let siteID = SiteStatsInformation.sharedInstance.siteID
 
     private lazy var mainContext: NSManagedObjectContext = {
         return ContextManager.sharedInstance().mainContext
@@ -274,7 +273,7 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
 
     func displayMediaWithID(_ mediaID: NSNumber) {
 
-        guard let siteID = siteID,
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID,
             let blog = blogService.blog(byBlogId: siteID) else {
                 DDLogInfo("Unable to get blog when trying to show media from Stats details.")
                 return


### PR DESCRIPTION
Fixes #11853

To test:
- On a site with a lot of Videos, go to Stats > Period > Videos.
  - Tip: en.blog is a good one.
- Select a video.
  - Verify the media details view appears.
- Select `View more`.
  - Select a video.
  - Verify the media details view appears.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
