### PR TITLE
Implement UISwipeActions / Remove MGSwipeTableCell

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -149,7 +149,6 @@ target 'WordPress' do
     pod 'Gifu', '3.2.0'
     pod 'GiphyCoreSDK', '~> 1.4.0'
     pod 'HockeySDK', '5.1.4', :configurations => ['Release-Internal', 'Release-Alpha']
-    pod 'MGSwipeTableCell', '1.6.8'
     pod 'MRProgress', '0.8.3'
     pod 'Starscream', '3.0.6'
     pod 'SVProgressHUD', '2.2.5'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -56,7 +56,6 @@ PODS:
     - HockeySDK/DefaultLib (= 5.1.4)
   - HockeySDK/DefaultLib (5.1.4)
   - lottie-ios (2.5.2)
-  - MGSwipeTableCell (1.6.8)
   - MRProgress (0.8.3):
     - MRProgress/ActivityIndicator (= 0.8.3)
     - MRProgress/Blur (= 0.8.3)
@@ -265,7 +264,6 @@ DEPENDENCIES:
   - Gridicons (~> 0.16)
   - Gutenberg (from `http://github.com/wordpress-mobile/gutenberg-mobile/`, tag `v1.9.0`)
   - HockeySDK (= 5.1.4)
-  - MGSwipeTableCell (= 1.6.8)
   - MRProgress (= 0.8.3)
   - Nimble (~> 7.3.1)
   - NSObject-SafeExpectations (= 0.0.3)
@@ -330,7 +328,6 @@ SPEC REPOS:
     - GTMSessionFetcher
     - HockeySDK
     - lottie-ios
-    - MGSwipeTableCell
     - MRProgress
     - Nimble
     - NSObject-SafeExpectations
@@ -448,7 +445,6 @@ SPEC CHECKSUMS:
   Gutenberg: 8746c62af11ee621863239e08dcb79f9c7a2fc40
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
   lottie-ios: 3fef45d3fabe63e3c7c2eb603dd64ddfffc73062
