### PR TITLE
[Stats Refresh] Improve Insights Store

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -44,11 +44,7 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
     static var defaultStoryboardName: String = "SiteStatsDashboard"
 
     // MARK: - Properties
-
-    private let insightsStore = StoreContainer.shared.statsInsights
     private var insightsChangeReceipt: Receipt?
-
-    private let periodStore = StoreContainer.shared.statsPeriod
 
     // TODO: update this array when Manage Insights is implemented.
     // Types of Insights to display. The array order dictates the display order.
@@ -106,9 +102,9 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
 private extension SiteStatsInsightsTableViewController {
 
     func initViewModel() {
-        viewModel = SiteStatsInsightsViewModel(insightsToShow: insightsToShow, insightsDelegate: self, insightsStore: insightsStore, periodStore: periodStore)
-
+        viewModel = SiteStatsInsightsViewModel(insightsToShow: insightsToShow, insightsDelegate: self)
         addViewModelListeners()
+        viewModel?.fetchInsights()
     }
 
     func addViewModelListeners() {
@@ -117,8 +113,8 @@ private extension SiteStatsInsightsTableViewController {
         }
 
         insightsChangeReceipt = viewModel?.onChange { [weak self] in
-            guard let store = self?.insightsStore,
-                !store.isFetchingOverview else {
+            if let viewModel = self?.viewModel,
+                viewModel.isFetchingOverview() {
                     return
             }
             self?.refreshTableView()
@@ -150,8 +146,8 @@ private extension SiteStatsInsightsTableViewController {
 
         tableHandler.viewModel = viewModel.tableViewModel()
 
-        if insightsStore.fetchingFailed(for: .insights) &&
-            !insightsStore.containsCachedData {
+        if viewModel.fetchingFailed() &&
+            !viewModel.containsCachedData() {
             displayFailureViewIfNecessary()
         } else {
             hideNoResults()
@@ -270,8 +266,12 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
     }
 
     func showPostingActivityDetails() {
+        guard let viewModel = viewModel else {
+            return
+        }
+
         let postingActivityViewController = PostingActivityViewController.loadFromStoryboard()
-        postingActivityViewController.yearData = insightsStore.getYearlyPostingActivityFrom(date: Date())
+        postingActivityViewController.yearData = viewModel.yearlyPostingActivity()
         navigationController?.pushViewController(postingActivityViewController, animated: true)
     }
 
@@ -296,7 +296,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         // When displaying Annual details, start from the most recent year available.
         var selectedDate: Date?
         if statSection == .insightsAnnualSiteStats,
-            let year = insightsStore.getAnnualAndMostPopularTime()?.annualInsightsYear {
+            let year = viewModel?.annualInsightsYear() {
             var dateComponents = Calendar.current.dateComponents([.year, .month, .day], from: Date())
             dateComponents.year = year
             selectedDate = Calendar.current.date(from: dateComponents)


### PR DESCRIPTION
Refs. #12146

This is a light PR that improves the Insights Store and the Insights View Model.
The biggest changes are:
- Hide the store removing all the other references to it and leave the ViewModel to bind the view
- Remove the PeriodStore reference and fetch the last posts directly in the Insights Store. 
The PR also fixes a small problem I saw when the pull to refresh is triggered.

@ScoutHarris I would merge this after #12159 

## To test:
- Open Stats -> Insights and check everything works as before

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
