### PR TITLE
[Fix] Fix NSRangeException in Stats running on iOS 11

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -35,7 +35,7 @@ enum InsightType: Int {
     @objc optional func showShareForPost(postID: NSNumber, fromView: UIView)
     @objc optional func showPostingActivityDetails()
     @objc optional func tabbedTotalsCellUpdated()
-    @objc optional func expandedRowUpdated(_ row: StatsTotalRow)
+    @objc optional func expandedRowUpdated(_ row: StatsTotalRow, didSelectRow: Bool)
     @objc optional func viewMoreSelectedForStatSection(_ statSection: StatSection)
     @objc optional func showPostStats(postID: Int, postTitle: String?, postURL: URL?)
 }
@@ -282,8 +282,10 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         applyTableUpdates()
     }
 
-    func expandedRowUpdated(_ row: StatsTotalRow) {
-        applyTableUpdates()
+    func expandedRowUpdated(_ row: StatsTotalRow, didSelectRow: Bool) {
+        if didSelectRow {
+            applyTableUpdates()
+        }
         StatsDataHelper.updatedExpandedState(forRow: row)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -5,7 +5,7 @@ import WordPressFlux
 @objc protocol SiteStatsPeriodDelegate {
     @objc optional func displayWebViewWithURL(_ url: URL)
     @objc optional func displayMediaWithID(_ mediaID: NSNumber)
-    @objc optional func expandedRowUpdated(_ row: StatsTotalRow)
+    @objc optional func expandedRowUpdated(_ row: StatsTotalRow, didSelectRow: Bool)
     @objc optional func viewMoreSelectedForStatSection(_ statSection: StatSection)
     @objc optional func showPostStats(postID: Int, postTitle: String?, postURL: URL?)
 }
@@ -287,8 +287,10 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
         })
     }
 
-    func expandedRowUpdated(_ row: StatsTotalRow) {
-        applyTableUpdates()
+    func expandedRowUpdated(_ row: StatsTotalRow, didSelectRow: Bool) {
+        if didSelectRow {
+            applyTableUpdates()
+        }
         StatsDataHelper.updatedExpandedState(forRow: row)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -3,7 +3,7 @@ import WordPressFlux
 
 @objc protocol PostStatsDelegate {
     @objc optional func displayWebViewWithURL(_ url: URL)
-    @objc optional func expandedRowUpdated(_ row: StatsTotalRow)
+    @objc optional func expandedRowUpdated(_ row: StatsTotalRow, didSelectRow: Bool)
     @objc optional func viewMoreSelectedForStatSection(_ statSection: StatSection)
 }
 
@@ -169,8 +169,11 @@ extension PostStatsTableViewController: PostStatsDelegate {
         present(navController, animated: true)
     }
 
-    func expandedRowUpdated(_ row: StatsTotalRow) {
-        applyTableUpdates()
+    func expandedRowUpdated(_ row: StatsTotalRow, didSelectRow: Bool) {
+        if didSelectRow {
+            applyTableUpdates()
+        }
+        StatsDataHelper.updatedExpandedState(forRow: row)
     }
 
     func viewMoreSelectedForStatSection(_ statSection: StatSection) {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -51,7 +51,7 @@ struct StatsTotalRowData {
 @objc protocol StatsTotalRowDelegate {
     @objc optional func displayWebViewWithURL(_ url: URL)
     @objc optional func displayMediaWithID(_ mediaID: NSNumber)
-    @objc optional func toggleChildRowsForRow(_ row: StatsTotalRow)
+    @objc optional func toggleChildRows(for row: StatsTotalRow, didSelectRow: Bool)
     @objc optional func showPostStats(postID: Int, postTitle: String?, postURL: URL?)
 }
 
@@ -296,7 +296,7 @@ private extension StatsTotalRow {
 
         if hasChildRows {
             expanded.toggle()
-            delegate?.toggleChildRowsForRow?(self)
+            delegate?.toggleChildRows?(for: self, didSelectRow: true)
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -133,13 +133,13 @@ private extension TopTotalsCell {
                 return
             }
 
-            toggleChildRowsForRow(row)
+            toggleChildRows(for: row, didSelectRow: false)
 
             row.childRowsView?.rowsStackView.arrangedSubviews.forEach { child in
                 guard let childRow = child as? StatsTotalRow else {
                     return
                 }
-                toggleChildRowsForRow(childRow)
+                toggleChildRows(for: childRow, didSelectRow: false)
             }
         }
     }
@@ -291,12 +291,12 @@ extension TopTotalsCell: StatsTotalRowDelegate {
         siteStatsDetailsDelegate?.displayMediaWithID?(mediaID)
     }
 
-    func toggleChildRowsForRow(_ row: StatsTotalRow) {
+    func toggleChildRows(for row: StatsTotalRow, didSelectRow: Bool) {
         row.expanded ? addChildRowsForRow(row) : removeChildRowsForRow(row)
         toggleSeparatorsAroundRow(row)
-        siteStatsInsightsDelegate?.expandedRowUpdated?(row)
-        siteStatsPeriodDelegate?.expandedRowUpdated?(row)
-        postStatsDelegate?.expandedRowUpdated?(row)
+        siteStatsInsightsDelegate?.expandedRowUpdated?(row, didSelectRow: didSelectRow)
+        siteStatsPeriodDelegate?.expandedRowUpdated?(row, didSelectRow: didSelectRow)
+        postStatsDelegate?.expandedRowUpdated?(row, didSelectRow: didSelectRow)
     }
 
     func showPostStats(postID: Int, postTitle: String?, postURL: URL?) {


### PR DESCRIPTION
Fixes #11949 

This crash happened on iOS 11 only. Calling the `performBatch` while scrolling the tableview caused a crash in Stats periods and insights. `performBatch` should be called only when the row is touched.

## To test:
- Run the branch on iOS 11
- Open Stats Insights and Period and scroll the overview.
- Expand and close the cells.
- Make the same test using a device with iOS 12 to make sure everything is working as expected.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
