### PR TITLE
Fetching a post after update

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,7 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.1.3'
+    pod 'WordPressKit', '~> 4.2.0-beta.2'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/stats-fetch-likes-separately'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'ef4f184f5a33ef628c053892e8f706046191d66c'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -191,7 +191,7 @@ PODS:
     - WordPressKit (~> 4.1)
     - WordPressShared (~> 1.8)
     - WordPressUI (~> 1.3)
-  - WordPressKit (4.1.3):
+  - WordPressKit (4.2.0-beta.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -253,7 +253,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.7.0)
   - WordPressAuthenticator (~> 1.5.3)
-  - WordPressKit (~> 4.1.3)
+  - WordPressKit (~> 4.2.0-beta.2)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.3)
   - WordPressUI (~> 1.3.4)
@@ -390,7 +390,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 2dc41978696cdae7537dab8035cb1a9df02d9e87
   WordPress-Editor-iOS: f032feafcd01282c9d4c24cd4ecf941a3b67f629
   WordPressAuthenticator: 413b3d8ddf5fce199d38abcc61afe0d9475a463b
-  WordPressKit: 4020ecfd93f2cf6c8207102da8e060df6f73e9d7
+  WordPressKit: b5ab5a121dcc0f2f55f71963dea0ae2f852807b8
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
   WordPressShared: a70fb1f5465c484cd54e8ce150dd8d16cada5791
   WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
@@ -400,6 +400,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 43cd58bf94d583440d51121abea95ff3ddc8c7a3
+PODFILE CHECKSUM: bda4021973887c1d0fc12aec58a629e674612e9a
 
 COCOAPODS: 1.6.1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 * Post Settings: Setting a Featured Image on a Post/Site should now work better in poor netowrk conditions.
 * Stats Insights: New two-column layout for All-Time stats.
 * Stats Insights: New two-column layout for Today stats.
+* Post preview: Fixed issue with preview for self hosted sites not working.
 
 12.6
 -----


### PR DESCRIPTION
Related WordPressKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/163
Fixes #11952 

When we upload a post on a request to preview we call the uploadPost method in PostService. 
That call creates a remotePost in https://github.com/wordpress-mobile/WordPress-iOS/blob/e26bb0f8ba71e7650a4149b145748aca68e66d59/WordPress/Classes/Services/PostService.m#L720

When the site is self hosted updatePost in PostServiceRemoteXMLRPC is called and it returns a boolean. We then invoke a callback with the captured remote post (that has no URL).

In this PR
Pointing to WordPressKit release 4.2.0-beta.2. With this change, we are fetching the post after it's update like we do in createPost so the returned post should contain a url (permalink)


To test:
1. Select a self-hosted site in the app.
2. Start a new post and enter title/content.
3. Save the draft.
4. Preview the post. The preview loads.
5. Go back to the editor and make a change to the post.
6. Update the draft.
7. Preview the post.

Before:
![post_update_before](https://user-images.githubusercontent.com/1335657/59947768-f57e3a00-9422-11e9-8d04-bfde733ec669.gif)

After:
![post_update](https://user-images.githubusercontent.com/1335657/59947784-fca54800-9422-11e9-82d9-f9d580a9f0f3.gif)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
