### PR TITLE
Stats details expandable rows: only rotate disclosure icon on selected row 

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -19,6 +19,10 @@ class StatsDataHelper {
     // Details table.
     static var expandedRowLabelsDetails = [StatSection: [String]]()
 
+    // Track when a detail row is updated.
+    // Used to determine if the disclosure icon needs animating.
+    static var detailRowDisclosureNeedsUpdating: String?
+
     class func updatedExpandedState(forRow row: StatsTotalRow, inDetails: Bool = false) {
 
         guard let rowData = row.rowData,
@@ -46,6 +50,7 @@ class StatsDataHelper {
 
         if inDetails {
             StatsDataHelper.expandedRowLabelsDetails = expandedRowsArray
+            detailRowDisclosureNeedsUpdating = rowData.name
         } else {
             StatsDataHelper.expandedRowLabels = expandedRowsArray
         }


### PR DESCRIPTION
Fixes #11743 

Since the whole detail view is refreshed when a row is expanded/collapsed, we need to know which row was selected. This adds a `detailRowDisclosureNeedsUpdating` property to `StatsDataHelper` to track that. 

When detail rows are recreated, only the disclosure icon for the row matching `detailRowDisclosureNeedsUpdating` is animated.

To test:
- Go to any detail view with expandable rows.
- Expand and collapse rows.
- Verify only the icon for the row selected is animated.

![icon_animation](https://user-images.githubusercontent.com/1816888/61902335-06691200-aedf-11e9-8f2f-b395066bb5c7.gif)


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
