### PR TITLE
[Stats Refresh] Fix locale of large value formatter

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 * The app now launches a bit more quickly.
 * Added a list of third-party library acknowledgements.
 * Updated messaging experience for a reply upload result.
+* Stats: Fixed an issue where chart axes may be formatted incorrectly in some locales.
 
 12.5
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+LargeValueFormatter.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+LargeValueFormatter.swift
@@ -51,6 +51,8 @@ public class LargeValueFormatter: NSObject, IValueFormatter, IAxisValueFormatter
 
     private static var formatter: NumberFormatter = {
         var numberFormatter = NumberFormatter()
+        // Fix the locale, as our code to replace the exponent may not function in some locales.
+        numberFormatter.locale = Locale(identifier: "en-US")
         numberFormatter.positiveFormat = "###E00"
         numberFormatter.minimumFractionDigits = 1
         numberFormatter.maximumFractionDigits = 3


### PR DESCRIPTION
Fixes #11954.

The large value formatter for stats charts was failing in locales that format large numbers differently. This PR fixes the locale of the large value formatter's number formatter to `en-US`, so that this won't happen.

**To test:**

* In your Xcode scheme settings, set the app region to Sweden.
* Build and run
* Before this change, the stats charts will have y axis labels like `15x10^00`. After this, they should be formatted correctly (the example just given would be `15`).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.