### PR TITLE
Default to Gutenberg upon opening a block based post

### DIFF
--- a/WordPress/Classes/Services/KeyValueDatabase.swift
+++ b/WordPress/Classes/Services/KeyValueDatabase.swift
@@ -7,9 +7,14 @@ import Foundation
 /// list objects.
 protocol KeyValueDatabase {
     func object(forKey defaultName: String) -> Any?
-    func bool(forKey: String) -> Bool
     func set(_ value: Any?, forKey defaultName: String)
     func removeObject(forKey defaultName: String)
+}
+
+extension KeyValueDatabase {
+    func bool(forKey key: String) -> Bool {
+        return object(forKey: key) as? Bool ?? false
+    }
 }
 
 // MARK: - Storage implementations
@@ -27,10 +32,6 @@ class EphemeralKeyValueDatabase: KeyValueDatabase {
 
     open func object(forKey defaultName: String) -> Any? {
         return memory[defaultName]
-    }
-
-    open func bool(forKey key: String) -> Bool {
-        return object(forKey: key) as? Bool ?? false
     }
 
     open func removeObject(forKey defaultName: String) {

--- a/WordPress/Classes/Services/KeyValueDatabase.swift
+++ b/WordPress/Classes/Services/KeyValueDatabase.swift
@@ -7,6 +7,7 @@ import Foundation
 /// list objects.
 protocol KeyValueDatabase {
     func object(forKey defaultName: String) -> Any?
+    func bool(forKey: String) -> Bool
     func set(_ value: Any?, forKey defaultName: String)
     func removeObject(forKey defaultName: String)
 }
@@ -26,6 +27,10 @@ class EphemeralKeyValueDatabase: KeyValueDatabase {
 
     open func object(forKey defaultName: String) -> Any? {
         return memory[defaultName]
+    }
+
+    open func bool(forKey key: String) -> Bool {
+        return object(forKey: key) as? Bool ?? false
     }
 
     open func removeObject(forKey defaultName: String) {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -6,8 +6,8 @@ extension GutenbergViewController {
     enum InfoDialog {
         static let key = "Gutenberg.InformativeDialog"
         static let message = NSLocalizedString(
-            "This post was originally created in the Block Editor, so we've enabled it for new Posts.",
-            comment: "Popup content about why this post is being opened in Block Editor"
+            "This post uses the block editor, which is the default editor for new posts. To enable the classic editor, go to Me > App Settings.",
+            comment: "Popup content about why this post is being opened in block editor"
         )
         static let title = NSLocalizedString("Block Editor Enabled", comment: "Popup title about why this post is being opened in Block Editor")
         static let okButtonTitle   = NSLocalizedString("OK", comment: "OK button to close the informative dialog on Gutenberg editor")

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -6,7 +6,7 @@ extension GutenbergViewController {
     enum InfoDialog {
         static let key = "Gutenberg.InformativeDialog"
         static let message = NSLocalizedString(
-            "This post was originally created in the Block Editor, so we've also enabled it on this Post. Switch back to Classic at any time by tapping ••• in the top bar.",
+            "This post was originally created in the Block Editor, so we've enabled it for new Posts.",
             comment: "Popup content about why this post is being opened in Block Editor"
         )
         static let title = NSLocalizedString("Block Editor Enabled", comment: "Popup title about why this post is being opened in Block Editor")
@@ -23,9 +23,13 @@ extension GutenbergViewController {
         on viewController: UIViewControllerTransitioningDelegate & UIViewController,
         animated: Bool = true
     ) {
-        guard !userDefaults.bool(forKey: InfoDialog.key),
-            post.containsGutenbergBlocks() else {
-            // Don't show if this was shown before or the post does not contain blocks
+        let settings = GutenbergSettings(database: userDefaults)
+        guard
+            !userDefaults.bool(forKey: InfoDialog.key),
+            post.containsGutenbergBlocks(),
+            settings.isGutenbergEnabled() == false
+        else {
+            // Don't show if this was shown before or the post does not contain blocks or gutenberg is already enabled.
             return
         }
         let okButton: (title: String, handler: FancyAlertViewController.FancyAlertButtonHandler?) =
@@ -51,5 +55,8 @@ extension GutenbergViewController {
         viewController.present(alert, animated: animated)
         // Save that this alert is shown
         userDefaults.set(true, forKey: InfoDialog.key)
+
+        // Toggle gutenberg default to true
+        settings.toggleGutenberg()
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -1,14 +1,5 @@
 import Foundation
 
-protocol GutenbergFlagsUserDefaultsProtocol {
-    func set(_ value: Bool, forKey defaultName: String)
-    func bool(forKey defaultName: String) -> Bool
-}
-
-extension UserDefaults: GutenbergFlagsUserDefaultsProtocol {
-
-}
-
 /// This extension handles Alert operations.
 extension GutenbergViewController {
 
@@ -27,7 +18,7 @@ extension GutenbergViewController {
     }
 
     static func showInformativeDialogIfNecessary(
-        using userDefaults: GutenbergFlagsUserDefaultsProtocol = UserDefaults.standard,
+        using userDefaults: KeyValueDatabase = UserDefaults.standard,
         showing post: AbstractPost,
         on viewController: UIViewControllerTransitioningDelegate & UIViewController,
         animated: Bool = true

--- a/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
+++ b/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
@@ -3,19 +3,6 @@ import UIKit
 import CoreData
 @testable import WordPress
 
-fileprivate class MockUserDefaults: GutenbergFlagsUserDefaultsProtocol {
-
-    private var boolDictionary: [String: Bool] = [:]
-
-    func set(_ value: Bool, forKey defaultName: String) {
-        boolDictionary[defaultName] = value
-    }
-
-    func bool(forKey defaultName: String) -> Bool {
-        return boolDictionary[defaultName] ?? false
-    }
-}
-
 fileprivate class MockUIViewController: UIViewController, UIViewControllerTransitioningDelegate {
     @objc func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
         return FancyAlertPresentationController(presentedViewController: presented, presenting: presenting)
@@ -38,7 +25,7 @@ class GutenbergInformativeDialogTests: XCTestCase {
 
     private var rootWindow: UIWindow!
     private var viewController: MockUIViewController!
-    private var mockUserDefaults: MockUserDefaults!
+    private var mockUserDefaults: EphemeralKeyValueDatabase!
     private var context: NSManagedObjectContext!
 
     override func setUp() {
@@ -47,7 +34,7 @@ class GutenbergInformativeDialogTests: XCTestCase {
         rootWindow.isHidden = false
         rootWindow.rootViewController = viewController
         context = setUpInMemoryManagedObjectContext()
-        mockUserDefaults = MockUserDefaults()
+        mockUserDefaults = EphemeralKeyValueDatabase()
     }
 
     override func tearDown() {
@@ -62,6 +49,7 @@ class GutenbergInformativeDialogTests: XCTestCase {
     func testShowInformativeDialogWithUserDefaultsFlagWithGutenbergContent() {
         let post = insertPost()
         post.content = PostContent.gutenberg
+
         mockUserDefaults.set(true, forKey: GutenbergViewController.InfoDialog.key)
         XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
@@ -70,6 +58,7 @@ class GutenbergInformativeDialogTests: XCTestCase {
                                                                  animated: false)
         XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
+
     }
 
     func testShowInformativeDialogWithNoUserDefaultsFlagWithGutenbergContent() {

--- a/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
+++ b/WordPress/WordPressTest/GutenbergInformativeDialogTests.swift
@@ -52,49 +52,64 @@ class GutenbergInformativeDialogTests: XCTestCase {
 
         mockUserDefaults.set(true, forKey: GutenbergViewController.InfoDialog.key)
         XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
-        GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
-                                                                 showing: post,
-                                                                 on: viewController,
-                                                                 animated: false)
+        showInformativeDialog(with: post)
+
         XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
-
+        XCTAssertFalse(GutenbergSettings(database: mockUserDefaults).isGutenbergEnabled())
     }
 
     func testShowInformativeDialogWithNoUserDefaultsFlagWithGutenbergContent() {
         let post = insertPost()
         post.content = PostContent.gutenberg
         XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
-        GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
-                                                                 showing: post,
-                                                                 on: viewController,
-                                                                 animated: false)
+        showInformativeDialog(with: post)
+
         XCTAssertTrue(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         XCTAssertNotNil(viewController.presentedViewController as? FancyAlertViewController)
+        XCTAssertTrue(GutenbergSettings(database: mockUserDefaults).isGutenbergEnabled())
     }
 
     func testShowInformativeDialogWithNoUserDefaultsFlagWithEmptyContent() {
         let post = insertPost()
         post.content = ""
         XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
-        GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
-                                                                 showing: post,
-                                                                 on: viewController,
-                                                                 animated: false)
+        showInformativeDialog(with: post)
+
         XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
         XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
+        XCTAssertFalse(GutenbergSettings(database: mockUserDefaults).isGutenbergEnabled())
     }
 
     func testShowInformativeDialogWithNoUserDefaultsFlagWithClassicContent() {
         let post = insertPost()
         post.content = PostContent.classic
         XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
+        showInformativeDialog(with: post)
+
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
+        XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
+        XCTAssertFalse(GutenbergSettings(database: mockUserDefaults).isGutenbergEnabled())
+    }
+
+    func testShowInformativeDialogWithGutenbergSetAsDefaultShouldNotShowDialog() {
+        let post = insertPost()
+        post.content = PostContent.gutenberg
+        GutenbergSettings(database: mockUserDefaults).toggleGutenberg()
+
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
+        showInformativeDialog(with: post)
+
+        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
+        XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
+        XCTAssertTrue(GutenbergSettings(database: mockUserDefaults).isGutenbergEnabled())
+    }
+
+    private func showInformativeDialog(with post: AbstractPost) {
         GutenbergViewController.showInformativeDialogIfNecessary(using: mockUserDefaults,
                                                                  showing: post,
                                                                  on: viewController,
                                                                  animated: false)
-        XCTAssertFalse(mockUserDefaults.bool(forKey: GutenbergViewController.InfoDialog.key))
-        XCTAssertNil(viewController.presentedViewController as? FancyAlertViewController)
     }
 
     private func insertPost() -> AbstractPost {

--- a/WordPress/WordPressTest/NullMockUserDefaults.swift
+++ b/WordPress/WordPressTest/NullMockUserDefaults.swift
@@ -7,10 +7,6 @@ class NullMockUserDefaults: KeyValueDatabase {
         return nil
     }
 
-    func bool(forKey: String) -> Bool {
-        return false
-    }
-
     func set(_ value: Any?, forKey defaultName: String) {
         //
     }

--- a/WordPress/WordPressTest/NullMockUserDefaults.swift
+++ b/WordPress/WordPressTest/NullMockUserDefaults.swift
@@ -7,6 +7,10 @@ class NullMockUserDefaults: KeyValueDatabase {
         return nil
     }
 
+    func bool(forKey: String) -> Bool {
+        return false
+    }
+
     func set(_ value: Any?, forKey defaultName: String) {
         //
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/1186

This PR flips the "default for new posts" switch to true the first time the block editor is launched, if the switch is off.

The alert text was changed to match https://github.com/wordpress-mobile/gutenberg-mobile/issues/1186#issuecomment-508231868

The logic is:
- The alert will be shown if:
  - The Gutenberg default switch is off
  - The post has gutenberg blocks
  - Is first time opening a gutenberg post

When the alert is shown, we automatically flip the switch located in App Settings.

This will trigger the tracks event `AppSettingsGutenbergEnabled` but I'd say that it is still desirable, unless we want a new tracks event for this particular case?

I'm unsure if we should add this to the release notes.

**To test:**

- Set `UserDefaults.standard.setValue(false, forKey: "Gutenberg.InformativeDialog")` to be triggered on app lunch. (on `applicationWillEnterForeground` is helpful to easily reset it)
- Make sure the gutenberg switch is off on App Settings
- Open a new post
  - It should open Aztec
- Open a post without gutenberg blocks
  - It should open Aztec
- Open a post with gutenberg blocks
  - It should open gutenberg and show the alert
- Open again the same post
  - It should open gutenberg without showing the alert
- Open a new post
  - It should open gutenberg
- Check the switch on AppSettings
  - It should be ON
- Flip the AppSettings switch to OFF
- Open a gutenberg post
  - It should open gutenberg
  - It should NOT show the alert
  - it should NOT flip the switch back to ON

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.