### PR TITLE
[Stats Refresh] Post Stats cells background view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -31,6 +31,7 @@ extension WPStyleGuide {
         }
 
         static func configureCell(_ cell: UITableViewCell) {
+            cell.backgroundColor = tableBackgroundColor
             cell.contentView.backgroundColor = cellBackgroundColor
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -128,6 +128,7 @@ class OverviewCell: UITableViewCell, NibLoadable {
 private extension OverviewCell {
 
     func applyStyles() {
+        Style.configureCell(self)
         Style.configureLabelForOverview(selectedLabel)
         Style.configureLabelForOverview(selectedData)
         Style.configureViewAsSeparator(topSeparatorLine)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
@@ -27,6 +27,7 @@ private extension PostStatsTitleCell {
     func applyStyles() {
         titleLabel.text = NSLocalizedString("Showing stats for:", comment: "Label on Post Stats view indicating which post the stats are for.")
 
+        Style.configureCell(self)
         Style.configureLabelAsPostStatsTitle(titleLabel)
         Style.configureLabelAsPostTitle(postTitleLabel)
         Style.configureViewAsSeparator(bottomSeparatorLine)


### PR DESCRIPTION
Fixes #11602 

![Simulator Screen Shot - iPhone X - 2019-07-22 at 16 43 27](https://user-images.githubusercontent.com/912252/61647765-fb776d00-aca5-11e9-85fe-9a8b9a4eedba.png)

This PR fixes the margins then the table is extended on either side. The table view cell background view extends fully to the edges but the content view is inset to stay within the safe area. To fix it then I set the white background only for the cell contentView, setting the cell background view color equal to the table view background color.

## To test:
- Open Stats for a site with data
- Open Post Stats table view
- Check the tableview margins in landscape

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
