### PR TITLE
[Stats Refresh] Change stats difference value to grey colour (12.7)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,8 @@
 * Stats Insights: New two-column layout for This Year stats.
 * Stats Insights: added details option for This Year stats.
 * Stats Insights: New two-column layout for Most Popular Time stats.
+* Post preview: Fixed issue with preview for self hosted sites not working. 
+* Stats: Updates the appearance of the 'difference to previous period' stats label to grey. 
 
 12.7
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+class StatsPeriodHelper {
+    private lazy var calendar: Calendar = {
+        var cal = Calendar(identifier: .iso8601)
+        cal.timeZone = .autoupdatingCurrent
+        return cal
+    }()
+    
+    func dateAvailableBeforeDate(_ dateIn: Date, period: StatsPeriodUnit, backLimit: Int) -> Bool {
+        // Use dates without time
+        let currentDate = Date().normalizedDate()
+        
+        guard var oldestDate = calendar.date(byAdding: period.calendarComponent, value: backLimit, to: currentDate) else {
+            return false
+        }
+        
+        let date = dateIn.normalizedDate()
+        oldestDate = oldestDate.normalizedDate()
+        
+        switch period {
+        case .day:
+            return date > oldestDate
+        case .week:
+            let week = weekIncludingDate(date)
+            guard let weekStart = week?.weekStart,
+                let oldestWeekStart = weekIncludingDate(oldestDate)?.weekStart else {
+                    return false
+            }
+            return weekStart > oldestWeekStart
+        case .month:
+            guard let month = monthFromDate(date),
+                let oldestMonth = monthFromDate(oldestDate) else {
+                    return false
+            }
+            return month > oldestMonth
+        case .year:
+            let year = yearFromDate(date)
+            return year > yearFromDate(oldestDate)
+        }
+    }
+    
+    func dateAvailableAfterDate(_ dateIn: Date, period: StatsPeriodUnit) -> Bool {
+        // Use dates without time
+        let currentDate = Date().normalizedDate()
+        let date = dateIn.normalizedDate()
+        
+        switch period {
+        case .day:
+            return date < currentDate
+        case .week:
+            let week = weekIncludingDate(date)
+            guard let weekEnd = week?.weekEnd,
+                let currentWeekEnd = weekIncludingDate(currentDate)?.weekEnd else {
+                    return false
+            }
+            return weekEnd < currentWeekEnd
+        case .month:
+            guard let month = monthFromDate(date),
+                let currentMonth = monthFromDate(currentDate) else {
+                    return false
+            }
+            return month < currentMonth
+        case .year:
+            let year = yearFromDate(date)
+            return year < yearFromDate(currentDate)
+        }
+    }
+    
+    func calculateEndDate(startDate: Date, offsetBy count: Int = 1, unit: StatsPeriodUnit) -> Date? {
+        let calendar = Calendar.autoupdatingCurrent
+        
+        guard let adjustedDate = calendar.date(byAdding: unit.calendarComponent, value: count, to: startDate) else {
+            DDLogError("[Stats] Couldn't do basic math on Calendars in Stats. Returning original value.")
+            return startDate
+        }
+        
+        switch unit {
+        case .day:
+            return adjustedDate.normalizedDate()
+            
+        case .week:
+            
+            // The hours component here is because the `dateInterval` returnd by Calendar is a closed range
+            // — so the "end" of a specific week is also simultenously a 'start' of the next one.
+            // This causes problem when calling this math on dates that _already are_ an end/start of a week.
+            // This doesn't work for our calculations, so we force it to rollover using this hack.
+            // (I *think* that's what's happening here. Doing Calendar math on this method has broken my brain.
+            // I spend like 10h on this ~50 LoC method. Beware.)
+            let components = DateComponents(day: 7 * count, hour: -12)
+            
+            guard let weekAdjusted = calendar.date(byAdding: components, to: startDate.normalizedDate()) else {
+                DDLogError("[Stats] Couldn't add a multiple of 7 days and -12 hours to a date in Stats. Returning original value.")
+                return startDate
+            }
+            
+            let endOfAdjustedWeek = calendar.dateInterval(of: .weekOfYear, for: weekAdjusted)?.end
+            
+            return endOfAdjustedWeek?.normalizedDate()
+            
+        case .month:
+            guard let maxComponent = calendar.range(of: .day, in: .month, for: adjustedDate)?.max() else {
+                DDLogError("[Stats] Couldn't determine number of days in a given month in Stats. Returning original value.")
+                return startDate
+            }
+            
+            return calendar.date(bySetting: .day, value: maxComponent, of: adjustedDate)?.normalizedDate()
+            
+        case .year:
+            guard
+                let maxMonth = calendar.range(of: .month, in: .year, for: adjustedDate)?.max(),
+                let adjustedMonthDate = calendar.date(bySetting: .month, value: maxMonth, of: adjustedDate),
+                let maxDay = calendar.range(of: .day, in: .month, for: adjustedMonthDate)?.max() else {
+                    DDLogError("[Stats] Couldn't determine number of months in a given year, or days in a given monthin Stats. Returning original value.")
+                    return startDate
+            }
+            let adjustedDayDate = calendar.date(bySetting: .day, value: maxDay, of: adjustedMonthDate)
+            
+            return adjustedDayDate?.normalizedDate()
+        }
+    }
+    
+    // MARK: - Date Helpers
+    
+    func weekIncludingDate(_ date: Date) -> (weekStart: Date, weekEnd: Date)? {
+        // Note: Week is Monday - Sunday
+        
+        guard let weekStart = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)),
+            let weekEnd = calendar.date(byAdding: .day, value: 6, to: weekStart) else {
+                return nil
+        }
+        
+        return (weekStart, weekEnd)
+    }
+    
+    func monthFromDate(_ date: Date) -> Date? {
+        let dateComponents = calendar.dateComponents([.month, .year], from: date)
+        return calendar.date(from: dateComponents)
+    }
+    
+    func yearFromDate(_ date: Date) -> Int {
+        return calendar.component(.year, from: date)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
@@ -6,18 +6,18 @@ class StatsPeriodHelper {
         cal.timeZone = .autoupdatingCurrent
         return cal
     }()
-    
+
     func dateAvailableBeforeDate(_ dateIn: Date, period: StatsPeriodUnit, backLimit: Int) -> Bool {
         // Use dates without time
         let currentDate = Date().normalizedDate()
-        
+
         guard var oldestDate = calendar.date(byAdding: period.calendarComponent, value: backLimit, to: currentDate) else {
             return false
         }
-        
+
         let date = dateIn.normalizedDate()
         oldestDate = oldestDate.normalizedDate()
-        
+
         switch period {
         case .day:
             return date > oldestDate
@@ -39,12 +39,12 @@ class StatsPeriodHelper {
             return year > yearFromDate(oldestDate)
         }
     }
-    
+
     func dateAvailableAfterDate(_ dateIn: Date, period: StatsPeriodUnit) -> Bool {
         // Use dates without time
         let currentDate = Date().normalizedDate()
         let date = dateIn.normalizedDate()
-        
+
         switch period {
         case .day:
             return date < currentDate
@@ -66,21 +66,21 @@ class StatsPeriodHelper {
             return year < yearFromDate(currentDate)
         }
     }
-    
+
     func calculateEndDate(startDate: Date, offsetBy count: Int = 1, unit: StatsPeriodUnit) -> Date? {
         let calendar = Calendar.autoupdatingCurrent
-        
+
         guard let adjustedDate = calendar.date(byAdding: unit.calendarComponent, value: count, to: startDate) else {
             DDLogError("[Stats] Couldn't do basic math on Calendars in Stats. Returning original value.")
             return startDate
         }
-        
+
         switch unit {
         case .day:
             return adjustedDate.normalizedDate()
-            
+
         case .week:
-            
+
             // The hours component here is because the `dateInterval` returnd by Calendar is a closed range
             // — so the "end" of a specific week is also simultenously a 'start' of the next one.
             // This causes problem when calling this math on dates that _already are_ an end/start of a week.
@@ -88,24 +88,24 @@ class StatsPeriodHelper {
             // (I *think* that's what's happening here. Doing Calendar math on this method has broken my brain.
             // I spend like 10h on this ~50 LoC method. Beware.)
             let components = DateComponents(day: 7 * count, hour: -12)
-            
+
             guard let weekAdjusted = calendar.date(byAdding: components, to: startDate.normalizedDate()) else {
                 DDLogError("[Stats] Couldn't add a multiple of 7 days and -12 hours to a date in Stats. Returning original value.")
                 return startDate
             }
-            
+
             let endOfAdjustedWeek = calendar.dateInterval(of: .weekOfYear, for: weekAdjusted)?.end
-            
+
             return endOfAdjustedWeek?.normalizedDate()
-            
+
         case .month:
             guard let maxComponent = calendar.range(of: .day, in: .month, for: adjustedDate)?.max() else {
                 DDLogError("[Stats] Couldn't determine number of days in a given month in Stats. Returning original value.")
                 return startDate
             }
-            
+
             return calendar.date(bySetting: .day, value: maxComponent, of: adjustedDate)?.normalizedDate()
-            
+
         case .year:
             guard
                 let maxMonth = calendar.range(of: .month, in: .year, for: adjustedDate)?.max(),
@@ -115,29 +115,29 @@ class StatsPeriodHelper {
                     return startDate
             }
             let adjustedDayDate = calendar.date(bySetting: .day, value: maxDay, of: adjustedMonthDate)
-            
+
             return adjustedDayDate?.normalizedDate()
         }
     }
-    
+
     // MARK: - Date Helpers
-    
+
     func weekIncludingDate(_ date: Date) -> (weekStart: Date, weekEnd: Date)? {
         // Note: Week is Monday - Sunday
-        
+
         guard let weekStart = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)),
             let weekEnd = calendar.date(byAdding: .day, value: 6, to: weekStart) else {
                 return nil
         }
-        
+
         return (weekStart, weekEnd)
     }
-    
+
     func monthFromDate(_ date: Date) -> Date? {
         let dateComponents = calendar.dateComponents([.month, .year], from: date)
         return calendar.date(from: dateComponents)
     }
-    
+
     func yearFromDate(_ date: Date) -> Int {
         return calendar.component(.year, from: date)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -47,7 +47,7 @@ struct OverviewTabData: FilterTabBarItem {
     }
 
     var differenceTextColor: UIColor {
-        return difference < 0 ? WPStyleGuide.Stats.negativeColor : WPStyleGuide.Stats.positiveColor
+        return WPStyleGuide.grey()
     }
 
     var title: String {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -56,7 +56,7 @@ struct OverviewTabData: FilterTabBarItem {
             StatsPeriodHelper().dateAvailableAfterDate(date, period: period) == false {
             return WPStyleGuide.grey()
         }
-        
+
         return difference < 0 ? WPStyleGuide.Stats.negativeColor : WPStyleGuide.Stats.positiveColor
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -6,13 +6,17 @@ struct OverviewTabData: FilterTabBarItem {
     var tabDataStub: String?
     var difference: Int
     var differencePercent: Int
+    var date: Date?
+    var period: StatsPeriodUnit?
 
-    init(tabTitle: String, tabData: Int, tabDataStub: String? = nil, difference: Int, differencePercent: Int) {
+    init(tabTitle: String, tabData: Int, tabDataStub: String? = nil, difference: Int, differencePercent: Int, date: Date? = nil, period: StatsPeriodUnit? = nil) {
         self.tabTitle = tabTitle
         self.tabData = tabData
         self.tabDataStub = tabDataStub
         self.difference = difference
         self.differencePercent = differencePercent
+        self.date = date
+        self.period = period
     }
 
     var attributedTitle: NSAttributedString? {
@@ -47,7 +51,13 @@ struct OverviewTabData: FilterTabBarItem {
     }
 
     var differenceTextColor: UIColor {
-        return WPStyleGuide.grey()
+        if let date = date,
+            let period = period,
+            StatsPeriodHelper().dateAvailableAfterDate(date, period: period) == false {
+            return WPStyleGuide.grey()
+        }
+        
+        return difference < 0 ? WPStyleGuide.Stats.negativeColor : WPStyleGuide.Stats.positiveColor
     }
 
     var title: String {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -126,18 +126,24 @@ private extension SiteStatsPeriodViewModel {
             mostRecentChartData = chartData
         }
 
+        let periodDate = summaryData.last?.periodStartDate
+        let period = periodSummary?.period
+
         let viewsData = intervalData(summaryData: summaryData, summaryType: .views)
         let viewsTabData = OverviewTabData(tabTitle: StatSection.periodOverviewViews.tabTitle,
                                            tabData: viewsData.count,
                                            difference: viewsData.difference,
-                                           differencePercent: viewsData.percentage)
+                                           differencePercent: viewsData.percentage,
+                                           date: periodDate,
+                                           period: period)
 
         let visitorsData = intervalData(summaryData: summaryData, summaryType: .visitors)
         let visitorsTabData = OverviewTabData(tabTitle: StatSection.periodOverviewVisitors.tabTitle,
                                               tabData: visitorsData.count,
                                               difference: visitorsData.difference,
-                                              differencePercent: visitorsData.percentage)
-
+                                              differencePercent: visitorsData.percentage,
+                                              date: periodDate,
+                                              period: period)
 
         // If Summary Likes is still loading, show dashes (instead of 0)
         // to indicate it's still loading.
@@ -148,13 +154,17 @@ private extension SiteStatsPeriodViewModel {
                                            tabData: likesData.count,
                                            tabDataStub: likesLoadingStub,
                                            difference: likesData.difference,
-                                           differencePercent: likesData.percentage)
+                                           differencePercent: likesData.percentage,
+                                           date: periodDate,
+                                           period: period)
 
         let commentsData = intervalData(summaryData: summaryData, summaryType: .comments)
         let commentsTabData = OverviewTabData(tabTitle: StatSection.periodOverviewComments.tabTitle,
                                               tabData: commentsData.count,
                                               difference: commentsData.difference,
-                                              differencePercent: commentsData.percentage)
+                                              differencePercent: commentsData.percentage,
+                                              date: periodDate,
+                                              period: period)
 
         var barChartData = [BarChartDataConvertible]()
         var barChartStyling = [BarChartStyling]()

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -111,7 +111,7 @@ private extension SiteStatsTableHeaderView {
             updateArrowStates()
             return
         }
-        
+
         let helper = StatsPeriodHelper()
         forwardButton.isEnabled = helper.dateAvailableAfterDate(date, period: period)
         backButton.isEnabled = helper.dateAvailableBeforeDate(date, period: period, backLimit: backLimit)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -73,7 +73,7 @@ private extension SiteStatsTableHeaderView {
         case .day, .month, .year:
             return dateFormatter.string(from: date)
         case .week:
-            let week = weekIncludingDate(date)
+            let week = StatsPeriodHelper().weekIncludingDate(date)
             guard let weekStart = week?.weekStart, let weekEnd = week?.weekEnd else {
                 return nil
             }
@@ -97,7 +97,7 @@ private extension SiteStatsTableHeaderView {
 
         let value = forward ? 1 : -1
 
-        self.date = calculateEndDate(startDate: date, offsetBy: value, unit: period)
+        self.date = StatsPeriodHelper().calculateEndDate(startDate: date, offsetBy: value, unit: period)
 
         delegate?.dateChangedTo(self.date)
         dateLabel.text = displayDate()
@@ -105,82 +105,22 @@ private extension SiteStatsTableHeaderView {
     }
 
     func updateButtonStates() {
-
-        // Use dates without time
-        let currentDate = Date().normalizedDate()
-
-        guard var date = date,
-            let period = period,
-            var oldestDate = calendar.date(byAdding: period.calendarComponent, value: backLimit, to: currentDate) else {
-            backButton.isEnabled = false
+        guard let date = date, let period = period else {
             forwardButton.isEnabled = false
+            backButton.isEnabled = false
             updateArrowStates()
             return
         }
-
-        date = date.normalizedDate()
-        oldestDate = oldestDate.normalizedDate()
-
-        switch period {
-        case .day:
-            forwardButton.isEnabled = date < currentDate
-            backButton.isEnabled = date > oldestDate
-        case .week:
-            let week = weekIncludingDate(date)
-            if let weekStart = week?.weekStart,
-                let weekEnd = week?.weekEnd,
-                let currentWeekEnd = weekIncludingDate(currentDate)?.weekEnd,
-                let oldestWeekStart = weekIncludingDate(oldestDate)?.weekStart {
-                forwardButton.isEnabled = weekEnd < currentWeekEnd
-                backButton.isEnabled = weekStart > oldestWeekStart
-            } else {
-                forwardButton.isEnabled = false
-                backButton.isEnabled = false
-            }
-        case .month:
-            if let month = monthFromDate(date),
-                let currentMonth = monthFromDate(currentDate),
-                let oldestMonth = monthFromDate(oldestDate) {
-                forwardButton.isEnabled = month < currentMonth
-                backButton.isEnabled = month > oldestMonth
-            } else {
-                backButton.isEnabled = false
-                forwardButton.isEnabled = false
-            }
-        case .year:
-            let year = yearFromDate(date)
-            forwardButton.isEnabled = year < yearFromDate(currentDate)
-            backButton.isEnabled = year > yearFromDate(oldestDate)
-        }
-
+        
+        let helper = StatsPeriodHelper()
+        forwardButton.isEnabled = helper.dateAvailableAfterDate(date, period: period)
+        backButton.isEnabled = helper.dateAvailableBeforeDate(date, period: period, backLimit: backLimit)
         updateArrowStates()
     }
 
     func updateArrowStates() {
         forwardArrow.image = Style.imageForGridiconType(.chevronRight, withTint: (forwardButton.isEnabled ? .darkGrey : .grey))
         backArrow.image = Style.imageForGridiconType(.chevronLeft, withTint: (backButton.isEnabled ? .darkGrey : .grey))
-    }
-
-    // MARK: - Date Helpers
-
-    func weekIncludingDate(_ date: Date) -> (weekStart: Date, weekEnd: Date)? {
-        // Note: Week is Monday - Sunday
-
-        guard let weekStart = calendar.date(from: calendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: date)),
-            let weekEnd = calendar.date(byAdding: .day, value: 6, to: weekStart) else {
-                return nil
-        }
-
-        return (weekStart, weekEnd)
-    }
-
-    func monthFromDate(_ date: Date) -> Date? {
-        let dateComponents = calendar.dateComponents([.month, .year], from: date)
-        return calendar.date(from: dateComponents)
-    }
-
-    func yearFromDate(_ date: Date) -> Int {
-        return calendar.component(.year, from: date)
     }
 }
 
@@ -192,65 +132,10 @@ extension SiteStatsTableHeaderView: StatsBarChartViewDelegate {
 
         let periodShift = -((entryCount - 1) - entryIndex)
 
-        self.date = calculateEndDate(startDate: Date().normalizedDate(), offsetBy: periodShift, unit: period)
+        self.date = StatsPeriodHelper().calculateEndDate(startDate: Date().normalizedDate(), offsetBy: periodShift, unit: period)
 
         delegate?.dateChangedTo(self.date)
         dateLabel.text = displayDate()
         updateButtonStates()
-    }
-}
-
-private extension SiteStatsTableHeaderView {
-    func calculateEndDate(startDate: Date, offsetBy count: Int = 1, unit: StatsPeriodUnit) -> Date? {
-        let calendar = Calendar.autoupdatingCurrent
-
-        guard let adjustedDate = calendar.date(byAdding: unit.calendarComponent, value: count, to: startDate) else {
-            DDLogError("[Stats] Couldn't do basic math on Calendars in Stats. Returning original value.")
-            return startDate
-        }
-
-        switch unit {
-        case .day:
-            return adjustedDate.normalizedDate()
-
-        case .week:
-
-            // The hours component here is because the `dateInterval` returnd by Calendar is a closed range
-            // — so the "end" of a specific week is also simultenously a 'start' of the next one.
-            // This causes problem when calling this math on dates that _already are_ an end/start of a week.
-            // This doesn't work for our calculations, so we force it to rollover using this hack.
-            // (I *think* that's what's happening here. Doing Calendar math on this method has broken my brain.
-            // I spend like 10h on this ~50 LoC method. Beware.)
-            let components = DateComponents(day: 7 * count, hour: -12)
-
-            guard let weekAdjusted = calendar.date(byAdding: components, to: startDate.normalizedDate()) else {
-                DDLogError("[Stats] Couldn't add a multiple of 7 days and -12 hours to a date in Stats. Returning original value.")
-                return startDate
-            }
-
-            let endOfAdjustedWeek = calendar.dateInterval(of: .weekOfYear, for: weekAdjusted)?.end
-
-            return endOfAdjustedWeek?.normalizedDate()
-
-        case .month:
-            guard let maxComponent = calendar.range(of: .day, in: .month, for: adjustedDate)?.max() else {
-                DDLogError("[Stats] Couldn't determine number of days in a given month in Stats. Returning original value.")
-                return startDate
-            }
-
-            return calendar.date(bySetting: .day, value: maxComponent, of: adjustedDate)?.normalizedDate()
-
-        case .year:
-            guard
-                let maxMonth = calendar.range(of: .month, in: .year, for: adjustedDate)?.max(),
-                let adjustedMonthDate = calendar.date(bySetting: .month, value: maxMonth, of: adjustedDate),
-                let maxDay = calendar.range(of: .day, in: .month, for: adjustedMonthDate)?.max() else {
-                    DDLogError("[Stats] Couldn't determine number of months in a given year, or days in a given monthin Stats. Returning original value.")
-                    return startDate
-            }
-            let adjustedDayDate = calendar.date(bySetting: .day, value: maxDay, of: adjustedMonthDate)
-
-            return adjustedDayDate?.normalizedDate()
-        }
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		17CE77ED20C6C2F3001DEA5A /* ReaderSiteSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */; };
 		17CE77EF20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */; };
 		17D2FDC21C6A468A00944265 /* PlanComparisonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */; };
+		17D4153C22C2308D006378EF /* StatsPeriodHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D4153B22C2308D006378EF /* StatsPeriodHelper.swift */; };
 		17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */; };
 		17D975AF1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */; };
 		17E24F5420FCF1D900BD70A3 /* Routes+MySites.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E24F5320FCF1D900BD70A3 /* Routes+MySites.swift */; };
