### PR TITLE
[Stats Refresh] Change stat card subtitles to be normal case.

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -60,7 +60,6 @@ extension WPStyleGuide {
         static func configureLabelAsSubtitle(_ label: UILabel) {
             label.textColor = secondaryTextColor
             label.font = subTitleFont
-            label.text = label.text?.localizedUppercase
         }
 
         static func configureLabelItemDetail(_ label: UILabel) {


### PR DESCRIPTION
Fixes #11979

To test:
- Go to all stats views (Insights, Period, Post Stats, details).
- Verify the card subtitles are now normal case.

Examples:

<img width="400" alt="Screen Shot 2019-06-24 at 1 36 11 PM" src="https://user-images.githubusercontent.com/1816888/60046682-265da980-9685-11e9-86e4-40661cdafc96.png">

<img width="400" alt="Screen Shot 2019-06-24 at 1 36 24 PM" src="https://user-images.githubusercontent.com/1816888/60046683-26f64000-9685-11e9-9139-58f71ae8aab2.png">

<img width="400" alt="Screen Shot 2019-06-24 at 1 36 35 PM" src="https://user-images.githubusercontent.com/1816888/60046684-26f64000-9685-11e9-8fa0-52ed76ba338c.png">

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
