### PR TITLE
Aztec Media: Clear existing errors when restarting

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2250,7 +2250,7 @@ extension AztecPostViewController {
         case .thumbnailReady(let url):
             handleThumbnailURL(url, attachment: attachment)
         case .uploading:
-            break
+            handleUploadStarted(attachment: attachment)
         case .ended:
             handleUploaded(media: media, mediaUploadID: media.uploadID)
         case .failed(let error):
@@ -2474,6 +2474,12 @@ extension AztecPostViewController {
             return
         }
         insert(exportableAsset: image, source: .otherApps, attachment: attachment)
+    }
+
+    private func handleUploadStarted(attachment: MediaAttachment) {
+        resetMediaAttachmentOverlay(attachment)
+        attachment.progress = 0
+        richTextView.refresh(attachment, overlayUpdateOnly: true)
     }
 
     private func handleUploaded(media: Media, mediaUploadID: String) {


### PR DESCRIPTION
Closes part of #11846. 

When a media upload fails and the upload is retried, the error label “Failed to insert media” never disappears even if the retry succeeded. This covers this scenario by clearing the error label when an upload is started or restarted.

| Before | After |
|--------|-------|
| ![old](https://user-images.githubusercontent.com/198826/60619996-4123d280-9d97-11e9-9168-0ea9b9a0044b.gif)       |   ![new](https://user-images.githubusercontent.com/198826/60620003-441ec300-9d97-11e9-96d5-8cd0fceae401.gif)    |

## Testing

1. Go offline.
2. Create a post and add an image. Do not leave the editor. 
3. Go online. The image upload should be restarted. 

Confirm that the error label is no longer shown. 

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
