### PR TITLE
[Stats Refresh] Avoid delay when a chart bar is selected

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -309,6 +309,7 @@ private extension StatsPeriodStore {
         // make a network call for whatever reason, we still want to load the data we have cached.
 
         guard shouldFetchOverview() else {
+            fetchingOverviewListener?(true, false)
             DDLogInfo("Stats Period Overview refresh triggered while one was in progress.")
             return
         }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -116,6 +116,7 @@ private extension SiteStatsPeriodTableViewController {
                                              periodDelegate: self)
         viewModel?.statsBarChartViewDelegate = self
         addViewModelListeners()
+        viewModel?.startFetchingOverview()
     }
 
     func addViewModelListeners() {
@@ -130,7 +131,6 @@ private extension SiteStatsPeriodTableViewController {
         viewModel?.overviewStoreStatusOnChange = { [weak self] status in
             guard let self = self,
                 let viewModel = self.viewModel,
-                self.viewIsVisible(),
                 self.changeReceipt != nil else {
                     return
             }

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -21,7 +21,7 @@ class SiteStatsPeriodViewModel: Observable {
             }
         }
     }
-    private let periodReceipt: Receipt
+    private var periodReceipt: Receipt?
     private var changeReceipt: Receipt?
     private typealias Style = WPStyleGuide.Stats
 
@@ -39,10 +39,6 @@ class SiteStatsPeriodViewModel: Observable {
         self.store = store
         self.lastRequestedDate = selectedDate
         self.lastRequestedPeriod = selectedPeriod
-        periodReceipt = store.query(.periods(date: selectedDate, period: selectedPeriod))
-        store.actionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: selectedDate,
-                                                                               period: selectedPeriod,
-                                                                               forceRefresh: true))
 
         changeReceipt = store.onChange { [weak self] in
             self?.emitChange()
@@ -56,6 +52,13 @@ class SiteStatsPeriodViewModel: Observable {
             let status: Status = fetching ? .fetchingData : .fetchingDataCompleted(success)
             self?.overviewStoreStatusOnChange?(status)
         }
+    }
+
+    func startFetchingOverview() {
+        periodReceipt = store.query(.periods(date: lastRequestedDate, period: lastRequestedPeriod))
+        store.actionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: lastRequestedDate,
+                                                                               period: lastRequestedPeriod,
+                                                                               forceRefresh: true))
     }
 
     // MARK: - Table Model
@@ -89,9 +92,9 @@ class SiteStatsPeriodViewModel: Observable {
     // MARK: - Refresh Data
 
     func refreshPeriodOverviewData(withDate date: Date, forPeriod period: StatsPeriodUnit) {
-        ActionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: date, period: period, forceRefresh: false))
         self.lastRequestedDate = date
         self.lastRequestedPeriod = period
+        ActionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: date, period: period, forceRefresh: false))
     }
 
     // MARK: - State


### PR DESCRIPTION
Fixes #12048 

This PR fixes the delay caused when the chart bar is selected (only for cached data).
Also it introduces an improvement when the cache data is loaded at the beginning and a fix to avoid displaying an empty table if the overview is fetching and a new request is triggered.

![sr-chart](https://user-images.githubusercontent.com/912252/60589809-b0e78c80-9d9a-11e9-8fcb-c6e82f2a8910.gif)

## To test:
- Select a site and open Stats
- Select one of the period DWMY
- Select different dates using the chart bars
- If the data is cached it should update the view immediately

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
