### PR TITLE
[Stats Refresh] Fix Insights Annual details date bar

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
@@ -7,9 +7,9 @@ class StatsPeriodHelper {
         return cal
     }()
 
-    func dateAvailableBeforeDate(_ dateIn: Date, period: StatsPeriodUnit, backLimit: Int) -> Bool {
+    func dateAvailableBeforeDate(_ dateIn: Date, period: StatsPeriodUnit, backLimit: Int, mostRecentDate: Date? = nil) -> Bool {
         // Use dates without time
-        let currentDate = Date().normalizedDate()
+        let currentDate =  mostRecentDate?.normalizedDate() ?? Date().normalizedDate()
 
         guard var oldestDate = calendar.date(byAdding: period.calendarComponent, value: backLimit, to: currentDate) else {
             return false
@@ -40,9 +40,9 @@ class StatsPeriodHelper {
         }
     }
 
-    func dateAvailableAfterDate(_ dateIn: Date, period: StatsPeriodUnit) -> Bool {
+    func dateAvailableAfterDate(_ dateIn: Date, period: StatsPeriodUnit, mostRecentDate: Date? = nil) -> Bool {
         // Use dates without time
-        let currentDate = Date().normalizedDate()
+        let currentDate =  mostRecentDate?.normalizedDate() ?? Date().normalizedDate()
         let date = dateIn.normalizedDate()
 
         switch period {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -21,6 +21,9 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
     private weak var delegate: SiteStatsTableHeaderDelegate?
     private var date: Date?
     private var period: StatsPeriodUnit?
+
+    // Allow the date bar to only go up to the most recent year available.
+    // Used by Insights 'This Year' details view.
     private var mostRecentDate: Date?
 
     // Limits how far back the date chooser can go.
@@ -136,8 +139,8 @@ private extension SiteStatsTableHeaderView {
         }
 
         let helper = StatsPeriodHelper()
-        forwardButton.isEnabled = helper.dateAvailableAfterDate(date, period: period)
-        backButton.isEnabled = helper.dateAvailableBeforeDate(date, period: period, backLimit: backLimit)
+        forwardButton.isEnabled = helper.dateAvailableAfterDate(date, period: period, mostRecentDate: mostRecentDate)
+        backButton.isEnabled = helper.dateAvailableBeforeDate(date, period: period, backLimit: backLimit, mostRecentDate: mostRecentDate)
         updateArrowStates()
         prepareForVoiceOver()
     }


### PR DESCRIPTION
Ref #11962, #12043

This fixes the date bar on Insights Annual details view that was broken when 12.7 was merged to `develop`. An attempt was made to fix it on #12043 but it wasn't quite right.

To test:
- Follow the steps noted on #11962 .
- Specifically what was broken - `mostRecentDate` is used to prevent the date bar from going past the site's most recent year. For example, on a site with no date for 2019, we don't want to use `Date()` for the current date as that will result in a broken view. So, on a site with no data for 2019:
   - Go to Insights > This Year > View more.
   - Verify the date bar only goes up to the year the site has data for.

<img width="400" alt="this_year" src="https://user-images.githubusercontent.com/1816888/60929051-f7425d00-a26c-11e9-84f8-1436dc33130b.png">

<img width="400" alt="details" src="https://user-images.githubusercontent.com/1816888/60929054-f9a4b700-a26c-11e9-9a8b-d94232cd2209.png">




Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
