### PR TITLE
Fix missing argument

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -75,7 +75,9 @@ class SiteStatsInsightsViewModel: Observable {
                                                    siteStatsInsightsDelegate: nil))
             case .followersTotals:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsFollowerTotals.title))
-                tableRows.append(TwoColumnStatsRow(dataRows: createTotalFollowersRows(), statSection: .insightsFollowerTotals))
+                tableRows.append(TwoColumnStatsRow(dataRows: createTotalFollowersRows(),
+                                                   statSection: .insightsFollowerTotals,
+                                                   siteStatsInsightsDelegate: nil))
             case .mostPopularTime:
                 tableRows.append(CellHeaderRow(title: StatSection.insightsMostPopularTime.title))
                 tableRows.append(TwoColumnStatsRow(dataRows: createMostPopularStatsRows(),


### PR DESCRIPTION
Fixes #n/a

Fixes a missing parameter when creating `TwoColumnStatsRow`. (caused by #11936 merge)

To test:
- Does the app build? 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
