### PR TITLE
Stats: Add accessibility label to Site Timezone label.

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -134,14 +134,17 @@ private extension SiteStatsTableHeaderView {
         guard !SiteStatsInformation.sharedInstance.timeZoneMatchesDevice(),
         let siteTimeZone = SiteStatsInformation.sharedInstance.siteTimeZone else {
             timezoneLabel.isHidden = true
+            timezoneLabel.accessibilityLabel = nil
             return
         }
 
         let hoursFromUTC = siteTimeZone.secondsFromGMT() / 3600
+        let absHours = String(abs(hoursFromUTC))
         let timezoneString = NSLocalizedString("Site timezone (UTC %@ %@)",
                                                comment: "Site timezone offset from UTC. The first %@ is plus or minus. The second %@ is the number of hours. Example: `Site timezone (UTC + 10)`.")
 
-        timezoneLabel.text = .localizedStringWithFormat(timezoneString, hoursFromUTC < 0 ? "-" : "+", String(abs(hoursFromUTC)))
+        timezoneLabel.text = .localizedStringWithFormat(timezoneString, hoursFromUTC < 0 ? "-" : "+", absHours)
+        timezoneLabel.accessibilityLabel = .localizedStringWithFormat(timezoneString, hoursFromUTC < 0 ? "minus" : "plus", absHours)
         timezoneLabel.isHidden = false
     }
 


### PR DESCRIPTION
Ref #12018

To test:
- Enable VoiceOver.
- Go to Stats > Period.
- Select the 'Site timezone' label.


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
