### PR TITLE
Limits auto-uploading temporarily.

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -256,7 +256,7 @@ extension PostCoordinator: Uploader {
             }
 
             posts.forEach() { post in
-                let shouldRetry = post.status == .draft && (!post.hasRemote() || post.original?.status == .draft)
+                let shouldRetry = post.status == .draft && !post.hasRemote()
 
                 if shouldRetry {
                     self.retrySave(of: post)

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -255,7 +255,13 @@ extension PostCoordinator: Uploader {
                 return
             }
 
-            posts.forEach() { self.retrySave(of: $0 ) }
+            posts.forEach() { post in
+                let shouldRetry = post.status == .draft && (!post.hasRemote() || post.original?.status == .draft)
+
+                if shouldRetry {
+                    self.retrySave(of: post)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
In this PR we're limiting auto-uploading of posts temporarily to new drafts or existing drafts that haven't changed status.

## To test:

Make sure you comment these lines out, so that we can have a post in CoreData that failed to publish without its status being changed to draft.

https://github.com/wordpress-mobile/WordPress-iOS/blob/c8403092a99194637e7917c0f24ca16d27ba650b/WordPress/Classes/Services/PostService.m#L263-L266

Make sure you test this using a device, as the simulator seems to have some issues with reachability.

1. Go offline
2. Create a new post
3. Publish the post
4. Create a new draft
5. Save the draft
6. Make sure both are marked as failed.
7. Reconnect the device and make sure that the published post isn't uploaded, but the draft is.

## Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.