### PR TITLE
[Stats Refresh] Improve x-axis label formatting

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
@@ -66,12 +66,7 @@ class HorizontalAxisFormatter: IAxisValueFormatter {
     private func weekIncludingDate(_ date: Date) -> (weekStart: Date, weekEnd: Date)? {
         // Note: Week is Monday - Sunday
 
-        let calendar: Calendar = {
-            var cal = Calendar(identifier: .iso8601)
-            cal.timeZone = .autoupdatingCurrent
-            return cal
-        }()
-
+        let calendar = Calendar.current
         guard let weekStart = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)),
             let weekEnd = calendar.date(byAdding: .day, value: 6, to: weekStart) else {
                 return nil

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
@@ -25,19 +25,6 @@ class HorizontalAxisFormatter: IAxisValueFormatter {
     private let initialDateInterval: TimeInterval
     private let period: StatsPeriodUnit
 
-    private var format: String {
-        switch period {
-        case .day:
-            return "MMM d, yyyy"
-        case .week:
-            return "MMM d"
-        case .month:
-            return "MMM, yyyy"
-        case .year:
-            return "yyyy"
-        }
-    }
-
     private lazy var formatter = DateFormatter()
 
     // MARK: HorizontalAxisFormatter
@@ -64,7 +51,7 @@ class HorizontalAxisFormatter: IAxisValueFormatter {
     }
 
     private func updateFormatterTemplate() {
-        formatter.setLocalizedDateFormatFromTemplate(format)
+        formatter.setLocalizedDateFormatFromTemplate(period.dateFormatTemplate)
     }
 
     private func formattedDate(forWeekStarting date: Date) -> String {

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+AxisFormatters.swift
@@ -44,7 +44,7 @@ class HorizontalAxisFormatter: IAxisValueFormatter {
 
         switch period {
             case .week:
-                return formattedDate(forWeekStarting: date)
+                return formattedDate(forWeekContaining: date)
             default:
                 return formatter.string(from: date)
         }
@@ -54,14 +54,30 @@ class HorizontalAxisFormatter: IAxisValueFormatter {
         formatter.setLocalizedDateFormatFromTemplate(period.dateFormatTemplate)
     }
 
-    private func formattedDate(forWeekStarting date: Date) -> String {
-        let oneWeek = DateComponents(weekOfYear: 1)
-
-        guard let weekAhead = Calendar.current.date(byAdding: oneWeek, to: date) else {
-            return formatter.string(from: date)
+    private func formattedDate(forWeekContaining date: Date) -> String {
+        let week = weekIncludingDate(date)
+        guard let weekStart = week?.weekStart, let weekEnd = week?.weekEnd else {
+            return ""
         }
 
-        return "\(formatter.string(from: date)) – \(formatter.string(from: weekAhead))"
+        return "\(formatter.string(from: weekStart)) – \(formatter.string(from: weekEnd))"
+    }
+
+    private func weekIncludingDate(_ date: Date) -> (weekStart: Date, weekEnd: Date)? {
+        // Note: Week is Monday - Sunday
+
+        let calendar: Calendar = {
+            var cal = Calendar(identifier: .iso8601)
+            cal.timeZone = .autoupdatingCurrent
+            return cal
+        }()
+
+        guard let weekStart = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)),
+            let weekEnd = calendar.date(byAdding: .day, value: 6, to: weekStart) else {
+                return nil
+        }
+
+        return (weekStart, weekEnd)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -56,22 +56,22 @@ private struct PeriodChartData: BarChartDataConvertible {
 
 private final class PeriodChartDataTransformer {
     static func transform(data: StatsSummaryTimeIntervalData) -> (barChartData: [BarChartDataConvertible], barChartStyling: [BarChartStyling]) {
-        let data = data.summaryData
+        let summaryData = data.summaryData
 
         let firstDateInterval: TimeInterval
         let lastDateInterval: TimeInterval
         let effectiveWidth: Double
 
-        if data.isEmpty {
+        if summaryData.isEmpty {
             firstDateInterval = 0
             lastDateInterval = 0
             effectiveWidth = 1
         } else {
-            firstDateInterval = data.first?.periodStartDate.timeIntervalSince1970 ?? 0
-            lastDateInterval = data.last?.periodStartDate.timeIntervalSince1970 ?? 0
+            firstDateInterval = summaryData.first?.periodStartDate.timeIntervalSince1970 ?? 0
+            lastDateInterval = summaryData.last?.periodStartDate.timeIntervalSince1970 ?? 0
 
             let range = lastDateInterval - firstDateInterval
-            let effectiveBars = Double(Double(data.count) * 1.2)
+            let effectiveBars = Double(Double(summaryData.count) * 1.2)
             effectiveWidth = range / effectiveBars
         }
 
@@ -79,7 +79,7 @@ private final class PeriodChartDataTransformer {
         var visitorEntries  = [BarChartDataEntry]()
         var likeEntries     = [BarChartDataEntry]()
         var commentEntries  = [BarChartDataEntry]()
-        for datum in data {
+        for datum in summaryData {
             let dateInterval = datum.periodStartDate.timeIntervalSince1970
             let offset = dateInterval - firstDateInterval
 
@@ -128,7 +128,7 @@ private final class PeriodChartDataTransformer {
             barChartDataConvertibles.append(periodChartData)
         }
 
-        let horizontalAxisFormatter = HorizontalAxisFormatter(initialDateInterval: firstDateInterval)
+        let horizontalAxisFormatter = HorizontalAxisFormatter(initialDateInterval: firstDateInterval, period: data.period)
         let chartStyling: [BarChartStyling] = [
             ViewsPeriodChartStyling(xAxisValueFormatter: horizontalAxisFormatter),
             DefaultPeriodChartStyling(xAxisValueFormatter: horizontalAxisFormatter),

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -192,6 +192,7 @@ private extension StatsBarChartView {
     func configureBarChartViewProperties() {
         drawBarShadowEnabled = false
         drawValueAboveBarEnabled = false
+        clipValuesToContentEnabled = false
         fitBars = true
     }
 
@@ -286,6 +287,7 @@ private extension StatsBarChartView {
         xAxis.labelTextColor = styling.labelColor
         xAxis.setLabelCount(Constants.horizontalAxisLabelCount, force: true)
         xAxis.valueFormatter = styling.xAxisValueFormatter
+        xAxis.avoidFirstLastClippingEnabled = true
     }
 
     func configureYAxis() {

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -276,7 +276,7 @@ extension StatsPeriodUnit {
         case .week:
             return "MMM d"
         case .month:
-            return "MMM yyyy"
+            return "MMM, yyyy"
         case .year:
             return "yyyy"
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -78,11 +78,7 @@ private extension SiteStatsTableHeaderView {
                 return nil
             }
 
-            let startDate = dateFormatter.string(from: weekStart)
-            let endDate = dateFormatter.string(from: weekEnd)
-
-            let weekFormat = NSLocalizedString("%@ - %@", comment: "Stats label for week date range. Ex: Mar 25 - Mar 31")
-            return String.localizedStringWithFormat(weekFormat, startDate, endDate)
+            return "\(dateFormatter.string(from: weekStart)) – \(dateFormatter.string(from: weekEnd))"
         }
     }
 


### PR DESCRIPTION
Fixes #11880. This PR updates the x axis label formatting to match android. The new formats are as follows:

Latest Post: MMM d, yyyy
Day: MMM d, yyyy
Week: MMM d – MMM d
Month: MMM, yyyy
Year: yyyy

These should now match Android:

![x-axislabels](https://user-images.githubusercontent.com/4780/59179894-57a18a00-8b5b-11e9-9d07-06c2991dfa33.png)

Note that while the formatting matches, the actual date ranges seem to be slightly different on Android, but I think this is an unrelated issue that we should check into.

**To test:**

* Build and run
* Verify that dates are formatted as expected!

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.