### PR TITLE
[Stats Refresh] Insights This Year: add `View more` details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 12.8
 -----
 * Stats Insights: New two-column layout for This Year stats.
+* Stats Insights: added details option for This Year stats.
 * Stats Insights: New two-column layout for Most Popular Time stats.
 
 12.7

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -307,3 +307,16 @@
     }
 
 }
+
+// MARK: - Strings specific to Annual Site Stats
+
+struct AnnualSiteStats {
+    static let year = NSLocalizedString("Year", comment: "'This Year' label for the the year.")
+    static let totalPosts = NSLocalizedString("Total Posts", comment: "'This Year' label for the total number of posts.")
+    static let totalComments = NSLocalizedString("Total Comments", comment: "'This Year' label for total number of comments.")
+    static let totalLikes = NSLocalizedString("Total Likes", comment: "'This Year' label for total number of likes.")
+    static let totalWords = NSLocalizedString("Total Words", comment: "'This Year' label for total number of words.")
+    static let commentsPerPost = NSLocalizedString("Avg Comments / Post", comment: "'This Year' label for average comments per post.")
+    static let likesPerPost = NSLocalizedString("Avg Likes / Post", comment: "'This Year' label for average likes per post.")
+    static let wordsPerPost = NSLocalizedString("Avg Words / Post", comment: "'This Year' label for average words per post.")
+}

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -209,6 +209,15 @@
         }
     }
 
+    var detailsTitle: String {
+        switch self {
+        case .insightsAnnualSiteStats:
+            return DetailsTitles.annualSiteStats
+        default:
+            return title
+        }
+    }
+
     // MARK: - Image Size Accessor
 
     static let defaultImageSize = CGFloat(24)
@@ -241,6 +250,10 @@
         static let followers = NSLocalizedString("Followers", comment: "Insights 'Followers' header")
         static let tagsAndCategories = NSLocalizedString("Tags and Categories", comment: "Insights 'Tags and Categories' header")
         static let annualSiteStats = NSLocalizedString("This Year", comment: "Insights 'This Year' header")
+    }
+
+    struct DetailsTitles {
+        static let annualSiteStats = NSLocalizedString("Annual Site Stats", comment: "Insights 'This Year' details view header")
     }
 
     struct PeriodHeaders {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -70,13 +70,17 @@ class SiteStatsInsightsViewModel: Observable {
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
             case .allTimeStats:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsAllTime.title))
-                tableRows.append(TwoColumnStatsRow(dataRows: createAllTimeStatsRows(), statSection: .insightsAllTime))
+                tableRows.append(TwoColumnStatsRow(dataRows: createAllTimeStatsRows(),
+                                                   statSection: .insightsAllTime,
+                                                   siteStatsInsightsDelegate: nil))
             case .followersTotals:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsFollowerTotals.title))
                 tableRows.append(SimpleTotalsStatsRow(dataRows: createTotalFollowersRows()))
             case .mostPopularTime:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsMostPopularTime.title))
-                tableRows.append(TwoColumnStatsRow(dataRows: createMostPopularStatsRows(), statSection: .insightsMostPopularTime))
+                tableRows.append(TwoColumnStatsRow(dataRows: createMostPopularStatsRows(),
+                                                   statSection: .insightsMostPopularTime,
+                                                   siteStatsInsightsDelegate: nil))
             case .tagsAndCategories:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsTagsAndCategories.title))
                 tableRows.append(TopTotalsInsightStatsRow(itemSubtitle: StatSection.insightsTagsAndCategories.itemSubtitle,
@@ -85,7 +89,9 @@ class SiteStatsInsightsViewModel: Observable {
                                                    siteStatsInsightsDelegate: siteStatsInsightsDelegate))
             case .annualSiteStats:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsAnnualSiteStats.title))
-                tableRows.append(TwoColumnStatsRow(dataRows: createAnnualRows(), statSection: .insightsAnnualSiteStats))
+                tableRows.append(TwoColumnStatsRow(dataRows: createAnnualRows(),
+                                                   statSection: .insightsAnnualSiteStats,
+                                                   siteStatsInsightsDelegate: siteStatsInsightsDelegate))
             case .comments:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsCommentsPosts.title))
                 tableRows.append(createCommentsRow())
@@ -94,7 +100,9 @@ class SiteStatsInsightsViewModel: Observable {
                 tableRows.append(createFollowersRow())
             case .todaysStats:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsTodaysStats.title))
