### PR TITLE
Don't show blocking alert on set feature image

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 12.7
 -----
 * Block Editor: Video, Quote and More blocks are available now.
+* Post Settings: Setting a Featured Image on a Post/Site should now work better in poor netowrk conditions.
 
 12.6
 -----

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.h
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.h
@@ -31,6 +31,14 @@
 /// currently being processed or uploaded.
 @property (nonatomic) BOOL includeUnsyncedMedia;
 
+/// Defaults to `NO`.
+/// By default, network errors (causes by e.g. devices being offline, or user using a slow network)
+/// will cause `-[WPMediaCollectionDataSource loadDataWithOptions:success:failure:]` to call the
+/// failure block. Setting this to `YES` will override this behavior and return an empty result instead.
+/// Note: this only applies to the fetching operation — write/upload operations will still return errors
+/// normal.
+@property (nonatomic) BOOL ignoreNetworkLoadingErrors;
+
 /// The total asset account, ignoring the current search query if there is one.
 @property (nonatomic, readonly) NSInteger totalAssetCount;
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.h
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.h
@@ -32,12 +32,12 @@
 @property (nonatomic) BOOL includeUnsyncedMedia;
 
 /// Defaults to `NO`.
-/// By default, network errors (causes by e.g. devices being offline, or user using a slow network)
+/// By default, errors (causes by e.g. devices being offline, or user using a slow network) when syncing
 /// will cause `-[WPMediaCollectionDataSource loadDataWithOptions:success:failure:]` to call the
-/// failure block. Setting this to `YES` will override this behavior and return an empty result instead.
-/// Note: this only applies to the fetching operation — write/upload operations will still return errors
+/// failure block. Setting this to `YES` will override this behavior, and will call the `successBlock` instead.
+/// Note: this only applies to the fetching operation — write/upload operations will still return errors as
 /// normal.
-@property (nonatomic) BOOL ignoreNetworkLoadingErrors;
+@property (nonatomic) BOOL ignoreSyncErrors;
 
 /// The total asset account, ignoring the current search query if there is one.
 @property (nonatomic, readonly) NSInteger totalAssetCount;

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -139,14 +139,14 @@
     // try to sync from the server
     MediaCoordinator *mediaCoordinator = [MediaCoordinator shared];
 
