### PR TITLE
Color tweaks: notifications unread color, domains credit icon, reader separators

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,7 +14,7 @@
 * Stats overview chart: Fixed issue with legend location on iOS 11.
 * Stats Periods: Fixed crash when the Countries map displayed one country only
 * Added a selection of user customizable app icons. Change it via Me > App Settings > App Icon.
-* Update the app's colors using the Muriel color pallete.
+* Update the app's colors using the Muriel color palette.
 * Stats Periods detail views: Fixed an issue where rotation would truncate data.
 * Stats Periods: Fixed an issue when a period interval was selected.
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+DomainCredit.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+DomainCredit.swift
@@ -7,7 +7,7 @@ extension BlogDetailsViewController {
         let row = BlogDetailsRow(title: NSLocalizedString("Register Domain", comment: "Action to redeem domain credit."),
                                  accessibilityIdentifier: "Register domain from site dashboard",
                                  image: image,
-                                 imageColor: UIColor.warning) { [weak self] in
+                                 imageColor: UIColor.warning(shade: .shade20)) { [weak self] in
                                     WPAnalytics.track(.domainCreditRedemptionTapped)
                                     self?.showDomainCreditRedemption()
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -26,7 +26,7 @@ extension WPStyleGuide {
         public static let noticonUnmoderatedColor   = UIColor.warning
 
         public static let noteBackgroundReadColor   = UIColor.white
-        public static let noteBackgroundUnreadColor = UIColor.neutral(shade: .shade0)
+        public static let noteBackgroundUnreadColor = UIColor.primary(shade: .shade0)
 
         public static let noteSeparatorColor        = blockSeparatorColor
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -255,7 +255,7 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         backgroundColor = .clear
         contentView.backgroundColor = .clear
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = 1.0
+        borderedView.layer.borderWidth = 0.5
 
         WPStyleGuide.applyReaderFollowButtonStyle(followButton)
         WPStyleGuide.applyReaderCardBlogNameStyle(blogNameLabel)

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -41,7 +41,7 @@ extension WPStyleGuide {
     }
 
     @objc public class func readerCardCellHighlightedBorderColor() -> UIColor {
-        return .neutral
+        return .neutral(shade: .shade10)
     }
 
     // MARK: - Card Attributed Text Attributes


### PR DESCRIPTION
This PR tweaks a few color items before we cut our release. Most important is the update to unread notification backgrounds, which were very difficult to differentiate.

![before-after](https://user-images.githubusercontent.com/4780/61135887-6d87cf00-a4ba-11e9-831d-5f24caf162f6.png)

* Unread notification row background is now blue-0 instead of neutral-0
* Domain credit icon is now yellow-20 to make it lighter
* Reader separators are lighter as they were quite heavy previously and didn't match other areas of the app

**To test:**

* Build and run (or check the screenshots)
* Ensure the colors look okay and match the description above.
* To get the domain credit row to show, you can modify `configureTableViewData` in `BlogDetailsViewController`.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt` (item was already present)