### PR TITLE
[Stats Refresh] Fix chart legend location

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * Post preview: Fixed issue with preview for self hosted sites not working.
 * Stats: modified appearance of empty charts.
 * Stats Insights: Fixed issue where refreshing would sometimes clear the stats.
+* Stats overview chart: Fixed issue with legend location on iOS 11.
 
 12.7
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -278,10 +278,12 @@ private extension StatsBarChartView {
         addSubview(chartLegend)
 
         NSLayoutConstraint.activate([
-            chartLegend.widthAnchor.constraint(equalTo: widthAnchor)
+            chartLegend.widthAnchor.constraint(equalTo: widthAnchor),
+            chartLegend.leadingAnchor.constraint(equalTo: leadingAnchor),
+            chartLegend.topAnchor.constraint(equalTo: topAnchor)
         ])
-        extraTopOffset = chartLegend.intrinsicContentSize.height + Constants.topOffsetWithLegend
 
+        extraTopOffset = chartLegend.intrinsicContentSize.height + Constants.topOffsetWithLegend
         self.legendView = chartLegend
     }
 


### PR DESCRIPTION
Fixes #11966 

To test:
- On iOS 11, go to Stats > any period.
- On the Overview chart, verify the _Visitors_ legend is on top of the y-axis.
- Verify iOS 12 still works as expected.

<img width="400" alt="legend" src="https://user-images.githubusercontent.com/1816888/60138861-10c1b000-9769-11e9-856b-659e9bc465c4.png">

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
