### PR TITLE
Muriel: Add a `tableBackground` semantic color

### DIFF
--- a/WordPress/Classes/Extensions/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/UIColor+MurielColors.swift
@@ -71,6 +71,7 @@ struct MurielColor {
 
     // MARK: - Additional iOS semantic colors
     static let navigationBar = MurielColor(name: .wordPressBlue)
+    static let tableBackground = MurielColor(name: .gray, shade: .shade0)
 
     /// The full name of the color, with required shade value
     func assetName() -> String {
@@ -245,6 +246,8 @@ extension UIColor {
     static var textInverted = UIColor.white
 
     static var navigationBar = muriel(color: .navigationBar)
+
+    static var tableBackground = muriel(color: .tableBackground)
 
     /// Muriel/iOS unselected color
     static var unselected: UIColor {

--- a/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
@@ -74,7 +74,7 @@ extension WPStyleGuide {
             return
         }
         if FeatureFlag.murielColors.enabled {
-            tableView.backgroundColor = .neutral(shade: .shade0)
+            tableView.backgroundColor = .tableBackground
             tableView.separatorColor = .neutral(shade: .shade10)
         } else {
             tableView.backgroundView = nil

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -815,7 +815,7 @@ extension WordPressAppDelegate {
 
 
         let cellAppearance = WPMediaCollectionViewCell.appearance(whenContainedInInstancesOf: [WPMediaPickerViewController.self])
-        cellAppearance.loadingBackgroundColor = .neutral(shade: .shade0)
+        cellAppearance.loadingBackgroundColor = .tableBackground
         cellAppearance.placeholderBackgroundColor = .neutral(shade: .shade70)
         cellAppearance.placeholderTintColor = .neutral(shade: .shade5)
         cellAppearance.setCellTintColor(.primary)

--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Blog.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Blog.swift
@@ -32,7 +32,7 @@ extension WPStyleGuide {
         cell.imageView?.layer.borderWidth = 1
         cell.imageView?.tintColor = .neutral(shade: .shade30)
 
-        cell.backgroundColor = .neutral(shade: .shade0)
+        cell.backgroundColor = .tableBackground
     }
 
  }

--- a/WordPress/Classes/ViewRelated/Media/CircularProgressView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CircularProgressView.swift
@@ -39,7 +39,7 @@ class CircularProgressView: UIView {
                     progressIndicatorAppearance: ProgressIndicatorView.Appearance(lineColor: .primary(shade: .shade40)),
                     backgroundColor: .clear,
                     accessoryViewTintColor: .neutral(shade: .shade70),
-                    accessoryViewBackgroundColor: .neutral(shade: .shade0))
+                    accessoryViewBackgroundColor: .tableBackground)
             case .mediaCell:
                 return Appearance(
                     progressIndicatorAppearance: ProgressIndicatorView.Appearance(lineColor: .white),

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -36,7 +36,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
     @objc init(blog: Blog) {
         WPMediaCollectionViewCell.appearance().placeholderTintColor = .neutral(shade: .shade5)
         WPMediaCollectionViewCell.appearance().placeholderBackgroundColor = .neutral(shade: .shade70)
-        WPMediaCollectionViewCell.appearance().loadingBackgroundColor = .neutral(shade: .shade0)
+        WPMediaCollectionViewCell.appearance().loadingBackgroundColor = .tableBackground
 
         self.blog = blog
         self.pickerDataSource = MediaLibraryPickerDataSource(blog: blog)

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -138,7 +138,7 @@ extension LoginEpilogueTableViewController {
 
         headerView.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
         headerView.textLabel?.textColor = .neutral(shade: .shade50)
-        headerView.contentView.backgroundColor = .neutral(shade: .shade0)
+        headerView.contentView.backgroundColor = .tableBackground
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -147,7 +147,7 @@ private extension LoginEpilogueViewController {
             buttonPanel.backgroundColor = .white
             shadowView.isHidden = false
         } else {
-            buttonPanel.backgroundColor = .neutral(shade: .shade0)
+            buttonPanel.backgroundColor = .tableBackground
             shadowView.isHidden = true
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -45,7 +45,7 @@ class WordPressAuthenticationManager: NSObject {
                                                 secondaryTitleColor: .text,
                                                 disabledTitleColor: .neutral(shade: .shade20),
                                                 subheadlineColor: .textSubtle,
-                                                viewControllerBackgroundColor: .neutral(shade: .shade0),
+                                                viewControllerBackgroundColor: .tableBackground,
                                                 navBarImage: Gridicon.iconOfType(.mySites),
                                                 prologueBackgroundColor: .primary,
                                                 prologueTitleColor: .textInverted)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -376,7 +376,7 @@ extension NotificationDetailsViewController {
     }
 
     func setupMainView() {
-        view.backgroundColor = .neutral(shade: .shade0)
+        view.backgroundColor = .tableBackground
     }
 
     func setupTableView() {
@@ -384,7 +384,7 @@ extension NotificationDetailsViewController {
         tableView.keyboardDismissMode       = .interactive
         tableView.backgroundColor           = .neutral(shade: .shade5)
         tableView.accessibilityIdentifier   = NSLocalizedString("Notification Details Table", comment: "Notifications Details Accessibility Identifier")
-        tableView.backgroundColor           = .neutral(shade: .shade0)
+        tableView.backgroundColor           = .tableBackground
     }
 
     func setupTableViewCells() {

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Reply.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Reply.swift
@@ -16,6 +16,6 @@ extension WPStyleGuide {
         public static let placeholderColor = UIColor.neutral(shade: .shade20)
         public static let textColor        = UIColor.text
         public static let separatorColor   = UIColor.neutral(shade: .shade20)
-        public static let backgroundColor  = UIColor.neutral(shade: .shade0)
+        public static let backgroundColor  = UIColor.tableBackground
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
@@ -18,8 +18,8 @@ extension WPStyleGuide {
     static let postCardBorderColor: UIColor = .neutral(shade: .shade10)
 
     class func applyPostCardStyle(_ cell: UITableViewCell) {
-        cell.backgroundColor = .neutral(shade: .shade0)
-        cell.contentView.backgroundColor = .neutral(shade: .shade0)
+        cell.backgroundColor = .tableBackground
+        cell.contentView.backgroundColor = .tableBackground
     }
 
     class func applyPostTitleStyle(_ label: UILabel) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.swift
@@ -11,7 +11,7 @@ open class ReaderBlockedSiteCell: UITableViewCell {
     }
 
     fileprivate func applyStyles() {
-        contentView.backgroundColor = .neutral(shade: .shade0)
+        contentView.backgroundColor = .tableBackground
         borderedContentView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedContentView.layer.borderWidth = 1.0
         label.font = WPStyleGuide.subtitleFont()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -54,8 +54,8 @@ open class ReaderCrossPostCell: UITableViewCell {
     // MARK: - Appearance
 
     fileprivate func applyStyles() {
-        contentView.backgroundColor = .neutral(shade: .shade0)
-        label?.backgroundColor = .neutral(shade: .shade0)
+        contentView.backgroundColor = .tableBackground
+        label?.backgroundColor = .tableBackground
     }
 
     fileprivate func applyHighlightedEffect(_ highlighted: Bool, animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
@@ -15,11 +15,11 @@ open class ReaderGapMarkerCell: UITableViewCell {
 
     fileprivate func applyStyles() {
         // Background styles
-        contentView.backgroundColor = .neutral(shade: .shade0)
+        contentView.backgroundColor = .tableBackground
         selectedBackgroundView = UIView(frame: contentView.frame)
-        selectedBackgroundView?.backgroundColor = .neutral(shade: .shade0)
-        contentView.backgroundColor = .neutral(shade: .shade0)
-        tearMaskView.backgroundColor = .neutral(shade: .shade0)
+        selectedBackgroundView?.backgroundColor = .tableBackground
+        contentView.backgroundColor = .tableBackground
+        tearMaskView.backgroundColor = .tableBackground
 
         // Draw the tear
         drawTearBackground()
@@ -55,7 +55,7 @@ open class ReaderGapMarkerCell: UITableViewCell {
         if highlighted {
             // Redraw the backgrounds when highlighted
             drawTearBackground()
-            tearMaskView.backgroundColor = .neutral(shade: .shade0)
+            tearMaskView.backgroundColor = .tableBackground
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderListStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderListStreamHeader.swift
@@ -19,7 +19,7 @@ import WordPressShared.WPStyleGuide
     }
 
     @objc func applyStyles() {
-        backgroundColor = .neutral(shade: .shade0)
+        backgroundColor = .tableBackground
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = 1.0
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
@@ -76,7 +76,7 @@ class ReaderSearchSuggestionsViewController: UIViewController {
 
         let buttonTitle = NSLocalizedString("Clear search history", comment: "Title of a button.")
         clearButton.setTitle(buttonTitle, for: UIControl.State())
-        let buttonBackgroundImage = UIImage(color: .neutral(shade: .shade0))
+        let buttonBackgroundImage = UIImage(color: .tableBackground)
         clearButton.setBackgroundImage(buttonBackgroundImage, for: UIControl.State())
 
         borderImageView.image = UIImage(color: .neutral(shade: .shade20), havingSize: CGSize(width: stackView.frame.width, height: 1))

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -46,7 +46,7 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     }
 
     @objc func applyStyles() {
-        backgroundColor = .neutral(shade: .shade0)
+        backgroundColor = .tableBackground
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = 1.0
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -19,7 +19,7 @@ import WordPressShared
     }
 
     @objc func applyStyles() {
-        backgroundColor = .neutral(shade: .shade0)
+        backgroundColor = .tableBackground
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = 1.0
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -176,7 +176,7 @@ extension WPStyleGuide {
         static let summaryFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         static let substringHighlightFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
 
-        static let tableBackgroundColor = UIColor.neutral(shade: .shade0)
+        static let tableBackgroundColor = UIColor.tableBackground
         static let cellBackgroundColor = UIColor.white
         static let separatorColor = UIColor.neutral(shade: .shade10)
         static let verticalSeparatorColor = UIColor.neutral(shade: .shade5)

--- a/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
+++ b/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
@@ -26,7 +26,7 @@ extension WPStyleGuide {
 
         // MARK: - Search Styles
 
-        public static let searchBarBackgroundColor: UIColor = .neutral(shade: .shade0)
+        public static let searchBarBackgroundColor: UIColor = .tableBackground
         public static let searchBarBorderColor: UIColor = .neutral(shade: .shade10)
 
         public static let searchTypeTitleFont = WPFontManager.systemSemiBoldFont(ofSize: 14)

--- a/WordPress/WordPressDraftActionExtension/MainDraftActionViewController.swift
+++ b/WordPress/WordPressDraftActionExtension/MainDraftActionViewController.swift
@@ -37,7 +37,7 @@ private extension MainDraftActionViewController {
     func setupAppearance() {
         self.view.backgroundColor = .white
         let navigationBarAppearace = UINavigationBar.appearance()
-        navigationBarAppearace.barTintColor = .neutral(shade: .shade0)
+        navigationBarAppearace.barTintColor = .tableBackground
         navigationBarAppearace.barStyle = .default
         navigationBarAppearace.tintColor = .primary
         navigationBarAppearace.titleTextAttributes = [.foregroundColor: UIColor.primary]

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -36,7 +36,7 @@ class MainShareViewController: UIViewController {
 private extension MainShareViewController {
     func setupAppearance() {
         let navigationBarAppearace = UINavigationBar.appearance()
-        navigationBarAppearace.barTintColor = .neutral(shade: .shade0)
+        navigationBarAppearace.barTintColor = .tableBackground
         navigationBarAppearace.barStyle = .default
         navigationBarAppearace.tintColor = .primary
         navigationBarAppearace.titleTextAttributes = [.foregroundColor: UIColor.primary]

--- a/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
@@ -1292,13 +1292,13 @@ fileprivate extension ShareExtensionEditorViewController {
 
         static var aztecFormatPickerSelectedCellBackgroundColor: UIColor {
             get {
-                return (UIDevice.current.userInterfaceIdiom == .pad) ? .neutral(shade: .shade0) : .neutral(shade: .shade5)
+                return (UIDevice.current.userInterfaceIdiom == .pad) ? .tableBackground : .neutral(shade: .shade5)
             }
         }
 
         static var aztecFormatPickerBackgroundColor: UIColor {
             get {
-                return (UIDevice.current.userInterfaceIdiom == .pad) ? .white : .neutral(shade: .shade0)
+                return (UIDevice.current.userInterfaceIdiom == .pad) ? .white : .tableBackground
             }
         }
     }


### PR DESCRIPTION
This PR just adds a new `tableBackground` semantic color to the Muriel palette, as we were referencing gray-0 all over the place. This should make it simpler if ever we need to update it in future.

**To test:**

* Check the code
* Build and run and check backgrounds look okay!

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
