### PR TITLE
Some iOS 13 fixes!

### DIFF
--- a/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
@@ -37,6 +37,7 @@ extension WPStyleGuide {
         navigationAppearance.barTintColor = .navigationBar
         navigationAppearance.barStyle = .black
 
+#if XCODE11
         if #available(iOS 13.0, *) {
             // Required to fix detail navigation controller appearance due to https://stackoverflow.com/q/56615513
             let appearance = UINavigationBarAppearance()
@@ -46,6 +47,7 @@ extension WPStyleGuide {
             navigationAppearance.standardAppearance = appearance
             navigationAppearance.scrollEdgeAppearance = navigationAppearance.standardAppearance
         }
+#endif
 
         let buttonBarAppearance = UIBarButtonItem.appearance()
         buttonBarAppearance.tintColor = .textInverted

--- a/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
@@ -37,6 +37,16 @@ extension WPStyleGuide {
         navigationAppearance.barTintColor = .navigationBar
         navigationAppearance.barStyle = .black
 
+        if #available(iOS 13.0, *) {
+            // Required to fix detail navigation controller appearance due to https://stackoverflow.com/q/56615513
+            let appearance = UINavigationBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = .brand
+            appearance.titleTextAttributes = [.foregroundColor: UIColor.textInverted]
+            navigationAppearance.standardAppearance = appearance
+            navigationAppearance.scrollEdgeAppearance = navigationAppearance.standardAppearance
+        }
+
         let buttonBarAppearance = UIBarButtonItem.appearance()
         buttonBarAppearance.tintColor = .textInverted
         buttonBarAppearance.setTitleTextAttributes([NSAttributedString.Key.font: WPFontManager.systemRegularFont(ofSize: 17.0),

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -769,7 +769,7 @@ extension WordPressAppDelegate {
 
 extension WordPressAppDelegate {
     func customizeAppearance() {
-        window?.backgroundColor = WPStyleGuide.itsEverywhereGrey()
+        window?.backgroundColor = .black
         window?.tintColor = WPStyleGuide.wordPressBlue()
 
         WPStyleGuide.configureTabBarAppearance()

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1520,7 +1520,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
             FancyAlertViewController *alert = [FancyAlertViewController makeNotificationPrimerAlertControllerWithApproveAction:^(FancyAlertViewController* controller) {
                 [[InteractiveNotificationsManager shared] requestAuthorizationWithCompletion:^() {
-                    [controller dismissViewControllerAnimated:true completion:^{}];
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        [controller dismissViewControllerAnimated:true completion:^{}];
+                    });
                 }];
             }];
             alert.modalPresentationStyle = UIModalPresentationCustom;

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1312,7 +1312,7 @@ private extension NotificationsViewController {
     }
 
     func loadNotification(near note: Notification, withIndexDelta delta: Int) -> Notification? {
-        guard let notifications = tableViewHandler.resultsController.fetchedObjects as? [Notification] else {
+        guard let notifications = tableViewHandler?.resultsController.fetchedObjects as? [Notification] else {
             return nil
         }
 


### PR DESCRIPTION
Refs #12211. This PR fixes some issues from 12211:

- Changes the window color to black to improve the appearance of the new style modal windows.
- Navigation bars in splitview detail controllers should now have correct styling. After these fixes I was seeing an issue on the iPad simulator where the status bar is incorrectly being colored `.darkContent`, but the iPhone simulators and my iPhone device are fine. If you could test on an iPad that'd be great.
- Fixes a crash when the notifications alert on first launch was dismissed.
- Fixes a crash when accessing the Notifications screen.

**To test:**

- Build and run (fresh install) with Xcode 11, iOS 13 SDK
- [ ] Check the login screen (which is still an incorrect type of modal) shows black behind it at the top
- Log in
- [ ] Say Yes to the notifications popup. Once it's been dismissed, ensure there's not a crash.
- [ ] On an iPad device or simulator, check that the detail view doesn't have a grey navigation bar and the title and buttons look correct.
- [ ] Tap on the Notifications tab and ensure there isn't a crash.
- [ ] Please also check the app still builds and runs correctly on iOS 12

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
