### PR TITLE
SiteCreation: Dictate the headers first

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
@@ -61,6 +61,7 @@ final class TitleSubtitleHeader: UIView {
         ])
 
         setStyles()
+        prepareForVoiceOver()
     }
 
     private func setStyles() {
@@ -85,12 +86,12 @@ final class TitleSubtitleHeader: UIView {
 
     func setTitle(_ text: String) {
         titleLabel.text = text
-        titleLabel.accessibilityLabel = text
+        refreshAccessibilityLabel()
     }
 
     func setSubtitle(_ text: String) {
         subtitleLabel.text = text
-        subtitleLabel.accessibilityLabel = text
+        refreshAccessibilityLabel()
     }
 }
 
@@ -105,5 +106,20 @@ extension TitleSubtitleHeader {
     func preferredContentSizeDidChange() {
         // Title needs to be forced to reset its style, otherwise the types do not change
         styleTitle()
+    }
+}
+
+// MARK: - VoiceOver
+
+private extension TitleSubtitleHeader {
+    func prepareForVoiceOver() {
+        isAccessibilityElement = true
+        accessibilityTraits = .header
+        refreshAccessibilityLabel()
+    }
+
+    func refreshAccessibilityLabel() {
+        let strings = [titleLabel.text ?? "", subtitleLabel.text ?? ""]
+        accessibilityLabel = strings.joined(separator: ". ")
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
@@ -145,8 +145,6 @@ final class SiteInformationWizardContent: UIViewController {
         header.setTitle(headerData.title)
         header.setSubtitle(headerData.subtitle)
 
-        header.accessibilityTraits = .header
-
         table.tableHeaderView = header
 
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
@@ -61,6 +61,11 @@ final class SiteInformationWizardContent: UIViewController {
         startListeningToKeyboardNotifications()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        postScreenChangedForVoiceOver()
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         stopListeningToKeyboardNotifications()
@@ -402,5 +407,13 @@ extension SiteInformationWizardContent {
     private func keyboardWillHide(_ notification: Foundation.Notification) {
         buttonWrapper.clearShadow()
         bottomConstraint.constant = Constants.bottomMargin
+    }
+}
+
+// MARK: - VoiceOver
+
+private extension SiteInformationWizardContent {
+    func postScreenChangedForVoiceOver() {
+        UIAccessibility.post(notification: .screenChanged, argument: table.tableHeaderView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
@@ -53,6 +53,11 @@ final class SiteSegmentsWizardContent: UIViewController {
         observeNetworkStatus()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        postScreenChangedForVoiceOver()
+    }
+
     private func applyTitle() {
         title = NSLocalizedString("Create Site", comment: "Site creation. Step 1. Screen title")
     }
@@ -253,5 +258,9 @@ extension SiteSegmentsWizardContent: Accessible {
 
     private func prepareTableForVoiceOver() {
         table.accessibilityLabel = NSLocalizedString("The kinds of sites that can be created", comment: "Accessibility hint for list")
+    }
+
+    private func postScreenChangedForVoiceOver() {
+        UIAccessibility.post(notification: .screenChanged, argument: table.tableHeaderView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
@@ -110,8 +110,6 @@ final class SiteSegmentsWizardContent: UIViewController {
         header.setTitle(headerData.title)
         header.setSubtitle(headerData.subtitle)
 
-        header.accessibilityTraits = .header
-
         table.tableHeaderView = header
 
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
@@ -99,6 +99,7 @@ final class VerticalsWizardContent: UIViewController {
         super.viewDidAppear(animated)
         restoreSearchIfNeeded()
         selectionHandled = false
+        postScreenChangedForVoiceOver()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -514,5 +515,13 @@ extension VerticalsWizardContent {
 
     func preferredContentSizeDidChange() {
         tableViewOffsetCoordinator?.adjustTableOffsetIfNeeded()
+    }
+}
+
+// MARK: - VoiceOver
+
+private extension VerticalsWizardContent {
+    func postScreenChangedForVoiceOver() {
+        UIAccessibility.post(notification: .screenChanged, argument: table.tableHeaderView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -131,6 +131,7 @@ final class WebAddressWizardContent: UIViewController {
         super.viewDidAppear(animated)
         restoreSearchIfNeeded()
         allowTextFieldFirstResponder()
+        postScreenChangedForVoiceOver()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -487,5 +488,13 @@ extension WebAddressWizardContent {
 
     func preferredContentSizeDidChange() {
         tableViewOffsetCoordinator?.adjustTableOffsetIfNeeded()
+    }
+}
+
+// MARK: - VoiceOver
+
+private extension WebAddressWizardContent {
+    func postScreenChangedForVoiceOver() {
+        UIAccessibility.post(notification: .screenChanged, argument: table.tableHeaderView)
     }
 }


### PR DESCRIPTION
Fixes part of #12127. 

This focuses on improving the accessibility of the headers for Site Creation. 

<img src="https://user-images.githubusercontent.com/198826/61908486-096aff00-aeed-11e9-902a-8ac064bbc77f.PNG" width="320">

## Changes 

1.  1eddad0 The title and subtitle are now dictated together. 
2. 1698f2e When a new screen is shown, VoiceOver will select and dictate the first element on the screen. Unfortunately for us, this is usually the _Cancel_ or the _Back_ button. Following [Apple's guidelines](https://developer.apple.com/library/archive/featuredarticles/ViewControllerPGforiPhoneOS/SupportingAccessibility.html#//apple_ref/doc/uid/TP40007457-CH12-SW1), the headers are now dictated first. 

## Testing

1. Turn on VoiceOver.
2. Navigate to My Sites and press the plus button to create a new site.
3. Go over the Site Creation flow. 

Please test:

- That the headers are read together
- The headers are read first when the screens are shown

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
