### PR TITLE
Add tests for media upload restart handling

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		4645AFC51961E1FB005F7509 /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4645AFC41961E1FB005F7509 /* AppImages.xcassets */; };
 		4B2DD0F29CD6AC353C056D41 /* Pods_WordPressUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DCE7542239FBC709B90EA85 /* Pods_WordPressUITests.framework */; };
 		4C8A715EBCE7E73AEE216293 /* Pods_WordPressShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */; };
+		4D520D4F22972BC9002F5924 /* acknowledgements.html in Resources */ = {isa = PBXBuildFile; fileRef = 4D520D4E22972BC9002F5924 /* acknowledgements.html */; };
 		570265152298921800F2214C /* PostListTableViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570265142298921800F2214C /* PostListTableViewHandler.swift */; };
 		570265172298960B00F2214C /* PostListTableViewHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570265162298960B00F2214C /* PostListTableViewHandlerTests.swift */; };
 		5703A4C622C003DC0028A343 /* WPStyleGuide+Posts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5703A4C522C003DC0028A343 /* WPStyleGuide+Posts.swift */; };
@@ -532,13 +533,13 @@
 		570BFD8D22823DE5007859A8 /* PostActionSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570BFD8C22823DE5007859A8 /* PostActionSheetTests.swift */; };
 		570BFD902282418A007859A8 /* PostBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570BFD8F2282418A007859A8 /* PostBuilder.swift */; };
 		5727EAF82284F5AC00822104 /* InteractivePostViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5727EAF72284F5AC00822104 /* InteractivePostViewDelegate.swift */; };
-		4D520D4F22972BC9002F5924 /* acknowledgements.html in Resources */ = {isa = PBXBuildFile; fileRef = 4D520D4E22972BC9002F5924 /* acknowledgements.html */; };
 		572FB401223A806000933C76 /* NoticeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572FB400223A806000933C76 /* NoticeStoreTests.swift */; };
 		575E126322973EBB0041B3EB /* PostCompactCellGhostableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575E126222973EBB0041B3EB /* PostCompactCellGhostableTests.swift */; };
 		575E126F229779E70041B3EB /* RestorePostTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575E126E229779E70041B3EB /* RestorePostTableViewCell.swift */; };
 		577C2AAB22936DCB00AD1F03 /* PostCardCellGhostableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577C2AAA22936DCB00AD1F03 /* PostCardCellGhostableTests.swift */; };
 		577C2AB422943FEC00AD1F03 /* PostCompactCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577C2AB322943FEC00AD1F03 /* PostCompactCell.swift */; };
 		577C2AB62294401800AD1F03 /* PostCompactCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 577C2AB52294401800AD1F03 /* PostCompactCell.xib */; };
+		5789E5C822D7D40800333698 /* AztecPostViewControllerAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5789E5C722D7D40800333698 /* AztecPostViewControllerAttachmentTests.swift */; };
 		57AA848F228715DA00D3C2A2 /* PostCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AA848E228715DA00D3C2A2 /* PostCardCell.swift */; };
 		57AA8491228715E700D3C2A2 /* PostCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57AA8490228715E700D3C2A2 /* PostCardCell.xib */; };
 		57AA8493228790AA00D3C2A2 /* PostCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AA8492228790AA00D3C2A2 /* PostCardCellTests.swift */; };
@@ -2571,6 +2572,7 @@
 		577C2AAA22936DCB00AD1F03 /* PostCardCellGhostableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardCellGhostableTests.swift; sourceTree = "<group>"; };
 		577C2AB322943FEC00AD1F03 /* PostCompactCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCompactCell.swift; sourceTree = "<group>"; };
 		577C2AB52294401800AD1F03 /* PostCompactCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PostCompactCell.xib; sourceTree = "<group>"; };
+		5789E5C722D7D40800333698 /* AztecPostViewControllerAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AztecPostViewControllerAttachmentTests.swift; path = Aztec/AztecPostViewControllerAttachmentTests.swift; sourceTree = "<group>"; };
 		57AA848E228715DA00D3C2A2 /* PostCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardCell.swift; sourceTree = "<group>"; };
 		57AA8490228715E700D3C2A2 /* PostCardCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PostCardCell.xib; sourceTree = "<group>"; };
 		57AA8492228790AA00D3C2A2 /* PostCardCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardCellTests.swift; sourceTree = "<group>"; };
@@ -4904,7 +4906,7 @@
 			path = Networking;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				F14B5F6F208E648200439554 /* config */,
