### PR TITLE
[Stats Refresh] Set empty chart bar height to chart height

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,8 @@
 * Stats Insights: New two-column layout for This Year stats.
 * Stats Insights: added details option for This Year stats.
 * Stats Insights: New two-column layout for Most Popular Time stats.
-* Post preview: Fixed issue with preview for self hosted sites not working. 
+* Post preview: Fixed issue with preview for self hosted sites not working.
+* Stats: modified appearance of empty charts.
 
 12.7
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -1,6 +1,4 @@
-
 import Foundation
-
 import Charts
 
 // MARK: - StatsPeriodFilterDimension
@@ -84,6 +82,7 @@ private final class PeriodChartDataTransformer {
         var visitorEntries  = [BarChartDataEntry]()
         var likeEntries     = [BarChartDataEntry]()
         var commentEntries  = [BarChartDataEntry]()
+
         for datum in summaryData {
             let dateInterval = datum.periodStartDate.timeIntervalSince1970
             let offset = dateInterval - firstDateInterval
@@ -91,10 +90,11 @@ private final class PeriodChartDataTransformer {
             let x = offset
 
             // If the chart has no data, show "stub" bars
-            let viewEntry = BarChartDataEntry(x: x, y: totalViews > 0 ? Double(datum.viewsCount) : 1.0)
-            let visitorEntry = BarChartDataEntry(x: x, y: totalVisitors > 0 ? Double(datum.visitorsCount) : 1.0)
-            let likeEntry = BarChartDataEntry(x: x, y: totalLikes > 0 ? Double(datum.likesCount) : 1.0)
-            let commentEntry = BarChartDataEntry(x: x, y: totalComments > 0 ? Double(datum.commentsCount) : 1.0)
+            let emptyChartBarHeight = StatsBarChartView.emptyChartBarHeight
+            let viewEntry = BarChartDataEntry(x: x, y: totalViews > 0 ? Double(datum.viewsCount) : emptyChartBarHeight)
+            let visitorEntry = BarChartDataEntry(x: x, y: totalVisitors > 0 ? Double(datum.visitorsCount) : emptyChartBarHeight)
+            let likeEntry = BarChartDataEntry(x: x, y: totalLikes > 0 ? Double(datum.likesCount) : emptyChartBarHeight)
+            let commentEntry = BarChartDataEntry(x: x, y: totalComments > 0 ? Double(datum.commentsCount) : emptyChartBarHeight)
 
             viewEntries.append(viewEntry)
             visitorEntries.append(visitorEntry)

--- a/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PostChart.swift
@@ -1,6 +1,4 @@
-
 import Foundation
-
 import Charts
 
 // MARK: - PostChartType
@@ -110,7 +108,7 @@ private final class PostChartDataTransformer {
 
             let x = offset
             // If the chart has no data, show "stub" bars
-            let y = totalViews > 0 ? Double(datum.viewsCount) : 1.0
+            let y = totalViews > 0 ? Double(datum.viewsCount) : StatsBarChartView.emptyChartBarHeight
             let entry = BarChartDataEntry(x: x, y: y)
 
             entries.append(entry)

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -1,6 +1,4 @@
-
 import UIKit
-
 import Charts
 
 // MARK: - StatsBarChartViewDelegate
@@ -31,6 +29,11 @@ class StatsBarChartView: BarChartView {
         static let trailingOffset           = CGFloat(20)
         static let verticalAxisLabelCount   = 5
     }
+
+    /// Height for "stub" bars when a chart is empty, which is the height of the default chart.
+    /// The value is just shy of the default height to prevent the chart height from automatically expanding.
+    ///
+    static let emptyChartBarHeight = Double(Constants.verticalAxisLabelCount - 1) - 0.01
 
     /// This adapts the data set for presentation by the Charts framework.
     ///


### PR DESCRIPTION
Ref #11876

For empty charts, the grey bars are now the height of the chart.

To test:

---
Latest Post Summary chart:
- The empty view on this one is a bit hard to trigger.
  - A site with views, but no views in the past 2 weeks.
  - A site with no views, but has Likes or Comments.
- Verify grey bars extend the height of the chart.

<img width="400" alt="latest_post_summary" src="https://user-images.githubusercontent.com/1816888/59955392-1c4e6780-9447-11e9-840e-fdfbbb3a5619.png">

---
Period Overview chart:
- On a site with no Views, Visitors, Likes, and/or Comments for _all the periods_ on the chart.
- Verify grey bars extend the height of the chart.

<img width="400" alt="no_views_visitors" src="https://user-images.githubusercontent.com/1816888/59955465-90890b00-9447-11e9-8124-c53af95985b1.png">

<img width="400" alt="no_likes" src="https://user-images.githubusercontent.com/1816888/59955469-954dbf00-9447-11e9-9f81-425e20bce9dc.png">

---
Post Stats chart:
- Access Post Stats for a site with no stats in the past 2 weeks.
- Verify grey bars extend the height of the chart.

<img width="400" alt="post_stats" src="https://user-images.githubusercontent.com/1816888/59955406-325c2800-9447-11e9-8b25-a5fabd54d959.png">

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
