### PR TITLE
Fixes an issue with the tour guide not initializing some values in time.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -106,6 +106,8 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 
 - (void)addQuickStartSpotlight
 {
+    [self.spotlightView removeFromSuperview];
+    
     self.spotlightView = [QuickStartSpotlightView new];
     [self addSubview:self.spotlightView];
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -99,6 +99,12 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
         self.blavatarImageView.image = [UIImage siteIconPlaceholder];
     }
 
+    [self refreshSpotlight];
+}
+
+- (void)refreshSpotlight {
+    [self removeQuickStartSpotlight];
+    
     if ([[QuickStartTourGuide find] isCurrentElement:QuickStartTourElementSiteIcon]) {
         [self addQuickStartSpotlight];
     }
@@ -106,8 +112,6 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 
 - (void)addQuickStartSpotlight
 {
-    [self.spotlightView removeFromSuperview];
-    
     self.spotlightView = [QuickStartSpotlightView new];
     [self addSubview:self.spotlightView];
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -92,13 +92,18 @@ class QuickStartChecklistViewController: UITableViewController {
         dataManager = QuickStartChecklistManager(blog: blog,
                                                  tours: configuration.tours,
                                                  didSelectTour: { [weak self] tour in
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
                 WPAnalytics.track(.quickStartChecklistItemTapped, withProperties: ["task_name": tour.analyticsKey])
-                self?.dismiss(animated: true) {
-                    if let blog = self?.blog,
-                        let tourGuide = QuickStartTourGuide.find() {
-                        tourGuide.start(tour: tour, for: blog)
-                    }
+
+                guard let self = self else {
+                    return
+                }
+
+                let tourGuide = QuickStartTourGuide.find()
+                tourGuide?.start(tour: tour, for: self.blog, immediately: false)
+
+                self.dismiss(animated: true) {
+                    tourGuide?.run()
                 }
             }
         }, didTapHeader: { [unowned self] expand in

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -100,10 +100,10 @@ class QuickStartChecklistViewController: UITableViewController {
                 }
 
                 let tourGuide = QuickStartTourGuide.find()
-                tourGuide?.start(tour: tour, for: self.blog, immediately: false)
+                tourGuide?.prepare(tour: tour, for: self.blog)
 
                 self.dismiss(animated: true) {
-                    tourGuide?.run()
+                    tourGuide?.begin()
                 }
             }
         }, didTapHeader: { [unowned self] expand in

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -101,7 +101,8 @@ open class QuickStartTourGuide: NSObject {
                                 self?.currentSuggestion = nil
 
                                 if accepted {
-                                    self?.start(tour: tour, for: blog)
+                                    self?.prepare(tour: tour, for: blog)
+                                    self?.begin()
                                     cancelTimer(false)
                                     WPAnalytics.track(.quickStartSuggestionButtonTapped, withProperties: ["type": "positive"])
                                 } else {
@@ -116,16 +117,13 @@ open class QuickStartTourGuide: NSObject {
         WPAnalytics.track(.quickStartSuggestionViewed)
     }
 
-    /// Starts the specified tour.
+    /// Prepares to begin the specified tour.
     ///
     /// - Parameters:
-    ///     - tour: the tour to start.
+    ///     - tour: the tour to prepare for running.
     ///     - blog: the blog in which the tour will take place.
-    ///     - immeditately: whether the tour must start immediately or not.  If this is `false`
-    ///         the tour will be initialized but the first step won't be executed.  The caller of
-    ///         this method must also call `run()` to effectively start the tour.
     ///
-    func start(tour: QuickStartTour, for blog: Blog, immediately: Bool = true) {
+    func prepare(tour: QuickStartTour, for blog: Blog) {
         endCurrentTour()
         dismissSuggestion()
 
@@ -135,17 +133,12 @@ open class QuickStartTourGuide: NSObject {
             fallthrough
         default:
             currentTourState = TourState(tour: tour, blog: blog, step: 0)
-
-            if immediately {
-                showCurrentStep()
-            }
         }
     }
 
-    /// Runs the current tour.  Only works after calling `startTour` with parameter `immediately` set to
-    /// `false`, and if the tour is in the first step.  Otherwise this method will do nothing.
+    /// Begins the prepared tour.  Should only be called after `prepare(tour:for:)`.
     ///
-    func run() {
+    func begin() {
         guard let state = currentTourState,
             state.step == 0 else {
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -116,7 +116,16 @@ open class QuickStartTourGuide: NSObject {
         WPAnalytics.track(.quickStartSuggestionViewed)
     }
 
-    func start(tour: QuickStartTour, for blog: Blog) {
+    /// Starts the specified tour.
+    ///
+    /// - Parameters:
+    ///     - tour: the tour to start.
+    ///     - blog: the blog in which the tour will take place.
+    ///     - immeditately: whether the tour must start immediately or not.  If this is `false`
+    ///         the tour will be initialized but the first step won't be executed.  The caller of
+    ///         this method must also call `run()` to effectively start the tour.
+    ///
+    func start(tour: QuickStartTour, for blog: Blog, immediately: Bool = false) {
         endCurrentTour()
         dismissSuggestion()
 
@@ -126,8 +135,24 @@ open class QuickStartTourGuide: NSObject {
             fallthrough
         default:
             currentTourState = TourState(tour: tour, blog: blog, step: 0)
-            showCurrentStep()
+
+            if immediately {
+                showCurrentStep()
+            }
         }
+    }
+
+    /// Runs the current tour.  Only works after calling `startTour` with parameter `immediately` set to
+    /// `false`, and if the tour is in the first step.  Otherwise this method will do nothing.
+    ///
+    func run() {
+        guard let state = currentTourState,
+            state.step == 0 else {
+
+            return
+        }
+
+        showCurrentStep()
     }
 
     func complete(tour: QuickStartTour, for blog: Blog, postNotification: Bool = true) {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -125,7 +125,7 @@ open class QuickStartTourGuide: NSObject {
     ///         the tour will be initialized but the first step won't be executed.  The caller of
     ///         this method must also call `run()` to effectively start the tour.
     ///
-    func start(tour: QuickStartTour, for blog: Blog, immediately: Bool = false) {
+    func start(tour: QuickStartTour, for blog: Blog, immediately: Bool = true) {
         endCurrentTour()
         dismissSuggestion()
 


### PR DESCRIPTION
Fixes #11687 

This PR also fixes two issues that could cause the spotlight effect to never go away:

1. If we run the "Upload an Icon" tutorial multiple times in a row without ever tapping the icon.
2. If we run the "Upload an Icon" tutorial and then a different one without ever tapping on the icon.

## Testing:

1. Create a WP.com site.
2. When offered to, request assistance to set the site up.
3. Make sure the spotlight dot effect is visible when the "Upload an Icon" tutorial is running.
4. Try multiple combinations of running "Upload an Icon" tutorial multiple times in a row with and without tapping on the icon.  Make sure it behaves well.
5. Try multiple combinations of running "Upload an Icon" tutorial and other tutorials multiple times in a row with and without tapping on the icon.  Make sure it behaves well.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.