### PR TITLE
[Stats Refresh] Stats details: fix expanding rows

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -77,7 +77,7 @@ extension DetailDataCell: StatsTotalRowDelegate {
         detailsDelegate?.showPostStats?(postID: postID, postTitle: postTitle, postURL: postURL)
     }
 
-    func toggleChildRowsForRow(_ row: StatsTotalRow) {
+    func toggleChildRows(for row: StatsTotalRow, didSelectRow: Bool) {
         detailsDelegate?.toggleChildRowsForRow?(row)
     }
 


### PR DESCRIPTION
Fixes #n/a

With #11964, the details table no longer updated as it was calling a delegate method that changed. The result was rows didn't expand and child rows were not shown.

<img width="400" alt="broken" src="https://user-images.githubusercontent.com/1816888/60222799-e856b600-983b-11e9-9496-98418f64aac6.png">

This restores the table update by calling the new delegate method.

To note, this also restores all chevrons updating when a row is expanded, but hey at least they expand.

To test:
- Go to any details view that has expandable rows. 
- Expand a row.
- Verify child rows appear.

<img width="400" alt="fixed" src="https://user-images.githubusercontent.com/1816888/60222813-f7d5ff00-983b-11e9-96d9-20e765a8722c.png">


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
