### PR TITLE
Post Stats header: fixed cell and label heights

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.xib
@@ -13,33 +13,55 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" rowHeight="94" id="KGk-i7-Jjw" customClass="PostStatsTitleCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="406" height="71"/>
+            <rect key="frame" x="0.0" y="0.0" width="406" height="70"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="406" height="70.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="406" height="69.5"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Showing stats for:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VQc-hL-Bbc">
-                        <rect key="frame" x="16" y="16" width="374" height="16"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Site Name" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IAo-11-r7k">
-                        <rect key="frame" x="16" y="34" width="374" height="20.5"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q7F-mg-QOb" userLabel="Post Title Button">
-                        <rect key="frame" x="16" y="34" width="374" height="20.5"/>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kmu-MC-d7s" userLabel="Labels View">
+                        <rect key="frame" x="16" y="16" width="374" height="37.5"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Showing stats for:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VQc-hL-Bbc">
+                                <rect key="frame" x="0.0" y="0.0" width="374" height="16"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Site Name" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IAo-11-r7k">
+                                <rect key="frame" x="0.0" y="15" width="374" height="22.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="IAo-11-r7k" firstAttribute="top" secondItem="VQc-hL-Bbc" secondAttribute="bottom" constant="-1" id="Cef-n6-wKg"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="Cfr-1R-7TK"/>
+                            <constraint firstItem="VQc-hL-Bbc" firstAttribute="leading" secondItem="kmu-MC-d7s" secondAttribute="leading" id="DQ2-Uk-7hy"/>
+                            <constraint firstAttribute="trailing" secondItem="VQc-hL-Bbc" secondAttribute="trailing" id="LZP-bx-uCY"/>
+                            <constraint firstAttribute="bottom" secondItem="IAo-11-r7k" secondAttribute="bottom" id="SE3-eR-4RW"/>
+                            <constraint firstItem="VQc-hL-Bbc" firstAttribute="top" secondItem="kmu-MC-d7s" secondAttribute="top" id="Xgh-ok-xLa"/>
+                            <constraint firstAttribute="trailing" secondItem="IAo-11-r7k" secondAttribute="trailing" id="gNW-ys-hEp"/>
+                            <constraint firstItem="IAo-11-r7k" firstAttribute="leading" secondItem="kmu-MC-d7s" secondAttribute="leading" id="gWe-st-Bq5"/>
+                        </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="Cfr-1R-7TK"/>
+                            </mask>
+                        </variation>
+                    </view>
+                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q7F-mg-QOb" userLabel="Post Title Button">
+                        <rect key="frame" x="16" y="33" width="374" height="20.5"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <connections>
                             <action selector="didTapPostTitle:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="DVU-yE-MhC"/>
                         </connections>
                     </button>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dJu-H6-3qo" userLabel="Bottom Separator Line">
-                        <rect key="frame" x="0.0" y="70" width="406" height="0.5"/>
+                        <rect key="frame" x="0.0" y="69" width="406" height="0.5"/>
                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0.5" id="y0D-Z6-7PP"/>
@@ -47,20 +69,13 @@
                     </view>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="kmu-MC-d7s" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="0m8-gH-SnY"/>
+                    <constraint firstAttribute="trailing" secondItem="kmu-MC-d7s" secondAttribute="trailing" constant="16" id="1KZ-6V-3Bg"/>
                     <constraint firstAttribute="bottom" secondItem="dJu-H6-3qo" secondAttribute="bottom" id="MKS-QE-IDd"/>
-                    <constraint firstAttribute="bottom" secondItem="IAo-11-r7k" secondAttribute="bottom" constant="16" id="OAe-F1-q3m"/>
                     <constraint firstAttribute="trailing" secondItem="dJu-H6-3qo" secondAttribute="trailing" id="QCn-b6-3ob"/>
-                    <constraint firstItem="VQc-hL-Bbc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="TIp-2M-tkj"/>
-                    <constraint firstItem="q7F-mg-QOb" firstAttribute="bottom" secondItem="IAo-11-r7k" secondAttribute="bottom" id="Tom-tr-1Cc"/>
-                    <constraint firstItem="q7F-mg-QOb" firstAttribute="top" secondItem="IAo-11-r7k" secondAttribute="top" id="Xpe-ec-0aG"/>
-                    <constraint firstItem="IAo-11-r7k" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="Yni-Dp-MXW"/>
-                    <constraint firstItem="IAo-11-r7k" firstAttribute="top" secondItem="VQc-hL-Bbc" secondAttribute="bottom" constant="2" id="Zcd-Qe-cRI"/>
-                    <constraint firstItem="q7F-mg-QOb" firstAttribute="trailing" secondItem="IAo-11-r7k" secondAttribute="trailing" id="eGe-Ux-cg8"/>
-                    <constraint firstAttribute="trailing" secondItem="VQc-hL-Bbc" secondAttribute="trailing" constant="16" id="fB6-eP-9H9"/>
-                    <constraint firstItem="q7F-mg-QOb" firstAttribute="leading" secondItem="IAo-11-r7k" secondAttribute="leading" id="hxy-ew-stt"/>
-                    <constraint firstAttribute="trailing" secondItem="IAo-11-r7k" secondAttribute="trailing" constant="16" id="kch-C9-JS2"/>
+                    <constraint firstAttribute="bottom" secondItem="kmu-MC-d7s" secondAttribute="bottom" constant="16" id="YEv-TF-quq"/>
+                    <constraint firstItem="kmu-MC-d7s" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="ZCZ-Mb-8ya"/>
                     <constraint firstItem="dJu-H6-3qo" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="t4N-kv-EoQ"/>
-                    <constraint firstItem="VQc-hL-Bbc" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="uNe-Lu-pCh"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>


### PR DESCRIPTION
Fixes #11637 

To test:
- Access Post Stats for a post with a single line title.
- Verify the cell height is about 70pt.
- Verify there is less space around the title label.

<img width="400" alt="Screen Shot 2019-07-25 at 4 02 39 PM" src="https://user-images.githubusercontent.com/1816888/61911984-3cfe5700-aef6-11e9-91b1-566a8176b8c8.png">

- Access Post Stats for a post with a multi-line title.
- Verify it's still spaced properly.

<img width="400" alt="Screen Shot 2019-07-25 at 4 02 51 PM" src="https://user-images.githubusercontent.com/1816888/61911999-47205580-aef6-11e9-9d20-f7388e9fec97.png">

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
