### PR TITLE
Don't repeatedly show failed upload notices after auto retry

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -391,6 +391,7 @@ class MediaCoordinator: NSObject {
     ///                    called when changes occur to _any_ media item.
     /// - returns: A UUID that can be used to unregister the observer block at a later time.
     ///
+    @discardableResult
     func addObserver(_ onUpdate: @escaping ObserverBlock, for media: Media? = nil) -> UUID {
         let uuid = UUID()
 
@@ -413,7 +414,8 @@ class MediaCoordinator: NSObject {
     ///                   with this post via its media relationship.
     /// - returns: A UUID that can be used to unregister the observer block at a later time.
     ///
-    @discardableResult func addObserver(_ onUpdate: @escaping ObserverBlock, forMediaFor post: AbstractPost) -> UUID {
+    @discardableResult
+    func addObserver(_ onUpdate: @escaping ObserverBlock, forMediaFor post: AbstractPost) -> UUID {
         let uuid = UUID()
 
         let original = post.original ?? post


### PR DESCRIPTION
Fixes #12213.

Okay, so fixing this one was a doozy. What helped me get on the right path was a log submitted by a user in 2204495-zen. 

A relevant excerpt is:

```
019-07-25 10:22:10:808 🔵 Tracked: media_service_upload_failed <error_code: 2, error_description: Error Domain=Alamofire.AFError Code=2 "The system returned an error while checking the provided URL for reachability. 
URL: file:///var/mobile/Containers/Data/Application/8E539821-37D0-47C1-A310-791005ADD3D2/Documents/Media/IMG_5144.JPG 
Error: Error Domain=NSCocoaErrorDomain Code=260 "The file “IMG_5144.JPG” couldn’t be opened because there is no such file." UserInfo={NSURL=file:///var/mobile/Containers/Data/Application/8E539821-37D0-47C1-A310-791005ADD3D2/Documents/Media/IMG_5144.JPG, NSFilePath=/var/mobile/Containers/Data/Application/8E539821-37D0-47C1-A310-791005ADD3D2/Documents/Media/IMG_5144.JPG, NSUnderlyingError=0x283ed5410 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}", error_domain: Alamofire.AFError> 
```

It looks for whatever reason, sometimes we have a `Media` object that wasn't uploaded properly, that has it's underlying backing file disappear from the disk.

That's not, what we usually call, "good".

This "fixes" it in two ways:

1) by silencing all notices created from errors caused by auto-retries of Media. the user hasn't explicitely initiated that action, so we shouldn't bother it with it. 
// ^- this is VERY MUCH open for discussion if it's the right thing to do in the long run. cc @wordpress-mobile/ravenclaw

2) by adding a error handler to check if an upload failed specifically because of the underlying file being gone, that then sends a log to sentry and deletes the `Media` object if that happens, since there isn't really a meaningful way for us to recover from that.

___

This is, like everything to do with this issue, a nightmare to test. The "simplest" way I found to trigger the underlying bug is so far this:

To test (*must* be done on Simulator):
1. Enable Network Link Conditioner on your Mac, with a `Very Bad Network` or `100% Packet Loss` Presets
1. Build latest `develop`
2. Go to Media Library
3. Add a new picture from your device (using the "Choose from My Device") option
4. Verify it fails to upload
5. Locate the file on disk (I usually just do `po NSHomeDirectory()` and `cd` to `Documents/Media` in iTerm) and delete it.
5. Turn off Network Link Conditioner
6. Relaunch the app
7. Verify that the "1 post, 1 file not uploaded" Notice shows up.


Now that you've been able to _reproduce_ the issue,
1. build the branch this PR is pointing to
2. launch the app
3. verify that the notice no longer shows up
4. go to media library and verify that the "broken" media object is no longer there
5. cry inside a bit how about how complicated media handling inherently is
6. **REMEMBER TO TURN OFF YOUR NETWORK LINK CONDITIONER**

