### PR TITLE
[Refresh Stats] Fix crash on rotation

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -28,7 +28,9 @@ class SiteStatsDashboardViewController: UIViewController {
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-        updatePeriodView(oldSelectedPeriod: currentSelectedPeriod, reloadData: false)
+        if traitCollection.verticalSizeClass == .regular, traitCollection.horizontalSizeClass == .compact {
+            updatePeriodView(oldSelectedPeriod: currentSelectedPeriod)
+        }
     }
 }
 
@@ -120,7 +122,7 @@ private extension SiteStatsDashboardViewController {
         currentSelectedPeriod = getSelectedPeriodFromUserDefaults()
     }
 
-    func updatePeriodView(oldSelectedPeriod: StatsPeriodType, reloadData: Bool = true) {
+    func updatePeriodView(oldSelectedPeriod: StatsPeriodType) {
         let selectedPeriodChanged = currentSelectedPeriod != oldSelectedPeriod
         let previousSelectedPeriodWasInsights = oldSelectedPeriod == .insights
         let pageViewControllerIsEmpty = pageViewController?.viewControllers?.isEmpty ?? true
@@ -132,20 +134,16 @@ private extension SiteStatsDashboardViewController {
                                                        direction: .forward,
                                                        animated: false)
             }
-            if reloadData {
-                insightsTableViewController.refreshInsights()
-            }
+            insightsTableViewController.refreshInsights()
         default:
             if previousSelectedPeriodWasInsights || pageViewControllerIsEmpty {
                 pageViewController?.setViewControllers([periodTableViewController],
                                                        direction: .forward,
                                                        animated: false)
             }
-            if reloadData {
-                periodTableViewController.selectedDate = Date()
-                let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
-                periodTableViewController.selectedPeriod = selectedPeriod
-            }
+            periodTableViewController.selectedDate = periodTableViewController.selectedDate ?? Date()
+            let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
+            periodTableViewController.selectedPeriod = selectedPeriod
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -26,6 +26,10 @@ class SiteStatsDashboardViewController: UIViewController {
             break
         }
     }
+
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        updatePeriodView(oldSelectedPeriod: currentSelectedPeriod, reloadData: false)
+    }
 }
 
 // MARK: - Private Extension
@@ -116,7 +120,7 @@ private extension SiteStatsDashboardViewController {
         currentSelectedPeriod = getSelectedPeriodFromUserDefaults()
     }
 
-    func updatePeriodView(oldSelectedPeriod: StatsPeriodType) {
+    func updatePeriodView(oldSelectedPeriod: StatsPeriodType, reloadData: Bool = true) {
         let selectedPeriodChanged = currentSelectedPeriod != oldSelectedPeriod
         let previousSelectedPeriodWasInsights = oldSelectedPeriod == .insights
         let pageViewControllerIsEmpty = pageViewController?.viewControllers?.isEmpty ?? true
@@ -128,17 +132,20 @@ private extension SiteStatsDashboardViewController {
                                                        direction: .forward,
                                                        animated: false)
             }
-            insightsTableViewController.refreshInsights()
-            break
+            if reloadData {
+                insightsTableViewController.refreshInsights()
+            }
         default:
             if previousSelectedPeriodWasInsights || pageViewControllerIsEmpty {
                 pageViewController?.setViewControllers([periodTableViewController],
                                                        direction: .forward,
                                                        animated: false)
             }
-            periodTableViewController.selectedDate = Date()
-            let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
-            periodTableViewController.selectedPeriod = selectedPeriod
+            if reloadData {
+                periodTableViewController.selectedDate = Date()
+                let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
+                periodTableViewController.selectedPeriod = selectedPeriod
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -29,7 +29,7 @@ class SiteStatsDashboardViewController: UIViewController {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         if traitCollection.verticalSizeClass == .regular, traitCollection.horizontalSizeClass == .compact {
-            updatePeriodView(oldSelectedPeriod: currentSelectedPeriod)
+            updatePeriodView(oldSelectedPeriod: currentSelectedPeriod, withDate: periodTableViewController.selectedDate)
         }
     }
 }
@@ -122,7 +122,7 @@ private extension SiteStatsDashboardViewController {
         currentSelectedPeriod = getSelectedPeriodFromUserDefaults()
     }
 
-    func updatePeriodView(oldSelectedPeriod: StatsPeriodType) {
+    func updatePeriodView(oldSelectedPeriod: StatsPeriodType, withDate periodDate: Date? = Date()) {
         let selectedPeriodChanged = currentSelectedPeriod != oldSelectedPeriod
         let previousSelectedPeriodWasInsights = oldSelectedPeriod == .insights
         let pageViewControllerIsEmpty = pageViewController?.viewControllers?.isEmpty ?? true
@@ -141,7 +141,7 @@ private extension SiteStatsDashboardViewController {
                                                        direction: .forward,
                                                        animated: false)
             }
-            periodTableViewController.selectedDate = periodTableViewController.selectedDate ?? Date()
+            periodTableViewController.selectedDate = periodDate
             let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
             periodTableViewController.selectedPeriod = selectedPeriod
         }


### PR DESCRIPTION
Fixes #11922 

This fix the crash when the Stats section is selected and the device rotates.
This bug should affect all the devices where you have a single screen in portrait and a split view in landscape.

## To test:
• Run the branch on and iPhone XR, X, 8 Plus, iPad
• Open Stats from a selected blog
• Rotate the device. It shouldn't crash.
• Change also period and rotate

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
