### PR TITLE
Issues/fixes login tracking

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -278,10 +278,10 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         [self setupAppExtensionsWithDefaultAccount];
         dispatch_async(dispatch_get_main_queue(), ^{
             [WPAnalytics refreshMetadata];
+            if (success) {
+                success();
+            }
         });
-        if (success) {
-            success();
-        }
     } failure:^(NSError *error) {
         DDLogError(@"Failed to fetch user details for account %@.  %@", account, error);
         if (failure) {

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -121,7 +121,14 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             accountPresent = YES;
         }
     }];
-    
+
+    if ([[NSUUID alloc] initWithUUIDString:username]) {
+        // User has authenticated but we're waiting for account details to sync.
+        // Once details are synced this method will be called again with the actual
+        // username. For now just exit without making changes.
+        return;
+    }
+
     BOOL dotcom_user = (accountPresent && username.length > 0);
     BOOL gutenbergEnabled = [GutenbergSettings isGutenbergEnabled];
     


### PR DESCRIPTION
This PR addresses an issue where tracks events were being miss-reported or lost during log in. For additional background see p9OQAC-h0-p2.

In https://github.com/wordpress-mobile/WordPress-iOS/pull/11294 I added changes to support authenticating with magic links generated from outside of the app. To limit the changes needed in the client code I relied on a temporary username, just a UUID, to create the initial WPAccount instance since the account was required to fetch account details. The actual username was obtained when syncing account details.   I missed how this could impact our tracks events. 

Problem one: We refresh tracks meta data when creating an account during login. This meant that tracks events would be de-anonymized with a UUID for a username. Ouch.
Problem two:  Even though we refresh meta data when updating account details, its done asynchronously leading to some events being dispatched before meta data was updated. 

This PR fixes the issue by ensuring we do not refresh meta data when there is a temporary username, and that meta data is refreshed before we call the success block when refreshing account details. 

To test:
You can confirm the glich by signing in with a magic link in the simulator.  I used a test account with a gmail email address and just checked gmail in safari in the simulator.  Check the tracks events in the tracks live view and confirm you only see the wpcom generated magic link events.  (Be paitent. It will take a few minutes for events to be picked up.)

Apply the patch and log in with a magic link again. Confirm that you see all expected wpios client events in the live view. 

I've targeted `develop` but we probably want to cherry pick these in to the `release/12.9` branch.

@astralbodies, would you do the honors? 