### PR TITLE
removing displayHasFailedMediaAlert

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,8 +6,8 @@
 * Stats Insights: New two-column layout for This Year stats.
 * Stats Insights: added details option for This Year stats.
 * Stats Insights: New two-column layout for Most Popular Time stats.
-
 * Improved messaging experience on failure to upload media.
+
 12.7
 -----
 * Block Editor: Video, Quote and More blocks are available now.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * Stats Insights: added details option for This Year stats.
 * Stats Insights: New two-column layout for Most Popular Time stats.
 
+* Improved messaging experience on failure to upload media.
 12.7
 -----
 * Block Editor: Video, Quote and More blocks are available now.

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -39,16 +39,6 @@ extension PostEditor where Self: UIViewController {
             return
         }
 
-        // If there is any failed media allow it to be removed or cancel publishing
-        if hasFailedMedia {
-            displayHasFailedMediaAlert(then: {
-                // Failed media is removed, try again.
-                // Note: Intentionally not tracking another analytics stat here (no appropriate one exists yet)
-                self.publishPost(action: action, dismissWhenDone: dismissWhenDone, analyticsStat: analyticsStat)
-            })
-            return
-        }
-
         // If the user is trying to publish to WP.com and they haven't verified their account, prompt them to do so.
         if let verificationHelper = verificationPromptHelper, verificationHelper.needsVerification(before: postEditorStateContext.action) {
             verificationHelper.displayVerificationPrompt(from: self) { [unowned self] verifiedInBackground in
@@ -127,17 +117,6 @@ extension PostEditor where Self: UIViewController {
     fileprivate func displayMediaIsUploadingAlert() {
         let alertController = UIAlertController(title: MediaUploadingAlert.title, message: MediaUploadingAlert.message, preferredStyle: .alert)
         alertController.addDefaultActionWithTitle(MediaUploadingAlert.acceptTitle)
-        present(alertController, animated: true, completion: nil)
-    }
-
-    fileprivate func displayHasFailedMediaAlert(then: @escaping () -> ()) {
-        let alertController = UIAlertController(title: FailedMediaRemovalAlert.title, message: FailedMediaRemovalAlert.message, preferredStyle: .alert)
-        alertController.addDefaultActionWithTitle(FailedMediaRemovalAlert.acceptTitle) { [weak self] alertAction in
-            self?.removeFailedMedia()
-            then()
-        }
-
-        alertController.addCancelActionWithTitle(FailedMediaRemovalAlert.cancelTitle)
         present(alertController, animated: true, completion: nil)
     }
 
@@ -459,11 +438,4 @@ private struct MediaUploadingAlert {
     static let title = NSLocalizedString("Uploading media", comment: "Title for alert when trying to save/exit a post before media upload process is complete.")
     static let message = NSLocalizedString("You are currently uploading media. Please wait until this completes.", comment: "This is a notification the user receives if they are trying to save a post (or exit) before the media upload process is complete.")
     static let acceptTitle  = NSLocalizedString("OK", comment: "Accept Action")
-}
-
-private struct FailedMediaRemovalAlert {
-    static let title = NSLocalizedString("Uploads failed", comment: "Title for alert when trying to save post with failed media items")
-    static let message = NSLocalizedString("Some media uploads failed. This action will remove all failed media from the post.\nSave anyway?", comment: "Confirms with the user if they save the post all media that failed to upload will be removed from it.")
-    static let acceptTitle  = NSLocalizedString("Yes", comment: "Accept Action")
-    static let cancelTitle  = NSLocalizedString("Not Now", comment: "Nicer dialog answer for \"No\".")
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -10781,7 +10781,6 @@
 				D865722E2186F96D0023A99C /* SiteSegmentsWizardContent.swift in Sources */,
 				E66969E01B9E648100EC9C00 /* ReaderTopicToReaderDefaultTopic37to38.swift in Sources */,
 				F1DB8D2B2288C24500906E2F /* UploadsManager.swift in Sources */,
-				9822AFA021EECB8E007D922D /* AnnualSiteStatsCell.swift in Sources */,
 				82A062DE2017BCBA0084CE7C /* ActivityListSectionHeaderView.swift in Sources */,
 				73FEC871220B358500CEF791 /* WPAccount+RestApi.swift in Sources */,
 				B5FF3BE71CAD881100C1D597 /* ImageCropOverlayView.swift in Sources */,


### PR DESCRIPTION
As we are showing the snack bar on a fail upload and giving the option to retry in multiple places we no longer need the popup alert
removing related code as suggested in: https://github.com/wordpress-mobile/WordPress-iOS/issues/11429#issuecomment-501737362

Fixes #11429 

To test:
1. Be offline
2. Add image to an existing Aztec post
3. See retry overlay and snack bar with error message
4. Choose update 
5. See the snack bar with "Error occurred while saving"

![IMG_4430](https://user-images.githubusercontent.com/1335657/59624481-d91d8d00-9104-11e9-8572-d595cb939cdb.PNG)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
