### PR TITLE
[Gutenberg] - PR 02 - Editor default and migration

### DIFF
--- a/WordPress/Classes/Models/Blog+Editor.swift
+++ b/WordPress/Classes/Models/Blog+Editor.swift
@@ -29,6 +29,9 @@ extension Blog {
     }
 
     @objc var isGutenbergEnabled: Bool {
-        return self.editor.mobile == .gutenberg
+        guard let selectedEditor = editor.mobile else {
+            return GutenbergSettings().getDefaultEditor(for: self) == .gutenberg
+        }
+        return selectedEditor == .gutenberg
     }
 }

--- a/WordPress/Classes/Models/Blog+Editor.swift
+++ b/WordPress/Classes/Models/Blog+Editor.swift
@@ -11,27 +11,38 @@ enum WebEditor: String {
 }
 
 extension Blog {
-    struct Editor {
-        fileprivate let blog: Blog
-        var mobile: MobileEditor? {
-            return MobileEditor(rawValue: blog.mobileEditor ?? "")
+    static let mobileEditorKeyPath = "mobileEditor"
+    static let webEditorKeyPath = "webEditor"
+
+    /// The stored setting for the default mobile editor
+    ///
+    var mobileEditor: MobileEditor? {
+        get {
+            return rawValue(forKey: Blog.mobileEditorKeyPath)
         }
-        var web: WebEditor? {
-            return WebEditor(rawValue: blog.webEditor ?? "")
-        }
-        func setMobileEditor(_ newValue: MobileEditor) {
-            blog.mobileEditor = newValue.rawValue
+        set {
+            setRawValue(newValue, forKey: Blog.mobileEditorKeyPath)
         }
     }
 
-    var editor: Editor {
-        return Editor(blog: self)
+    /// The stored setting for the default web editor
+    ///
+    var webEditor: WebEditor? {
+        get {
+            return rawValue(forKey: Blog.webEditorKeyPath)
+        }
+        set {
+            setRawValue(newValue, forKey: Blog.webEditorKeyPath)
+        }
+    }
+
+    /// The editor to use when creating a new post
+    ///
+    var editor: MobileEditor {
+        return mobileEditor ?? GutenbergSettings().getDefaultEditor(for: self)
     }
 
     @objc var isGutenbergEnabled: Bool {
-        guard let selectedEditor = editor.mobile else {
-            return GutenbergSettings().getDefaultEditor(for: self) == .gutenberg
-        }
-        return selectedEditor == .gutenberg
+        return editor == .gutenberg
     }
 }

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -130,9 +130,6 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 /// Disk quota for site, this is only available for WP.com sites
 @property (nonatomic, strong, readwrite, nullable) NSNumber *quotaSpaceAllowed;
 @property (nonatomic, strong, readwrite, nullable) NSNumber *quotaSpaceUsed;
-// Editor settings
-@property (nonatomic, strong, readwrite, nullable) NSString *mobileEditor;
-@property (nonatomic, strong, readwrite, nullable) NSString *webEditor;
 
 
 /**

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -82,8 +82,6 @@ NSString * const OptionsKeyIsAutomatedTransfer = @"is_automated_transfer";
 @dynamic userID;
 @dynamic quotaSpaceAllowed;
 @dynamic quotaSpaceUsed;
-@dynamic mobileEditor;
-@dynamic webEditor;
 
 @synthesize isSyncingPosts;
 @synthesize isSyncingPages;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -292,16 +292,12 @@ CGFloat const OneHourInSeconds = 60.0 * 60.0;
         dispatch_group_leave(syncGroup);
     }];
 
-    EditorSettingsService *editorService = [[EditorSettingsService alloc] init];
+    EditorSettingsService *editorService = [[EditorSettingsService alloc] initWithManagedObjectContext:self.managedObjectContext];
     dispatch_group_enter(syncGroup);
-    [editorService syncEditorSettingsFor:blog success:^{
+    [editorService syncEditorSettingsForBlog:blog success:^{
         dispatch_group_leave(syncGroup);
     } failure:^(NSError * _Nonnull error) {
-        if ([error.domain isEqualToString:EditorSettingsServiceErrorDomain] && error.code == EditorSettingsServiceErrorMobileEditorNotSet) {
-            /// DO MIGRATION
-        } else {
-            DDLogError(@"Failed to sync Editor settings");
-        }
+        DDLogError(@"Failed to sync Editor settings");
         dispatch_group_leave(syncGroup);
     }];
 

--- a/WordPress/Classes/Services/EditorSettingsService.swift
+++ b/WordPress/Classes/Services/EditorSettingsService.swift
@@ -64,6 +64,17 @@ import Foundation
         }, failure: failure)
     }
 
+    func syncEditorSettingsForAllBlogs() {
+        let blogService = BlogService(managedObjectContext: managedObjectContext)
+        guard let blogs = blogService.blogsForAllAccounts() as? [Blog] else {
+            return
+        }
+        let blogsWithAccount = blogs.filter({ $0.account != nil })
+        for blog in blogsWithAccount {
+            syncEditorSettings(for: blog, success: {}, failure: { _ in })
+        }
+    }
+
     func api(for blog: Blog) -> WordPressComRestApi? {
         return blog.wordPressComRestApi()
     }

--- a/WordPress/Classes/Services/EditorSettingsService.swift
+++ b/WordPress/Classes/Services/EditorSettingsService.swift
@@ -19,7 +19,7 @@ import Foundation
         let service = EditorServiceRemote(wordPressComRestApi: api)
         service.getEditorSettings(siteID, success: { (settings) in
             do {
-                try self.saveRemoteEditorSettings(settings, on: blog)
+                try self.update(blog, remoteEditorSettings: settings)
                 ContextManager.sharedInstance().save(self.managedObjectContext)
                 success()
             } catch EditorSettingsServiceError.mobileEditorNotSet {
@@ -30,12 +30,12 @@ import Foundation
         }, failure: failure)
     }
 
-    private func saveRemoteEditorSettings(_ settings: EditorSettings, on blog: Blog) throws {
+    private func update(_ blog: Blog, remoteEditorSettings settings: EditorSettings) throws {
+        blog.webEditor = WebEditor(rawValue: settings.web.rawValue)
         guard settings.mobile != .notSet else {
             throw EditorSettingsServiceError.mobileEditorNotSet
         }
         blog.mobileEditor = MobileEditor(rawValue: settings.mobile.rawValue)
-        blog.webEditor = WebEditor(rawValue: settings.web.rawValue)
     }
 
     private func migrateLocalSettingToRemote(for blog: Blog, success: @escaping () -> Void, failure: @escaping (Swift.Error) -> Void) {

--- a/WordPress/Classes/Services/EditorSettingsService.swift
+++ b/WordPress/Classes/Services/EditorSettingsService.swift
@@ -71,7 +71,9 @@ import Foundation
         }
         let blogsWithAccount = blogs.filter({ $0.account != nil })
         for blog in blogsWithAccount {
-            syncEditorSettings(for: blog, success: {}, failure: { _ in })
+            syncEditorSettings(for: blog, success: {}, failure: { (error) in
+                DDLogError("Error saving editor settings: \(error)")
+            })
         }
     }
 

--- a/WordPress/Classes/Services/EditorSettingsService.swift
+++ b/WordPress/Classes/Services/EditorSettingsService.swift
@@ -5,16 +5,13 @@ import Foundation
 }
 
 @objc class EditorSettingsService: LocalCoreDataService {
-
-    let database: KeyValueDatabase
     let wpcomApi: WordPressComRestApi?
 
     @objc convenience override init(managedObjectContext: NSManagedObjectContext) {
         self.init(managedObjectContext: managedObjectContext, wpcomApi: nil)
     }
 
-    init(managedObjectContext: NSManagedObjectContext, database: KeyValueDatabase = UserDefaults(), wpcomApi: WordPressComRestApi? = nil) {
-        self.database = database
+    init(managedObjectContext: NSManagedObjectContext, wpcomApi: WordPressComRestApi? = nil) {
         self.wpcomApi = wpcomApi
         super.init(managedObjectContext: managedObjectContext)
     }
@@ -54,7 +51,7 @@ import Foundation
 
     private func migrateLocalSettingToRemote(for blog: Blog, success: @escaping () -> Void, failure: @escaping (Swift.Error) -> Void) {
         if blog.editor.mobile == nil {
-            let settings = GutenbergSettings(database: database)
+            let settings = GutenbergSettings()
             let defaultEditor = settings.getDefaultEditor(for: blog)
             settings.setGutenbergEnabled(defaultEditor == .gutenberg, for: blog)
         }

--- a/WordPress/Classes/Services/EditorSettingsService.swift
+++ b/WordPress/Classes/Services/EditorSettingsService.swift
@@ -45,12 +45,12 @@ import Foundation
         guard settings.mobile != .notSet else {
             throw EditorSettingsServiceError.mobileEditorNotSet
         }
-        blog.mobileEditor = settings.mobile.rawValue
-        blog.webEditor = settings.web.rawValue
+        blog.mobileEditor = MobileEditor(rawValue: settings.mobile.rawValue)
+        blog.webEditor = WebEditor(rawValue: settings.web.rawValue)
     }
 
     private func migrateLocalSettingToRemote(for blog: Blog, success: @escaping () -> Void, failure: @escaping (Swift.Error) -> Void) {
-        if blog.editor.mobile == nil {
+        if blog.mobileEditor == nil {
             let settings = GutenbergSettings()
             let defaultEditor = settings.getDefaultEditor(for: blog)
             settings.setGutenbergEnabled(defaultEditor == .gutenberg, for: blog)
@@ -60,7 +60,7 @@ import Foundation
 
     func postEditorSetting(for blog: Blog, success: @escaping () -> Void, failure: @escaping (Swift.Error) -> Void) {
         guard
-            let selectedEditor = blog.editor.mobile,
+            let selectedEditor = blog.mobileEditor,
             let remoteEditor = EditorSettings.Mobile(rawValue: selectedEditor.rawValue),
             let api = wpcomApi ?? blog.wordPressComRestApi(),
             let siteID = blog.dotComID?.intValue

--- a/WordPress/Classes/Services/EditorSettingsService.swift
+++ b/WordPress/Classes/Services/EditorSettingsService.swift
@@ -35,7 +35,7 @@ import Foundation
         guard settings.mobile != .notSet else {
             throw EditorSettingsServiceError.mobileEditorNotSet
         }
-        blog.mobileEditor = MobileEditor(rawValue: settings.mobile.rawValue)
+        GutenbergSettings().setGutenbergEnabled(settings.mobile == .gutenberg, for: blog)
     }
 
     private func migrateLocalSettingToRemote(for blog: Blog, success: @escaping () -> Void, failure: @escaping (Swift.Error) -> Void) {

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -88,6 +88,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         PushNotificationsManager.shared.deletePendingLocalNotifications()
 
+        NotificationCenter.default.post(name: .applicationLaunchCompleted, object: nil)
         return true
     }
 
@@ -281,6 +282,13 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
     var runningInBackground: Bool {
         return UIApplication.shared.applicationState == .background
+    }
+}
+
+/// Declares Notification Names
+extension Foundation.Notification.Name {
+    static var applicationLaunchCompleted: Foundation.NSNotification.Name {
+        return Foundation.Notification.Name("org.wordpress.startup.completed")
     }
 }
 

--- a/WordPress/Classes/Utility/Editor/EditorFactory.swift
+++ b/WordPress/Classes/Utility/Editor/EditorFactory.swift
@@ -26,6 +26,7 @@ class EditorFactory {
         if gutenbergSettings.shouldAutoenableGutenberg(for: post) {
             gutenbergSettings.setGutenbergEnabled(true, for: post.blog)
             gutenbergSettings.postSettingsToRemote(for: post.blog)
+            gutenbergSettings.didAutoenableGutenberg()
             gutenbergVC.shouldPresentInformativeDialog = true
         }
 

--- a/WordPress/Classes/Utility/Editor/EditorFactory.swift
+++ b/WordPress/Classes/Utility/Editor/EditorFactory.swift
@@ -26,7 +26,6 @@ class EditorFactory {
         if gutenbergSettings.shouldAutoenableGutenberg(for: post) {
             gutenbergSettings.setGutenbergEnabled(true, for: post.blog)
             gutenbergSettings.postSettingsToRemote(for: post.blog)
-            gutenbergSettings.didAutoenableGutenberg()
             gutenbergVC.shouldPresentInformativeDialog = true
         }
 

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -54,7 +54,7 @@ class GutenbergSettings {
     }
 
     private func shouldUpdateSettings(with newSetting: MobileEditor, for blog: Blog) -> Bool {
-        return !wasGutenbergEnabledOnce(for: blog) || blog.editor.mobile != newSetting
+        return blog.editor.mobile != newSetting
     }
 
     private func trackSettingChange(to isEnabled: Bool) {
@@ -82,7 +82,13 @@ class GutenbergSettings {
     /// True if gutenberg should be autoenabled for the blog hosting the given post.
     func shouldAutoenableGutenberg(for post: AbstractPost) -> Bool {
         let blog = post.blog
-        return post.containsGutenbergBlocks() && !wasGutenbergEnabledOnce(for: blog)
+        return !blog.isGutenbergEnabled &&
+            post.containsGutenbergBlocks() &&
+            !wasGutenbergEnabledOnce(for: blog)
+    }
+
+    func didAutoenableGutenberg() {
+        database.set(true, forKey: Key.appWideEnabled)
     }
 
     // MARK: - Gutenberg Choice Logic

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -101,19 +101,11 @@ class GutenbergSettings {
         let blog = post.blog
 
         if post.isContentEmpty() {
-            return shouldUseGutenbergForNewPosts(on: blog)
+            return blog.isGutenbergEnabled
         } else {
             // It's an existing post
             return post.containsGutenbergBlocks()
         }
-    }
-
-    private func shouldUseGutenbergForNewPosts(on blog: Blog) -> Bool {
-        guard let userSelectedEditor = blog.mobileEditor else {
-            return getDefaultEditor(for: blog) == .gutenberg
-        }
-
-        return userSelectedEditor == .gutenberg
     }
 
     func getDefaultEditor(for blog: Blog) -> MobileEditor {

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -8,6 +8,10 @@ class GutenbergSettings {
     // MARK: - Enabled Editors Keys
     enum Key {
         static let enabledOnce = "kUserDefaultsGutenbergEditorEnabled"
+        static func enabledOnce(for blog: Blog) -> String {
+            let url = (blog.displayURL ?? "") as String
+            return "com.wordpress.gutenberg-autoenabled-" + url
+        }
     }
 
     // MARK: - Internal variables
@@ -48,9 +52,9 @@ class GutenbergSettings {
         }
 
         if isEnabled {
-            /// After the migrations are finished, this value will be used to decide if we should auto-enable gutenberg
-            database.set(isEnabled, forKey: Key.enabledOnce)
+            database.set(true, forKey: Key.enabledOnce(for: blog))
         }
+
         blog.editor.setMobileEditor(selectedEditor)
         ContextManager.sharedInstance().save(context)
 
@@ -79,7 +83,8 @@ class GutenbergSettings {
 
     /// True if gutenberg editor has been enabled at least once on the given blog
     func wasGutenbergEnabledOnce(for blog: Blog) -> Bool {
-        return database.object(forKey: Key.enabledOnce) != nil
+        // If gutenberg was "globaly" enabled before, will take precedence over the new per-site flag
+        return database.object(forKey: Key.enabledOnce) != nil || database.object(forKey: Key.enabledOnce(for: blog)) != nil
     }
 
     /// True if gutenberg should be autoenabled for the blog hosting the given post.

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -120,14 +120,8 @@ class GutenbergSettings {
     }
 
     func getDefaultEditor(for blog: Blog) -> MobileEditor {
-        if blog.isAccessibleThroughWPCom() {
-            if let appWideEnabled = database.object(forKey: Key.appWideEnabled) as? Bool, appWideEnabled == false {
-                // Return Aztec just if gutenberg was explicitly disabled
-                return .aztec
-            }
-            return .gutenberg
-        }
-        return oldAppWideIsGutenbergEnabled ? .gutenberg : .aztec
+        // Default to gutenberg on WPCom/Jetpack sites
+        return blog.isAccessibleThroughWPCom() ? .gutenberg : .aztec
     }
 }
 

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -26,12 +26,6 @@ class GutenbergSettings {
         self.init(database: UserDefaults() as KeyValueDatabase)
     }
 
-    /// Get the deprecated app-wide value of gutenberg enabled.
-    /// This is useful for the local to remote migration, and for the global to per-site migration.
-    private var oldAppWideIsGutenbergEnabled: Bool {
-        return database.bool(forKey: Key.appWideEnabled)
-    }
-
     // MARK: Public accessors
 
     /// Sets gutenberg enabled state locally for the given site.

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -75,17 +75,12 @@ class GutenbergSettings {
 
     /// True if gutenberg editor has been enabled at least once on the given blog
     func wasGutenbergEnabledOnce(for blog: Blog) -> Bool {
-        // If gutenberg was "globaly" enabled before, will take precedence over the new per-site flag
-        return database.object(forKey: Key.appWideEnabled) != nil || database.object(forKey: Key.enabledOnce(for: blog)) != nil
+        return database.object(forKey: Key.enabledOnce(for: blog)) != nil
     }
 
     /// True if gutenberg should be autoenabled for the blog hosting the given post.
     func shouldAutoenableGutenberg(for post: AbstractPost) -> Bool {
         return !wasGutenbergEnabledOnce(for: post.blog)
-    }
-
-    func didAutoenableGutenberg() {
-        database.set(true, forKey: Key.appWideEnabled)
     }
 
     // MARK: - Gutenberg Choice Logic

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -81,10 +81,7 @@ class GutenbergSettings {
 
     /// True if gutenberg should be autoenabled for the blog hosting the given post.
     func shouldAutoenableGutenberg(for post: AbstractPost) -> Bool {
-        let blog = post.blog
-        return !blog.isGutenbergEnabled &&
-            post.containsGutenbergBlocks() &&
-            !wasGutenbergEnabledOnce(for: blog)
+        return !wasGutenbergEnabledOnce(for: post.blog)
     }
 
     func didAutoenableGutenberg() {

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -53,6 +53,15 @@ class GutenbergSettings {
         WPAnalytics.refreshMetadata()
     }
 
+
+    /// Sets gutenberg enabled without tracking events and without registering the enabled action ("enabledOnce")
+    ///
+    /// - Parameter blog: The site to set the
+    func softEnableGutenberg(for blog: Blog) {
+        blog.mobileEditor = .gutenberg
+        ContextManager.sharedInstance().save(context)
+    }
+
     private func shouldUpdateSettings(with newSetting: MobileEditor, for blog: Blog) -> Bool {
         return blog.mobileEditor != newSetting
     }
@@ -80,7 +89,7 @@ class GutenbergSettings {
 
     /// True if gutenberg should be autoenabled for the blog hosting the given post.
     func shouldAutoenableGutenberg(for post: AbstractPost) -> Bool {
-        return !post.isContentEmpty() && !wasGutenbergEnabledOnce(for: post.blog)
+        return !wasGutenbergEnabledOnce(for: post.blog)
     }
 
     // MARK: - Gutenberg Choice Logic

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -47,14 +47,14 @@ class GutenbergSettings {
             database.set(true, forKey: Key.enabledOnce(for: blog))
         }
 
-        blog.editor.setMobileEditor(selectedEditor)
+        blog.mobileEditor = selectedEditor
         ContextManager.sharedInstance().save(context)
 
         WPAnalytics.refreshMetadata()
     }
 
     private func shouldUpdateSettings(with newSetting: MobileEditor, for blog: Blog) -> Bool {
-        return blog.editor.mobile != newSetting
+        return blog.mobileEditor != newSetting
     }
 
     private func trackSettingChange(to isEnabled: Bool) {
@@ -109,7 +109,7 @@ class GutenbergSettings {
     }
 
     private func shouldUseGutenbergForNewPosts(on blog: Blog) -> Bool {
-        guard let userSelectedEditor = blog.editor.mobile else {
+        guard let userSelectedEditor = blog.mobileEditor else {
             return getDefaultEditor(for: blog) == .gutenberg
         }
 

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -80,7 +80,7 @@ class GutenbergSettings {
 
     /// True if gutenberg should be autoenabled for the blog hosting the given post.
     func shouldAutoenableGutenberg(for post: AbstractPost) -> Bool {
-        return !wasGutenbergEnabledOnce(for: post.blog)
+        return !post.isContentEmpty() && !wasGutenbergEnabledOnce(for: post.blog)
     }
 
     // MARK: - Gutenberg Choice Logic

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -109,8 +109,7 @@ class GutenbergSettings {
     }
 
     func getDefaultEditor(for blog: Blog) -> MobileEditor {
-        // Default to gutenberg on WPCom/Jetpack sites
-        return blog.isAccessibleThroughWPCom() ? .gutenberg : .aztec
+        return .aztec
     }
 }
 

--- a/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
+++ b/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
@@ -4,20 +4,8 @@ class BlogToBlogMigration87to88: NSEntityMigrationPolicy {
     override func createRelationships(forDestination dInstance: NSManagedObject, in mapping: NSEntityMapping, manager: NSMigrationManager) throws {
         try super.createRelationships(forDestination: dInstance, in: mapping, manager: manager)
 
-        guard let sourceBlog = manager.sourceInstances(forEntityMappingName: "BlogToBlog", destinationInstances: [dInstance]).first else {
-            return
-        }
-
-        let editor: String
-
-        if let isGutenbergEnabled = UserDefaults.standard.object(forKey: "kUserDefaultsGutenbergEditorEnabled") as? Bool {
-            // Keep previous user selection
-            editor = isGutenbergEnabled ? "gutenberg" : "aztec"
-        } else {
-            let isAccessibleThroughWPCom = sourceBlog.value(forKey: "account") != nil
-            // Default to Gutenberg for WPCom/Jetpack sites
-            editor = isAccessibleThroughWPCom ? "gutenberg" : "aztec"
-        }
+        let isGutenbergEnabled = UserDefaults.standard.object(forKey: "kUserDefaultsGutenbergEditorEnabled") as? Bool ?? false
+        let editor = isGutenbergEnabled ? "gutenberg" : "aztec"
 
         dInstance.setValue(editor, forKey: "mobileEditor")
     }

--- a/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
+++ b/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
@@ -9,4 +9,12 @@ class BlogToBlogMigration87to88: NSEntityMigrationPolicy {
 
         dInstance.setValue(editor, forKey: "mobileEditor")
     }
+
+    override func end(_ mapping: NSEntityMapping, manager: NSMigrationManager) throws {
+        NotificationCenter.default.observeOnce(forName: .applicationLaunchCompleted, object: nil, queue: .main, using: { (_) in
+            let context = ContextManager.shared.mainContext
+            let service = EditorSettingsService(managedObjectContext: context)
+            service.syncEditorSettingsForAllBlogs()
+        })
+    }
 }

--- a/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
+++ b/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
@@ -8,17 +8,17 @@ class BlogToBlogMigration87to88: NSEntityMigrationPolicy {
             return
         }
 
-        let editor: MobileEditor
+        let editor: String
 
-        if let isGutenbergEnabled = UserDefaults.standard.object(forKey: GutenbergSettings.Key.appWideEnabled) as? Bool {
+        if let isGutenbergEnabled = UserDefaults.standard.object(forKey: "kUserDefaultsGutenbergEditorEnabled") as? Bool {
             // Keep previous user selection
-            editor = isGutenbergEnabled ? .gutenberg : .aztec
+            editor = isGutenbergEnabled ? "gutenberg" : "aztec"
         } else {
             let isAccessibleThroughWPCom = sourceBlog.value(forKey: "account") != nil
             // Default to Gutenberg for WPCom/Jetpack sites
-            editor = isAccessibleThroughWPCom ? .gutenberg : .aztec
+            editor = isAccessibleThroughWPCom ? "gutenberg" : "aztec"
         }
 
-        dInstance.setValue(editor.rawValue, forKey: "mobileEditor")
+        dInstance.setValue(editor, forKey: "mobileEditor")
     }
 }

--- a/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
+++ b/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
@@ -2,8 +2,6 @@ import CoreData
 
 class BlogToBlogMigration87to88: NSEntityMigrationPolicy {
     override func createRelationships(forDestination dInstance: NSManagedObject, in mapping: NSEntityMapping, manager: NSMigrationManager) throws {
-        DDLogInfo("---> \(type(of: self)) \(#function) \(String(describing: mapping.sourceEntityName)) -> \(String(describing: mapping.destinationEntityName)))")
-
         try super.createRelationships(forDestination: dInstance, in: mapping, manager: manager)
 
         guard let sourceBlog = manager.sourceInstances(forEntityMappingName: "BlogToBlog", destinationInstances: [dInstance]).first else {
@@ -13,11 +11,11 @@ class BlogToBlogMigration87to88: NSEntityMigrationPolicy {
         let editor: MobileEditor
 
         if let isGutenbergEnabled = UserDefaults.standard.object(forKey: GutenbergSettings.Key.appWideEnabled) as? Bool {
+            // Keep previous user selection
             editor = isGutenbergEnabled ? .gutenberg : .aztec
         } else {
-            let isWPcom = sourceBlog.value(forKeyPath: "account.isWpcom") as? Bool ?? false
-            let isJetpack = sourceBlog.value(forKey: "isJetpack") as? Bool ?? false
-            let isAccessibleThroughWPCom = isWPcom || isJetpack
+            let isAccessibleThroughWPCom = sourceBlog.value(forKey: "account") != nil
+            // Default to Gutenberg for WPCom/Jetpack sites
             editor = isAccessibleThroughWPCom ? .gutenberg : .aztec
         }
 

--- a/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
+++ b/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
@@ -1,0 +1,26 @@
+import CoreData
+
+class BlogToBlogMigration87to88: NSEntityMigrationPolicy {
+    override func createRelationships(forDestination dInstance: NSManagedObject, in mapping: NSEntityMapping, manager: NSMigrationManager) throws {
+        DDLogInfo("---> \(type(of: self)) \(#function) \(String(describing: mapping.sourceEntityName)) -> \(String(describing: mapping.destinationEntityName)))")
+
+        try super.createRelationships(forDestination: dInstance, in: mapping, manager: manager)
+
+        guard let sourceBlog = manager.sourceInstances(forEntityMappingName: "BlogToBlog", destinationInstances: [dInstance]).first else {
+            return
+        }
+
+        let editor: MobileEditor
+
+        if let isGutenbergEnabled = UserDefaults.standard.object(forKey: GutenbergSettings.Key.appWideEnabled) as? Bool {
+            editor = isGutenbergEnabled ? .gutenberg : .aztec
+        } else {
+            let isWPcom = sourceBlog.value(forKeyPath: "account.isWpcom") as? Bool ?? false
+            let isJetpack = sourceBlog.value(forKey: "isJetpack") as? Bool ?? false
+            let isAccessibleThroughWPCom = isWPcom || isJetpack
+            editor = isAccessibleThroughWPCom ? .gutenberg : .aztec
+        }
+
+        dInstance.setValue(editor.rawValue, forKey: "mobileEditor")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -5,7 +5,7 @@ extension GutenbergViewController {
 
     enum InfoDialog {
         static let message = NSLocalizedString(
-            "This post uses the block editor, which is the default editor for new posts. To enable the classic editor, go to Me > App Settings.",
+            "This post uses the block editor, which is the default editor for new posts. To enable the classic editor, go to Site Settings.",
             comment: "Popup content about why this post is being opened in block editor"
         )
         static let title = NSLocalizedString("Block Editor Enabled", comment: "Popup title about why this post is being opened in Block Editor")

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+InformativeDialog.swift
@@ -5,7 +5,7 @@ extension GutenbergViewController {
 
     enum InfoDialog {
         static let message = NSLocalizedString(
-            "This post uses the block editor, which is the default editor for new posts. To enable the classic editor, go to Site Settings.",
+            "You're currently using the block editor to create new posts. Want to use the classic editor by default? Head to Site Settings.",
             comment: "Popup content about why this post is being opened in block editor"
         )
         static let title = NSLocalizedString("Block Editor Enabled", comment: "Popup title about why this post is being opened in Block Editor")

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -298,7 +298,7 @@ class GutenbergViewController: UIViewController, PostEditor {
     }
 
     func focusTitleIfNeeded() {
-        guard !post.hasContent() else {
+        guard !post.hasContent() && shouldPresentInformativeDialog == false else {
             return
         }
         gutenberg.setFocusOnTitle()

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -111,6 +111,13 @@ final class SiteAssemblyWizardContent: UIViewController {
                     self.installErrorStateViewController(with: errorType)
                 } else if status == .succeeded {
                     let blog = self.service.createdBlog
+                    // Default all new blogs to use Gutenberg
+                    if let createdBlog = blog {
+                        let gutenbergSettings = GutenbergSettings()
+                        gutenbergSettings.setGutenbergEnabled(true, for: createdBlog)
+                        gutenbergSettings.postSettingsToRemote(for: createdBlog)
+                    }
+
                     self.contentView.siteURLString = blog?.url as String?
                     self.contentView.siteName = blog?.displayURL as String?
                     self.createdBlog = blog

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -114,7 +114,7 @@ final class SiteAssemblyWizardContent: UIViewController {
                     // Default all new blogs to use Gutenberg
                     if let createdBlog = blog {
                         let gutenbergSettings = GutenbergSettings()
-                        gutenbergSettings.softEnableGutenberg(for: createdBlog)
+                        gutenbergSettings.softSetGutenbergEnabled(true, for: createdBlog)
                         gutenbergSettings.postSettingsToRemote(for: createdBlog)
                     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -114,7 +114,7 @@ final class SiteAssemblyWizardContent: UIViewController {
                     // Default all new blogs to use Gutenberg
                     if let createdBlog = blog {
                         let gutenbergSettings = GutenbergSettings()
-                        gutenbergSettings.setGutenbergEnabled(true, for: createdBlog)
+                        gutenbergSettings.softEnableGutenberg(for: createdBlog)
                         gutenbergSettings.postSettingsToRemote(for: createdBlog)
                     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -920,6 +920,8 @@
 		7E846FF120FD0A0500881F5A /* ContentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */; };
 		7E846FF320FD37BD00881F5A /* ActivityCommentRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */; };
 		7E8980B922E73F4000C567B0 /* EditorSettingsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8980B822E73F4000C567B0 /* EditorSettingsServiceTests.swift */; };
+		7E8980C822E8C73500C567B0 /* WordPress-87-88.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = 7E8980C722E8C73500C567B0 /* WordPress-87-88.xcmappingmodel */; };
+		7E8980CA22E8C7A600C567B0 /* BlogToBlogMigration87to88.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8980C922E8C7A600C567B0 /* BlogToBlogMigration87to88.swift */; };
 		7E92828921090E9A00BBD8A3 /* notifications-pingback.json in Resources */ = {isa = PBXBuildFile; fileRef = 7E92828821090E9A00BBD8A3 /* notifications-pingback.json */; };
 		7E929CD12110D4F200BCAD88 /* FormattableRangesFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E929CD02110D4F200BCAD88 /* FormattableRangesFactory.swift */; };
 		7E987F562108017B00CAFB88 /* NotificationContentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */; };
