### PR TITLE
[Stats Refresh] disable preloading Stats

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1224,8 +1224,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)preloadStats
 {
     NSString *oauthToken = self.blog.authToken;
-
-    if (oauthToken) {
+    
+    if (oauthToken && ![Feature enabled:FeatureFlagStatsRefresh]) {
+        NSLog(@"BlogDetails: preloading stats.");
         self.statsService = [self statsServiceWithSiteId:self.blog.dotComID siteTimeZone:[self.blogService timeZoneForBlog:self.blog] oauth2Token:oauthToken cacheExpirationInterval:5 * 60];
         [self.statsService retrieveInsightsStatsWithAllTimeStatsCompletionHandler:nil insightsCompletionHandler:nil todaySummaryCompletionHandler:nil latestPostSummaryCompletionHandler:nil commentsAuthorCompletionHandler:nil commentsPostsCompletionHandler:nil tagsCategoriesCompletionHandler:nil followersDotComCompletionHandler:nil followersEmailCompletionHandler:nil publicizeCompletionHandler:nil streakCompletionHandler:nil progressBlock:nil andOverallCompletionHandler:nil];
     }


### PR DESCRIPTION
Fixes #n/a

Previously, if the device was on WiFi, `BlogDetailsViewController` would pre-load the old Insights. This change disables that for Stats Refresh to avoid an unnecessary (and expensive) network call. I'll open a separate issue to replace that behavior.

To test:
- Launch the app.
- Verify `BlogDetails: preloading stats.` does _not_ appear in the logs.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
