### PR TITLE
[Stats Refresh] Save Insights overview to Core Data when refreshed.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * Stats Insights: New two-column layout for Most Popular Time stats.
 * Post preview: Fixed issue with preview for self hosted sites not working.
 * Stats: modified appearance of empty charts.
+* Stats Insights: Fixed issue where refreshing would sometimes clear the stats.
 
 12.7
 -----

--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -161,6 +161,10 @@ class StatsInsightsStore: QueryStore<InsightStoreState, InsightQuery> {
         case .refreshAnnual:
             refreshAnnual()
         }
+
+        if !isFetchingOverview {
+            DDLogInfo("Stats: Insights Overview fetching operations finished.")
+        }
     }
 
     override func queriesChanged() {
@@ -357,6 +361,7 @@ private extension StatsInsightsStore {
             return
         }
 
+        persistToCoreData()
         fetchInsights()
     }
 

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -213,7 +213,7 @@ class StatsPeriodStore: QueryStore<PeriodStoreState, PeriodQuery> {
         }
 
         if !isFetchingOverview {
-            DDLogInfo("Stats: All fetching operations finished.")
+            DDLogInfo("Stats: Period Overview fetching operations finished.")
             fetchingOverviewListener?(false, fetchingOverviewHasFailed)
         }
     }


### PR DESCRIPTION
Fixes #11983 

To test:
- Go to Stats Insights.
- Pull to refresh.
- Verify the stats are not cleared, and the table continues to show data. (See #11983 for example of what it should _not_ do.)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
