### PR TITLE
[Jetpack] Jetpack Remote Install Error log

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -43,9 +43,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.3.0-beta.1'
+#    pod 'WordPressKit', '~> 4.3.0-beta.1'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/stats_timezone'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'ef4f184f5a33ef628c053892e8f706046191d66c'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '3eaf8f8863dee3d38c4e4b66b8334e8c80ebee6d'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -43,9 +43,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-#    pod 'WordPressKit', '~> 4.3.0-beta.1'
+    pod 'WordPressKit', '~> 4.3.0-beta.3'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/stats_timezone'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '3eaf8f8863dee3d38c4e4b66b8334e8c80ebee6d'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '3eaf8f8863dee3d38c4e4b66b8334e8c80ebee6d'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -222,7 +222,7 @@ PODS:
     - WordPressKit (~> 4.1)
     - WordPressShared (~> 1.8)
     - WordPressUI (~> 1.3)
-  - WordPressKit (4.3.0-beta.1):
+  - WordPressKit (4.3.0-beta.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -301,7 +301,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.8.0)
   - WordPressAuthenticator (~> 1.7.0-beta.2)
-  - WordPressKit (~> 4.3.0-beta.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `3eaf8f8863dee3d38c4e4b66b8334e8c80ebee6d`)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.5)
   - WordPressUI (~> 1.3.4)
@@ -346,7 +346,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -411,6 +410,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.9.0
+  WordPressKit:
+    :commit: 3eaf8f8863dee3d38c4e4b66b8334e8c80ebee6d
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.9.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -424,6 +426,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.9.0
+  WordPressKit:
+    :commit: 3eaf8f8863dee3d38c4e4b66b8334e8c80ebee6d
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -486,7 +491,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 5022d76e7c4cd2a492f670944e24b9dd05639763
   WordPress-Editor-iOS: e0116fe2c4d3e0d2c325f053d9becdf637bfd708
   WordPressAuthenticator: 1ab1d36fd9a50fefdbeb0c0cb115e364673b473c
-  WordPressKit: e1cbbeb673e00b63cfa5e1336030606b404b2e06
+  WordPressKit: 1ac85c92ba7de01152f61eaf9d8da9a1d42bf0f9
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
   WordPressShared: 18f7bce275fb88e269906eef1b16efab8b7c1bc3
   WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
@@ -496,6 +501,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 259ed4a38aed4cf1dffa3db4e3262ce8136253a0
+PODFILE CHECKSUM: 70c46a637aea453fe6a05ed4949a79b2305fac70
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -221,7 +221,7 @@ PODS:
     - WordPressKit (~> 4.1)
     - WordPressShared (~> 1.8)
     - WordPressUI (~> 1.3)
-  - WordPressKit (4.3.0-beta.1):
+  - WordPressKit (4.3.0-beta.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -299,7 +299,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.8.0)
   - WordPressAuthenticator (~> 1.7.0-beta.2)
-  - WordPressKit (~> 4.3.0-beta.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `3eaf8f8863dee3d38c4e4b66b8334e8c80ebee6d`)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.5)
   - WordPressUI (~> 1.3.4)
@@ -343,7 +343,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -408,6 +407,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.9.0
+  WordPressKit:
+    :commit: 3eaf8f8863dee3d38c4e4b66b8334e8c80ebee6d
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.9.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -421,6 +423,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.9.0
+  WordPressKit:
+    :commit: 3eaf8f8863dee3d38c4e4b66b8334e8c80ebee6d
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -482,7 +487,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 5022d76e7c4cd2a492f670944e24b9dd05639763
   WordPress-Editor-iOS: e0116fe2c4d3e0d2c325f053d9becdf637bfd708
   WordPressAuthenticator: 1ab1d36fd9a50fefdbeb0c0cb115e364673b473c
-  WordPressKit: e1cbbeb673e00b63cfa5e1336030606b404b2e06
+  WordPressKit: 1ac85c92ba7de01152f61eaf9d8da9a1d42bf0f9
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
   WordPressShared: 18f7bce275fb88e269906eef1b16efab8b7c1bc3
   WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
