### PR TITLE
[Stats Refresh] Period details: Show all data on rotation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 * Stats Periods: Fixed crash when the Countries map displayed one country only
 * Added a selection of user customizable app icons. Change it via Me > App Settings > App Icon.
 * Update the app's colors using the Muriel color pallete.
+* Stats Periods detail views: Fixed an issue where rotation would truncate data.
 
 12.7
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -185,7 +185,8 @@ private extension SiteStatsPeriodTableViewController {
     func refreshData() {
 
         guard let selectedDate = selectedDate,
-            let selectedPeriod = selectedPeriod else {
+            let selectedPeriod = selectedPeriod,
+            viewIsVisible() else {
                 refreshControl?.endRefreshing()
                 return
         }


### PR DESCRIPTION
Fixes #12072 

This fixes an issue where on rotation the Period details views would revert to showing only 10 rows.

The issue was caused by Period being refreshed via `viewWillTransition` in `SiteStatsDashboardViewController`, resulting in the data to be overwritten in `StatsPeriodStore`.

This changes Period to only refresh data if the view is visible. 

To note, the original issue specifically states Posts and Pages, but it actually affected _all_ Period details.

To test:
- On a site with a lot of data (so you get more than 10 detail data rows), go to Period, and select `View more` for any stat.
- Verify all the data is shown (i.e. is not limited to 10 rows).

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
