### PR TITLE
Improve VoiceOver in Me → Help & Support page

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -775,6 +775,7 @@ private extension ZendeskUtils {
         alertController.addTextField(configurationHandler: { textField in
             textField.clearButtonMode = .always
             textField.placeholder = LocalizedText.emailPlaceholder
+            textField.accessibilityLabel = LocalizedText.emailAccessibilityLabel
             textField.text = ZendeskUtils.sharedInstance.userEmail
             textField.isEnabled = false
 
@@ -788,6 +789,7 @@ private extension ZendeskUtils {
             alertController.addTextField { textField in
                 textField.clearButtonMode = .always
                 textField.placeholder = LocalizedText.namePlaceholder
+                textField.accessibilityLabel = LocalizedText.nameAccessibilityLabel
                 textField.text = ZendeskUtils.sharedInstance.userName
                 textField.delegate = ZendeskUtils.sharedInstance
                 textField.isEnabled = false
@@ -959,7 +961,9 @@ private extension ZendeskUtils {
         static let alertSubmit = NSLocalizedString("OK", comment: "Submit button on prompt for user information.")
         static let alertCancel = NSLocalizedString("Cancel", comment: "Cancel prompt for user information.")
         static let emailPlaceholder = NSLocalizedString("Email", comment: "Email address text field placeholder")
+        static let emailAccessibilityLabel = NSLocalizedString("Email", comment: "Accessibility label for the Email text field.")
         static let namePlaceholder = NSLocalizedString("Name", comment: "Name text field placeholder")
+        static let nameAccessibilityLabel = NSLocalizedString("Name", comment: "Accessibility label for the Email text field.")
     }
 
 }

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -776,6 +776,7 @@ private extension ZendeskUtils {
             textField.clearButtonMode = .always
             textField.placeholder = LocalizedText.emailPlaceholder
             textField.text = ZendeskUtils.sharedInstance.userEmail
+            textField.isEnabled = false
 
             textField.addTarget(self,
                                 action: #selector(emailTextFieldDidChange),
@@ -789,12 +790,19 @@ private extension ZendeskUtils {
                 textField.placeholder = LocalizedText.namePlaceholder
                 textField.text = ZendeskUtils.sharedInstance.userName
                 textField.delegate = ZendeskUtils.sharedInstance
+                textField.isEnabled = false
                 ZendeskUtils.sharedInstance.alertNameField = textField
             }
         }
 
         // Show alert
-        presentInController?.present(alertController, animated: true)
+        presentInController?.present(alertController, animated: true) {
+            // Enable text fields only after the alert is shown so that VoiceOver will dictate
+            // the message first. 
+            alertController.textFields?.forEach { textField in
+                textField.isEnabled = true
+            }
+        }
     }
 
     @objc static func emailTextFieldDidChange(_ textField: UITextField) {

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -280,6 +280,7 @@ private extension SupportTableViewController {
             WPStyleGuide.configureTableViewCell(cell)
             cell.textLabel?.textColor = .primary
             cell.showIndicator = showIndicator
+            cell.accessibilityTraits = .button
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -122,6 +122,7 @@ private extension SupportTableViewController {
             helpSectionRows.append(HelpRow(title: LocalizedText.myTickets, action: myTicketsSelected(), showIndicator: ZendeskUtils.showSupportNotificationIndicator))
             helpSectionRows.append(SupportEmailRow(title: LocalizedText.contactEmail,
                                                    value: ZendeskUtils.userSupportEmail() ?? LocalizedText.emailNotSet,
+                                                   accessibilityHint: LocalizedText.contactEmailAccessibilityHint,
                                                    action: supportEmailSelected()))
         } else {
             helpSectionRows.append(HelpRow(title: LocalizedText.wpForums, action: contactUsSelected()))
@@ -289,6 +290,7 @@ private extension SupportTableViewController {
 
         let title: String
         let value: String
+        let accessibilityHint: String
         let action: ImmuTableAction?
 
         func configureCell(_ cell: UITableViewCell) {
@@ -296,6 +298,8 @@ private extension SupportTableViewController {
             cell.detailTextLabel?.text = value
             WPStyleGuide.configureTableViewCell(cell)
             cell.textLabel?.textColor = .primary
+            cell.accessibilityTraits = .button
+            cell.accessibilityHint = accessibilityHint
         }
     }
 
@@ -320,6 +324,7 @@ private extension SupportTableViewController {
         static let activityLogs = NSLocalizedString("Activity Logs", comment: "Option in Support view to see activity logs.")
         static let informationFooter = NSLocalizedString("The Extra Debug feature includes additional information in activity logs, and can help us troubleshoot issues with the app.", comment: "Support screen footer text explaining the Extra Debug feature.")
         static let contactEmail = NSLocalizedString("Contact Email", comment: "Support email label.")
+        static let contactEmailAccessibilityHint = NSLocalizedString("Shows a dialog for changing the Contact Email.", comment: "Accessibility hint describing what happens if the Contact Email button is tapped.")
         static let emailNotSet = NSLocalizedString("Not Set", comment: "Display value for Support email field if there is no user email address.")
     }
 


### PR DESCRIPTION
Closes #12177.

This improves the accessibility of the Me → Help & Support page. 

## Changes 

| Where | What |
|--------|-------|
| <img src="https://user-images.githubusercontent.com/198826/61835270-3dd0b380-ae38-11e9-851e-f91219505c7f.PNG" width="240">       | 64af8f8  d752e17   The buttons _WordPress Help Center_, _Contact Us_, _My Tickets_, and _Contact Email_ are now dictated as "buttons". |
| <img src="https://user-images.githubusercontent.com/198826/61835289-4d4ffc80-ae38-11e9-8690-6b17e5eb02a9.PNG" width="240"> | eacb586 The message of the alert shown when pressing the _Contact Email_ is now dictated first. |
| <img src="https://user-images.githubusercontent.com/198826/61835288-4d4ffc80-ae38-11e9-9380-54e44f47fef2.PNG" width="240"> | b3aa0b5 Added labels to the text fields so the user can identify what the text field is for -- email or name. |

## That Contact Us Page

As described in #12177, the Contact Us page also has some accessibility issues. Unfortunately, these views are from the Zendesk SDK. I don't think there's anything we can do about that at this point. I'll send a request to Zendesk for this instead. 

## Testing

1. Navigate to Me → Help & Support.
2. Turn on VoiceOver. 
3. Hover over the places described above. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.

## Tasks

- [ ] Report accessibility suggestion to Zendesk