### PR TITLE
Add Slack notifications to CircleCI UI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   ios: wordpress-mobile/ios@0.0.29
+  slack: circleci/slack@2.5.0
 
 jobs:
   build-ui-tests:
@@ -43,6 +44,16 @@ jobs:
           command: test-without-building
           arguments: -xctestrun DerivedData/Build/Products/WordPressUITests_iphonesimulator12.2-x86_64.xctestrun -destination "platform=iOS Simulator,id=$SIMULATOR_UDID"
       - ios/save-xcodebuild-artifacts
+      - run:
+          name: Prepare Slack message
+          when: always
+          command: |
+            # Get the name of the device that is running. Using "<< parameters.device >>" can cause slack formatting errors.
+            DEVICE_NAME=$(xcrun simctl list -j | jq -r --arg UDID $SIMULATOR_UDID '.devices[] | .[] | select(.udid == "\($UDID)") | .name')
+            echo "export SLACK_FAILURE_MESSAGE=':red_circle: WordPress iOS UI tests have failed on ${DEVICE_NAME}!'" >> $BASH_ENV
+      - slack/status:
+          fail_only: 'true'
+          failure_message: '${SLACK_FAILURE_MESSAGE}'
 
 workflows:
   wordpress_ios:


### PR DESCRIPTION
This adds failure notifications to the A8C Slack when the UI tests fail on CircleCI. They go to the `#ios-osx-dev` channel. We can move them somewhere else if needed. Here is what it looks like:

![image](https://user-images.githubusercontent.com/1773641/60278442-60ce7d00-98f7-11e9-9bfd-06e937f673d0.png)

Related: https://github.com/wordpress-mobile/WordPress-Android/pull/10116

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
