### PR TITLE
[Stats Refresh] Insights Today: update to new design

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Block Editor: Video, Quote and More blocks are available now.
 * Post Settings: Setting a Featured Image on a Post/Site should now work better in poor netowrk conditions.
 * Stats Insights: New two-column layout for All-Time stats.
+* Stats Insights: New two-column layout for Today stats.
 
 12.6
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -235,7 +235,7 @@
         static let mostPopularTime = NSLocalizedString("Most Popular Time", comment: "Insights 'Most Popular Time' header")
         static let followerTotals = NSLocalizedString("Follower Totals", comment: "Insights 'Follower Totals' header")
         static let publicize = NSLocalizedString("Publicize", comment: "Insights 'Publicize' header")
-        static let todaysStats = NSLocalizedString("Today's Stats", comment: "Insights 'Today's Stats' header")
+        static let todaysStats = NSLocalizedString("Today", comment: "Insights 'Today' header")
         static let postingActivity = NSLocalizedString("Posting Activity", comment: "Insights 'Posting Activity' header")
         static let comments = NSLocalizedString("Comments", comment: "Insights 'Comments' header")
         static let followers = NSLocalizedString("Followers", comment: "Insights 'Followers' header")

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -94,7 +94,7 @@ class SiteStatsInsightsViewModel: Observable {
                 tableRows.append(createFollowersRow())
             case .todaysStats:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsTodaysStats.title))
-                tableRows.append(SimpleTotalsStatsRow(dataRows: createTodaysStatsRows()))
+                tableRows.append(TwoColumnStatsRow(dataRows: createTodaysStatsRows(), statSection: .insightsTodaysStats))
             case .postingActivity:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsPostingActivity.title))
                 tableRows.append(createPostingActivityRow())
@@ -151,11 +151,7 @@ private extension SiteStatsInsightsViewModel {
         static let viewsTitle = NSLocalizedString("Views", comment: "Today's Stats 'Views' label")
         static let visitorsTitle = NSLocalizedString("Visitors", comment: "Today's Stats 'Visitors' label")
         static let likesTitle = NSLocalizedString("Likes", comment: "Today's Stats 'Likes' label")
-        static let likesIcon = Style.imageForGridiconType(.star)
         static let commentsTitle = NSLocalizedString("Comments", comment: "Today's Stats 'Comments' label")
-        static let viewsIcon = Style.imageForGridiconType(.visible)
-        static let visitorsIcon = Style.imageForGridiconType(.user)
-        static let commentsIcon = Style.imageForGridiconType(.comment)
     }
 
     struct AnnualSiteStats {
@@ -273,35 +269,31 @@ private extension SiteStatsInsightsViewModel {
         }
     }
 
-    func createTodaysStatsRows() -> [StatsTotalRowData] {
+    func createTodaysStatsRows() -> [StatsTwoColumnRowData] {
         guard let todaysStats = insightsStore.getTodaysStats() else {
             return []
         }
-        var dataRows = [StatsTotalRowData]()
 
-        if todaysStats.viewsCount > 0 {
-            dataRows.append(StatsTotalRowData.init(name: TodaysStats.viewsTitle,
-                                                   data: todaysStats.viewsCount.abbreviatedString(),
-                                                   icon: TodaysStats.viewsIcon))
+        let totalCounts = todaysStats.viewsCount +
+                          todaysStats.visitorsCount +
+                          todaysStats.likesCount +
+                          todaysStats.commentsCount
+
+        guard totalCounts > 0 else {
+            return []
         }
 
-        if todaysStats.visitorsCount > 0 {
-            dataRows.append(StatsTotalRowData.init(name: TodaysStats.visitorsTitle,
-                                                   data: todaysStats.visitorsCount.abbreviatedString(),
-                                                   icon: TodaysStats.visitorsIcon))
-        }
+        var dataRows = [StatsTwoColumnRowData]()
 
-        if todaysStats.likesCount > 0 {
-            dataRows.append(StatsTotalRowData.init(name: TodaysStats.likesTitle,
-                                                   data: todaysStats.likesCount.abbreviatedString(),
-                                                   icon: TodaysStats.likesIcon))
-        }
+        dataRows.append(StatsTwoColumnRowData.init(leftColumnName: TodaysStats.viewsTitle,
+                                                   leftColumnData: todaysStats.viewsCount.abbreviatedString(),
+                                                   rightColumnName: TodaysStats.visitorsTitle,
+                                                   rightColumnData: todaysStats.visitorsCount.abbreviatedString()))
 
-        if todaysStats.commentsCount > 0 {
-            dataRows.append(StatsTotalRowData.init(name: TodaysStats.commentsTitle,
-                                                   data: todaysStats.commentsCount.abbreviatedString(),
-                                                   icon: TodaysStats.commentsIcon))
-        }
+        dataRows.append(StatsTwoColumnRowData.init(leftColumnName: TodaysStats.likesTitle,
+                                                   leftColumnData: todaysStats.likesCount.abbreviatedString(),
+                                                   rightColumnName: TodaysStats.commentsTitle,
+                                                   rightColumnData: todaysStats.commentsCount.abbreviatedString()))
 
         return dataRows
     }


### PR DESCRIPTION
Fixes #11904  

This updates Insights _Today_ to use the two-column stat card.

To test:

- On a site with no Today data, go to Insights _Today_.
  - Verify `No data yet` is shown.
- On a site with Today data, go to Insights _Today_.
  - Verify the data is shown in two columns.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
