### PR TITLE
[Stats Refresh] Follower detail count: show correct value

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -344,7 +344,7 @@ private extension SiteStatsDetailsViewModel {
         switch followerType {
         case .insightsFollowersWordPress:
             followers = insightsStore.getAllDotComFollowers()?.topDotComFollowers ?? []
-            totalFollowers = insightsStore.getDotComFollowers()?.dotComFollowersCount
+            totalFollowers = insightsStore.getAllDotComFollowers()?.dotComFollowersCount
         case .insightsFollowersEmail:
             followers = insightsStore.getAllEmailFollowers()?.topEmailFollowers ?? []
             totalFollowers = insightsStore.getAllEmailFollowers()?.emailFollowersCount


### PR DESCRIPTION
Fixes #11869 

To test:
- Go to Stats > Insights > Followers > View more.
  - To note, the issue didn't happen for every site, but I was able to repro it 100% of the time on mobile.blog.
- Verify the total matches that on the Insights card.

<img width="400" alt="followers_insights" src="https://user-images.githubusercontent.com/1816888/59060926-748a4480-885f-11e9-80e6-02700d48a1f2.png">

<img width="400" alt="followers_details" src="https://user-images.githubusercontent.com/1816888/59060931-79e78f00-885f-11e9-9940-2c7fa130a8a1.png">

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