@@ -492,6 +497,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: f4c60defa0b191e0b24e1cf2059048bf5b9b8026
+PODFILE CHECKSUM: 796ab37c8112a14b776eebe1147edb64302c9d0d
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -221,7 +221,7 @@ PODS:
     - WordPressKit (~> 4.1)
     - WordPressShared (~> 1.8)
     - WordPressUI (~> 1.3)
-  - WordPressKit (4.3.0-beta.2):
+  - WordPressKit (4.3.0-beta.3):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -299,7 +299,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.8.0)
   - WordPressAuthenticator (~> 1.7.0-beta.2)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `3eaf8f8863dee3d38c4e4b66b8334e8c80ebee6d`)
+  - WordPressKit (~> 4.3.0-beta.3)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.5)
   - WordPressUI (~> 1.3.4)
@@ -343,6 +343,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -407,9 +408,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.9.0
-  WordPressKit:
-    :commit: 3eaf8f8863dee3d38c4e4b66b8334e8c80ebee6d
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.9.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -423,9 +421,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.9.0
-  WordPressKit:
-    :commit: 3eaf8f8863dee3d38c4e4b66b8334e8c80ebee6d
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -487,7 +482,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 5022d76e7c4cd2a492f670944e24b9dd05639763
   WordPress-Editor-iOS: e0116fe2c4d3e0d2c325f053d9becdf637bfd708
   WordPressAuthenticator: 1ab1d36fd9a50fefdbeb0c0cb115e364673b473c
-  WordPressKit: 1ac85c92ba7de01152f61eaf9d8da9a1d42bf0f9
+  WordPressKit: e68529848b490fd0d0b0042d702799cd13f92ca3
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
   WordPressShared: 18f7bce275fb88e269906eef1b16efab8b7c1bc3
   WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
@@ -497,6 +492,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 796ab37c8112a14b776eebe1147edb64302c9d0d
+PODFILE CHECKSUM: c0dec09b591ae8ea20f30bb619080908ef7e59e5
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/Error/JetpackInstallError+Blocking.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/Error/JetpackInstallError+Blocking.swift
@@ -10,18 +10,4 @@ extension JetpackInstallError {
             return true
         }
     }
