### PR TITLE
Issues/11683 navigation bar problems

### DIFF
--- a/WordPress/Classes/Extensions/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/UIColor+MurielColors.swift
@@ -235,10 +235,9 @@ extension UIColor {
     }
 
     /// Muriel/iOS navigation color
-    static var navigationBar = muriel(color: .navigationBar)
+    static var textInverted = UIColor.white
 
-    /// Muriel/iOS navgiation shadow color
-    static var navigationBarShadow = muriel(color: .navigationBarShadow)
+    static var navigationBar = muriel(color: .navigationBar)
 
     /// Muriel/iOS unselected color
     static var unselected: UIColor {

--- a/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
@@ -17,18 +17,24 @@ extension WPStyleGuide {
 
     /// Style the navigation appearance using Muriel colors
     class func configureNavigationAppearance() {
+        guard FeatureFlag.murielColors.enabled else {
+            configureNavigationBarAppearance()
+            return
+        }
+
         let navigationAppearance = UINavigationBar.appearance()
         navigationAppearance.isTranslucent = false
+        navigationAppearance.tintColor = .textInverted
         navigationAppearance.barTintColor = .navigationBar
         navigationAppearance.barStyle = .black
 
         let buttonBarAppearance = UIBarButtonItem.appearance()
-        buttonBarAppearance.tintColor = .white
+        buttonBarAppearance.tintColor = .textInverted
         buttonBarAppearance.setTitleTextAttributes([NSAttributedString.Key.font: WPFontManager.systemRegularFont(ofSize: 17.0),
-                                                    NSAttributedString.Key.foregroundColor: UIColor.white],
+                                                    NSAttributedString.Key.foregroundColor: UIColor.textInverted],
                                                    for: .normal)
         buttonBarAppearance.setTitleTextAttributes([NSAttributedString.Key.font: WPFontManager.systemRegularFont(ofSize: 17.0),
-                                                    NSAttributedString.Key.foregroundColor: UIColor(white: 1.0, alpha: 0.25)],
+                                                    NSAttributedString.Key.foregroundColor: UIColor.textInverted.withAlphaComponent(0.25)],
                                                    for: .disabled)
 
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -754,11 +754,8 @@ extension WordPressAppDelegate {
         window?.tintColor = WPStyleGuide.wordPressBlue()
 
         WPStyleGuide.configureTabBarAppearance()
-        if Feature.enabled(.murielColors) {
-            WPStyleGuide.configureNavigationAppearance()
-        } else {
-            WPStyleGuide.configureNavigationBarAppearance()
-
+        WPStyleGuide.configureNavigationAppearance()
+        if !FeatureFlag.murielColors.enabled {
             UITabBar.appearance().shadowImage = UIImage(color: UIColor(red: 210.0/255.0, green: 222.0/255.0, blue: 230.0/255.0, alpha: 1.0))
 
             let navigationAppearance = UINavigationBar.appearance()

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -674,7 +674,7 @@ class AztecPostViewController: UIViewController, PostEditor {
     /// nothing or the resetting wasn't permanent.
     ///
     fileprivate func resetNavigationColors() {
-        WPStyleGuide.configureNavigationBarAppearance()
+        WPStyleGuide.configureNavigationAppearance()
     }
 
     func configureDismissButton() {

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -104,7 +104,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
      or the resetting wasn't permanent.
      */
     fileprivate func resetNavigationColors() {
-        WPStyleGuide.configureNavigationBarAppearance()
+        WPStyleGuide.configureNavigationAppearance()
     }
 
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
Refs #11683

This fixes situations that would cause the navigation bar to revert to the old colors.

| Before | After |
| ---- | ---- |
| ![nav-bar-before](https://user-images.githubusercontent.com/517257/60292311-aa0bd600-98d1-11e9-81a9-75a11d2bff40.gif) | ![nav-bar-after](https://user-images.githubusercontent.com/517257/60292322-b2fca780-98d1-11e9-88b7-8b49afa1520d.gif) |

To test:
- open the editor
- open the media picker to full size (see GIF)
- open the document picker
- close the editor
- switch tabs
- ensure the navigation bar doesn't revert to old colors

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
