### PR TITLE
[Stats Refresh] Accessibility labels in Period Bar

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -116,6 +116,7 @@ private extension SiteStatsTableHeaderView {
         dateLabel.text = displayDate()
         updateButtonStates()
         prepareForVoiceOver()
+        postAccessibilityPeriodLabel()
     }
 
     func updateButtonStates() {
@@ -137,6 +138,10 @@ private extension SiteStatsTableHeaderView {
         forwardArrow.image = Style.imageForGridiconType(.chevronRight, withTint: (forwardButton.isEnabled ? .darkGrey : .grey))
         backArrow.image = Style.imageForGridiconType(.chevronLeft, withTint: (backButton.isEnabled ? .darkGrey : .grey))
     }
+
+    func postAccessibilityPeriodLabel() {
+        UIAccessibility.post(notification: .screenChanged, argument: dateLabel)
+    }
 }
 
 extension SiteStatsTableHeaderView: StatsBarChartViewDelegate {
@@ -153,5 +158,6 @@ extension SiteStatsTableHeaderView: StatsBarChartViewDelegate {
         dateLabel.text = displayDate()
         updateButtonStates()
         prepareForVoiceOver()
+        postAccessibilityPeriodLabel()
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -4,7 +4,7 @@ protocol SiteStatsTableHeaderDelegate: class {
     func dateChangedTo(_ newDate: Date?)
 }
 
-class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable {
+class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Accessible {
 
     // MARK: - Properties
 
@@ -50,8 +50,21 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable {
         self.expectedPeriodCount = expectedPeriodCount
         dateLabel.text = displayDate()
         updateButtonStates()
+        prepareForVoiceOver()
     }
 
+    func prepareForVoiceOver() {
+        if let period = dateLabel.text {
+            let localizedLabel = NSLocalizedString("Current period: %@", comment: "Period Accessibility label. Prefix the current selected period. Ex. Current period: 2019")
+            dateLabel.accessibilityLabel = .localizedStringWithFormat(localizedLabel, period)
+        }
+
+        backButton.accessibilityLabel = NSLocalizedString("Previous period", comment: "Accessibility label")
+        backButton.accessibilityHint = NSLocalizedString("Tap to select the previous period", comment: "Accessibility hint")
+
+        forwardButton.accessibilityLabel = NSLocalizedString("Next period", comment: "Accessibility label")
+        forwardButton.accessibilityHint = NSLocalizedString("Tap to select the next period", comment: "Accessibility hint")
+    }
 }
 
 private extension SiteStatsTableHeaderView {
@@ -102,6 +115,7 @@ private extension SiteStatsTableHeaderView {
         delegate?.dateChangedTo(self.date)
         dateLabel.text = displayDate()
         updateButtonStates()
+        prepareForVoiceOver()
     }
 
     func updateButtonStates() {
@@ -116,6 +130,7 @@ private extension SiteStatsTableHeaderView {
         forwardButton.isEnabled = helper.dateAvailableAfterDate(date, period: period)
         backButton.isEnabled = helper.dateAvailableBeforeDate(date, period: period, backLimit: backLimit)
         updateArrowStates()
+        prepareForVoiceOver()
     }
 
     func updateArrowStates() {
@@ -137,5 +152,6 @@ extension SiteStatsTableHeaderView: StatsBarChartViewDelegate {
         delegate?.dateChangedTo(self.date)
         dateLabel.text = displayDate()
         updateButtonStates()
+        prepareForVoiceOver()
     }
 }


### PR DESCRIPTION
Refs. #11955 

This PR adds the accessibility labels in the Period Bar

<img width="377" alt="Screenshot 2019-06-27 at 10 46 09" src="https://user-images.githubusercontent.com/912252/60256088-ce16e980-98c8-11e9-9bd4-6cbb66e5c70b.png">


## To test:
• Switch on the VoiceOver
• Open Stats from a selected site
• Inspect the period bar tapping the current date and the back/forward arrows

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