-    __weak __typeof(self) weakSelf = self;
+    __block BOOL ignoreSyncError = self.ignoreSyncErrors;
     [mediaCoordinator syncMediaFor:self.blog
                            success:^{
                                if (!localResultsAvailable && successBlock) {
                                    successBlock();
                                }
                            } failure:^(NSError * _Nonnull error) {
-                               if ([error.domain isEqualToString:NSURLErrorDomain] && weakSelf.ignoreNetworkLoadingErrors && successBlock) {
+                               if (ignoreSyncError && successBlock) {
                                    successBlock();
                                    return;
                                }

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -5,7 +5,7 @@ enum MediaNoticeUserInfoKey {
 }
 
 struct MediaProgressCoordinatorNoticeViewModel {
-    static let ErrorNoticeTag: Notice.Tag = "MediaProgressCoordinatorNoticeViewModel.tag"
+    static let uploadErrorNoticeTag: Notice.Tag = "MediaProgressCoordinatorNoticeViewModel.UploadError"
 
     private let mediaProgressCoordinator: MediaProgressCoordinator
     private let successfulMedia: [Media]
@@ -64,7 +64,7 @@ struct MediaProgressCoordinatorNoticeViewModel {
                       feedbackType: .error,
                       notificationInfo: notificationInfo,
                       actionTitle: NSLocalizedString("Retry", comment: "User action to retry media upload."),
-                      tag: MediaProgressCoordinatorNoticeViewModel.ErrorNoticeTag,
+                      tag: MediaProgressCoordinatorNoticeViewModel.uploadErrorNoticeTag,
                       actionHandler: { _ in
                         for media in self.failedMedia {
                             MediaCoordinator.shared.retryMedia(media)

--- a/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaProgressCoordinatorNoticeViewModel.swift
@@ -5,6 +5,8 @@ enum MediaNoticeUserInfoKey {
 }
 
 struct MediaProgressCoordinatorNoticeViewModel {
+    static let ErrorNoticeTag: Notice.Tag = "MediaProgressCoordinatorNoticeViewModel.tag"
+
     private let mediaProgressCoordinator: MediaProgressCoordinator
     private let successfulMedia: [Media]
     private let failedMedia: [Media]
@@ -62,6 +64,7 @@ struct MediaProgressCoordinatorNoticeViewModel {
                       feedbackType: .error,
                       notificationInfo: notificationInfo,
                       actionTitle: NSLocalizedString("Retry", comment: "User action to retry media upload."),
+                      tag: MediaProgressCoordinatorNoticeViewModel.ErrorNoticeTag,
                       actionHandler: { _ in
                         for media in self.failedMedia {
                             MediaCoordinator.shared.retryMedia(media)

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.h
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.h
@@ -22,6 +22,4 @@ typedef NS_ENUM(NSUInteger, MediaPickerDataSourceType) {
 - (instancetype)initWithPost:(AbstractPost *)post
        initialDataSourceType:(MediaPickerDataSourceType)sourceType;
 
-@property (nonatomic) BOOL mediaLibraryIgnoresNetworkLoadingErrors;
-
 @end

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.h
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.h
@@ -22,4 +22,6 @@ typedef NS_ENUM(NSUInteger, MediaPickerDataSourceType) {
 - (instancetype)initWithPost:(AbstractPost *)post
        initialDataSourceType:(MediaPickerDataSourceType)sourceType;
 
+@property (nonatomic) BOOL mediaLibraryIgnoresNetworkLoadingErrors;
+
 @end

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -56,7 +56,7 @@
     _observers = [[NSMutableDictionary alloc] init];
     _groupObservers = [[NSMutableDictionary alloc] init];
     _searchQuery = @"";
-    _mediaLibraryDataSource.ignoreNetworkLoadingErrors = YES;
+    _mediaLibraryDataSource.ignoreSyncErrors = YES;
     
     [self setDataSourceType:sourceType];
 }

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -78,6 +78,10 @@
     }
 }
 
+- (void)setMediaLibraryIgnoresNetworkLoadingErrors:(BOOL)mediaLibraryIgnoresNetworkLoadingErrors {
+    self.mediaLibraryDataSource.ignoreNetworkLoadingErrors = mediaLibraryIgnoresNetworkLoadingErrors;
+}
+
 - (NSInteger)numberOfGroups
 {
     return [self.mediaLibraryDataSource numberOfGroups] + [self.deviceLibraryDataSource numberOfGroups];

--- a/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/WPAndDeviceMediaLibraryDataSource.m
@@ -56,6 +56,7 @@
     _observers = [[NSMutableDictionary alloc] init];
     _groupObservers = [[NSMutableDictionary alloc] init];
     _searchQuery = @"";
+    _mediaLibraryDataSource.ignoreNetworkLoadingErrors = YES;
     
     [self setDataSourceType:sourceType];
 }
@@ -76,10 +77,6 @@
         default:
             break;
     }
-}
-
-- (void)setMediaLibraryIgnoresNetworkLoadingErrors:(BOOL)mediaLibraryIgnoresNetworkLoadingErrors {
-    self.mediaLibraryDataSource.ignoreNetworkLoadingErrors = mediaLibraryIgnoresNetworkLoadingErrors;
 }
 
 - (NSInteger)numberOfGroups

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
@@ -69,7 +69,7 @@ extension PostSettingsViewController {
             let errorTitle = NSLocalizedString("Couldn't upload the featured image", comment: "The title for an alert that says to the user that the featured image he selected couldn't be uploaded.")
             let notice = Notice(title: errorTitle, message: error.localizedDescription)
 
-            ActionDispatcher.dispatch(NoticeAction.clearWithTag(MediaProgressCoordinatorNoticeViewModel.ErrorNoticeTag))
+            ActionDispatcher.dispatch(NoticeAction.clearWithTag(MediaProgressCoordinatorNoticeViewModel.uploadErrorNoticeTag))
             // The Media coordinator shows its own notice about a failed upload. We have a better, more explanatory message for users here
             // so we want to supress the one coming from the coordinator and show ours.
             ActionDispatcher.dispatch(NoticeAction.post(notice))

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Photos
+import WordPressFlux
 
 extension PostSettingsViewController {
 
@@ -64,7 +65,14 @@ extension PostSettingsViewController {
                 apost.removeMediaObject(media)
                 break
             }
-            WPError.showAlert(withTitle: NSLocalizedString("Couldn't upload the featured image", comment: "The title for an alert that says to the user that the featured image he selected couldn't be uploaded."), message: error.localizedDescription)
+
+            let errorTitle = NSLocalizedString("Couldn't upload the featured image", comment: "The title for an alert that says to the user that the featured image he selected couldn't be uploaded.")
+            let notice = Notice(title: errorTitle, message: error.localizedDescription)
+
+            ActionDispatcher.dispatch(NoticeAction.clearWithTag(MediaProgressCoordinatorNoticeViewModel.ErrorNoticeTag))
+            // The Media coordinator shows its own notice about a failed upload. We have a better, more explanatory message for users here
+            // so we want to supress the one coming from the coordinator and show ours.
+            ActionDispatcher.dispatch(NoticeAction.post(notice))
         case .progress:
             break
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1328,14 +1328,19 @@ FeaturedImageViewControllerDelegate>
     options.badgedUTTypes = [NSSet setWithObject: (__bridge NSString *)kUTTypeGIF];
     options.preferredStatusBarStyle = UIStatusBarStyleLightContent;
     WPNavigationMediaPickerViewController *picker = [[WPNavigationMediaPickerViewController alloc] initWithOptions:options];
-    self.mediaDataSource = [[WPAndDeviceMediaLibraryDataSource alloc] initWithPost:self.apost
-                                                             initialDataSourceType:MediaPickerDataSourceTypeMediaLibrary];
-    picker.dataSource = self.mediaDataSource;
+
+    WPAndDeviceMediaLibraryDataSource *mediaDataSource = [[WPAndDeviceMediaLibraryDataSource alloc] initWithPost:self.apost
+                                                                                           initialDataSourceType:MediaPickerDataSourceTypeMediaLibrary];
+    mediaDataSource.mediaLibraryIgnoresNetworkLoadingErrors = YES;
+
+    picker.dataSource = mediaDataSource;
     picker.delegate = self;
     [self registerChangeObserverForPicker:picker.mediaPicker];
 
     picker.modalPresentationStyle = UIModalPresentationFormSheet;
     [self presentViewController:picker animated:YES completion:nil];
+
+    self.mediaDataSource = mediaDataSource;
 }
 
 - (void)showCategoriesSelection

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -1331,7 +1331,6 @@ FeaturedImageViewControllerDelegate>
 
     WPAndDeviceMediaLibraryDataSource *mediaDataSource = [[WPAndDeviceMediaLibraryDataSource alloc] initWithPost:self.apost
                                                                                            initialDataSourceType:MediaPickerDataSourceTypeMediaLibrary];
-    mediaDataSource.mediaLibraryIgnoresNetworkLoadingErrors = YES;
 
     picker.dataSource = mediaDataSource;
     picker.delegate = self;


### PR DESCRIPTION
Fixes #11433.

Before, trying to set a Featured image on a post while offline/on a slow connection, would throw up this ugly modal pop-up.

Now, it lets you pick an image and tries to upload it anyway — displaying a notice if it fails.

|before|after|
|---|---|
|![Simulator Screen Shot - iPhone Xs Max - 2019-06-12 at 05 40 33](https://user-images.githubusercontent.com/1594081/59322002-a32b7380-8cd4-11e9-966d-a09509cbe75a.png)|![Simulator Screen Shot - iPhone Xs Max - 2019-06-12 at 05 33 20](https://user-images.githubusercontent.com/1594081/59321854-f7822380-8cd3-11e9-9ec4-d010904fc07b.png)|




To test:
1. Put your device/sim offline.
2. Go to Posts
3. Open editor for any given Post
4. Go to Post Settings
5. Try to set a featured image
6. Verify that the app lets you try to do that, even when offline