### PR TITLE
[Stats Refresh] change Post Stats chart delegate

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -19,6 +19,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
     private var postURL: URL?
     private var postID: Int?
     private var selectedDate = Date()
+    private var tableHeaderView: SiteStatsTableHeaderView?
     private typealias Style = WPStyleGuide.Stats
     private var viewModel: PostStatsViewModel?
     private let store = StoreContainer.shared.statsPeriod
@@ -55,8 +56,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
         }
 
         cell.configure(date: selectedDate, period: .day, delegate: self)
-        viewModel?.statsBarChartViewDelegate = cell
-
+        tableHeaderView = cell
         return cell
     }
 
@@ -90,6 +90,8 @@ private extension PostStatsTableViewController {
 
             self?.refreshTableView()
         }
+
+        viewModel?.statsBarChartViewDelegate = self
     }
 
     func trackAccessEvent() {
@@ -181,6 +183,14 @@ extension PostStatsTableViewController: PostStatsDelegate {
         navigationController?.pushViewController(detailTableViewController, animated: true)
     }
 
+}
+
+// MARK: - StatsBarChartViewDelegate
+
+extension PostStatsTableViewController: StatsBarChartViewDelegate {
+    func statsBarChartValueSelected(_ statsBarChartView: StatsBarChartView, entryIndex: Int, entryCount: Int) {
+        tableHeaderView?.statsBarChartValueSelected(statsBarChartView, entryIndex: entryIndex, entryCount: entryCount)
+    }
 }
 
 // MARK: - SiteStatsTableHeaderDelegate Methods


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/11882#issuecomment-500704850

The problem is that sometimes the date bar is created _after_ the overview chart. This resulted in the chart delegate being `nil` because the delegate was the date bar.

This changes the chart delegate to be `PostStatsTableViewController`. Which then inform the date bar when a chart bar has been selected.

To test:
- Access Post Stats via both:
  - Insights > Latest Post Summary > View more.
  - Period > Post and Pages > row selection.
- Verify selecting a chart bar updates the data.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
