### PR TITLE
Fix crash when syncing editor settings

### DIFF
--- a/WordPress/Classes/Services/EditorSettingsService.swift
+++ b/WordPress/Classes/Services/EditorSettingsService.swift
@@ -17,7 +17,7 @@ import Foundation
             do {
                 try self.saveRemoteEditorSettings(settings, on: blog)
             } catch {
-                failure(error)
+                return failure(error)
             }
             ContextManager.sharedInstance().save(self.managedObjectContext)
             success()


### PR DESCRIPTION
When the mobile setting is not set, the saveRemoteEditorSettings will throw an error. This will call the failure handler but it doesn't return, so it will also call success a couple of lines later.

This means that the handler in BlogService will call dispatch_group_leave once too many times and the app will crash.

This change makes sure the error case returns early and the sync method doesn't call their callbacks more than once.

To test:

Log in to the app with a site that doesn't have a setting for Mobile Gutenberg opt in (or force throwing an error in `saveRemoteEditorSettings`). The app shouldn't crash