### PR TITLE
Improve UI test output (logs and screenshots)

### DIFF
--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -21,23 +21,29 @@ class LoginFlow {
     }
 
     static func logoutIfNeeded() {
-        if TabNavComponent.isLoaded() {
-            Logger.log(message: "Logging out...", event: .i)
-            let meScreen = TabNavComponent().gotoMeScreen()
-            if meScreen.isLoggedInToWpcom() {
-                _ = meScreen.logout()
-            } else {
-                _ = TabNavComponent().gotoMySiteScreen()
-                .removeSelfHostedSite()
+        XCTContext.runActivity(named: "Log out of app if currently logged in") { (activity) in
+            if TabNavComponent.isLoaded() {
+                Logger.log(message: "Logging out...", event: .i)
+                let meScreen = TabNavComponent().gotoMeScreen()
+                if meScreen.isLoggedInToWpcom() {
+                    _ = meScreen.logout()
+                } else {
+                    _ = TabNavComponent().gotoMySiteScreen()
+                        .removeSelfHostedSite()
+                }
+                return
             }
-            return
         }
 
-        while LoginPasswordScreen.isLoaded() || LoginEmailScreen.isLoaded() || LinkOrPasswordScreen.isLoaded() || LoginSiteAddressScreen.isLoaded() || LoginUsernamePasswordScreen.isLoaded() || LoginCheckMagicLinkScreen.isLoaded() {
-            if LoginEmailScreen.isLoaded() && LoginEmailScreen.isEmailEntered() {
-                LoginEmailScreen().emailTextField.clearTextIfNeeded()
+        XCTContext.runActivity(named: "Return to app prologue screen if needed") { (activity) in
+            if !WelcomeScreen.isLoaded() {
+                while LoginPasswordScreen.isLoaded() || LoginEmailScreen.isLoaded() || LinkOrPasswordScreen.isLoaded() || LoginSiteAddressScreen.isLoaded() || LoginUsernamePasswordScreen.isLoaded() || LoginCheckMagicLinkScreen.isLoaded() {
+                    if LoginEmailScreen.isLoaded() && LoginEmailScreen.isEmailEntered() {
+                        LoginEmailScreen().emailTextField.clearTextIfNeeded()
+                    }
+                    navBackButton.tap()
+                }
             }
-            navBackButton.tap()
         }
     }
 }

--- a/WordPress/WordPressUITests/Screens/BaseScreen.swift
+++ b/WordPress/WordPressUITests/Screens/BaseScreen.swift
@@ -19,9 +19,11 @@ class BaseScreen {
 
     @discardableResult
     func waitForPage() throws -> BaseScreen {
-        let result = waitFor(element: expectedElement, predicate: "isEnabled == true", timeout: 20)
-        XCTAssert(result, "Page \(self) is not loaded.")
-        Logger.log(message: "Page \(self) is loaded", event: .i)
+        XCTContext.runActivity(named: "Confirm page \(self) is loaded") { (activity) in
+            let result = waitFor(element: expectedElement, predicate: "isEnabled == true", timeout: 20)
+            XCTAssert(result, "Page \(self) is not loaded.")
+            Logger.log(message: "Page \(self) is loaded", event: .i)
+        }
         return self
     }
 
@@ -46,23 +48,25 @@ class BaseScreen {
     }
 
     func openMagicLink() {
-        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
-        safari.launch()
+        XCTContext.runActivity(named: "Open magic link in Safari") { (activity) in
+            let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+            safari.launch()
 
-        // Select the URL bar when Safari opens
-        let urlBar = safari.otherElements["URL"]
-        waitFor(element: urlBar, predicate: "exists == true")
-        urlBar.tap()
+            // Select the URL bar when Safari opens
+            let urlBar = safari.otherElements["URL"]
+            waitFor(element: urlBar, predicate: "exists == true")
+            urlBar.tap()
 
-        // Follow the magic link
-        var magicLinkComponents = URLComponents(url: WireMock.URL(), resolvingAgainstBaseURL: false)!
-        magicLinkComponents.path = "/magic-link"
-        magicLinkComponents.queryItems = [URLQueryItem(name: "scheme", value: "wpdebug")]
+            // Follow the magic link
+            var magicLinkComponents = URLComponents(url: WireMock.URL(), resolvingAgainstBaseURL: false)!
+            magicLinkComponents.path = "/magic-link"
+            magicLinkComponents.queryItems = [URLQueryItem(name: "scheme", value: "wpdebug")]
 
-        safari.textFields["URL"].typeText("\(magicLinkComponents.url!.absoluteString)\n")
+            safari.textFields["URL"].typeText("\(magicLinkComponents.url!.absoluteString)\n")
 
-        // Accept the prompt to open the deep link
-        safari.scrollViews.element(boundBy: 0).buttons.element(boundBy: 1).tap()
+            // Accept the prompt to open the deep link
+            safari.scrollViews.element(boundBy: 0).buttons.element(boundBy: 1).tap()
+        }
     }
 }
 

--- a/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
@@ -253,7 +253,8 @@ class AztecEditorScreen: BaseScreen {
                 }
             }
 
-            XCTAssert(!AztecEditorScreen.isLoaded(), "Aztec editor should be closed but is still loaded.")
+            let editorClosed = waitFor(element: editorCloseButton, predicate: "isEnabled == false")
+            XCTAssert(editorClosed, "Aztec editor should be closed but is still loaded.")
         }
     }
 

