### PR TITLE
Stats: adjust 'relativeStringInPast' logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -187,57 +187,57 @@ extension Date {
         let hours = components.hour ?? 0
         let minutes = components.minute ?? 0
 
-        if days >= DateFormattingBreakpoints.aboutYearAndAHalf.rawValue {
+        if days >= DateBreakpoints.aboutYearAndAHalf {
             return String(format: NSLocalizedString("%d years", comment: "Age between dates over one year."), Int(round(Float(days) / Float(365))))
         }
 
-        if days >= DateFormattingBreakpoints.almostAYear.rawValue {
+        if days >= DateBreakpoints.almostAYear {
             return String(format: NSLocalizedString("a year", comment: "Age between dates equaling one year."))
         }
 
-        if days >= DateFormattingBreakpoints.monthAndAHalf.rawValue {
+        if days >= DateBreakpoints.monthAndAHalf {
             let components = calendar.dateComponents([.minute, .hour, .day, .month, .year], from: self, to: now)
             let months = components.month ?? 0
             let days = components.day ?? 0
-            let adjustedMonths = days > DateFormattingBreakpoints.halfAMonth.rawValue ? months + 1 : months
+            let adjustedMonths = days > DateBreakpoints.halfAMonth ? months + 1 : months
             return String(format: NSLocalizedString("%d months", comment: "Age between dates over one month."), adjustedMonths)
         }
 
-        if days >= DateFormattingBreakpoints.almostAMonth.rawValue {
+        if days >= DateBreakpoints.almostAMonth {
             return String(format: NSLocalizedString("a month", comment: "Age between dates equaling one month."))
         }
 
-        if days > 1 || (days == 1 && hours >= DateFormattingBreakpoints.halfADay.rawValue) {
+        if days > 1 || (days == 1 && hours >= DateBreakpoints.halfADay) {
             let totalHours = (days * 24) + hours
             return String(format: NSLocalizedString("%d days", comment: "Age between dates over one day."), Int(round(Float(totalHours) / Float(24))))
         }
 
-        if days == 1 || hours > DateFormattingBreakpoints.almostADay.rawValue {
+        if days == 1 || hours > DateBreakpoints.almostADay {
             return String(format: NSLocalizedString("a day", comment: "Age between dates equaling one day."))
         }
 
-        if hours > 1 || (hours == 1 && minutes >= DateFormattingBreakpoints.halfAnHour.rawValue) {
+        if hours > 1 || (hours == 1 && minutes >= DateBreakpoints.halfAnHour) {
             let totalMinutes = (hours * 60) + minutes
             return String(format: NSLocalizedString("%d hours", comment: "Age between dates over one hour."), Int(round(Float(totalMinutes) / Float(60))))
         }
 
-        if hours == 1 || minutes >= DateFormattingBreakpoints.almostAnHour.rawValue {
+        if hours == 1 || minutes >= DateBreakpoints.almostAnHour {
             return String(format: NSLocalizedString("an hour", comment: "Age between dates equaling one hour."))
         }
 
         return NSLocalizedString("< 1 hour", comment: "Age between dates less than one hour.")
     }
 
-    private enum DateFormattingBreakpoints: Int {
-        case aboutYearAndAHalf = 548
-        case almostAYear = 305
-        case monthAndAHalf = 44
-        case halfAMonth = 15
-        case almostAMonth = 25
-        case halfADay = 12
-        case almostADay = 22
-        case halfAnHour = 30
-        case almostAnHour = 45
+    private struct DateBreakpoints {
+        static let aboutYearAndAHalf = 548
+        static let almostAYear = 305
+        static let monthAndAHalf = 44
+        static let halfAMonth = 15
+        static let almostAMonth = 25
+        static let halfADay = 12
+        static let almostADay = 22
+        static let halfAnHour = 30
+        static let almostAnHour = 45
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -198,7 +198,11 @@ extension Date {
         }
 
         if days >= DateFormattingBreakpoints.monthAndAHalf.rawValue {
-            return String(format: NSLocalizedString("%d months", comment: "Age between dates over one month."), niceComponents.month!)
+            let components = calendar.dateComponents([.minute, .hour, .day, .month, .year], from: self, to: now)
+            let months = components.month ?? 0
+            let days = components.day ?? 0
+            let adjustedMonths = days > DateFormattingBreakpoints.halfAMonth.rawValue ? months + 1 : months
+            return String(format: NSLocalizedString("%d months", comment: "Age between dates over one month."), adjustedMonths)
         }
 
         if days >= DateFormattingBreakpoints.almostAMonth.rawValue {
@@ -230,8 +234,9 @@ extension Date {
 
     private enum DateFormattingBreakpoints: Int {
         case aboutYearAndAHalf = 548
-        case almostAYear = 345
-        case monthAndAHalf = 35
+        case almostAYear = 305
+        case monthAndAHalf = 44
+        case halfAMonth = 15
         case almostAMonth = 25
         case halfADay = 12
         case almostADay = 22

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -190,7 +190,7 @@ extension Date {
         let minutes = components.minute ?? 0
 
         if days >= DateFormattingBreakpoints.aboutYearAndAHalf.rawValue {
-            return String(format: NSLocalizedString("%d years", comment: "Age between dates over one year."), niceComponents.year!)
+            return String(format: NSLocalizedString("%d years", comment: "Age between dates over one year."), Int(round(Float(days) / Float(365))))
         }
 
         if days >= DateFormattingBreakpoints.almostAYear.rawValue {
@@ -206,7 +206,8 @@ extension Date {
         }
 
         if days > 1 || (days == 1 && hours >= DateFormattingBreakpoints.halfADay.rawValue) {
-            return String(format: NSLocalizedString("%d days", comment: "Age between dates over one day."), niceComponents.day!)
+            let totalHours = (days * 24) + hours
+            return String(format: NSLocalizedString("%d days", comment: "Age between dates over one day."), Int(round(Float(totalHours) / Float(24))))
         }
 
         if hours > DateFormattingBreakpoints.almostADay.rawValue {
@@ -214,7 +215,8 @@ extension Date {
         }
 
         if hours > 1 || (hours == 1 && minutes >= DateFormattingBreakpoints.halfAnHour.rawValue) {
-            return String(format: NSLocalizedString("%d hours", comment: "Age between dates over one hour."), niceComponents.hour!)
+            let totalMinutes = (hours * 60) + minutes
+            return String(format: NSLocalizedString("%d hours", comment: "Age between dates over one hour."), Int(round(Float(totalMinutes) / Float(60))))
         }
 
         if minutes >= DateFormattingBreakpoints.almostAnHour.rawValue {

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -183,8 +183,6 @@ extension Date {
         let now = StatsDataHelper.currentDateForSite()
 
         let components = calendar.dateComponents([.minute, .hour, .day], from: self, to: now)
-        let niceComponents = calendar.dateComponents([.minute, .hour, .day, .month, .year], from: self, to: now)
-
         let days = components.day ?? 0
         let hours = components.hour ?? 0
         let minutes = components.minute ?? 0
@@ -206,7 +204,7 @@ extension Date {
         }
 
         if days >= DateFormattingBreakpoints.almostAMonth.rawValue {
-            return String(format: NSLocalizedString("a month", comment: "Age between dates equaling one month"))
+            return String(format: NSLocalizedString("a month", comment: "Age between dates equaling one month."))
         }
 
         if days > 1 || (days == 1 && hours >= DateFormattingBreakpoints.halfADay.rawValue) {
@@ -227,9 +225,7 @@ extension Date {
             return String(format: NSLocalizedString("an hour", comment: "Age between dates equaling one hour."))
         }
 
-        return NSLocalizedString("<1 hour", comment: "Age between dates less than one hour.")
-
-
+        return NSLocalizedString("< 1 hour", comment: "Age between dates less than one hour.")
     }
 
     private enum DateFormattingBreakpoints: Int {

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -214,7 +214,7 @@ extension Date {
             return String(format: NSLocalizedString("%d days", comment: "Age between dates over one day."), Int(round(Float(totalHours) / Float(24))))
         }
 
-        if hours > DateFormattingBreakpoints.almostADay.rawValue {
+        if days == 1 || hours > DateFormattingBreakpoints.almostADay.rawValue {
             return String(format: NSLocalizedString("a day", comment: "Age between dates equaling one day."))
         }
 
@@ -223,7 +223,7 @@ extension Date {
             return String(format: NSLocalizedString("%d hours", comment: "Age between dates over one hour."), Int(round(Float(totalMinutes) / Float(60))))
         }
 
-        if minutes >= DateFormattingBreakpoints.almostAnHour.rawValue {
+        if hours == 1 || minutes >= DateFormattingBreakpoints.almostAnHour.rawValue {
             return String(format: NSLocalizedString("an hour", comment: "Age between dates equaling one hour."))
         }
 


### PR DESCRIPTION
Fixes #12172 

This modifies the logic used to determine `relativeStringInPast` (used by Latest Post Summary and Followers).

- When a time falls into the `AndaHalf` categories, the time is now rounded accordingly.
  - Ex: previously 1.75 days would display as "1 days". Now it displays as "2 days".
- 1 day and 1 hour are now displayed as "a day" and "an hour". 
  - Previously, they would display as "1 days" and "1 hours".
- Updated month breakpoints to be more inline with Calypso.

To test:
- On sites with varying periods since the Latest Post Summary was published, go to Insights LPS.
- Verify the periods are as expected.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
