### PR TITLE
Editor Analytics ContentType now is set to new when it should

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -14,7 +14,7 @@ struct PostEditorAnalyticsSession {
         currentEditor = editor
         postType = post.analyticsPostType ?? "unsupported"
         blogType = post.blog.analyticsType.rawValue
-        contentType = ContentType(post: post).rawValue
+        contentType = ContentType(for: post, and: editor).rawValue
     }
 
     mutating func start(hasUnsupportedBlocks: Bool) {
@@ -87,10 +87,10 @@ extension PostEditorAnalyticsSession {
         case gutenberg
         case classic
 
-        init(post: AbstractPost) {
-            if post.isContentEmpty() {
+        init(for post: AbstractPost, and editor: Editor) {
+            if !post.hasContent() {
                 self = .new
-            } else if post.containsGutenbergBlocks() {
+            } else if editor == .gutenberg {
                 self = .gutenberg
             } else {
                 self = .classic

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -14,7 +14,7 @@ struct PostEditorAnalyticsSession {
         currentEditor = editor
         postType = post.analyticsPostType ?? "unsupported"
         blogType = post.blog.analyticsType.rawValue
-        contentType = ContentType(for: post, and: editor).rawValue
+        contentType = ContentType(post: post).rawValue
     }
 
     mutating func start(hasUnsupportedBlocks: Bool) {
@@ -87,10 +87,10 @@ extension PostEditorAnalyticsSession {
         case gutenberg
         case classic
 
-        init(for post: AbstractPost, and editor: Editor) {
+        init(post: AbstractPost) {
             if !post.hasContent() {
                 self = .new
-            } else if editor == .gutenberg {
+            } else if post.containsGutenbergBlocks() {
                 self = .gutenberg
             } else {
                 self = .classic


### PR DESCRIPTION
This PR fixes the issue spotted here: https://github.com/wordpress-mobile/WordPress-iOS/pull/12005#issuecomment-506250177

`hasContent()` method checks for both Title and Body of the post, so it's better suited to check if a post is new.
~With an empty body, `containsGutenbergBlock()` was failing (there are no blocks - yet), but the editor information is already given by the `Editor` enum instance, being a more reliable source for this information.~
**Edit:** As discussed in the comment, the current behavior is the desired behavior

To test:

- Create a new post.
- Check that `editor_session_start` is tracked with `content_type: new`.
- Edit the title and save as draft.
- Open the saved post using **gutenberg**:
  - Check that `editor_session_start` is tracked with `content_type: classic`
- Open the saved post using **Aztec**:
  - Check that `editor_session_start` is tracked with `content_type: classic`

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.