@@ -9038,6 +9040,7 @@
 				FF8032651EE9E22200861F28 /* MediaProgressCoordinatorTests.swift */,
 				FF1FD02520912AA900186384 /* URL+LinkNormalizationTests.swift */,
 				7320C8BC2190C9FC0082FED5 /* UITextView+SummaryTests.swift */,
+				5789E5C722D7D40800333698 /* AztecPostViewControllerAttachmentTests.swift */,
 			);
 			name = Aztec;
 			sourceTree = "<group>";
@@ -9421,7 +9424,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -11718,6 +11721,7 @@
 				BE1071FF1BC75FFA00906AFF /* WPStyleGuide+BlogTests.swift in Sources */,
 				932645A41E7C206600134988 /* GutenbergSettingsTests.swift in Sources */,
 				933D1F471EA64108009FB462 /* TestingAppDelegate.m in Sources */,
+				5789E5C822D7D40800333698 /* AztecPostViewControllerAttachmentTests.swift in Sources */,
 				400199AB222590E100EB0906 /* AllTimeStatsRecordValueTests.swift in Sources */,
 				4054F4642214F94D00D261AB /* StreakStatsRecordValueTests.swift in Sources */,
 				85B125411B028E34008A3D95 /* PushAuthenticationManagerTests.swift in Sources */,

--- a/WordPress/WordPressTest/Aztec/AztecPostViewControllerAttachmentTests.swift
+++ b/WordPress/WordPressTest/Aztec/AztecPostViewControllerAttachmentTests.swift
@@ -1,0 +1,86 @@
+
+@testable import WordPress
+import Aztec
+import WordPressEditor
+import Nimble
+
+class AztecPostViewControllerAttachmentTests: XCTestCase {
+
+    private var contextManager: TestContextManager!
+    private var context: NSManagedObjectContext!
+
+    override func setUp() {
+        super.setUp()
+
+        contextManager = TestContextManager()
+        context = contextManager.newDerivedContext()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        context = nil
+        contextManager = nil
+    }
+
+    func testMediaUploadErrorsWillShowAnErrorMessageAndOverlay() {
+        // Arrange
+        let media = Media(context: context)
+        let post = Fixtures.createPost(context: context, with: media)
+        let vc = Fixtures.createAztecPostViewController(with: post)
+
+        let attachment = vc.findAttachment(withUploadID: media.uploadID)!
+        expect(attachment.message).to(beNil())
+        expect(attachment.overlayImage).to(beNil())
+
+        // Act
+        let error = NSError(domain: "domain", code: 0, userInfo: nil)
+        vc.mediaObserver(media: media, state: .failed(error: error))
+
+        // Assert
+        expect(attachment.message).notTo(beNil())
+        expect(attachment.overlayImage).notTo(beNil())
+        expect(attachment.progress).to(beNil())
+    }
+
+    func testRestartingOfMediaUploadsWillClearErrorMessageAndOverlay() {
+        // Arrange
+        let media = Media(context: context)
+        let post = Fixtures.createPost(context: context, with: media)
+        let vc = Fixtures.createAztecPostViewController(with: post)
+
+        let attachment = vc.findAttachment(withUploadID: media.uploadID)!
+
+        // Trigger an error
+        let error = NSError(domain: "domain", code: 0, userInfo: nil)
+        vc.mediaObserver(media: media, state: .failed(error: error))
+
+        // Act
+        // Simulate the restarting of uploads
+        vc.mediaObserver(media: media, state: .uploading(progress: Progress(totalUnitCount: 100)))
+
+        // Assert
+        expect(attachment.message).to(beNil())
+        expect(attachment.overlayImage).to(beNil())
+        expect(attachment.progress).to(equal(0))
+    }
+
+    private struct Fixtures {
+        static func createPost(context: NSManagedObjectContext, with media: Media) -> Post {
+            let post = Post(context: context)
+            post.content = """
+                <p><img src="" \(MediaAttachment.uploadKey)="\(media.uploadID)"></p>
+            """
+            return post
+        }
+
+        static func createAztecPostViewController(with post: Post) -> AztecPostViewController {
+            let vc = AztecPostViewController(post: post, replaceEditor: { (_, _) in
+                // noop
+            })
+            // Manually setting the post here so that the `post.didSet` will be called. Without
+            // this, the attachments will not be initialized.
+            vc.post = post
+            return vc
+        }
+    }
+}


### PR DESCRIPTION
Closes #11846.  

This adds simple tests for the code that was added in #12058. 

## Testing

Running the new test class, `AztecPostViewControllerAttachmentTests`, should be enough. 

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
