### PR TITLE
[Gutenberg] - PR 03 - Adding `UserDefaults` to Environment

### DIFF
--- a/WordPress/Classes/Services/EditorSettingsService.swift
+++ b/WordPress/Classes/Services/EditorSettingsService.swift
@@ -5,16 +5,13 @@ import Foundation
 }
 
 @objc class EditorSettingsService: LocalCoreDataService {
-
-    let database: KeyValueDatabase
     let wpcomApi: WordPressComRestApi?
 
     @objc convenience override init(managedObjectContext: NSManagedObjectContext) {
         self.init(managedObjectContext: managedObjectContext, wpcomApi: nil)
     }
 
-    init(managedObjectContext: NSManagedObjectContext, database: KeyValueDatabase = UserDefaults(), wpcomApi: WordPressComRestApi? = nil) {
-        self.database = database
+    init(managedObjectContext: NSManagedObjectContext, wpcomApi: WordPressComRestApi? = nil) {
         self.wpcomApi = wpcomApi
         super.init(managedObjectContext: managedObjectContext)
     }
@@ -54,7 +51,7 @@ import Foundation
 
     private func migrateLocalSettingToRemote(for blog: Blog, success: @escaping () -> Void, failure: @escaping (Swift.Error) -> Void) {
         if blog.editor.mobile == nil {
-            let settings = GutenbergSettings(database: database)
+            let settings = GutenbergSettings()
             let defaultEditor = settings.getDefaultEditor(for: blog)
             settings.setGutenbergEnabled(defaultEditor == .gutenberg, for: blog)
         }

--- a/WordPress/Classes/Utility/Environment/Environment.swift
+++ b/WordPress/Classes/Utility/Environment/Environment.swift
@@ -14,6 +14,9 @@ struct Environment {
     /// A type to create derived context, save context, etc...
     let contextManager: ContextManagerType
 
+    /// A simple database to store any kind of key-value pairs.
+    let userDefaults: KeyValueDatabase
+
     /// The base url to use for WP.com api requests
     let wordPressComApiBase: String
 
@@ -31,13 +34,16 @@ struct Environment {
 
     // MARK: - Initialization
 
+    // Defaults defined here will be normally unless explicitly overriden with a `replaceEnvironment()` call
     private init(
         appRatingUtility: AppRatingUtilityType = AppRatingUtility.shared,
         contextManager: ContextManagerType = ContextManager.shared,
+        userDefaults: KeyValueDatabase = UserDefaults.standard,
         wordPressComApiBase: String = WordPressComRestApi.apiBaseURLString) {
 
         self.appRatingUtility = appRatingUtility
         self.contextManager = contextManager
+        self.userDefaults = userDefaults
         self.wordPressComApiBase = wordPressComApiBase
     }
 }
@@ -49,11 +55,13 @@ extension Environment {
     static func replaceEnvironment(
         appRatingUtility: AppRatingUtilityType = Environment.current.appRatingUtility,
         contextManager: ContextManagerType = Environment.current.contextManager,
+        userDefaults: KeyValueDatabase = Environment.current.userDefaults,
         wordPressComApiBase: String = Environment.current.wordPressComApiBase) -> Environment {
 
         current = Environment(
             appRatingUtility: appRatingUtility,
             contextManager: contextManager,
+            userDefaults: userDefaults,
             wordPressComApiBase: wordPressComApiBase
         )
         return current

--- a/WordPress/WordPressTest/EditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsServiceTests.swift
@@ -6,7 +6,6 @@ class EditorSettingsServiceTest: XCTestCase {
     var context: NSManagedObjectContext!
     var remoteApi: MockWordPressComRestApi!
     var service: EditorSettingsService!
-    var database: KeyValueDatabase!
 
     override func setUp() {
         super.setUp()
@@ -14,8 +13,8 @@ class EditorSettingsServiceTest: XCTestCase {
         context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         context.parent = contextManager.mainContext
         remoteApi = MockWordPressComRestApi()
-        database = EphemeralKeyValueDatabase()
-        service = EditorSettingsService(managedObjectContext: context, database: database, wpcomApi: remoteApi)
+        Environment.replaceEnvironment(contextManager: contextManager, userDefaults: EphemeralKeyValueDatabase())
+        service = EditorSettingsService(managedObjectContext: context, wpcomApi: remoteApi)
     }
 
     override func tearDown() {
@@ -90,7 +89,7 @@ extension EditorSettingsServiceTest {
 
     func responseWith(mobileEditor: String) -> AnyObject {
         return [
-            "editor_mobile": "",
+            "editor_mobile": mobileEditor,
             "editor_web": "classic",
         ] as AnyObject
     }

--- a/WordPress/WordPressTest/GutenbergSettingsTests.swift
+++ b/WordPress/WordPressTest/GutenbergSettingsTests.swift
@@ -41,9 +41,11 @@ class GutenbergSettingsTests: XCTestCase {
         context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         context.parent = contextManager.mainContext
         database = EphemeralKeyValueDatabase()
-        settings = GutenbergSettings(database: database)
+        settings = GutenbergSettings()
         blog = newTestBlog()
         post = newTestPost(with: blog)
+
+        Environment.replaceEnvironment(contextManager: contextManager, userDefaults: database)
     }
 
     override func tearDown() {
@@ -55,10 +57,10 @@ class GutenbergSettingsTests: XCTestCase {
     func testGutenbergDisabledByDefaultAndToggleEnablesInSecondLaunch() {
 
         let testClosure: () -> () = { () in
-            let database = EphemeralKeyValueDatabase()
+            Environment.replaceEnvironment(contextManager: TestContextManager(), userDefaults: EphemeralKeyValueDatabase())
             let blog = self.newTestBlog()
             // This simulates the first launch
-            let settings = GutenbergSettings(database: database)
+            let settings = GutenbergSettings()
 
             XCTAssertFalse(blog.isGutenbergEnabled)
 


### PR DESCRIPTION
On https://github.com/wordpress-mobile/WordPress-iOS/pull/12189 it was needed to add a `database: KeyValueDatabase` property on `EditorSettingsService.init`, in order to inject the Mock version and let the UnitTests pass.

This is a small PR to help simplify dependency injection on init signatures and on unit tests.

To test:
- Check that the changes look good.
- Unit Tests should pass
