### PR TITLE
Stats date bar: correct date used to determine back/forward availability

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
@@ -9,7 +9,7 @@ class StatsPeriodHelper {
 
     func dateAvailableBeforeDate(_ dateIn: Date, period: StatsPeriodUnit, backLimit: Int, mostRecentDate: Date? = nil) -> Bool {
         // Use dates without time
-        let currentDate =  mostRecentDate?.normalizedDate() ?? StatsDataHelper.currentDateForSite().normalizedDate()
+        let currentDate =  mostRecentDate?.normalizedDate() ?? StatsDataHelper.currentDateForSite().normalizedForSite()
 
         guard var oldestDate = calendar.date(byAdding: period.calendarComponent, value: backLimit, to: currentDate) else {
             return false
@@ -42,7 +42,7 @@ class StatsPeriodHelper {
 
     func dateAvailableAfterDate(_ dateIn: Date, period: StatsPeriodUnit, mostRecentDate: Date? = nil) -> Bool {
         // Use dates without time
-        let currentDate =  mostRecentDate?.normalizedDate() ?? StatsDataHelper.currentDateForSite().normalizedDate()
+        let currentDate =  mostRecentDate?.normalizedDate() ?? StatsDataHelper.currentDateForSite().normalizedForSite()
         let date = dateIn.normalizedDate()
 
         switch period {


### PR DESCRIPTION
Ref #12159 

Issues I noticed for sites with a timezone ahead of my local:
- When going back by one day I couldn't go forward again.
- The oldest day was one day older than it should have been.

This corrects the date used in the date comparison for the date bar.

To test:
On the Day period, verify:
- When going back a day (either via the bar or chart), you can go forward again to the most recent day.
- When going back to the oldest day (either via the bar or chart), the date bar disables going back further.

Please also test this with site timezones:
- Ahead of your local.
- Behind your local.
- Equal to your local.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
