### PR TITLE
[Stats Refresh] Avoid deselect action when a chart bar is selected

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -120,7 +120,7 @@ class StatsBarChartView: BarChartView {
 private extension StatsBarChartView {
     func setupGestures() {
         gestureRecognizers = gestureRecognizers?.filter { gesture in
-            if let gesture = (gesture as? UITapGestureRecognizer) {
+            if let gesture = gesture as? UITapGestureRecognizer {
                 return gesture.numberOfTapsRequired != 1
             }
             return true

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -103,6 +103,7 @@ class StatsBarChartView: BarChartView {
         super.init(frame: .zero)
 
         initialize()
+        setupGestures()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -117,6 +118,26 @@ class StatsBarChartView: BarChartView {
 // MARK: - Private behavior
 
 private extension StatsBarChartView {
+    func setupGestures() {
+        gestureRecognizers = gestureRecognizers?.filter { gesture in
+            if let gesture = (gesture as? UITapGestureRecognizer) {
+                return gesture.numberOfTapsRequired != 1
+            }
+            return true
+        }
+        let tapGestureRecognizer = NSUITapGestureRecognizer(target: self, action: #selector(barTapGestureRecognized(_:)))
+        addGestureRecognizer(tapGestureRecognizer)
+    }
+
+    @objc func barTapGestureRecognized(_ recognizer: NSUITapGestureRecognizer) {
+        if data != nil, recognizer.state == .ended,
+            let highlight = getHighlightByTouchPoint(recognizer.location(in: self)),
+            highlight != lastHighlighted {
+            lastHighlighted = highlight
+            highlightValue(highlight, callDelegate: true)
+        }
+    }
+
     func applyStyling() {
         configureBarChartViewProperties()
         configureBarLineChartViewBaseProperties()


### PR DESCRIPTION
Refs. #11852

This PR removes the possibility to deselect a selected chart bar. Unfortunately there's no property to enable/disable this feature and there's no public method to override the behaviour.
For this reason I replaced the default tap gesture implementing a new one owned by the `StatsBarChartView` itself.

![sr-deselect-bar](https://user-images.githubusercontent.com/912252/60672297-4f482080-9e75-11e9-8507-424eb1fb97b1.gif)

## To test:
- Open a DWMY period and select a date from the chart
- Try to tap on the same bar verifying the bar is not deselected

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
