### PR TITLE
Fixes a bug that was causing previews to publish some posts.

### DIFF
--- a/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
+++ b/WordPress/Classes/Extensions/AbstractPost+PostInformation.swift
@@ -9,7 +9,7 @@ extension AbstractPost: ImageSourceInformation {
     }
 
     var isLocalRevision: Bool {
-        return self.isDraft() && self.isRevision() && self.remoteStatus == .local
+        return self.originalIsDraft() && self.isRevision() && self.remoteStatus == .local
     }
 
 }

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -154,6 +154,11 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 - (BOOL)isDraft;
 
 /**
+ Returns YES if the original post is a draft
+ */
+- (BOOL)originalIsDraft;
+
+/**
  Returns YES if the post has a future date_created_gmt.
  This is different from "isScheduled" in that  a post with a draft, pending, or
  trashed status can also have a date_created_gmt with a future value.

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -450,6 +450,11 @@
 
 - (BOOL)isDraft
 {
+    return [self.status isEqualToString:PostStatusDraft];
+}
+
+- (BOOL)originalIsDraft
+{
     if ([self.status isEqualToString:PostStatusDraft]) {
         return YES;
     } else if (self.isRevision && [self.original.status isEqualToString:PostStatusDraft]) {
@@ -466,7 +471,7 @@
 
 - (BOOL)shouldPublishImmediately
 {
-    return [self isDraft] && [self dateCreatedIsNilOrEqualToDateModified];
+    return [self originalIsDraft] && [self dateCreatedIsNilOrEqualToDateModified];
 }
 
 - (NSString *)authorNameForDisplay
@@ -506,7 +511,7 @@
 
 - (NSString *)dateStringForDisplay
 {
-    if ([self isDraft] || [self.status isEqualToString:PostStatusPending]) {
+    if ([self originalIsDraft] || [self.status isEqualToString:PostStatusPending]) {
         NSString *shortDate = [[self dateModified] mediumString];
         NSString *lastModified = NSLocalizedString(@"last-modified",@"A label for a post's last-modified date.");
         return [NSString stringWithFormat:@"%@ (%@)", shortDate, lastModified];

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -323,11 +323,6 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
             failure(error);
         };
         
-        // We should upload the post if:
-        //
-        // - The post is a draft, and has no assigned ID; or
-        // - The post is a draft, and is not accessible through WP.com (because self-hosted doesn't support autosaving).
-        //
         BOOL needsUploading = [post isDraft] && [post.postID longLongValue] <= 0;
         
         if (needsUploading) {

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -63,7 +63,7 @@ class EditPostViewController: UIViewController {
     fileprivate init(post: Post?, blog: Blog) {
         self.post = post
         if let post = post {
-            if !post.isDraft() {
+            if !post.originalIsDraft() {
                 editingExistingPost = true
             }
         }
@@ -216,7 +216,7 @@ class EditPostViewController: UIViewController {
         if postPost.revealPost {
             return true
         }
-        if post.isDraft() {
+        if post.originalIsDraft() {
             return false
         }
         return hasChanges

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -26,7 +26,6 @@ extension PostEditor where Self: UIViewController {
     private func savePostBeforePreview(completion: @escaping ((String?, Error?) -> Void)) {
         let context = ContextManager.sharedInstance().mainContext
         let postService = PostService(managedObjectContext: context)
-        let draftStatus = NSLocalizedString("Saving...", comment: "Text displayed in HUD while a post is being saved as a draft.")
         let publishedStatus = NSLocalizedString("Generating Preview...", comment: "Text displayed in HUD while a post is being saved.")
         SVProgressHUD.setDefaultMaskType(.clear)
 
@@ -35,32 +34,30 @@ extension PostEditor where Self: UIViewController {
             return
         }
 
-        if post.isDraft() {
-            SVProgressHUD.show(withStatus: draftStatus)
-            postService.uploadPost(post, success: { [weak self] savedPost in
-                self?.post = savedPost
-                self?.createPostRevisionBeforePreview() {
-                    completion(nil, nil)
-                }
-                SVProgressHUD.dismiss()
-                }, failure: { error in
-                    DDLogError("Error while trying to upload draft before preview: \(String(describing: error))")
-                    completion(nil, nil)
-                    SVProgressHUD.dismiss()
-            })
-        } else {
-            SVProgressHUD.show(withStatus: publishedStatus)
-            postService.autoSave(post, success: { [weak self] savedPost, previewURL in
-                self?.post = savedPost
-                ContextManager.sharedInstance().save(context)
-                SVProgressHUD.dismiss()
-                completion(previewURL, nil)
-            }) { error in
-                //When failing to save a published post will result in "preview not available"
-                DDLogError("Error while trying to save post before preview: \(String(describing: error))")
-                SVProgressHUD.dismiss()
-                completion(nil, error)
+        SVProgressHUD.show(withStatus: publishedStatus)
+        postService.autoSave(post, success: { [weak self] savedPost, previewURL in
+            SVProgressHUD.dismiss()
+
+            guard let self = self else {
+                return
             }
+
+            self.post = savedPost
+
+            if self.post.isRevision() {
+                ContextManager.sharedInstance().save(context)
+                completion(previewURL, nil)
+            } else {
+                self.createPostRevisionBeforePreview() {
+                    completion(previewURL, nil)
+                }
+            }
+        }) { error in
+            SVProgressHUD.dismiss()
+
+            //When failing to save a published post will result in "preview not available"
+            DDLogError("Error while trying to save post before preview: \(String(describing: error))")
+            completion(nil, error)
         }
     }
 


### PR DESCRIPTION
Fixes #12100 

Changes:
- Renames `isDraft()` to `originalIsDraft()` since it better represents what that method was doing.
- Introduces a new `isDraft()` method, which is used to fix part of the preview issues.
- Moves some code into the service layer, to make it part of the autosaving logic.
- The new logic prefers autosaving (over uploading) whenever possible.  Even for drafts.  This is much safer as it means it's much less likely that something will be saved by mistake during previews.

## Testing:

### Test 1:

1. Create a new post
2. Type a title and some content
3. Don't save yet!  Tap "..." and then "Preview".

In a WP.com blog: Make sure the preview shows as expected.  The post should be saved as a draft.
In a self-hosted blog: Make sure the preview shows as expected.  The post should be saved as a draft.

### Test 2:

1. Create a new post
2. Type a title and some content
3. Save it as a draft.
4. Tap "..." and then "Preview".

In a WP.com blog: Make sure the preview shows as expected.  The changes should be autosaved.
In a self-hosted blog: Make sure the preview shows as expected.  The post should be saved as a draft.

### Test 3:

1. Create a new post
2. Type a title and some content
3. Save it as a draft.
4. Go to Settings.
5. Change the status to "Publish", and go back to the post.
6. Tap "..." and then "Preview".

In a WP.com blog: Make sure the preview shows as expected.  The changes should be autosaved.
In a self-hosted blog: The preview should be unavailable.

### Test 4:

1. Create a new post
2. Type a title and some content
3. Publish it.
4. Go to Settings.
5. Change the status to "Draft", and go back to the post.
6. Tap "..." and then "Preview".

In a WP.com blog: Make sure the preview shows as expected.  The changes should be autosaved.
In a self-hosted blog: The preview should be unavailable.

## Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.