### PR TITLE
Update Gutenberg to 1.9.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -30,7 +30,7 @@ def aztec
     ## pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'b8c53761b89a092ac690a90f1d33bd800a9025a6'
     ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'b8c53761b89a092ac690a90f1d33bd800a9025a6'
     ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag => '1.5.0.beta.1'
-    pod 'WordPress-Editor-iOS', '~> 1.8.0'
+    pod 'WordPress-Editor-iOS', '~> 1.9.0'
 end
 
 def wordpress_ui
@@ -120,7 +120,7 @@ target 'WordPress' do
     ## Gutenberg (React Native)
     ## =====================
     ##
-    gutenberg :tag => 'v1.8.0'
+    gutenberg :tag => 'v1.9.0'
 
     pod 'RNSVG', :git => 'https://github.com/wordpress-mobile/react-native-svg.git', :tag => '9.3.3-gb'
     pod 'react-native-keyboard-aware-scroll-view', :git => 'https://github.com/wordpress-mobile/react-native-keyboard-aware-scroll-view.git', :tag => 'gb-v0.8.7'

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,9 @@
 12.9
 -----
 * Offline support: Create Post is now available from empty results view in offline mode.
+* Block editor: Tapping on an empty editor area will create a new paragraph block
+* Block editor: Fix content loss issue when loading unsupported blocks containing inner blocks.
+* Block editor: Adding a block from the Post Title now inserts the block at the top of the Post.
 
 12.8
 -----


### PR DESCRIPTION
This PR updates the gutenberg-mobile reference to point to the latest release, v1.9.0.

The reference is currently pointing to the release/1.9.0 branch on https://github.com/wordpress-mobile/gutenberg-mobile. Relevant PR: https://github.com/wordpress-mobile/gutenberg-mobile/pull/1216.

To test:
The block editor should work as normal.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