-                tableRows.append(TwoColumnStatsRow(dataRows: createTodaysStatsRows(), statSection: .insightsTodaysStats))
+                tableRows.append(TwoColumnStatsRow(dataRows: createTodaysStatsRows(),
+                                                   statSection: .insightsTodaysStats,
+                                                   siteStatsInsightsDelegate: nil))
             case .postingActivity:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsPostingActivity.title))
                 tableRows.append(createPostingActivityRow())
@@ -153,17 +161,6 @@ private extension SiteStatsInsightsViewModel {
         static let visitorsTitle = NSLocalizedString("Visitors", comment: "Today's Stats 'Visitors' label")
         static let likesTitle = NSLocalizedString("Likes", comment: "Today's Stats 'Likes' label")
         static let commentsTitle = NSLocalizedString("Comments", comment: "Today's Stats 'Comments' label")
-    }
-
-    struct AnnualSiteStats {
-        static let year = NSLocalizedString("Year", comment: "'This Year' label for the the year.")
-        static let totalPosts = NSLocalizedString("Total Posts", comment: "'This Year' label for the total number of posts.")
-        static let totalComments = NSLocalizedString("Total Comments", comment: "'This Year' label for total number of comments.")
-        static let totalLikes = NSLocalizedString("Total Likes", comment: "'This Year' label for total number of likes.")
-        static let totalWords = NSLocalizedString("Total Words", comment: "'This Year' label for total number of words.")
-        static let commentsPerPost = NSLocalizedString("Avg Comments / Post", comment: "'This Year' label for average comments per post.")
-        static let likesPerPost = NSLocalizedString("Avg Likes / Post", comment: "'This Year' label for average likes per post.")
-        static let wordsPerPost = NSLocalizedString("Avg Words / Post", comment: "'This Year' label for average words per post.")
     }
 
     func createAllTimeStatsRows() -> [StatsTwoColumnRowData] {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
@@ -16,7 +16,7 @@ class TwoColumnCell: UITableViewCell, NibLoadable {
     private typealias Style = WPStyleGuide.Stats
     private var dataRows = [StatsTwoColumnRowData]()
     private var statSection: StatSection?
-
+    private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
 
     // MARK: - View
 
@@ -30,9 +30,10 @@ class TwoColumnCell: UITableViewCell, NibLoadable {
         removeRowsFromStackView(rowsStackView)
     }
 
-    func configure(dataRows: [StatsTwoColumnRowData], statSection: StatSection) {
+    func configure(dataRows: [StatsTwoColumnRowData], statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
         self.dataRows = dataRows
         self.statSection = statSection
+        self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
         addRows()
         toggleViewMore()
     }
@@ -69,6 +70,13 @@ private extension TwoColumnCell {
         viewMoreView.isHidden = !showViewMore
         rowsStackViewBottomConstraint.constant = showViewMore ? viewMoreHeightConstraint.constant :
                                                                 bottomSeparatorLineHeightConstraint.constant
+    }
+
+    @IBAction func didTapViewMore(_ sender: UIButton) {
+        guard let statSection = statSection else {
+            return
+        }
+        siteStatsInsightsDelegate?.viewMoreSelectedForStatSection?(statSection)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.xib
@@ -45,22 +45,29 @@
                                     <constraint firstAttribute="height" constant="13" id="qmf-Yb-GSl"/>
                                 </constraints>
                             </imageView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uon-fL-Zcd" userLabel="View More Button">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <connections>
+                                    <action selector="didTapViewMore:" destination="oVo-l2-Jhn" eventType="touchUpInside" id="gKm-HN-PCI"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="44" id="44e-cc-T7y"/>
+                            <constraint firstItem="uon-fL-Zcd" firstAttribute="leading" secondItem="Cfy-Hl-Mjq" secondAttribute="leading" id="KZ2-hk-YCD"/>
                             <constraint firstItem="1To-pb-uoT" firstAttribute="top" secondItem="Cfy-Hl-Mjq" secondAttribute="top" constant="12" id="Qwi-ZL-iXt"/>
                             <constraint firstAttribute="trailing" secondItem="YNj-gn-f07" secondAttribute="trailing" constant="16" id="SYx-K1-v17"/>
+                            <constraint firstAttribute="trailing" secondItem="uon-fL-Zcd" secondAttribute="trailing" id="Vmf-wW-kgh"/>
+                            <constraint firstItem="uon-fL-Zcd" firstAttribute="top" secondItem="Cfy-Hl-Mjq" secondAttribute="top" id="Waq-GV-Y7c"/>
                             <constraint firstItem="YNj-gn-f07" firstAttribute="leading" secondItem="1To-pb-uoT" secondAttribute="trailing" constant="16" id="aEU-Da-e0s"/>
                             <constraint firstItem="1To-pb-uoT" firstAttribute="leading" secondItem="Cfy-Hl-Mjq" secondAttribute="leading" constant="16" id="d7O-Xe-V7P"/>
                             <constraint firstAttribute="bottom" secondItem="1To-pb-uoT" secondAttribute="bottom" constant="12" id="jBf-At-vUw"/>
                             <constraint firstItem="YNj-gn-f07" firstAttribute="centerY" secondItem="Cfy-Hl-Mjq" secondAttribute="centerY" id="sgg-5x-f5z"/>
+                            <constraint firstAttribute="bottom" secondItem="uon-fL-Zcd" secondAttribute="bottom" id="zPx-Uo-fJ0"/>
                         </constraints>
                     </view>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uon-fL-Zcd" userLabel="View More Button">
-                        <rect key="frame" x="0.0" y="350" width="375" height="44"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    </button>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cm8-Qw-O9e" userLabel="Bottom Separator Line">
                         <rect key="frame" x="0.0" y="394" width="375" height="0.5"/>
                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -77,17 +84,13 @@
                     <constraint firstItem="NTK-eu-Zrd" firstAttribute="top" secondItem="aea-rN-rAD" secondAttribute="top" id="ARx-Y7-BtJ"/>
                     <constraint firstItem="Cfy-Hl-Mjq" firstAttribute="leading" secondItem="aea-rN-rAD" secondAttribute="leading" id="CW9-bq-3C0"/>
                     <constraint firstItem="Cm8-Qw-O9e" firstAttribute="top" secondItem="Cfy-Hl-Mjq" secondAttribute="bottom" id="GOc-lk-WGg"/>
-                    <constraint firstItem="uon-fL-Zcd" firstAttribute="top" secondItem="Cfy-Hl-Mjq" secondAttribute="top" id="H52-Pc-bsG"/>
                     <constraint firstAttribute="trailing" secondItem="53U-Zk-ZGa" secondAttribute="trailing" id="I9H-dB-FKj"/>
-                    <constraint firstItem="uon-fL-Zcd" firstAttribute="leading" secondItem="Cfy-Hl-Mjq" secondAttribute="leading" id="I9I-ov-7RB"/>
                     <constraint firstAttribute="trailing" secondItem="Cm8-Qw-O9e" secondAttribute="trailing" id="PzX-nO-5NH"/>
                     <constraint firstItem="53U-Zk-ZGa" firstAttribute="top" secondItem="NTK-eu-Zrd" secondAttribute="bottom" id="ZCG-4P-igX"/>
                     <constraint firstItem="53U-Zk-ZGa" firstAttribute="leading" secondItem="aea-rN-rAD" secondAttribute="leading" id="aWs-1X-FnG"/>
-                    <constraint firstItem="uon-fL-Zcd" firstAttribute="bottom" secondItem="Cfy-Hl-Mjq" secondAttribute="bottom" id="axy-z3-ahd"/>
                     <constraint firstAttribute="trailing" secondItem="Cfy-Hl-Mjq" secondAttribute="trailing" id="bAa-4j-6TL"/>
                     <constraint firstAttribute="trailing" secondItem="NTK-eu-Zrd" secondAttribute="trailing" id="jHo-RQ-WZe"/>
                     <constraint firstItem="Cm8-Qw-O9e" firstAttribute="leading" secondItem="aea-rN-rAD" secondAttribute="leading" id="s6O-Ci-p80"/>
-                    <constraint firstItem="uon-fL-Zcd" firstAttribute="trailing" secondItem="Cfy-Hl-Mjq" secondAttribute="trailing" id="zrQ-sh-aXJ"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="5pF-Tt-Ldy"/>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -188,6 +188,8 @@ private extension SiteStatsDetailTableViewController {
             viewModel?.refreshComments()
         case .insightsTagsAndCategories:
             viewModel?.refreshTagsAndCategories()
+        case .insightsAnnualSiteStats:
+            viewModel?.refreshAnnualAndMostPopularTime()
         case .periodPostsAndPages:
             viewModel?.refreshPostsAndPages()
         case .periodSearchTerms:

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -67,7 +67,7 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
         self.selectedPeriod = selectedPeriod
         self.postID = postID
         statType = StatSection.allInsights.contains(statSection) ? .insights : .period
-        title = statSection.title
+        title = statSection.detailsTitle
         initViewModel()
         displayLoadingViewIfNecessary()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -144,6 +144,9 @@ class SiteStatsDetailsViewModel: Observable {
             tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: StatSection.insightsTagsAndCategories.itemSubtitle,
                                                       dataSubtitle: StatSection.insightsTagsAndCategories.dataSubtitle))
             tableRows.append(contentsOf: tagsAndCategoriesRows())
+        case .insightsAnnualSiteStats:
+            tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: "", dataSubtitle: ""))
+            tableRows.append(contentsOf: annualRows())
         case .periodPostsAndPages:
             tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: StatSection.periodPostsAndPages.itemSubtitle,
                                                       dataSubtitle: StatSection.periodPostsAndPages.dataSubtitle))