@@ -2992,6 +2994,8 @@
 		7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCoordinator.swift; sourceTree = "<group>"; };
 		7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityCommentRange.swift; sourceTree = "<group>"; };
 		7E8980B822E73F4000C567B0 /* EditorSettingsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSettingsServiceTests.swift; sourceTree = "<group>"; };
+		7E8980C722E8C73500C567B0 /* WordPress-87-88.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-87-88.xcmappingmodel"; sourceTree = "<group>"; };
+		7E8980C922E8C7A600C567B0 /* BlogToBlogMigration87to88.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BlogToBlogMigration87to88.swift; path = "87-88/BlogToBlogMigration87to88.swift"; sourceTree = "<group>"; };
 		7E92828821090E9A00BBD8A3 /* notifications-pingback.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "notifications-pingback.json"; sourceTree = "<group>"; };
 		7E929CD02110D4F200BCAD88 /* FormattableRangesFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableRangesFactory.swift; sourceTree = "<group>"; };
 		7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentRouter.swift; sourceTree = "<group>"; };
@@ -6359,6 +6363,14 @@
 			path = Ranges;
 			sourceTree = "<group>";
 		};
+		7E8980CB22E8C81B00C567B0 /* 87-88 */ = {
+			isa = PBXGroup;
+			children = (
+				7E8980C922E8C7A600C567B0 /* BlogToBlogMigration87to88.swift */,
+			);
+			name = "87-88";
+			sourceTree = "<group>";
+		};
 		7EAA66ED22CB36DA00869038 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
