### PR TITLE
Use readable content in Revision diffs

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewViewController.swift
@@ -22,13 +22,11 @@ class RevisionPreviewViewController: UIViewController, StoryboardLoadable {
                               defaultMissingImage: UIImage())
         aztext.translatesAutoresizingMaskIntoConstraints = false
         aztext.isEditable = false
-        aztext.delegate = self
         return aztext
     }()
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = WPFontManager.notoBoldFont(ofSize: 24.0)
-        label.autoresizingMask = [.flexibleWidth]
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         label.textAlignment = .natural
@@ -45,7 +43,6 @@ class RevisionPreviewViewController: UIViewController, StoryboardLoadable {
 
     override func updateViewConstraints() {
         updateTitleHeight()
-        refreshTitlePosition()
         super.updateViewConstraints()
     }
 
@@ -90,7 +87,6 @@ private extension RevisionPreviewViewController {
         textView.setHTML(html)
 
         updateTitleHeight()
-        refreshTitlePosition()
     }
 }
 
@@ -101,30 +97,28 @@ private extension RevisionPreviewViewController {
 private extension RevisionPreviewViewController {
     private func addSubviews() {
         view.addSubview(textView)
-        view.addSubview(titleLabel)
+        textView.addSubview(titleLabel)
     }
 
     private func configureConstraints() {
         updateTitleHeight()
 
+        let guide = view.readableContentGuide
         NSLayoutConstraint.activate([
-            textView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: textViewInsets.left),
-            textView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -textViewInsets.right),
+            textView.leadingAnchor.constraint(equalTo: guide.leadingAnchor),
+            textView.trailingAnchor.constraint(equalTo: guide.trailingAnchor),
             textView.topAnchor.constraint(equalTo: view.topAnchor),
             textView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
             ])
     }
 
