### PR TITLE
Color schemes: Improve Reader colors to match new palette

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 13.0
 -----
- 
+* Improved color scheme consistency.
+
 12.9
 -----
 * Offline support: Create Post is now available from empty results view in offline mode.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -95,6 +95,10 @@ class ReaderCommentCell: UITableViewCell {
         authorButton.titleLabel?.lineBreakMode = .byTruncatingTail
 
         textView.textContainerInset = Constants.textViewInsets
+
+        let backgroundView = UIView()
+        backgroundView.backgroundColor = .primary(shade: .shade0)
+        selectedBackgroundView = backgroundView
     }
 
     func setupContentView() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentCell.swift
@@ -105,32 +105,29 @@ class ReaderCommentCell: UITableViewCell {
     }
 
     @objc func setupReplyButton() {
-        let icon = Gridicon.iconOfType(.reply, withSize: Constants.buttonSize)
-        let tintedIcon = icon.imageWithTintColor(.neutral(shade: .shade20))?.rotate180Degrees()
-        let highlightedIcon = icon.imageWithTintColor(.primaryLight)?.rotate180Degrees()
-
-        replyButton.setImage(tintedIcon, for: .normal)
-        replyButton.setImage(highlightedIcon, for: .highlighted)
+        let icon = Gridicon.iconOfType(.reply, withSize: Constants.buttonSize).rotate180Degrees()
+        replyButton.setImage(icon, for: .normal)
+        replyButton.setImage(icon, for: .highlighted)
 
         let title = NSLocalizedString("Reply", comment: "Verb. Title of the Reader comments screen reply button. Tapping the button sends a reply to a comment or post.")
         replyButton.setTitle(title, for: .normal)
-        replyButton.setTitleColor(.neutral(shade: .shade20), for: .normal)
+
+        WPStyleGuide.applyReaderActionButtonStyle(replyButton)
     }
 
 
     @objc func setupLikeButton() {
         let size = Constants.buttonSize
-        let tintedIcon = Gridicon.iconOfType(.starOutline, withSize: size).imageWithTintColor(.neutral(shade: .shade20))
-        let highlightedIcon = Gridicon.iconOfType(.star, withSize: size).imageWithTintColor(.primaryLight)
-        let selectedIcon = Gridicon.iconOfType(.star, withSize: size).imageWithTintColor(.accent)
+        let star = Gridicon.iconOfType(.star, withSize: size)
+        let starOutline = Gridicon.iconOfType(.starOutline, withSize: size)
 
-        likeButton.setImage(tintedIcon, for: .normal)
-        likeButton.setImage(highlightedIcon, for: .highlighted)
-        likeButton.setImage(selectedIcon, for: .selected)
+        likeButton.setImage(starOutline, for: .normal)
+        likeButton.setImage(star, for: .highlighted)
+        likeButton.setImage(star, for: .selected)
+        likeButton.setImage(star, for: [.selected, .highlighted])
 
-        likeButton.setTitleColor(.textSubtle, for: .normal)
+        WPStyleGuide.applyReaderActionButtonStyle(likeButton)
     }
-
 
     // MARK: - Configuration
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -282,7 +282,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
     // Border
     CGSize borderSize = CGSizeMake(CGRectGetWidth(self.view.bounds), 1.0);
-    UIImage *borderImage = [UIImage imageWithColor:[WPStyleGuide readGrey] havingSize:borderSize];
+    UIImage *borderImage = [UIImage imageWithColor:[UIColor murielNeutral5] havingSize:borderSize];
     UIImageView *borderView = [[UIImageView alloc] initWithImage:borderImage];
     borderView.translatesAutoresizingMaskIntoConstraints = NO;
     borderView.contentMode = UIViewContentModeScaleAspectFill;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -819,9 +819,13 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         button.setTitle(title, for: .disabled)
         button.setImage(image, for: UIControl.State())
         button.setImage(highlightedImage, for: .highlighted)
+        button.setImage(highlightedImage, for: .selected)
+        button.setImage(highlightedImage, for: [.highlighted, .selected])
         button.setImage(image, for: .disabled)
         button.isSelected = selected
         button.isHidden = false
+
+        WPStyleGuide.applyReaderActionButtonStyle(button)
     }
 
 
@@ -830,11 +834,10 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
         let title = post!.likeCountForDisplay()
         let selected = post!.isLiked
