### PR TITLE
Reader: Do not hide bars if VoiceOver is turned on

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -1007,6 +1007,14 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         }
 
         if hidden {
+            // Do not hide the navigation bars if VoiceOver is running because switching between
+            // hidden and visible causes the dictation to assume that the number of pages has
+            // changed. For example, when transitioning from hidden to visible, VoiceOver will
+            // dictate "page 4 of 4" and then dictate "page 5 of 5".
+            if UIAccessibility.isVoiceOverRunning {
+                return
+            }
+
             // Hides the navbar and footer view
             navigationController?.setNavigationBarHidden(true, animated: animated)
             currentPreferredStatusBarStyle = .default
@@ -1401,6 +1409,17 @@ extension ReaderDetailViewController: Accessible {
         prepareHeaderForVoiceOver()
         prepareContentForVoiceOver()
         prepareActionButtonsForVoiceOver()
+
+        NotificationCenter.default.addObserver(self,
+            selector: #selector(setBarsAsVisibleIfVoiceOverIsEnabled),
+            name: UIAccessibility.voiceOverStatusDidChangeNotification,
+            object: nil)
+    }
+
+    @objc func setBarsAsVisibleIfVoiceOverIsEnabled() {
+        if UIAccessibility.isVoiceOverRunning {
+            setBarsHidden(false)
+        }
     }
 
     private func prepareMenuForVoiceOver() {


### PR DESCRIPTION
Fixes #11486.

## Findings

At first, I thought that this can be fixed by simply adding a `setBarsHidden(false)` if the `contentOffset.y` is `0`. It worked. However, I found out that VoiceOver cannot properly dictate the total number of pages if the `scrollView`'s height is dynamic. The dictation looks like this:

| Action | Dictation |
|--------|-------|
| The user is halfway and scrolls down. | "Page 3 of 4" |
| The user scrolls to the bottom. | "Page 4 of 4" |
| The bars are automatically shown. | "Page 5 of 5" ¯\\\_(ツ)\_/¯ |

The change in the total pages can be confusing to the user.

## Solution

With this in mind, I opted to disallow hiding of the bars when VoiceOver is turned on. This keeps the dictated total pages static.

## Testing

1. Navigate to Reader.
2. Select a post to view.
3. Turn on VoiceOver.
4. Scroll down and up.

Please also test:

- Turning VoiceOver on when halfway on the page. The bars should be immediately shown.
- Possible regressions in the auto-showing and hiding of bars.

## Reviewing

Only 1 reviewer is needed but anyone can review.

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