@@ -206,6 +209,10 @@ class SiteStatsDetailsViewModel: Observable {
 
     func refreshTagsAndCategories() {
         ActionDispatcher.dispatch(InsightAction.refreshTagsAndCategories)
+    }
+
+    func refreshAnnualAndMostPopularTime() {
+        ActionDispatcher.dispatch(InsightAction.refreshAnnualAndMostPopularTime)
     }
 
     func refreshPostsAndPages() {
@@ -296,6 +303,8 @@ private extension SiteStatsDetailsViewModel {
             return .allComments
         case .insightsTagsAndCategories:
             return .allTagsAndCategories
+        case .insightsAnnualSiteStats:
+            return .allAnnualAndMostPopularTime
         default:
             return nil
         }
@@ -425,6 +434,33 @@ private extension SiteStatsDetailsViewModel {
                                      childRows: StatsDataHelper.childRowsForItems($0.children),
                                      statSection: .insightsTagsAndCategories)
         }
+    }
+
+    // MARK: - Annual Site Stats
+
+    func annualRows() -> [DetailDataRow] {
+        return dataRowsFor(annualRowData())
+    }
+
+    func annualRowData() -> [StatsTotalRowData] {
+        guard let annualInsights = insightsStore.getAllAnnualAndMostPopularTime() else {
+            return []
+        }
+
+        return [StatsTotalRowData(name: AnnualSiteStats.totalPosts,
+                                  data: annualInsights.annualInsightsTotalPostsCount.abbreviatedString()),
+                StatsTotalRowData(name: AnnualSiteStats.totalComments,
+                                  data: annualInsights.annualInsightsTotalCommentsCount.abbreviatedString()),
+                StatsTotalRowData(name: AnnualSiteStats.commentsPerPost,
+                                  data: Int(round(annualInsights.annualInsightsAverageCommentsCount)).abbreviatedString()),
+                StatsTotalRowData(name: AnnualSiteStats.totalLikes,
+                                  data: annualInsights.annualInsightsTotalLikesCount.abbreviatedString()),
+                StatsTotalRowData(name: AnnualSiteStats.likesPerPost,
+                                  data: Int(round(annualInsights.annualInsightsAverageLikesCount)).abbreviatedString()),
+                StatsTotalRowData(name: AnnualSiteStats.totalWords,
+                                  data: annualInsights.annualInsightsTotalWordsCount.abbreviatedString()),
+                StatsTotalRowData(name: AnnualSiteStats.wordsPerPost,
+                                  data: Int(round(annualInsights.annualInsightsAverageWordsCount)).abbreviatedString())]
     }
 
     // MARK: - Posts and Pages

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -223,6 +223,7 @@ struct TwoColumnStatsRow: ImmuTableRow {
 
     let dataRows: [StatsTwoColumnRowData]
     let statSection: StatSection
+    weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -231,7 +232,7 @@ struct TwoColumnStatsRow: ImmuTableRow {
             return
         }
 
-        cell.configure(dataRows: dataRows, statSection: statSection)
+        cell.configure(dataRows: dataRows, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
     }
 }
 


### PR DESCRIPTION
Ref #11908 

This is step one of adding a `View more` option to Insights _This Year_. The detail view shows the current year's data. 

Not done yet: showing a date bar, and displaying data for the selected year.

Also, there is a bug that's causing extra space above the first row. That's not new (it happens on Period _Published_ as well). I'll fix that separately.

To test:
- On a site with data for this year, go to Insights _This Year_.
- Select `View more`.
- Verify the yearly data is shown.

<img width="400" alt="annual_details" src="https://user-images.githubusercontent.com/1816888/59725178-f415fd00-91e9-11e9-9588-fd88b62108e3.png">

Update release notes:
- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