@@ -2095,6 +2096,7 @@
 		17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchService.swift; sourceTree = "<group>"; };
 		17CE77EE20C6CDAA001DEA5A /* ReaderSiteSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchViewController.swift; sourceTree = "<group>"; };
 		17D2FDC11C6A468A00944265 /* PlanComparisonViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlanComparisonViewController.swift; sourceTree = "<group>"; };
+		17D4153B22C2308D006378EF /* StatsPeriodHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodHelper.swift; sourceTree = "<group>"; };
 		17D5C3F61FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaProgressCoordinatorNoticeViewModel.swift; sourceTree = "<group>"; };
 		17D975AE1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Aztec.swift"; sourceTree = "<group>"; };
 		17E24F5320FCF1D900BD70A3 /* Routes+MySites.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+MySites.swift"; sourceTree = "<group>"; };
@@ -4527,7 +4529,7 @@
 			path = Networking;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				F14B5F6F208E648200439554 /* config */,
@@ -6600,6 +6602,7 @@
 				9874767221963D320080967F /* SiteStatsInformation.swift */,
 				98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */,
 				98CAD295221B4ED1003E8F45 /* StatSection.swift */,
+				17D4153B22C2308D006378EF /* StatsPeriodHelper.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -9007,7 +9010,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -10648,6 +10651,7 @@
 				73F76E1E222851E300FDDAD2 /* Charts+AxisFormatters.swift in Sources */,
 				40EC1F0F2249CA8400F6785E /* OtherAndTotalViewsCount+CoreDataClass.swift in Sources */,
 				98579BC7203DD86F004086E4 /* EpilogueSectionHeaderFooter.swift in Sources */,
+				17D4153C22C2308D006378EF /* StatsPeriodHelper.swift in Sources */,
 				7E3E7A5920E44D2F0075D159 /* FooterContentStyles.swift in Sources */,
 				E19B17B21E5C8F36007517C6 /* AbstractPost.swift in Sources */,
 				912347762216E27200BD9F97 /* GutenbergViewController+Localization.swift in Sources */,


### PR DESCRIPTION
(Same as #11980 but targeting 12.7)

Fixes #11976. This PR updates the color of the difference value in stats to grey to de-emphasize how positive / negative the change is.

<img width="374" alt="Screenshot 2019-06-24 at 14 35 11" src="https://user-images.githubusercontent.com/4780/60023419-aee04800-968d-11e9-8063-f0dd824dfcc9.png">

**To test:**

* Build and run, check the appearance of the difference label

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.