### PR TITLE
[Stats Refresh] Change stats difference value to grey colour

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * Stats Insights: added details option for This Year stats.
 * Stats Insights: New two-column layout for Most Popular Time stats.
 * Post preview: Fixed issue with preview for self hosted sites not working. 
+* Stats: Updates the appearance of the 'difference to previous period' stats label to grey. 
 
 12.7
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -47,7 +47,7 @@ struct OverviewTabData: FilterTabBarItem {
     }
 
     var differenceTextColor: UIColor {
-        return difference < 0 ? WPStyleGuide.Stats.negativeColor : WPStyleGuide.Stats.positiveColor
+        return WPStyleGuide.grey()
     }
 
     var title: String {


### PR DESCRIPTION
Fixes #11976. This PR updates the color of the difference value in stats to grey to de-emphasize how positive / negative the change is.

<img width="374" alt="Screenshot 2019-06-24 at 14 35 11" src="https://user-images.githubusercontent.com/4780/60023419-aee04800-968d-11e9-8063-f0dd824dfcc9.png">

**To test:**

* Build and run, check the appearance of the difference label

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.