### PR TITLE
Revert fix for Discard losing changes

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -236,13 +236,8 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     };
     void (^failureBlock)(NSError *error) = ^(NSError *error) {
         [self.managedObjectContext performBlock:^{
-            AbstractPost *postInContext = (AbstractPost *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
+            Post *postInContext = (Post *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
-                if ([postInContext isRevision]) {
-                    postInContext = postInContext.original;
-                    [postInContext applyRevision];
-                    [postInContext deleteRevision];
-                }
                 postInContext.remoteStatus = AbstractPostRemoteStatusFailed;
                 // If the post was not created on the server yet we convert the post to a local draft post with the current date.
                 if (!postInContext.hasRemote) {


### PR DESCRIPTION
Reverts #11736 (fac83ab447507b7fb9afb6f0e41e03ed8276bcf8) as it caused the Editor to discard the contents when pressing the _Update_ button while offline. This was found while finding the solution for #11905. 

<img src="https://user-images.githubusercontent.com/198826/59392627-87a48500-8d35-11e9-9e7b-284106fde0a8.gif" width="320">

The #11736 changes will have to be reverted for `develop` too. After that, we will find a way to fix it without causing the regression. 

## Testing

1. While online, create a draft. Make sure the draft is uploaded to the server. 
2. Stay on the Post List and go offline. 
3. Edit the draft. Make some changes.
4. Click on the _Update_ button. The contents should not disappear.

Please also test other statuses like published or when online. 

There's another unrelated issue here. After exiting and retrying the upload, the Post List will not show the updated contents. However, after pulling-to-refresh, it will be back to normal. The remote is uploaded before the pull-to-refresh so no data was lost. 

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.

