### PR TITLE
Update WordPressMocks to include sign up and make development easier

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -315,7 +315,9 @@ target 'WordPressComStatsiOSTests' do
 end
 
 def wordpress_mocks
-  pod 'WordPressMocks', '~> 0.0.3'
+  pod 'WordPressMocks', '~> 0.0.4'
+  # pod 'WordPressMocks', :git => 'https://github.com/wordpress-mobile/WordPressMocks.git', :commit => ''
+  # pod 'WordPressMocks', :path => '../WordPressMocks'
 end
 
 ## Screenshot Generation

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -198,7 +198,7 @@ PODS:
     - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
-  - WordPressMocks (0.0.3)
+  - WordPressMocks (0.0.4)
   - WordPressShared (1.8.3-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
@@ -254,7 +254,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.6.5)
   - WordPressAuthenticator (~> 1.5.3-beta)
   - WordPressKit (~> 4.1.3-beta)
-  - WordPressMocks (~> 0.0.3)
+  - WordPressMocks (~> 0.0.4)
   - WordPressShared (~> 1.8.3-beta)
   - WordPressUI (~> 1.3.4)
   - WPMediaPicker (~> 1.4.1)
@@ -391,7 +391,7 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: b744ea2f6ca051bf2fd965f9b3ac12eef3272419
   WordPressAuthenticator: 229726b4d090984c70abb69e9c619b94355838cc
   WordPressKit: c611c1ec513c7662cfa2e89142df8a1a4ece3c5f
-  WordPressMocks: 08001205dae38f6afb8d0c0a4dd573ff0b4d62fd
+  WordPressMocks: 6d5830ec362084029b9928c3718ea4a8e09e95d6
   WordPressShared: 7f3007a57331b4567c2c5bc539990818dd9a9965
   WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
   WPMediaPicker: 8cff8dff846f3440c0c6d088c12240ab85570ee5
@@ -400,6 +400,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: a2b693eb27e5060617116b36cbb3fd70fe03d5dc
+PODFILE CHECKSUM: 6249ded901973aff64d37716c57e875405e892c7
 
 COCOAPODS: 1.6.1

--- a/Rakefile
+++ b/Rakefile
@@ -118,7 +118,13 @@ CLOBBER << "vendor"
 
 desc "Mocks"
 task :mocks do
-  sh "./Pods/WordPressMocks/scripts/start.sh 8282"
+  wordpress_mocks_path = "./Pods/WordPressMocks"
+  # If WordPressMocks is referenced by a local path, use that.
+  unless lockfile_hash.dig("EXTERNAL SOURCES", "WordPressMocks", :path).nil?
+    wordpress_mocks_path = lockfile_hash.dig("EXTERNAL SOURCES", "WordPressMocks", :path)
+  end
+
+  sh "#{wordpress_mocks_path}/scripts/start.sh 8282"
 end
 
 desc "Build #{XCODE_SCHEME}"
@@ -252,13 +258,17 @@ def pod(args)
   sh(*args)
 end
 
+def lockfile_hash
+  YAML.load(File.read("Podfile.lock"))
+end
+
 def lockfiles_match?
   File.file?('Pods/Manifest.lock') && FileUtils.compare_file('Podfile.lock', 'Pods/Manifest.lock')
 end
 
 def podfile_locked?
   podfile_checksum = Digest::SHA1.file("Podfile")
-  lockfile_checksum = YAML.load(File.read("Podfile.lock"))["PODFILE CHECKSUM"]
+  lockfile_checksum = lockfile_hash["PODFILE CHECKSUM"]
 
   podfile_checksum == lockfile_checksum
 end


### PR DESCRIPTION
This has two quick improvements to the mocks:

- Include @JavonDavis's changes for sign up (https://github.com/wordpress-mobile/WordPressMocks/pull/5).
- Make `rake mocks` work if you are using a local copy of `WordPressMocks` to make development easier.

To test:

- Run `rake mocks`.
- Run the UI tests to confirm they still pass.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
