### PR TITLE
Fix internal app icon issues

### DIFF
--- a/Scripts/BuildPhases/AddVersionToIcons.sh
+++ b/Scripts/BuildPhases/AddVersionToIcons.sh
@@ -92,9 +92,9 @@ function processIcon() {
 }
 
 # Process all app icons and create the corresponding internal icons
-# icons_dir="${SRCROOT}/Images.xcassets/AppIcon.appiconset"
-icons_path="${PROJECT_DIR}/Images.xcassets/AppIcon.appiconset"
-icons_dest_path="${PROJECT_DIR}/Images.xcassets/AppIcon-Internal.appiconset"
+# icons_dir="${SRCROOT}/AppImages.xcassets/AppIcon.appiconset"
+icons_path="${PROJECT_DIR}/Resources/MurielImages.xcassets/AppIcon.appiconset"
+icons_dest_path="${PROJECT_DIR}/Resources/MurielImages.xcassets/AppIcon-Internal.appiconset"
 icons_set=`basename "${icons_path}"`
 tmp_path="${TEMP_DIR}/IconVersioning"
 

--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -6,6 +6,107 @@
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
 	<string>WP Internal</string>
+	<key>CFBundleIcons</key>
+	<dict>
+		<key>CFBundlePrimaryIcon</key>
+		<dict>
+			<key>CFBundleIconFiles</key>
+			<array>
+				<string>AppIcon</string>
+			</array>
+			<key>UIPrerenderedIcon</key>
+			<true/>
+		</dict>
+		<key>CFBundleAlternateIcons</key>
+		<dict>
+			<key>WordPress Dark</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>wordpress_dark_icon_20pt</string>
+					<string>wordpress_dark_icon_29pt</string>
+					<string>wordpress_dark_icon_40pt</string>
+					<string>wordpress_dark_icon_60pt</string>
+					<string>wordpress_dark_icon_76pt</string>
+					<string>wordpress_dark_icon_83.5</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+			</dict>
+			<key>Open Source</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>open_source_icon_20pt</string>
+					<string>open_source_icon_29pt</string>
+					<string>open_source_icon_40pt</string>
+					<string>open_source_icon_60pt</string>
+					<string>open_source_icon_76pt</string>
+					<string>open_source_icon_83.5</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+				<key>WPRequiresBorder</key>
+				<true/>
+			</dict>
+			<key>Open Source Dark</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>open_source_dark_icon_20pt</string>
+					<string>open_source_dark_icon_29pt</string>
+					<string>open_source_dark_icon_40pt</string>
+					<string>open_source_dark_icon_60pt</string>
+					<string>open_source_dark_icon_76pt</string>
+					<string>open_source_dark_icon_83.5</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+			</dict>
+			<key>Hot Pink</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>hot_pink_icon_20pt</string>
+					<string>hot_pink_icon_29pt</string>
+					<string>hot_pink_icon_40pt</string>
+					<string>hot_pink_icon_60pt</string>
+					<string>hot_pink_icon_76pt</string>
+					<string>hot_pink_icon_83.5</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+			</dict>
+			<key>Jetpack Green</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>jetpack_green_icon_20pt</string>
+					<string>jetpack_green_icon_29pt</string>
+					<string>jetpack_green_icon_40pt</string>
+					<string>jetpack_green_icon_60pt</string>
+					<string>jetpack_green_icon_76pt</string>
+					<string>jetpack_green_icon_83.5</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+			</dict>
+			<key>Pride</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>pride_icon_20pt</string>
+					<string>pride_icon_29pt</string>
+					<string>pride_icon_40pt</string>
+					<string>pride_icon_60pt</string>
+					<string>pride_icon_76pt</string>
+					<string>pride_icon_83.5</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>

--- a/WordPress/Wordpress-Alpha-Info.plist
+++ b/WordPress/Wordpress-Alpha-Info.plist
@@ -6,6 +6,107 @@
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
 	<string>WP Alpha</string>
+	<key>CFBundleIcons</key>
+	<dict>
+		<key>CFBundlePrimaryIcon</key>
+		<dict>
+			<key>CFBundleIconFiles</key>
+			<array>
+				<string>AppIcon</string>
+			</array>
+			<key>UIPrerenderedIcon</key>
+			<true/>
+		</dict>
+		<key>CFBundleAlternateIcons</key>
+		<dict>
+			<key>WordPress Dark</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>wordpress_dark_icon_20pt</string>
+					<string>wordpress_dark_icon_29pt</string>
+					<string>wordpress_dark_icon_40pt</string>
+					<string>wordpress_dark_icon_60pt</string>
+					<string>wordpress_dark_icon_76pt</string>
+					<string>wordpress_dark_icon_83.5</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+			</dict>
+			<key>Open Source</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>open_source_icon_20pt</string>
+					<string>open_source_icon_29pt</string>
+					<string>open_source_icon_40pt</string>
+					<string>open_source_icon_60pt</string>
+					<string>open_source_icon_76pt</string>
+					<string>open_source_icon_83.5</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+				<key>WPRequiresBorder</key>
+				<true/>
+			</dict>
+			<key>Open Source Dark</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>open_source_dark_icon_20pt</string>
+					<string>open_source_dark_icon_29pt</string>
+					<string>open_source_dark_icon_40pt</string>
+					<string>open_source_dark_icon_60pt</string>
+					<string>open_source_dark_icon_76pt</string>
+					<string>open_source_dark_icon_83.5</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+			</dict>
+			<key>Hot Pink</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>hot_pink_icon_20pt</string>
+					<string>hot_pink_icon_29pt</string>
+					<string>hot_pink_icon_40pt</string>
+					<string>hot_pink_icon_60pt</string>
+					<string>hot_pink_icon_76pt</string>
+					<string>hot_pink_icon_83.5</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+			</dict>
+			<key>Jetpack Green</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>jetpack_green_icon_20pt</string>
+					<string>jetpack_green_icon_29pt</string>
+					<string>jetpack_green_icon_40pt</string>
+					<string>jetpack_green_icon_60pt</string>
+					<string>jetpack_green_icon_76pt</string>
+					<string>jetpack_green_icon_83.5</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+			</dict>
+			<key>Pride</key>
+			<dict>
+				<key>CFBundleIconFiles</key>
+				<array>
+					<string>pride_icon_20pt</string>
+					<string>pride_icon_29pt</string>
+					<string>pride_icon_40pt</string>
+					<string>pride_icon_60pt</string>
+					<string>pride_icon_76pt</string>
+					<string>pride_icon_83.5</string>
+				</array>
+				<key>UIPrerenderedIcon</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
This PR fixes a couple of issues with the app icon for internal (and alpha) builds:

* Updated the icon versioning script to use the new `MurielImages.xcasset` asset catalog. Otherwise I was seeing an error on build.
* Adds the new alternate icons to the Internal and Alpha info plists. Otherwise they don't show up in the app.

**To test:**

* Do an internal build in Xcode, check there are no errors.
* Run the internal build (you can disable login if it's quicker by adding a `return` to the start of `showWelcomeScreenIfNeeded`). Go Me > App Settings > App Icon and check you can see the alternate icons and switch to one.
