### PR TITLE
[Stats Refresh] Show grey bars when chart is empty

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -764,7 +764,6 @@ private extension StatsPeriodStore {
             state.summary = newSummary
         }
 
-        persistToCoreData()
     }
 
     func receivedPostsAndPages(_ postsAndPages: StatsTopPostsTimeIntervalData?, _ error: Error?) {

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -764,6 +764,7 @@ private extension StatsPeriodStore {
             state.summary = newSummary
         }
 
+        persistToCoreData()
     }
 
     func receivedPostsAndPages(_ postsAndPages: StatsTopPostsTimeIntervalData?, _ error: Error?) {

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
@@ -37,6 +37,9 @@ protocol BarChartStyling {
     /// This corresponds to the color of labels on the chart
     var labelColor: UIColor { get }
 
+    /// This corresponds to the legend color; currently only applicable when Views/Visitors overlaid.
+    var legendColor: UIColor? { get }
+
     /// If specified, a legend will be presented with this value. It maps to the secondary bar color above.
     var legendTitle: String? { get }
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
@@ -18,7 +18,7 @@ extension BarChartDataSet {
 
 // MARK: - Charts protocols
 
-/// Describes the visual appearance of a BarChartView. Implementation TBD.
+/// Describes the visual appearance of a BarChartView.
 ///
 protocol BarChartStyling {
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -137,9 +137,9 @@ private final class PeriodChartDataTransformer {
         let horizontalAxisFormatter = HorizontalAxisFormatter(initialDateInterval: firstDateInterval, period: data.period)
         let chartStyling: [BarChartStyling] = [
             ViewsPeriodChartStyling(primaryBarColor: primaryBarColor(forCount: totalViews),
-                                    secondaryBarColor: secondaryBarColor(forCount: totalViews),
+                                    secondaryBarColor: secondaryBarColor(forCount: totalVisitors),
                                     primaryHighlightColor: primaryHighlightColor(forCount: totalViews),
-                                    secondaryHighlightColor: secondaryHighlightColor(forCount: totalViews),
+                                    secondaryHighlightColor: secondaryHighlightColor(forCount: totalVisitors),
                                     xAxisValueFormatter: horizontalAxisFormatter),
             DefaultPeriodChartStyling(primaryBarColor: primaryBarColor(forCount: totalVisitors),
                                       primaryHighlightColor: primaryHighlightColor(forCount: totalVisitors),

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -136,27 +136,50 @@ private final class PeriodChartDataTransformer {
 
         let horizontalAxisFormatter = HorizontalAxisFormatter(initialDateInterval: firstDateInterval)
         let chartStyling: [BarChartStyling] = [
-            ViewsPeriodChartStyling(primaryBarColor: (totalViews > 0 ? WPStyleGuide.wordPressBlue() : WPStyleGuide.lightGrey()),
+            ViewsPeriodChartStyling(primaryBarColor: primaryBarColor(forCount: totalViews),
+                                    secondaryBarColor: secondaryBarColor(forCount: totalViews),
+                                    primaryHighlightColor: primaryHighlightColor(forCount: totalViews),
+                                    secondaryHighlightColor: secondaryHighlightColor(forCount: totalViews),
                                     xAxisValueFormatter: horizontalAxisFormatter),
-            DefaultPeriodChartStyling(primaryBarColor: (totalVisitors > 0 ? WPStyleGuide.wordPressBlue() : WPStyleGuide.lightGrey()),
+            DefaultPeriodChartStyling(primaryBarColor: primaryBarColor(forCount: totalVisitors),
+                                      primaryHighlightColor: primaryHighlightColor(forCount: totalVisitors),
                                       xAxisValueFormatter: horizontalAxisFormatter),
-            DefaultPeriodChartStyling(primaryBarColor: (totalLikes > 0 ? WPStyleGuide.wordPressBlue() : WPStyleGuide.lightGrey()),
+            DefaultPeriodChartStyling(primaryBarColor: primaryBarColor(forCount: totalLikes),
+                                      primaryHighlightColor: primaryHighlightColor(forCount: totalLikes),
                                       xAxisValueFormatter: horizontalAxisFormatter),
-            DefaultPeriodChartStyling(primaryBarColor: (totalComments > 0 ? WPStyleGuide.wordPressBlue() : WPStyleGuide.lightGrey()),
+            DefaultPeriodChartStyling(primaryBarColor: primaryBarColor(forCount: totalComments),
+                                      primaryHighlightColor: primaryHighlightColor(forCount: totalComments),
                                       xAxisValueFormatter: horizontalAxisFormatter),
         ]
 
         return (barChartDataConvertibles, chartStyling)
     }
+
+    static func primaryBarColor(forCount count: Int) -> UIColor {
+        return count > 0 ? WPStyleGuide.wordPressBlue() : WPStyleGuide.lightGrey()
+    }
+
+    static func secondaryBarColor(forCount count: Int) -> UIColor {
+        return count > 0 ? WPStyleGuide.darkBlue() : WPStyleGuide.lightGrey()
+    }
+
+    static func primaryHighlightColor(forCount count: Int) -> UIColor? {
+        return count > 0 ? WPStyleGuide.jazzyOrange() : nil
+    }
+
+    static func secondaryHighlightColor(forCount count: Int) -> UIColor? {
+        return count > 0 ? WPStyleGuide.fireOrange() : nil
+    }
+
 }
 
 // MARK: - ViewsPeriodChartStyling
 
 private struct ViewsPeriodChartStyling: BarChartStyling {
     let primaryBarColor: UIColor
-    let secondaryBarColor: UIColor?                 = WPStyleGuide.darkBlue()
-    let primaryHighlightColor: UIColor?             = WPStyleGuide.jazzyOrange()
-    let secondaryHighlightColor: UIColor?           = WPStyleGuide.fireOrange()
+    let secondaryBarColor: UIColor?
+    let primaryHighlightColor: UIColor?
+    let secondaryHighlightColor: UIColor?
     let labelColor: UIColor                         = WPStyleGuide.grey()
     let legendTitle: String?                        = NSLocalizedString("Visitors", comment: "This appears in the legend of the period chart; Visitors are superimposed over Views in that case.")
     let lineColor: UIColor                          = WPStyleGuide.greyLighten30()
@@ -169,7 +192,7 @@ private struct ViewsPeriodChartStyling: BarChartStyling {
 private struct DefaultPeriodChartStyling: BarChartStyling {
     let primaryBarColor: UIColor
     let secondaryBarColor: UIColor?                 = nil
-    let primaryHighlightColor: UIColor?             = WPStyleGuide.jazzyOrange()
+    let primaryHighlightColor: UIColor?
     let secondaryHighlightColor: UIColor?           = nil
     let labelColor: UIColor                         = WPStyleGuide.grey()
     let legendTitle: String?                        = nil

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -75,6 +75,11 @@ private final class PeriodChartDataTransformer {
             effectiveWidth = range / effectiveBars
         }
 
+        let totalViews = data.compactMap({$0.viewsCount}).reduce(0, +)
+        let totalVisitors = data.compactMap({$0.visitorsCount}).reduce(0, +)
+        let totalLikes = data.compactMap({$0.likesCount}).reduce(0, +)
+        let totalComments = data.compactMap({$0.commentsCount}).reduce(0, +)
+
         var viewEntries     = [BarChartDataEntry]()
         var visitorEntries  = [BarChartDataEntry]()
         var likeEntries     = [BarChartDataEntry]()
@@ -85,10 +90,11 @@ private final class PeriodChartDataTransformer {
 
             let x = offset
 
-            let viewEntry = BarChartDataEntry(x: x, y: Double(datum.viewsCount))
-            let visitorEntry = BarChartDataEntry(x: x, y: Double(datum.visitorsCount))
-            let likeEntry = BarChartDataEntry(x: x, y: Double(datum.likesCount))
-            let commentEntry = BarChartDataEntry(x: x, y: Double(datum.commentsCount))
+            // If the chart has no data, show "stub" bars
+            let viewEntry = BarChartDataEntry(x: x, y: totalViews > 0 ? Double(datum.viewsCount) : 1.0)
+            let visitorEntry = BarChartDataEntry(x: x, y: totalVisitors > 0 ? Double(datum.visitorsCount) : 1.0)
+            let likeEntry = BarChartDataEntry(x: x, y: totalLikes > 0 ? Double(datum.likesCount) : 1.0)
+            let commentEntry = BarChartDataEntry(x: x, y: totalComments > 0 ? Double(datum.commentsCount) : 1.0)
 
             viewEntries.append(viewEntry)
             visitorEntries.append(visitorEntry)
@@ -130,10 +136,14 @@ private final class PeriodChartDataTransformer {
 
         let horizontalAxisFormatter = HorizontalAxisFormatter(initialDateInterval: firstDateInterval)
         let chartStyling: [BarChartStyling] = [
-            ViewsPeriodChartStyling(xAxisValueFormatter: horizontalAxisFormatter),
-            DefaultPeriodChartStyling(xAxisValueFormatter: horizontalAxisFormatter),
-            DefaultPeriodChartStyling(xAxisValueFormatter: horizontalAxisFormatter),
-            DefaultPeriodChartStyling(xAxisValueFormatter: horizontalAxisFormatter),
+            ViewsPeriodChartStyling(primaryBarColor: (totalViews > 0 ? WPStyleGuide.wordPressBlue() : WPStyleGuide.lightGrey()),
+                                    xAxisValueFormatter: horizontalAxisFormatter),
+            DefaultPeriodChartStyling(primaryBarColor: (totalVisitors > 0 ? WPStyleGuide.wordPressBlue() : WPStyleGuide.lightGrey()),
+                                      xAxisValueFormatter: horizontalAxisFormatter),
+            DefaultPeriodChartStyling(primaryBarColor: (totalLikes > 0 ? WPStyleGuide.wordPressBlue() : WPStyleGuide.lightGrey()),
+                                      xAxisValueFormatter: horizontalAxisFormatter),
+            DefaultPeriodChartStyling(primaryBarColor: (totalComments > 0 ? WPStyleGuide.wordPressBlue() : WPStyleGuide.lightGrey()),
+                                      xAxisValueFormatter: horizontalAxisFormatter),
         ]
 
         return (barChartDataConvertibles, chartStyling)
@@ -143,7 +153,7 @@ private final class PeriodChartDataTransformer {
 // MARK: - ViewsPeriodChartStyling
 
 private struct ViewsPeriodChartStyling: BarChartStyling {
-    let primaryBarColor: UIColor                    = WPStyleGuide.wordPressBlue()
+    let primaryBarColor: UIColor
     let secondaryBarColor: UIColor?                 = WPStyleGuide.darkBlue()
     let primaryHighlightColor: UIColor?             = WPStyleGuide.jazzyOrange()
     let secondaryHighlightColor: UIColor?           = WPStyleGuide.fireOrange()
@@ -157,7 +167,7 @@ private struct ViewsPeriodChartStyling: BarChartStyling {
 // MARK: - DefaultPeriodChartStyling
 
 private struct DefaultPeriodChartStyling: BarChartStyling {
-    let primaryBarColor: UIColor                    = WPStyleGuide.wordPressBlue()
+    let primaryBarColor: UIColor
     let secondaryBarColor: UIColor?                 = nil
     let primaryHighlightColor: UIColor?             = WPStyleGuide.jazzyOrange()
     let secondaryHighlightColor: UIColor?           = nil

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -181,6 +181,7 @@ private struct ViewsPeriodChartStyling: BarChartStyling {
     let primaryHighlightColor: UIColor?
     let secondaryHighlightColor: UIColor?
     let labelColor: UIColor                         = WPStyleGuide.grey()
+    let legendColor: UIColor?                       = WPStyleGuide.wordPressBlue()
     let legendTitle: String?                        = NSLocalizedString("Visitors", comment: "This appears in the legend of the period chart; Visitors are superimposed over Views in that case.")
     let lineColor: UIColor                          = WPStyleGuide.greyLighten30()
     let xAxisValueFormatter: IAxisValueFormatter
@@ -195,6 +196,7 @@ private struct DefaultPeriodChartStyling: BarChartStyling {
     let primaryHighlightColor: UIColor?
     let secondaryHighlightColor: UIColor?           = nil
     let labelColor: UIColor                         = WPStyleGuide.grey()
+    let legendColor: UIColor?                       = nil
     let legendTitle: String?                        = nil
     let lineColor: UIColor                          = WPStyleGuide.greyLighten30()
     let xAxisValueFormatter: IAxisValueFormatter

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -75,10 +75,10 @@ private final class PeriodChartDataTransformer {
             effectiveWidth = range / effectiveBars
         }
 
-        let totalViews = data.compactMap({$0.viewsCount}).reduce(0, +)
-        let totalVisitors = data.compactMap({$0.visitorsCount}).reduce(0, +)
-        let totalLikes = data.compactMap({$0.likesCount}).reduce(0, +)
-        let totalComments = data.compactMap({$0.commentsCount}).reduce(0, +)
+        let totalViews = summaryData.compactMap({$0.viewsCount}).reduce(0, +)
+        let totalVisitors = summaryData.compactMap({$0.visitorsCount}).reduce(0, +)
+        let totalLikes = summaryData.compactMap({$0.likesCount}).reduce(0, +)
+        let totalComments = summaryData.compactMap({$0.commentsCount}).reduce(0, +)
 
         var viewEntries     = [BarChartDataEntry]()
         var visitorEntries  = [BarChartDataEntry]()

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
@@ -145,6 +145,7 @@ private struct PostChartStyling: BarChartStyling {
     let primaryHighlightColor: UIColor?
     let secondaryHighlightColor: UIColor?           = nil
     let labelColor: UIColor                         = WPStyleGuide.grey()
+    let legendColor: UIColor?                       = nil
     let legendTitle: String?                        = nil
     let lineColor: UIColor                          = WPStyleGuide.greyLighten30()
     let xAxisValueFormatter: IAxisValueFormatter

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
@@ -119,16 +119,22 @@ private final class PostChartDataTransformer {
         let chartData = BarChartData(entries: entries)
         chartData.barWidth = effectiveWidth
 
-        let primaryBarColor = totalViews > 0 ? WPStyleGuide.wordPressBlue() : WPStyleGuide.lightGrey()
         let xAxisFormatter: IAxisValueFormatter = HorizontalAxisFormatter(initialDateInterval: firstDateInterval)
-
-        let styling = PostChartStyling(primaryBarColor: primaryBarColor,
-                                       primaryHighlightColor: type.highlightColor,
+        let styling = PostChartStyling(primaryBarColor: primaryBarColor(forCount: totalViews),
+                                       primaryHighlightColor: primaryHighlightColor(forType: type, withCount: totalViews),
                                        xAxisValueFormatter: xAxisFormatter)
-
 
         return (chartData, styling)
     }
+
+    static func primaryBarColor(forCount count: Int) -> UIColor {
+        return count > 0 ? WPStyleGuide.wordPressBlue() : WPStyleGuide.lightGrey()
+    }
+
+    static func primaryHighlightColor(forType type: PostChartType, withCount count: Int) -> UIColor? {
+        return count > 0 ? type.highlightColor : nil
+    }
+
 }
 
 // MARK: - PostChartStyling

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
@@ -101,13 +101,16 @@ private final class PostChartDataTransformer {
             effectiveWidth = range / effectiveBars
         }
 
+        let totalViews = data.compactMap({$0.viewsCount}).reduce(0, +)
+
         var entries = [BarChartDataEntry]()
         for datum in data {
             let dateInterval = datum.postDateTimeInterval ?? 0
             let offset = dateInterval - firstDateInterval
 
             let x = offset
-            let y = Double(datum.viewsCount)
+            // If the chart has no data, show "stub" bars
+            let y = totalViews > 0 ? Double(datum.viewsCount) : 1.0
             let entry = BarChartDataEntry(x: x, y: y)
 
             entries.append(entry)
@@ -116,8 +119,13 @@ private final class PostChartDataTransformer {
         let chartData = BarChartData(entries: entries)
         chartData.barWidth = effectiveWidth
 
+        let primaryBarColor = totalViews > 0 ? WPStyleGuide.wordPressBlue() : WPStyleGuide.lightGrey()
         let xAxisFormatter: IAxisValueFormatter = HorizontalAxisFormatter(initialDateInterval: firstDateInterval)
-        let styling = PostChartStyling(primaryHighlightColor: type.highlightColor, xAxisValueFormatter: xAxisFormatter)
+
+        let styling = PostChartStyling(primaryBarColor: primaryBarColor,
+                                       primaryHighlightColor: type.highlightColor,
+                                       xAxisValueFormatter: xAxisFormatter)
+
 
         return (chartData, styling)
     }
@@ -126,7 +134,7 @@ private final class PostChartDataTransformer {
 // MARK: - PostChartStyling
 
 private struct PostChartStyling: BarChartStyling {
-    let primaryBarColor: UIColor                    = WPStyleGuide.wordPressBlue()
+    let primaryBarColor: UIColor
     let secondaryBarColor: UIColor?                 = nil
     let primaryHighlightColor: UIColor?
     let secondaryHighlightColor: UIColor?           = nil

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -263,7 +263,7 @@ private extension StatsBarChartView {
     func configureLegendIfNeeded() {
         legend.enabled = false
 
-        guard let legendColor = styling.secondaryBarColor, let legendTitle = styling.legendTitle, legendView == nil else {
+        guard let legendColor = styling.legendColor, let legendTitle = styling.legendTitle, legendView == nil else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -221,9 +221,13 @@ private extension StatsBarChartView {
         primaryDataSet.colors = [ styling.primaryBarColor ]
         primaryDataSet.drawValuesEnabled = false
 
-        primaryDataSet.highlightAlpha = Constants.highlightAlpha
         if let initialHighlightColor = styling.primaryHighlightColor {
+            primaryDataSet.highlightAlpha = Constants.highlightAlpha
             primaryDataSet.highlightColor = initialHighlightColor
+            primaryDataSet.highlightEnabled = true
+        } else {
+            primaryDataSet.highlightEnabled = false
+            highlightPerTapEnabled = false
         }
 
         // Secondary

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -118,6 +118,10 @@ private extension SiteStatsPeriodViewModel {
 
         if mostRecentChartData == nil {
             mostRecentChartData = periodSummary
+        } else if let mostRecentChartData = mostRecentChartData,
+            let periodSummary = periodSummary,
+            mostRecentChartData.periodEndDate == periodSummary.periodEndDate {
+            self.mostRecentChartData = periodSummary
         } else if let periodSummary = periodSummary, let chartData = mostRecentChartData, periodSummary.periodEndDate > chartData.periodEndDate {
             mostRecentChartData = chartData
         }


### PR DESCRIPTION
Ref #11876
Fixes #11888 

This change displays light grey bars when a chart view is empty. 

This also fixes an issue where chart Likes was not being updated after the Likes query finished.

To test:

---
Latest Post Summary chart:
- The empty view on this one is a bit hard to trigger.
  - A site with views, but no views in the past 2 weeks.
  - A site with no views, but has Likes or Comments.
- Verify light grey bars appear on the chart.

<img width="400" alt="lps" src="https://user-images.githubusercontent.com/1816888/59235667-b42e9480-8baf-11e9-9e5b-8a051c45508f.png">

---
Period Overview chart:
- On a site with no Views, Visitors, Likes, and/or Comments for _all the periods_ on the chart.
- Verify light grey bars appear on the chart.

<img width="400" alt="no_likes" src="https://user-images.githubusercontent.com/1816888/59235734-0f608700-8bb0-11e9-8a5d-4a13e0837204.png">

<img width="400" alt="no_views" src="https://user-images.githubusercontent.com/1816888/59235778-5484b900-8bb0-11e9-9431-1b202ed7f960.png">

---
Post Stats chart:
- Access Post Stats for a site with no stats in the past 2 weeks.
- Verify light grey bars appear on the chart.

<img width="400" alt="post_stats" src="https://user-images.githubusercontent.com/1816888/59235816-86961b00-8bb0-11e9-80a6-7d5a0088a54b.png">

---
Chart Likes:
- On a site with Likes.
- Verify Likes updates after the query finishes.

<img width="400" alt="likes_init" src="https://user-images.githubusercontent.com/1816888/59235917-f5737400-8bb0-11e9-829a-330dce4506ba.png">

<img width="400" alt="likes_updated" src="https://user-images.githubusercontent.com/1816888/59235921-f86e6480-8bb0-11e9-89aa-a7086a206204.png">


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
