### PR TITLE
[Stats Refresh] Tapping Chart bars doesn't work

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartConfiguration.swift
@@ -3,16 +3,15 @@ struct StatsBarChartConfiguration {
     let data: BarChartDataConvertible
     let styling: BarChartStyling
     let analyticsGranularity: BarChartAnalyticsPropertyGranularityValue?
-    let delegate: StatsBarChartViewDelegate?
     let indexToHighlight: Int?
 }
 
 extension StatsBarChartConfiguration {
     init(data: BarChartDataConvertible, styling: BarChartStyling) {
-        self.init(data: data, styling: styling, analyticsGranularity: nil, delegate: nil, indexToHighlight: nil)
+        self.init(data: data, styling: styling, analyticsGranularity: nil, indexToHighlight: nil)
     }
 
     init(data: BarChartDataConvertible, styling: BarChartStyling, analyticsGranularity: BarChartAnalyticsPropertyGranularityValue?) {
-        self.init(data: data, styling: styling, analyticsGranularity: analyticsGranularity, delegate: nil, indexToHighlight: nil)
+        self.init(data: data, styling: styling, analyticsGranularity: analyticsGranularity, indexToHighlight: nil)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -90,11 +90,11 @@ class StatsBarChartView: BarChartView {
         }
     }
 
-    init(configuration: StatsBarChartConfiguration) {
+    init(configuration: StatsBarChartConfiguration, delegate: StatsBarChartViewDelegate? = nil) {
         self.barChartData = configuration.data
         self.styling = configuration.styling
         self.analyticsGranularity = configuration.analyticsGranularity
-        self.statsBarChartViewDelegate = configuration.delegate
+        self.statsBarChartViewDelegate = delegate
         self.highlightIndex = configuration.indexToHighlight
 
         super.init(frame: .zero)

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -179,8 +179,11 @@ private extension OverviewCell {
             return
         }
 
-        let configuration = StatsBarChartConfiguration(data: chartData[filterSelectedIndex], styling: chartStyling[filterSelectedIndex], analyticsGranularity: period?.analyticsGranularity, delegate: statsBarChartViewDelegate, indexToHighlight: chartHighlightIndex)
-        let chartView = StatsBarChartView(configuration: configuration)
+        let configuration = StatsBarChartConfiguration(data: chartData[filterSelectedIndex],
+                                                       styling: chartStyling[filterSelectedIndex],
+                                                       analyticsGranularity: period?.analyticsGranularity,
+                                                       indexToHighlight: chartHighlightIndex)
+        let chartView = StatsBarChartView(configuration: configuration, delegate: statsBarChartViewDelegate)
 
         resetChartContainerView()
         chartContainerView.addSubview(chartView)

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -54,6 +54,7 @@ class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoada
     private var changeReceipt: Receipt?
 
     private var viewModel: SiteStatsPeriodViewModel?
+    private var tableHeaderView: SiteStatsTableHeaderView?
 
     private let analyticsTracker = BottomScrollAnalyticsTracker()
 
@@ -81,13 +82,18 @@ class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoada
         }
 
         cell.configure(date: selectedDate, period: selectedPeriod, delegate: self)
-        viewModel?.statsBarChartViewDelegate = cell
-
+        tableHeaderView = cell
         return cell
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return SiteStatsTableHeaderView.height
+    }
+}
+
+extension SiteStatsPeriodTableViewController: StatsBarChartViewDelegate {
+    func statsBarChartValueSelected(_ statsBarChartView: StatsBarChartView, entryIndex: Int, entryCount: Int) {
+        tableHeaderView?.statsBarChartValueSelected(statsBarChartView, entryIndex: entryIndex, entryCount: entryCount)
     }
 }
 
@@ -108,6 +114,7 @@ private extension SiteStatsPeriodTableViewController {
                                              selectedDate: selectedDate,
                                              selectedPeriod: selectedPeriod,
                                              periodDelegate: self)
+        viewModel?.statsBarChartViewDelegate = self
         addViewModelListeners()
     }
 


### PR DESCRIPTION
Fixes #12037 

This is an _hotfix_ and it fixes a problem when a user is trying to change a period selecting the chart bar.
I saw the delegate injected in the Chart View was nil. I think this is caused by the element passed trough the configuration object. This is owned by the function scope, which means it will be released when the function returns. Injecting the delegate reference in the view init fixes the problem.

## To test:
• Open Stats and select one of the period DWMY
• Tap the bars to change the date
• It should reload the data

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
