### PR TITLE
[Stats Refresh] Use primary dark as legend color

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift
@@ -181,7 +181,7 @@ private struct ViewsPeriodChartStyling: BarChartStyling {
     let primaryHighlightColor: UIColor?
     let secondaryHighlightColor: UIColor?
     let labelColor: UIColor                         = .neutral(shade: .shade300)
-    let legendColor: UIColor?                       = .primary
+    let legendColor: UIColor?                       = .primaryDark
     let legendTitle: String?                        = NSLocalizedString("Visitors", comment: "This appears in the legend of the period chart; Visitors are superimposed over Views in that case.")
     let lineColor: UIColor                          = .neutral(shade: .shade50)
     let xAxisValueFormatter: IAxisValueFormatter


### PR DESCRIPTION
Fixes #12035 

This PR fixes the color used by the Period Chart legend.

![sr-legend-detail](https://user-images.githubusercontent.com/912252/60440738-bebfd500-9c15-11e9-9b70-8eb0a22ceb2d.png)

![sr-legend](https://user-images.githubusercontent.com/912252/60438933-15c3ab00-9c12-11e9-9473-9ab4b184e901.png)

(Pictures on the left: without Muriel colors)

## To test:
• Open stats form a selected site
• Select a DWMY period
• The Period Chart legend should use the `primaryDark` color

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
