### PR TITLE
[Stats Refresh] Insights Comments: don't show 'view more' option

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -405,9 +405,14 @@ private extension SiteStatsInsightsViewModel {
 
         var rowItems: [StatsTotalRowData] = []
 
+        // Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/11713
+        // For now, don't show `View more` for Insights Comments.
+        // To accomplish this, return only the max number of rows displayed on the Insights card,
+        // as `View more` is added if the number of rows exceeds the max.
+
         switch commentType {
         case .insightsCommentsAuthors:
-            let authors = commentsInsight?.topAuthors ?? []
+            let authors = commentsInsight?.topAuthors.prefix(StatsDataHelper.maxRowsToDisplay) ?? []
             rowItems = authors.map {
                 StatsTotalRowData(name: $0.name,
                                   data: $0.commentCount.abbreviatedString(),
@@ -416,7 +421,7 @@ private extension SiteStatsInsightsViewModel {
                                   statSection: .insightsCommentsAuthors)
             }
         case .insightsCommentsPosts:
-            let posts = commentsInsight?.topPosts ?? []
+            let posts = commentsInsight?.topPosts.prefix(StatsDataHelper.maxRowsToDisplay) ?? []
             rowItems = posts.map {
                 StatsTotalRowData(name: $0.name,
                                   data: $0.commentCount.abbreviatedString(),


### PR DESCRIPTION
Ref #11713

Due to the issue described in #11713 , this disables the `View more` option for Insights _Comments_.

To test:
- On a site with a lot of Comments, go to Stats > Insights > Comments.
  - en.blog is a good one.
- Verify 6 rows are displayed for _Authors_ and _Posts and Pages_.
- Verify `View more` is _not_ displayed.

cc @SylvesterWilmott 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
