### PR TITLE
[Stats Refresh] add new analytics tracks

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,13 +13,13 @@ plugin 'cocoapods-repo-update'
 ##
 def wordpress_shared
     ## for production:
-    # pod 'WordPressShared', '~> 1.8.4-beta.1'
+    pod 'WordPressShared', '~> 1.8.4-beta.2'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'add_new_stats_tracks'
+    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'add_new_stats_tracks'
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> ''
 end
 

--- a/Podfile
+++ b/Podfile
@@ -13,13 +13,13 @@ plugin 'cocoapods-repo-update'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.8.4-beta.1'
+    # pod 'WordPressShared', '~> 1.8.4-beta.1'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'issues/11946-remove-table-styling'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'add_new_stats_tracks'
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> ''
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -200,7 +200,7 @@ PODS:
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
   - WordPressMocks (0.0.5)
-  - WordPressShared (1.8.4-beta.1):
+  - WordPressShared (1.8.4-beta.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.3.4)
@@ -257,7 +257,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.5.4-beta.2)
   - WordPressKit (~> 4.2.0-beta.1)
   - WordPressMocks (~> 0.0.5)
-  - WordPressShared (~> 1.8.4-beta.1)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `add_new_stats_tracks`)
   - WordPressUI (~> 1.3.4)
   - WPMediaPicker (~> 1.4.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.7.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -304,7 +304,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -332,6 +331,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.7.0
+  WordPressShared:
+    :branch: add_new_stats_tracks
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.7.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -348,6 +350,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.7.0
+  WordPressShared:
+    :commit: 723d5d67b7f25fe22d73dad2a12e360b11ff820b
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -396,7 +401,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: c0e1417124f02885d55a7fb65e7fc4938ce135b5
   WordPressKit: 387ef89aff02fe5d042ef3657833ad71f9b4e6a5
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
-  WordPressShared: 067bb60eb036bf9c7943a02cfcfdb7118e323728
+  WordPressShared: d7a7f5aec9870ac6b0aac88c55ba94cb93282506
   WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
   WPMediaPicker: 1897f312c7b41114ffd239fb782431ae602134a1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -404,6 +409,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: e267e8521d1473e0464a2adb27b727d92fdf60d6
+PODFILE CHECKSUM: 74d04e956efba722b85857cf565eeeee05bafddb
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -257,7 +257,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.5.4-beta.2)
   - WordPressKit (~> 4.2.0-beta.2)
   - WordPressMocks (~> 0.0.5)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `add_new_stats_tracks`)
+  - WordPressShared (~> 1.8.4-beta.2)
   - WordPressUI (~> 1.3.4)
   - WPMediaPicker (~> 1.4.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.7.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -304,6 +304,7 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -331,9 +332,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.7.0
-  WordPressShared:
-    :branch: add_new_stats_tracks
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.7.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -350,9 +348,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.7.0
-  WordPressShared:
-    :commit: 723d5d67b7f25fe22d73dad2a12e360b11ff820b
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -409,6 +404,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 53560347370cf7438fcef9b766d747664fad34e2
+PODFILE CHECKSUM: 8f2fed4847583c44ab9cacc157a7967bc96eb5bc
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1615,6 +1615,12 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatStatsAccessed:
             eventName = @"stats_accessed";
             break;
+            case WPAnalyticsStatStatsDateTappedBackward:
+            eventName = @"stats_date_tapped_backward";
+            break;
+            case WPAnalyticsStatStatsDateTappedForward:
+            eventName = @"stats_date_tapped_forward";
+            break;
         case WPAnalyticsStatStatsInsightsAccessed:
             eventName = @"stats_insights_accessed";
             break;
@@ -1651,8 +1657,17 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatStatsOverviewBarChartTapped:
             eventName = @"stats_overview_bar_chart_tapped";
             break;
-        case WPAnalyticsStatStatsOverviewTypeTapped:
-            eventName = @"stats_overview_type_tapped";
+        case WPAnalyticsStatStatsOverviewTypeTappedComments:
+            eventName = @"stats_overview_type_tapped_comments";
+            break;
+        case WPAnalyticsStatStatsOverviewTypeTappedLikes:
+            eventName = @"stats_overview_type_tapped_likes";
+            break;
+        case WPAnalyticsStatStatsOverviewTypeTappedViews:
+            eventName = @"stats_overview_type_tapped_views";
+            break;
+        case WPAnalyticsStatStatsOverviewTypeTappedVisitors:
+            eventName = @"stats_overview_type_tapped_visitors";
             break;
         case WPAnalyticsStatStatsPeriodDaysAccessed:
             eventName = @"stats_period_accessed";
@@ -1694,6 +1709,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatStatsViewMoreTappedCountries:
             eventName = @"stats_countries_view_more_tapped";
             break;
+        case WPAnalyticsStatStatsViewMoreTappedFileDownloads:
+            eventName = @"stats_file_downloads_view_more_tapped";
+            break;
         case WPAnalyticsStatStatsViewMoreTappedFollowers:
             eventName = @"stats_followers_view_more_tapped";
             break;
@@ -1711,6 +1729,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             break;
         case WPAnalyticsStatStatsViewMoreTappedTagsAndCategories:
             eventName = @"stats_tags_and_categories_view_more_tapped";
+            break;
+        case WPAnalyticsStatStatsViewMoreTappedThisYear:
+            eventName = @"stats_this_year_view_more_tapped";
             break;
         case WPAnalyticsStatStatsViewMoreTappedVideoPlays:
             eventName = @"stats_video_plays_view_more_tapped";

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -234,4 +234,17 @@ extension StatsPeriodUnit {
         }
     }
 
