### PR TITLE
Added Create Post button to empty results view displayed on no connectivity from post list

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+12.9
+-----
+* Offline support: Create Post is now available from empty results view in offline mode.
+
 12.8
 -----
 * Stats Insights: New two-column layout for Follower Totals stats.

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -261,14 +261,16 @@ static NSInteger HideSearchMinSites = 3;
     
     // If we have no sites, show the No Results VC.
     if (siteCount == 0) {
-            [self.noResultsViewController configureWithTitle: NSLocalizedString(@"Create a new site for your business, magazine, or personal blog; or connect an existing WordPress installation.", "Text shown when the account has no sites.")
-                                                 buttonTitle:NSLocalizedString(@"Add new site","Title of button to add a new site.")
-                                                    subtitle:nil
-                                          attributedSubtitle:nil
-                             attributedSubtitleConfiguration:nil
-                                                       image:@"mysites-nosites"
-                                               subtitleImage:nil
-                                               accessoryView:nil];
+        [self.noResultsViewController configureWithTitle:NSLocalizedString(@"Create a new site for your business, magazine, or personal blog; or connect an existing WordPress installation.", "Text shown when the account has no sites.")
+                                       noConnectionTitle:nil
+                                             buttonTitle:NSLocalizedString(@"Add new site","Title of button to add a new site.")
+                                                subtitle:nil
+                                    noConnectionSubtitle:nil
+                                      attributedSubtitle:nil
+                         attributedSubtitleConfiguration:nil
+                                                   image:@"mysites-nosites"
+                                           subtitleImage:nil
+                                           accessoryView:nil];
         [self addNoResultsToView];
     }
 }
