### PR TITLE
Post List: Update to Muriel color scheme

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -113,7 +113,7 @@ static CGFloat const FeaturedImageSize = 120.0;
     self.titleLabel.textColor = [UIColor murielNeutral70];
     self.timestampLabel.textColor = [UIColor murielNeutral30];
     self.badgesLabel.textColor = [UIColor murielWarningDark];
-    self.menuButton.tintColor = [UIColor murielNeutral20];
+    self.menuButton.tintColor = [UIColor murielTextSubtle];
     [self.menuButton setImage:[Gridicon iconOfType:GridiconTypeEllipsis] forState:UIControlStateNormal];
 
     self.backgroundColor = [UIColor murielNeutral5];

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
@@ -21,6 +21,7 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
     @IBOutlet weak var containerView: UIView!
     @IBOutlet weak var upperBorder: UIView!
     @IBOutlet weak var bottomBorder: UIView!
+    @IBOutlet weak var actionBarSeparator: UIView!
     @IBOutlet weak var topPadding: NSLayoutConstraint!
     @IBOutlet weak var contentStackView: UIStackView!
     @IBOutlet weak var ghostStackView: UIStackView!
@@ -263,6 +264,7 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
     private func setupBorders() {
         WPStyleGuide.applyBorderStyle(upperBorder)
         WPStyleGuide.applyBorderStyle(bottomBorder)
+        WPStyleGuide.applyBorderStyle(actionBarSeparator)
     }
 
     private func setupActionBar() {

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -228,6 +229,14 @@
                                 </constraints>
                                 <color key="trackTintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </progressView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kcO-mG-FcD">
+                                <rect key="frame" x="0.0" y="404.5" width="326" height="1"/>
+                                <color key="backgroundColor" name="Gray10"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="1" id="Nuu-dr-YF0"/>
+                                    <constraint firstAttribute="width" constant="326" id="Zzv-2b-WyX"/>
+                                </constraints>
+                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9eW-ex-CSu">
                                 <rect key="frame" x="0.0" y="448.5" width="326" height="1"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -242,13 +251,16 @@
                             <constraint firstItem="9eW-ex-CSu" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="3u1-2g-wAg"/>
                             <constraint firstAttribute="bottom" secondItem="33v-Uz-9S6" secondAttribute="bottom" id="6IU-Qy-TAU"/>
                             <constraint firstItem="33v-Uz-9S6" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="84P-oH-EZa"/>
+                            <constraint firstAttribute="trailing" secondItem="kcO-mG-FcD" secondAttribute="trailing" id="AEy-Bg-FgQ"/>
                             <constraint firstAttribute="trailing" secondItem="9eW-ex-CSu" secondAttribute="trailing" id="HUj-hh-Ili"/>
                             <constraint firstAttribute="trailing" secondItem="JqA-of-VBn" secondAttribute="trailing" id="MY8-mP-ASa"/>
                             <constraint firstAttribute="bottom" secondItem="JqA-of-VBn" secondAttribute="bottom" id="NwA-tt-aRf"/>
+                            <constraint firstItem="kcO-mG-FcD" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="WNn-kw-WAj"/>
                             <constraint firstItem="sev-PH-HG8" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="Yrw-8m-Cu0"/>
                             <constraint firstAttribute="bottom" secondItem="9eW-ex-CSu" secondAttribute="bottom" id="a2Y-qy-DA8"/>
                             <constraint firstItem="JqA-of-VBn" firstAttribute="leading" secondItem="Lk7-nZ-b0t" secondAttribute="leading" id="bPW-Sv-fZu"/>
                             <constraint firstItem="JqA-of-VBn" firstAttribute="top" secondItem="Lk7-nZ-b0t" secondAttribute="top" constant="16" id="hLL-be-nDD"/>
+                            <constraint firstItem="A8f-pJ-oKt" firstAttribute="top" secondItem="kcO-mG-FcD" secondAttribute="bottom" id="rKR-Zt-Tm7"/>
                             <constraint firstAttribute="trailing" secondItem="sev-PH-HG8" secondAttribute="trailing" id="uus-mZ-ErN"/>
                             <constraint firstAttribute="trailing" secondItem="33v-Uz-9S6" secondAttribute="trailing" id="xYe-gc-ksZ"/>
                         </constraints>
@@ -265,6 +277,7 @@
             </tableViewCellContentView>
             <variation key="widthClass=regular" layoutMarginsFollowReadableWidth="YES" preservesSuperviewLayoutMargins="YES"/>
             <connections>
+                <outlet property="actionBarSeparator" destination="kcO-mG-FcD" id="UJZ-Bx-3Dw"/>
                 <outlet property="actionBarView" destination="6Zz-tH-1DC" id="BX0-Jw-TD9"/>
                 <outlet property="authorLabel" destination="l4E-Qn-Vgl" id="13b-bv-tba"/>
                 <outlet property="bottomBorder" destination="9eW-ex-CSu" id="wXM-fE-LEN"/>
@@ -296,5 +309,8 @@
         <image name="icon-post-actionbar-more" width="18" height="18"/>
         <image name="icon-post-actionbar-restore" width="18" height="18"/>
         <image name="icon-post-actionbar-view" width="18" height="18"/>
+        <namedColor name="Gray10">
+            <color red="0.80784313725490198" green="0.78823529411764703" blue="0.80784313725490198" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -63,6 +63,7 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
 
     private func applyStyles() {
         WPStyleGuide.configureTableViewCell(self)
+        WPStyleGuide.applyPostCardStyle(self)
         WPStyleGuide.applyPostProgressViewStyle(progressView)
         WPStyleGuide.configureLabel(timestampLabel, textStyle: .subheadline)
         WPStyleGuide.configureLabel(badgesLabel, textStyle: .subheadline)
@@ -70,15 +71,16 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
         titleLabel.font = WPStyleGuide.notoBoldFontForTextStyle(.headline)
         titleLabel.adjustsFontForContentSizeCategory = true
 
-        titleLabel.textColor = WPStyleGuide.darkGrey()
-        timestampLabel.textColor = WPStyleGuide.grey()
-        menuButton.tintColor = WPStyleGuide.greyLighten10()
+        titleLabel.textColor = .text
+        timestampLabel.textColor = .textSubtle
+        menuButton.tintColor = .textSubtle
 
         menuButton.setImage(Gridicon.iconOfType(.ellipsis), for: .normal)
 
-        backgroundColor = WPStyleGuide.greyLighten30()
-
         featuredImageView.layer.cornerRadius = Constants.imageRadius
+
+        backgroundColor = innerView.backgroundColor
+        contentView.backgroundColor = innerView.backgroundColor
     }
 
     private func setupReadableGuideForiPad() {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -233,6 +233,8 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
         let headerNib = UINib(nibName: ActivityListSectionHeaderView.identifier, bundle: nil)
         tableView.register(headerNib, forHeaderFooterViewReuseIdentifier: ActivityListSectionHeaderView.identifier)
+
+        WPStyleGuide.configureColors(view: view, tableView: tableView)
     }
 
     override func configureAuthorFilter() {

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Gridicons
 
 class RestorePostTableViewCell: UITableViewCell, ConfigurablePostView, InteractivePostView {
     @IBOutlet var postContentView: UIView!
@@ -38,6 +39,8 @@ class RestorePostTableViewCell: UITableViewCell, ConfigurablePostView, Interacti
         restoreLabel.text = NSLocalizedString("Post moved to trash.", comment: "A short message explaining that a post was moved to the trash bin.")
         let buttonTitle = NSLocalizedString("Undo", comment: "The title of an 'undo' button. Tapping the button moves a trashed post out of the trash folder.")
         restoreButton.setTitle(buttonTitle, for: .normal)
+        restoreButton.setImage(Gridicon.iconOfType(.undo, withSize: CGSize(width: Constants.imageSize,
+                                                                           height: Constants.imageSize)), for: .normal)
     }
 
     private func configureCompact() {
@@ -47,7 +50,7 @@ class RestorePostTableViewCell: UITableViewCell, ConfigurablePostView, Interacti
 
     private func configureDefault() {
         topMargin.constant = Constants.defaultMargin
-        postContentView.layer.borderColor = WPStyleGuide.postCardBorderColor?.cgColor
+        postContentView.layer.borderColor = WPStyleGuide.postCardBorderColor.cgColor
         postContentView.layer.borderWidth = 1.0 / UIScreen.main.scale
     }
 
@@ -72,5 +75,6 @@ class RestorePostTableViewCell: UITableViewCell, ConfigurablePostView, Interacti
     private enum Constants {
         static let defaultMargin: CGFloat = 16
         static let compactMargin: CGFloat = 0
+        static let imageSize: CGFloat = 18.0
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
@@ -15,46 +15,47 @@ extension WPStyleGuide {
     }
 
     // MARK: - Card View Styles
-    static var postCardBorderColor = UIColor(fromRGBAColorWithRed: 215.0, green: 227.0, blue: 235.0, alpha: 1.0)
+    static let postCardBorderColor: UIColor = .neutral(shade: .shade10)
 
     class func applyPostCardStyle(_ cell: UITableViewCell) {
-        cell.backgroundColor = greyLighten30()
-        cell.contentView.backgroundColor = greyLighten30()
+        cell.backgroundColor = .neutral(shade: .shade0)
+        cell.contentView.backgroundColor = .neutral(shade: .shade0)
     }
 
     class func applyPostTitleStyle(_ label: UILabel) {
-        label.textColor = darkGrey()
+        label.textColor = .text
     }
 
     class func applyPostSnippetStyle(_ label: UILabel) {
-        label.textColor = darkGrey()
+        label.textColor = .text
     }
 
     class func applyPostDateStyle(_ label: UILabel) {
         configureLabelForRegularFontStyle(label)
-        label.textColor = grey()
+        label.textColor = .textSubtle
     }
 
     class func applyPostButtonStyle(_ button: UIButton) {
         configureLabelForRegularFontStyle(button.titleLabel)
-        button.setTitleColor(grey(), for: .normal)
+        button.setTitleColor(.textSubtle, for: .normal)
     }
 
     class func applyPostProgressViewStyle(_ progressView: UIProgressView) {
-        progressView.trackTintColor = greyLighten20()
-        progressView.progressTintColor = mediumBlue()
-        progressView.tintColor = mediumBlue()
+        progressView.trackTintColor = .divider
+        progressView.progressTintColor = .primary
+        progressView.tintColor = .primary
     }
 
     class func applyRestorePostLabelStyle(_ label: UILabel) {
         configureLabelForRegularFontStyle(label)
-        label.textColor = grey()
+        label.textColor = .textSubtle
     }
 
     class func applyRestorePostButtonStyle(_ button: UIButton) {
         configureLabelForRegularFontStyle(button.titleLabel)
-        button.setTitleColor(wordPressBlue(), for: .normal)
-        button.setTitleColor(darkBlue(), for: .highlighted)
+        button.setTitleColor(.accent, for: .normal)
+        button.setTitleColor(.accentDark, for: .highlighted)
+        button.tintColor = .accent
     }
 
     class func applyBorderStyle(_ view: UIView) {
@@ -64,10 +65,10 @@ extension WPStyleGuide {
 
     class func applyActionBarButtonStyle(_ button: UIButton) {
         button.flipInsetsForRightToLeftLayoutDirection()
-        button.setImage(button.imageView?.image?.imageWithTintColor(grey()), for: .normal)
-        button.setTitleColor(grey(), for: .normal)
-        button.setTitleColor(darkGrey(), for: .highlighted)
-        button.setTitleColor(darkGrey(), for: .selected)
+        button.setImage(button.imageView?.image?.imageWithTintColor(.textSubtle), for: .normal)
+        button.setTitleColor(.textSubtle, for: .normal)
+        button.setTitleColor(.text, for: .highlighted)
+        button.setTitleColor(.text, for: .selected)
     }
 
     class func insertSelectedBackgroundSubview(_ selectedBackgroundView: UIView, topMargin: CGFloat) {
@@ -80,7 +81,7 @@ extension WPStyleGuide {
             marginMask.trailingAnchor.constraint(equalTo: selectedBackgroundView.trailingAnchor),
             marginMask.heightAnchor.constraint(equalToConstant: topMargin)
         ])
-        marginMask.backgroundColor = greyLighten30()
+        marginMask.backgroundColor = .neutral(shade: .shade5)
     }
 
     // MARK: - Attributed String Attributes


### PR DESCRIPTION
This PR updates the new post list to use the new Muriel colors.

**To test:**

* Build and run
* Navigate to the post list and ensure nothing looks out of place – compare to standard screens like BlogDetailsViewController and MeViewController
* Try expanding and deleting cells
* Try deleting a post and checking the style of the 'restore' row

@mattmiklic here are some screenshots for you. I used `primary` for the upload progress bar instead of `accent`, as I figured it's not tappable. Let me know what you think.

![Simulator Screen Shot - iPhone X - 2019-07-11 at 14 10 55](https://user-images.githubusercontent.com/4780/61055063-9cce0b80-a3e8-11e9-90dd-e3ca05e50c0f.png)

![Simulator Screen Shot - iPhone X - 2019-07-11 at 14 10 54](https://user-images.githubusercontent.com/4780/61055071-a22b5600-a3e8-11e9-8a19-6d94272bce83.png)

![Simulator Screen Shot - iPhone X - 2019-07-11 at 13 52 37](https://user-images.githubusercontent.com/4780/61055106-a9eafa80-a3e8-11e9-8c29-18a2dc11d05b.png)

![Simulator Screen Shot - iPhone X - 2019-07-11 at 13 49 25](https://user-images.githubusercontent.com/4780/61055112-ae171800-a3e8-11e9-894b-fd91d250cfc0.png)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.