-        let normalImage = UIImage(named: "icon-reader-like")?.imageWithTintColor(.neutral(shade: .shade30))
-        let highlightImage = UIImage(named: "icon-reader-like")?.imageWithTintColor(.neutral)
-        let selectedImage = UIImage(named: "icon-reader-liked")?.imageWithTintColor(.primary(shade: .shade40))
-        configureActionButton(likeButton, title: title, image: normalImage, highlightedImage: highlightImage, selected: selected)
-        likeButton.setImage(selectedImage, for: .selected)
+        let likeImage = UIImage(named: "icon-reader-like")
+        let likedImage = UIImage(named: "icon-reader-liked")
+
+        configureActionButton(likeButton, title: title, image: likeImage, highlightedImage: likedImage, selected: selected)
 
         if animated {
             playLikeButtonAnimation()
@@ -908,7 +911,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     fileprivate func configureCommentActionButton() {
         let title = post!.commentCount.stringValue
         let image = UIImage(named: "icon-reader-comment")?.imageFlippedForRightToLeftLayoutDirection()
-        let highlightImage = UIImage(named: "icon-reader-comment-highlight")?.imageWithTintColor(.neutral)?.imageFlippedForRightToLeftLayoutDirection()
+        let highlightImage = UIImage(named: "icon-reader-comment-highlight")?.imageFlippedForRightToLeftLayoutDirection()
         configureActionButton(commentButton, title: title, image: image, highlightedImage: highlightImage, selected: false)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -152,18 +152,21 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         // Brent C. Aug/25/2016
         interfaceVerticalSizingHelperView.isHidden = true
 
-        applyStyles()
-        applyOpaqueBackgroundColors()
-        setupFeaturedImageView()
-        setupVisitButton()
-
-        setupSaveForLaterButton()
-
         setupMenuButton()
-        setupSummaryLabel()
-        setupAttributionView()
+        setupVisitButton()
+        setupSaveForLaterButton()
         setupCommentActionButton()
         setupLikeActionButton()
+
+        // Buttons must be set up before applying styles,
+        // as this tints the images used in the buttons
+        applyStyles()
+
+        applyOpaqueBackgroundColors()
+        setupFeaturedImageView()
+
+        setupSummaryLabel()
+        setupAttributionView()
         adjustInsetsForTextDirection()
         insetFollowButtonIcon()
     }
@@ -197,26 +200,27 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
 
     fileprivate func setupCommentActionButton() {
         let image = UIImage(named: "icon-reader-comment")?.imageFlippedForRightToLeftLayoutDirection()
-        let highlightImage = UIImage(named: "icon-reader-comment-highlight")?.imageWithTintColor(.neutral)?.imageFlippedForRightToLeftLayoutDirection()
+        let highlightImage = UIImage(named: "icon-reader-comment-highlight")?.imageFlippedForRightToLeftLayoutDirection()
         commentActionButton.setImage(image, for: UIControl.State())
         commentActionButton.setImage(highlightImage, for: .highlighted)
     }
 
     fileprivate func setupLikeActionButton() {
-        let normalImage = UIImage(named: "icon-reader-like")?.imageWithTintColor(.neutral(shade: .shade30))
-        let highlightImage = UIImage(named: "icon-reader-like")?.imageWithTintColor(.neutral)
-        let selectedImage = UIImage(named: "icon-reader-liked")?.imageWithTintColor(.primary(shade: .shade40))
-        likeActionButton.setImage(normalImage, for: UIControl.State())
-        likeActionButton.setImage(highlightImage, for: .highlighted)
-        likeActionButton.setImage(selectedImage, for: .selected)
+        let likeImage = UIImage(named: "icon-reader-like")
+        let likedImage = UIImage(named: "icon-reader-liked")
+
+        likeActionButton.setImage(likeImage, for: .normal)
+        likeActionButton.setImage(likedImage, for: .highlighted)
+        likeActionButton.setImage(likedImage, for: .selected)
+        likeActionButton.setImage(likedImage, for: [.highlighted, .selected])
     }
 
     fileprivate func setupVisitButton() {
         let size = CGSize(width: 20, height: 20)
         let title = NSLocalizedString("Visit", comment: "Verb. Button title.  Tap to visit a website.")
         let icon = Gridicon.iconOfType(.external, withSize: size)
-        let tintedIcon = icon.imageWithTintColor(.neutral(shade: .shade30))?.imageFlippedForRightToLeftLayoutDirection()
-        let highlightIcon = icon.imageWithTintColor(.neutral)?.imageFlippedForRightToLeftLayoutDirection()
+        let tintedIcon = icon.imageFlippedForRightToLeftLayoutDirection()
+        let highlightIcon = icon.imageFlippedForRightToLeftLayoutDirection()
 
         visitButton.setTitle(title, for: UIControl.State())
         visitButton.setImage(tintedIcon, for: .normal)
@@ -262,10 +266,10 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         WPStyleGuide.applyReaderCardBylineLabelStyle(bylineLabel)
         WPStyleGuide.applyReaderCardTitleLabelStyle(titleLabel)
         WPStyleGuide.applyReaderCardSummaryLabelStyle(summaryLabel)
-        WPStyleGuide.applyReaderCardActionButtonStyle(commentActionButton)
-        WPStyleGuide.applyReaderCardActionButtonStyle(likeActionButton)
-        WPStyleGuide.applyReaderCardActionButtonStyle(visitButton)
-        WPStyleGuide.applyReaderCardActionButtonStyle(saveForLaterButton)
+        WPStyleGuide.applyReaderActionButtonStyle(commentActionButton)
+        WPStyleGuide.applyReaderActionButtonStyle(likeActionButton)
+        WPStyleGuide.applyReaderActionButtonStyle(visitButton)
+        WPStyleGuide.applyReaderActionButtonStyle(saveForLaterButton)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -31,7 +31,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
         [self setupStackView];
         [self setupAvatarImageView];
         [self setupLabelsStackView];
-        [self setupSubtTitleLabel];
+        [self setupSubtitleLabel];
         [self setupTitleLabel];
         [self setupDisclosureButton];
         [self setupTapGesture];
@@ -94,7 +94,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     [stackView setContentHuggingPriority:UILayoutPriorityDefaultLow forAxis:UILayoutConstraintAxisHorizontal];
 }
 
-- (void)setupSubtTitleLabel
+- (void)setupSubtitleLabel
 {
     NSAssert(self.labelsStackView != nil, @"labelsStackView was nil");
 
@@ -102,7 +102,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     label.translatesAutoresizingMaskIntoConstraints = NO;
     label.backgroundColor = [UIColor whiteColor];
     label.opaque = YES;
-    label.textColor = [WPStyleGuide allTAllShadeGrey];
+    label.textColor = [UIColor murielTextSubtle];
     label.font = [WPStyleGuide subtitleFont];
     label.adjustsFontForContentSizeCategory = YES;
 
@@ -118,7 +118,7 @@ const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
     label.translatesAutoresizingMaskIntoConstraints = NO;
     label.backgroundColor = [UIColor whiteColor];
     label.opaque = YES;
-    label.textColor = [WPStyleGuide littleEddieGrey];
+    label.textColor = [UIColor murielText];
     label.font = [WPStyleGuide subtitleFont];
     label.adjustsFontForContentSizeCategory = YES;
 

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -193,12 +193,9 @@ extension WPStyleGuide {
             return
         }
         WPStyleGuide.configureLabel(titleLabel, textStyle: Cards.buttonTextStyle)
-        button.setTitleColor(.neutral(shade: .shade30), for: UIControl.State())
-        button.setTitleColor(.neutral, for: .highlighted)
-        button.setTitleColor(.primary(shade: .shade40), for: .selected)
-        button.setTitleColor(.neutral(shade: .shade10), for: .disabled)
-    }
 
+        WPStyleGuide.applyReaderActionButtonStyle(button)
+    }
 
     // MARK: - Apply Stream Header Styles
 