--- a/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
@@ -248,6 +248,8 @@ class AztecEditorScreen: BaseScreen {
             Logger.log(message: "Discarding unsaved changes", event: .v)
             discardButton.tap()
         }
+
+        XCTAssert(!AztecEditorScreen.isLoaded(), "Aztec editor should be closed but is still loaded.")
     }
 
     func publish() -> EditorNoticeComponent {

--- a/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
@@ -232,24 +232,29 @@ class AztecEditorScreen: BaseScreen {
 
     // returns void since return screen depends on from which screen it loaded
     func closeEditor() {
-        // Close the More menu if needed
-        if actionSheet.exists {
-            if isIpad {
-                app.otherElements["PopoverDismissRegion"].tap()
-            } else {
-                keepEditingButton.tap()
+        XCTContext.runActivity(named: "Close the Aztec editor") { (activity) in
+            XCTContext.runActivity(named: "Close the More menu if needed") { (activity) in
+                if actionSheet.exists {
+                    if isIpad {
+                        app.otherElements["PopoverDismissRegion"].tap()
+                    } else {
+                        keepEditingButton.tap()
+                    }
+                }
             }
-        }
 
-        // Close the editor and discard any local changes
-        editorCloseButton.tap()
-        let notSavedState = app.staticTexts["You have unsaved changes."]
-        if notSavedState.exists {
-            Logger.log(message: "Discarding unsaved changes", event: .v)
-            discardButton.tap()
-        }
+            editorCloseButton.tap()
 
-        XCTAssert(!AztecEditorScreen.isLoaded(), "Aztec editor should be closed but is still loaded.")
+            XCTContext.runActivity(named: "Discard any local changes") { (activity) in
+                let notSavedState = app.staticTexts["You have unsaved changes."]
+                if notSavedState.exists {
+                    Logger.log(message: "Discarding unsaved changes", event: .v)
+                    discardButton.tap()
+                }
+            }
+
+            XCTAssert(!AztecEditorScreen.isLoaded(), "Aztec editor should be closed but is still loaded.")
+        }
     }
 
     func publish() -> EditorNoticeComponent {

--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -65,23 +65,29 @@ class BlockEditorScreen: BaseScreen {
 
     // returns void since return screen depends on from which screen it loaded
     func closeEditor() {
-        // Close the More menu if needed
-        if actionSheet.exists {
-            if isIpad {
-                app.otherElements["PopoverDismissRegion"].tap()
-            } else {
-                keepEditingButton.tap()
+        XCTContext.runActivity(named: "Close the block editor") { (activity) in
+            XCTContext.runActivity(named: "Close the More menu if needed") { (activity) in
+                if actionSheet.exists {
+                    if isIpad {
+                        app.otherElements["PopoverDismissRegion"].tap()
+                    } else {
+                        keepEditingButton.tap()
+                    }
+                }
             }
-        }
-        // Close the editor and discard any local changes
-        editorCloseButton.tap()
-        let notSavedState = app.staticTexts["You have unsaved changes."]
-        if notSavedState.exists {
-            Logger.log(message: "Discarding unsaved changes", event: .v)
-            discardButton.tap()
-        }
 
-        XCTAssert(!BlockEditorScreen.isLoaded(), "Block editor should be closed but is still loaded.")
+            editorCloseButton.tap()
+
+            XCTContext.runActivity(named: "Discard any local changes") { (activity) in
+                let notSavedState = app.staticTexts["You have unsaved changes."]
+                if notSavedState.exists {
+                    Logger.log(message: "Discarding unsaved changes", event: .v)
+                    discardButton.tap()
+                }
+            }
+
+            XCTAssert(!BlockEditorScreen.isLoaded(), "Block editor should be closed but is still loaded.")
+        }
     }
 
     func publish() -> EditorNoticeComponent {

--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -86,7 +86,8 @@ class BlockEditorScreen: BaseScreen {
                 }
             }
 
-            XCTAssert(!BlockEditorScreen.isLoaded(), "Block editor should be closed but is still loaded.")
+            let editorClosed = waitFor(element: editorNavBar, predicate: "isEnabled == false")
+            XCTAssert(editorClosed, "Block editor should be closed but is still loaded.")
         }
     }
 

--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -80,6 +80,8 @@ class BlockEditorScreen: BaseScreen {
             Logger.log(message: "Discarding unsaved changes", event: .v)
             discardButton.tap()
         }
+
+        XCTAssert(!BlockEditorScreen.isLoaded(), "Block editor should be closed but is still loaded.")
     }
 
     func publish() -> EditorNoticeComponent {

--- a/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
@@ -13,6 +13,7 @@ class EditorAztecTests: XCTestCase {
     }
 
     override func tearDown() {
+        takeScreenshotOfFailedTest()
         if editorScreen != nil && !TabNavComponent.isVisible() {
             EditorFlow.returnToMainEditorScreen()
             editorScreen.closeEditor()

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -13,6 +13,7 @@ class EditorGutenbergTests: XCTestCase {
     }
 
     override func tearDown() {
+        takeScreenshotOfFailedTest()
         if editorScreen != nil && !TabNavComponent.isVisible() {
             EditorFlow.returnToMainEditorScreen()
             editorScreen.closeEditor()

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -9,6 +9,7 @@ class LoginTests: XCTestCase {
     }
 
     override func tearDown() {
+        takeScreenshotOfFailedTest()
         LoginFlow.logoutIfNeeded()
         super.tearDown()
     }

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -27,6 +27,9 @@ class MainNavigationTests: XCTestCase {
             .tabBar.gotoBlockEditorScreen()
             .closeEditor()
 
-        XCTAssert(NotificationsScreen.isLoaded())
+        XCTContext.runActivity(named: "Confirm Notifications screen and main navigation bar are loaded.") { (activity) in
+            XCTAssert(NotificationsScreen.isLoaded(), "Notifications screen isn't loaded.")
+            XCTAssert(TabNavComponent.isVisible(), "Main navigation bar isn't visible.")
+        }
     }
 }

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -14,6 +14,7 @@ class MainNavigationTests: XCTestCase {
     }
 
     override func tearDown() {
+        takeScreenshotOfFailedTest()
         LoginFlow.logoutIfNeeded()
         super.tearDown()
     }

--- a/WordPress/WordPressUITests/Tests/SignupTests.swift
+++ b/WordPress/WordPressUITests/Tests/SignupTests.swift
@@ -9,6 +9,7 @@ class SignupTests: XCTestCase {
     }
 
     override func tearDown() {
+        takeScreenshotOfFailedTest()
         LoginFlow.logoutIfNeeded()
         super.tearDown()
     }

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -52,6 +52,14 @@ extension XCTestCase {
         systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: "OK")
     }
 
+    public func takeScreenshotOfFailedTest() {
+        if let failureCount = testRun?.failureCount, failureCount > 0 {
+            XCTContext.runActivity(named: "Take a screenshot at the end of a failed test") { (activity) in
+                add(XCTAttachment(screenshot: XCUIApplication().windows.firstMatch.screenshot()))
+            }
+        }
+    }
+
     public func systemAlertHandler(alertTitle: String, alertButton: String) {
         addUIInterruptionMonitor(withDescription: alertTitle) { (alert) -> Bool in
             let alertButtonElement = alert.buttons[alertButton]


### PR DESCRIPTION
This PR improves some of the UI test output, to help us better understand some flaky test failures we have seen in recent test runs:

* When a UI test fails, we'll take a screenshot after the failure. That way we can see the state of the app when it fails.
* It [groups some test steps](https://developer.apple.com/documentation/xctest/activities_and_attachments/grouping_tests_into_substeps_with_activities) into named activities, to clarify in the logs what step we're at in the test and why certain actions are being taken.

To test:
* Start the mocking server with `rake mocks`.
* Open the simulator.
* Run the UI tests in the `WordPressUITests` target. In the test logs, confirm you see the new named activities as expected.
* Force a test to fail (e.g. remove one of the test steps and re-run that test) and confirm that the test report includes a screenshot showing the state of the app when the test failed (taken during tear down).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
