### PR TITLE
Reader: Fix card borders to account for display scale

### DIFF
--- a/WordPress/Classes/Extensions/UIView+Borders.swift
+++ b/WordPress/Classes/Extensions/UIView+Borders.swift
@@ -3,7 +3,7 @@ extension UIView {
         let borderView = makeBorderView(withColor: bgColor)
 
         NSLayoutConstraint.activate([
-            borderView.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
+            borderView.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
             borderView.topAnchor.constraint(equalTo: topAnchor),
             borderView.centerXAnchor.constraint(equalTo: centerXAnchor),
             borderView.widthAnchor.constraint(equalTo: widthAnchor)
@@ -14,7 +14,7 @@ extension UIView {
         let borderView = makeBorderView(withColor: bgColor)
 
         NSLayoutConstraint.activate([
-            borderView.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
+            borderView.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
             borderView.bottomAnchor.constraint(equalTo: bottomAnchor),
             borderView.centerXAnchor.constraint(equalTo: centerXAnchor),
             borderView.widthAnchor.constraint(equalTo: widthAnchor)
@@ -28,5 +28,11 @@ extension UIView {
         self.addSubview(borderView)
 
         return borderView
+    }
+}
+
+extension CGFloat {
+    static var hairlineBorderWidth: CGFloat {
+        return 1.0 / UIScreen.main.scale
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.swift
@@ -51,7 +51,7 @@ class RestorePostTableViewCell: UITableViewCell, ConfigurablePostView, Interacti
     private func configureDefault() {
         topMargin.constant = Constants.defaultMargin
         postContentView.layer.borderColor = WPStyleGuide.postCardBorderColor.cgColor
-        postContentView.layer.borderWidth = 1.0 / UIScreen.main.scale
+        postContentView.layer.borderWidth = .hairlineBorderWidth
     }
 
     private func applyStyles() {

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
@@ -17,7 +17,7 @@ extension WPStyleGuide {
     // MARK: - Card View Styles
     static let postCardBorderColor: UIColor = .neutral(shade: .shade10)
 
-    static let separatorHeight: CGFloat = 1.0 / UIScreen.main.scale
+    static let separatorHeight: CGFloat = .hairlineBorderWidth
 
     class func applyPostCardStyle(_ cell: UITableViewCell) {
         cell.backgroundColor = .tableBackground

--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
@@ -89,7 +89,7 @@ final class NewsCard: UIViewController {
 
     private func styleBorderedView() {
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = 1.0 / UIScreen.main.scale
+        borderedView.layer.borderWidth = .hairlineBorderWidth
     }
 
     private func styleLabels() {

--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
@@ -89,7 +89,7 @@ final class NewsCard: UIViewController {
 
     private func styleBorderedView() {
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = 1.0
+        borderedView.layer.borderWidth = 1.0 / UIScreen.main.scale
     }
 
     private func styleLabels() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.swift
@@ -13,7 +13,7 @@ open class ReaderBlockedSiteCell: UITableViewCell {
     fileprivate func applyStyles() {
         contentView.backgroundColor = .tableBackground
         borderedContentView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedContentView.layer.borderWidth = 1.0
+        borderedContentView.layer.borderWidth = .hairlineBorderWidth
         label.font = WPStyleGuide.subtitleFont()
         label.textColor = .textSubtle
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
@@ -26,7 +26,7 @@ import WordPressShared.WPStyleGuide
     @objc func applyStyles() {
         backgroundColor = .clear
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = 1.0
+        borderedView.layer.borderWidth = 1.0 / UIScreen.main.scale
 
         titleLabel.font = WPStyleGuide.tableviewTextFont()
         titleLabel.textColor = .neutral(shade: .shade70)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
@@ -26,7 +26,7 @@ import WordPressShared.WPStyleGuide
     @objc func applyStyles() {
         backgroundColor = .clear
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = 1.0 / UIScreen.main.scale
+        borderedView.layer.borderWidth = .hairlineBorderWidth
 
         titleLabel.font = WPStyleGuide.tableviewTextFont()
         titleLabel.textColor = .neutral(shade: .shade70)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,7 +16,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xw2-zx-vFl">
-                    <rect key="frame" x="-1" y="-1" width="322" height="66"/>
+                    <rect key="frame" x="-1" y="0.0" width="322" height="64"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="66b-Vx-jim">
@@ -68,9 +68,9 @@
                 <constraint firstItem="66b-Vx-jim" firstAttribute="leading" secondItem="Vwe-fC-L9o" secondAttribute="leading" id="DrB-NJ-7H5"/>
                 <constraint firstItem="EFi-ME-clV" firstAttribute="trailing" secondItem="66b-Vx-jim" secondAttribute="trailing" id="F3b-dE-zr6"/>
                 <constraint firstItem="Xw2-zx-vFl" firstAttribute="leading" secondItem="66b-Vx-jim" secondAttribute="leading" constant="-1" id="FHM-OF-ETt"/>
-                <constraint firstItem="Xw2-zx-vFl" firstAttribute="bottom" secondItem="66b-Vx-jim" secondAttribute="bottom" constant="1" id="Lhh-zn-p0L"/>
+                <constraint firstItem="Xw2-zx-vFl" firstAttribute="bottom" secondItem="66b-Vx-jim" secondAttribute="bottom" id="Lhh-zn-p0L"/>
                 <constraint firstItem="EFi-ME-clV" firstAttribute="leading" secondItem="66b-Vx-jim" secondAttribute="leading" id="Lm7-gy-xkH"/>
-                <constraint firstItem="Xw2-zx-vFl" firstAttribute="top" secondItem="66b-Vx-jim" secondAttribute="top" constant="-1" id="Xxl-3x-g1u"/>
+                <constraint firstItem="Xw2-zx-vFl" firstAttribute="top" secondItem="66b-Vx-jim" secondAttribute="top" id="Xxl-3x-g1u"/>
                 <constraint firstAttribute="trailing" secondItem="66b-Vx-jim" secondAttribute="trailing" id="dMM-Of-rln"/>
                 <constraint firstAttribute="bottom" secondItem="66b-Vx-jim" secondAttribute="bottom" priority="999" constant="8" id="gSJ-ga-kkv"/>
                 <constraint firstItem="66b-Vx-jim" firstAttribute="trailing" secondItem="Xw2-zx-vFl" secondAttribute="trailing" constant="-1" id="lz9-34-niQ"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderListStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderListStreamHeader.swift
@@ -21,7 +21,7 @@ import WordPressShared.WPStyleGuide
     @objc func applyStyles() {
         backgroundColor = .tableBackground
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = 1.0
+        borderedView.layer.borderWidth = .hairlineBorderWidth
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)
         WPStyleGuide.applyReaderStreamHeaderDetailStyle(detailLabel)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -255,7 +255,7 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         backgroundColor = .clear
         contentView.backgroundColor = .clear
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = 0.5
+        borderedView.layer.borderWidth = 1.0 / UIScreen.main.scale
 
         WPStyleGuide.applyReaderFollowButtonStyle(followButton)
         WPStyleGuide.applyReaderCardBlogNameStyle(blogNameLabel)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -255,7 +255,7 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         backgroundColor = .clear
         contentView.backgroundColor = .clear
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = 1.0 / UIScreen.main.scale
+        borderedView.layer.borderWidth = .hairlineBorderWidth
 
         WPStyleGuide.applyReaderFollowButtonStyle(followButton)
         WPStyleGuide.applyReaderCardBlogNameStyle(blogNameLabel)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
@@ -49,7 +49,7 @@ final class ReaderSavedPostUndoCell: UITableViewCell {
 
     private func applyStyles() {
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = 1.0
+        borderedView.layer.borderWidth = .hairlineBorderWidth
 
         WPStyleGuide.applyRestoreSavedPostLabelStyle(removed)
         WPStyleGuide.applyRestoreSavedPostTitleLabelStyle(title)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -48,7 +48,7 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     @objc func applyStyles() {
         backgroundColor = .tableBackground
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = 1.0
+        borderedView.layer.borderWidth = .hairlineBorderWidth
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)
         WPStyleGuide.applyReaderStreamHeaderDetailStyle(detailLabel)
         WPStyleGuide.applyReaderSiteStreamDescriptionStyle(descriptionLabel)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -21,7 +21,7 @@ import WordPressShared
     @objc func applyStyles() {
         backgroundColor = .tableBackground
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
-        borderedView.layer.borderWidth = 1.0
+        borderedView.layer.borderWidth = .hairlineBorderWidth
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)
     }
 

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -313,7 +313,7 @@ fileprivate extension UIView {
         let borderView = makeBorderView()
 
         NSLayoutConstraint.activate([
-            borderView.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale),
+            borderView.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
             borderView.topAnchor.constraint(equalTo: topAnchor),
             borderView.centerXAnchor.constraint(equalTo: centerXAnchor),
             borderView.widthAnchor.constraint(equalTo: widthAnchor)
@@ -327,7 +327,7 @@ fileprivate extension UIView {
             borderView.heightAnchor.constraint(equalTo: heightAnchor),
             borderView.trailingAnchor.constraint(equalTo: trailingAnchor),
             borderView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            borderView.widthAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale)
+            borderView.widthAnchor.constraint(equalToConstant: .hairlineBorderWidth)
             ])
     }
 


### PR DESCRIPTION
Fixes #12153, by reducing the width of the border on Reader cards.

![reader-borders-1](https://user-images.githubusercontent.com/4780/61566581-97219700-aa74-11e9-9302-6afd6569e88b.png)

**To test:**

* Build and run, and view a stream in the Reader
* Ensure that the cards have single pixel borders on both 2x and 3x screen types (e.g. iPhone XS and iPhone XS Max).

@etoledom, would you mind reviewing?

cc @mattmiklic 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
(I didn't update release notes and I think it's so minor it can just be included in "Improved color scheme consistency" that I've added in another branch)