### PR TITLE
[Stats Refresh] Update Insights Posting activity colors

### DIFF
--- a/WordPress/Classes/Extensions/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/UIColor+MurielColors.swift
@@ -114,6 +114,9 @@ extension UIColor {
 
     /// Muriel brand color
     static var brand = muriel(color: .brand)
+    class func brand(shade: MurielColorShade) -> UIColor {
+        return muriel(color: MurielColor(from: .brand, shade: shade))
+    }
 
     /// Muriel divider color
     static var divider = muriel(color: .divider)

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -199,10 +199,10 @@ extension WPStyleGuide {
 
         struct PostingActivityColors {
             static let lightGrey = UIColor.neutral(shade: .shade10)
-            static let lightBlue = UIColor.brand(shade: .shade10)
-            static let mediumBlue = UIColor.brand(shade: .shade30)
-            static let blue = UIColor.brand
-            static let darkBlue = UIColor.brand(shade: .shade70)
+            static let lightBlue = UIColor.primary(shade: .shade5)
+            static let mediumBlue = UIColor.primaryLight
+            static let blue = UIColor.primary
+            static let darkBlue = UIColor.primaryDark
             static let pink = UIColor.accent
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -199,11 +199,11 @@ extension WPStyleGuide {
 
         struct PostingActivityColors {
             static let lightGrey = UIColor.neutral(shade: .shade10)
-            static let lightBlue = UIColor(fromRGBAColorWithRed: 145.0, green: 226.0, blue: 251.0, alpha: 1)
-            static let mediumBlue = UIColor(fromRGBAColorWithRed: 0.0, green: 190.0, blue: 246.0, alpha: 1)
-            static let darkBlue = UIColor(fromRGBAColorWithRed: 0.0, green: 131.0, blue: 169.0, alpha: 1)
-            static let darkGrey = UIColor.neutral(shade: .shade70)
-            static let orange = UIColor(fromRGBAColorWithRed: 245.0, green: 131.0, blue: 53.0, alpha: 1)
+            static let lightBlue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade10))
+            static let mediumBlue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade30))
+            static let blue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade50))
+            static let darkBlue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade70))
+            static let pink = UIColor.accent(shade: .shade50)
         }
 
         // MARK: - Posting Activity Collection View Styles

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -199,11 +199,11 @@ extension WPStyleGuide {
 
         struct PostingActivityColors {
             static let lightGrey = UIColor.neutral(shade: .shade10)
-            static let lightBlue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade10))
-            static let mediumBlue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade30))
+            static let lightBlue = UIColor.brand(shade: .shade10)
+            static let mediumBlue = UIColor.brand(shade: .shade30)
             static let blue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade50))
             static let darkBlue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade70))
-            static let pink = UIColor.accent(shade: .shade50)
+            static let pink = UIColor.accent
         }
 
         // MARK: - Posting Activity Collection View Styles

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -199,9 +199,9 @@ extension WPStyleGuide {
 
         struct PostingActivityColors {
             static let lightGrey = UIColor.neutral(shade: .shade10)
-            static let lightBlue = UIColor.brand(shade: .shade10)
-            static let mediumBlue = UIColor.brand(shade: .shade30)
-            static let blue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade50))
+            static let lightBlue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade10))
+            static let mediumBlue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade30))
+            static let blue = UIColor.brand
             static let darkBlue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade70))
             static let pink = UIColor.accent
         }

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -199,10 +199,10 @@ extension WPStyleGuide {
 
         struct PostingActivityColors {
             static let lightGrey = UIColor.neutral(shade: .shade10)
-            static let lightBlue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade10))
-            static let mediumBlue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade30))
+            static let lightBlue = UIColor.brand(shade: .shade10)
+            static let mediumBlue = UIColor.brand(shade: .shade30)
             static let blue = UIColor.brand
-            static let darkBlue = UIColor.muriel(color: MurielColor(name: .airo, shade: .shade70))
+            static let darkBlue = UIColor.brand(shade: .shade70)
             static let pink = UIColor.accent
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
@@ -48,7 +48,7 @@ private extension PostingActivityDay {
     }
 
     @IBAction func dayButtonPressed(_ sender: UIButton) {
-        dayButton.backgroundColor = WPStyleGuide.Stats.PostingActivityColors.orange
+        dayButton.backgroundColor = WPStyleGuide.Stats.PostingActivityColors.pink
         delegate?.daySelected(self)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityLegend.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityLegend.swift
@@ -29,9 +29,9 @@ class PostingActivityLegend: UIView, NibLoadable {
         case 3...5:
             return Style.PostingActivityColors.mediumBlue
         case 6...7:
-            return Style.PostingActivityColors.darkBlue
+            return Style.PostingActivityColors.blue
         default:
-            return Style.PostingActivityColors.darkGrey
+            return Style.PostingActivityColors.darkBlue
         }
     }
 


### PR DESCRIPTION
Refs. #11852 

This PR updates the colors used in _Insights -> Posting Activity_

![sr-post-activity-colors](https://user-images.githubusercontent.com/912252/60721007-d1475080-9f2c-11e9-8194-e3345d176860.jpg)
**Left Image:** _Old colors_    |    **Right Image:** _New colors_

## To test:
- Select a site with some Posting activity
- Open Stats -> Insights and scroll until Posting activity is displayed

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
