### PR TITLE
Numerous color palette tweaks

### DIFF
--- a/WordPress/Classes/Extensions/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/UIColor+MurielColors.swift
@@ -59,7 +59,7 @@ struct MurielColor {
     // MARK: - Muriel's semantic colors
     static let accent = MurielColor(name: .pink)
     static let brand = MurielColor(name: .airo)
-    static let divider = MurielColor(name: .gray, shade: .shade5)
+    static let divider = MurielColor(name: .gray, shade: .shade10)
     static let error = MurielColor(name: .red)
     static let neutral = MurielColor(name: .gray)
     static let primary = MurielColor(name: .blue)

--- a/WordPress/Classes/Extensions/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/UIColor+MurielColors.swift
@@ -58,10 +58,11 @@ struct MurielColor {
 
     // MARK: - Muriel's semantic colors
     static let accent = MurielColor(name: .pink)
+    static let brand = MurielColor(name: .airo)
     static let divider = MurielColor(name: .gray, shade: .shade5)
     static let error = MurielColor(name: .red)
     static let neutral = MurielColor(name: .gray)
-    static let primary = MurielColor(name: .airo)
+    static let primary = MurielColor(name: .blue)
     static let success = MurielColor(name: .green)
     static let text = MurielColor(name: .gray, shade: .shade80)
     static let textSubtle = MurielColor(name: .gray, shade: .shade50)
@@ -110,6 +111,9 @@ extension UIColor {
     class func accent(shade: MurielColorShade) -> UIColor {
         return muriel(color: MurielColor(from: .accent, shade: shade))
     }
+
+    /// Muriel brand color
+    static var brand = muriel(color: .brand)
 
     /// Muriel divider color
     static var divider = muriel(color: .divider)

--- a/WordPress/Classes/Extensions/UIColor+MurielColorsObjC.swift
+++ b/WordPress/Classes/Extensions/UIColor+MurielColorsObjC.swift
@@ -67,6 +67,16 @@
     }
 
     @available(swift, obsoleted: 1.0)
+    static func murielText() -> UIColor {
+        return .text
+    }
+
+    @available(swift, obsoleted: 1.0)
+    static func murielTextSubtle() -> UIColor {
+        return .textSubtle
+    }
+
+    @available(swift, obsoleted: 1.0)
     static func murielAccent() -> UIColor {
         return .accent
     }

--- a/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
@@ -20,7 +20,7 @@ extension WPStyleGuide {
             configureNavigationBarAppearance()
             return
         }
-        
+
         UIWindow.appearance().tintColor = .primary
     }
 

--- a/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
@@ -64,7 +64,10 @@ extension WPStyleGuide {
         guard let tableView = tableView else {
             return
         }
-        if !FeatureFlag.murielColors.enabled {
+        if FeatureFlag.murielColors.enabled {
+            tableView.backgroundColor = .neutral(shade: .shade0)
+            tableView.separatorColor = .neutral(shade: .shade10)
+        } else {
             tableView.backgroundView = nil
             tableView.backgroundColor = greyLighten30()
             tableView.separatorColor = greyLighten20()

--- a/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
@@ -15,6 +15,15 @@ extension WPStyleGuide {
         return UIImage(color: UIColor(fromHex: 0x007eb1))
     }
 
+    class func configureDefaultTint() {
+        guard FeatureFlag.murielColors.enabled else {
+            configureNavigationBarAppearance()
+            return
+        }
+        
+        UIWindow.appearance().tintColor = .primary
+    }
+
     /// Style the navigation appearance using Muriel colors
     class func configureNavigationAppearance() {
         guard FeatureFlag.murielColors.enabled else {

--- a/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
@@ -91,7 +91,7 @@ extension WPStyleGuide {
         // we only set the text subtle color, so that system colors are used otherwise
         if FeatureFlag.murielColors.enabled {
             cell.detailTextLabel?.textColor = .textSubtle
-            cell.imageView?.tintColor = .neutral
+            cell.imageView?.tintColor = .neutral(shade: .shade30)
         } else {
             cell.textLabel?.textColor = darkGrey()
             cell.detailTextLabel?.textColor = grey()

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -770,6 +770,7 @@ extension WordPressAppDelegate {
 
         WPStyleGuide.configureTabBarAppearance()
         WPStyleGuide.configureNavigationAppearance()
+        WPStyleGuide.configureDefaultTint()
         if !FeatureFlag.murielColors.enabled {
             UITabBar.appearance().shadowImage = UIImage(color: UIColor(red: 210.0/255.0, green: 222.0/255.0, blue: 230.0/255.0, alpha: 1.0))
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -3254,7 +3254,7 @@ extension AztecPostViewController {
         static let mediaProgressOverlay         = UIColor.neutral(shade: .shade70).withAlphaComponent(CGFloat(0.6))
         static let mediaProgressBarBackground   = UIColor.neutral(shade: .shade0)
         static let mediaProgressBarTrack        = UIColor.primary
-        static let aztecLinkColor               = UIColor.primary(shade: .shade40)
+        static let aztecLinkColor               = UIColor.primary
         static let mediaOverlayBorderColor      = UIColor.primary
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -4,7 +4,6 @@
 #import "WordPress-Swift.h"
 
 
-
 const CGFloat BlogDetailHeaderViewBlavatarSize = 40.0;
 const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 
@@ -221,7 +220,7 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     label.numberOfLines = 1;
     label.backgroundColor = [UIColor clearColor];
     label.opaque = YES;
-    label.textColor = [WPStyleGuide littleEddieGrey];
+    label.textColor = [UIColor murielText];
     label.adjustsFontSizeToFitWidth = NO;
     [WPStyleGuide configureLabel:label textStyle:UIFontTextStyleCallout];
 
@@ -239,7 +238,7 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     label.numberOfLines = 1;
     label.backgroundColor = [UIColor clearColor];
     label.opaque = YES;
-    label.textColor = [WPStyleGuide allTAllShadeGrey];
+    label.textColor = [UIColor murielNeutral];
     label.adjustsFontSizeToFitWidth = NO;
     [WPStyleGuide configureLabel:label textStyle:UIFontTextStyleCaption1 symbolicTraits:UIFontDescriptorTraitItalic];
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -109,7 +109,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                     identifier:identifier
        accessibilityIdentifier:accessibilityIdentifier
                          image:image
-                    imageColor:[UIColor murielNeutral]
+                    imageColor:[UIColor murielNeutral30]
                       callback:callback];
 }
     

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -393,7 +393,7 @@ static NSInteger HideSearchMinSites = 3;
         _headerLabel = [[UILabel alloc] initWithFrame:CGRectZero];
         _headerLabel.numberOfLines = 0;
         _headerLabel.textAlignment = NSTextAlignmentCenter;
-        _headerLabel.textColor = [WPStyleGuide allTAllShadeGrey];
+        _headerLabel.textColor = [UIColor murielText];
         _headerLabel.font = [WPFontManager systemRegularFontOfSize:14.0];
         _headerLabel.text = NSLocalizedString(@"Select which sites will be shown in the site picker.", @"Blog list page edit mode header label");
     }

--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Blog.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Blog.swift
@@ -9,7 +9,7 @@ extension WPStyleGuide {
 
         cell.detailTextLabel?.font = self.subtitleFont()
         cell.detailTextLabel?.sizeToFit()
-        cell.detailTextLabel?.textColor = .neutral(shade: .shade20)
+        cell.detailTextLabel?.textColor = .textSubtle
 
         cell.imageView?.layer.borderColor = UIColor.white.cgColor
         cell.imageView?.layer.borderWidth = 1

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -21,12 +21,12 @@ extension WPStyleGuide {
         // NoteTableViewCell
         public static let noticonFont               = UIFont(name: "Noticons", size: 16)
         public static let noticonTextColor          = UIColor.white
-        public static let noticonReadColor          = UIColor(red: 0xA4/255.0, green: 0xB9/255.0, blue: 0xC9/255.0, alpha: 0xFF/255.0)
-        public static let noticonUnreadColor        = UIColor(red: 0x25/255.0, green: 0x9C/255.0, blue: 0xCF/255.0, alpha: 0xFF/255.0)
-        public static let noticonUnmoderatedColor   = WPStyleGuide.alertYellowDark()
+        public static let noticonReadColor          = UIColor.neutral(shade: .shade20)
+        public static let noticonUnreadColor        = UIColor.primary
+        public static let noticonUnmoderatedColor   = UIColor.warning
 
         public static let noteBackgroundReadColor   = UIColor.white
-        public static let noteBackgroundUnreadColor = UIColor(red: 0xF1/255.0, green: 0xF6/255.0, blue: 0xF9/255.0, alpha: 0xFF/255.0)
+        public static let noteBackgroundUnreadColor = UIColor.neutral(shade: .shade0)
 
         public static let noteSeparatorColor        = blockSeparatorColor
 
@@ -74,7 +74,7 @@ extension WPStyleGuide {
         public static let headerTitleColor          = blockTextColor
         public static let headerTitleBoldFont       = blockBoldFont
 
-        public static let headerDetailsColor        = UIColor(red: 0x00/255.0, green: 0xAA/255.0, blue: 0xDC/255.0, alpha: 0xFF/255.0)
+        public static let headerDetailsColor        = UIColor.primary
         public static let headerDetailsRegularFont  = blockRegularFont
 
         public static var headerTitleRegularStyle: [NSAttributedString.Key: Any] {
@@ -118,15 +118,15 @@ extension WPStyleGuide {
         public static let blockRegularFont          = WPFontManager.systemRegularFont(ofSize: blockFontSize)
         public static let blockBoldFont             = WPFontManager.systemSemiBoldFont(ofSize: blockFontSize)
 
-        public static let blockTextColor            = WPStyleGuide.littleEddieGrey()
-        public static let blockQuotedColor          = UIColor(red: 0x7E/255.0, green: 0x9E/255.0, blue: 0xB5/255.0, alpha: 0xFF/255.0)
+        public static let blockTextColor            = UIColor.text
+        public static let blockQuotedColor          = UIColor.neutral
         public static let blockBackgroundColor      = UIColor.white
         public static let blockLinkColor            = UIColor.primary
-        public static let blockSeparatorColor       = WPStyleGuide.readGrey()
+        public static let blockSeparatorColor       = UIColor.divider
 
         public static let blockApprovedBgColor      = UIColor.clear
 
-        public static let blockUnapprovedSideColor  = WPStyleGuide.alertYellowDark()
+        public static let blockUnapprovedSideColor  = UIColor.warning(shade: .shade60)
         public static let blockUnapprovedBgColor    = UIColor.warning(shade: .shade0)
         public static let blockUnapprovedTextColor  = UIColor.errorDark
         public static let blockUnapprovedLinkColor  = UIColor.primary
@@ -198,8 +198,8 @@ extension WPStyleGuide {
         }
 
         // Action Buttons
-        public static let blockActionDisabledColor  = UIColor(red: 0x7F/255.0, green: 0x9E/255.0, blue: 0xB4/255.0, alpha: 0xFF/255.0)
-        public static let blockActionEnabledColor   = UIColor(red: 0xEA/255.0, green: 0x6D/255.0, blue: 0x1B/255.0, alpha: 0xFF/255.0)
+        public static let blockActionDisabledColor  = UIColor.neutral
+        public static let blockActionEnabledColor   = UIColor.primary
 
         // RichText Helpers
         public static func blockBackgroundColorForRichText(_ isBadge: Bool) -> UIColor {
@@ -318,13 +318,13 @@ extension WPStyleGuide {
         )
 
         // Colors
-        fileprivate static let sectionHeaderTextColor   = UIColor(red: 0xA7/255.0, green: 0xBB/255.0, blue: 0xCA/255.0, alpha: 0xFF/255.0)
-        fileprivate static let subjectTextColor         = WPStyleGuide.littleEddieGrey()
+        fileprivate static let sectionHeaderTextColor   = UIColor.neutral(shade: .shade20)
+        fileprivate static let subjectTextColor         = UIColor.text
         fileprivate static let subjectNoticonColor      = noticonReadColor
-        fileprivate static let footerTextColor          = WPStyleGuide.allTAllShadeGrey()
-        fileprivate static let blockNoticonColor        = WPStyleGuide.allTAllShadeGrey()
-        fileprivate static let snippetColor             = WPStyleGuide.allTAllShadeGrey()
-        fileprivate static let headerTitleContextColor  = WPStyleGuide.allTAllShadeGrey()
+        fileprivate static let footerTextColor          = UIColor.textSubtle
+        fileprivate static let blockNoticonColor        = UIColor.error
+        fileprivate static let snippetColor             = UIColor.neutral
+        fileprivate static let headerTitleContextColor  = UIColor.primary
 
         // Fonts
         fileprivate static var sectionHeaderFont: UIFont {

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -121,7 +121,7 @@ extension WPStyleGuide {
         public static let blockTextColor            = WPStyleGuide.littleEddieGrey()
         public static let blockQuotedColor          = UIColor(red: 0x7E/255.0, green: 0x9E/255.0, blue: 0xB5/255.0, alpha: 0xFF/255.0)
         public static let blockBackgroundColor      = UIColor.white
-        public static let blockLinkColor            = WPStyleGuide.baseLighterBlue()
+        public static let blockLinkColor            = UIColor.primary
         public static let blockSeparatorColor       = WPStyleGuide.readGrey()
 
         public static let blockApprovedBgColor      = UIColor.clear
@@ -129,7 +129,7 @@ extension WPStyleGuide {
         public static let blockUnapprovedSideColor  = WPStyleGuide.alertYellowDark()
         public static let blockUnapprovedBgColor    = UIColor.warning(shade: .shade0)
         public static let blockUnapprovedTextColor  = UIColor.errorDark
-        public static let blockUnapprovedLinkColor  = UIColor.primary(shade: .shade40)
+        public static let blockUnapprovedLinkColor  = UIColor.primary
 
         public static var contentBlockRegularStyle: [NSAttributedString.Key: Any] {
             return  [.paragraphStyle: contentBlockParagraph,

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -198,7 +198,7 @@ extension WPStyleGuide {
         }
 
         // Action Buttons
-        public static let blockActionDisabledColor  = UIColor.neutral
+        public static let blockActionDisabledColor  = UIColor.neutral(shade: .shade30)
         public static let blockActionEnabledColor   = UIColor.primary
 
         // RichText Helpers
@@ -322,7 +322,7 @@ extension WPStyleGuide {
         fileprivate static let subjectTextColor         = UIColor.text
         fileprivate static let subjectNoticonColor      = noticonReadColor
         fileprivate static let footerTextColor          = UIColor.textSubtle
-        fileprivate static let blockNoticonColor        = UIColor.error
+        fileprivate static let blockNoticonColor        = UIColor.neutral
         fileprivate static let snippetColor             = UIColor.neutral
         fileprivate static let headerTitleContextColor  = UIColor.primary
 

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Reply.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Reply.swift
@@ -11,11 +11,11 @@ extension WPStyleGuide {
         public static var textFont: UIFont {
             return WPStyleGuide.notoFontForTextStyle(.subheadline)
         }
-        public static let enabledColor     = WPStyleGuide.newKidOnTheBlockBlue()
-        public static let disabledColor    = UIColor(red: 0xA1/255.0, green: 0xB9/255.0, blue: 0xCA/255.0, alpha: 0xFF/255.0)
-        public static let placeholderColor = UIColor(red: 0xA3/255.0, green: 0xB9/255.0, blue: 0xCA/255.0, alpha: 0xFF/255.0)
-        public static let textColor        = WPStyleGuide.littleEddieGrey()
-        public static let separatorColor   = placeholderColor
-        public static let backgroundColor  = UIColor(red: 0xF1/255.0, green: 0xF6/255.0, blue: 0xF9/255.0, alpha: 0xFF/255.0)
+        public static let enabledColor     = UIColor.primary
+        public static let disabledColor    = UIColor.neutral(shade: .shade20)
+        public static let placeholderColor = UIColor.neutral(shade: .shade20)
+        public static let textColor        = UIColor.text
+        public static let separatorColor   = UIColor.neutral(shade: .shade20)
+        public static let backgroundColor  = UIColor.neutral(shade: .shade0)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -211,16 +211,19 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
 
         btnEdit.setTitle(EditComment.title, for: UIControl.State())
         btnEdit.setTitleColor(textNormalColor, for: UIControl.State())
+        btnEdit.tintColor = textNormalColor
         btnEdit.accessibilityLabel = EditComment.title
         btnEdit.accessibilityHint = EditComment.hint
 
         btnSpam.setTitle(MarkAsSpam.title, for: .normal)
         btnSpam.setTitleColor(textNormalColor, for: UIControl.State())
+        btnSpam.tintColor = textNormalColor
         btnSpam.accessibilityLabel = MarkAsSpam.title
         btnSpam.accessibilityHint = MarkAsSpam.hint
 
         btnTrash.setTitle(TrashComment.title, for: .normal)
         btnTrash.setTitleColor(textNormalColor, for: UIControl.State())
+        btnTrash.tintColor = textNormalColor
         btnTrash.accessibilityLabel = TrashComment.title
         btnTrash.accessibilityHint = TrashComment.hint
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,13 +19,13 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="8I0-Zx-4NW">
-                        <rect key="frame" x="0.0" y="0.0" width="389" height="72"/>
+                        <rect key="frame" x="0.0" y="0.0" width="389" height="71.5"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="V3D-QS-G4g">
-                                <rect key="frame" x="20" y="11" width="349" height="50.5"/>
+                                <rect key="frame" x="20" y="11" width="349" height="50"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Agc-K2-0vs" userLabel="Approve" customClass="VerticallyStackedButton">
-                                        <rect key="frame" x="0.0" y="9" width="58" height="33"/>
+                                        <rect key="frame" x="0.0" y="8.5" width="58" height="33"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="6" maxX="0.0" maxY="6"/>
                                         <state key="normal" title="Approve" image="notifications-approve">
@@ -39,7 +39,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hU3-yd-ZtO" userLabel="Spam" customClass="VerticallyStackedButton">
-                                        <rect key="frame" x="58" y="9" width="58.5" height="33"/>
+                                        <rect key="frame" x="58" y="8.5" width="58.5" height="33"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="6" maxX="0.0" maxY="6"/>
                                         <state key="normal" title="Spam" image="notifications-spam">
@@ -51,7 +51,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TYK-fl-vc7" userLabel="Trash" customClass="VerticallyStackedButton">
-                                        <rect key="frame" x="116.5" y="9" width="58" height="33"/>
+                                        <rect key="frame" x="116.5" y="8.5" width="58" height="33"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="6" maxX="0.0" maxY="6"/>
                                         <state key="normal" title="Trash" image="notifications-trash">
@@ -63,7 +63,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="e8r-Uo-uFk" userLabel="Like" customClass="VerticallyStackedButton">
-                                        <rect key="frame" x="174.5" y="9" width="58" height="33"/>
+                                        <rect key="frame" x="174.5" y="8.5" width="58" height="33"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="6" maxX="0.0" maxY="6"/>
                                         <state key="normal" title="Like" image="notifications-like">
@@ -77,7 +77,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LLz-LW-VxX" userLabel="Edit" customClass="VerticallyStackedButton">
-                                        <rect key="frame" x="232.5" y="9.5" width="58.5" height="32"/>
+                                        <rect key="frame" x="232.5" y="9" width="58.5" height="32"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="6" maxX="0.0" maxY="6"/>
                                         <state key="normal" title="Edit" image="icon-pencil">
@@ -91,7 +91,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DXE-y2-DWd" userLabel="Reply" customClass="VerticallyStackedButton">
-                                        <rect key="frame" x="291" y="9" width="58" height="33"/>
+                                        <rect key="frame" x="291" y="8.5" width="58" height="33"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="6" maxX="0.0" maxY="6"/>
                                         <state key="normal" title="Reply" image="notifications-reply">

--- a/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
+++ b/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -115,7 +115,7 @@
                     <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="GUI-3V-x2m">
                         <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" red="0.9137254901960784" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </refreshControl>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="SeM-Uk-MdX" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardActionBar.m
@@ -344,6 +344,7 @@ static const UIEdgeInsets MoreButtonImageInsets = {0.0, 0.0, 0.0, 4.0};
 
         item.imageInsets = imageInsets;
     }
+    item.tintColor = [UIColor murielPrimary];
     return item;
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTableViewCell.m
@@ -674,6 +674,7 @@ typedef NS_ENUM(NSUInteger, ActionBarMode) {
                                                       highlightedImage:nil];
     item.callback = callback;
     item.imageInsets = imageInsets;
+    item.tintColor = [UIColor murielPrimary];
     return item;
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardTextCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -215,7 +215,6 @@
                         </constraints>
                     </view>
                 </subviews>
-                <color key="backgroundColor" red="0.60000002379999995" green="0.60000002379999995" blue="0.60000002379999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 <constraints>
                     <constraint firstItem="Lk7-nZ-b0t" firstAttribute="trailing" secondItem="MWK-lj-FaS" secondAttribute="trailingMargin" constant="2" id="2At-kP-Urm">
                         <variation key="widthClass=regular" constant="0.0"/>

--- a/WordPress/Classes/ViewRelated/Post/PostListFooterView.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListFooterView.m
@@ -15,8 +15,8 @@
 {
     [super awakeFromNib];
 
-    self.backgroundColor = [UIColor murielNeutral5];
-    self.bannerView.backgroundColor = [UIColor murielNeutral5];
+    self.backgroundColor = [UIColor clearColor];
+    self.bannerView.backgroundColor = [UIColor murielNeutral0];
     self.bannerView.hidden = YES;
 }
 

--- a/WordPress/Classes/ViewRelated/Post/Posts.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Posts.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -120,7 +119,6 @@
                     <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="yaY-3g-ZFU">
                         <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" red="0.91372549020000005" green="0.93725490199999995" blue="0.95294117649999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                     </refreshControl>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="YkQ-BC-2ME" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -30,13 +30,13 @@
 
 + (UIColor *)postCardBorderColor
 {
-    return [UIColor colorWithRed:215.0/255.0 green:227.0/255.0 blue:235.0/255.0 alpha:1.0];
+    return [UIColor murielNeutral10];
 }
 
 + (void)applyPostCardStyle:(UITableViewCell *)cell
 {
-    cell.backgroundColor = [UIColor murielNeutral5];
-    cell.contentView.backgroundColor = [UIColor murielNeutral5];
+    cell.backgroundColor = [UIColor clearColor];
+    cell.contentView.backgroundColor = [UIColor clearColor];
 }
 
 + (void)applyPostAuthorSiteStyle:(UILabel *)label

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -42,41 +42,41 @@
 + (void)applyPostAuthorSiteStyle:(UILabel *)label
 {
     [self configureLabelForRegularFontStyle:label];
-    label.textColor = [self greyDarken20];
+    label.textColor = [UIColor murielText];
 }
 
 + (void)applyPostAuthorNameStyle:(UILabel *)label
 {
     [self configureLabelForSmallFontStyle:label];
-    label.textColor = [self grey];
+    label.textColor = [UIColor murielTextSubtle];
 }
 
 + (void)applyPostTitleStyle:(UILabel *)label
 {
-    label.textColor = [self darkGrey];
+    label.textColor = [UIColor murielText];
 }
 
 + (void)applyPostSnippetStyle:(UILabel *)label
 {
-    label.textColor = [self darkGrey];
+    label.textColor = [UIColor murielText];
 }
 
 + (void)applyPostDateStyle:(UILabel *)label
 {
     [self configureLabelForDeviceDependantStyle:label];
-    label.textColor = [self grey];
+    label.textColor = [UIColor murielNeutral30];
 }
 
 + (void)applyPostStatusStyle:(UILabel *)label
 {
     [self configureLabelForDeviceDependantStyle:label];
-    label.textColor = [self grey];
+    label.textColor = [UIColor murielTextSubtle];
 }
 
 + (void)applyPostMetaButtonStyle:(UIButton *)button
 {
     [self configureLabelForDeviceDependantStyle:button.titleLabel];
-    [button setTitleColor:[self grey] forState:UIControlStateNormal];
+    [button setTitleColor:[UIColor murielNeutral30] forState:UIControlStateNormal];
 }
 
 + (void)applyPostProgressViewStyle:(UIProgressView *)progressView
@@ -89,7 +89,7 @@
 + (void)applyRestorePostLabelStyle:(UILabel *)label
 {
     [self configureLabelForDeviceDependantStyle:label];
-    label.textColor = [self grey];
+    label.textColor = [UIColor murielTextSubtle];
 }
 
 + (void)applyRestorePostButtonStyle:(UIButton *)button

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.m
@@ -30,7 +30,7 @@
 
 + (UIColor *)postCardBorderColor
 {
-    return [UIColor murielNeutral10];
+    return [UIColor murielNeutral5];
 }
 
 + (void)applyPostCardStyle:(UITableViewCell *)cell

--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
@@ -84,7 +84,7 @@ final class NewsCard: UIViewController {
     }
 
     private func styleBackground() {
-        view.backgroundColor = .neutral(shade: .shade5)
+        view.backgroundColor = .clear
     }
 
     private func styleBorderedView() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.swift
@@ -11,7 +11,7 @@ open class ReaderBlockedSiteCell: UITableViewCell {
     }
 
     fileprivate func applyStyles() {
-        contentView.backgroundColor = .neutral(shade: .shade5)
+        contentView.backgroundColor = .neutral(shade: .shade0)
         borderedContentView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedContentView.layer.borderWidth = 1.0
         label.font = WPStyleGuide.subtitleFont()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -54,8 +54,8 @@ open class ReaderCrossPostCell: UITableViewCell {
     // MARK: - Appearance
 
     fileprivate func applyStyles() {
-        contentView.backgroundColor = .neutral(shade: .shade5)
-        label?.backgroundColor = .neutral(shade: .shade5)
+        contentView.backgroundColor = .neutral(shade: .shade0)
+        label?.backgroundColor = .neutral(shade: .shade0)
     }
 
     fileprivate func applyHighlightedEffect(_ highlighted: Bool, animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -829,11 +829,12 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         likeButton.isEnabled = ReaderHelpers.isLoggedIn()
 
         let title = post!.likeCountForDisplay()
-        let imageName = post!.isLiked ? "icon-reader-liked" : "icon-reader-like"
-        let image = UIImage(named: imageName)
-        let highlightImage = UIImage(named: "icon-reader-like-highlight")
         let selected = post!.isLiked
-        configureActionButton(likeButton, title: title, image: image, highlightedImage: highlightImage, selected: selected)
+        let normalImage = UIImage(named: "icon-reader-like")?.imageWithTintColor(.neutral(shade: .shade30))
+        let highlightImage = UIImage(named: "icon-reader-like")?.imageWithTintColor(.neutral)
+        let selectedImage = UIImage(named: "icon-reader-liked")?.imageWithTintColor(.primary(shade: .shade40))
+        configureActionButton(likeButton, title: title, image: normalImage, highlightedImage: highlightImage, selected: selected)
+        likeButton.setImage(selectedImage, for: .selected)
 
         if animated {
             playLikeButtonAnimation()
@@ -907,7 +908,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     fileprivate func configureCommentActionButton() {
         let title = post!.commentCount.stringValue
         let image = UIImage(named: "icon-reader-comment")?.imageFlippedForRightToLeftLayoutDirection()
-        let highlightImage = UIImage(named: "icon-reader-comment-highlight")?.imageFlippedForRightToLeftLayoutDirection()
+        let highlightImage = UIImage(named: "icon-reader-comment-highlight")?.imageWithTintColor(.neutral)?.imageFlippedForRightToLeftLayoutDirection()
         configureActionButton(commentButton, title: title, image: image, highlightedImage: highlightImage, selected: false)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
@@ -33,7 +33,7 @@ import WordPressShared.WPStyleGuide
         titleLabel.text = NSLocalizedString("Manage", comment: "Button title. Tapping lets the user manage the sites they follow.")
 
         disclosureIcon.image = Gridicon.iconOfType(.chevronRight, withSize: disclosureIcon.frame.size).imageFlippedForRightToLeftLayoutDirection()
-        disclosureIcon.tintColor = WPStyleGuide.accessoryDefaultTintColor()
+        disclosureIcon.tintColor = .neutral(shade: .shade30)
 
         imageView.image = Gridicon.iconOfType(.cog)
         imageView.tintColor = UIColor.white
@@ -57,7 +57,7 @@ import WordPressShared.WPStyleGuide
 
 
     @IBAction func didTouchDown(_ sender: UIButton) {
-        borderedView.backgroundColor = WPStyleGuide.cellDefaultHighlightColor()
+        borderedView.backgroundColor = .textInverted
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
@@ -24,7 +24,7 @@ import WordPressShared.WPStyleGuide
 
 
     @objc func applyStyles() {
-        backgroundColor = .neutral(shade: .shade5)
+        backgroundColor = .clear
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = 1.0
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
@@ -15,11 +15,11 @@ open class ReaderGapMarkerCell: UITableViewCell {
 
     fileprivate func applyStyles() {
         // Background styles
-        contentView.backgroundColor = .neutral(shade: .shade5)
+        contentView.backgroundColor = .neutral(shade: .shade0)
         selectedBackgroundView = UIView(frame: contentView.frame)
-        selectedBackgroundView?.backgroundColor = .neutral(shade: .shade5)
-        contentView.backgroundColor = .neutral(shade: .shade5)
-        tearMaskView.backgroundColor = .neutral(shade: .shade5)
+        selectedBackgroundView?.backgroundColor = .neutral(shade: .shade0)
+        contentView.backgroundColor = .neutral(shade: .shade0)
+        tearMaskView.backgroundColor = .neutral(shade: .shade0)
 
         // Draw the tear
         drawTearBackground()
@@ -55,7 +55,7 @@ open class ReaderGapMarkerCell: UITableViewCell {
         if highlighted {
             // Redraw the backgrounds when highlighted
             drawTearBackground()
-            tearMaskView.backgroundColor = .neutral(shade: .shade5)
+            tearMaskView.backgroundColor = .neutral(shade: .shade0)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderListStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderListStreamHeader.swift
@@ -19,7 +19,7 @@ import WordPressShared.WPStyleGuide
     }
 
     @objc func applyStyles() {
-        backgroundColor = .neutral(shade: .shade5)
+        backgroundColor = .neutral(shade: .shade0)
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = 1.0
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -205,7 +205,7 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     fileprivate func setupLikeActionButton() {
         let normalImage = UIImage(named: "icon-reader-like")?.imageWithTintColor(.neutral(shade: .shade30))
         let highlightImage = UIImage(named: "icon-reader-like")?.imageWithTintColor(.neutral)
-        let selectedImage = UIImage(named: "icon-reader-liked")?.imageWithTintColor(.accent)
+        let selectedImage = UIImage(named: "icon-reader-liked")?.imageWithTintColor(.primary(shade: .shade40))
         likeActionButton.setImage(normalImage, for: UIControl.State())
         likeActionButton.setImage(highlightImage, for: .highlighted)
         likeActionButton.setImage(selectedImage, for: .selected)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -252,8 +252,8 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         Applies the default styles to the cell's subviews
     */
     fileprivate func applyStyles() {
-        backgroundColor = .neutral(shade: .shade5)
-        contentView.backgroundColor = .neutral(shade: .shade5)
+        backgroundColor = .clear
+        contentView.backgroundColor = .clear
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = 1.0
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -203,10 +203,10 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     }
 
     fileprivate func setupLikeActionButton() {
-        let image = UIImage(named: "icon-reader-like")
-        let highlightImage = UIImage(named: "icon-reader-like-highlight")
-        let selectedImage = UIImage(named: "icon-reader-liked")
-        likeActionButton.setImage(image, for: UIControl.State())
+        let normalImage = UIImage(named: "icon-reader-like")?.imageWithTintColor(.neutral(shade: .shade30))
+        let highlightImage = UIImage(named: "icon-reader-like")?.imageWithTintColor(.neutral)
+        let selectedImage = UIImage(named: "icon-reader-liked")?.imageWithTintColor(.accent)
+        likeActionButton.setImage(normalImage, for: UIControl.State())
         likeActionButton.setImage(highlightImage, for: .highlighted)
         likeActionButton.setImage(selectedImage, for: .selected)
     }
@@ -215,8 +215,8 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         let size = CGSize(width: 20, height: 20)
         let title = NSLocalizedString("Visit", comment: "Verb. Button title.  Tap to visit a website.")
         let icon = Gridicon.iconOfType(.external, withSize: size)
-        let tintedIcon = icon.imageWithTintColor(.textSubtle)?.imageFlippedForRightToLeftLayoutDirection()
-        let highlightIcon = icon.imageWithTintColor(.primary)?.imageFlippedForRightToLeftLayoutDirection()
+        let tintedIcon = icon.imageWithTintColor(.neutral(shade: .shade30))?.imageFlippedForRightToLeftLayoutDirection()
+        let highlightIcon = icon.imageWithTintColor(.neutral)?.imageFlippedForRightToLeftLayoutDirection()
 
         visitButton.setTitle(title, for: UIControl.State())
         visitButton.setImage(tintedIcon, for: .normal)
@@ -230,8 +230,8 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     fileprivate func setupMenuButton() {
         let size = CGSize(width: 20, height: 20)
         let icon = Gridicon.iconOfType(.ellipsis, withSize: size)
-        let tintedIcon = icon.imageWithTintColor(.textSubtle)
-        let highlightIcon = icon.imageWithTintColor(.primary)
+        let tintedIcon = icon.imageWithTintColor(.neutral(shade: .shade30))
+        let highlightIcon = icon.imageWithTintColor(.neutral)
 
         menuButton.setImage(tintedIcon, for: .normal)
         menuButton.setImage(highlightIcon, for: .highlighted)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -197,7 +197,7 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
 
     fileprivate func setupCommentActionButton() {
         let image = UIImage(named: "icon-reader-comment")?.imageFlippedForRightToLeftLayoutDirection()
-        let highlightImage = UIImage(named: "icon-reader-comment-highlight")?.imageFlippedForRightToLeftLayoutDirection()
+        let highlightImage = UIImage(named: "icon-reader-comment-highlight")?.imageWithTintColor(.neutral)?.imageFlippedForRightToLeftLayoutDirection()
         commentActionButton.setImage(image, for: UIControl.State())
         commentActionButton.setImage(highlightImage, for: .highlighted)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -46,7 +46,7 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     }
 
     @objc func applyStyles() {
-        backgroundColor = .neutral(shade: .shade5)
+        backgroundColor = .neutral(shade: .shade0)
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = 1.0
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -105,7 +105,7 @@
                             <subviews>
                                 <view contentMode="scaleToFill" horizontalHuggingPriority="240" translatesAutoresizingMaskIntoConstraints="NO" id="olT-MT-DPn">
                                     <rect key="frame" x="16" y="15" width="90.5" height="1"/>
-                                    <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294119999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="C4p-fx-ahc"/>
                                     </constraints>
@@ -118,7 +118,7 @@
                                 </label>
                                 <view contentMode="scaleToFill" horizontalHuggingPriority="240" translatesAutoresizingMaskIntoConstraints="NO" id="MHU-Fa-6Rd">
                                     <rect key="frame" x="213.5" y="15" width="90.5" height="1"/>
-                                    <color key="backgroundColor" red="0.7843137255" green="0.84313725490000002" blue="0.88235294119999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="1" id="ab3-9s-zRC"/>
                                     </constraints>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -19,7 +19,7 @@ import WordPressShared
     }
 
     @objc func applyStyles() {
-        backgroundColor = .neutral(shade: .shade5)
+        backgroundColor = .neutral(shade: .shade0)
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = 1.0
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -245,10 +245,13 @@ extension WPStyleGuide {
         let followIcon = Gridicon.iconOfType(.readerFollow, withSize: size)
         let followingIcon = Gridicon.iconOfType(.readerFollowing, withSize: size)
 
-        let tintedFollowIcon = followIcon.imageWithTintColor(.primary(shade: .shade40))
-        let tintedFollowingIcon = followingIcon.imageWithTintColor(.success(shade: .shade50))
+        let normalColor = UIColor.primary
+        let highlightedColor = UIColor.primaryDark
+        let selectedColor = UIColor.success
 
-        let highlightIcon = followingIcon.imageWithTintColor(.primaryLight)
+        let tintedFollowIcon = followIcon.imageWithTintColor(normalColor)
+        let tintedFollowingIcon = followingIcon.imageWithTintColor(selectedColor)
+        let highlightIcon = followingIcon.imageWithTintColor(highlightedColor)
 
         button.setImage(tintedFollowIcon, for: .normal)
         button.setImage(tintedFollowingIcon, for: .selected)
@@ -257,6 +260,10 @@ extension WPStyleGuide {
         button.setTitle(followStringForDisplay, for: UIControl.State())
         button.setTitle(followingStringForDisplay, for: .selected)
         button.setTitle(followingStringForDisplay, for: .highlighted)
+
+        button.setTitleColor(normalColor, for: UIControl.State())
+        button.setTitleColor(highlightedColor, for: .highlighted)
+        button.setTitleColor(selectedColor, for: .selected)
     }
 
     @objc public class func applyReaderSaveForLaterButtonStyle(_ button: UIButton) {

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -6,18 +6,6 @@ import Gridicons
 ///
 extension WPStyleGuide {
 
-    // MARK: - System Defaults
-
-    @objc public class func accessoryDefaultTintColor() -> UIColor {
-        return UIColor(fromRGBAColorWithRed: 199.0, green: 199.0, blue: 204.0, alpha: 1.0)
-    }
-
-
-    @objc public class func cellDefaultHighlightColor() -> UIColor {
-        return UIColor(fromRGBAColorWithRed: 217.0, green: 217.0, blue: 217.0, alpha: 1.0)
-    }
-
-
     // MARK: - Original Post/Site Attribution Styles.
 
     @objc public class func originalAttributionParagraphAttributes() -> [NSAttributedString.Key: Any] {
@@ -49,12 +37,11 @@ extension WPStyleGuide {
 
     // MARK: - Custom Colors
     @objc public class func readerCardCellBorderColor() -> UIColor {
-        return UIColor(red: 215.0/255.0, green: 227.0/255.0, blue: 235.0/255.0, alpha: 1.0)
+        return .neutral(shade: .shade10)
     }
 
     @objc public class func readerCardCellHighlightedBorderColor() -> UIColor {
-        // #87a6bc
-        return UIColor(red: 135/255.0, green: 166/255.0, blue: 188/255.0, alpha: 1.0)
+        return .neutral
     }
 
     // MARK: - Card Attributed Text Attributes

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -206,8 +206,8 @@ extension WPStyleGuide {
             return
         }
         WPStyleGuide.configureLabel(titleLabel, textStyle: Cards.buttonTextStyle)
-        button.setTitleColor(.neutral(shade: .shade10), for: UIControl.State())
-        button.setTitleColor(.primaryLight, for: .highlighted)
+        button.setTitleColor(.neutral(shade: .shade30), for: UIControl.State())
+        button.setTitleColor(.neutral, for: .highlighted)
         button.setTitleColor(.accent, for: .selected)
         button.setTitleColor(.neutral(shade: .shade10), for: .disabled)
     }
@@ -264,8 +264,8 @@ extension WPStyleGuide {
         let icon = Gridicon.iconOfType(.bookmarkOutline, withSize: size)
         let selectedIcon = Gridicon.iconOfType(.bookmark, withSize: size)
 
-        let normalColor: UIColor = .text
-        let selectedColor: UIColor = .primary(shade: .shade60)
+        let normalColor: UIColor = .neutral(shade: .shade30)
+        let selectedColor: UIColor = .accent
         let highlightedColor: UIColor = .primary
 
         let tintedIcon = icon.imageWithTintColor(normalColor)

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -208,7 +208,7 @@ extension WPStyleGuide {
         WPStyleGuide.configureLabel(titleLabel, textStyle: Cards.buttonTextStyle)
         button.setTitleColor(.neutral(shade: .shade30), for: UIControl.State())
         button.setTitleColor(.neutral, for: .highlighted)
-        button.setTitleColor(.accent, for: .selected)
+        button.setTitleColor(.primary(shade: .shade40), for: .selected)
         button.setTitleColor(.neutral(shade: .shade10), for: .disabled)
     }
 
@@ -265,8 +265,8 @@ extension WPStyleGuide {
         let selectedIcon = Gridicon.iconOfType(.bookmark, withSize: size)
 
         let normalColor: UIColor = .neutral(shade: .shade30)
-        let selectedColor: UIColor = .accent
-        let highlightedColor: UIColor = .primary
+        let selectedColor: UIColor = .primary(shade: .shade40)
+        let highlightedColor: UIColor = .neutral
 
         let tintedIcon = icon.imageWithTintColor(normalColor)
         let tintedSelectedIcon = selectedIcon.imageWithTintColor(selectedColor)

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -176,7 +176,7 @@ extension WPStyleGuide {
         static let summaryFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         static let substringHighlightFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
 
-        static let tableBackgroundColor = UIColor.neutral(shade: .shade5)
+        static let tableBackgroundColor = UIColor.neutral(shade: .shade0)
         static let cellBackgroundColor = UIColor.white
         static let separatorColor = UIColor.neutral(shade: .shade10)
         static let verticalSeparatorColor = UIColor.neutral(shade: .shade5)

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -63,7 +63,7 @@ struct OverviewTabData: FilterTabBarItem {
         if let date = date,
             let period = period,
             StatsPeriodHelper().dateAvailableAfterDate(date, period: period) == false {
-            return WPStyleGuide.grey()
+            return .neutral(shade: .shade40)
         }
 
         return difference < 0 ? WPStyleGuide.Stats.negativeColor : WPStyleGuide.Stats.positiveColor

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeStyle.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeStyle.swift
@@ -30,8 +30,8 @@ public struct NormalNoticeStyle: NoticeStyle {
     public var actionButtonFont: UIFont? { return UIFont.systemFont(ofSize: 14.0, weight: .medium) }
     public let cancelButtonFont: UIFont? = nil
 
-    public let titleColor: UIColor = .white
-    public let messageColor: UIColor = .white
+    public let titleColor: UIColor = .textInverted
+    public let messageColor: UIColor = .textInverted
     public let backgroundColor: UIColor = .neutral(shade: .shade80)
 
     public let layoutMargins = UIEdgeInsets(top: 10.0, left: 16.0, bottom: 10.0, right: 16.0)

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -60,12 +60,18 @@ class WPRichContentView: UITextView {
     }
 
     @objc class func formattedAttributedStringForString(_ string: String) -> NSAttributedString {
+        let fallbackTextColorHex = "000"
+        let textColorHex = UIColor.text.hexString() ?? fallbackTextColorHex
+        let blockQuoteColorHex = UIColor.textSubtle.hexString() ?? fallbackTextColorHex
+        let linkColorHex = UIColor.primary.hexString() ?? fallbackTextColorHex
+        let linkColorActiveHex = UIColor.primaryDark.hexString() ?? fallbackTextColorHex
+
         let style = "<style>" +
-            "body { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; line-height:1.6; color: #2e4453; }" +
-            "blockquote { color:#4f748e; } " +
+            "body { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; line-height:1.6; color: #\(textColorHex); }" +
+            "blockquote { color:#\(blockQuoteColorHex); } " +
             "em, i { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; font-style: italic; line-height:1.6; } " +
-            "a { color: #0087be; text-decoration: none; } " +
-            "a:active { color: #005082; } " +
+            "a { color: #\(linkColorHex); text-decoration: none; } " +
+            "a:active { color: #\(linkColorActiveHex); } " +
         "</style>"
         let html = style + string
 
@@ -434,7 +440,7 @@ class ContentInformation: ImageSourceInformation {
 @objc fileprivate class BlockquoteBackgroundLayoutManager: NSLayoutManager {
     /// Blockquote's Left Border Color
     ///
-    let blockquoteBorderColor = UIColor(red: 0.52, green: 0.65, blue: 0.73, alpha: 1.0)
+    let blockquoteBorderColor = UIColor.textSubtle
 
     /// Blockquote's Left Border width
     ///

--- a/WordPress/Resources/MurielImages.xcassets/icon-pencil.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/icon-pencil.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-back.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-back.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-edit.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-edit.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-publish.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-publish.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-restore.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-restore.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-stats.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-stats.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-trash.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-trash.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-view.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/icon-post-actionbar-view.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/icon-reader-like-highlight.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/icon-reader-like-highlight.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/icon-reader-like.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/icon-reader-like.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/icon-reader-liked.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/icon-reader-liked.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/notifications-approved.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/notifications-approved.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/notifications-liked.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/notifications-liked.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/notifications-spam.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/notifications-spam.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/notifications-trash.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/notifications-trash.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/WordPressTest/NewsCardTests.swift
+++ b/WordPress/WordPressTest/NewsCardTests.swift
@@ -61,7 +61,7 @@ final class NewsCardTests: XCTestCase {
     }
 
     func testViewHasTheExpectedBackgroundColor() {
-        XCTAssertEqual(subject?.view.backgroundColor, .neutral(shade: .shade5))
+        XCTAssertEqual(subject?.view.backgroundColor, .clear)
     }
 
     func testTitleHasTheExpectedColor() {


### PR DESCRIPTION
Refs #11683

This changes numerous colors throughout the app to improve the look with the new color palette. I can provide a PDF of changes for review, if you'd like.

<img width="440" alt="image" src="https://user-images.githubusercontent.com/517257/60834430-88360d00-a175-11e9-81a8-5ee50d7af3d5.png">
<img width="425" alt="image" src="https://user-images.githubusercontent.com/517257/60834439-8c622a80-a175-11e9-9c47-96ff0445fa75.png">
<img width="411" alt="image" src="https://user-images.githubusercontent.com/517257/60834456-94ba6580-a175-11e9-8c55-d327c0464630.png">


To test:
- Build app and look through all the top-level screens. Particularly:
  - all links should be the new blue
  - all table views should have the new gray background
  - more text should be very dark, and a more true neutral, no dark-blue text, etc.

Update release notes:
- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
