### PR TITLE
Fixes an issue that was causing new site previews to show behind the "Done" button.

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
@@ -36,9 +36,6 @@ final class SiteAssemblyContentView: UIView {
     /// This influences the top of the assembled site, which varies by device & orientation.
     private var assembledSiteTopConstraint: NSLayoutConstraint?
 
-    /// This influences the height of the assembled site, which varies by device & orientation.
-    private var assembledSiteHeightConstraint: NSLayoutConstraint?
-
     /// This influences the width of the assembled site, which varies by device & orientation.
     private var assembledSiteWidthConstraint: NSLayoutConstraint?
 
@@ -227,8 +224,6 @@ final class SiteAssemblyContentView: UIView {
         let assembledSiteTopInset = Parameters.verticalSpacing
 
         let preferredAssembledSiteSize = assembledSiteView.preferredSize
-        let assembledSiteHeightConstraint = assembledSiteView.heightAnchor.constraint(greaterThanOrEqualToConstant: preferredAssembledSiteSize.height)
-        self.assembledSiteHeightConstraint = assembledSiteHeightConstraint
 
         let assembledSiteWidthConstraint = assembledSiteView.widthAnchor.constraint(equalToConstant: preferredAssembledSiteSize.width)
         self.assembledSiteWidthConstraint = assembledSiteWidthConstraint
@@ -236,10 +231,9 @@ final class SiteAssemblyContentView: UIView {
         NSLayoutConstraint.activate([
             initialSiteTopConstraint,
             assembledSiteView.topAnchor.constraint(greaterThanOrEqualTo: completionLabel.bottomAnchor, constant: assembledSiteTopInset),
-            assembledSiteView.bottomAnchor.constraint(greaterThanOrEqualTo: bottomAnchor),
+            assembledSiteView.bottomAnchor.constraint(equalTo: buttonContainerView?.topAnchor ?? bottomAnchor),
             assembledSiteView.centerXAnchor.constraint(equalTo: centerXAnchor),
             assembledSiteWidthConstraint,
-            assembledSiteHeightConstraint
         ])
 
         self.assembledSiteView = assembledSiteView


### PR DESCRIPTION
Fixes #12046 

In the last step of the Site Creation flow, the preview is no longer being laid out behind the "Done" button.

## Testing:

Please test in both iPhone and iPad.

1. Go to the list of sites.
2. Create a new WP.com site.
3. Fill out all of the required information, and reach the last step (site preview).
4. Make sure you can scroll all the way down to the bottom of the site and that the site doesn't finish behind the "Done" button.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
