### PR TITLE
Submit Tracks event when receiving a push notification

### DIFF
--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -166,6 +166,9 @@ final public class PushNotificationsManager: NSObject {
             return
         }
 
+        // Analytics
+        trackNotification(with: userInfo)
+
         // Handling!
         let handlers = [handleSupportNotification,
                         handleAuthenticationNotification,
@@ -338,6 +341,7 @@ extension PushNotificationsManager {
         return true
     }
 }
+
 
 // MARK: - Nested Types
 //


### PR DESCRIPTION
Fixes #12193 

It looks like the event `wpios_push_notification_received` stopped firing with v11.4. For more context, see p77Llu-cng-p2

This PR forces the PushNotificationsManager to fire the `wpios_push_notification_received` event, to partially undo the changes in PR #10551

To test:
- Trigger a push notification
- Check that the event `wpios_push_notification_received` is received in Tracks