+    var description: String {
+        switch self {
+        case .day: return "day"
+        case .week: return "week"
+        case .month: return "month"
+        case .year: return "year"
+        }
+    }
+
+    static var analyticsPeriodKey: String {
+        return "period"
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
@@ -76,7 +76,38 @@ private extension TwoColumnCell {
         guard let statSection = statSection else {
             return
         }
+
+        captureAnalyticsEventsFor(statSection)
         siteStatsInsightsDelegate?.viewMoreSelectedForStatSection?(statSection)
     }
 
+    // MARK: - Analytics support
+
+    func captureAnalyticsEventsFor(_ statSection: StatSection) {
+        if let event = statSection.analyticsViewMoreEvent {
+            captureAnalyticsEvent(event)
+        }
+    }
+
+    func captureAnalyticsEvent(_ event: WPAnalyticsStat) {
+        if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
+            WPAppAnalytics.track(event, withBlogID: blogIdentifier)
+        } else {
+            WPAppAnalytics.track(event)
+        }
+    }
+
+}
+
+// MARK: - Analytics support
+
+private extension StatSection {
+    var analyticsViewMoreEvent: WPAnalyticsStat? {
+        switch self {
+        case .insightsAnnualSiteStats:
+            return .statsViewMoreTappedThisYear
+        default:
+            return nil
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -6,13 +6,20 @@ struct OverviewTabData: FilterTabBarItem {
     var tabDataStub: String?
     var difference: Int
     var differencePercent: Int
+    var analyticsStat: WPAnalyticsStat?
 
-    init(tabTitle: String, tabData: Int, tabDataStub: String? = nil, difference: Int, differencePercent: Int) {
+    init(tabTitle: String,
+         tabData: Int,
+         tabDataStub: String? = nil,
+         difference: Int,
+         differencePercent: Int,
+         analyticsStat: WPAnalyticsStat? = nil) {
         self.tabTitle = tabTitle
         self.tabData = tabData
         self.tabDataStub = tabDataStub
         self.difference = difference
         self.differencePercent = differencePercent
+        self.analyticsStat = analyticsStat
     }
 
     var attributedTitle: NSAttributedString? {
@@ -148,6 +155,10 @@ private extension OverviewCell {
     }
 
     @objc func selectedFilterDidChange(_ filterBar: FilterTabBar) {
+        if let event = tabsData[filterTabBar.selectedIndex].analyticsStat {
+            captureAnalyticsEvent(event)
+        }
+
         configureChartView()
         updateLabels()
     }
@@ -192,6 +203,18 @@ private extension OverviewCell {
     enum ChartBottomMargin {
         static let filterTabBarShown = CGFloat(16)
         static let filterTabBarHidden = CGFloat(24)
+    }
+
+    // MARK: - Analytics support
+
+    func captureAnalyticsEvent(_ event: WPAnalyticsStat) {
+        let properties: [AnyHashable: Any] = [StatsPeriodUnit.analyticsPeriodKey: period?.description as Any]
+
+        if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
+            WPAppAnalytics.track(event, withProperties: properties, withBlogID: blogIdentifier)
+        } else {
+            WPAppAnalytics.track(event, withProperties: properties)
+        }
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -130,13 +130,15 @@ private extension SiteStatsPeriodViewModel {
         let viewsTabData = OverviewTabData(tabTitle: StatSection.periodOverviewViews.tabTitle,
                                            tabData: viewsData.count,
                                            difference: viewsData.difference,
-                                           differencePercent: viewsData.percentage)
+                                           differencePercent: viewsData.percentage,
+                                           analyticsStat: .statsOverviewTypeTappedViews)
 
         let visitorsData = intervalData(summaryData: summaryData, summaryType: .visitors)
         let visitorsTabData = OverviewTabData(tabTitle: StatSection.periodOverviewVisitors.tabTitle,
                                               tabData: visitorsData.count,
                                               difference: visitorsData.difference,
-                                              differencePercent: visitorsData.percentage)
+                                              differencePercent: visitorsData.percentage,
+                                              analyticsStat: .statsOverviewTypeTappedVisitors)
 
 
         // If Summary Likes is still loading, show dashes (instead of 0)
@@ -148,13 +150,15 @@ private extension SiteStatsPeriodViewModel {
                                            tabData: likesData.count,
                                            tabDataStub: likesLoadingStub,
                                            difference: likesData.difference,
-                                           differencePercent: likesData.percentage)
+                                           differencePercent: likesData.percentage,
+                                           analyticsStat: .statsOverviewTypeTappedLikes)
 
         let commentsData = intervalData(summaryData: summaryData, summaryType: .comments)
         let commentsTabData = OverviewTabData(tabTitle: StatSection.periodOverviewComments.tabTitle,
                                               tabData: commentsData.count,
                                               difference: commentsData.difference,
-                                              differencePercent: commentsData.percentage)
+                                              differencePercent: commentsData.percentage,
+                                              analyticsStat: .statsOverviewTypeTappedComments)
 
         var barChartData = [BarChartDataConvertible]()
         var barChartStyling = [BarChartStyling]()

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -89,10 +89,12 @@ private extension SiteStatsTableHeaderView {
     }
 
     @IBAction func didTapBackButton(_ sender: UIButton) {
+        captureAnalyticsEvent(.statsDateTappedBackward)
         updateDate(forward: false)
     }
 
     @IBAction func didTapForwardButton(_ sender: UIButton) {
+        captureAnalyticsEvent(.statsDateTappedForward)
         updateDate(forward: true)
     }
 
@@ -188,6 +190,19 @@ private extension SiteStatsTableHeaderView {
     func yearFromDate(_ date: Date) -> Int {
         return calendar.component(.year, from: date)
     }
+
+    // MARK: - Analytics support
+
+    func captureAnalyticsEvent(_ event: WPAnalyticsStat) {
+        let properties: [AnyHashable: Any] = [StatsPeriodUnit.analyticsPeriodKey: period?.description as Any]
+
+        if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
+            WPAppAnalytics.track(event, withProperties: properties, withBlogID: blogIdentifier)
+        } else {
+            WPAppAnalytics.track(event, withProperties: properties)
+        }
+    }
+
 }
 
 extension SiteStatsTableHeaderView: StatsBarChartViewDelegate {


### PR DESCRIPTION
Fixes #11775
Ref #11908

This adds analytics tracks for:
- Insights _This Year_ `View more`.
- Date Bar: tapping backward and forward. Includes the selected period in the event properties.
- Period Overview chart: selecting filter bar tabs _Views_, _Visitors_, _Likes_, and _Comments_. Includes the selected period event properties.

NOTE: Accompanying Shared PR: https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/210

To test:
- Go to Insights _This Year_ `View more`. Verify the action is tracked.
```
🔵 Tracked: stats_this_year_view_more_tapped, properties: {
    "blog_id" = <id>;
}
```

- Go to any period and change the date via the Date Bar. Verify the actions are tracked.
```
🔵 Tracked: stats_date_tapped_backward, properties: {
    "blog_id" = <id>;
    period = day;
}
```

```
🔵 Tracked: stats_date_tapped_forward, properties: {
    "blog_id" = <id>;
    period = month;
}
```


- Go to any period and select the different filters on the overview chart. Verify the actions are tracked.
```
🔵 Tracked: stats_overview_type_tapped_visitors, properties: {
    "blog_id" = <id>;
    period = month;
}
```

```
🔵 Tracked: stats_overview_type_tapped_likes, properties: {
    "blog_id" = <id>;
    period = week;
}
```

```
🔵 Tracked: stats_overview_type_tapped_comments, properties: {
    "blog_id" = <id>;
    period = year;
}
```

```
🔵 Tracked: stats_overview_type_tapped_views, properties: {
    "blog_id" = <id>;
    period = day;
}
```


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
