### PR TITLE
[Stats Refresh] Countries section - fix map separator height

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
@@ -13,6 +13,8 @@ class CountriesCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var subtitlesStackViewTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var rowsStackViewTopConstraint: NSLayoutConstraint!
 
+    @IBOutlet private var topSeparatorLineHeightConstraint: NSLayoutConstraint!
+
     private weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
     private var dataRows = [StatsTotalRowData]()
     private typealias Style = WPStyleGuide.Stats
@@ -69,6 +71,7 @@ private extension CountriesCell {
         }
 
         rowsStackViewTopConstraint.constant = !dataRows.isEmpty ? subtitleHeight : 0
+        topSeparatorLineHeightConstraint.constant = dataRows.isEmpty ? 0.5 : 0.33
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.xib
@@ -83,6 +83,7 @@
                 <outlet property="subtitleStackView" destination="WGt-7n-PjC" id="5JN-Yn-YM9"/>
                 <outlet property="subtitlesStackViewTopConstraint" destination="u2O-MU-b7v" id="ya9-A4-B6Y"/>
                 <outlet property="topSeparatorLine" destination="OxT-ul-sgW" id="qjZ-f6-e57"/>
+                <outlet property="topSeparatorLineHeightConstraint" destination="tep-qB-gA1" id="7JT-Pm-BKH"/>
             </connections>
             <point key="canvasLocation" x="-263.19999999999999" y="204.64767616191907"/>
         </tableViewCell>


### PR DESCRIPTION
Refs. #11852

This PR fixes the Countries map cell separator line. If the map is visible, the bottom separator line should have the same height of the default separator line.

![Simulator Screen Shot - iPhone X - 2019-06-20 at 11 00 26](https://user-images.githubusercontent.com/912252/59842564-aebf1000-934e-11e9-8b27-8280595c018c.png)

![Simulator Screen Shot - iPhone X - 2019-06-20 at 11 00 39](https://user-images.githubusercontent.com/912252/59842565-aebf1000-934e-11e9-9ccc-95e4082a224d.png)

## To test:
• Select a site that contains data to display and select a stats period
• Scroll until the countries section is displayed and check the separator line between the map and the countries list. The separator height should be the same.
• Do the same test selecting a site with no data.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
