### PR TITLE
Share Extension: Plain Text is no longer Blockquoted

### DIFF
--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -578,7 +578,7 @@ private struct PlainTextExtractor: TypeBasedExtensionContentExtractor {
             url.absoluteString.count == payload.count {
             returnedItem.url = url
         } else {
-            returnedItem.selectedText = payload
+            returnedItem.importedText = payload
         }
         return returnedItem
     }


### PR DESCRIPTION
### Details:
When importing Plain Text by means of the Share Extension, by default the text gets blockquoted.

We'd like to update this behavior, so that this is no longer the case.

@nheagy May I bug you with a super small PR?
Thanks in advance!!

cc @bummytime YAY for one line fixes!

### Testing:
1. Install both WPiOS and Simplenote
2. Log into both apps
3. Launch Simplenote
4. Open any random note
5. Press over the top right `( i )` button
6. Press over the `Send` button that shows up in the share sheet
7. Pick WordPress iOS from the App List
8. Verify the imported text is no longer blockquoted
