### PR TITLE
remove blocking spinner on upload and autosave before preview 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,8 @@
 12.9
 -----
 * Offline support: Create Post is now available from empty results view in offline mode.
+* Post Preview: Displaying preview generation status in navigation bar instead of a  
+                blocking spinner. 
 
 12.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,6 @@
 * Offline support: Create Post is now available from empty results view in offline mode.
 * Post Preview: Displaying preview generation status in navigation bar instead of a  
                 blocking spinner. 
-* Post Preview: Displaying preview generation status in navigation bar instead of blocking spinner. 
 
 12.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * Offline support: Create Post is now available from empty results view in offline mode.
 * Post Preview: Displaying preview generation status in navigation bar instead of a  
                 blocking spinner. 
+* Post Preview: Displaying preview generation status in navigation bar instead of blocking spinner. 
 
 12.8
 -----

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3190,7 +3190,7 @@ extension AztecPostViewController {
         static let defaultMargin            = CGFloat(20)
         static let blogPickerCompactSize    = CGSize(width: 125, height: 30)
         static let blogPickerRegularSize    = CGSize(width: 300, height: 30)
-        static let savingDraftButtonSize      = CGSize(width: 130, height: 30)
+        static let savingDraftButtonSize    = CGSize(width: 130, height: 30)
         static let uploadingButtonSize      = CGSize(width: 150, height: 30)
         static let moreAttachmentText       = "more"
         static let placeholderPadding       = UIEdgeInsets(top: 8, left: 5, bottom: 0, right: 0)

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3192,7 +3192,6 @@ extension AztecPostViewController {
         static let blogPickerRegularSize    = CGSize(width: 300, height: 30)
         static let savingDraftButtonSize      = CGSize(width: 130, height: 30)
         static let uploadingButtonSize      = CGSize(width: 150, height: 30)
-        static let generatingPreviewButtonSize = CGSize(width: 170, height: 30)
         static let moreAttachmentText       = "more"
         static let placeholderPadding       = UIEdgeInsets(top: 8, left: 5, bottom: 0, right: 0)
         static let headers                  = [Header.HeaderType.none, .h1, .h2, .h3, .h4, .h5, .h6]
@@ -3298,10 +3297,6 @@ extension AztecPostViewController: PostEditorNavigationBarManagerDelegate {
 
     var uploadingButtonSize: CGSize {
         return Constants.uploadingButtonSize
-    }
-
-    var generatingPreviewButtonSize: CGSize {
-        return Constants.generatingPreviewButtonSize
     }
 
     var savingDraftButtonSize: CGSize {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3299,11 +3299,11 @@ extension AztecPostViewController: PostEditorNavigationBarManagerDelegate {
     var uploadingButtonSize: CGSize {
         return Constants.uploadingButtonSize
     }
-    
+
     var generatingPreviewButtonSize: CGSize {
         return Constants.generatingPreviewButtonSize
     }
-    
+
     var savingDraftButtonSize: CGSize {
         return Constants.savingDraftButtonSize
     }
@@ -3327,7 +3327,7 @@ extension AztecPostViewController: PostEditorNavigationBarManagerDelegate {
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, displayCancelMediaUploads sender: UIButton) {
         displayCancelMediaUploads()
     }
-    
+
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, reloadLeftNavigationItems items: [UIBarButtonItem]) {
         navigationItem.leftBarButtonItems = items
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3190,7 +3190,9 @@ extension AztecPostViewController {
         static let defaultMargin            = CGFloat(20)
         static let blogPickerCompactSize    = CGSize(width: 125, height: 30)
         static let blogPickerRegularSize    = CGSize(width: 300, height: 30)
+        static let savingDraftButtonSize      = CGSize(width: 130, height: 30)
         static let uploadingButtonSize      = CGSize(width: 150, height: 30)
+        static let generatingPreviewButtonSize = CGSize(width: 170, height: 30)
         static let moreAttachmentText       = "more"
         static let placeholderPadding       = UIEdgeInsets(top: 8, left: 5, bottom: 0, right: 0)
         static let headers                  = [Header.HeaderType.none, .h1, .h2, .h3, .h4, .h5, .h6]
@@ -3297,6 +3299,14 @@ extension AztecPostViewController: PostEditorNavigationBarManagerDelegate {
     var uploadingButtonSize: CGSize {
         return Constants.uploadingButtonSize
     }
+    
+    var generatingPreviewButtonSize: CGSize {
+        return Constants.generatingPreviewButtonSize
+    }
+    
+    var savingDraftButtonSize: CGSize {
+        return Constants.savingDraftButtonSize
+    }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, closeWasPressed sender: UIButton) {
         closeWasPressed()
@@ -3316,5 +3326,9 @@ extension AztecPostViewController: PostEditorNavigationBarManagerDelegate {
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, displayCancelMediaUploads sender: UIButton) {
         displayCancelMediaUploads()
+    }
+    
+    func navigationBarManager(_ manager: PostEditorNavigationBarManager, reloadLeftNavigationItems items: [UIBarButtonItem]) {
+        navigationItem.leftBarButtonItems = items
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -581,6 +581,14 @@ extension GutenbergViewController: PostEditorNavigationBarManagerDelegate {
     var uploadingButtonSize: CGSize {
         return AztecPostViewController.Constants.uploadingButtonSize
     }
+    
+    var generatingPreviewButtonSize: CGSize {
+        return AztecPostViewController.Constants.generatingPreviewButtonSize
+    }
+    
+    var savingDraftButtonSize: CGSize {
+        return AztecPostViewController.Constants.savingDraftButtonSize
+    }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, closeWasPressed sender: UIButton) {
         requestHTML(for: .close)
@@ -600,6 +608,10 @@ extension GutenbergViewController: PostEditorNavigationBarManagerDelegate {
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, displayCancelMediaUploads sender: UIButton) {
 
+    }
+    
+    func navigationBarManager(_ manager: PostEditorNavigationBarManager, reloadLeftNavigationItems items: [UIBarButtonItem]) {
+        navigationItem.leftBarButtonItems = items
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -582,10 +582,6 @@ extension GutenbergViewController: PostEditorNavigationBarManagerDelegate {
         return AztecPostViewController.Constants.uploadingButtonSize
     }
 
-    var generatingPreviewButtonSize: CGSize {
-        return AztecPostViewController.Constants.generatingPreviewButtonSize
-    }
-
     var savingDraftButtonSize: CGSize {
         return AztecPostViewController.Constants.savingDraftButtonSize
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -581,11 +581,11 @@ extension GutenbergViewController: PostEditorNavigationBarManagerDelegate {
     var uploadingButtonSize: CGSize {
         return AztecPostViewController.Constants.uploadingButtonSize
     }
-    
+
     var generatingPreviewButtonSize: CGSize {
         return AztecPostViewController.Constants.generatingPreviewButtonSize
     }
-    
+
     var savingDraftButtonSize: CGSize {
         return AztecPostViewController.Constants.savingDraftButtonSize
     }
@@ -609,7 +609,7 @@ extension GutenbergViewController: PostEditorNavigationBarManagerDelegate {
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, displayCancelMediaUploads sender: UIButton) {
 
     }
-    
+
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, reloadLeftNavigationItems items: [UIBarButtonItem]) {
         navigationItem.leftBarButtonItems = items
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -64,27 +64,29 @@ extension PostEditor where Self: UIViewController {
 
     func displayPreview() {
         savePostBeforePreview() { [weak self] previewURLString, error in
-            if error != nil {
-                let title = NSLocalizedString("Preview Unavailable", comment: "Title on display preview error" )
-                self?.displayPreviewNotAvailable(title: title)
+            guard let self = self else {
                 return
             }
-            guard let post = self?.post else {
+            let navigationBarManager = self.navigationBarManager
+            navigationBarManager.reloadLeftBarButtonItems(navigationBarManager.leftBarButtonItems)
+            if error != nil {
+                let title = NSLocalizedString("Preview Unavailable", comment: "Title on display preview error" )
+                self.displayPreviewNotAvailable(title: title)
                 return
             }
             var previewController: PostPreviewViewController
             if let previewURLString = previewURLString, let previewURL = URL(string: previewURLString) {
-                previewController = PostPreviewViewController(post: post, previewURL: previewURL)
+                previewController = PostPreviewViewController(post: self.post, previewURL: previewURL)
             } else {
-                if post.permaLink == nil {
+                if self.post.permaLink == nil {
                     DDLogError("displayPreview: Post permalink is unexpectedly nil")
-                    self?.displayPreviewNotAvailable(title: NSLocalizedString("Preview Unavailable", comment: "Title on display preview error" ))
+                    self.displayPreviewNotAvailable(title: NSLocalizedString("Preview Unavailable", comment: "Title on display preview error" ))
                     return
                 }
-                previewController = PostPreviewViewController(post: post)
+                previewController = PostPreviewViewController(post: self.post)
             }
             previewController.hidesBottomBarWhenPushed = true
-            self?.navigationController?.pushViewController(previewController, animated: true)
+            self.navigationController?.pushViewController(previewController, animated: true)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -26,39 +26,31 @@ extension PostEditor where Self: UIViewController {
     private func savePostBeforePreview(completion: @escaping ((String?, Error?) -> Void)) {
         let context = ContextManager.sharedInstance().mainContext
         let postService = PostService(managedObjectContext: context)
-        let draftStatus = NSLocalizedString("Saving...", comment: "Text displayed in HUD while a post is being saved as a draft.")
-        let publishedStatus = NSLocalizedString("Generating Preview...", comment: "Text displayed in HUD while a post is being saved.")
-        SVProgressHUD.setDefaultMaskType(.clear)
-
         if !post.hasUnsavedChanges() {
             completion(nil, nil)
             return
         }
 
         if post.isDraft() {
-            SVProgressHUD.show(withStatus: draftStatus)
+            navigationBarManager.reloadLeftBarButtonItems(navigationBarManager.savingDraftLeftBarButtonItems)
             postService.uploadPost(post, success: { [weak self] savedPost in
                 self?.post = savedPost
                 self?.createPostRevisionBeforePreview() {
                     completion(nil, nil)
                 }
-                SVProgressHUD.dismiss()
                 }, failure: { error in
                     DDLogError("Error while trying to upload draft before preview: \(String(describing: error))")
                     completion(nil, nil)
-                    SVProgressHUD.dismiss()
             })
         } else {
-            SVProgressHUD.show(withStatus: publishedStatus)
+            navigationBarManager.reloadLeftBarButtonItems(navigationBarManager.generatingPreviewLeftBarButtonItems)
             postService.autoSave(post, success: { [weak self] savedPost, previewURL in
                 self?.post = savedPost
                 ContextManager.sharedInstance().save(context)
-                SVProgressHUD.dismiss()
                 completion(previewURL, nil)
             }) { error in
                 //When failing to save a published post will result in "preview not available"
                 DDLogError("Error while trying to save post before preview: \(String(describing: error))")
-                SVProgressHUD.dismiss()
                 completion(nil, error)
             }
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -78,12 +78,10 @@ class PostEditorNavigationBarManager {
 
     /// Preview Generating Button
     ///
-    private lazy var previewGeneratingButton: WPUploadStatusButton = {
-        let button = WPUploadStatusButton(frame: CGRect(origin: .zero, size: delegate?.generatingPreviewButtonSize ?? .zero))
-        button.setTitle(NSLocalizedString("Generating Preview", comment: "Message to indicate progress of generating preview"), for: .normal)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        return button
+    private lazy var previewGeneratingView: LocadingStatusView = {
+        let view = LocadingStatusView(title:NSLocalizedString("Generating Preview", comment: "Message to indicate progress of generating preview"))
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
     }()
 
     /// Draft Saving Button
@@ -135,7 +133,7 @@ class PostEditorNavigationBarManager {
     /// Preview Generating Status Button
     ///
     private lazy var previewGeneratingBarButtonItem: UIBarButtonItem = {
-        let barButton = UIBarButtonItem(customView: self.previewGeneratingButton)
+        let barButton = UIBarButtonItem(customView: self.previewGeneratingView)
         barButton.accessibilityLabel = NSLocalizedString("Generating Preview", comment: "Message to indicate progress of generating preview")
         return barButton
     }()

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -4,12 +4,15 @@ protocol PostEditorNavigationBarManagerDelegate: class {
     var publishButtonText: String { get }
     var isPublishButtonEnabled: Bool { get }
     var uploadingButtonSize: CGSize { get }
+    var generatingPreviewButtonSize: CGSize { get }
+    var savingDraftButtonSize: CGSize { get }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, closeWasPressed sender: UIButton)
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, moreWasPressed sender: UIButton)
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, blogPickerWasPressed sender: UIButton)
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, publishButtonWasPressed sender: UIButton)
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, displayCancelMediaUploads sender: UIButton)
+    func navigationBarManager(_ manager: PostEditorNavigationBarManager, reloadLeftNavigationItems items: [UIBarButtonItem])
 }
 
 // A class to share the navigation bar UI of the Post Editor.
@@ -72,7 +75,27 @@ class PostEditorNavigationBarManager {
         button.setContentHuggingPriority(.defaultLow, for: .horizontal)
         return button
     }()
+    
+    /// Preview Generating Button
+    ///
+    private lazy var previewGeneratingButton: WPUploadStatusButton = {
+        let button = WPUploadStatusButton(frame: CGRect(origin: .zero, size: delegate?.generatingPreviewButtonSize ?? .zero))
+        button.setTitle(NSLocalizedString("Generating Preview", comment: "Message to indicate progress of generating preview"), for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        return button
+    }()
 
+    /// Draft Saving Button
+    ///
+    private lazy var savingDraftButton: WPUploadStatusButton = {
+        let button = WPUploadStatusButton(frame: CGRect(origin: .zero, size: delegate?.savingDraftButtonSize ?? .zero))
+        button.setTitle(NSLocalizedString("Saving Draft", comment: "Message to indicate progress of saving draft"), for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        return button
+    }()
+    
     // MARK: - Bar button items
 
     /// Negative Offset BarButtonItem: Used to fine tune navigationBar Items
@@ -106,6 +129,22 @@ class PostEditorNavigationBarManager {
     private lazy var mediaUploadingBarButtonItem: UIBarButtonItem = {
         let barButton = UIBarButtonItem(customView: self.mediaUploadingButton)
         barButton.accessibilityLabel = NSLocalizedString("Media Uploading", comment: "Message to indicate progress of uploading media to server")
+        return barButton
+    }()
+    
+    /// Preview Generating Status Button
+    ///
+    private lazy var previewGeneratingBarButtonItem: UIBarButtonItem = {
+        let barButton = UIBarButtonItem(customView: self.previewGeneratingButton)
+        barButton.accessibilityLabel = NSLocalizedString("Generating Preview", comment: "Message to indicate progress of generating preview")
+        return barButton
+    }()
+    
+    /// Saving draft Status Button
+    ///
+    private lazy var savingDraftBarButtonItem: UIBarButtonItem = {
+        let barButton = UIBarButtonItem(customView: self.savingDraftButton)
+        barButton.accessibilityLabel = NSLocalizedString("Saving Draft", comment: "Message to indicate progress of saving draft")
         return barButton
     }()
 
@@ -154,6 +193,14 @@ class PostEditorNavigationBarManager {
     var uploadingMediaLeftBarButtonItems: [UIBarButtonItem] {
         return [separatorButtonItem, closeBarButtonItem, mediaUploadingBarButtonItem]
     }
+    
+    var generatingPreviewLeftBarButtonItems: [UIBarButtonItem] {
+        return [separatorButtonItem, closeBarButtonItem, previewGeneratingBarButtonItem]
+    }
+    
+    var savingDraftLeftBarButtonItems: [UIBarButtonItem] {
+        return [separatorButtonItem, closeBarButtonItem, savingDraftBarButtonItem]
+    }
 
     var rightBarButtonItems: [UIBarButtonItem] {
         return [moreBarButtonItem, publishBarButtonItem, separatorButtonItem]
@@ -171,6 +218,10 @@ class PostEditorNavigationBarManager {
         blogPickerButton.setAttributedTitle(titleText, for: .normal)
         blogPickerButton.buttonMode = enabled ? .multipleSite : .singleSite
         blogPickerButton.isEnabled = enabled
+    }
+    
+    func reloadLeftBarButtonItems(_ items: [UIBarButtonItem]) {
+        delegate?.navigationBarManager(self, reloadLeftNavigationItems: items)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -4,7 +4,6 @@ protocol PostEditorNavigationBarManagerDelegate: class {
     var publishButtonText: String { get }
     var isPublishButtonEnabled: Bool { get }
     var uploadingButtonSize: CGSize { get }
-    var generatingPreviewButtonSize: CGSize { get }
     var savingDraftButtonSize: CGSize { get }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, closeWasPressed sender: UIButton)
@@ -78,8 +77,8 @@ class PostEditorNavigationBarManager {
 
     /// Preview Generating Button
     ///
-    private lazy var previewGeneratingView: LocadingStatusView = {
-        let view = LocadingStatusView(title:NSLocalizedString("Generating Preview", comment: "Message to indicate progress of generating preview"))
+    private lazy var previewGeneratingView: LoadingStatusView = {
+        let view = LoadingStatusView(title: NSLocalizedString("Generating Preview", comment: "Message to indicate progress of generating preview"))
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -75,7 +75,7 @@ class PostEditorNavigationBarManager {
         button.setContentHuggingPriority(.defaultLow, for: .horizontal)
         return button
     }()
-    
+
     /// Preview Generating Button
     ///
     private lazy var previewGeneratingButton: WPUploadStatusButton = {
@@ -95,7 +95,7 @@ class PostEditorNavigationBarManager {
         button.setContentHuggingPriority(.defaultLow, for: .horizontal)
         return button
     }()
-    
+
     // MARK: - Bar button items
 
     /// Negative Offset BarButtonItem: Used to fine tune navigationBar Items
@@ -131,7 +131,7 @@ class PostEditorNavigationBarManager {
         barButton.accessibilityLabel = NSLocalizedString("Media Uploading", comment: "Message to indicate progress of uploading media to server")
         return barButton
     }()
-    
+
     /// Preview Generating Status Button
     ///
     private lazy var previewGeneratingBarButtonItem: UIBarButtonItem = {
@@ -139,7 +139,7 @@ class PostEditorNavigationBarManager {
         barButton.accessibilityLabel = NSLocalizedString("Generating Preview", comment: "Message to indicate progress of generating preview")
         return barButton
     }()
-    
+
     /// Saving draft Status Button
     ///
     private lazy var savingDraftBarButtonItem: UIBarButtonItem = {
@@ -193,11 +193,11 @@ class PostEditorNavigationBarManager {
     var uploadingMediaLeftBarButtonItems: [UIBarButtonItem] {
         return [separatorButtonItem, closeBarButtonItem, mediaUploadingBarButtonItem]
     }
-    
+
     var generatingPreviewLeftBarButtonItems: [UIBarButtonItem] {
         return [separatorButtonItem, closeBarButtonItem, previewGeneratingBarButtonItem]
     }
-    
+
     var savingDraftLeftBarButtonItems: [UIBarButtonItem] {
         return [separatorButtonItem, closeBarButtonItem, savingDraftBarButtonItem]
     }
@@ -219,7 +219,7 @@ class PostEditorNavigationBarManager {
         blogPickerButton.buttonMode = enabled ? .multipleSite : .singleSite
         blogPickerButton.isEnabled = enabled
     }
-    
+
     func reloadLeftBarButtonItems(_ items: [UIBarButtonItem]) {
         delegate?.navigationBarManager(self, reloadLeftNavigationItems: items)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -79,7 +79,6 @@ class PostEditorNavigationBarManager {
     ///
     private lazy var previewGeneratingView: LoadingStatusView = {
         let view = LoadingStatusView(title: NSLocalizedString("Generating Preview", comment: "Message to indicate progress of generating preview"))
-        view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
 

--- a/WordPress/Classes/ViewRelated/Views/LoadingStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Views/LoadingStatusView.swift
@@ -1,19 +1,18 @@
 import Foundation
 
-class LocadingStatusView: UIView {
+class LoadingStatusView: UIView {
     init(title: String) {
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
         backgroundColor = .clear
-        autoresizingMask = .flexibleWidth;
+        autoresizingMask = .flexibleWidth
         accessibilityHint = NSLocalizedString("Tap to cancel uploading.", comment: "This is a status indicator on the editor")
-        let localizedString = NSLocalizedString("%@", comment:  "\"Uploading\" Status text")
+        let localizedString = NSLocalizedString("%@", comment: "\"Uploading\" Status text")
         titleLabel.text = String.localizedStringWithFormat(localizedString, title)
         activityIndicator.startAnimating()
         configureLayout()
     }
-    
-    
+
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.textColor = .white
@@ -38,7 +37,7 @@ class LocadingStatusView: UIView {
         addSubview(indicator)
         return indicator
     }()
-    
+
     private func configureLayout() {
         NSLayoutConstraint.activate([
             titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -48,9 +47,8 @@ class LocadingStatusView: UIView {
             activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor)
             ])
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
 }

--- a/WordPress/Classes/ViewRelated/Views/LocadingStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Views/LocadingStatusView.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+class LocadingStatusView: UIView {
+    init(title: String) {
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        backgroundColor = .clear
+        autoresizingMask = .flexibleWidth;
+        accessibilityHint = NSLocalizedString("Tap to cancel uploading.", comment: "This is a status indicator on the editor")
+        let localizedString = NSLocalizedString("%@", comment:  "\"Uploading\" Status text")
+        titleLabel.text = String.localizedStringWithFormat(localizedString, title)
+        activityIndicator.startAnimating()
+        configureLayout()
+    }
+    
+    
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .white
+        label.font = WPFontManager.systemBoldFont(ofSize: 14.0)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.sizeToFit()
+        label.numberOfLines = 1
+        label.textAlignment = .natural
+        label.lineBreakMode = .byTruncatingTail
+        label.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        addSubview(label)
+        return label
+    }()
+
+    private lazy var activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .white)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            indicator.widthAnchor.constraint(equalToConstant: 20.0),
+            indicator.heightAnchor.constraint(equalToConstant: 20.0),
+            ])
+        addSubview(indicator)
+        return indicator
+    }()
+    
+    private func configureLayout() {
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            titleLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            activityIndicator.leadingAnchor.constraint(equalTo: titleLabel.trailingAnchor, constant: 2.0),
+            activityIndicator.trailingAnchor.constraint(equalTo: trailingAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor)
+            ])
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -304,7 +304,7 @@
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
 		296890780FE971DC00770264 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296890770FE971DC00770264 /* Security.framework */; };
 		2F08ECFC2283A4FB000F8E11 /* PostService+UnattachedMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F08ECFB2283A4FB000F8E11 /* PostService+UnattachedMedia.swift */; };
-		2F161B0622CC2DC70066A5C5 /* LocadingStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F161B0522CC2DC70066A5C5 /* LocadingStatusView.swift */; };
+		2F161B0622CC2DC70066A5C5 /* LoadingStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F161B0522CC2DC70066A5C5 /* LoadingStatusView.swift */; };
 		2FA37B1A215724E900C80377 /* LongPressGestureLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA37B19215724E900C80377 /* LongPressGestureLabel.swift */; };
 		2FA6511321F26949009AA935 /* SiteVerticalsPromptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA6511221F26949009AA935 /* SiteVerticalsPromptService.swift */; };
 		2FA6511521F269A6009AA935 /* VerticalsTableViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA6511421F269A6009AA935 /* VerticalsTableViewProvider.swift */; };
@@ -2317,7 +2317,7 @@
 		292CECFF1027259000BD407D /* SFHFKeychainUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFHFKeychainUtils.m; sourceTree = "<group>"; };
 		296890770FE971DC00770264 /* Security.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		2F08ECFB2283A4FB000F8E11 /* PostService+UnattachedMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+UnattachedMedia.swift"; sourceTree = "<group>"; };
-		2F161B0522CC2DC70066A5C5 /* LocadingStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocadingStatusView.swift; sourceTree = "<group>"; };
+		2F161B0522CC2DC70066A5C5 /* LoadingStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingStatusView.swift; sourceTree = "<group>"; };
 		2F970F970DF929B8006BD934 /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		2FA37B19215724E900C80377 /* LongPressGestureLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LongPressGestureLabel.swift; sourceTree = "<group>"; };
 		2FA6511221F26949009AA935 /* SiteVerticalsPromptService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteVerticalsPromptService.swift; sourceTree = "<group>"; };
@@ -4437,7 +4437,7 @@
 				740BD8341A0D4C3600F04D18 /* WPUploadStatusButton.m */,
 				1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */,
 				177076201EA206C000705A4A /* PlayIconView.swift */,
-				2F161B0522CC2DC70066A5C5 /* LocadingStatusView.swift */,
+				2F161B0522CC2DC70066A5C5 /* LoadingStatusView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -10669,7 +10669,7 @@
 				E69BA1981BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m in Sources */,
 				7E4123C320F4097B00DF8486 /* FormattableContentStyles.swift in Sources */,
 				735A9681228E421F00461135 /* StatsBarChartConfiguration.swift in Sources */,
-				2F161B0622CC2DC70066A5C5 /* LocadingStatusView.swift in Sources */,
+				2F161B0622CC2DC70066A5C5 /* LoadingStatusView.swift in Sources */,
 				080C44A91CE14A9F00B3A02F /* MenuDetailsViewController.m in Sources */,
 				2FA6511B21F26A57009AA935 /* InlineErrorRetryTableViewCell.swift in Sources */,
 				08216FCF1CDBF96000304BA7 /* MenuItemSourceCell.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 		2906F812110CDA8900169D56 /* EditCommentViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2906F810110CDA8900169D56 /* EditCommentViewController.m */; };
 		296890780FE971DC00770264 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 296890770FE971DC00770264 /* Security.framework */; };
 		2F08ECFC2283A4FB000F8E11 /* PostService+UnattachedMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F08ECFB2283A4FB000F8E11 /* PostService+UnattachedMedia.swift */; };
+		2F161B0622CC2DC70066A5C5 /* LocadingStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F161B0522CC2DC70066A5C5 /* LocadingStatusView.swift */; };
 		2FA37B1A215724E900C80377 /* LongPressGestureLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA37B19215724E900C80377 /* LongPressGestureLabel.swift */; };
 		2FA6511321F26949009AA935 /* SiteVerticalsPromptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA6511221F26949009AA935 /* SiteVerticalsPromptService.swift */; };
 		2FA6511521F269A6009AA935 /* VerticalsTableViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FA6511421F269A6009AA935 /* VerticalsTableViewProvider.swift */; };
@@ -2316,6 +2317,7 @@
 		292CECFF1027259000BD407D /* SFHFKeychainUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SFHFKeychainUtils.m; sourceTree = "<group>"; };
 		296890770FE971DC00770264 /* Security.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		2F08ECFB2283A4FB000F8E11 /* PostService+UnattachedMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+UnattachedMedia.swift"; sourceTree = "<group>"; };
+		2F161B0522CC2DC70066A5C5 /* LocadingStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocadingStatusView.swift; sourceTree = "<group>"; };
 		2F970F970DF929B8006BD934 /* Constants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constants.h; sourceTree = "<group>"; };
 		2FA37B19215724E900C80377 /* LongPressGestureLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LongPressGestureLabel.swift; sourceTree = "<group>"; };
 		2FA6511221F26949009AA935 /* SiteVerticalsPromptService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteVerticalsPromptService.swift; sourceTree = "<group>"; };
@@ -4435,6 +4437,7 @@
 				740BD8341A0D4C3600F04D18 /* WPUploadStatusButton.m */,
 				1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */,
 				177076201EA206C000705A4A /* PlayIconView.swift */,
+				2F161B0522CC2DC70066A5C5 /* LocadingStatusView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -10666,6 +10669,7 @@
 				E69BA1981BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m in Sources */,
 				7E4123C320F4097B00DF8486 /* FormattableContentStyles.swift in Sources */,
 				735A9681228E421F00461135 /* StatsBarChartConfiguration.swift in Sources */,
+				2F161B0622CC2DC70066A5C5 /* LocadingStatusView.swift in Sources */,
 				080C44A91CE14A9F00B3A02F /* MenuDetailsViewController.m in Sources */,
 				2FA6511B21F26A57009AA935 /* InlineErrorRetryTableViewCell.swift in Sources */,
 				08216FCF1CDBF96000304BA7 /* MenuItemSourceCell.m in Sources */,


### PR DESCRIPTION
Fixes #11812 

As described in the issue when saving a draft or autosaving a post before preview we used to show a blocking spinner which would block the user from performing any actions till preview is generated. 
This issue is prominent in low connectivity.

This PR aims to improve the experience by showing the saving/generating status in the navigation bar the same way we do when uploading media. 

![generating](https://user-images.githubusercontent.com/1335657/60378698-1e7e6c00-99db-11e9-9e7d-b61dcd2cacc6.gif)

**This improvement brings up the need to also remove the blocking spinner when loading the preview (web view loading). It will be tackled in a separate [PR](https://github.com/wordpress-mobile/WordPress-iOS/issues/12032)**

To test:
1. Go to device settings -> Developer and turn on Network Link Conditioner with "Very Bad Network"
POSTS:
2. Open the app and go to published posts
3. Update a post
4. tap preview
5. See "Generating Preview" in the nav bar.
6. Make sure you can exist the editor and perform other actions. 
7. Go back from the preview and see that the navigation bar in the editor is back to default.

DRAFTS:
2. Open the app and go to drafts
3. Update a draft
4. tap preview
5. See "Saving Draft" in the nav bar.
6. Make sure you can exist the editor and perform other actions. 
7. Go back from the preview and see that the navigation bar in the editor is back to default.


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
