### PR TITLE
Change launch screen background to Blue-500

### DIFF
--- a/WordPress/Launch Screen.storyboard
+++ b/WordPress/Launch Screen.storyboard
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -26,7 +27,7 @@
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" red="0.0" green="0.52941176470588003" blue="0.74509803921568996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" name="Blue-500"/>
                         <constraints>
                             <constraint firstItem="FfR-yo-4a1" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="T0u-ej-Kyp"/>
                             <constraint firstItem="FfR-yo-4a1" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="a6p-Lx-MaV"/>
@@ -40,5 +41,8 @@
     </scenes>
     <resources>
         <image name="icon-wp" width="50" height="52"/>
+        <namedColor name="Blue-500">
+            <color red="0.0039215686274509803" green="0.37647058823529411" blue="0.52941176470588236" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>


### PR DESCRIPTION
This PR updates the launch screen to use a Blue-500 background. It seemed like it would be difficult to feature flag this, and I figured it wasn't necessary as the feature flag is already open to everyone and it's an easy revert.

![Simulator Screen Shot - iPhone X - 2019-06-29 at 09 02 28](https://user-images.githubusercontent.com/4780/60381442-efa0de00-9a4c-11e9-8f60-959de05f39f8.png)

**To test:**

* Build and run, and check the launch screen uses a darker blue (Blue-500)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt` (color scheme updates are already mentioned there).