@@ -8630,6 +8642,7 @@
 				E1C4F4E61B29D5B900DAAB8E /* 32-33 */,
 				E66969D01B9E3D5000EC9C00 /* 37-38 */,
 				E10520591F2B1CD400A948F6 /* 61-62 */,
+				7E8980CB22E8C81B00C567B0 /* 87-88 */,
 				E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */,
 				5D51ADAE19A832AF00539C0B /* WordPress-20-21.xcmappingmodel */,
 				937D9A0E19F83812007B9D5F /* WordPress-22-23.xcmappingmodel */,
@@ -8638,6 +8651,7 @@
 				E603C76F1BC94AED00AD49D7 /* WordPress-37-38.xcmappingmodel */,
 				B555E1141C04A68D00CEC81B /* WordPress-41-42.xcmappingmodel */,
 				E10520571F2B1CC900A948F6 /* WordPress-61-62.xcmappingmodel */,
+				7E8980C722E8C73500C567B0 /* WordPress-87-88.xcmappingmodel */,
 			);
 			path = Migrations;
 			sourceTree = "<group>";
@@ -11293,6 +11307,7 @@
 				4020B2BD2007AC850002C963 /* WPStyleGuide+Gridicon.swift in Sources */,
 				FF4258501BA092EE00580C68 /* RelatedPostsSettingsViewController.m in Sources */,
 				74729CA32056FA0900D1394D /* SearchManager.swift in Sources */,
