### PR TITLE
Add README with UI test documentation

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3382,6 +3382,7 @@
 		CC8A5EAA22159FA6001B7874 /* WPUITestCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPUITestCredentials.swift; sourceTree = "<group>"; };
 		CC94FC67221452A4002E5825 /* EditorNoticeComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorNoticeComponent.swift; sourceTree = "<group>"; };
 		CC94FC692214532D002E5825 /* FancyAlertComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FancyAlertComponent.swift; sourceTree = "<group>"; };
+		CCA44DF422C4C4D6006E294F /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		CCE55E982242715C002A9634 /* CategoriesComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CategoriesComponent.swift; sourceTree = "<group>"; };
 		CCE911BB221D8497007E1D4E /* LoginSiteAddressScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSiteAddressScreen.swift; sourceTree = "<group>"; };
 		CCE911BD221D85E4007E1D4E /* LoginUsernamePasswordScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUsernamePasswordScreen.swift; sourceTree = "<group>"; };
@@ -8642,6 +8643,7 @@
 				BE2B4E991FD6640E007AE3E4 /* Screens */,
 				FF2716931CAAC87B0006E2D4 /* Info.plist */,
 				CC8A5EAA22159FA6001B7874 /* WPUITestCredentials.swift */,
+				CCA44DF422C4C4D6006E294F /* README.md */,
 			);
 			path = WordPressUITests;
 			sourceTree = "<group>";

--- a/WordPress/WordPressUITests/README.md
+++ b/WordPress/WordPressUITests/README.md
@@ -2,19 +2,19 @@
 
 WordPress for iOS has UI acceptance tests for critical user flows through the app, such as login, signup, and publishing a post. The tests use mocked network requests with [WireMock](http://wiremock.org/), defined in [WordPressMocks](https://github.com/wordpress-mobile/WordPressMocks).
 
-## Run the Tests
+## Running tests
 
 Note that due to the mock server setup, tests cannot be run on physical devices right now.
 
-1. Follow the [build instructions](https://github.com/wordpress-mobile/WordPress-iOS#build-instructions) (steps 1-5) to clone the project, install the dependencies, and open it in Xcode.
+1. Follow the [build instructions](https://github.com/wordpress-mobile/WordPress-iOS#build-instructions) (steps 1-5) to clone the project, install the dependencies, and open the project in Xcode.
 2. `rake mocks` to start a local mock server.
 3. Run the tests in the `WordPressUITests` target on a simulator.
 
-## Add a Test
+## Adding tests
 
 When adding a new UI test, consider:
 
-* Whether you need to test a user flow through the app to accomplish a specific task or goal, or the complexities of a specific feature.
+* Whether you need to test a user flow (to accomplish a task or goal) or a specific feature (e.g. boundary testing).
 * What screens are being tested (defined as page objects in `Screens/`).
 * Whether there are repeated flows across tests (defined in `Flows/`).
 * What network requests are made during the test (defined in the `WordPressMocks` repo).
@@ -23,7 +23,7 @@ It's preferred to focus UI tests on entire user flows, and group tests with rela
 
 When you add a new test, you may need to add new screens, methods, and flows. We use page objects and method chaining for clarity in our tests. Wherever possible, use an existing `accessibilityIdentifier` (or add one to the app) instead of a string to select a UI element on the screen. This ensures tests can be run regardless of the device language.
 
-## Add or update network mocks
+## Adding or updating network mocks
 
 When you add a test (or when the app changes), the request definitions for WireMock need to be updated. You can read WireMock’s documentation [here](http://wiremock.org/docs/).
 

--- a/WordPress/WordPressUITests/README.md
+++ b/WordPress/WordPressUITests/README.md
@@ -8,7 +8,7 @@ Note that due to the mock server setup, tests cannot be run on physical devices 
 
 1. Follow the [build instructions](https://github.com/wordpress-mobile/WordPress-iOS#build-instructions) (steps 1-5) to clone the project, install the dependencies, and open it in Xcode.
 2. `rake mocks` to start a local mock server.
-3. Run the tests in the `WordPressUITests` target.
+3. Run the tests in the `WordPressUITests` target on a simulator.
 
 ## Add a Test
 
@@ -18,6 +18,10 @@ When adding a new UI test, consider:
 * What screens are being tested (defined as page objects in `Screens/`).
 * Whether there are repeated flows across tests (defined in `Flows/`).
 * What network requests are made during the test (defined in the `WordPressMocks` repo).
+
+It's preferred to focus UI tests on entire user flows, and group tests with related flows or goals in the same test suite.
+
+When you add a new test, you may need to add new screens, methods, and flows. We use page objects and method chaining for clarity in our tests. Wherever possible, use an existing `accessibilityIdentifier` (or add one to the app) instead of a string to select a UI element on the screen. This ensures tests can be run regardless of the device language.
 
 ## Add or update network mocks
 

--- a/WordPress/WordPressUITests/README.md
+++ b/WordPress/WordPressUITests/README.md
@@ -1,0 +1,28 @@
+#  UI Tests
+
+WordPress for iOS has UI acceptance tests for critical user flows through the app, such as login, signup, and publishing a post. The tests use mocked network requests with [WireMock](http://wiremock.org/), defined in [WordPressMocks](https://github.com/wordpress-mobile/WordPressMocks).
+
+## Run the Tests
+
+Note that due to the mock server setup, tests cannot be run on physical devices right now.
+
+1. Follow the [build instructions](https://github.com/wordpress-mobile/WordPress-iOS#build-instructions) (steps 1-5) to clone the project, install the dependencies, and open it in Xcode.
+2. `rake mocks` to start a local mock server.
+3. Run the tests in the `WordPressUITests` target.
+
+## Add a Test
+
+When adding a new UI test, consider:
+
+* Whether you need to test a user flow through the app to accomplish a specific task or goal, or the complexities of a specific feature.
+* What screens are being tested (defined as page objects in `Screens/`).
+* Whether there are repeated flows across tests (defined in `Flows/`).
+* What network requests are made during the test (defined in the `WordPressMocks` repo).
+
+## Add or update network mocks
+
+When you add a test (or when the app changes), the request definitions for WireMock need to be updated. You can read WireMock’s documentation [here](http://wiremock.org/docs/).
+
+If you are unsure what network requests need to be mocked for a test, an easy way to find out is to run the app through [Charles Proxy](https://www.charlesproxy.com/) and observe the required requests.
+
+Since `WordPressMocks` is included as a pod in `WordPress-iOS`, you can update your `Podfile` to point to your local version and make changes there. Submit a pull request to the `WordPressMocks` repo so a new version of the pod can be released with those changes.


### PR DESCRIPTION
This adds a README to the repo (under `WordPress/WordPressUITests/`) with documentation for running the UI tests, adding a test, and adding/updating the network mocks.

**To review:**

* You can view the README here: https://github.com/wordpress-mobile/WordPress-iOS/tree/add/ui-tests-readme/WordPress/WordPressUITests
* In addition to proofreading, please let me know if there's anything you think we should add, clarify, or remove here.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
