### PR TITLE
[Stats Refresh] Update Y axis chart formatting to match Android's behaviour

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
@@ -65,4 +65,20 @@ class VerticalAxisFormatter: IAxisValueFormatter {
 
         return largeValueFormatter.stringForValue(value, axis: axis)
     }
+
+    // Matches WPAndroid behavior to produce neater rounded values on
+    // the vertical axis.
+    static func roundUpAxisMaximum(_ input: Double) -> Double {
+        if input > 100 {
+            return roundUpAxisMaximum(input / 10) * 10
+        } else {
+            for i in 1..<25 {
+                let limit = Double(4 * i)
+                if input < limit {
+                    return limit
+                }
+            }
+            return Double(100)
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+LargeValueFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+LargeValueFormatter.swift
@@ -11,8 +11,8 @@ public class LargeValueFormatter: NSObject, IValueFormatter, IAxisValueFormatter
 
     /// Suffix to be appended after the values.
     ///
-    /// **default**: suffix: ["", "k", "m", "b", "t"]
-    public var suffix = ["", "k", "m", "b", "t"]
+    /// **default**: suffixes: ["", "k", "m", "b", "t"]
+    public var suffixes = ["", "k", "m", "b", "t"]
 
     /// An appendix text to be added at the end of the formatted value.
     public var appendix: String?
@@ -22,26 +22,23 @@ public class LargeValueFormatter: NSObject, IValueFormatter, IAxisValueFormatter
     }
 
     fileprivate func format(value: Double) -> String {
-        var sig = value
-        var length = 0
-        let maxLength = suffix.count - 1
-
-        while sig >= 1000.0 && length < maxLength {
-            sig /= 1000.0
-            length += 1
+        guard let string = LargeValueFormatter.formatter.string(from: NSNumber(value: value)) else {
+            return ""
         }
 
-        var r = String(format: "%2.1f", sig) + suffix[length]
+        // Grab the exponent value
+        let penultimateIndex = string.index(string.endIndex, offsetBy: -2)
+        let exponent = string[penultimateIndex...]
+        let exponentInt = Int(exponent) ?? 0
 
-        if let appendix = appendix {
-            r += appendix
-        }
+        // Replace the exponent with the correct suffix
+        let replaced = string.replacingOccurrences(of: "E[0-9][0-9]", with: suffixes[exponentInt / 3], options: .regularExpression)
 
-        return r
-    }
+        return replaced
+   }
 
     public func stringForValue(_ value: Double, axis: AxisBase?) -> String {
-        return format(value: value)
+        return format(value: round(value))
     }
 
     public func stringForValue(
@@ -49,6 +46,14 @@ public class LargeValueFormatter: NSObject, IValueFormatter, IAxisValueFormatter
         entry: ChartDataEntry,
         dataSetIndex: Int,
         viewPortHandler: ViewPortHandler?) -> String {
-        return format(value: value)
+        return format(value: round(value))
     }
+
+    private static var formatter: NumberFormatter = {
+        var numberFormatter = NumberFormatter()
+        numberFormatter.positiveFormat = "###E00"
+        numberFormatter.minimumFractionDigits = 1
+        numberFormatter.maximumFractionDigits = 3
+        return numberFormatter
+    }()
 }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -185,6 +185,8 @@ private extension StatsBarChartView {
 
         configureLegendIfNeeded()
         data = barChartData
+
+        configureYAxisMaximum()
     }
 
     func configureBarChartViewProperties() {
@@ -303,6 +305,17 @@ private extension StatsBarChartView {
         // This adjustment is intended to prevent clipping observed with some labels
         // Potentially relevant : https://github.com/danielgindi/Charts/issues/992
         extraTopOffset = Constants.topOffsetSansLegend
+    }
+
+    func configureYAxisMaximum() {
+        let lowestMaxValue = Double(Constants.verticalAxisLabelCount - 1)
+
+        if let maxY = data?.getYMax(),
+            maxY >= lowestMaxValue {
+            leftAxis.axisMaximum = VerticalAxisFormatter.roundUpAxisMaximum(maxY)
+        } else {
+            leftAxis.axisMaximum = lowestMaxValue
+        }
     }
 
     func drawChartMarker(for entry: ChartDataEntry) {


### PR DESCRIPTION
Fixes #11859. This PR updates the y axis formatting of the stats charts to better match Android's behaviour. Main changes:

* Updating the logic of the `LargeValueFormatter` to match Android's implementation. On Android this is bundled with the library, but on iOS there's a Swift version with the library's demo app which has different behaviour. We'll now only show a decimal point for values between 1000 and 100,000.
* Rounding the y axis values to produce a nicer set of rounded values on the Y axis. e.g. if the highest value is 96, we would previously have had axis lines at 24, 48, 72, 96. Now they'll be 25, 50, 75, 100. Again, this matches Android.
* Charts with no data now have a default y axis of 0, 1, 2, 3, 4. Previously we were showing 0, 0.2, 0.5, 0.8, 1.0.

![chart-y-axis](https://user-images.githubusercontent.com/4780/59109764-8d652980-8935-11e9-95a0-b180ff987aab.png)

**To test:**

* Build and run
* Ideally, if you have an Android device to hand, build and run and check the y values match for the various period charts.
* Otherwise, check they look similar to the screenshots above.

cc @SylvesterWilmott 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.