### PR TITLE
[Stats Refresh] remove references to old stats service

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -1,7 +1,6 @@
 import Foundation
 import WordPressKit
 import WordPressFlux
-import WordPressComStatsiOS
 
 enum InsightAction: Action {
 

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -1,6 +1,5 @@
 import Foundation
 import WordPressFlux
-import WordPressComStatsiOS
 
 enum PeriodAction: Action {
 

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
@@ -1,5 +1,4 @@
 import Foundation
-import WordPressComStatsiOS
 
 /// Singleton class to contain site related information for Stats.
 ///
@@ -13,24 +12,5 @@ import WordPressComStatsiOS
     @objc var siteID: NSNumber?
     @objc var siteTimeZone: TimeZone?
     @objc var oauth2Token: String?
-
-    static let cacheExpirationInterval = Double(300)
-
-    // MARK: - Instance Methods
-
-    static func statsService() -> WPStatsService? {
-
-        guard let siteID = SiteStatsInformation.sharedInstance.siteID,
-            let siteTimeZone = SiteStatsInformation.sharedInstance.siteTimeZone,
-            let oauth2Token = SiteStatsInformation.sharedInstance.oauth2Token else {
-                return nil
-        }
-
-        return WPStatsService.init(siteId: siteID,
-                                   siteTimeZone: siteTimeZone,
-                                   oauth2Token: oauth2Token,
-                                   andCacheExpirationInterval: SiteStatsInformation.cacheExpirationInterval,
-                                   apiBaseUrlString: Environment.current.wordPressComApiBase)
-    }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -1,5 +1,4 @@
 import UIKit
-import WordPressComStatsiOS
 import Gridicons
 
 class LatestPostSummaryCell: UITableViewCell, NibLoadable {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import WordPressComStatsiOS
 import WordPressFlux
 
 /// The view model used by Stats Insights.

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -1,5 +1,4 @@
 import UIKit
-import WordPressComStatsiOS
 
 // MARK: - Shared Rows
 


### PR DESCRIPTION
Fixes #n/a

This mainly just removes importing `WordPressComStatsiOS` in various new Stats files. It's not been used since `StatsServiceRemoteV2` was fully implemented.

I also made a minor change to the way `StatsServiceRemoteV2` is created for Insights. 

To test:
- Sanity check Insights, make sure the stats appear as expected.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
