### PR TITLE
[Jetpack Remote Install] Add more info in analytics failure event 

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
@@ -73,7 +73,9 @@ private extension JetpackRemoteInstallViewController {
             case .success:
                 WPAnalytics.track(.installJetpackRemoteCompleted)
             case .failure(let error):
-                WPAnalytics.track(.installJetpackRemoteFailed)
+                WPAnalytics.track(.installJetpackRemoteFailed,
+                                  withProperties: ["error": error.rawValue,
+                                                   "siteURL": self?.blog.url ?? "unknown"])
                 if error.isBlockingError {
                     self?.delegate?.jetpackRemoteInstallWebviewFallback()
                 }


### PR DESCRIPTION
Fixes #12158

This PR adds the jetpack error name and the site URL as properties when the Jetpack Install fails.
If we want more info from the error we get from the API response we need to update WP Kit as well.

## To test:
- Try to install Jetpack on a website that might fail (Use a slow connection profile to generate a timeout)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
