### PR TITLE
Muriel Colors: update FancyButtons

### DIFF
--- a/WordPress/Classes/Extensions/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/UIColor+MurielColors.swift
@@ -107,6 +107,7 @@ extension UIColor {
             return WPStyleGuide.jazzyOrange()
         }
     }
+
     static var accentDark: UIColor {
         if FeatureFlag.murielColors.enabled {
             return muriel(color: MurielColor(from: .accent, shade: .shade700))
@@ -114,6 +115,7 @@ extension UIColor {
             return WPStyleGuide.fireOrange()
         }
     }
+
     class func accent(shade: MurielColorShade) -> UIColor {
         return muriel(color: MurielColor(from: .accent, shade: shade))
     }
@@ -129,6 +131,7 @@ extension UIColor {
             return WPStyleGuide.errorRed()
         }
     }
+
     static var errorDark: UIColor {
         if FeatureFlag.murielColors.enabled {
             return muriel(color: MurielColor(from: .error, shade: .shade700))
@@ -136,6 +139,7 @@ extension UIColor {
             return WPStyleGuide.alertRedDarker()
         }
     }
+
     class func error(shade: MurielColorShade) -> UIColor {
         return muriel(color: MurielColor(from: .error, shade: shade))
     }
@@ -178,6 +182,7 @@ extension UIColor {
             return WPStyleGuide.wordPressBlue()
         }
     }
