### PR TITLE
[Stats Refresh] Some VoiceOver improvements for StatsTotalRow

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -178,11 +178,11 @@ class StatsTotalRow: UIView, NibLoadable, Accessible {
     // MARK: - Accessibility
     func prepareForVoiceOver() {
         isAccessibilityElement = true
-        
+
         let itemTitle = itemLabel.text ?? ""
         let dataTitle = dataLabel.text ?? ""
         accessibilityLabel = [itemTitle, dataTitle].joined(separator: ", ")
-        
+
         let showDisclosure = rowData?.showDisclosure ?? false
         accessibilityTraits = (showDisclosure) ? .button : .staticText
         accessibilityHint = (showDisclosure) ? NSLocalizedString("Tap for more detail.", comment: "Accessibility hint") : ""

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -55,7 +55,7 @@ struct StatsTotalRowData {
     @objc optional func showPostStats(postID: Int, postTitle: String?, postURL: URL?)
 }
 
-class StatsTotalRow: UIView, NibLoadable {
+class StatsTotalRow: UIView, NibLoadable, Accessible {
 
     // MARK: - Properties
 
@@ -167,6 +167,7 @@ class StatsTotalRow: UIView, NibLoadable {
         dataLabel.isHidden = rowData.data.isEmpty
 
         applyStyles()
+        prepareForVoiceOver()
     }
 
     override func layoutSubviews() {
@@ -174,6 +175,18 @@ class StatsTotalRow: UIView, NibLoadable {
         configureDataBar()
     }
 
+    // MARK: - Accessibility
+    func prepareForVoiceOver() {
+        isAccessibilityElement = true
+        
+        let itemTitle = itemLabel.text ?? ""
+        let dataTitle = dataLabel.text ?? ""
+        accessibilityLabel = [itemTitle, dataTitle].joined(separator: ", ")
+        
+        let showDisclosure = rowData?.showDisclosure ?? false
+        accessibilityTraits = (showDisclosure) ? .button : .staticText
+        accessibilityHint = (showDisclosure) ? NSLocalizedString("Tap for more detail.", comment: "Accessibility hint") : ""
+    }
 }
 
 private extension StatsTotalRow {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -323,14 +323,14 @@ extension TopTotalsCell: ViewMoreRowDelegate {
 extension TopTotalsCell: Accessible {
     func prepareForVoiceOver() {
         accessibilityTraits = .summaryElement
-        
+
         guard dataRows.count > 0 else {
             return
         }
-        
+
         let itemTitle = itemSubtitleLabel.text
         let dataTitle = dataSubtitleLabel.text
-        
+
         if let itemTitle = itemTitle, let dataTitle = dataTitle {
             let description = String(format: "Table showing %@ and %@", itemTitle, dataTitle)
             accessibilityLabel = NSLocalizedString(description, comment: "Accessibility of stats table. Placeholders will be populated with names of data shown in table.")

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -23,7 +23,7 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
     private var forDetails = false
     private var limitRowsDisplayed = true
     private let maxChildRowsToDisplay = 10
-    private var dataRows = [StatsTotalRowData]()
+    fileprivate var dataRows = [StatsTotalRowData]()
     private var subtitlesProvided = true
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     private weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
@@ -66,6 +66,7 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
 
         setSubtitleVisibility()
         applyStyles()
+        prepareForVoiceOver()
     }
 
     override func prepareForReuse() {
@@ -86,7 +87,6 @@ class TopTotalsCell: UITableViewCell, NibLoadable {
 
         removeRowsFromStackView(rowsStackView)
     }
-
 }
 
 // MARK: - Private Extension
@@ -316,4 +316,29 @@ extension TopTotalsCell: ViewMoreRowDelegate {
         postStatsDelegate?.viewMoreSelectedForStatSection?(statSection)
     }
 
+}
+
+// MARK: - Accessibility
+
+extension TopTotalsCell: Accessible {
+    func prepareForVoiceOver() {
+        accessibilityTraits = .summaryElement
+        
+        guard dataRows.count > 0 else {
+            return
+        }
+        
+        let itemTitle = itemSubtitleLabel.text
+        let dataTitle = dataSubtitleLabel.text
+        
+        if let itemTitle = itemTitle, let dataTitle = dataTitle {
+            let description = String(format: "Table showing %@ and %@", itemTitle, dataTitle)
+            accessibilityLabel = NSLocalizedString(description, comment: "Accessibility of stats table. Placeholders will be populated with names of data shown in table.")
+        } else {
+            if let title = (itemTitle ?? dataTitle) {
+                let description = String(format: "Table showing %@", title)
+                accessibilityLabel = NSLocalizedString(description, comment: "Accessibility of stats table. Placeholder will be populated with name of data shown in table.")
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR makes a few small improvements to VoiceOver support for StatsTotalRow and its container TopTotalsCell.

* StatsTotalRow should now read the name of the cell followed by the value, and if tappable state that it's a button and to tap for more detail.
* TopTotalsCell should read that it's a table, followed by the names of the columns.

For example:

![IMG_4836](https://user-images.githubusercontent.com/4780/60036136-66815400-96a6-11e9-82bc-c441c682c9c6.jpg)

* Tapping / selecting this entire table will read "Table showing Link and Clicks".
* Tapping the row shown on the screenshot will read "WordPress.com, 53. Button. Tap for more detail."

**To test:**

* Build and run and enable VoiceOver
* Navigate through a stats period screen and check that the rows are read correctly. 

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

There are user facing changes but as we're going to have a large dump of VoiceOver changes, let's just add a single item for them at the end.