### PR TITLE
Stats: fix Period Authors details expanded row height

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -20,6 +20,7 @@ class DetailDataCell: UITableViewCell, NibLoadable {
     private weak var detailsDelegate: SiteStatsDetailsDelegate?
     private var rowData: StatsTotalRowData?
     private typealias Style = WPStyleGuide.Stats
+    private var row: StatsTotalRow?
 
     // MARK: - Configure
 
@@ -62,9 +63,15 @@ class DetailDataCell: UITableViewCell, NibLoadable {
             }
         }
 
+        self.row = row
         dataView.addSubview(row)
         row.translatesAutoresizingMaskIntoConstraints = false
         dataView.pinSubviewToAllEdges(row)
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        row?.removeFromSuperview()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -52,6 +52,14 @@ class DetailDataCell: UITableViewCell, NibLoadable {
         if isChildRow {
             Style.configureLabelAsChildRowTitle(row.itemLabel)
             row.imageView.isHidden = !showChildRowImage
+
+            // If the imageView is being shown but there is no image (i.e. the row is "indented"),
+            // reduce the image height so it doesn't affect the row height.
+            if showChildRowImage && !row.hasIcon {
+                row.imageHeightConstraint.constant = 1
+            } else {
+                row.imageHeightConstraint.constant = rowData.statSection?.imageSize ?? StatSection.defaultImageSize
+            }
         }
 
         dataView.addSubview(row)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -598,7 +598,9 @@ private extension SiteStatsDetailsViewModel {
                               dataBarPercent: Float($0.viewsCount) / Float(authors.first!.viewsCount),
                               userIconURL: $0.iconURL,
                               showDisclosure: true,
-                              childRows: $0.posts.map { StatsTotalRowData(name: $0.title, data: $0.viewsCount.abbreviatedString()) },
+                              childRows: $0.posts.map { StatsTotalRowData(name: $0.title,
+                                                                          data: $0.viewsCount.abbreviatedString(),
+                                                                          statSection: .periodAuthors) },
                               statSection: .periodAuthors)
         }
     }


### PR DESCRIPTION
Fixes #11824 

To test:
- Go to Period > Authors > View more.
- Expand an Author.
- Verify the child row height is approximately 44pt high (the rows are dynamic, but it should be close).

<img width="400" alt="author_details_child_rows" src="https://user-images.githubusercontent.com/1816888/61751519-de09d800-ad65-11e9-9583-216f399fb355.png">


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
