### PR TITLE
[Stats Refresh] Show new Follower stats from Follower notification.

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -66,6 +66,19 @@ struct DefaultContentCoordinator: ContentCoordinator {
             throw DisplayError.missingParameter
         }
 
+        if FeatureFlag.statsRefresh.enabled {
+            let service = BlogService(managedObjectContext: mainContext)
+            SiteStatsInformation.sharedInstance.siteTimeZone = service.timeZone(for: blog)
+            SiteStatsInformation.sharedInstance.oauth2Token = blog.authToken
+            SiteStatsInformation.sharedInstance.siteID = blog.dotComID
+
+            let detailTableViewController = SiteStatsDetailTableViewController.loadFromStoryboard()
+            detailTableViewController.configure(statSection: StatSection.insightsFollowersWordPress)
+            controller?.navigationController?.pushViewController(detailTableViewController, animated: true)
+
+            return
+        }
+
         let statsViewController = newStatsViewController()
         statsViewController.selectedDate = Date()
         statsViewController.statsSection = .followers


### PR DESCRIPTION
Fixes #11870 

To test:
- Follow repro steps on #11870.
- Verify the new stats Followers is displayed. This should look exactly like Insights > Followers > View more.
- Note: I've created issue #11869 (Follower details sometimes shows 0 total) as that is unrelated to this change.

<img width="400" alt="follower_details" src="https://user-images.githubusercontent.com/1816888/59057435-94b60580-8857-11e9-8900-982dcfa556cd.png">


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
