### PR TITLE
Stats Voiceover Audit: Fixes most popular hour and latest post summary header

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -220,15 +220,14 @@ private extension SiteStatsInsightsViewModel {
         }
 
         let timeFormatter = DateFormatter()
-        timeFormatter.dateStyle = .none
-        timeFormatter.timeStyle = .short
+        timeFormatter.setLocalizedDateFormatFromTemplate("h a")
 
         let timeString = timeFormatter.string(from: timeModifiedDate)
 
         return [StatsTwoColumnRowData.init(leftColumnName: MostPopularStats.bestDay,
                                    leftColumnData: dayString,
                                    rightColumnName: MostPopularStats.bestHour,
-                                   rightColumnData: timeString.replacingOccurrences(of: ":00", with: ""))]
+                                   rightColumnData: timeString.uppercased())]
     }
 
     func createTotalFollowersRows() -> [StatsTwoColumnRowData] {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -26,6 +26,7 @@ class StatsCellHeader: UITableViewCell, NibLoadable, Accessible {
     func configure(withTitle title: String, adjustHeightForPostStats: Bool = false) {
         headerLabel.text = title
         self.adjustHeightForPostStats = adjustHeightForPostStats
+        prepareForVoiceOver()
         applyStyles()
     }
 
@@ -45,7 +46,6 @@ private extension StatsCellHeader {
         Style.configureLabelAsHeader(headerLabel)
         configureManageInsightButton()
         updateStackView()
-        prepareForVoiceOver()
     }
 
     func updateStackView() {


### PR DESCRIPTION
Refs #11919 

Just a small PR to fix two of the stats audit issues.

1. The latest post summary header was being prepared for voiceover after styles were applied. This meant the accessibility label was set to "LATEST POST SUMMARY" (uppercased), which was read as "Latest P O S T summary". I've changed to prepare the accessibility label before the uppercasing happens.
2. The "most popular time" entry in Insights was displaying a localised hour number, but this wasn't necessarily clear even for users without accessibility issues. And with Voiceover, hearing "Best hour 17" was perhaps even less clear. Even living in a country that typically uses the 24 hour clock, I wouldn't usually expect to see the hour number on its own. I changed this to use a format of "12-hour hour AM/PM" – this matches Calypso: https://github.com/Automattic/wp-calypso/blob/69a6c225b85b3c828689362e825ef702989e1471/client/state/stats/lists/utils.js#L404

<img width="374" alt="image" src="https://user-images.githubusercontent.com/4780/61863132-f1808480-aec6-11e9-8181-a32a15873f22.png">

**To test:**

* Build and run
* Navigate to Insights in Stats
* Activate Voiceover
* Read the "Latest Post Summary" header at the top and check it sounds okay.
* Go down to the "Most Popular Time" block and check the "best hour" sounds okay.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.