### PR TITLE
[Stats Refresh] Change Latest Post Summary chart height

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift
@@ -16,7 +16,7 @@ class StatsBarChartView: BarChartView {
     // MARK: Properties
 
     private struct Constants {
-        static let intrinsicHeight          = CGFloat(170)      // height via Zeplin
+        static let intrinsicHeight          = CGFloat(150)
         static let highlightAlpha           = CGFloat(1)
         static let horizontalAxisLabelCount = 2
         static let markerAlpha              = CGFloat(0.2)


### PR DESCRIPTION
Fixes #11978 

This changes the Latest Post Summary chart height to be the same as the Overview charts, which is 150.

To test:
- Go to Insights > Latest Post Summary.
- Verify the height of the chart area is 150.

![lps_chart](https://user-images.githubusercontent.com/1816888/60841051-1e762d00-a18e-11e9-8fc2-7c2acf223905.png)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
