### PR TITLE
[Gutenberg] - Send unsupported blocks list to Tracks

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -480,7 +480,7 @@ class AztecPostViewController: UIViewController, PostEditor {
         }
 
         if !editorSession.started {
-            editorSession.start(hasUnsupportedBlocks: false)
+            editorSession.start()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -503,8 +503,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
     func gutenbergDidMount(unsupportedBlockNames: [String]) {
         startAutoSave()
         if !editorSession.started {
-            let hasUnsupportedBlocks = !unsupportedBlockNames.isEmpty
-            editorSession.start(hasUnsupportedBlocks: hasUnsupportedBlocks)
+            editorSession.start(unsupportedBlocks: unsupportedBlockNames)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -181,7 +181,7 @@ extension PostEditor where Self: UIViewController {
             properties[WPAnalyticsStatEditorPublishedPostPropertyVideo] = post.hasVideo()
         }
 
-        editorSession.track(stat, with: properties, post: post)
+        WPAppAnalytics.track(stat, withProperties: properties, with: post)
     }
 
     // MARK: - Close button handling
@@ -211,7 +211,7 @@ extension PostEditor where Self: UIViewController {
             return postDeleted
         }
 
-        editorSession.track(.editorDiscardedChanges, with: [WPAppAnalyticsKeyEditorSource: analyticsEditorSource], post: post)
+        WPAppAnalytics.track(.editorDiscardedChanges, withProperties: [WPAppAnalyticsKeyEditorSource: analyticsEditorSource], with: post)
 
         let shouldCreateDummyRevision: Bool
 
@@ -383,7 +383,7 @@ extension PostEditor where Self: UIViewController {
     func dismissOrPopView(didSave: Bool = true) {
         stopEditing()
 
-        editorSession.track(.editorDiscardedChanges, with: [WPAppAnalyticsKeyEditorSource: analyticsEditorSource], post: post)
+        WPAppAnalytics.track(.editorClosed, withProperties: [WPAppAnalyticsKeyEditorSource: analyticsEditorSource], with: post)
 
         if let onClose = onClose {
             onClose(didSave, false)

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -181,7 +181,7 @@ extension PostEditor where Self: UIViewController {
             properties[WPAnalyticsStatEditorPublishedPostPropertyVideo] = post.hasVideo()
         }
 
-        WPAppAnalytics.track(stat, withProperties: properties, with: post)
+        editorSession.track(stat, with: properties, post: post)
     }
 
     // MARK: - Close button handling
@@ -211,7 +211,7 @@ extension PostEditor where Self: UIViewController {
             return postDeleted
         }
 
-        WPAppAnalytics.track(.editorDiscardedChanges, withProperties: [WPAppAnalyticsKeyEditorSource: analyticsEditorSource], with: post)
+        editorSession.track(.editorDiscardedChanges, with: [WPAppAnalyticsKeyEditorSource: analyticsEditorSource], post: post)
 
         let shouldCreateDummyRevision: Bool
 
@@ -383,7 +383,7 @@ extension PostEditor where Self: UIViewController {
     func dismissOrPopView(didSave: Bool = true) {
         stopEditing()
 
-        WPAppAnalytics.track(.editorClosed, withProperties: [WPAppAnalyticsKeyEditorSource: analyticsEditorSource], with: post)
+        editorSession.track(.editorDiscardedChanges, with: [WPAppAnalyticsKeyEditorSource: analyticsEditorSource], post: post)
 
         if let onClose = onClose {
             onClose(didSave, false)

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -52,11 +52,6 @@ struct PostEditorAnalyticsSession {
 
         WPAppAnalytics.track(.editorSessionEnd, withProperties: properties)
     }
-
-    func track(_ stat: WPAnalyticsStat, with properties: [String: Any], post: AbstractPost) {
-        let finalProperties = properties.merging(commonProperties) { $1 }
-        WPAppAnalytics.track(stat, withProperties: finalProperties, with: post)
-    }
 }
 
 private extension PostEditorAnalyticsSession {

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -72,7 +72,7 @@ private extension PostEditorAnalyticsSession {
         static let sessionId = "session_id"
     }
 
-    var commonProperties: [String: Any] {
+    var commonProperties: [String: String] {
         return [
             Property.editor: currentEditor.rawValue,
             Property.contentType: contentType,

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -28,8 +28,9 @@ struct PostEditorAnalyticsSession {
     }
 
     private func startEventProperties(with unsupportedBlocks: [String]) -> [String: Any] {
-        let unsupportedBlocksProperty: [String: Any] = hasUnsupportedBlocks ? [Property.unsupportedBlocks: unsupportedBlocks] : [:]
-        return unsupportedBlocksProperty.merging(commonProperties, uniquingKeysWith: { $1 })
+        return [
+            Property.unsupportedBlocks: unsupportedBlocks
+        ].merging(commonProperties, uniquingKeysWith: { $1 })
     }
 
     mutating func `switch`(editor: Editor) {

--- a/WordPress/WordPressTest/Analytics/EditorAnalytics/PostEditorAnalyticsSessionTests.swift
+++ b/WordPress/WordPressTest/Analytics/EditorAnalytics/PostEditorAnalyticsSessionTests.swift
@@ -78,6 +78,19 @@ class PostEditorAnalyticsSessionTests: XCTestCase {
         XCTAssertEqual(tracked?.value(for: "has_unsupported_blocks"), "1")
     }
 
+    func testTrackUnsupportedBlocksOnStartWithEmptyList() {
+        let unsupportedBlocks = [String]()
+        startSession(editor: .gutenberg, unsupportedBlocks: unsupportedBlocks)
+
+        XCTAssertEqual(TestAnalyticsTracker.tracked.count, 1)
+
+        let tracked = TestAnalyticsTracker.tracked.first
+
+        XCTAssertEqual(tracked?.stat, WPAnalyticsStat.editorSessionStart)
+        XCTAssertEqual(tracked?.value(for: "unsupported_blocks"), unsupportedBlocks)
+        XCTAssertEqual(tracked?.value(for: "has_unsupported_blocks"), "0")
+    }
+
     func testTrackUnsupportedBlocksOnSwitch() {
         let unsupportedBlocks = ["unsupported"]
         var session = startSession(editor: .gutenberg, unsupportedBlocks: unsupportedBlocks)

--- a/WordPress/WordPressTest/Analytics/EditorAnalytics/PostEditorAnalyticsSessionTests.swift
+++ b/WordPress/WordPressTest/Analytics/EditorAnalytics/PostEditorAnalyticsSessionTests.swift
@@ -88,8 +88,8 @@ class PostEditorAnalyticsSessionTests: XCTestCase {
         let tracked = TestAnalyticsTracker.tracked.last
 
         XCTAssertEqual(tracked?.stat, WPAnalyticsStat.editorSessionSwitchEditor)
-        XCTAssertEqual(tracked?.value(for: "unsupported_blocks"), unsupportedBlocks)
         XCTAssertEqual(tracked?.value(for: "has_unsupported_blocks"), "1")
+        XCTAssertNil(tracked?.value(for: "unsupported_blocks"))
     }
 
     func testTrackUnsupportedBlocksOnEnd() {
@@ -102,8 +102,8 @@ class PostEditorAnalyticsSessionTests: XCTestCase {
         let tracked = TestAnalyticsTracker.tracked.last
 
         XCTAssertEqual(tracked?.stat, WPAnalyticsStat.editorSessionEnd)
-        XCTAssertEqual(tracked?.value(for: "unsupported_blocks"), unsupportedBlocks)
         XCTAssertEqual(tracked?.value(for: "has_unsupported_blocks"), "1")
+        XCTAssertNil(tracked?.value(for: "unsupported_blocks"))
     }
 }
 


### PR DESCRIPTION
WPiOS side of https://github.com/wordpress-mobile/gutenberg-mobile/issues/1174
Analog of Android PR: https://github.com/wordpress-mobile/WordPress-Android/pull/10237

**UPDATE:**
The new property has been added just to EDITOR_SESSION_START event.

**Old description:**
A new property unsupported_blocks is added to the EDITOR_SESSION_* events, and it does hold the list of unsupported blocks found in the post.

**Note:**

Since the unsupported blocks list is stored at the beginning of the editor session, subsequent editions to the post won't affect this property.

If the user remove all blocks, then save and close the post, tracks will still track the original list of unsupported blocks. and also track: `has_gutenberg_blocks: 0` creating an inconsistency.

Talking with @daniloercoli , on Android the value of `has_gutenberg_blocks` is also recorded at the beginning of the editing session, so there won't be inconsistencies, even though the data is not accurate.

I decided to keep the real `has_gutenberg_blocks` value for now. Ideally we could update the list of unsupported blocks when we request the updated content to gutenberg.

To test:

- Start the app and open a GB post that does contain unsupported blocks.
- Check that the events `🔵 Tracked: editor_session*` record the list of unsupported blocks accordingly.
- Open a gutenberg post without unsupported blocks.
- Check that the property `unsupported_blocks` is not recorded.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

cc @daniloercoli 