### PR TITLE
Make the Site header accessible

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -68,7 +68,7 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     }
     
     NSString *localizedLabel =
-        NSLocalizedString(@"Site named %@ located at %@",
+        NSLocalizedString(@"%@, at %@",
                           @"Accessibility label for the site header. The first variable is the blog name, the second is the domain.");
     self.stackView.accessibilityLabel =
         [NSString stringWithFormat:localizedLabel, title, blog.displayURL];

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -37,12 +37,15 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
 - (void)performSetup
 {
     self.preservesSuperviewLayoutMargins = YES;
+    
     [self setupStackView];
     [self setupBlavatarImageView];
     [self setupBlavatarDropTarget];
     [self setupLabelsStackView];
     [self setupTitleLabel];
     [self setupSubtitleLabel];
+    
+    self.accessibilityElements = @[self.stackView, self.blavatarDropTarget];
 }
 
 #pragma mark - Public Methods
@@ -63,6 +66,12 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
         UIDropInteraction *dropInteraction = [[UIDropInteraction alloc] initWithDelegate:self];
         [self.blavatarDropTarget addInteraction:dropInteraction];
     }
+    
+    NSString *localizedLabel =
+        NSLocalizedString(@"Site named %@ located at %@",
+                          @"Accessibility label for the site header. The first variable is the blog name, the second is the domain.");
+    self.stackView.accessibilityLabel =
+        [NSString stringWithFormat:localizedLabel, title, blog.displayURL];
 }
 
 - (void)setTitleText:(NSString *)title
@@ -144,6 +153,9 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
                                               [stackView.topAnchor constraintEqualToAnchor:self.topAnchor],
                                               [stackView.bottomAnchor constraintEqualToAnchor:self.bottomAnchor],
                                               ]];
+    
+    stackView.isAccessibilityElement = YES;
+
     _stackView = stackView;
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailHeaderView.m
@@ -171,6 +171,10 @@ const CGFloat BlogDetailHeaderViewLabelHorizontalPadding = 10.0;
     self.blavatarDropTarget = [UIView new];
     [self.blavatarDropTarget setTranslatesAutoresizingMaskIntoConstraints:NO];
     self.blavatarDropTarget.backgroundColor = [UIColor clearColor];
+    self.blavatarDropTarget.accessibilityLabel = NSLocalizedString(@"Site Icon", @"Site Icon accessibility label.");
+    self.blavatarDropTarget.accessibilityTraits = UIAccessibilityTraitImage | UIAccessibilityTraitButton;
+    self.blavatarDropTarget.accessibilityHint = NSLocalizedString(@"Shows a menu for changing the Site Icon.", @"Accessibility hint describing what happens if the Site Icon is tapped.");
+    self.blavatarDropTarget.isAccessibilityElement = YES;
 
     UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                                 action:@selector(blavatarImageTapped)];


### PR DESCRIPTION
Closes #12179, and closes #12180. 

This applies accessibility labels to the Site Page's icon, title, and domain. The title and domain are now considered as one and will be triggered if hovering over them and the icon. 

| Main | Site Icon |
|--------|-------|
| <img src="https://user-images.githubusercontent.com/198826/61750362-700fe180-ad62-11e9-9296-0df696e4b168.PNG" width="320"> |   <img src="https://user-images.githubusercontent.com/198826/61750296-3e971600-ad62-11e9-8bf2-84b4d69bde3c.PNG" width="320">   |

## Testing

1. Navigate to a Site Page.
2. Turn on VoiceOver. 
3. Hover over the title, domain, and icon. The icon should be dictated as a button. 

This is my first time adding VoiceOver support so I'd be happy to hear your comments. 🙂 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