-
-    var message: String {
-        switch self.type {
-        case .loginFailure:
-            return NSLocalizedString("Jetpack could not be installed at this time.",
-                                     comment: "The default Jetpack view message used when a 'login failure' error occurred")
-        case .siteIsJetpack:
-            return NSLocalizedString("Jetpack could not be installed at this time.",
-                                     comment: "The default Jetpack view message used when a 'site is Jetpack' error occurred")
-        default:
-            return NSLocalizedString("Jetpack could not be installed at this time.",
-                                     comment: "The default Jetpack view message used when an error occurred")
-        }
-    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/Error/JetpackInstallError+Blocking.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/Error/JetpackInstallError+Blocking.swift
@@ -3,11 +3,25 @@ extension JetpackInstallError {
     /// If the error is blocking,
     /// use the webview as fallback to install Jetpack
     var isBlockingError: Bool {
-        switch self {
+        switch self.type {
         case .loginFailure, .siteIsJetpack, .unknown:
             return false
         default:
             return true
+        }
+    }
+
+    var message: String {
+        switch self.type {
+        case .loginFailure:
+            return NSLocalizedString("Jetpack could not be installed at this time.",
+                                     comment: "The default Jetpack view message used when a 'login failure' error occurred")
+        case .siteIsJetpack:
+            return NSLocalizedString("Jetpack could not be installed at this time.",
+                                     comment: "The default Jetpack view message used when a 'site is Jetpack' error occurred")
+        default:
+            return NSLocalizedString("Jetpack could not be installed at this time.",
+                                     comment: "The default Jetpack view message used when an error occurred")
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
@@ -74,9 +74,15 @@ private extension JetpackRemoteInstallViewController {
                 WPAnalytics.track(.installJetpackRemoteCompleted)
             case .failure(let error):
                 WPAnalytics.track(.installJetpackRemoteFailed,
-                                  withProperties: ["error": error.rawValue,
-                                                   "siteURL": self?.blog.url ?? "unknown"])
+                                  withProperties: ["error": error.type.rawValue,
+                                                   "site_url": self?.blog.url ?? "unknown"])
+
+                DDLogInfo("Jetpack Remote Install Error Site URL: \(self?.blog.url ?? "unknown")")
+                DDLogInfo("Jetpack Remote Install Error Type: \(error.type.rawValue)")
+                DDLogInfo("Jetpack Remote Install Error Code: \(error.code)")
+                DDLogInfo("Jetpack Remote Install Error Title: \(error.title ?? "no error message")")
                 if error.isBlockingError {
+                    DDLogInfo("Jetpack Remote Install Error: Blocking error")
                     self?.delegate?.jetpackRemoteInstallWebviewFallback()
                 }
             default:

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
@@ -76,13 +76,14 @@ private extension JetpackRemoteInstallViewController {
                 WPAnalytics.track(.installJetpackRemoteFailed,
                                   withProperties: ["error": error.type.rawValue,
                                                    "site_url": self?.blog.url ?? "unknown"])
+                let url = self?.blog.url ?? "unknown"
+                let title = error.title ?? "no error message"
+                let type = error.type.rawValue
+                let code = error.code
+                DDLogError("Jetpack Remote Install error for site \(url) – \(title) (\(code): \(type))")
 
-                DDLogInfo("Jetpack Remote Install Error Site URL: \(self?.blog.url ?? "unknown")")
-                DDLogInfo("Jetpack Remote Install Error Type: \(error.type.rawValue)")
-                DDLogInfo("Jetpack Remote Install Error Code: \(error.code)")
-                DDLogInfo("Jetpack Remote Install Error Title: \(error.title ?? "no error message")")
                 if error.isBlockingError {
-                    DDLogInfo("Jetpack Remote Install Error: Blocking error")
+                    DDLogInfo("Jetpack Remote Install error - Blocking error")
                     self?.delegate?.jetpackRemoteInstallWebviewFallback()
                 }
             default:

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/State/JetpackRemoteInstallState.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/State/JetpackRemoteInstallState.swift
@@ -25,12 +25,11 @@ enum JetpackRemoteInstallState: Equatable {
         case .installing:
             return NSLocalizedString("Installing Jetpack on your site. This can take up to a few minutes to complete.",
                                      comment: "The Jetpack view message used while the state is installing")
-        case .failure:
-            return NSLocalizedString("Jetpack could not be installed at this time.",
-                                     comment: "The default Jetpack view message used when an error occurred")
         case .success:
             return NSLocalizedString("Now that Jetpack is installed, we just need to get you set up. This will only take a minute.",
                                      comment: "The default Jetpack view message for the success state")
+        case .failure(let error):
+            return error.message
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/State/JetpackRemoteInstallState.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/State/JetpackRemoteInstallState.swift
@@ -28,8 +28,9 @@ enum JetpackRemoteInstallState: Equatable {
         case .success:
             return NSLocalizedString("Now that Jetpack is installed, we just need to get you set up. This will only take a minute.",
                                      comment: "The default Jetpack view message for the success state")
-        case .failure(let error):
-            return error.message
+        case .failure:
+            return NSLocalizedString("Jetpack could not be installed at this time.",
+                                     comment: "The default Jetpack view message used when an error occurred")
         }
     }
 


### PR DESCRIPTION
Refs. #12138 

This PR adds more log info about the JRI error received.

New log example:
```
Jetpack Remote Install error for site SITE_URL – The request timed out. (-1001: unknown)
```

I will update the Podfile as soon [#171](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/171) is merged.

## To test:
• Try to install Jetpack on a website that might fail (Use a slow connection profile to generate a timeout)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
