### PR TITLE
Documents some critical stats we're tracking.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -159,9 +159,9 @@ target 'WordPress' do
     
     pod 'Gridicons', '~> 0.16'
 
-    # pod 'WordPressAuthenticator', '~> 1.5.3'
+    pod 'WordPressAuthenticator', '~> 1.5.4-beta.1'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '60bc9589b3fb94d2b55086c7ff50f38a4b97bd14'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
 
     aztec
     wordpress_ui

--- a/Podfile
+++ b/Podfile
@@ -159,9 +159,9 @@ target 'WordPress' do
     
     pod 'Gridicons', '~> 0.16'
 
-    pod 'WordPressAuthenticator', '~> 1.5.3'
+    # pod 'WordPressAuthenticator', '~> 1.5.3'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '60bc9589b3fb94d2b55086c7ff50f38a4b97bd14'
 
     aztec
     wordpress_ui

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -254,7 +254,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.7.0)
-  - WordPressAuthenticator (~> 1.5.3)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `60bc9589b3fb94d2b55086c7ff50f38a4b97bd14`)
   - WordPressKit (~> 4.1.3)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.3)
@@ -301,7 +301,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -332,6 +331,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.7.0
+  WordPressAuthenticator:
+    :commit: 60bc9589b3fb94d2b55086c7ff50f38a4b97bd14
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.7.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -348,6 +350,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.7.0
+  WordPressAuthenticator:
+    :commit: 60bc9589b3fb94d2b55086c7ff50f38a4b97bd14
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -404,6 +409,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 52835b6d983daf27dc07b5c6aa16584ee7158454
+PODFILE CHECKSUM: d53eaee41c3f2e313da38112184528381e411a5d
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -180,7 +180,7 @@ PODS:
   - WordPress-Aztec-iOS (1.7.0)
   - WordPress-Editor-iOS (1.7.0):
     - WordPress-Aztec-iOS (= 1.7.0)
-  - WordPressAuthenticator (1.5.3):
+  - WordPressAuthenticator (1.5.4-beta.1):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (~> 3.5)
@@ -254,7 +254,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.7.0)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `60bc9589b3fb94d2b55086c7ff50f38a4b97bd14`)
+  - WordPressAuthenticator (~> 1.5.4-beta.1)
   - WordPressKit (~> 4.1.3)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.3)
@@ -301,6 +301,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -331,9 +332,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.7.0
-  WordPressAuthenticator:
-    :commit: 60bc9589b3fb94d2b55086c7ff50f38a4b97bd14
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.7.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -350,9 +348,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.7.0
-  WordPressAuthenticator:
-    :commit: 60bc9589b3fb94d2b55086c7ff50f38a4b97bd14
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -398,7 +393,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-Aztec-iOS: 2dc41978696cdae7537dab8035cb1a9df02d9e87
   WordPress-Editor-iOS: f032feafcd01282c9d4c24cd4ecf941a3b67f629
-  WordPressAuthenticator: 413b3d8ddf5fce199d38abcc61afe0d9475a463b
+  WordPressAuthenticator: a2ca65bbb342de7da496a37b4a241cb7ba398382
   WordPressKit: 4020ecfd93f2cf6c8207102da8e060df6f73e9d7
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
   WordPressShared: a70fb1f5465c484cd54e8ce150dd8d16cada5791
@@ -409,6 +404,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: d53eaee41c3f2e313da38112184528381e411a5d
+PODFILE CHECKSUM: 803503d962dd407692437e2d05affcc34d3211ff
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -204,6 +204,9 @@ static NSString * const WPAppAnalyticsKeyTimeInApp                  = @"time_in_
         return;
     }
     self.applicationOpenedTime = [NSDate date];
+    
+    // This stat is part of a funnel that provides critical information.  Before
+    // making ANY modification to this stat please refer to: p4qSXL-35X-p2
     [WPAnalytics track:WPAnalyticsStatApplicationOpened];
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -115,6 +115,8 @@ final class SiteAssemblyWizardContent: UIViewController {
                     self.contentView.siteName = blog?.displayURL as String?
                     self.createdBlog = blog
 
+                    // This stat is part of a funnel that provides critical information.  Before
+                    // making ANY modification to this stat please refer to: p4qSXL-35X-p2
                     WPAnalytics.track(.createdSite)
                 }
 


### PR DESCRIPTION
This is a follow up to https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/103

Closes #11893 by adding the required documentation.

## Testing:

Since we're only adding comments, we only need to check the code still compiles.

1. Reinstall the pods.
2. Make sure the project builds correctly.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.