### PR TITLE
Stats: Post Stats: restrict date bar back button to data available.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * Stats: now use site timezone instead of device.
 * Improved color scheme consistency.
+* Post Stats: date bar no longer goes prior to earliest date available.
 
 12.9
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -55,7 +55,14 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
             return nil
         }
 
-        cell.configure(date: selectedDate, period: .day, delegate: self, mostRecentDate: store.getMostRecentDate(forPost: postID))
+        let lastTwoWeeks = store.getPostStats(for: postID)?.lastTwoWeeks ?? []
+
+        cell.configure(date: selectedDate,
+                       period: .day,
+                       delegate: self,
+                       expectedPeriodCount: lastTwoWeeks.count,
+                       mostRecentDate: store.getMostRecentDate(forPost: postID))
+
         tableHeaderView = cell
         return cell
     }


### PR DESCRIPTION
Fixes #12157 

To test:
- Access Post Stats for a post with little data the past two weeks.
- Verify the back button on the date bar no longer goes prior to the earliest date available.

<img width="350" alt="post_stats" src="https://user-images.githubusercontent.com/1816888/61672781-34b1dc00-acaa-11e9-9973-5761ee61711b.png">

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