+
     static var primaryLight: UIColor {
         if FeatureFlag.murielColors.enabled {
             return muriel(color: MurielColor(from: .primary, shade: .shade300))
@@ -185,6 +190,7 @@ extension UIColor {
             return WPStyleGuide.lightBlue()
         }
     }
+
     static var primaryDark: UIColor {
         if FeatureFlag.murielColors.enabled {
             return muriel(color: MurielColor(from: .primary, shade: .shade700))
@@ -192,6 +198,7 @@ extension UIColor {
             return WPStyleGuide.darkBlue()
         }
     }
+
     class func primary(shade: MurielColorShade) -> UIColor {
         if FeatureFlag.murielColors.enabled {
             return muriel(color: MurielColor(from: .primary, shade: shade))
@@ -218,6 +225,7 @@ extension UIColor {
             return WPStyleGuide.validGreen()
         }
     }
+
     class func success(shade: MurielColorShade) -> UIColor {
         return muriel(color: MurielColor(from: .success, shade: shade))
     }
@@ -249,28 +257,31 @@ extension UIColor {
     }
 
     /// MARK: Muriel colors for buttons
-    static var buttonBase: UIColor {
+    static var primaryButtonBackground: UIColor {
         if FeatureFlag.murielColors.enabled {
             return .accent
         } else {
             return WPStyleGuide.mediumBlue()
         }
     }
-    static var buttonBorder: UIColor {
+
+    static var primaryButtonBorder: UIColor {
         if FeatureFlag.murielColors.enabled {
             return .accentDark
         } else {
             return WPStyleGuide.wordPressBlue()
         }
     }
-    static var buttonDown: UIColor {
+
+    static var primaryButtonDownBackground: UIColor {
         if FeatureFlag.murielColors.enabled {
             return muriel(color: MurielColor(name: .hotPink, shade: .shade800))
         } else {
             return WPStyleGuide.wordPressBlue()
         }
     }
-    static var buttonDownBorder: UIColor {
+
+    static var primaryButtonDownBorder: UIColor {
         if FeatureFlag.murielColors.enabled {
             return muriel(color: MurielColor(name: .hotPink, shade: .shade900))
         } else {

--- a/WordPress/Classes/Extensions/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/UIColor+MurielColors.swift
@@ -247,4 +247,38 @@ extension UIColor {
             return WPStyleGuide.greyLighten10()
         }
     }
+
+    /// MARK: Muriel colors for buttons
+    static var buttonBase: UIColor {
+        if FeatureFlag.murielColors.enabled {
+            return .accent
+        } else {
+            return WPStyleGuide.mediumBlue()
+        }
+    }
+    static var buttonBorder: UIColor {
+        if FeatureFlag.murielColors.enabled {
+            return .accentDark
+        } else {
+            return WPStyleGuide.wordPressBlue()
+        }
+    }
+    static var buttonDown: UIColor {
+        if FeatureFlag.murielColors.enabled {
+            return muriel(color: MurielColor(name: .hotPink, shade: .shade800))
+        } else {
+            return WPStyleGuide.wordPressBlue()
+        }
+    }
+    static var buttonDownBorder: UIColor {
+        if FeatureFlag.murielColors.enabled {
+            return muriel(color: MurielColor(name: .hotPink, shade: .shade900))
+        } else {
+            return WPStyleGuide.wordPressBlue()
+        }
+    }
+    static var buttonSecondaryBase = UIColor.textInverted
+    static var buttonSecondaryBorder = UIColor.neutral(shade: .shade100)
+    static var buttonSecondaryDown = UIColor.neutral(shade: .shade100)
+    static var buttonSecondaryDownBorder = UIColor.neutral(shade: .shade400)
 }

--- a/WordPress/Classes/Extensions/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/UIColor+MurielColors.swift
@@ -277,8 +277,4 @@ extension UIColor {
             return WPStyleGuide.wordPressBlue()
         }
     }
-    static var buttonSecondaryBase = UIColor.textInverted
-    static var buttonSecondaryBorder = UIColor.neutral(shade: .shade100)
-    static var buttonSecondaryDown = UIColor.neutral(shade: .shade100)
-    static var buttonSecondaryDownBorder = UIColor.neutral(shade: .shade400)
 }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -457,10 +457,10 @@ extension WordPressAppDelegate {
         let appearance = FancyButton.appearance()
         appearance.titleFont = WPStyleGuide.fontForTextStyle(.headline)
         appearance.primaryTitleColor = .textInverted
-        appearance.primaryNormalBackgroundColor = .buttonBase
-        appearance.primaryNormalBorderColor = .buttonBorder
-        appearance.primaryHighlightBackgroundColor = .buttonDown
-        appearance.primaryHighlightBorderColor = .buttonDownBorder
+        appearance.primaryNormalBackgroundColor = .primaryButtonBackground
+        appearance.primaryNormalBorderColor = .primaryButtonBorder
+        appearance.primaryHighlightBackgroundColor = .primaryButtonDownBackground
+        appearance.primaryHighlightBorderColor = .primaryButtonDownBorder
 
         appearance.secondaryTitleColor = .text
         appearance.secondaryNormalBackgroundColor = UIColor.textInverted

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -456,6 +456,14 @@ extension WordPressAppDelegate {
     private func setupFancyButtonAppearance() {
         let appearance = FancyButton.appearance()
         appearance.titleFont = WPStyleGuide.fontForTextStyle(.headline)
+        appearance.primaryNormalBackgroundColor = .buttonBase
+        appearance.primaryNormalBorderColor = .buttonBorder
+        appearance.primaryHighlightBackgroundColor = .buttonDown
+        appearance.primaryHighlightBorderColor = .buttonDownBorder
+        appearance.secondaryNormalBackgroundColor = .buttonSecondaryBase
+        appearance.secondaryNormalBorderColor = .buttonSecondaryBorder
+        appearance.secondaryHighlightBackgroundColor = .buttonSecondaryDown
+        appearance.secondaryHighlightBorderColor = .buttonSecondaryDownBorder
     }
 }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -456,14 +456,21 @@ extension WordPressAppDelegate {
     private func setupFancyButtonAppearance() {
         let appearance = FancyButton.appearance()
         appearance.titleFont = WPStyleGuide.fontForTextStyle(.headline)
+        appearance.primaryTitleColor = .textInverted
         appearance.primaryNormalBackgroundColor = .buttonBase
         appearance.primaryNormalBorderColor = .buttonBorder
         appearance.primaryHighlightBackgroundColor = .buttonDown
         appearance.primaryHighlightBorderColor = .buttonDownBorder
-        appearance.secondaryNormalBackgroundColor = .buttonSecondaryBase
-        appearance.secondaryNormalBorderColor = .buttonSecondaryBorder
-        appearance.secondaryHighlightBackgroundColor = .buttonSecondaryDown
-        appearance.secondaryHighlightBorderColor = .buttonSecondaryDownBorder
+
+        appearance.secondaryTitleColor = .text
+        appearance.secondaryNormalBackgroundColor = UIColor.textInverted
+        appearance.secondaryNormalBorderColor = UIColor.neutral(shade: .shade100)
+        appearance.secondaryHighlightBackgroundColor = UIColor.neutral(shade: .shade100)
+        appearance.secondaryHighlightBorderColor = UIColor.neutral(shade: .shade400)
+
+        appearance.disabledTitleColor = .neutral(shade: .shade200)
+        appearance.disabledBackgroundColor = .textInverted
+        appearance.disabledBorderColor = .neutral(shade: .shade100)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -289,7 +289,6 @@ private extension NoResultsViewController {
         configureSubtitleView()
 
         if let buttonText = buttonText {
-            configureButton()
             actionButton?.setTitle(buttonText, for: UIControl.State())
             actionButton?.setTitle(buttonText, for: .highlighted)
             actionButton?.titleLabel?.adjustsFontForContentSizeCategory = true
@@ -442,64 +441,6 @@ private extension NoResultsViewController {
         static let leading = CGFloat(38)
         static let trailing = CGFloat(-38)
         static let maxWidth = CGFloat(360)
-    }
-
-    // MARK: - Button Configuration
-
-    func configureButton() {
-        actionButton.contentEdgeInsets = DefaultRenderMetrics.contentInsets
-
-        // TODO: Murielize these colors when buttons are done
-        let normalImage = renderBackgroundImage(fill: .primary(shade: .shade400), border: WPStyleGuide.wordPressBlue())
-        let highlightedImage = renderBackgroundImage(fill: WPStyleGuide.wordPressBlue(), border: WPStyleGuide.wordPressBlue())
-
-        actionButton.setBackgroundImage(normalImage, for: .normal)
-        actionButton.setBackgroundImage(highlightedImage, for: .highlighted)
-    }
-
-    func renderBackgroundImage(fill: UIColor, border: UIColor) -> UIImage {
-
-        let renderer = UIGraphicsImageRenderer(size: DefaultRenderMetrics.backgroundImageSize)
-        let image = renderer.image { context in
-
-            let lineWidthInPixels = 1 / UIScreen.main.scale
-            let cgContext = context.cgContext
-
-            // Apply a 1px inset to the bounds, for our bezier (so that the border doesn't fall outside)
-            var bounds = renderer.format.bounds
-            bounds.origin.x += lineWidthInPixels
-            bounds.origin.y += lineWidthInPixels
-            bounds.size.height -= lineWidthInPixels * 2 + DefaultRenderMetrics.backgroundShadowOffset.height
-            bounds.size.width -= lineWidthInPixels * 2 + DefaultRenderMetrics.backgroundShadowOffset.width
-
-            let path = UIBezierPath(roundedRect: bounds, cornerRadius: DefaultRenderMetrics.backgroundCornerRadius)
-
-            // Draw: Background + Shadow
-            cgContext.saveGState()
-            cgContext.setShadow(offset: DefaultRenderMetrics.backgroundShadowOffset,
-                                blur: DefaultRenderMetrics.backgroundShadowBlurRadius,
-                                color: border.cgColor)
-            fill.setFill()
-
-            path.fill()
-
-            cgContext.restoreGState()
-
-            // Draw: Border
-            border.setStroke()
-            path.stroke()
-        }
-
-        return image.resizableImage(withCapInsets: DefaultRenderMetrics.backgroundCapInsets)
-    }
-
-    struct DefaultRenderMetrics {
-        public static let backgroundImageSize = CGSize(width: 44, height: 44)
-        public static let backgroundCornerRadius = CGFloat(8)
-        public static let backgroundCapInsets = UIEdgeInsets(top: 18, left: 18, bottom: 18, right: 18)
-        public static let backgroundShadowOffset = CGSize(width: 0, height: 2)
-        public static let backgroundShadowBlurRadius = CGFloat(0)
-        public static let contentInsets = UIEdgeInsets(top: 12, left: 20, bottom: 12, right: 20)
     }
 
     // MARK: - Button Handling

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
@@ -36,34 +36,40 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="ydF-z6-fhv">
                                         <rect key="frame" x="20" y="20" width="343" height="108"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tcY-eU-7MY">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tcY-eU-7MY" customClass="FancyButton" customModule="WordPressUI">
                                                 <rect key="frame" x="0.0" y="0.0" width="343" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="connectSite"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="kqU-iq-5lx"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                <state key="normal" title="Connect another site" backgroundImage="beveled-secondary-button">
+                                                <state key="normal" title="Connect another site">
                                                     <color key="titleColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                                                 </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
+                                                </userDefinedRuntimeAttributes>
                                                 <connections>
                                                     <action selector="handleConnectAnotherButton" destination="FBE-8U-liw" eventType="touchUpInside" id="WYK-td-6aY"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="51h-er-sEL">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="51h-er-sEL" customClass="FancyButton" customModule="WordPressUI">
                                                 <rect key="frame" x="0.0" y="64" width="343" height="44"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="8TV-5o-H50"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                <state key="normal" title="Continue" backgroundImage="beveled-blue-button">
+                                                <state key="normal" title="Continue">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 </state>
                                                 <state key="selected" backgroundImage="beveled-blue-button-down"/>
                                                 <state key="highlighted" backgroundImage="beveled-blue-button-down">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                 </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                </userDefinedRuntimeAttributes>
                                                 <connections>
                                                     <action selector="dismissEpilogue" destination="FBE-8U-liw" eventType="touchUpInside" id="BG7-Nv-R8k"/>
                                                 </connections>
@@ -183,9 +189,7 @@
         </scene>
     </scenes>
     <resources>
-        <image name="beveled-blue-button" width="18.5" height="19.5"/>
         <image name="beveled-blue-button-down" width="18.5" height="19.5"/>
-        <image name="beveled-secondary-button" width="18.5" height="19.5"/>
         <image name="darkgrey-shadow" width="10" height="10"/>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,16 +19,16 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Ae-eX-ae9" userLabel="No Results View">
-                                <rect key="frame" x="30" y="116.5" width="315" height="454"/>
+                                <rect key="frame" x="30" y="175.5" width="315" height="336"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mkl-mm-wtH">
-                                        <rect key="frame" x="0.0" y="0.0" width="315" height="454"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="315" height="336"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-LB-oOz" userLabel="Accessory Stack View">
-                                                <rect key="frame" x="38" y="0.0" width="239" height="234"/>
+                                                <rect key="frame" x="107.5" y="0.0" width="100" height="116"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="czl-5D-gem" userLabel="Accessory View">
-                                                        <rect key="frame" x="69.5" y="0.0" width="100" height="100"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="100" height="100"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="100" id="AYV-Gw-aKL"/>
@@ -36,12 +36,12 @@
                                                         </constraints>
                                                     </view>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="wp-illustration-empty-results" translatesAutoresizingMaskIntoConstraints="NO" id="Fwm-rl-dKS" userLabel="Image View">
-                                                        <rect key="frame" x="0.0" y="100" width="239" height="134"/>
+                                                        <rect key="frame" x="42" y="100" width="16" height="16"/>
                                                     </imageView>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Button Stack View">
-                                                <rect key="frame" x="37.5" y="254" width="240.5" height="200"/>
+                                                <rect key="frame" x="37.5" y="136" width="240.5" height="200"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">
                                                         <rect key="frame" x="26.5" y="0.0" width="187.5" height="72"/>
@@ -66,7 +66,7 @@
                                                             <constraint firstAttribute="height" constant="44" id="GdA-7V-dg9"/>
                                                         </constraints>
                                                     </imageView>
-                                                    <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CPl-cH-d7b">
+                                                    <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CPl-cH-d7b" customClass="FancyButton" customModule="WordPressUI">
                                                         <rect key="frame" x="78" y="156" width="84" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="ALu-HJ-Bk4"/>
@@ -75,6 +75,9 @@
                                                         <state key="normal" title="Button title">
                                                             <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         </state>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="YES"/>
+                                                        </userDefinedRuntimeAttributes>
                                                         <connections>
                                                             <action selector="actionButtonPressed:" destination="m07-8o-jn8" eventType="touchUpInside" id="PLr-qh-sJP"/>
                                                         </connections>


### PR DESCRIPTION
Refs #11683

This updates the FancyButtons to match the muriel colors.

| Flag Off/Old Colors | Flag On/Muriel |
| ---- | ---- |
| ![Simulator Screen Shot - iPhone Xʀ - 2019-06-27 at 15 29 18](https://user-images.githubusercontent.com/517257/60306629-c3267e00-98f5-11e9-88b4-429a633faba0.png) | ![Simulator Screen Shot - iPhone Xʀ - 2019-06-27 at 15 23 37](https://user-images.githubusercontent.com/517257/60306640-cb7eb900-98f5-11e9-8315-7f1328cc390a.png) |

### Reference mockup:

<img width="429" alt="Screen Shot 2019-06-26 at 2 22 31 PM" src="https://user-images.githubusercontent.com/517257/60306694-084ab000-98f6-11e9-887d-4b8fc068d9d1.png">


**Note:** The secondary colors were so similar between the two, I didn't have to add new semantic colors for them. But since the primary is blue vs. pink, I did for those.

To test:
- Check out the login epilogue screen
- And a `no results view`
- Also a FancyAlert, like when you login for the first time on a fresh install
- Ensure the buttons are the proper colors

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