-    private func refreshTitlePosition() {
-        titleLabel.frame.origin.y = -(textView.contentOffset.y + textView.contentInset.top) + titleInsets.top
-    }
-
     private func updateTitleHeight() {
-        let size = titleLabel.sizeThatFits(CGSize(width: view.frame.width - (titleInsets.left * 2.0), height: CGFloat.greatestFiniteMagnitude))
-        titleLabel.frame = CGRect(x: titleInsets.left, y: titleInsets.top, width: size.width, height: size.height)
+        let size = titleLabel.sizeThatFits(CGSize(width: textView.frame.width,
+                                                  height: CGFloat.greatestFiniteMagnitude))
+        titleLabel.frame = CGRect(x: 0, y: -(titleInsets.top + size.height), width: size.width, height: size.height)
 
         var contentInset = textView.contentInset
-        contentInset.top = titleLabel.frame.maxY + titleInsets.bottom
+        contentInset.top = titleInsets.top + size.height + titleInsets.bottom
         textView.contentInset = contentInset
         textView.setContentOffset(CGPoint(x: 0, y: -textView.contentInset.top), animated: false)
 
@@ -137,12 +131,5 @@ private extension RevisionPreviewViewController {
         rightMargin -= view.safeAreaInsets.right
         scrollInsets.right = -rightMargin
         textView.scrollIndicatorInsets = scrollInsets
-    }
-}
-
-
-extension RevisionPreviewViewController: UITextViewDelegate {
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        refreshTitlePosition()
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Revisions.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Revisions.storyboard
@@ -35,79 +35,80 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rsS-xc-ge8">
-                                <rect key="frame" x="0.0" y="547" width="375" height="56"/>
+                                <rect key="frame" x="0.0" y="539" width="375" height="64"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2sd-Cz-oer">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="48"/>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rSD-aC-9V4">
+                                        <rect key="frame" x="0.0" y="7" width="50" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="kHo-9b-a0K"/>
+                                            <constraint firstAttribute="width" constant="50" id="xyN-oS-DyY"/>
+                                        </constraints>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Und-hy-I90">
+                                        <rect key="frame" x="325" y="7" width="50" height="50"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="50" id="MHQ-95-69R"/>
+                                            <constraint firstAttribute="width" constant="50" id="gYY-PG-gPN"/>
+                                        </constraints>
+                                    </button>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7EM-Lu-3t1" userLabel="Stroke">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
+                                        <color key="backgroundColor" red="0.78431372549019607" green="0.84313725490196079" blue="0.84313725490196079" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="irb-X1-ceq"/>
+                                        </constraints>
+                                    </view>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0zh-of-VUW">
+                                        <rect key="frame" x="107.5" y="11" width="160" height="42"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Revision Description" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Hg-z8-YVh">
-                                                <rect key="frame" x="117.5" y="8" width="140" height="18"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="160" height="20"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="14" id="LKL-8N-EMV"/>
+                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="LKL-8N-EMV"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <color key="textColor" red="0.32549019607843138" green="0.47450980392156861" blue="0.58039215686274503" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="T2k-GK-3TX">
-                                                <rect key="frame" x="107.5" y="30" width="160" height="18"/>
+                                                <rect key="frame" x="0.0" y="24" width="160" height="18"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="width" constant="160" id="ENz-lo-ACI"/>
                                                     <constraint firstAttribute="height" constant="18" id="Mzl-br-Npx"/>
                                                 </constraints>
                                                 <connections>
                                                     <segue destination="NGj-2N-mgj" kind="embed" id="yNH-Su-ENV"/>
                                                 </connections>
                                             </containerView>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rSD-aC-9V4">
-                                                <rect key="frame" x="-5" y="0.0" width="50" height="50"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="50" id="kHo-9b-a0K"/>
-                                                    <constraint firstAttribute="width" constant="50" id="xyN-oS-DyY"/>
-                                                </constraints>
-                                            </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Und-hy-I90">
-                                                <rect key="frame" x="330" y="0.0" width="50" height="50"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="50" id="MHQ-95-69R"/>
-                                                    <constraint firstAttribute="width" constant="50" id="gYY-PG-gPN"/>
-                                                </constraints>
-                                            </button>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7EM-Lu-3t1" userLabel="Stroke">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
-                                                <color key="backgroundColor" red="0.78431372549019607" green="0.84313725490196079" blue="0.84313725490196079" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="1" id="irb-X1-ceq"/>
-                                                </constraints>
-                                            </view>
                                         </subviews>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
-                                            <constraint firstItem="rSD-aC-9V4" firstAttribute="top" secondItem="2sd-Cz-oer" secondAttribute="top" id="0NR-XG-8oT"/>
-                                            <constraint firstItem="rSD-aC-9V4" firstAttribute="leading" secondItem="2sd-Cz-oer" secondAttribute="leadingMargin" constant="-13" id="0Yx-9O-f8Z"/>
-                                            <constraint firstItem="Und-hy-I90" firstAttribute="top" secondItem="2sd-Cz-oer" secondAttribute="top" id="5yn-Ry-XWr"/>
-                                            <constraint firstItem="T2k-GK-3TX" firstAttribute="centerX" secondItem="2sd-Cz-oer" secondAttribute="centerX" id="7Cm-Jp-MCY"/>
-                                            <constraint firstAttribute="trailingMargin" secondItem="Und-hy-I90" secondAttribute="trailing" constant="-13" id="9ir-ww-2ld"/>
-                                            <constraint firstItem="1Hg-z8-YVh" firstAttribute="centerX" secondItem="2sd-Cz-oer" secondAttribute="centerX" id="BXl-ng-Iq7"/>
-                                            <constraint firstAttribute="trailing" secondItem="7EM-Lu-3t1" secondAttribute="trailing" id="C5H-cg-l5R"/>
-                                            <constraint firstItem="T2k-GK-3TX" firstAttribute="top" secondItem="1Hg-z8-YVh" secondAttribute="bottom" constant="4" id="H2J-G4-f1h"/>
-                                            <constraint firstAttribute="bottom" secondItem="T2k-GK-3TX" secondAttribute="bottom" id="ZFA-eY-Y7g"/>
-                                            <constraint firstItem="7EM-Lu-3t1" firstAttribute="top" secondItem="2sd-Cz-oer" secondAttribute="top" id="Zc3-Ep-T1y"/>
-                                            <constraint firstItem="1Hg-z8-YVh" firstAttribute="top" secondItem="2sd-Cz-oer" secondAttribute="top" constant="8" id="m4x-Gg-2Ya"/>
-                                            <constraint firstItem="7EM-Lu-3t1" firstAttribute="leading" secondItem="2sd-Cz-oer" secondAttribute="leading" id="mKE-IF-AzL"/>
+                                            <constraint firstItem="T2k-GK-3TX" firstAttribute="top" secondItem="1Hg-z8-YVh" secondAttribute="bottom" constant="4" id="C5J-9t-sd9"/>
+                                            <constraint firstItem="1Hg-z8-YVh" firstAttribute="top" secondItem="0zh-of-VUW" secondAttribute="top" id="Isk-s9-MoC"/>
+                                            <constraint firstItem="T2k-GK-3TX" firstAttribute="leading" secondItem="0zh-of-VUW" secondAttribute="leading" id="OVE-Zq-Uop"/>
+                                            <constraint firstAttribute="trailing" secondItem="1Hg-z8-YVh" secondAttribute="trailing" id="SbP-Xp-OCn"/>
+                                            <constraint firstAttribute="trailing" secondItem="T2k-GK-3TX" secondAttribute="trailing" id="czM-JZ-dus"/>
+                                            <constraint firstAttribute="bottom" secondItem="T2k-GK-3TX" secondAttribute="bottom" id="rKc-Iv-WgV"/>
+                                            <constraint firstAttribute="width" constant="160" id="uEm-5C-vAN"/>
+                                            <constraint firstItem="1Hg-z8-YVh" firstAttribute="leading" secondItem="0zh-of-VUW" secondAttribute="leading" id="zUA-k6-qCc"/>
                                         </constraints>
                                     </view>
                                 </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="bottomMargin" secondItem="2sd-Cz-oer" secondAttribute="bottom" id="07B-Ah-IAY"/>
-                                    <constraint firstAttribute="trailing" secondItem="2sd-Cz-oer" secondAttribute="trailing" id="Mos-24-tGJ"/>
-                                    <constraint firstItem="2sd-Cz-oer" firstAttribute="top" secondItem="rsS-xc-ge8" secondAttribute="top" id="a54-V2-8On"/>
-                                    <constraint firstItem="2sd-Cz-oer" firstAttribute="leading" secondItem="rsS-xc-ge8" secondAttribute="leading" id="mBV-uA-g4X"/>
+                                    <constraint firstItem="0zh-of-VUW" firstAttribute="centerX" secondItem="rsS-xc-ge8" secondAttribute="centerX" id="0Xi-Yi-tLJ"/>
+                                    <constraint firstAttribute="trailing" secondItem="7EM-Lu-3t1" secondAttribute="trailing" id="377-um-dZe"/>
+                                    <constraint firstItem="0zh-of-VUW" firstAttribute="centerY" secondItem="rsS-xc-ge8" secondAttribute="centerY" id="A67-DC-y8V"/>
+                                    <constraint firstItem="Und-hy-I90" firstAttribute="centerY" secondItem="rsS-xc-ge8" secondAttribute="centerY" id="O8C-zl-BsG"/>
+                                    <constraint firstItem="7EM-Lu-3t1" firstAttribute="leading" secondItem="rsS-xc-ge8" secondAttribute="leading" id="Q3Q-rc-osC"/>
+                                    <constraint firstAttribute="height" constant="64" id="ZMi-lo-De1"/>
+                                    <constraint firstItem="rSD-aC-9V4" firstAttribute="leading" secondItem="rsS-xc-ge8" secondAttribute="leadingMargin" constant="-8" id="ZTE-mW-bps"/>
+                                    <constraint firstItem="7EM-Lu-3t1" firstAttribute="top" secondItem="rsS-xc-ge8" secondAttribute="top" id="taB-tA-qKm"/>
+                                    <constraint firstItem="rSD-aC-9V4" firstAttribute="centerY" secondItem="rsS-xc-ge8" secondAttribute="centerY" id="wvg-Ks-iGq"/>
+                                    <constraint firstAttribute="trailingMargin" secondItem="Und-hy-I90" secondAttribute="trailing" constant="-8" id="zjk-z8-Shi"/>
                                 </constraints>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uhq-mq-TeO">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="547"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="539"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <connections>
                                     <segue destination="1re-Hq-Vps" kind="embed" id="UdL-Ti-ban"/>
@@ -120,7 +121,7 @@
                             <constraint firstItem="rsS-xc-ge8" firstAttribute="bottom" secondItem="cG0-G3-XU5" secondAttribute="bottom" id="5dU-hU-vJF"/>
                             <constraint firstItem="rsS-xc-ge8" firstAttribute="leading" secondItem="lB6-fr-eSA" secondAttribute="leading" id="BPA-G1-UR0"/>
                             <constraint firstItem="uhq-mq-TeO" firstAttribute="trailing" secondItem="lB6-fr-eSA" secondAttribute="trailing" id="N9d-9c-2sc"/>
-                            <constraint firstItem="2sd-Cz-oer" firstAttribute="top" secondItem="uhq-mq-TeO" secondAttribute="bottom" id="THE-MA-LZh"/>
+                            <constraint firstItem="rsS-xc-ge8" firstAttribute="top" secondItem="uhq-mq-TeO" secondAttribute="bottom" id="WUr-tZ-ajf"/>
                             <constraint firstItem="uhq-mq-TeO" firstAttribute="top" secondItem="lB6-fr-eSA" secondAttribute="top" id="fNe-Eg-VBR"/>
                             <constraint firstItem="uhq-mq-TeO" firstAttribute="leading" secondItem="lB6-fr-eSA" secondAttribute="leading" id="kqQ-bM-OaU"/>
                         </constraints>

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Revisions.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Revisions.storyboard
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -53,7 +54,7 @@
                                     </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7EM-Lu-3t1" userLabel="Stroke">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
-                                        <color key="backgroundColor" red="0.78431372549019607" green="0.84313725490196079" blue="0.84313725490196079" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <color key="backgroundColor" name="Gray40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="irb-X1-ceq"/>
                                         </constraints>
@@ -67,7 +68,7 @@
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="LKL-8N-EMV"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <color key="textColor" red="0.32549019607843138" green="0.47450980392156861" blue="0.58039215686274503" alpha="1" colorSpace="calibratedRGB"/>
+                                                <color key="textColor" name="Gray40"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="T2k-GK-3TX">
@@ -246,4 +247,9 @@ Nulla sodales mauris ullamcorper massa tincidunt, eu pretium erat fringilla. Sed
             <point key="canvasLocation" x="359" y="-170"/>
         </scene>
     </scenes>
+    <resources>
+        <namedColor name="Gray40">
+            <color red="0.50196078431372548" green="0.50196078431372548" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Revisions.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Revisions.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9BX-ta-eQr">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9BX-ta-eQr">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -30,14 +30,14 @@
         <scene sceneID="b16-UI-OVT">
             <objects>
                 <viewController id="aEY-1G-H9o" customClass="RevisionDiffsBrowserViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="cG0-G3-XU5">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="cG0-G3-XU5">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rsS-xc-ge8">
+                            <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rsS-xc-ge8">
                                 <rect key="frame" x="0.0" y="547" width="375" height="56"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2sd-Cz-oer">
+                                    <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2sd-Cz-oer">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="48"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Revision Description" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Hg-z8-YVh">
@@ -84,10 +84,10 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstItem="rSD-aC-9V4" firstAttribute="top" secondItem="2sd-Cz-oer" secondAttribute="top" id="0NR-XG-8oT"/>
-                                            <constraint firstItem="rSD-aC-9V4" firstAttribute="leading" secondItem="2sd-Cz-oer" secondAttribute="leading" constant="-5" id="0Yx-9O-f8Z"/>
+                                            <constraint firstItem="rSD-aC-9V4" firstAttribute="leading" secondItem="2sd-Cz-oer" secondAttribute="leadingMargin" constant="-13" id="0Yx-9O-f8Z"/>
                                             <constraint firstItem="Und-hy-I90" firstAttribute="top" secondItem="2sd-Cz-oer" secondAttribute="top" id="5yn-Ry-XWr"/>
                                             <constraint firstItem="T2k-GK-3TX" firstAttribute="centerX" secondItem="2sd-Cz-oer" secondAttribute="centerX" id="7Cm-Jp-MCY"/>
-                                            <constraint firstAttribute="trailing" secondItem="Und-hy-I90" secondAttribute="trailing" constant="-5" id="9ir-ww-2ld"/>
+                                            <constraint firstAttribute="trailingMargin" secondItem="Und-hy-I90" secondAttribute="trailing" constant="-13" id="9ir-ww-2ld"/>
                                             <constraint firstItem="1Hg-z8-YVh" firstAttribute="centerX" secondItem="2sd-Cz-oer" secondAttribute="centerX" id="BXl-ng-Iq7"/>
                                             <constraint firstAttribute="trailing" secondItem="7EM-Lu-3t1" secondAttribute="trailing" id="C5H-cg-l5R"/>
                                             <constraint firstItem="T2k-GK-3TX" firstAttribute="top" secondItem="1Hg-z8-YVh" secondAttribute="bottom" constant="4" id="H2J-G4-f1h"/>
@@ -106,7 +106,7 @@
                                     <constraint firstItem="2sd-Cz-oer" firstAttribute="leading" secondItem="rsS-xc-ge8" secondAttribute="leading" id="mBV-uA-g4X"/>
                                 </constraints>
                             </view>
-                            <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uhq-mq-TeO">
+                            <containerView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uhq-mq-TeO">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="547"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <connections>
@@ -142,14 +142,14 @@
         <scene sceneID="hhd-wv-eJw">
             <objects>
                 <viewController storyboardIdentifier="RevisionDiffViewController" id="zhH-St-dBr" customClass="RevisionDiffViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="lxH-jU-9dc">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="lxH-jU-9dc">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mb8-Xb-lI6">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mb8-Xb-lI6">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Uaa-Yz-aE2">
+                                    <stackView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Uaa-Yz-aE2">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="1426.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GAe-1S-aM6">
@@ -191,9 +191,9 @@ Nulla sodales mauris ullamcorper massa tincidunt, eu pretium erat fringilla. Sed
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="bottom" secondItem="mb8-Xb-lI6" secondAttribute="bottom" id="W3Y-Jf-i31"/>
-                            <constraint firstItem="mb8-Xb-lI6" firstAttribute="leading" secondItem="lxH-jU-9dc" secondAttribute="leading" id="hs4-hl-CAs"/>
+                            <constraint firstItem="mb8-Xb-lI6" firstAttribute="leading" secondItem="LhI-on-qxn" secondAttribute="leading" id="hs4-hl-CAs"/>
                             <constraint firstItem="mb8-Xb-lI6" firstAttribute="top" secondItem="lxH-jU-9dc" secondAttribute="top" id="mRH-2V-B47"/>
-                            <constraint firstAttribute="trailing" secondItem="mb8-Xb-lI6" secondAttribute="trailing" id="xjh-3u-ybK"/>
+                            <constraint firstItem="LhI-on-qxn" firstAttribute="trailing" secondItem="mb8-Xb-lI6" secondAttribute="trailing" id="xjh-3u-ybK"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="LhI-on-qxn"/>
                     </view>
@@ -210,7 +210,7 @@ Nulla sodales mauris ullamcorper massa tincidunt, eu pretium erat fringilla. Sed
         <scene sceneID="8bZ-0Y-ew9">
             <objects>
                 <viewController id="NGj-2N-mgj" customClass="RevisionOperationViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="GfE-RI-5IB">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="GfE-RI-5IB">
                         <rect key="frame" x="0.0" y="0.0" width="160" height="18"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -225,7 +225,7 @@ Nulla sodales mauris ullamcorper massa tincidunt, eu pretium erat fringilla. Sed
         <scene sceneID="Un9-in-nSa">
             <objects>
                 <viewController storyboardIdentifier="RevisionPreviewViewController" id="V7o-xA-JuH" customClass="RevisionPreviewViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="tXX-ja-77L">
+                    <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="tXX-ja-77L">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>


### PR DESCRIPTION
Fixes #11999 

This PR fixes the layout used by the Revision diffs view, using a readable width when the device is an iPad. It also fixes the bottom navigation button alignment.

![Simulator Screen Shot - iPad Air 2 - 2019-07-15 at 11 59 07](https://user-images.githubusercontent.com/912252/61209177-4e2ab500-a6f9-11e9-85dd-7137f89be31c.png)

![Simulator Screen Shot - iPad Air 2 - 2019-07-15 at 11 59 09](https://user-images.githubusercontent.com/912252/61209179-4ec34b80-a6f9-11e9-8e76-aa694e97cbee.png)

![Simulator Screen Shot - iPad Air 2 - 2019-07-15 at 11 59 15](https://user-images.githubusercontent.com/912252/61209181-4ec34b80-a6f9-11e9-9d87-dc9b9217ab16.png)

![Simulator Screen Shot - iPad Air 2 - 2019-07-15 at 11 59 17](https://user-images.githubusercontent.com/912252/61209182-4ec34b80-a6f9-11e9-98f6-4c437770d4b4.png)

## To test:
• Open a _post/page_ with multiple revisions
• Tap on `•••` to open menu
• Tap on History to open _History/Revisions_ viewer
• In History/Revisions viewer, tap `•••`, to switch between _HTML/Visual_ modes

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