+				7E8980CA22E8C7A600C567B0 /* BlogToBlogMigration87to88.swift in Sources */,
 				FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */,
 				5D1181E71B4D6DEB003F3084 /* WPStyleGuide+Reader.swift in Sources */,
 				E17FEAD8221490F7006E1D2D /* PostEditorAnalyticsSession.swift in Sources */,
@@ -11320,6 +11335,7 @@
 				40FC6B7F2072E3EC00B9A1CD /* ActivityDetailViewController.swift in Sources */,
 				E16FB7E11F8B5D7D0004DD9F /* WebViewControllerConfiguration.swift in Sources */,
 				98B3FA8421C05BDC00148DD4 /* ViewMoreRow.swift in Sources */,
+				7E8980C822E8C73500C567B0 /* WordPress-87-88.xcmappingmodel in Sources */,
 				D816B8BE2112CC000052CE4D /* NewsItem.swift in Sources */,
 				D8380CA42192E77F00250609 /* VerticalsCell.swift in Sources */,
 				B5416D011C17693B00006DD8 /* UIApplication+Helpers.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -919,6 +919,7 @@
 		7E7BEF7322E1DD27009A880D /* EditorSettingsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E7BEF7222E1DD27009A880D /* EditorSettingsService.swift */; };
 		7E846FF120FD0A0500881F5A /* ContentCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */; };
 		7E846FF320FD37BD00881F5A /* ActivityCommentRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */; };
