### PR TITLE
Fixing an issue with post content disappearing on visible editor

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -238,7 +238,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
         [self.managedObjectContext performBlock:^{
             AbstractPost *postInContext = (AbstractPost *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
-                if ([postInContext isRevision]) {
+                if ([postInContext isRevision] && [postInContext isDraft]) {
                     postInContext = postInContext.original;
                     [postInContext applyRevision];
                     [postInContext deleteRevision];


### PR DESCRIPTION
Fixes #11897 

This issue was introduced with [this fix ](https://github.com/wordpress-mobile/WordPress-iOS/pull/11736)

Now we're only going to merge the revision back to the base post if its status is draft. Seems like a work around but I'm expecting this to be solved more elegantly with the implementation of the uplaod manager. 

To test:
1. Be offline
2.Edit a published post
3. Choose update
See a snack bar with "error occurred while saving" and the post content remains as is.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
