### PR TITLE
Remove release note from 12.8 as it was fixed in 12.7

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,6 @@
 * Stats Insights: New two-column layout for This Year stats.
 * Stats Insights: added details option for This Year stats.
 * Stats Insights: New two-column layout for Most Popular Time stats.
-* Post preview: Fixed issue with preview for self hosted sites not working.
 * Stats: modified appearance of empty charts.
 
 12.7


### PR DESCRIPTION
https://github.com/wordpress-mobile/WordPress-iOS/pull/11985 updated release notes for 12.7