@@ -224,6 +221,32 @@ extension WPStyleGuide {
 
 
     // MARK: - Button Styles and Text
+
+    public class func applyReaderActionButtonStyle(_ button: UIButton) {
+        let defaultColor: UIColor = .neutral(shade: .shade30)
+        let highlightedColor: UIColor = .neutral
+        let selectedColor: UIColor = .primary(shade: .shade40)
+        let bothColor: UIColor = .primaryLight
+        let disabledColor: UIColor = .neutral(shade: .shade10)
+
+        let normalImage = button.image(for: .normal)
+        let highlightedImage = button.image(for: .highlighted)
+        let selectedImage = button.image(for: .selected)
+        let bothImage = button.image(for: [.highlighted, .selected])
+        let disabledImage = button.image(for: .disabled)
+
+        button.setImage(normalImage?.imageWithTintColor(defaultColor), for: .normal)
+        button.setImage(highlightedImage?.imageWithTintColor(highlightedColor), for: .highlighted)
+        button.setImage(selectedImage?.imageWithTintColor(selectedColor), for: .selected)
+        button.setImage(bothImage?.imageWithTintColor(bothColor), for: [.selected, .highlighted])
+        button.setImage(disabledImage?.imageWithTintColor(disabledColor), for: .disabled)
+
+        button.setTitleColor(defaultColor, for: .normal)
+        button.setTitleColor(highlightedColor, for: .highlighted)
+        button.setTitleColor(selectedColor, for: .selected)
+        button.setTitleColor(bothColor, for: [.selected, .highlighted])
+        button.setTitleColor(disabledColor, for: .disabled)
+    }
 
     @objc public class func applyReaderFollowButtonStyle(_ button: UIButton) {
         let side = WPStyleGuide.fontSizeForTextStyle(Cards.buttonTextStyle)
@@ -258,24 +281,12 @@ extension WPStyleGuide {
         let icon = Gridicon.iconOfType(.bookmarkOutline, withSize: size)
         let selectedIcon = Gridicon.iconOfType(.bookmark, withSize: size)
 
-        let normalColor: UIColor = .neutral(shade: .shade30)
-        let selectedColor: UIColor = .primary(shade: .shade40)
-        let highlightedColor: UIColor = .neutral
+        button.setImage(icon, for: .normal)
+        button.setImage(selectedIcon, for: .selected)
+        button.setImage(selectedIcon, for: .highlighted)
+        button.setImage(selectedIcon, for: [.highlighted, .selected])
 
-        let tintedIcon = icon.imageWithTintColor(normalColor)
-        let tintedSelectedIcon = selectedIcon.imageWithTintColor(selectedColor)
-        let tintedHighlightedIcon = icon.imageWithTintColor(highlightedColor)
-        let tintedSelectedHighlightedIcon = selectedIcon.imageWithTintColor(highlightedColor)
-
-        button.setImage(tintedIcon, for: .normal)
-        button.setImage(tintedSelectedIcon, for: .selected)
-        button.setImage(tintedHighlightedIcon, for: .highlighted)
-        button.setImage(tintedSelectedHighlightedIcon, for: [.highlighted, .selected])
-
-        button.setTitleColor(normalColor, for: .normal)
-        button.setTitleColor(selectedColor, for: .selected)
-        button.setTitleColor(highlightedColor, for: .highlighted)
-        button.setTitleColor(highlightedColor, for: [.highlighted, .selected])
+        applyReaderActionButtonStyle(button)
     }
 
     @objc public class func applyReaderSaveForLaterButtonTitles(_ button: UIButton) {


### PR DESCRIPTION
Refs #11683.

This PR makes some changes to the Reader to handle the new color palette. The largest change is improving consistency between all the different places action buttons appear (comment, like, save for later, etc).

---

**To test**

Updated Reader comments view header to match comments in the [master issue](#11683). Navigate to a post in the Reader, and then click the comments button:

![reader-before-after1](https://user-images.githubusercontent.com/4780/61530174-40d43a00-aa1b-11e9-9103-906a0b75b895.png)

* The border below this header should be neutral-5.
* The “Comment on…” text should be neutral-50.
* The “Weekly hangout” text can be the default text color.

---

Reader action buttons should now be consistent. Resolves these issues from the [master issue](#11683):

* Number of likes button text in Reader comments is still orange
* Likes star color in Reader comments view should match reader post list

All icons and labels for reader actions should now be:

* Unselected: neutral-30
* Unselected, highlighted: neutral
* Selected: primary-40
* Selected and highlighted: primaryLight
* Disabled: neutral-10

![reader-before-after2](https://user-images.githubusercontent.com/4780/61530591-69106880-aa1c-11e9-970f-44cd2003c389.png)

Please verify this at each of the navigation :

* Reader stream:

<img width="372" alt="Screenshot 2019-07-19 at 11 58 51" src="https://user-images.githubusercontent.com/4780/61530654-978e4380-aa1c-11e9-8cfa-3cb3e5b808b1.png">

* Reader detail (at the bottom of the screen):

<img width="370" alt="Screenshot 2019-07-19 at 11 59 25" src="https://user-images.githubusercontent.com/4780/61533924-189e0880-aa26-11e9-8019-e59e3cdea481.png">

* Reader comments:

<img width="172" alt="Screenshot 2019-07-19 at 12 00 50" src="https://user-images.githubusercontent.com/4780/61530753-df14cf80-aa1c-11e9-8b29-48df57a07183.png">

---

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.