### PR TITLE
Issue/12015 notification formatting

### DIFF
--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -64,13 +64,14 @@ class NotificationService: UNNotificationServiceExtension {
         service.loadNotes(noteIds: [noteID]) { [tracks] error, notifications in
             if let error = error {
                 tracks.trackNotificationRetrievalFailed(notificationIdentifier: noteID, errorDescription: error.localizedDescription)
+                contentHandler(notificationContent)
                 return
             }
 
             guard let remoteNotifications = notifications,
                 remoteNotifications.count == 1,
                 let notification = remoteNotifications.first else {
-
+                contentHandler(notificationContent)
                 return
             }
 

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -85,8 +85,11 @@ class NotificationService: UNNotificationServiceExtension {
                 notificationReadStatus: notification.read,
                 noticon: notification.noticon)
 
-            notificationContent.title = contentFormatter.attributedSubject?.string ?? apsAlert
-            notificationContent.body = contentFormatter.body ?? ""
+            // Only populate title / body for notification kinds with rich body content
+            if !NotificationKind.omitsRichNotificationBody(notificationKind) {
+                notificationContent.title = contentFormatter.attributedSubject?.string ?? apsAlert
+                notificationContent.body = contentFormatter.body ?? ""
+            }
             notificationContent.userInfo[CodingUserInfoKey.richNotificationViewModel.rawValue] = viewModel.data
 
             tracks.trackNotificationAssembled()

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -57,6 +57,18 @@ class NotificationService: UNNotificationServiceExtension {
             notificationContent.categoryIdentifier = category
         }
 
+        // If the notification has a body but not a title, and is a notification
+        // type that _can_ have a separate title and body, in case of failure later
+        // for now let's just populate the title with what we have.
+        // In practice, this means that notifications other than likes and
+        // comment likes will always have a bolded title.
+        if notificationContent.title.isEmpty,
+            !notificationContent.body.isEmpty,
+            !NotificationKind.omitsRichNotificationBody(notificationKind) {
+            notificationContent.title = notificationContent.body
+            notificationContent.body = ""
+        }
+
         let api = WordPressComRestApi(oAuthToken: token)
         let service = NotificationSyncServiceRemote(wordPressComRestApi: api)
         self.notificationService = service


### PR DESCRIPTION
Fixes #12015. Please see the original issue for background.

This PR improves consistency of notification formatting.

For background, here's how notification formatting currently works:

* A push notification comes in and is processed by our Notification Service Extension.
* Our service extension attempts to load the related Notification object from wpcom. If successful, we parse out a proper title and body content from that notification, and update the `UNNotificationContent` object.
* When the `UNNotificationContent` has a `title` assigned like this, the system displays it in bold.
* If we fail to load the remote notification, we currently do nothing so the notification only has a body. This means it's not displayed in bold.

I think the inconsistency mentioned in the original issue is due to the remote notification request sometimes failing, resulting in sometimes a title being assigned and sometimes not.

To improve consistency, I made a few changes:

* We now only ever set a title for notification types that include a rich body content. This means everything except for Likes and Comment Likes. This means that Likes and Comment Likes will never appear in bold (after chatting to @elibud and @mattmiklic we thought this looked better visually).
* For notification types that do include a rich body content, we'll set the title of the `UNNotificationContent` first before we attempt to fetch the remote notification. That way, in case of failure we'll always have a bold title, and we can always replace it later.

**Intended appearance:**

![IMG_4866](https://user-images.githubusercontent.com/4780/60259345-f4d81e80-98ce-11e9-9d47-175e5933e491.jpg)

Note that there is one situation this doesn't quite fix, where I observed that the notification service just doesn't ever get called. I had this happen once (and saw reports of it on Stack Overflow) and the only solution was to reboot my device. However, with these changes this means that Like and Comment Like notifications will now be consistent as they'll never have bold text applied.

**To test:**

* If you're familiar running the debug push notification server then do that, otherwise ask me for instructions (or I can do it for you!)
* Build and run
* Trigger a **Like** notification and a **Comment** notification. Ensure that the like doesn't appear in bold and the comment's title does.
* In `NotificationService.swift`, after line 76 (`service.loadNotes(noteIds: [noteID]) { [tracks] error, notifications in`), add:
```
contentHandler(notificationContent)
return
```
to simulate the request failing.
* Trigger another **Like** and another **Comment**. They should still be formatted the same. Note that the rich previews (3D Touch) aren't populated in this situation, but that's a pre-existing issue.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt` (I don't think this one is worth mentioning there as it's mainly backend).