### PR TITLE
Bundle patch

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -35,7 +35,7 @@ end
 
 def wordpress_ui
     ## for production:
-    pod 'WordPressUI', '~> 1.3.3'
+    pod 'WordPressUI', '~> 1.3.4'
     ## for development:
     ## pod 'WordPressUI', :path => '../WordPressUI-iOS'
     ## while PR is in review:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -201,7 +201,7 @@ PODS:
   - WordPressShared (1.8.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
-  - WordPressUI (1.3.3)
+  - WordPressUI (1.3.4)
   - WPMediaPicker (1.4.1)
   - wpxmlrpc (0.8.4)
   - yoga (0.59.3.React)
@@ -254,7 +254,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.5.0)
   - WordPressKit (~> 4.1.2)
   - WordPressShared (~> 1.8.1)
-  - WordPressUI (~> 1.3.3)
+  - WordPressUI (~> 1.3.4)
   - WPMediaPicker (~> 1.4.1)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/36c0aa9845001cd632ef6969a59036f0216b8ad1/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
   - ZendeskSDK (= 2.3.1)
@@ -389,13 +389,13 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: e8617f67da0cb013ffaade1f4410f8cfbbe30d97
   WordPressKit: 09a28afc17dc63d35b6bd76c69fa94a7049183eb
   WordPressShared: 34f7a1386d28d7e4650c1a225c554ee024401ca3
-  WordPressUI: 0ea6df25bf6e63f0619376fa23870177cb37646f
+  WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
   WPMediaPicker: 8cff8dff846f3440c0c6d088c12240ab85570ee5
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   yoga: 0cb6e1c4f763ba12d1c825f2d6f863da6614a2a4
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 5315e44e17e1374a1beae9c70402e24c6bf8fc48
+PODFILE CHECKSUM: 14839efe9b9af8e0bd3e536cfcf875ff13fe14b9
 
 COCOAPODS: 1.6.1

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		17FCA6811FD84B4600DBA9C8 /* NoticeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */; };
 		1A433B1D2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */; };
 		1A82EC9F229EBAFB000F141E /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2B4EA11FD6654A007AE3E4 /* Logger.swift */; };
+		1ABA150822AE5F870039311A /* WordPressUIBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */; };
 		1AE0F2AE2296EDD4000BDD7F /* BlogDetailsViewController+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AE0F2AD2296EDD4000BDD7F /* BlogDetailsViewController+Stats.swift */; };
 		1D36FCB53C05724865D41F7A /* Pods_WordPress.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 556E3A9C1600564F6A3CADF6 /* Pods_WordPress.framework */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
@@ -2092,6 +2093,7 @@
 		17F7C24822770B68002E5C2E /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStore.swift; sourceTree = "<group>"; };
 		1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComRestApi+Defaults.swift"; sourceTree = "<group>"; };
+		1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressUIBundleTests.swift; sourceTree = "<group>"; };
 		1AE0F2AD2296EDD4000BDD7F /* BlogDetailsViewController+Stats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+Stats.swift"; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D6058910D05DD3D006BFB54 /* WordPress.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordPress.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -6077,6 +6079,7 @@
 				5948AD101AB73D19006E8882 /* WPAppAnalyticsTests.m */,
 				E1E4CE0C177439D100430844 /* WPAvatarSourceTest.m */,
 				5981FE041AB8A89A0009E080 /* WPUserAgentTests.m */,
+				1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -11075,6 +11078,7 @@
 				40EE948222132F5800CD264F /* PublicizeConectionStatsRecordValueTests.swift in Sources */,
 				02761EC4227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift in Sources */,
 				732A473D218787500015DA74 /* WPRichTextFormatterTests.swift in Sources */,
+				1ABA150822AE5F870039311A /* WordPressUIBundleTests.swift in Sources */,
 				1797373720EBAA4100377B4E /* RouteMatcherTests.swift in Sources */,
 				73178C2A21BEE09300E37C9A /* SiteSegmentsCellTests.swift in Sources */,
 				B5416CFE1C1756B900006DD8 /* PushNotificationsManagerTests.m in Sources */,

--- a/WordPress/WordPressTest/WordPressUIBundleTests.swift
+++ b/WordPress/WordPressTest/WordPressUIBundleTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import WordPressUI
+
+/// This tests are intended to ensure that WordPressUI resources are loaded correctly in the app.
+/// It should prevent a regression of issues like https://github.com/wordpress-mobile/WordPress-iOS/issues/11848
+class WordPressUIBundleTests: XCTestCase {
+
+    func testImageLoading() {
+        let gravatarImage = UIImage.gravatarPlaceholderImage
+        XCTAssertNotNil(gravatarImage)
+    }
+
+    func testFancyAlertsLoading() {
+        let config = FancyAlertViewController.Config(titleText: "Title",
+                                                     bodyText: "Body",
+                                                     headerImage: UIImage.gravatarPlaceholderImage,
+                                                     dividerPosition: .bottom,
+                                                     defaultButton: nil,
+                                                     cancelButton: nil,
+                                                     neverButton: nil,
+                                                     moreInfoButton: nil,
+                                                     titleAccessoryButton: nil,
+                                                     switchConfig: nil,
+                                                     appearAction: nil,
+                                                     dismissAction: nil)
+        let vc = FancyAlertViewController.controllerWithConfiguration(configuration: config)
+        XCTAssertNotNil(vc)
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/11848

This fixes the image loading crash by updating WordPressUI (see https://github.com/wordpress-mobile/WordPressUI-iOS/pull/37) and adding regression tests to ensure it can't happen again.

To test:

- See that the tests pass.
- A smoke test works as expected without crashing.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
