### PR TITLE
Revert fix for Discard losing changes in develop

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -236,13 +236,8 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     };
     void (^failureBlock)(NSError *error) = ^(NSError *error) {
         [self.managedObjectContext performBlock:^{
-            AbstractPost *postInContext = (AbstractPost *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
+            Post *postInContext = (Post *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
-                if ([postInContext isRevision]) {
-                    postInContext = postInContext.original;
-                    [postInContext applyRevision];
-                    [postInContext deleteRevision];
-                }
                 postInContext.remoteStatus = AbstractPostRemoteStatusFailed;
                 // If the post was not created on the server yet we convert the post to a local draft post with the current date.
                 if (!postInContext.hasRemote) {

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -238,7 +238,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
         [self.managedObjectContext performBlock:^{
             AbstractPost *postInContext = (AbstractPost *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
-                if ([postInContext isRevision] && [postInContext isDraft]) {
+                if ([postInContext isRevision]) {
                     postInContext = postInContext.original;
                     [postInContext applyRevision];
                     [postInContext deleteRevision];


### PR DESCRIPTION
Completely reverts the fixes for #11435. 

This reverts the PRs #11898 and #11736. They caused the Editor to discard the contents when pressing the Update button while offline, both for drafts and published posts. This was found while finding the solution for #11905.

The #11736 was already reverted for `release/12.6` in https://github.com/wordpress-mobile/WordPress-iOS/pull/11920.

## Proposal 

As I commented in https://github.com/wordpress-mobile/WordPress-iOS/issues/11435#issuecomment-501859629, we still need to fix the #11435 issue but we should wait until the discussion in wordpress-mobile/WordPress-Android#9561 is finished so the iOS and Android solutions will match. 

## Testing

1. While online, create a draft. Make sure the draft is uploaded to the server. 
2. Stay on the Post List and go offline. 
3. Edit the draft. Make some changes.
4. Click on the _Update_ button. The contents should not disappear.

Please also test other statuses like published or when online.

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.