+		7E8980B922E73F4000C567B0 /* EditorSettingsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E8980B822E73F4000C567B0 /* EditorSettingsServiceTests.swift */; };
 		7E92828921090E9A00BBD8A3 /* notifications-pingback.json in Resources */ = {isa = PBXBuildFile; fileRef = 7E92828821090E9A00BBD8A3 /* notifications-pingback.json */; };
 		7E929CD12110D4F200BCAD88 /* FormattableRangesFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E929CD02110D4F200BCAD88 /* FormattableRangesFactory.swift */; };
 		7E987F562108017B00CAFB88 /* NotificationContentRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */; };
@@ -2990,6 +2991,7 @@
 		7E7BEF7222E1DD27009A880D /* EditorSettingsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSettingsService.swift; sourceTree = "<group>"; };
 		7E846FF020FD0A0500881F5A /* ContentCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentCoordinator.swift; sourceTree = "<group>"; };
 		7E846FF220FD37BD00881F5A /* ActivityCommentRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityCommentRange.swift; sourceTree = "<group>"; };
+		7E8980B822E73F4000C567B0 /* EditorSettingsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSettingsServiceTests.swift; sourceTree = "<group>"; };
 		7E92828821090E9A00BBD8A3 /* notifications-pingback.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "notifications-pingback.json"; sourceTree = "<group>"; };
 		7E929CD02110D4F200BCAD88 /* FormattableRangesFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableRangesFactory.swift; sourceTree = "<group>"; };
 		7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentRouter.swift; sourceTree = "<group>"; };
@@ -7816,6 +7818,7 @@
 				FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */,
 				59FBD5611B5684F300734466 /* ThemeServiceTests.m */,
 				40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */,
+				7E8980B822E73F4000C567B0 /* EditorSettingsServiceTests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -11685,6 +11688,7 @@
 				02761EC4227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift in Sources */,
 				732A473D218787500015DA74 /* WPRichTextFormatterTests.swift in Sources */,
 				1ABA150822AE5F870039311A /* WordPressUIBundleTests.swift in Sources */,
+				7E8980B922E73F4000C567B0 /* EditorSettingsServiceTests.swift in Sources */,
 				1797373720EBAA4100377B4E /* RouteMatcherTests.swift in Sources */,
 				73178C2A21BEE09300E37C9A /* SiteSegmentsCellTests.swift in Sources */,
 				B5416CFE1C1756B900006DD8 /* PushNotificationsManagerTests.m in Sources */,