-  MGSwipeTableCell: dc4eca3212ed38a563b27d6aa7b3c01ce656c1e2
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
@@ -496,6 +492,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: f075a0ead752c549336d218cd0a32c08bc315568
+PODFILE CHECKSUM: b747609362113ce604917c925432ab5d2509adf9
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
@@ -1,5 +1,3 @@
-import MGSwipeTableCell
-
 /// Encapsulates logic to approve a cooment
 class ApproveComment: DefaultNotificationActionCommand {
     enum TitleStrings {

--- a/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
@@ -1,7 +1,7 @@
 import MGSwipeTableCell
 
 /// Encapsulates logic to approve a cooment
-class ApproveComment: DefaultNotificationActionCommand, AccessibleFormattableContentActionCommand {
+class ApproveComment: DefaultNotificationActionCommand {
     enum TitleStrings {
         static let approve = NSLocalizedString("Approve", comment: "Approves a Comment")
         static let unapprove = NSLocalizedString("Unapprove", comment: "Unapproves a Comment")
@@ -19,7 +19,6 @@ class ApproveComment: DefaultNotificationActionCommand, AccessibleFormattableCon
             let newTitle = newValue ? TitleStrings.unapprove : TitleStrings.approve
             let newHint = newValue ? TitleHints.unapprove : TitleHints.approve
 
-            setIconStrings(title: newTitle, label: newTitle, hint: newHint)
 
             updateVisualState()
         }
@@ -48,10 +47,6 @@ class ApproveComment: DefaultNotificationActionCommand, AccessibleFormattableCon
     }
 
     private func unApprove(block: FormattableCommentContent) {
-        setIconStrings(title: TitleStrings.unapprove,
-                       label: TitleStrings.unapprove,
-                       hint: TitleHints.unapprove)
-
         ReachabilityUtils.onAvailableInternetConnectionDo {
             actionsService?.unapproveCommentWithBlock(block, completion: { [weak self] success in
                 if success {
@@ -62,10 +57,6 @@ class ApproveComment: DefaultNotificationActionCommand, AccessibleFormattableCon
     }
 
     private func approve(block: FormattableCommentContent) {
-        setIconStrings(title: TitleStrings.approve,
-                       label: TitleStrings.approve,
-                       hint: TitleHints.approve)
-
         ReachabilityUtils.onAvailableInternetConnectionDo {
             actionsService?.approveCommentWithBlock(block, completion: { [weak self] success in
                 if success {

--- a/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
@@ -5,36 +5,19 @@ class ApproveComment: DefaultNotificationActionCommand {
     enum TitleStrings {
         static let approve = NSLocalizedString("Approve", comment: "Approves a Comment")
         static let unapprove = NSLocalizedString("Unapprove", comment: "Unapproves a Comment")
-        static let selected = NSLocalizedString("Approved", comment: "Unapprove a comment")
     }
 
     enum TitleHints {
         static let approve = NSLocalizedString("Approves the Comment.", comment: "VoiceOver accessibility hint, informing the user the button can be used to approve a comment")
         static let unapprove = NSLocalizedString("Unapproves the Comment.", comment: "VoiceOver accessibility hint, informing the user the button can be used to unapprove a comment")
-        static let selected = NSLocalizedString("Unapproves the comment", comment: "Unapproves a comment. Spoken Hint.")
     }
 
-    override var on: Bool {
-        willSet {
-            let newTitle = newValue ? TitleStrings.unapprove : TitleStrings.approve
-            let newHint = newValue ? TitleHints.unapprove : TitleHints.approve
+    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
+        let action = UIContextualAction(style: .normal,
+                                        title: on ? TitleStrings.unapprove : TitleStrings.approve, handler: handler)
 
-
-            updateVisualState()
-        }
-    }
-
-    let approveIcon: UIButton = {
-        let title = TitleStrings.approve
-        let button = MGSwipeButton(title: title, backgroundColor: .primary)
-        button.accessibilityLabel = title
-        button.accessibilityTraits = UIAccessibilityTraits.button
-        button.accessibilityHint = TitleHints.approve
-        return button
-    }()
-
-    override var icon: UIButton? {
-        return approveIcon
+        action.backgroundColor = on ? .neutral(shade: .shade30) : .primary
+        return action
     }
 
     override func execute<ObjectType: FormattableCommentContent>(context: ActionContext<ObjectType>) {
@@ -50,7 +33,7 @@ class ApproveComment: DefaultNotificationActionCommand {
         ReachabilityUtils.onAvailableInternetConnectionDo {
             actionsService?.unapproveCommentWithBlock(block, completion: { [weak self] success in
                 if success {
-                    self?.switchOnState()
+                    self?.on.toggle()
                 }
             })
         }
@@ -60,34 +43,9 @@ class ApproveComment: DefaultNotificationActionCommand {
         ReachabilityUtils.onAvailableInternetConnectionDo {
             actionsService?.approveCommentWithBlock(block, completion: { [weak self] success in
                 if success {
-                    self?.switchOnState()
+                    self?.on.toggle()
                 }
             })
         }
-    }
-
-    private func switchOnState() {
-        on = !on
-        updateVisualState()
-    }
-
-    private func updateVisualState() {
-        guard let button = icon as? MGSwipeButton else {
-            return
-        }
-
-        let newBackgroundColor = on ? UIColor.neutral(shade: .shade30) : .primary
-        button.backgroundColor = newBackgroundColor
-
-        resetDefaultPadding()
-    }
-
-    private func resetDefaultPadding() {
-        guard let button = icon as? MGSwipeButton else {
-            return
-        }
-
-        let buttonDefaultPadding: CGFloat = 10
-        button.setPadding(buttonDefaultPadding)
     }
 }

--- a/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ApproveComment.swift
@@ -10,12 +10,12 @@ class ApproveComment: DefaultNotificationActionCommand {
         static let unapprove = NSLocalizedString("Unapproves the Comment.", comment: "VoiceOver accessibility hint, informing the user the button can be used to unapprove a comment")
     }
 
-    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
-        let action = UIContextualAction(style: .normal,
-                                        title: on ? TitleStrings.unapprove : TitleStrings.approve, handler: handler)
+    override var actionTitle: String {
+        return on ? TitleStrings.unapprove : TitleStrings.approve
+    }
 
-        action.backgroundColor = on ? .neutral(shade: .shade30) : .primary
-        return action
+    override var actionColor: UIColor {
+        return on ? .neutral(shade: .shade30) : .primary
     }
 
     override func execute<ObjectType: FormattableCommentContent>(context: ActionContext<ObjectType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
@@ -3,12 +3,8 @@ class EditComment: DefaultNotificationActionCommand {
     static let title = NSLocalizedString("Edit", comment: "Edits a Comment")
     static let hint = NSLocalizedString("Edits the comment.", comment: "VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment.")
 
-    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
-        let action = UIContextualAction(style: .normal,
-                                        title: EditComment.title,
-                                        handler: handler)
-        action.backgroundColor = .primary
-        return action
+    override var actionTitle: String {
+        return EditComment.title
     }
 
     override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
@@ -1,5 +1,3 @@
-import MGSwipeTableCell
-
 /// Encapsulates logic to Edit a comment
 class EditComment: DefaultNotificationActionCommand {
     static let title = NSLocalizedString("Edit", comment: "Edits a Comment")

--- a/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/EditComment.swift
@@ -4,16 +4,13 @@ import MGSwipeTableCell
 class EditComment: DefaultNotificationActionCommand {
     static let title = NSLocalizedString("Edit", comment: "Edits a Comment")
     static let hint = NSLocalizedString("Edits the comment.", comment: "VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment.")
-    let editIcon: UIButton = {
-        let button = MGSwipeButton(title: title, backgroundColor: .primary)
-        button.accessibilityLabel = title
-        button.accessibilityTraits = UIAccessibilityTraits.button
-        button.accessibilityHint = hint
-        return button
-    }()
 
-    override var icon: UIButton? {
-        return editIcon
+    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
+        let action = UIContextualAction(style: .normal,
+                                        title: EditComment.title,
+                                        handler: handler)
+        action.backgroundColor = .primary
+        return action
     }
 
     override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/Follow.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/Follow.swift
@@ -7,16 +7,12 @@ final class Follow: DefaultNotificationActionCommand {
     static let selectedTitle = NSLocalizedString("Following", comment: "User is following the blog.")
     static let selectedHint = NSLocalizedString("Unfollows the blog.", comment: "VoiceOver accessibility hint, informing the user the button can be used to unfollow a blog.")
 
-    let followIcon: UIButton = {
-        let button = MGSwipeButton(title: title, backgroundColor: .primary)
-        button.accessibilityLabel = title
-        button.accessibilityTraits = UIAccessibilityTraits.button
-        button.accessibilityHint = hint
-        return button
-    }()
-
-    override var icon: UIButton? {
-        return followIcon
+    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
+        let action = UIContextualAction(style: .normal,
+                                        title: Follow.title,
+                                        handler: handler)
+        action.backgroundColor = on ? .neutral(shade: .shade30) : .primary
+        return action
     }
 
     override func execute<ContentType: FormattableUserContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/Follow.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/Follow.swift
@@ -1,5 +1,3 @@
-import MGSwipeTableCell
-
 /// Encapsulates logic to follow a blog
 final class Follow: DefaultNotificationActionCommand {
     static let title = NSLocalizedString("Follow", comment: "Prompt to follow a blog.")

--- a/WordPress/Classes/Models/Notifications/Actions/Follow.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/Follow.swift
@@ -5,12 +5,12 @@ final class Follow: DefaultNotificationActionCommand {
     static let selectedTitle = NSLocalizedString("Following", comment: "User is following the blog.")
     static let selectedHint = NSLocalizedString("Unfollows the blog.", comment: "VoiceOver accessibility hint, informing the user the button can be used to unfollow a blog.")
 
-    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
-        let action = UIContextualAction(style: .normal,
-                                        title: Follow.title,
-                                        handler: handler)
-        action.backgroundColor = on ? .neutral(shade: .shade30) : .primary
-        return action
+    override var actionTitle: String {
+        return Follow.title
+    }
+
+    override var actionColor: UIColor {
+        return on ? .neutral(shade: .shade30) : .primary
     }
 
     override func execute<ContentType: FormattableUserContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
@@ -11,17 +11,12 @@ class LikeComment: DefaultNotificationActionCommand {
         static let unlike = NSLocalizedString("Unlike the Comment.", comment: "VoiceOver accessibility hint, informing the user the button can be used to stop liking a comment")
     }
 
-    let likeIcon: UIButton = {
-        let title = TitleStrings.like
-        let button = MGSwipeButton(title: title, backgroundColor: .primary)
-        button.accessibilityLabel = title
-        button.accessibilityTraits = UIAccessibilityTraits.button
-        button.accessibilityHint = TitleHints.like
-        return button
-    }()
+    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
+        let action = UIContextualAction(style: .normal,
+                                        title: on ? TitleStrings.like : TitleStrings.unlike, handler: handler)
 
-    override var icon: UIButton? {
-        return likeIcon
+        action.backgroundColor = .primary
+        return action
     }
 
     override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
@@ -1,4 +1,3 @@
-import MGSwipeTableCell
 /// Encapsulates logic to Like a comment
 class LikeComment: DefaultNotificationActionCommand {
     enum TitleStrings {

--- a/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
@@ -1,6 +1,6 @@
 import MGSwipeTableCell
 /// Encapsulates logic to Like a comment
-class LikeComment: DefaultNotificationActionCommand, AccessibleFormattableContentActionCommand {
+class LikeComment: DefaultNotificationActionCommand {
     enum TitleStrings {
         static let like = NSLocalizedString("Like", comment: "Likes a Comment")
         static let unlike = NSLocalizedString("Liked", comment: "A comment is marked as liked")
@@ -20,14 +20,6 @@ class LikeComment: DefaultNotificationActionCommand, AccessibleFormattableConten
         return button
     }()
 
-    override var on: Bool {
-        willSet {
-            let newTitle = newValue ? TitleStrings.like : TitleStrings.unlike
-            let newHint = newValue ? TitleHints.like : TitleHints.unlike
-            setIconStrings(title: newTitle, label: newTitle, hint: newHint)
-        }
-    }
-
     override var icon: UIButton? {
         return likeIcon
     }
@@ -43,17 +35,9 @@ class LikeComment: DefaultNotificationActionCommand, AccessibleFormattableConten
 
     private func like(block: FormattableCommentContent) {
         actionsService?.likeCommentWithBlock(block)
-
-        setIconStrings(title: TitleStrings.unlike,
-                       label: TitleStrings.unlike,
-                       hint: TitleHints.unlike)
     }
 
     private func removeLike(block: FormattableCommentContent) {
         actionsService?.unlikeCommentWithBlock(block)
-
-        setIconStrings(title: TitleStrings.like,
-                       label: TitleStrings.like,
-                       hint: TitleHints.like)
     }
 }

--- a/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
@@ -13,7 +13,6 @@ class LikeComment: DefaultNotificationActionCommand {
     override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
         let action = UIContextualAction(style: .normal,
                                         title: on ? TitleStrings.like : TitleStrings.unlike, handler: handler)
-
         action.backgroundColor = .primary
         return action
     }

--- a/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikeComment.swift
@@ -10,11 +10,8 @@ class LikeComment: DefaultNotificationActionCommand {
         static let unlike = NSLocalizedString("Unlike the Comment.", comment: "VoiceOver accessibility hint, informing the user the button can be used to stop liking a comment")
     }
 
-    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
-        let action = UIContextualAction(style: .normal,
-                                        title: on ? TitleStrings.like : TitleStrings.unlike, handler: handler)
-        action.backgroundColor = .primary
-        return action
+    override var actionTitle: String {
+        return on ? TitleStrings.like : TitleStrings.unlike
     }
 
     override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
@@ -1,11 +1,7 @@
 /// Encapsulates logic to Like a Post
 final class LikePost: DefaultNotificationActionCommand {
-    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
-        let action = UIContextualAction(style: .normal,
-                                        title: NSLocalizedString("Like", comment: "Like a post."),
-                                        handler: handler)
-        action.backgroundColor = .primary
-        return action
+    override var actionTitle: String {
+        return NSLocalizedString("Like", comment: "Like a post.")
     }
 
     override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
@@ -1,5 +1,3 @@
-import MGSwipeTableCell
-
 /// Encapsulates logic to Like a Post
 final class LikePost: DefaultNotificationActionCommand {
     override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {

--- a/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/LikePost.swift
@@ -2,17 +2,12 @@ import MGSwipeTableCell
 
 /// Encapsulates logic to Like a Post
 final class LikePost: DefaultNotificationActionCommand {
-    let likeIcon: UIButton = {
-        let title = NSLocalizedString("Like", comment: "Like a post.")
-        let button = MGSwipeButton(title: title, backgroundColor: .primary)
-        button.accessibilityLabel = title
-        button.accessibilityTraits = UIAccessibilityTraits.button
-        button.accessibilityHint = NSLocalizedString("Likes the post.", comment: "VoiceOver accessibility hint, informing the user the button can be used to Like a Post.")
-        return button
-    }()
-
-    override var icon: UIButton? {
-        return likeIcon
+    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
+        let action = UIContextualAction(style: .normal,
+                                        title: NSLocalizedString("Like", comment: "Like a post."),
+                                        handler: handler)
+        action.backgroundColor = .primary
+        return action
     }
 
     override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
@@ -3,11 +3,8 @@ class MarkAsSpam: DefaultNotificationActionCommand {
     static let title = NSLocalizedString("Spam", comment: "Marks comment as spam.")
     static let hint = NSLocalizedString("Mark as spam.", comment: "VoiceOver accessibility hint, informing the user the button can be used to Mark a comment as spam.")
 
-    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
-        let action = UIContextualAction(style: .normal,
-                                        title: MarkAsSpam.title, handler: handler)
-        action.backgroundColor = .primary
-        return action
+    override var actionTitle: String {
+        return MarkAsSpam.title
     }
 
     override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
@@ -1,17 +1,7 @@
-import MGSwipeTableCell
-
 /// Encapsulates logic to mark a comment as spam
 class MarkAsSpam: DefaultNotificationActionCommand {
     static let title = NSLocalizedString("Spam", comment: "Marks comment as spam.")
     static let hint = NSLocalizedString("Mark as spam.", comment: "VoiceOver accessibility hint, informing the user the button can be used to Mark a comment as spam.")
-
-    let spamIcon: UIButton = {
-        let button = MGSwipeButton(title: title, backgroundColor: .primary)
-        button.accessibilityLabel = title
-        button.accessibilityTraits = UIAccessibilityTraits.button
-        button.accessibilityHint = hint
-        return button
-    }()
 
     override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
         let action = UIContextualAction(style: .normal,

--- a/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/MarkAsSpam.swift
@@ -13,8 +13,11 @@ class MarkAsSpam: DefaultNotificationActionCommand {
         return button
     }()
 
-    override var icon: UIButton? {
-        return spamIcon
+    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
+        let action = UIContextualAction(style: .normal,
+                                        title: MarkAsSpam.title, handler: handler)
+        action.backgroundColor = .primary
+        return action
     }
 
     override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/NotificationAction.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/NotificationAction.swift
@@ -6,6 +6,14 @@ class DefaultNotificationActionCommand: FormattableContentActionCommand {
         return type(of: self).commandIdentifier()
     }
 
+    var actionTitle: String? {
+        return nil
+    }
+
+    var actionColor: UIColor? {
+        return .primary
+    }
+
     private(set) lazy var mainContext: NSManagedObjectContext? = {
         return ContextManager.sharedInstance().mainContext
     }()
@@ -16,10 +24,6 @@ class DefaultNotificationActionCommand: FormattableContentActionCommand {
 
     init(on: Bool) {
         self.on = on
-    }
-
-    func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
-        return nil
     }
 
     func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>) { }

--- a/WordPress/Classes/Models/Notifications/Actions/NotificationAction.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/NotificationAction.swift
@@ -14,12 +14,12 @@ class DefaultNotificationActionCommand: FormattableContentActionCommand {
         return NotificationActionsService(managedObjectContext: mainContext!)
     }()
 
-    var icon: UIButton? {
-        return nil
-    }
-
     init(on: Bool) {
         self.on = on
+    }
+
+    func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
+        return nil
     }
 
     func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>) { }

--- a/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
@@ -3,11 +3,8 @@ class ReplyToComment: DefaultNotificationActionCommand {
     static let title = NSLocalizedString("Reply", comment: "Reply to a comment.")
     static let hint = NSLocalizedString("Replies to a comment.", comment: "VoiceOver accessibility hint, informing the user the button can be used to reply to a comment.")
 
-    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
-        let action = UIContextualAction(style: .normal,
-                                        title: ReplyToComment.title, handler: handler)
-        action.backgroundColor = .primary
-        return action
+    override var actionTitle: String {
+        return ReplyToComment.title
     }
 
     override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
@@ -1,5 +1,3 @@
-import MGSwipeTableCell
-
 /// Encapsulates logic to reply to a comment
 class ReplyToComment: DefaultNotificationActionCommand {
     static let title = NSLocalizedString("Reply", comment: "Reply to a comment.")

--- a/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/ReplyToComment.swift
@@ -5,16 +5,11 @@ class ReplyToComment: DefaultNotificationActionCommand {
     static let title = NSLocalizedString("Reply", comment: "Reply to a comment.")
     static let hint = NSLocalizedString("Replies to a comment.", comment: "VoiceOver accessibility hint, informing the user the button can be used to reply to a comment.")
 
-    let replyIcon: UIButton = {
-        let button = MGSwipeButton(title: title, backgroundColor: .primary)
-        button.accessibilityLabel = title
-        button.accessibilityTraits = UIAccessibilityTraits.button
-        button.accessibilityHint = hint
-        return button
-    }()
-
-    override var icon: UIButton? {
-        return replyIcon
+    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
+        let action = UIContextualAction(style: .normal,
+                                        title: ReplyToComment.title, handler: handler)
+        action.backgroundColor = .primary
+        return action
     }
 
     override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
@@ -1,5 +1,3 @@
-import MGSwipeTableCell
-
 /// Encapsulates logic to trash a comment
 class TrashComment: DefaultNotificationActionCommand {
     static let title = NSLocalizedString("Trash", comment: "Trashes the comment")

--- a/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
@@ -3,13 +3,12 @@ class TrashComment: DefaultNotificationActionCommand {
     static let title = NSLocalizedString("Trash", comment: "Trashes the comment")
     static let hint = NSLocalizedString("Moves the comment to the Trash.", comment: "VoiceOver accessibility hint, informing the user the button can be used to Move a comment to the Trash.")
 
-    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
-        // Not set to 'destructive' style as that immediately removes the cell on activation,
-        // but we want to display our own undo cell in place.
-        let action = UIContextualAction(style: .normal,
-                                        title: TrashComment.title, handler: handler)
-        action.backgroundColor = .error
-        return action
+    override var actionTitle: String {
+        return TrashComment.title
+    }
+
+    override var actionColor: UIColor {
+        return .error
     }
 
     override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
@@ -6,7 +6,9 @@ class TrashComment: DefaultNotificationActionCommand {
     static let hint = NSLocalizedString("Moves the comment to the Trash.", comment: "VoiceOver accessibility hint, informing the user the button can be used to Move a comment to the Trash.")
 
     override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
-        let action = UIContextualAction(style: .destructive,
+        // Not set to 'destructive' style as that immediately removes the cell on activation,
+        // but we want to display our own undo cell in place.
+        let action = UIContextualAction(style: .normal,
                                         title: TrashComment.title, handler: handler)
         action.backgroundColor = .error
         return action

--- a/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/TrashComment.swift
@@ -5,16 +5,11 @@ class TrashComment: DefaultNotificationActionCommand {
     static let title = NSLocalizedString("Trash", comment: "Trashes the comment")
     static let hint = NSLocalizedString("Moves the comment to the Trash.", comment: "VoiceOver accessibility hint, informing the user the button can be used to Move a comment to the Trash.")
 
-    let trashIcon: UIButton = {
-        let button = MGSwipeButton(title: title, backgroundColor: .error)
-        button.accessibilityLabel =  title
-        button.accessibilityTraits = UIAccessibilityTraits.button
-        button.accessibilityHint = hint
-        return button
-    }()
-
-    override var icon: UIButton? {
-        return trashIcon
+    override func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction? {
+        let action = UIContextualAction(style: .destructive,
+                                        title: TrashComment.title, handler: handler)
+        action.backgroundColor = .error
+        return action
     }
 
     override func execute<ContentType: FormattableCommentContent>(context: ActionContext<ContentType>) {

--- a/WordPress/Classes/Utility/FormattableContent/Actions/FormattableContentActionCommand.swift
+++ b/WordPress/Classes/Utility/FormattableContent/Actions/FormattableContentActionCommand.swift
@@ -1,11 +1,12 @@
 /// Abstracts the logic behind contextual actions that can be applied to FormattableContent.
-/// i.e. the actions applied to notifications (Approve, Mark a comment as Spam)
-
+///
 protocol FormattableContentActionCommand: CustomStringConvertible {
     var identifier: Identifier { get }
     var on: Bool { get set }
 
-    func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction?
+    var actionTitle: String? { get }
+    var actionColor: UIColor? { get }
+
     func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>)
 }
 

--- a/WordPress/Classes/Utility/FormattableContent/Actions/FormattableContentActionCommand.swift
+++ b/WordPress/Classes/Utility/FormattableContent/Actions/FormattableContentActionCommand.swift
@@ -5,6 +5,7 @@ protocol FormattableContentActionCommand: CustomStringConvertible {
     var identifier: Identifier { get }
     var on: Bool { get set }
 
+    func action(handler: @escaping UIContextualAction.Handler) -> UIContextualAction?
     func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>)
 }
 

--- a/WordPress/Classes/Utility/FormattableContent/Actions/FormattableContentActionCommand.swift
+++ b/WordPress/Classes/Utility/FormattableContent/Actions/FormattableContentActionCommand.swift
@@ -3,7 +3,6 @@
 
 protocol FormattableContentActionCommand: CustomStringConvertible {
     var identifier: Identifier { get }
-    var icon: UIButton? { get }
     var on: Bool { get set }
 
     func execute<ContentType: FormattableContent>(context: ActionContext<ContentType>)
@@ -19,29 +18,4 @@ extension FormattableContentActionCommand {
     var description: String {
         return identifier.description
     }
-}
-
-protocol AccessibleFormattableContentActionCommand {
-    func setIconStrings(title: String, label: String, hint: String)
-}
-
-extension AccessibleFormattableContentActionCommand where Self: FormattableContentActionCommand {
-    func setIconStrings(title: String, label: String, hint: String) {
-        setIconTitle(title)
-        setAccessibilityLabel(label)
-        setAccessibilityHint(hint)
-    }
-
-    private func setIconTitle(_ title: String) {
-        icon?.setTitle(title, for: .normal)
-    }
-
-    private func setAccessibilityLabel(_ label: String) {
-        icon?.accessibilityLabel = label
-    }
-
-    private func setAccessibilityHint(_ hint: String) {
-        icon?.accessibilityHint = hint
-    }
-
 }

--- a/WordPress/Classes/Utility/WPTableViewHandler.h
+++ b/WordPress/Classes/Utility/WPTableViewHandler.h
@@ -50,6 +50,8 @@
 #pragma mark - Editing actions
 
 - (nullable NSArray<UITableViewRowAction *> *)tableView:(nonnull UITableView *)tableView editActionsForRowAtIndexPath:(nonnull NSIndexPath *)indexPath;
+- (nullable UISwipeActionsConfiguration *)tableView:(nonnull UITableView *)tableView leadingSwipeActionsConfigurationForRowAtIndexPath:(nonnull NSIndexPath *)indexPath;
+- (nullable UISwipeActionsConfiguration *)tableView:(nonnull UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(nonnull NSIndexPath *)indexPath;
 
 #pragma mark - Tracking the removal of views
 

--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -339,6 +339,24 @@ static CGFloat const DefaultCellHeight = 44.0;
     return nil;
 }
 
+- (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView leadingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:leadingSwipeActionsConfigurationForRowAtIndexPath:)]) {
+        return [self.delegate tableView:tableView leadingSwipeActionsConfigurationForRowAtIndexPath:indexPath];
+    }
+
+    return nil;
+}
+
+- (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath
+{
+    if ([self.delegate respondsToSelector:@selector(tableView:trailingSwipeActionsConfigurationForRowAtIndexPath:)]) {
+        return [self.delegate tableView:tableView trailingSwipeActionsConfigurationForRowAtIndexPath:indexPath];
+    }
+
+    return nil;
+}
+
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
     if ([self.delegate respondsToSelector:@selector(tableView:cellForRowAtIndexPath:)]) {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1,7 +1,6 @@
 import Foundation
 import CoreData
 import CocoaLumberjack
-import MGSwipeTableCell
 import WordPressShared
 import WordPressAuthenticator
 
@@ -174,6 +173,9 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         tableViewHandler.updateRowAnimation = .none
     }
 
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        return true
+    }
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
@@ -323,6 +325,38 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         showDetails(for: note)
     }
 
+    override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+        return .none
+    }
+
+    override func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        guard let note = tableViewHandler.resultsController.object(at: indexPath) as? Notification else {
+            return nil
+        }
+
+        let isRead = note.read
+
+        let title = isRead ? NSLocalizedString("Mark Unread", comment: "Marks a notification as unread") : NSLocalizedString("Mark Read", comment: "Marks a notification as unread")
+
+        let action = UIContextualAction(style: .normal, title: title, handler: { (action, view, completionHandler) in
+            if isRead {
+                self.markAsUnread(note: note)
+            } else {
+                self.markAsRead(note: note)
+            }
+            completionHandler(true)
+        })
+
+        action.backgroundColor = .neutral(shade: .shade50)
+
+        let configuration = UISwipeActionsConfiguration(actions: [action])
+        return configuration
+    }
+
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        return nil
+    }
+    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         guard let note = sender as? Notification else {
             return
@@ -967,28 +1001,6 @@ extension NotificationsViewController: WPTableViewHandlerDelegate {
         }
 
         cell.downloadIconWithURL(note.iconURL)
-
-        configureCellActions(cell, note: note)
-    }
-
-    @objc func configureCellActions(_ cell: NoteTableViewCell, note: Notification) {
-        // Let "Mark as Read / Unread" expand
-        let leadingExpansionButton = 0
-
-        // Don't expand "Trash"
-        let trailingExpansionButton = -1
-
-        if UIView.userInterfaceLayoutDirection(for: view.semanticContentAttribute) == .leftToRight {
-            cell.leftButtons = leadingButtons(note: note)
-            cell.leftExpansion.buttonIndex = leadingExpansionButton
-            cell.rightButtons = trailingButtons(note: note)
-            cell.rightExpansion.buttonIndex = trailingExpansionButton
-        } else {
-            cell.rightButtons = leadingButtons(note: note)
-            cell.rightExpansion.buttonIndex = trailingExpansionButton
-            cell.leftButtons = trailingButtons(note: note)
-            cell.leftExpansion.buttonIndex = trailingExpansionButton
-        }
     }
 
     func sectionNameKeyPath() -> String {
@@ -1024,72 +1036,6 @@ extension NotificationsViewController: WPTableViewHandlerDelegate {
         }
     }
 }
-
-
-
-// MARK: - Actions
-//
-private extension NotificationsViewController {
-    func leadingButtons(note: Notification) -> [MGSwipeButton] {
-        let isRead = note.read
-
-        let title = isRead ? NSLocalizedString("Mark Unread", comment: "Marks a notification as unread") : NSLocalizedString("Mark Read", comment: "Marks a notification as unread")
-
-        return [
-            MGSwipeButton(title: title,
-                          backgroundColor: .neutral(shade: .shade50),
-                          callback: { _ in
-                            if isRead {
-                                self.markAsUnread(note: note)
-                            } else {
-                                self.markAsRead(note: note)
-                            }
-                            return true
-            })
-        ]
-    }
-
-    func trailingButtons(note: Notification) -> [MGSwipeButton] {
-        var rightButtons = [MGSwipeButton]()
-
-        guard let block: FormattableCommentContent = note.contentGroup(ofKind: .comment)?.blockOfKind(.comment) else {
-            return []
-        }
-
-        // Comments: Trash
-        if let trashAction = block.action(id: TrashCommentAction.actionIdentifier()), let button = trashAction.command?.icon as? MGSwipeButton {
-            button.callback = { [weak self] _ in
-                let actionContext = ActionContext(block: block, completion: { [weak self] (request, success) in
-                    guard let request = request else {
-                        return
-                    }
-                    self?.showUndeleteForNoteWithID(note.objectID, request: request)
-                })
-                trashAction.execute(context: actionContext)
-                return true
-            }
-            rightButtons.append(button)
-        }
-
-        guard let approveEnabled = block.action(id: ApproveCommentAction.actionIdentifier())?.enabled, approveEnabled == true else {
-            return rightButtons
-        }
-
-        let approveAction = block.action(id: ApproveCommentAction.actionIdentifier())
-        let button = approveAction?.command?.icon as? MGSwipeButton
-
-        button?.callback = { _ in
-            let actionContext = ActionContext(block: block)
-            approveAction?.execute(context: actionContext)
-            return true
-        }
-
-        rightButtons.append(button!)
-
-        return rightButtons
-    }
-}
-
 
 
 // MARK: - Filter Helpers

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -362,7 +362,8 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         // Trash comment
         if let trashAction = block.action(id: TrashCommentAction.actionIdentifier()),
             let command = trashAction.command,
-            let action = command.action(handler: { (_, _, completionHandler) in
+            let title = command.actionTitle {
+            let action = UIContextualAction(style: .normal, title: title, handler: { (_, _, completionHandler) in
                 let actionContext = ActionContext(block: block, completion: { [weak self] (request, success) in
                     guard let request = request else {
                         return
@@ -371,7 +372,8 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
                 })
                 trashAction.execute(context: actionContext)
                 completionHandler(true)
-            }) {
+            })
+            action.backgroundColor = command.actionColor
             actions.append(action)
         }
 
@@ -381,11 +383,13 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         }
 
         let approveAction = block.action(id: ApproveCommentAction.actionIdentifier())
-        if let action = approveAction?.command?.action(handler: { (_, _, completionHandler) in
-            let actionContext = ActionContext(block: block)
-            approveAction?.execute(context: actionContext)
-            completionHandler(true)
-        }) {
+        if let title = approveAction?.command?.actionTitle {
+            let action = UIContextualAction(style: .normal, title: title, handler: { (_, _, completionHandler) in
+                let actionContext = ActionContext(block: block)
+                approveAction?.execute(context: actionContext)
+                completionHandler(true)
+            })
+            action.backgroundColor = approveAction?.command?.actionColor
             actions.append(action)
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -353,8 +353,24 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         return configuration
     }
 
-    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        return nil
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {    
+        guard let note = tableViewHandler.resultsController.object(at: indexPath) as? Notification,
+            let block: FormattableCommentContent = note.contentGroup(ofKind: .comment)?.blockOfKind(.comment) else {
+            return nil
+        }
+
+        guard let approveEnabled = block.action(id: ApproveCommentAction.actionIdentifier())?.enabled, approveEnabled == true else {
+            return nil
+        }
+
+        let approveAction = block.action(id: ApproveCommentAction.actionIdentifier())
+        let action = approveAction?.command?.action(handler: { (_, _, completionHandler) in
+            let actionContext = ActionContext(block: block)
+            approveAction?.execute(context: actionContext)
+            completionHandler(true)
+        })
+
+        return UISwipeActionsConfiguration(actions: [action!])
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockActionsTableViewCell.swift
@@ -156,13 +156,13 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
     /// Returns the accessibility label for the Approve Button
     ///
     fileprivate var approveAccesibilityLabel: String {
-        return isApproveOn ? ApproveComment.TitleStrings.selected : ApproveComment.TitleStrings.approve
+        return isApproveOn ? ApproveComment.TitleStrings.unapprove : ApproveComment.TitleStrings.approve
     }
 
     /// Returns the accessibility hint for the Approve Button
     ///
     fileprivate var approveAccesibilityHint: String {
-        return isApproveOn ? ApproveComment.TitleHints.selected : ApproveComment.TitleHints.approve
+        return isApproveOn ? ApproveComment.TitleHints.unapprove : ApproveComment.TitleHints.approve
     }
 
     /// Returns the accessibility label for the Like Button
@@ -203,8 +203,8 @@ class NoteBlockActionsTableViewCell: NoteBlockTableViewCell {
         btnLike.setTitleColor(textSelectedColor, for: .selected)
 
         btnApprove.setTitle(ApproveComment.TitleStrings.approve, for: UIControl.State())
-        btnApprove.setTitle(ApproveComment.TitleStrings.selected, for: .highlighted)
-        btnApprove.setTitle(ApproveComment.TitleStrings.selected, for: .selected)
+        btnApprove.setTitle(ApproveComment.TitleStrings.unapprove, for: .highlighted)
+        btnApprove.setTitle(ApproveComment.TitleStrings.unapprove, for: .selected)
         btnApprove.setTitleColor(textNormalColor, for: UIControl.State())
         btnApprove.setTitleColor(textSelectedColor, for: .highlighted)
         btnApprove.setTitleColor(textSelectedColor, for: .selected)

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteTableViewCell.swift
@@ -1,6 +1,5 @@
 import Foundation
 import WordPressShared
-import MGSwipeTableCell
 
 /// The purpose of this class is to render a Notification entity, onscreen.
 /// This cell should be loaded from its nib, since the autolayout constraints and outlets are not generated
@@ -8,7 +7,7 @@ import MGSwipeTableCell
 /// Supports specific styles for Unapproved Comment Notifications, Unread Notifications, and a brand
 /// new "Undo Deletion" mechanism has been implemented. See "NoteUndoOverlayView" for reference.
 ///
-class NoteTableViewCell: MGSwipeTableCell {
+class NoteTableViewCell: UITableViewCell {
     // MARK: - Public Properties
     @objc var read: Bool = false {
         didSet {

--- a/WordPress/WordPressTest/ApproveCommentActionTests.swift
+++ b/WordPress/WordPressTest/ApproveCommentActionTests.swift
@@ -25,9 +25,6 @@ final class ApproveCommentActionTests: XCTestCase {
     }
 
     private var action: ApproveComment?
-
-    private var mockHandler: UIContextualAction.Handler = { (_, _, _) in }
-
     private let utility = NotificationUtility()
 
     private struct Constants {
@@ -52,23 +49,20 @@ final class ApproveCommentActionTests: XCTestCase {
         XCTAssertEqual(action?.on, Constants.initialStatus)
     }
 
-    func testContextualActionTitleIsExpected() {
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, ApproveComment.TitleStrings.approve)
+    func testActionTitleIsExpected() {
+        XCTAssertEqual(action?.actionTitle, ApproveComment.TitleStrings.approve)
     }
 
     func testSettingActionOnSetsExpectedTitle() {
         action?.on = true
 
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, ApproveComment.TitleStrings.unapprove)
+        XCTAssertEqual(action?.actionTitle, ApproveComment.TitleStrings.unapprove)
     }
 
     func testSettingActionOffSetsExpectedTitle() {
         action?.on = false
 
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, ApproveComment.TitleStrings.approve)
+        XCTAssertEqual(action?.actionTitle, ApproveComment.TitleStrings.approve)
     }
 
     func testExecuteCallsUnapproveWhenActionIsOn() {
@@ -84,13 +78,11 @@ final class ApproveCommentActionTests: XCTestCase {
         XCTAssertTrue(mockService.unapproveWasCalled)
     }
 
-    func testExecuteUpdatesContextualActionTitleWhenActionIsOn() {
+    func testExecuteUpdatesActionTitleWhenActionIsOn() {
         action?.on = true
 
         action?.execute(context: utility.mockCommentContext())
-
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, ApproveComment.TitleStrings.approve)
+        XCTAssertEqual(action?.actionTitle, ApproveComment.TitleStrings.approve)
     }
 
     func testExecuteCallsApproveWhenActionIsOff() {
@@ -106,12 +98,10 @@ final class ApproveCommentActionTests: XCTestCase {
         XCTAssertTrue(mockService.approveWasCalled)
     }
 
-    func testExecuteUpdatesContextualActionTitleWhenActionIsOff() {
+    func testExecuteUpdatesActionTitleWhenActionIsOff() {
         action?.on = false
 
         action?.execute(context: utility.mockCommentContext())
-
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, ApproveComment.TitleStrings.unapprove)
+        XCTAssertEqual(action?.actionTitle, ApproveComment.TitleStrings.unapprove)
     }
 }

--- a/WordPress/WordPressTest/ApproveCommentActionTests.swift
+++ b/WordPress/WordPressTest/ApproveCommentActionTests.swift
@@ -10,21 +10,24 @@ final class ApproveCommentActionTests: XCTestCase {
     }
 
     private class MockNotificationActionsService: NotificationActionsService {
-        var unaproveWasCalled: Bool = false
-        var aproveWasCalled: Bool = false
+        var unapproveWasCalled: Bool = false
+        var approveWasCalled: Bool = false
 
         override func unapproveCommentWithBlock(_ block: FormattableCommentContent, completion: ((Bool) -> Void)?) {
-            unaproveWasCalled = true
+            unapproveWasCalled = true
             completion?(true)
         }
 
         override func approveCommentWithBlock(_ block: FormattableCommentContent, completion: ((Bool) -> Void)?) {
-            aproveWasCalled = true
+            approveWasCalled = true
             completion?(true)
         }
     }
 
     private var action: ApproveComment?
+
+    private var mockHandler: UIContextualAction.Handler = { (_, _, _) in }
+
     private let utility = NotificationUtility()
 
     private struct Constants {
@@ -49,49 +52,26 @@ final class ApproveCommentActionTests: XCTestCase {
         XCTAssertEqual(action?.on, Constants.initialStatus)
     }
 
+    func testContextualActionTitleIsExpected() {
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, ApproveComment.TitleStrings.approve)
+    }
+
     func testSettingActionOnSetsExpectedTitle() {
         action?.on = true
-        XCTAssertEqual(action?.icon?.titleLabel?.text, ApproveComment.TitleStrings.unapprove)
-    }
 
-    func testSettingActionOnSetsExpectedAccessibilityLabel() {
-        action?.on = true
-        XCTAssertEqual(action?.icon?.accessibilityLabel, ApproveComment.TitleStrings.unapprove)
-    }
-
-    func testSettingActionOnSetsExpectedAccessibilityHint() {
-        action?.on = true
-        XCTAssertEqual(action?.icon?.accessibilityHint, ApproveComment.TitleHints.unapprove)
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, ApproveComment.TitleStrings.unapprove)
     }
 
     func testSettingActionOffSetsExpectedTitle() {
         action?.on = false
-        XCTAssertEqual(action?.icon?.titleLabel?.text, ApproveComment.TitleStrings.approve)
+
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, ApproveComment.TitleStrings.approve)
     }
 
-    func testSettingActionOffSetsExpectedAccessibilityLabel() {
-        action?.on = false
-        XCTAssertEqual(action?.icon?.accessibilityLabel, ApproveComment.TitleStrings.approve)
-    }
-
-    func testSettingActionOffSetsExpectedAccessibilityHint() {
-        action?.on = false
-        XCTAssertEqual(action?.icon?.accessibilityHint, ApproveComment.TitleHints.approve)
-    }
-
-    func testDefaultTitleIsExpected() {
-        XCTAssertEqual(action?.icon?.titleLabel?.text, ApproveComment.TitleStrings.approve)
-    }
-
-    func testDefaultAccessibilityLabelIsExpected() {
-        XCTAssertEqual(action?.icon?.accessibilityLabel, ApproveComment.TitleStrings.approve)
-    }
-
-    func testDefaultAccessibilityHintIsExpected() {
-        XCTAssertEqual(action?.icon?.accessibilityHint, ApproveComment.TitleHints.approve)
-    }
-
-    func testExecuteCallsUnapproveWhenIconIsOn() {
+    func testExecuteCallsUnapproveWhenActionIsOn() {
         action?.on = true
 
         action?.execute(context: utility.mockCommentContext())
@@ -101,34 +81,19 @@ final class ApproveCommentActionTests: XCTestCase {
             return
         }
 
-        XCTAssertTrue(mockService.unaproveWasCalled)
+        XCTAssertTrue(mockService.unapproveWasCalled)
     }
 
-    func testExecuteUpdatesIconTitleWhenIconIsOn() {
+    func testExecuteUpdatesContextualActionTitleWhenActionIsOn() {
         action?.on = true
 
         action?.execute(context: utility.mockCommentContext())
 
-        XCTAssertEqual(action?.icon?.titleLabel?.text, ApproveComment.TitleStrings.approve)
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, ApproveComment.TitleStrings.approve)
     }
 
-    func testExecuteUpdatesIconAccessibilityLabelWhenIconIsOn() {
-        action?.on = true
-
-        action?.execute(context: utility.mockCommentContext())
-
-        XCTAssertEqual(action?.icon?.accessibilityLabel, ApproveComment.TitleStrings.approve)
-    }
-
-    func testExecuteUpdatesIconAccessibilityHintWhenIconIsOn() {
-        action?.on = true
-
-        action?.execute(context: utility.mockCommentContext())
-
-        XCTAssertEqual(action?.icon?.accessibilityHint, ApproveComment.TitleHints.approve)
-    }
-
-    func testExecuteCallsApproveWhenIconIsOff() {
+    func testExecuteCallsApproveWhenActionIsOff() {
         action?.on = false
 
         action?.execute(context: utility.mockCommentContext())
@@ -138,30 +103,15 @@ final class ApproveCommentActionTests: XCTestCase {
             return
         }
 
-        XCTAssertTrue(mockService.aproveWasCalled)
+        XCTAssertTrue(mockService.approveWasCalled)
     }
 
-    func testExecuteUpdatesIconTitleWhenIconIsOff() {
+    func testExecuteUpdatesContextualActionTitleWhenActionIsOff() {
         action?.on = false
 
         action?.execute(context: utility.mockCommentContext())
 
-        XCTAssertEqual(action?.icon?.titleLabel?.text, ApproveComment.TitleStrings.unapprove)
-    }
-
-    func testExecuteUpdatesIconAccessibilityLabelWhenIconIsOff() {
-        action?.on = false
-
-        action?.execute(context: utility.mockCommentContext())
-
-        XCTAssertEqual(action?.icon?.accessibilityLabel, ApproveComment.TitleStrings.unapprove)
-    }
-
-    func testExecuteUpdatesIconAccessibilityHintWhenIconIsOff() {
-        action?.on = false
-
-        action?.execute(context: utility.mockCommentContext())
-
-        XCTAssertEqual(action?.icon?.accessibilityHint, ApproveComment.TitleHints.unapprove)
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, ApproveComment.TitleStrings.unapprove)
     }
 }

--- a/WordPress/WordPressTest/EditCommentActionTests.swift
+++ b/WordPress/WordPressTest/EditCommentActionTests.swift
@@ -19,6 +19,9 @@ final class EditCommentActionTests: XCTestCase {
     }
 
     private var action: EditComment?
+
+    private var mockHandler: UIContextualAction.Handler = { (_, _, _) in }
+
     private let utility = NotificationUtility()
 
     private struct Constants {
@@ -37,16 +40,9 @@ final class EditCommentActionTests: XCTestCase {
         super.tearDown()
     }
 
-    func testDefaultTitleIsExpected() {
-        XCTAssertEqual(action?.icon?.titleLabel?.text, EditComment.title)
-    }
-
-    func testDefaultAccessibilityLabelIsExpected() {
-        XCTAssertEqual(action?.icon?.accessibilityLabel, EditComment.title)
-    }
-
-    func testDefaultAccessibilityHintIsExpected() {
-        XCTAssertEqual(action?.icon?.accessibilityHint, EditComment.hint)
+    func testContextualActionTitleIsExpected() {
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, EditComment.title)
     }
 
     func testExecuteCallsEdit() {

--- a/WordPress/WordPressTest/EditCommentActionTests.swift
+++ b/WordPress/WordPressTest/EditCommentActionTests.swift
@@ -19,9 +19,6 @@ final class EditCommentActionTests: XCTestCase {
     }
 
     private var action: EditComment?
-
-    private var mockHandler: UIContextualAction.Handler = { (_, _, _) in }
-
     private let utility = NotificationUtility()
 
     private struct Constants {
@@ -40,9 +37,8 @@ final class EditCommentActionTests: XCTestCase {
         super.tearDown()
     }
 
-    func testContextualActionTitleIsExpected() {
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, EditComment.title)
+    func testActionTitleIsExpected() {
+        XCTAssertEqual(action?.actionTitle, EditComment.title)
     }
 
     func testExecuteCallsEdit() {

--- a/WordPress/WordPressTest/LikeCommentActionTests.swift
+++ b/WordPress/WordPressTest/LikeCommentActionTests.swift
@@ -25,9 +25,6 @@ final class LikeCommentActionTests: XCTestCase {
     }
 
     private var action: LikeComment?
-
-    private var mockHandler: UIContextualAction.Handler = { (_, _, _) in }
-
     private let utility = NotificationUtility()
 
     private struct Constants {
@@ -55,15 +52,13 @@ final class LikeCommentActionTests: XCTestCase {
     func testSettingActionOnSetsExpectedTitle() {
         action?.on = true
 
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, LikeComment.TitleStrings.like)
+        XCTAssertEqual(action?.actionTitle, LikeComment.TitleStrings.like)
     }
 
     func testSettingActionOffSetsExpectedTitle() {
         action?.on = false
 
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, LikeComment.TitleStrings.unlike)
+        XCTAssertEqual(action?.actionTitle, LikeComment.TitleStrings.unlike)
     }
 
     func testExecuteCallsUnlikeWhenActionIsOn() {
@@ -84,8 +79,7 @@ final class LikeCommentActionTests: XCTestCase {
 
         action?.execute(context: utility.mockCommentContext())
 
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, LikeComment.TitleStrings.like)
+        XCTAssertEqual(action?.actionTitle, LikeComment.TitleStrings.like)
     }
 
     func testExecuteCallsLikeWhenActionIsOff() {
@@ -106,7 +100,6 @@ final class LikeCommentActionTests: XCTestCase {
 
         action?.execute(context: utility.mockCommentContext())
 
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, LikeComment.TitleStrings.unlike)
+        XCTAssertEqual(action?.actionTitle, LikeComment.TitleStrings.unlike)
     }
 }

--- a/WordPress/WordPressTest/LikeCommentActionTests.swift
+++ b/WordPress/WordPressTest/LikeCommentActionTests.swift
@@ -25,6 +25,9 @@ final class LikeCommentActionTests: XCTestCase {
     }
 
     private var action: LikeComment?
+
+    private var mockHandler: UIContextualAction.Handler = { (_, _, _) in }
+
     private let utility = NotificationUtility()
 
     private struct Constants {
@@ -51,47 +54,19 @@ final class LikeCommentActionTests: XCTestCase {
 
     func testSettingActionOnSetsExpectedTitle() {
         action?.on = true
-        XCTAssertEqual(action?.icon?.titleLabel?.text, LikeComment.TitleStrings.like)
-    }
 
-    func testSettingActionOnSetsExpectedAccessibilityLabel() {
-        action?.on = true
-        XCTAssertEqual(action?.icon?.accessibilityLabel, LikeComment.TitleStrings.like)
-    }
-
-    func testSettingActionOnSetsExpectedAccessibilityHint() {
-        action?.on = true
-        XCTAssertEqual(action?.icon?.accessibilityHint, LikeComment.TitleHints.like)
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, LikeComment.TitleStrings.like)
     }
 
     func testSettingActionOffSetsExpectedTitle() {
         action?.on = false
-        XCTAssertEqual(action?.icon?.titleLabel?.text, LikeComment.TitleStrings.unlike)
+
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, LikeComment.TitleStrings.unlike)
     }
 
-    func testSettingActionOffSetsExpectedAccessibilityLabel() {
-        action?.on = false
-        XCTAssertEqual(action?.icon?.accessibilityLabel, LikeComment.TitleStrings.unlike)
-    }
-
-    func testSettingActionOffSetsExpectedAccessibilityHint() {
-        action?.on = false
-        XCTAssertEqual(action?.icon?.accessibilityHint, LikeComment.TitleHints.unlike)
-    }
-
-    func testDefaultTitleIsExpected() {
-        XCTAssertEqual(action?.icon?.titleLabel?.text, LikeComment.TitleStrings.like)
-    }
-
-    func testDefaultAccessibilityLabelIsExpected() {
-        XCTAssertEqual(action?.icon?.accessibilityLabel, LikeComment.TitleStrings.like)
-    }
-
-    func testDefaultAccessibilityHintIsExpected() {
-        XCTAssertEqual(action?.icon?.accessibilityHint, LikeComment.TitleHints.like)
-    }
-
-    func testExecuteCallsUnlikeWhenIconIsOn() {
+    func testExecuteCallsUnlikeWhenActionIsOn() {
         action?.on = true
 
         action?.execute(context: utility.mockCommentContext())
@@ -104,31 +79,16 @@ final class LikeCommentActionTests: XCTestCase {
         XCTAssertTrue(mockService.unlikeWasCalled)
     }
 
-    func testExecuteUpdatesIconTitleWhenIconIsOn() {
+    func testExecuteUpdatesActionTitleWhenActionIsOn() {
         action?.on = true
 
         action?.execute(context: utility.mockCommentContext())
 
-        XCTAssertEqual(action?.icon?.titleLabel?.text, LikeComment.TitleStrings.like)
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, LikeComment.TitleStrings.like)
     }
 
-    func testExecuteUpdatesIconAccessibilityLabelWhenIconIsOn() {
-        action?.on = true
-
-        action?.execute(context: utility.mockCommentContext())
-
-        XCTAssertEqual(action?.icon?.accessibilityLabel, LikeComment.TitleStrings.like)
-    }
-
-    func testExecuteUpdatesIconAccessibilityHintWhenIconIsOn() {
-        action?.on = true
-
-        action?.execute(context: utility.mockCommentContext())
-
-        XCTAssertEqual(action?.icon?.accessibilityHint, LikeComment.TitleHints.like)
-    }
-
-    func testExecuteCallsLikeWhenIconIsOff() {
+    func testExecuteCallsLikeWhenActionIsOff() {
         action?.on = false
 
         action?.execute(context: utility.mockCommentContext())
@@ -141,27 +101,12 @@ final class LikeCommentActionTests: XCTestCase {
         XCTAssertTrue(mockService.likeWasCalled)
     }
 
-    func testExecuteUpdatesIconTitleWhenIconIsOff() {
+    func testExecuteUpdatesActionTitleWhenActionIsOff() {
         action?.on = false
 
         action?.execute(context: utility.mockCommentContext())
 
-        XCTAssertEqual(action?.icon?.titleLabel?.text, LikeComment.TitleStrings.unlike)
-    }
-
-    func testExecuteUpdatesIconAccessibilityLabelWhenIconIsOff() {
-        action?.on = false
-
-        action?.execute(context: utility.mockCommentContext())
-
-        XCTAssertEqual(action?.icon?.accessibilityLabel, LikeComment.TitleStrings.unlike)
-    }
-
-    func testExecuteUpdatesIconAccessibilityHintWhenIconIsOff() {
-        action?.on = false
-
-        action?.execute(context: utility.mockCommentContext())
-
-        XCTAssertEqual(action?.icon?.accessibilityHint, LikeComment.TitleHints.unlike)
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, LikeComment.TitleStrings.unlike)
     }
 }

--- a/WordPress/WordPressTest/MarkAsSpamActionTests.swift
+++ b/WordPress/WordPressTest/MarkAsSpamActionTests.swift
@@ -16,9 +16,6 @@ final class MarkAsSpamActionTests: XCTestCase {
     }
 
     private var action: MarkAsSpam?
-
-    private var mockHandler: UIContextualAction.Handler = { (_, _, _) in }
-
     let utility = NotificationUtility()
 
     private struct Constants {
@@ -43,9 +40,8 @@ final class MarkAsSpamActionTests: XCTestCase {
         XCTAssertEqual(action?.on, Constants.initialStatus)
     }
 
-    func testContextualActionTitleIsExpected() {
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, MarkAsSpam.title)
+    func testActionTitleIsExpected() {
+        XCTAssertEqual(action?.actionTitle, MarkAsSpam.title)
     }
 
     func testExecuteCallsSpam() {

--- a/WordPress/WordPressTest/MarkAsSpamActionTests.swift
+++ b/WordPress/WordPressTest/MarkAsSpamActionTests.swift
@@ -16,6 +16,9 @@ final class MarkAsSpamActionTests: XCTestCase {
     }
 
     private var action: MarkAsSpam?
+
+    private var mockHandler: UIContextualAction.Handler = { (_, _, _) in }
+
     let utility = NotificationUtility()
 
     private struct Constants {
@@ -40,16 +43,9 @@ final class MarkAsSpamActionTests: XCTestCase {
         XCTAssertEqual(action?.on, Constants.initialStatus)
     }
 
-    func testDefaultTitleIsExpected() {
-        XCTAssertEqual(action?.icon?.titleLabel?.text, MarkAsSpam.title)
-    }
-
-    func testDefaultAccessibilityLabelIsExpected() {
-        XCTAssertEqual(action?.icon?.accessibilityLabel, MarkAsSpam.title)
-    }
-
-    func testDefaultAccessibilityHintIsExpected() {
-        XCTAssertEqual(action?.icon?.accessibilityHint, MarkAsSpam.hint)
+    func testContextualActionTitleIsExpected() {
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, MarkAsSpam.title)
     }
 
     func testExecuteCallsSpam() {

--- a/WordPress/WordPressTest/ReplyToCommentActionTests.swift
+++ b/WordPress/WordPressTest/ReplyToCommentActionTests.swift
@@ -18,6 +18,9 @@ final class ReplyToCommentActionTests: XCTestCase {
     }
 
     private var action: ReplyToComment?
+
+    private var mockHandler: UIContextualAction.Handler = { (_, _, _) in }
+
     let utility = NotificationUtility()
 
     private struct Constants {
@@ -42,16 +45,9 @@ final class ReplyToCommentActionTests: XCTestCase {
         XCTAssertEqual(action?.on, Constants.initialStatus)
     }
 
-    func testDefaultTitleIsExpected() {
-        XCTAssertEqual(action?.icon?.titleLabel?.text, ReplyToComment.title)
-    }
-
-    func testDefaultAccessibilityLabelIsExpected() {
-        XCTAssertEqual(action?.icon?.accessibilityLabel, ReplyToComment.title)
-    }
-
-    func testDefaultAccessibilityHintIsExpected() {
-        XCTAssertEqual(action?.icon?.accessibilityHint, ReplyToComment.hint)
+    func testContextualActionTitleIsExpected() {
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, ReplyToComment.title)
     }
 
     func testExecuteCallsReply() {

--- a/WordPress/WordPressTest/ReplyToCommentActionTests.swift
+++ b/WordPress/WordPressTest/ReplyToCommentActionTests.swift
@@ -18,9 +18,6 @@ final class ReplyToCommentActionTests: XCTestCase {
     }
 
     private var action: ReplyToComment?
-
-    private var mockHandler: UIContextualAction.Handler = { (_, _, _) in }
-
     let utility = NotificationUtility()
 
     private struct Constants {
@@ -45,9 +42,8 @@ final class ReplyToCommentActionTests: XCTestCase {
         XCTAssertEqual(action?.on, Constants.initialStatus)
     }
 
-    func testContextualActionTitleIsExpected() {
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, ReplyToComment.title)
+    func testActionTitleIsExpected() {
+        XCTAssertEqual(action?.actionTitle, ReplyToComment.title)
     }
 
     func testExecuteCallsReply() {

--- a/WordPress/WordPressTest/TrashCommentActionTests.swift
+++ b/WordPress/WordPressTest/TrashCommentActionTests.swift
@@ -16,9 +16,6 @@ final class TrashCommentActionTests: XCTestCase {
     }
 
     private var action: TrashComment?
-
-    private var mockHandler: UIContextualAction.Handler = { (_, _, _) in }
-
     let utils = NotificationUtility()
 
     private struct Constants {
@@ -43,9 +40,8 @@ final class TrashCommentActionTests: XCTestCase {
         XCTAssertEqual(action?.on, Constants.initialStatus)
     }
 
-    func testContextualActionTitleIsExpected() {
-        let contextualAction = action?.action(handler: mockHandler)
-        XCTAssertEqual(contextualAction?.title, TrashComment.title)
+    func testActionTitleIsExpected() {
+        XCTAssertEqual(action?.actionTitle, TrashComment.title)
     }
 
     func testExecuteCallsTrash() {

--- a/WordPress/WordPressTest/TrashCommentActionTests.swift
+++ b/WordPress/WordPressTest/TrashCommentActionTests.swift
@@ -17,6 +17,8 @@ final class TrashCommentActionTests: XCTestCase {
 
     private var action: TrashComment?
 
+    private var mockHandler: UIContextualAction.Handler = { (_, _, _) in }
+
     let utils = NotificationUtility()
 
     private struct Constants {
@@ -41,16 +43,9 @@ final class TrashCommentActionTests: XCTestCase {
         XCTAssertEqual(action?.on, Constants.initialStatus)
     }
 
-    func testDefaultTitleIsExpected() {
-        XCTAssertEqual(action?.icon?.titleLabel?.text, TrashComment.title)
-    }
-
-    func testDefaultAccessibilityLabelIsExpected() {
-        XCTAssertEqual(action?.icon?.accessibilityLabel, TrashComment.title)
-    }
-
-    func testDefaultAccessibilityHintIsExpected() {
-        XCTAssertEqual(action?.icon?.accessibilityHint, TrashComment.hint)
+    func testContextualActionTitleIsExpected() {
+        let contextualAction = action?.action(handler: mockHandler)
+        XCTAssertEqual(contextualAction?.title, TrashComment.title)
     }
 
     func testExecuteCallsTrash() {


### PR DESCRIPTION
Now that we've bumped our base SDK up to iOS 11, we can drop MGSwipeTableCell and use native UISwipeActions instead. This PR does just that. Apologies that it's a little long, but the majority of the changes are just cookie cutter across the different types of notifications and their tests.

![before-after-swipes](https://user-images.githubusercontent.com/4780/61718299-9cbffb00-ad5a-11e9-8f8e-189de768d0eb.png)

A few notes:

* I was kind of confused by our existing setup for these actions. From what I can tell, every notification action type (such as Like Comment, Like Post, Reply, Spam) implemented a method returning a button, but it seems as though we were only using Approve and Trash (and mark as read, but that's separate). I've implemented contextual actions for all of them for consistency, but I'm not sure they're all needed right now. When testing, please ensure the actions still show up in places like the comment detail screen.
* You may notice the text size by default is a little smaller than previously. It's not configurable by us, but it does support dynamic type, so that should be fine.
* It also doesn't appear to support accessibility labels or hints unfortunately, but system swipe actions are accessible whereas I don't think MGSwipeTableCell was. If you're interested in testing this, with Voice Over active: tap a row to select it, make a two finger rotate gesture to bring up the 'rotor', and change it to Actions, then swipe up and down with one finger. It should read the available actions such as Approve, Trash, etc.

**To test:**

* Build and run
* Check unit tests pass and look ok (I had to update them)
* Ensure that you can do the same things you could previously do with notifications:
- [ ] Swipe to mark as read
- [ ] Swipe to mark as unread
- [ ] Swipe to approve
- [ ] Swipe to unapprove
- [ ] Swipe to trash
* Check you can undo a trash
* Check you can still trigger notification actions from other places: comment notification detail views, and push notification actions

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
(I don't think this is directly user facing as it should be largely invisible)