@@ -290,8 +292,10 @@ static NSInteger HideSearchMinSites = 3;
 
     if (count == 1) {
         [self.noResultsViewController configureWithTitle:singularTitle
+                                       noConnectionTitle:nil
                                              buttonTitle:buttonTitle
-                                                subtitle:singularSubtitle
+                                                subtitle:singularTitle
+                                    noConnectionSubtitle:nil
                                       attributedSubtitle:nil
                          attributedSubtitleConfiguration:nil
                                                    image:imageName
@@ -299,8 +303,10 @@ static NSInteger HideSearchMinSites = 3;
                                            accessoryView:nil];
     } else {
         [self.noResultsViewController configureWithTitle:multipleTitle
+                                       noConnectionTitle:nil
                                              buttonTitle:buttonTitle
                                                 subtitle:multipleSubtitle
+                                    noConnectionSubtitle:nil
                                       attributedSubtitle:nil
                          attributedSubtitleConfiguration:nil
                                                    image:imageName

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -147,17 +147,27 @@ import Reachability
     ///   - accessoryView:      View to show instead of the image. Optional.
     ///
     @objc func configure(title: String,
+                         noConnectionTitle: String? = nil,
                          buttonTitle: String? = nil,
                          subtitle: String? = nil,
+                         noConnectionSubtitle: String? = nil,
                          attributedSubtitle: NSAttributedString? = nil,
                          attributedSubtitleConfiguration: AttributedSubtitleConfiguration? = nil,
                          image: String? = nil,
                          subtitleImage: String? = nil,
                          accessoryView: UIView? = nil) {
         let isReachable = reachability?.isReachable()
-        titleText = isReachable == false ? NoConnection.title : title
-        subtitleText = isReachable == false ? NoConnection.subTitle : subtitle
-        attributedSubtitleText = isReachable == false ? NSAttributedString(string: NoConnection.subTitle) : attributedSubtitle
+        if (isReachable == false) {
+            titleText = noConnectionTitle != nil ? noConnectionTitle : NoConnection.title
+            let subtitle = noConnectionSubtitle != nil ? noConnectionSubtitle : NoConnection.subTitle
+            subtitleText = subtitle
+            attributedSubtitleText = NSAttributedString(string: subtitleText!)
+        } else {
+            titleText = title
+            subtitleText = subtitle
+            attributedSubtitleText = attributedSubtitle
+        }
+
         configureAttributedSubtitle = attributedSubtitleConfiguration
         buttonText = buttonTitle
         imageName = isReachable == false ? NoConnection.imageName : image
@@ -174,14 +184,6 @@ import Reachability
     func configureForNoSearchResults(title: String) {
         configure(title: title)
         displayTitleViewOnly = true
-    }
-
-    func configureForNoConnectionInPostList() {
-        titleText = NoConnection.titlePostList
-        subtitleText = NoConnection.subTitlePostList
-        attributedSubtitleText = NSAttributedString(string: NoConnection.subTitlePostList)
-        buttonText = NoConnection.buttonTitlePostList
-        imageName = NoConnection.imageName
     }
 
     /// Public method to remove No Results View from parent view.
@@ -550,9 +552,6 @@ private extension NoResultsViewController {
     struct NoConnection {
         static let title: String = NSLocalizedString("Unable to load this page right now.", comment: "Title for No results full page screen displayed when there is no connection")
         static let subTitle: String = NSLocalizedString("Check your network connection and try again.", comment: "Subtitle for No results full page screen displayed when there is no connection")
-        static let titlePostList: String = NSLocalizedString("Unable to load posts right now.", comment: "Title for No results full page screen displayedfrom post list when there is no connection")
-        static let subTitlePostList: String = NSLocalizedString("Check your network connection and try again. Or draft a post.", comment: "Subtitle for No results full page screen displayed from post list when there is no connection")
-           static let buttonTitlePostList: String = NSLocalizedString("Create Post", comment: "Button title, encourages users to create a post.")
         static let imageName = "cloud"
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -175,7 +175,7 @@ import Reachability
         configure(title: title)
         displayTitleViewOnly = true
     }
-    
+
     func configureForNoConnectionInPostsList() {
         titleText = NoConnection.titlePostList
         subtitleText = NoConnection.subTitlePostList
@@ -553,7 +553,6 @@ private extension NoResultsViewController {
         static let titlePostList: String = NSLocalizedString("Unable to load posts right now.", comment: "Title for No results full page screen displayed when there is no connection")
         static let subTitlePostList: String = NSLocalizedString("Check your network connection and try again. Or draft a post.", comment: "Subtitle for No results full page screen displayed from post lisy when there is no connection")
            static let buttonTitlePostList: String = NSLocalizedString("Create Post", comment: "Button title, encourages users to create a post.")
-        
         static let imageName = "cloud"
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -176,7 +176,7 @@ import Reachability
         displayTitleViewOnly = true
     }
 
-    func configureForNoConnectionInPostsList() {
+    func configureForNoConnectionInPostList() {
         titleText = NoConnection.titlePostList
         subtitleText = NoConnection.subTitlePostList
         attributedSubtitleText = NSAttributedString(string: NoConnection.subTitlePostList)
@@ -550,8 +550,8 @@ private extension NoResultsViewController {
     struct NoConnection {
         static let title: String = NSLocalizedString("Unable to load this page right now.", comment: "Title for No results full page screen displayed when there is no connection")
         static let subTitle: String = NSLocalizedString("Check your network connection and try again.", comment: "Subtitle for No results full page screen displayed when there is no connection")
-        static let titlePostList: String = NSLocalizedString("Unable to load posts right now.", comment: "Title for No results full page screen displayed when there is no connection")
-        static let subTitlePostList: String = NSLocalizedString("Check your network connection and try again. Or draft a post.", comment: "Subtitle for No results full page screen displayed from post lisy when there is no connection")
+        static let titlePostList: String = NSLocalizedString("Unable to load posts right now.", comment: "Title for No results full page screen displayedfrom post list when there is no connection")
+        static let subTitlePostList: String = NSLocalizedString("Check your network connection and try again. Or draft a post.", comment: "Subtitle for No results full page screen displayed from post list when there is no connection")
            static let buttonTitlePostList: String = NSLocalizedString("Create Post", comment: "Button title, encourages users to create a post.")
         static let imageName = "cloud"
     }

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -157,7 +157,7 @@ import Reachability
                          subtitleImage: String? = nil,
                          accessoryView: UIView? = nil) {
         let isReachable = reachability?.isReachable()
-        if (isReachable == false) {
+        if isReachable == false {
             titleText = noConnectionTitle != nil ? noConnectionTitle : NoConnection.title
             let subtitle = noConnectionSubtitle != nil ? noConnectionSubtitle : NoConnection.subTitle
             subtitleText = subtitle

--- a/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/NoResultsViewController.swift
@@ -175,6 +175,14 @@ import Reachability
         configure(title: title)
         displayTitleViewOnly = true
     }
+    
+    func configureForNoConnectionInPostsList() {
+        titleText = NoConnection.titlePostList
+        subtitleText = NoConnection.subTitlePostList
+        attributedSubtitleText = NSAttributedString(string: NoConnection.subTitlePostList)
+        buttonText = NoConnection.buttonTitlePostList
+        imageName = NoConnection.imageName
+    }
 
     /// Public method to remove No Results View from parent view.
     ///
@@ -542,6 +550,10 @@ private extension NoResultsViewController {
     struct NoConnection {
         static let title: String = NSLocalizedString("Unable to load this page right now.", comment: "Title for No results full page screen displayed when there is no connection")
         static let subTitle: String = NSLocalizedString("Check your network connection and try again.", comment: "Subtitle for No results full page screen displayed when there is no connection")
+        static let titlePostList: String = NSLocalizedString("Unable to load posts right now.", comment: "Title for No results full page screen displayed when there is no connection")
+        static let subTitlePostList: String = NSLocalizedString("Check your network connection and try again. Or draft a post.", comment: "Subtitle for No results full page screen displayed from post lisy when there is no connection")
+           static let buttonTitlePostList: String = NSLocalizedString("Create Post", comment: "Button title, encourages users to create a post.")
+        
         static let imageName = "cloud"
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -523,9 +523,11 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
         return;
     }
 
-    [self.noResultsViewController configureWithTitle:[self noResultsViewTitle]
+    [self.noResultsViewController configureWithTitle:self.noResultsViewTitle
+                                   noConnectionTitle:nil
                                          buttonTitle:nil
                                             subtitle:nil
+                                noConnectionSubtitle:nil
                                   attributedSubtitle:nil
                      attributedSubtitleConfiguration:nil
                                                image:nil

--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -529,8 +529,10 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
     }
 
     [self.noResultsViewController configureWithTitle:title
+                                   noConnectionTitle:nil
                                          buttonTitle:nil
                                             subtitle:nil
+                                noConnectionSubtitle:nil
                                   attributedSubtitle:nil
                      attributedSubtitleConfiguration:nil
                                                image:nil

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -597,7 +597,7 @@ private extension PostListViewController {
     func handleRefreshNoResultsViewController(_ noResultsViewController: NoResultsViewController) {
 
         guard connectionAvailable() else {
-            noResultsViewController.configure(title: "", noConnectionTitle: NoResultsText.noConnectionTitle, buttonTitle: NoResultsText.noConnectionButtonTitle, subtitle: nil, noConnectionSubtitle: NoResultsText.noConnectionSubtitle, attributedSubtitle: nil, attributedSubtitleConfiguration: nil, image: nil, subtitleImage: nil, accessoryView: nil)
+            noResultsViewController.configure(title: "", noConnectionTitle: NoResultsText.noConnectionTitle, buttonTitle: NoResultsText.buttonTitle, subtitle: nil, noConnectionSubtitle: NoResultsText.noConnectionSubtitle, attributedSubtitle: nil, attributedSubtitleConfiguration: nil, image: nil, subtitleImage: nil, accessoryView: nil)
             return
         }
 
@@ -653,7 +653,7 @@ private extension PostListViewController {
     }
 
     struct NoResultsText {
-        static let buttonTitle = NSLocalizedString("Create a Post", comment: "Button title, encourages users to create their first post on their blog.")
+        static let buttonTitle = NSLocalizedString("Create Post", comment: "Button title, encourages users to create post on their blog.")
         static let fetchingTitle = NSLocalizedString("Fetching posts...", comment: "A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new posts.")
         static let noMatchesTitle = NSLocalizedString("No posts matching your search", comment: "Displayed when the user is searching the posts list and there are no matching posts")
         static let noDraftsTitle = NSLocalizedString("You don't have any draft posts", comment: "Displayed when the user views drafts in the posts list and there are no posts")
@@ -662,6 +662,5 @@ private extension PostListViewController {
         static let noPublishedTitle = NSLocalizedString("You haven't published any posts yet", comment: "Displayed when the user views published posts in the posts list and there are no posts")
         static let noConnectionTitle: String = NSLocalizedString("Unable to load posts right now.", comment: "Title for No results full page screen displayedfrom post list when there is no connection")
         static let noConnectionSubtitle: String = NSLocalizedString("Check your network connection and try again. Or draft a post.", comment: "Subtitle for No results full page screen displayed from post list when there is no connection")
-        static let noConnectionButtonTitle: String = NSLocalizedString("Create Post", comment: "Button title, encourages users to create a post.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -597,7 +597,7 @@ private extension PostListViewController {
     func handleRefreshNoResultsViewController(_ noResultsViewController: NoResultsViewController) {
 
         guard connectionAvailable() else {
-            noResultsViewController.configureForNoConnectionInPostsList()
+            noResultsViewController.configureForNoConnectionInPostList()
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -597,8 +597,7 @@ private extension PostListViewController {
     func handleRefreshNoResultsViewController(_ noResultsViewController: NoResultsViewController) {
 
         guard connectionAvailable() else {
-            noResultsViewController.configure(title: noConnectionMessage(),
-                                              image: noResultsImageName)
+            noResultsViewController.configureForNoConnectionInPostsList()
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -597,7 +597,7 @@ private extension PostListViewController {
     func handleRefreshNoResultsViewController(_ noResultsViewController: NoResultsViewController) {
 
         guard connectionAvailable() else {
-            noResultsViewController.configureForNoConnectionInPostList()
+            noResultsViewController.configure(title: "", noConnectionTitle: NoResultsText.noConnectionTitle, buttonTitle: NoResultsText.noConnectionButtonTitle, subtitle: nil, noConnectionSubtitle: NoResultsText.noConnectionSubtitle, attributedSubtitle: nil, attributedSubtitleConfiguration: nil, image: nil, subtitleImage: nil, accessoryView: nil)
             return
         }
 
@@ -660,5 +660,8 @@ private extension PostListViewController {
         static let noScheduledTitle = NSLocalizedString("You don't have any scheduled posts", comment: "Displayed when the user views scheduled posts in the posts list and there are no posts")
         static let noTrashedTitle = NSLocalizedString("You don't have any trashed posts", comment: "Displayed when the user views trashed in the posts list and there are no posts")
         static let noPublishedTitle = NSLocalizedString("You haven't published any posts yet", comment: "Displayed when the user views published posts in the posts list and there are no posts")
+        static let noConnectionTitle: String = NSLocalizedString("Unable to load posts right now.", comment: "Title for No results full page screen displayedfrom post list when there is no connection")
+        static let noConnectionSubtitle: String = NSLocalizedString("Check your network connection and try again. Or draft a post.", comment: "Subtitle for No results full page screen displayed from post list when there is no connection")
+        static let noConnectionButtonTitle: String = NSLocalizedString("Create Post", comment: "Button title, encourages users to create a post.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -676,10 +676,11 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
         
         hideImageView = (WPDeviceIdentification.isiPhone && !isLandscape) || (WPDeviceIdentification.isiPad && isLandscape);
     }
-    
     [self.noResultsViewController configureWithTitle:self.noResultsTitleText
+                                   noConnectionTitle:nil
                                          buttonTitle:nil
                                             subtitle:nil
+                                noConnectionSubtitle:nil
                                   attributedSubtitle:nil
                      attributedSubtitleConfiguration:nil
                                                image:nil


### PR DESCRIPTION
When displaying  NoResultsView due to no connection from post lists
we want to display a specific copy and a create post button.

Fixes #11997 

Before:
 ![2019-04-10 13 39 31](https://user-images.githubusercontent.com/198826/55908429-b025cc80-5b96-11e9-9b64-5de51e900bc1.png)

After:
<img width="366" alt="Screen Shot 2019-06-27 at 5 36 03 PM" src="https://user-images.githubusercontent.com/1335657/60309312-10105180-9902-11e9-913c-8f7e9dc4f97d.png">


To test:
1. Be offline
2. Go to Published or Drafts tab 
3. See the "no results view" with the right copy
4. See the "Create Post" button
5. Tap create post button
6. See that when exiting the editor or from the menu you have save as draft option
7. Tap save as draft
8. See the post was created as draft but fails to upload.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