--- a/WordPress/WordPressTest/CoreDataMigrationTests.m
+++ b/WordPress/WordPressTest/CoreDataMigrationTests.m
@@ -1047,10 +1047,10 @@
     NSArray *results = [context executeFetchRequest:request error:nil];
     XCTAssert(results.count == 2, @"Error Fetching Blogs");
 
-    // WPCom/Jetpack sites should migrate to Gutenberg
+    // WPCom/Jetpack sites should migrate to Aztec
 
     NSManagedObject *wpcomBlog = [results firstObject];
-    XCTAssertEqualObjects([wpcomBlog valueForKey:@"mobileEditor"], @"gutenberg");
+    XCTAssertEqualObjects([wpcomBlog valueForKey:@"mobileEditor"], @"aztec");
 
     // SelfHosted (non-jetpack) should migrate to Aztec
 

--- a/WordPress/WordPressTest/CoreDataMigrationTests.m
+++ b/WordPress/WordPressTest/CoreDataMigrationTests.m
@@ -967,6 +967,100 @@
     XCTAssertNotNil(ps);
 }
 
+- (void)testMigrate87to88
+{
+    NSURL *model87Url = [self urlForModelName:@"WordPress 87" inDirectory:nil];
+    NSURL *model88Url = [self urlForModelName:@"WordPress 88" inDirectory:nil];
+    NSURL *storeUrl = [self urlForStoreWithName:@"WordPress87.sqlite"];
+
+        // Load a Model 74 Stack
+    NSManagedObjectModel *model87 = [[NSManagedObjectModel alloc] initWithContentsOfURL:model87Url];
+    NSPersistentStoreCoordinator *psc = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:model87];
+
+    NSDictionary *options = @{
+                              NSInferMappingModelAutomaticallyOption          : @(YES),
+                              NSMigratePersistentStoresAutomaticallyOption    : @(YES)
+                              };
+
+    NSError *error = nil;
+    NSPersistentStore *ps = [psc addPersistentStoreWithType:NSSQLiteStoreType
+                                              configuration:nil
+                                                        URL:storeUrl
+                                                    options:options
+                                                      error:&error];
+
+    NSManagedObjectContext *context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+    context.persistentStoreCoordinator = psc;
+
+    XCTAssertNil(error, @"Error while loading the PSC for Model 74");
+    XCTAssertNotNil(context, @"Invalid NSManagedObjectContext");
+
+    NSManagedObject *account1 = [NSEntityDescription insertNewObjectForEntityForName:@"Account" inManagedObjectContext:context];
+    [account1 setValue:@"dotcomuser1" forKey:@"username"];
+
+    //WPCom Blog
+    NSManagedObject *blog1 = [NSEntityDescription insertNewObjectForEntityForName:@"Blog" inManagedObjectContext:context];
+    [blog1 setValue:@(1001) forKey:@"blogID"];
+    [blog1 setValue:@"https://test1.wordpress.com" forKey:@"url"];
+    [blog1 setValue:@"https://test1.wordpress.com/xmlrpc.php" forKey:@"xmlrpc"];
+    [blog1 setValue:account1 forKey:@"account"];
+
+    //SelfHosted Blog
+    NSManagedObject *blog2 = [NSEntityDescription insertNewObjectForEntityForName:@"Blog" inManagedObjectContext:context];
+    [blog2 setValue:@(1002) forKey:@"blogID"];
+    [blog2 setValue:@"https://test1.wordpress.com" forKey:@"url"];
+    [blog2 setValue:@"https://test1.wordpress.com/xmlrpc.php" forKey:@"xmlrpc"];
+
+    [context save:&error];
+    XCTAssertNil(error, @"Error while saving context");
+
+    // Cleanup
+    XCTAssertNotNil(ps);
+    psc = nil;
+
+    // Migrate to Model 88
+    NSManagedObjectModel *model88 = [[NSManagedObjectModel alloc] initWithContentsOfURL:model88Url];
+    BOOL migrateResult = [ALIterativeMigrator iterativeMigrateURL:storeUrl
+                                                           ofType:NSSQLiteStoreType
+                                                          toModel:model88
+                                                orderedModelNames:@[@"WordPress 87", @"WordPress 88"]
+                                                            error:&error];
+    if (!migrateResult) {
+        NSLog(@"Error while migrating: %@", error);
+    }
+    XCTAssertTrue(migrateResult);
+
+    // Load a Model 88 Stack
+    psc = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:model88];
+    ps = [psc addPersistentStoreWithType:NSSQLiteStoreType
+                           configuration:nil
+                                     URL:storeUrl
+                                 options:options
+                                   error:&error];
+
+    context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+    context.persistentStoreCoordinator = psc;
+
+    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:@"Blog"];
+    request.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"blogID" ascending:YES]];
+
+    NSArray *results = [context executeFetchRequest:request error:nil];
+    XCTAssert(results.count == 2, @"Error Fetching Blogs");
+
+    // WPCom/Jetpack sites should migrate to Gutenberg
+
+    NSManagedObject *wpcomBlog = [results firstObject];
+    XCTAssertEqualObjects([wpcomBlog valueForKey:@"mobileEditor"], @"gutenberg");
+
+    // SelfHosted (non-jetpack) should migrate to Aztec
+
+    NSManagedObject *selfHostedBlog = [results lastObject];
+    XCTAssertEqualObjects([selfHostedBlog valueForKey:@"mobileEditor"], @"aztec");
+
+    XCTAssertNil(error, @"Error while loading the PSC for Model 88");
+    XCTAssertNotNil(ps);
+}
+
 #pragma mark - Private Helpers
 
 // Returns the URL for a model file with the given name in the given directory.

--- a/WordPress/WordPressTest/EditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsServiceTests.swift
@@ -47,7 +47,7 @@ class EditorSettingsServiceTest: XCTestCase {
 
         waitForExpectations(timeout: 0.1) { (error) in
             // The default value should be now on local and remote
-            XCTAssertEqual(blog.editor.mobile, .aztec)
+            XCTAssertEqual(blog.mobileEditor, .aztec)
         }
     }
 
@@ -75,7 +75,7 @@ class EditorSettingsServiceTest: XCTestCase {
 
         waitForExpectations(timeout: 0.1) { (error) in
             // The default value should be now on local and remote
-            XCTAssertEqual(blog.editor.mobile, .gutenberg)
+            XCTAssertEqual(blog.mobileEditor, .gutenberg)
         }
     }
 }

--- a/WordPress/WordPressTest/EditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsServiceTests.swift
@@ -63,34 +63,6 @@ class EditorSettingsServiceTest: XCTestCase {
             XCTAssertEqual(blog.mobileEditor, .aztec)
         }
     }
