### PR TITLE
Fix issue where some cells in Custom Domains would become untappable

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -24,9 +24,8 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
 
     override var accessoryType: UITableViewCell.AccessoryType {
         didSet {
-            if accessoryType != .none {
-                valueTextField.isEnabled = false
-            }
+            let textFieldEnabled = accessoryType == .none
+            valueTextField.isEnabled = textFieldEnabled
         }
     }
 


### PR DESCRIPTION
Fixes #12019.

This fixes an issue with cell reuse in Custom Domains, when some cells would incorrectly get their `UITextField`s disabled.

## To test:

1. Go to PluginViewModel.swift, and on line 178 add:
```
self.presentDomainRegistration(for: directoryEntry)
return
```
1. Go to Plugin section in app on site that has them enabled (AT/Biz plan site)
1. Go to any plugin that isn't yet installed on the site
1. Try to install it — the Custom Domain flow should pop up instead
1. Go to second page of Custom Domain flow, where you're asked to provide your data
1. Verify that you can select and input text into any text fields


