### PR TITLE
Muriel colors: fix the dang blue icons on Me tab

### DIFF
--- a/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
@@ -86,6 +86,7 @@ extension WPStyleGuide {
         // we only set the text subtle color, so that system colors are used otherwise
         if FeatureFlag.murielColors.enabled {
             cell.detailTextLabel?.textColor = .textSubtle
+            cell.imageView?.tintColor = .neutral
         } else {
             cell.textLabel?.textColor = darkGrey()
             cell.detailTextLabel?.textColor = grey()

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -109,7 +109,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                     identifier:identifier
        accessibilityIdentifier:accessibilityIdentifier
                          image:image
-                    imageColor:[UIColor murielNeutral200]
+                    imageColor:[UIColor murielNeutral]
                       callback:callback];
 }
     


### PR DESCRIPTION
Refs #11683

Changes the icons on the Me tab to be `neutral` from the Muriel palette. Also changes the site details screen to match.

![table view icon colors](https://user-images.githubusercontent.com/517257/60239331-21098600-9862-11e9-8943-fb88ecb4d4e8.png)

To test:
- look at Me tab and My Sites > details.
- observe that the icons have a better color

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
