### PR TITLE
Run WordPressUITests nightly on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,48 @@
 version: 2.1
 
 orbs:
-  ios: wordpress-mobile/ios@0.0.25
+  ios: wordpress-mobile/ios@0.0.29
+
+jobs:
+  build-ui-tests:
+    executor:
+      name: ios/default
+      xcode-version: "10.2.0"
+    steps:
+      - checkout
+      - ios/install-dependencies:
+          bundle-install: true
+          pod-install: true
+      - ios/xcodebuild:
+          command: build-for-testing
+          arguments: -workspace 'WordPress.xcworkspace' -scheme 'WordPressUITests' -configuration 'Debug' -sdk iphonesimulator -derivedDataPath DerivedData
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - DerivedData/Build/Products
+            - Pods/WordPressMocks
+  run-ui-tests:
+    parameters:
+      device:
+        type: string
+    executor:
+      name: ios/default
+      xcode-version: "10.2.0"
+    steps:
+      - ios/boot-simulator:
+          xcode-version: "10.2.0"
+          device: << parameters.device >>
+      - attach_workspace:
+          at: ./
+      - run:
+          name: Run mocks
+          command: ./Pods/WordPressMocks/scripts/start.sh 8282
+          background: true
+      - ios/wait-for-simulator
+      - ios/xcodebuild:
+          command: test-without-building
+          arguments: -xctestrun DerivedData/Build/Products/WordPressUITests_iphonesimulator12.2-x86_64.xctestrun -destination "platform=iOS Simulator,id=$SIMULATOR_UDID"
+      - ios/save-xcodebuild-artifacts
 
 workflows:
   wordpress_ios:
@@ -12,6 +53,22 @@ workflows:
           workspace: WordPress.xcworkspace
           scheme: WordPress
           device: iPhone XS
-          ios-version: "12.2"
-          # If you want to reset the CircleCI cache, increment the number in the cache prefix below
-          cache-prefix: dependency-cache-v1
+  ui_tests:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - build-ui-tests:
+          name: Build UI Tests
+      - run-ui-tests:
+          name: UI Tests (iPhone Xs)
+          device: iPhone Xs
+          requires: [ "Build UI Tests" ]
+      - run-ui-tests:
+          name: UI Tests (iPad 6th generation)
+          device: iPad \\(6th generation\\)
+          requires: [ "Build UI Tests" ]

--- a/Podfile
+++ b/Podfile
@@ -315,7 +315,7 @@ target 'WordPressComStatsiOSTests' do
 end
 
 def wordpress_mocks
-  pod 'WordPressMocks', '~> 0.0.1'
+  pod 'WordPressMocks', '~> 0.0.3'
 end
 
 ## Screenshot Generation

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -198,7 +198,7 @@ PODS:
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
-  - WordPressMocks (0.0.1)
+  - WordPressMocks (0.0.3)
   - WordPressShared (1.8.3-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
@@ -254,7 +254,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.6.5)
   - WordPressAuthenticator (~> 1.5.3-beta)
   - WordPressKit (~> 4.1.3-beta)
-  - WordPressMocks (~> 0.0.1)
+  - WordPressMocks (~> 0.0.3)
   - WordPressShared (~> 1.8.3-beta)
   - WordPressUI (~> 1.3.4)
   - WPMediaPicker (~> 1.4.1)
@@ -391,7 +391,7 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: b744ea2f6ca051bf2fd965f9b3ac12eef3272419
   WordPressAuthenticator: 229726b4d090984c70abb69e9c619b94355838cc
   WordPressKit: c611c1ec513c7662cfa2e89142df8a1a4ece3c5f
-  WordPressMocks: bdebffc38f4fa8097e95e204b9a293aab670fcce
+  WordPressMocks: 08001205dae38f6afb8d0c0a4dd573ff0b4d62fd
   WordPressShared: 7f3007a57331b4567c2c5bc539990818dd9a9965
   WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
   WPMediaPicker: 8cff8dff846f3440c0c6d088c12240ab85570ee5
@@ -400,6 +400,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: acc35ffbe869f334703d3b7dd910f484be2592dc
+PODFILE CHECKSUM: a2b693eb27e5060617116b36cbb3fd70fe03d5dc
 
 COCOAPODS: 1.6.1

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -8786,7 +8786,6 @@
 			buildConfigurationList = FF27169A1CAAC87B0006E2D4 /* Build configuration list for PBXNativeTarget "WordPressUITests" */;
 			buildPhases = (
 				37F48D4CB364EA4BCC1EAE82 /* [CP] Check Pods Manifest.lock */,
-				928885381E5E057F001F9637 /* Reset Simulator */,
 				FF27168B1CAAC87A0006E2D4 /* Sources */,
 				FF27168C1CAAC87A0006E2D4 /* Frameworks */,
 				FF27168D1CAAC87A0006E2D4 /* Resources */,
@@ -9523,20 +9522,6 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WordPress/Pods-WordPress-resources.sh\"\n";
 			showEnvVarsInLog = 0;
-		};
-		928885381E5E057F001F9637 /* Reset Simulator */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Reset Simulator";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/bin/xcrun simctl uninstall booted org.wordpress";
 		};
 		9879533A2135D77500743763 /* Zendesk Strip Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
This adds the necessary CircleCI config to run the full UI test suite every night.

It depends on the following open PRs:

- ~https://github.com/wordpress-mobile/circleci-orbs/pull/28~ Now merged.
- ~https://github.com/wordpress-mobile/WordPressMocks/pull/4~ Now merged.

To test:

There is not much you can do to test this apart from seeing that the UI tests pass on CircleCI: https://circleci.com/gh/wordpress-mobile/WordPress-iOS/8374.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
