### PR TITLE
Remove extra editor_session_end tracks event

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -282,7 +282,6 @@ extension PostEditor where Self: UIViewController {
 
             // The post is a local or remote draft
             alertController.addDefaultActionWithTitle(title) { _ in
-                self.editorSession.end(outcome: .save)
                 let action: PostEditorAction = (self.post.status == .draft) ? .saveAsDraft : .publish
                 self.publishPost(action: action, dismissWhenDone: true, analyticsStat: self.postEditorStateContext.publishActionAnalyticsStat)
             }


### PR DESCRIPTION
This PR removes an extra track of the event `editor_session_end` on save/update posts.

As showed [in this comment](https://github.com/wordpress-mobile/WordPress-Android/issues/10098#issuecomment-505755839), this event was being double tracked on save/update events.

This event is already properly tracked for all interactions here:
https://github.com/wordpress-mobile/WordPress-iOS/blob/c504303b0962001b8f77fbb3cf071e633e908b26/WordPress/Classes/ViewRelated/Post/PostEditor%2BPublish.swift#L92

To test:

Even though this should only affect save/update actions, to be sure let's check that in all possible editor closing actions, `editor_session_end` is tracked only once.

**Tip:** To clear the console: 

- Activate the `OS_ACTIVITY_MODE: disable` environment variable in the Run scheme editor.
- On `GutenbergViewController:212 (init)` add `RCTSetLogThreshold(RCTLogLevel.warning)`
- On `GutenbergViewController:gutenbergDidEmitLog`(around L:512), comment `.trace` and `.info` logs (I think this one helps when running metro server).

A PR will come soon to help with these verbose logs from RN.


- Discard new post
    - New post
    - Discard post
- Discard changes on Draft post
    - Open a saved draft
    - Make some changes
    - Close via X button saving changes
- Close published post
    - Open a published post
    - Close it without any changes
- Discard changes on Published post
    - Open a published post
    - Make some changes
    - Close the post discarding changes
- Publish new post
    - Create a new post
    - Add content
    - Publish the post via Publish button
- Publish draft post
    - Open a draft
    - Press the menu (…) button
    - Publish now
    - Publish now
- Save new post as draft
  - Create new post
  - Add some content
  - Press X button
  - Save as Draft
- Update existing draft post
  - Open existing draft
  - Edit content
  - Press X button
  - Update draft
- Update published post
  - Open a published post
  - Edit content
  - Press X button
  - Update post

Repeat for pages.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

cc @daniloercoli 