### PR TITLE
Improve logging of tracks events

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -72,7 +72,11 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     if (eventPair.properties == nil && properties == nil) {
         DDLogInfo(@"🔵 Tracked: %@", eventPair.eventName);
     } else {
-        DDLogInfo(@"🔵 Tracked: %@, properties: %@", eventPair.eventName, mergedProperties);
+        NSArray<NSString *> *propertyKeys = [[mergedProperties allKeys] sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
+        NSString *propertiesDescription = [[propertyKeys wp_map:^NSString *(NSString *key) {
+            return [NSString stringWithFormat:@"%@: %@", key, mergedProperties[key]];
+        }] componentsJoinedByString:@", "];
+        DDLogInfo(@"🔵 Tracked: %@ <%@>", eventPair.eventName, propertiesDescription);
     }
 
     [self.tracksService trackEventName:eventPair.eventName withCustomProperties:mergedProperties];


### PR DESCRIPTION
Instead of relying on the default description of the properties dictionary, use a custom transformation so it all fits in one line.

While reviewing #12005, there were some instructions to try to tame all the noise in the console when debugging tracks events. A better approach could be to use the search function in the Xcode console and filter lines with `🔵` or `Tracked:`. However, since we print event properties across several lines, they would get lost in the filter.

So instead of this...

```
🔵 Tracked: editor_session_end, properties: {
    "blog_type" = jetpack;
    "content_type" = new;
    editor = gutenberg;
    "has_unsupported_blocks" = 0;
    outcome = cancel;
    "post_type" = post;
    "session_id" = "B8CF1CB8-31B5-4716-879C-DD5A559ED7F3";
}
```

...we are logging like this...

```
🔵 Tracked: editor_session_end <blog_type: jetpack, content_type: new, editor: gutenberg, has_unsupported_blocks: 0, outcome: cancel, post_type: post, session_id: F4E2939E-8DAD-4A65-AF4D-1CE40EA1CC91>
```

And when you add a filter to the log, this is what you would see:

Before:

```
🔵 Tracked: application_opened
🔵 Tracked: my_site_tab_accessed
🔵 Tracked: site_menu_opened, properties: {
🔵 Tracked: editor_post_created, properties: {
🔵 Tracked: editor_session_start, properties: {
🔵 Tracked: editor_session_end, properties: {
🔵 Tracked: editor_discarded_changes, properties: {
🔵 Tracked: editor_closed, properties: {
```

After:

```
🔵 Tracked: application_opened
🔵 Tracked: my_site_tab_accessed
🔵 Tracked: site_menu_opened <blog_id: 137551970, menu_item: posts>
🔵 Tracked: editor_post_created <blog_id: 137551970, tap_source: tab_bar>
🔵 Tracked: editor_session_start <blog_type: jetpack, content_type: new, editor: gutenberg, has_unsupported_blocks: 0, post_type: post, session_id: F4E2939E-8DAD-4A65-AF4D-1CE40EA1CC91>
🔵 Tracked: editor_session_end <blog_type: jetpack, content_type: new, editor: gutenberg, has_unsupported_blocks: 0, outcome: cancel, post_type: post, session_id: F4E2939E-8DAD-4A65-AF4D-1CE40EA1CC91>
🔵 Tracked: editor_discarded_changes <blog_id: 137551970, editor_source: gutenberg, has_gutenberg_blocks: 0>
🔵 Tracked: editor_closed <blog_id: 137551970, editor_source: gutenberg, has_gutenberg_blocks: 0>
```

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.