### PR TITLE
Change quick start highlight color to white

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -349,7 +349,7 @@ private extension String {
     private enum Constants {
         static let iconOffset: CGFloat = 1.0
         static let iconSize: CGFloat = 16.0
-        static let highlightColor = WPStyleGuide.lightBlue()
+        static let highlightColor: UIColor = .white
         static var highlightFont: UIFont {
             get {
                 return WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)


### PR DESCRIPTION
Fixes #11688 

Changes the Quick Start notices to have a white highlight

<img width="390" alt="image" src="https://user-images.githubusercontent.com/517257/58919160-f2c0dc80-86e1-11e9-9b2f-b967450d67a9.png">

To test:
- Start a Quick Start tour (let me know if you need help with this)
- Ensure the notices use white as a highlight color

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