-
-    func testLocalSettingsMigrationPostGutenberg() {
-        // WPCom sites will default to gutenberg
-        let blog = makeTestBlog()
-
-        // Mobile editor not yet set on the server
-        let response = responseWith(mobileEditor: "")
-
-        sync(with: blog)
-
-        // Call GET settings from remote
-        XCTAssertTrue(remoteApi.getMethodCalled)
-        remoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
-
-        // Begin migration from local to remote
-
-        // Should call POST local settings to remote (migration)
-        XCTAssertTrue(remoteApi.postMethodCalled)
-        XCTAssertTrue(remoteApi.URLStringPassedIn?.contains("platform=mobile&editor=gutenberg") ?? false)
-        // Respond with mobile editor set on the server
-        let finalResponse = responseWith(mobileEditor: "gutenberg")
-        remoteApi.successBlockPassedIn?(finalResponse, HTTPURLResponse())
-
-        waitForExpectations(timeout: 0.1) { (error) in
-            // The default value should be now on local and remote
-            XCTAssertEqual(blog.mobileEditor, .gutenberg)
-        }
-    }
 }
 
 extension EditorSettingsServiceTest {

--- a/WordPress/WordPressTest/EditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsServiceTests.swift
@@ -15,7 +15,7 @@ class EditorSettingsServiceTest: XCTestCase {
         context.parent = contextManager.mainContext
         remoteApi = MockWordPressComRestApi()
         database = EphemeralKeyValueDatabase()
-        service = EditorSettingsService(managedObjectContext: context, database: database, wpcomApi: remoteApi)
+        service = EditorSettingsService(managedObjectContext: context, wpcomApi: remoteApi)
     }
 
     override func tearDown() {
@@ -24,9 +24,9 @@ class EditorSettingsServiceTest: XCTestCase {
     }
 
     func testLocalSettingsMigrationPostAztec() {
-        // Gutenberg globaly disable to migrate to Aztec
-        database.set(false, forKey: GutenbergSettings.Key.appWideEnabled)
         let blog = blogWith()
+        // Self-Hosted sites will default to Aztec
+        blog.account = nil
 
         sync(with: blog)
 
@@ -52,8 +52,7 @@ class EditorSettingsServiceTest: XCTestCase {
     }
 
     func testLocalSettingsMigrationPostGutenberg() {
-        // Gutenberg globaly enabled to migrate to Aztec
-        database.set(true, forKey: GutenbergSettings.Key.appWideEnabled)
+        // WPCom sites will default to gutenberg
         let blog = blogWith()
 
         // Mobile editor not yet set on the server

--- a/WordPress/WordPressTest/EditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsServiceTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+@testable import WordPress
+
+class EditorSettingsServiceTest: XCTestCase {
+    var contextManager: TestContextManager!
+    var context: NSManagedObjectContext!
+    var remoteApi: MockWordPressComRestApi!
+    var service: EditorSettingsService!
+    var database: KeyValueDatabase!
+
+    override func setUp() {
+        super.setUp()
+        contextManager = TestContextManager()
+        context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        context.parent = contextManager.mainContext
+        remoteApi = MockWordPressComRestApi()
+        database = EphemeralKeyValueDatabase()
+        service = EditorSettingsService(managedObjectContext: context, database: database, wpcomApi: remoteApi)
+    }
+
+    override func tearDown() {
+        ContextManager.overrideSharedInstance(nil)
+        super.tearDown()
+    }
+
+    func testLocalSettingsMigrationPostAztec() {
+        // Blog from an old account should default to Aztec
+        let blog = blogWith(userId: 1)
+
+        sync(with: blog)
+
+        // Call GET settings from remote
+        XCTAssertTrue(remoteApi.getMethodCalled)
+        // Respond with mobile editor not yet set on the server
+        let response = responseWith(mobileEditor: "")
+        remoteApi.successBlockPassedIn?(response, HTTPURLResponse())
+
+        // Begin migration from local to remote
+
+        // Should call POST local settings to remote (migration)
+        XCTAssertTrue(remoteApi.postMethodCalled)
+        XCTAssertTrue(remoteApi.URLStringPassedIn?.contains("platform=mobile&editor=aztec") ?? false)
+        // Respond with mobile editor set on the server
+        let finalResponse = responseWith(mobileEditor: "aztec")
+        remoteApi.successBlockPassedIn?(finalResponse, HTTPURLResponse())
+
+        waitForExpectations(timeout: 0.1) { (error) in
+            // The default value should be now on local and remote
+            XCTAssertEqual(blog.editor.mobile, .aztec)
+        }
+    }
+
+    func testLocalSettingsMigrationPostGutenberg() {
+        // Blog from a new account should default to Gutenberg
+        let blog = blogWith(userId: Int.max)
+
+        // Mobile editor not yet set on the server
+        let response = responseWith(mobileEditor: "")
+
+        sync(with: blog)
+
+        // Call GET settings from remote
+        XCTAssertTrue(remoteApi.getMethodCalled)
+        remoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
+
+        // Begin migration from local to remote
+
+        // Should call POST local settings to remote (migration)
+        XCTAssertTrue(remoteApi.postMethodCalled)
+        XCTAssertTrue(remoteApi.URLStringPassedIn?.contains("platform=mobile&editor=gutenberg") ?? false)
+        // Respond with mobile editor set on the server
+        let finalResponse = responseWith(mobileEditor: "gutenberg")
+        remoteApi.successBlockPassedIn?(finalResponse, HTTPURLResponse())
+
+        waitForExpectations(timeout: 0.1) { (error) in
+            // The default value should be now on local and remote
+            XCTAssertEqual(blog.editor.mobile, .gutenberg)
+        }
+    }
+}
+
+extension EditorSettingsServiceTest {
+    func blogWith(userId: Int) -> Blog {
+        let blog = ModelTestHelper.insertDotComBlog(context: context)
+        blog.dotComID = 1
+        blog.account?.userID = NSNumber(value: userId)
+        blog.account?.authToken = "auth"
+        return blog
+    }
+
+    func responseWith(mobileEditor: String) -> AnyObject {
+        return [
+            "editor_mobile": "",
+            "editor_web": "classic",
+        ] as AnyObject
+    }
+
+    func sync(with blog: Blog) {
+        let expec = expectation(description: "success")
+        expec.assertForOverFulfill = true
+
+        service.syncEditorSettings(for: blog, success: {
+            expec.fulfill()
+        }) { (error) in
+            XCTFail("This call should succeed. Error: \(error)")
+            expec.fulfill()
+        }
+    }
+}

--- a/WordPress/WordPressTest/EditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsServiceTests.swift
@@ -1,6 +1,19 @@
 import Foundation
 @testable import WordPress
 
+private class TestableEditorSettingsService: EditorSettingsService {
+    let mockApi: WordPressComRestApi
+
+    init(managedObjectContext context: NSManagedObjectContext, wpcomApi: WordPressComRestApi) {
+        mockApi = wpcomApi
+        super.init(managedObjectContext: context)
+    }
+
+    override func api(for blog: Blog) -> WordPressComRestApi? {
+        return mockApi
+    }
+}
+
 class EditorSettingsServiceTest: XCTestCase {
     var contextManager: TestContextManager!
     var context: NSManagedObjectContext!
@@ -15,7 +28,7 @@ class EditorSettingsServiceTest: XCTestCase {
         context.parent = contextManager.mainContext
         remoteApi = MockWordPressComRestApi()
         database = EphemeralKeyValueDatabase()
-        service = EditorSettingsService(managedObjectContext: context, wpcomApi: remoteApi)
+        service = TestableEditorSettingsService(managedObjectContext: context, wpcomApi: remoteApi)
     }
 
     override func tearDown() {

--- a/WordPress/WordPressTest/EditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsServiceTests.swift
@@ -24,8 +24,9 @@ class EditorSettingsServiceTest: XCTestCase {
     }
 
     func testLocalSettingsMigrationPostAztec() {
-        // Blog from an old account should default to Aztec
-        let blog = blogWith(userId: 1)
+        // Gutenberg globaly disable to migrate to Aztec
+        database.set(false, forKey: GutenbergSettings.Key.appWideEnabled)
+        let blog = blogWith()
 
         sync(with: blog)
 
@@ -51,8 +52,9 @@ class EditorSettingsServiceTest: XCTestCase {
     }
 
     func testLocalSettingsMigrationPostGutenberg() {
-        // Blog from a new account should default to Gutenberg
-        let blog = blogWith(userId: Int.max)
+        // Gutenberg globaly enabled to migrate to Aztec
+        database.set(true, forKey: GutenbergSettings.Key.appWideEnabled)
+        let blog = blogWith()
 
         // Mobile editor not yet set on the server
         let response = responseWith(mobileEditor: "")
@@ -80,17 +82,16 @@ class EditorSettingsServiceTest: XCTestCase {
 }
 
 extension EditorSettingsServiceTest {
-    func blogWith(userId: Int) -> Blog {
+    func blogWith() -> Blog {
         let blog = ModelTestHelper.insertDotComBlog(context: context)
         blog.dotComID = 1
-        blog.account?.userID = NSNumber(value: userId)
         blog.account?.authToken = "auth"
         return blog
     }
 
     func responseWith(mobileEditor: String) -> AnyObject {
         return [
-            "editor_mobile": "",
+            "editor_mobile": mobileEditor,
             "editor_web": "classic",
         ] as AnyObject
     }

--- a/WordPress/WordPressTest/EditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsServiceTests.swift
@@ -37,7 +37,7 @@ class EditorSettingsServiceTest: XCTestCase {
     }
 
     func testLocalSettingsMigrationPostAztec() {
-        let blog = blogWith()
+        let blog = makeTestBlog()
         // Self-Hosted sites will default to Aztec
         blog.account = nil
 
@@ -66,7 +66,7 @@ class EditorSettingsServiceTest: XCTestCase {
 
     func testLocalSettingsMigrationPostGutenberg() {
         // WPCom sites will default to gutenberg
-        let blog = blogWith()
+        let blog = makeTestBlog()
 
         // Mobile editor not yet set on the server
         let response = responseWith(mobileEditor: "")
@@ -94,7 +94,7 @@ class EditorSettingsServiceTest: XCTestCase {
 }
 
 extension EditorSettingsServiceTest {
-    func blogWith() -> Blog {
+    func makeTestBlog() -> Blog {
         let blog = ModelTestHelper.insertDotComBlog(context: context)
         blog.dotComID = 1
         blog.account?.authToken = "auth"

--- a/WordPress/WordPressTest/GutenbergSettingsTests.swift
+++ b/WordPress/WordPressTest/GutenbergSettingsTests.swift
@@ -59,6 +59,7 @@ class GutenbergSettingsTests: XCTestCase {
             let blog = self.newTestBlog()
             // This simulates the first launch
             let settings = GutenbergSettings(database: database)
+            settings.setGutenbergEnabled(false, for: blog)
 
             XCTAssertFalse(blog.isGutenbergEnabled)
 
@@ -74,6 +75,7 @@ class GutenbergSettingsTests: XCTestCase {
     }
 
     func testGutenbergAlwaysUsedForExistingGutenbergPosts() {
+        settings.setGutenbergEnabled(false, for: blog)
         XCTAssertFalse(isGutenbergEnabled)
 
         post.content = "<!-- wp:paragraph -->\n<p>Hello world</p>\n<!-- /wp:paragraph -->"
@@ -87,6 +89,7 @@ class GutenbergSettingsTests: XCTestCase {
     }
 
     func testAztecAlwaysUsedForExistingAztecPosts() {
+        settings.setGutenbergEnabled(false, for: blog)
         XCTAssertFalse(isGutenbergEnabled)
 
         post.content = "<p>Hello world</p>"
@@ -99,37 +102,22 @@ class GutenbergSettingsTests: XCTestCase {
         XCTAssertFalse(mustUseGutenberg)
     }
 
-    func testUseGutenbergForNewPostsIfWebAndMobileAreSetToGutenberg() {
-        XCTAssertFalse(isGutenbergEnabled)
-        XCTAssertFalse(mustUseGutenberg)
-
-        settings.setGutenbergEnabled(true, for: blog)
-        blog.webEditor = WebEditor.gutenberg.rawValue
-
-        XCTAssertTrue(isGutenbergEnabled)
-        XCTAssertTrue(mustUseGutenberg)
-    }
-
     // Thests for defaults when `mobile_editor` haven't been sync from remote
 
     func testSelfHostedDefaultsToAztec() {
         blog = newTestBlog(isWPComAPIEnabled: false)
+        post = newTestPost(with: blog)
         XCTAssertFalse(mustUseGutenberg)
     }
 
     func testSelfHostedUsesOldGlobalEditorSetting() {
         blog = newTestBlog(isWPComAPIEnabled: false)
-        database.set(true, forKey: GutenbergSettings.Key.enabledOnce)
+        post = newTestPost(with: blog)
+        database.set(true, forKey: GutenbergSettings.Key.appWideEnabled)
         XCTAssertTrue(mustUseGutenberg)
     }
 
-    func testOldWPComAccountsDefaultsToAztec() {
-        blog.account?.userID = 1
-        XCTAssertFalse(mustUseGutenberg)
-    }
-
-    func testNewWPComAccountsDefaultToGutenberg() {
-        blog.account?.userID = NSNumber(value: Int.max)
+    func testWPComAccountsDefaultsToGutenberg() {
         XCTAssertTrue(mustUseGutenberg)
     }
 }

--- a/WordPress/WordPressTest/GutenbergSettingsTests.swift
+++ b/WordPress/WordPressTest/GutenbergSettingsTests.swift
@@ -110,13 +110,6 @@ class GutenbergSettingsTests: XCTestCase {
         XCTAssertFalse(mustUseGutenberg)
     }
 
-    func testSelfHostedUsesOldGlobalEditorSetting() {
-        blog = newTestBlog(isWPComAPIEnabled: false)
-        post = newTestPost(with: blog)
-        database.set(true, forKey: GutenbergSettings.Key.appWideEnabled)
-        XCTAssertTrue(mustUseGutenberg)
-    }
-
     func testWPComAccountsDefaultsToGutenberg() {
         XCTAssertTrue(mustUseGutenberg)
     }

--- a/WordPress/WordPressTest/GutenbergSettingsTests.swift
+++ b/WordPress/WordPressTest/GutenbergSettingsTests.swift
@@ -110,7 +110,7 @@ class GutenbergSettingsTests: XCTestCase {
         XCTAssertFalse(mustUseGutenberg)
     }
 
-    func testWPComAccountsDefaultsToGutenberg() {
-        XCTAssertTrue(mustUseGutenberg)
+    func testWPComAccountsDefaultsToAztec() {
+        XCTAssertFalse(mustUseGutenberg)
     }
 }


### PR DESCRIPTION
Third step to implement https://github.com/wordpress-mobile/gutenberg-mobile/issues/1233
Based on https://github.com/wordpress-mobile/WordPress-iOS/pull/12166

This PR implements the editor default logic and the migration of the local setting to remote, when the remote setting is empty.

To test:
- Open the test user's report card
  - Check that nothing is set on `SELECTED EDITORS` for mobile platform.
  - You can press `reset` to remove the setting if there's any.

**Sync and Migration from local to remote:**
- Login with a test user.
  - Check that the locally defined default editor was set on the report card.
- Toggle the switch 
  - Check that the new value was set on the report card.

**Sync from remote to local**
- Set a blog on Aztec and a blog on Gutenberg
- Uninstall the app, install and login again
- Check that the editor switch correspond to the editor set on the report card for both blogs

**Auto-enabled dialog**
- Open a Gutenberg post on a blog originally set to use Aztec (from a clean install)
  - Check that the dialog appears and both the switch and the report card is set to gutenberg for that blog
- Open the other blog set to gutenberg.
- Switch it back to Aztec.
- Open a blog with gutenberg blocks.
  - Check that it opens with Gutenberg, but the switch and the report card remain as Aztec, and no dialog appears.

**Migration from global setting to per-site setting**
- On 12.9 set to Gutenberg:
  - Updating to 13.0, all blogs should default to gutenberg
  - No autoenable-dialog should appear for any blog.

- On 12.9 set to Aztec:
  - Updating to 13.0 should: 
    - Keep Aztec on older users (most users)
    - Auto-enable gutenberg for newer users

**New installs from 13.0 and beyond**
- The default editor should be Gutenberg for all newer users
- The default editor should be Aztec for all older users

**Note:** A newer user is defined as having a userID > 149287441

cc @daniloercoli 