### PR TITLE
Add support for versioned alternate icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ Scripts/fastlane/report.xml
 Scripts/fastlane/README.md
 Scripts/Preview.html
 Scripts/fastlane/test_output/
+
+# Generated Internal Icons
+/WordPress/Resources/MurielImages.xcassets/AppIcon-Internal.appiconset
+/WordPress/Resources/Icons-Internal

--- a/Scripts/BuildPhases/AddVersionToIcons.sh
+++ b/Scripts/BuildPhases/AddVersionToIcons.sh
@@ -117,3 +117,16 @@ while IFS= read -r -d '' file; do
     echo "$file"
     processIcon "${file}" "${tmp_path}" "${icons_dest_path}"
 done
+
+# Process all alternate app icons
+icons_path="${PROJECT_DIR}/Resources/Icons"
+icons_dest_path="${PROJECT_DIR}/Resources/Icons-Internal"
+
+# Empty and re-make the icon destination directory
+rm -rf "${icons_dest_path}" && mkdir "${icons_dest_path}"
+
+find "${icons_path}" -type f -name "*.png" -print0 |
+while IFS= read -r -d '' file; do
+    echo "$file"
+    processIcon "${file}" "${tmp_path}" "${icons_dest_path}"
+done

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -9955,7 +9955,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\n\n# This script adds the version number to the icon of internal releases.\n\n#export PATH=/opt/local/bin/:/opt/local/sbin:$PATH:/usr/local/bin:\n#if [ \"${CONFIGURATION}\" != \"Release-Internal\" ]; then\n#exit 0;\n#fi\n\nsh ../Scripts/BuildPhases/AddVersionToIcons.sh\n";
+			shellScript = "#!/bin/sh\n\n# This script adds the version number to the icon of internal releases.\n\nexport PATH=/opt/local/bin/:/opt/local/sbin:$PATH:/usr/local/bin:\nif [ \"${CONFIGURATION}\" != \"Release-Internal\" ]; then\nexit 0;\nfi\n\nsh ../Scripts/BuildPhases/AddVersionToIcons.sh\n";
 		};
 		920B9A6DAD47189622A86A9C /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -10151,7 +10151,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Overwrite the icons in the bundle with the updated internal icons\necho \"cp -R ${PROJECT_DIR}/Resources/Icons-Internal/*.png ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/\"\ncp -R ${PROJECT_DIR}/Resources/Icons-Internal/*.png \"${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/\"\n";
+			shellScript = "# Overwrite the icons in the bundle with the updated internal icons\nif [ \"${CONFIGURATION}\" != \"Release-Internal\" ]; then\nexit 0;\nfi\n\ncp -R ${PROJECT_DIR}/Resources/Icons-Internal/*.png \"${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/\"\n";
 		};
 		FFA8E2301F94E3EF0002170F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -9009,6 +9009,7 @@
 				E1756E61169493AD00D9EC00 /* Generate API credentials */,
 				825F0EBF1F7EBF7C00321528 /* App Icons: Add Version For Internal Releases */,
 				1D60588D0D05DD3D006BFB54 /* Resources */,
+				F9C5CF0222CD5DB0007CEF56 /* Copy Alternate Internal Icons (if needed) */,
 				832D4F01120A6F7C001708D4 /* CopyFiles */,
 				1D60588E0D05DD3D006BFB54 /* Sources */,
 				1D60588F0D05DD3D006BFB54 /* Frameworks */,
@@ -9954,7 +9955,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\n\n# This script adds the version number to the icon of internal releases.\n\nexport PATH=/opt/local/bin/:/opt/local/sbin:$PATH:/usr/local/bin:\nif [ \"${CONFIGURATION}\" != \"Release-Internal\" ]; then\nexit 0;\nfi\n\nsh ../Scripts/BuildPhases/AddVersionToIcons.sh";
+			shellScript = "#!/bin/sh\n\n# This script adds the version number to the icon of internal releases.\n\n#export PATH=/opt/local/bin/:/opt/local/sbin:$PATH:/usr/local/bin:\n#if [ \"${CONFIGURATION}\" != \"Release-Internal\" ]; then\n#exit 0;\n#fi\n\nsh ../Scripts/BuildPhases/AddVersionToIcons.sh\n";
 		};
 		920B9A6DAD47189622A86A9C /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -10133,6 +10134,24 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension-resources.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		F9C5CF0222CD5DB0007CEF56 /* Copy Alternate Internal Icons (if needed) */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Alternate Internal Icons (if needed)";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Overwrite the icons in the bundle with the updated internal icons\necho \"cp -R ${PROJECT_DIR}/Resources/Icons-Internal/*.png ${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/\"\ncp -R ${PROJECT_DIR}/Resources/Icons-Internal/*.png \"${CONFIGURATION_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/\"\n";
 		};
 		FFA8E2301F94E3EF0002170F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Adds support for versioned alternate icons for internal builds.

**To Test:**
1) Check out this branch and run `bundle exec pod install`
2) In Xcode, select the "WordPress Internal" target, then the "Generic iOS Device"
3) Choose Product > Archive
4) Once the build is complete, choose Window > Organizer > WordPress Internal. Right-click on the latest archive, and choose "Show in Finder". Right click on the `xcarchive`, and choose "Show Package Contents". Navigate to Products > Applications > WordPress. Right click on the app and choose "Show Package Contents".
5) Verify that all of the `.png` icon files have the right version number. 

6) Back in Xcode, select the "WordPress" target, then the "Generic iOS Device"
7) Choose Product > Archive
8) Once the build is complete, choose Window > Organizer > WordPress. Right-click on the latest archive, and choose "Show in Finder". Right click on the `xcarchive`, and choose "Show Package Contents". Navigate to Products > Applications > WordPress. Right click on the app and choose "Show Package Contents".
9) Verify that none of the `.png` files have the version number on them.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
