### PR TITLE
[Stats Refresh] Improve accessibility

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Gridicons
 
-class StatsCellHeader: UITableViewCell, NibLoadable {
+class StatsCellHeader: UITableViewCell, NibLoadable, Accessible {
 
     // MARK: - Properties
 
@@ -29,6 +29,12 @@ class StatsCellHeader: UITableViewCell, NibLoadable {
         applyStyles()
     }
 
+    func prepareForVoiceOver() {
+        isAccessibilityElement = !(headerLabel.text?.isEmpty ?? true)
+        accessibilityElementsHidden = (headerLabel.text?.isEmpty ?? true)
+        accessibilityLabel = headerLabel.text
+        accessibilityTraits = .staticText
+    }
 }
 
 private extension StatsCellHeader {
@@ -39,6 +45,7 @@ private extension StatsCellHeader {
         Style.configureLabelAsHeader(headerLabel)
         configureManageInsightButton()
         updateStackView()
+        prepareForVoiceOver()
     }
 
     func updateStackView() {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsNoDataRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsNoDataRow.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class StatsNoDataRow: UIView, NibLoadable {
+class StatsNoDataRow: UIView, NibLoadable, Accessible {
 
     // MARK: - Properties
 
@@ -15,6 +15,13 @@ class StatsNoDataRow: UIView, NibLoadable {
     func configure(forType statType: StatType) {
         noDataLabel.text = statType == .insights ? insightsNoDataLabel : periodNoDataLabel
         WPStyleGuide.Stats.configureLabelAsNoData(noDataLabel)
+        prepareForVoiceOver()
     }
 
+    func prepareForVoiceOver() {
+        isAccessibilityElement = true
+
+        accessibilityLabel = noDataLabel.text
+        accessibilityTraits = .staticText
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -186,6 +186,16 @@ class StatsTotalRow: UIView, NibLoadable, Accessible {
         let showDisclosure = rowData?.showDisclosure ?? false
         accessibilityTraits = (showDisclosure) ? .button : .staticText
         accessibilityHint = (showDisclosure) ? NSLocalizedString("Tap for more detail.", comment: "Accessibility hint") : ""
+
+        switch (showDisclosure, hasChildRows) {
+        case (true, true):
+            let hint = expanded ? "Expanded. Tap to collapse." : "Collapsed. Tap to expand."
+            accessibilityHint = NSLocalizedString(hint, comment: "Accessibility hint")
+        case (true, false):
+            accessibilityHint = NSLocalizedString("Tap for more detail.", comment: "Accessibility hint")
+        default:
+            break
+        }
     }
 }
 
@@ -309,6 +319,7 @@ private extension StatsTotalRow {
 
         if hasChildRows {
             expanded.toggle()
+            prepareForVoiceOver()
             delegate?.toggleChildRows?(for: self, didSelectRow: true)
             return
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
@@ -4,7 +4,7 @@ protocol ViewMoreRowDelegate: class {
     func viewMoreSelectedForStatSection(_ statSection: StatSection)
 }
 
-class ViewMoreRow: UIView, NibLoadable {
+class ViewMoreRow: UIView, NibLoadable, Accessible {
 
     // MARK: - Properties
 
@@ -19,8 +19,16 @@ class ViewMoreRow: UIView, NibLoadable {
         self.statSection = statSection
         self.delegate = delegate
         applyStyles()
+        prepareForVoiceOver()
     }
 
+    func prepareForVoiceOver() {
+        isAccessibilityElement = true
+
+        accessibilityLabel = viewMoreLabel.text
+        accessibilityTraits = .button
+        accessibilityHint = NSLocalizedString("Tap for more detail.", comment: "Accessibility hint")
+    }
 }
 
 // MARK: - Private Methods


### PR DESCRIPTION
Refs. #11995 

This PR is a first part of the accessibility improvements:
- View More rows
- No data rows
- Reflect expanded / collapsed state of expandable rows
- If the table header is empty the element is not accessible

## To test:
- Enable Accessibility -> VoiceOver
- Select a site and open Stats
- Try to tap on the grey spacer row below date bar (is not inspectable anymore)
- Tap on a View More row
- Tap on a collapsed/expanded row

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
