### PR TITLE
Add + icon back to Posts list

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
+++ b/WordPress/Classes/ViewRelated/Pages/Pages.storyboard
@@ -60,40 +60,14 @@
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <nil key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="addButton" destination="AUi-GI-97s" id="D1f-jZ-iVb"/>
                         <outlet property="filterTabBar" destination="kb7-5Y-cyY" id="yfM-1V-Kgn"/>
                         <outlet property="filterTabBarBottomConstraint" destination="VTs-hm-pCI" id="8xw-da-7bY"/>
                         <outlet property="filterTabBarTopConstraint" destination="Iu4-wT-NJl" id="ncb-1g-VsV"/>
                         <outlet property="filterTabBariOS10TopConstraint" destination="N3R-GK-VXe" id="qgA-sx-Yrb"/>
-                        <outlet property="rightBarButtonView" destination="eMR-fX-0uB" id="tkm-aq-s67"/>
                         <outlet property="tableViewTopConstraint" destination="hqa-P7-bPN" id="Mas-aT-2OZ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qQg-Lr-ANj" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <view clipsSubviews="YES" contentMode="scaleToFill" id="eMR-fX-0uB">
-                    <rect key="frame" x="0.0" y="0.0" width="80" height="44"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AUi-GI-97s">
-                            <rect key="frame" x="40" y="0.0" width="40" height="44"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="40" id="csV-Ow-Cyb"/>
-                            </constraints>
-                            <state key="normal" image="icon-post-add">
-                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="highlighted" image="icon-post-add-highlight"/>
-                            <connections>
-                                <action selector="handleAddButtonTapped:" destination="RgW-to-XfM" eventType="touchUpInside" id="vcJ-37-Dhr"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <constraints>
-                        <constraint firstAttribute="trailing" secondItem="AUi-GI-97s" secondAttribute="trailing" id="BBb-fa-dJF"/>
-                        <constraint firstAttribute="bottom" secondItem="AUi-GI-97s" secondAttribute="bottom" id="cqe-SB-jlh"/>
-                        <constraint firstItem="AUi-GI-97s" firstAttribute="top" secondItem="eMR-fX-0uB" secondAttribute="top" id="hWW-a3-5U0"/>
-                    </constraints>
-                </view>
             </objects>
             <point key="canvasLocation" x="517.60000000000002" y="317.99100449775113"/>
         </scene>
@@ -194,8 +168,4 @@
             <point key="canvasLocation" x="1240.8" y="1047.5262368815593"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="icon-post-add" width="22" height="22"/>
-        <image name="icon-post-add-highlight" width="22" height="22"/>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Gridicons
 import CocoaLumberjack
 import WordPressShared
 import wpxmlrpc
@@ -123,8 +124,10 @@ class AbstractPostListViewController: UIViewController,
     @objc var postListFooterView: PostListFooterView!
 
     @IBOutlet var filterTabBar: FilterTabBar!
-    @IBOutlet var rightBarButtonView: UIView!
-    @IBOutlet var addButton: UIButton!
+
+    @objc lazy var addButton: UIBarButtonItem = {
+        return UIBarButtonItem(image: Gridicon.iconOfType(.plus), style: .plain, target: self, action: #selector(handleAddButtonTapped))
+    }()
 
     @objc var searchController: UISearchController!
     @objc var recentlyTrashedPostObjectIDs = [NSManagedObjectID]() // IDs of trashed posts. Cleared on refresh or when filter changes.
@@ -226,10 +229,7 @@ class AbstractPostListViewController: UIViewController,
         //
         let backButton = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
         navigationItem.backBarButtonItem = backButton
-
-        let rightBarButtonItem = UIBarButtonItem(customView: rightBarButtonView)
-        rightBarButtonItem.width = rightBarButtonView.frame.size.width
-        WPStyleGuide.setRightBarButtonItemWithCorrectSpacing(rightBarButtonItem, for: navigationItem)
+        navigationItem.rightBarButtonItem = addButton
     }
 
     func configureFilterBar() {
@@ -371,7 +371,6 @@ class AbstractPostListViewController: UIViewController,
 
     func hideNoResultsView() {
         postListFooterView.isHidden = false
-        rightBarButtonView.isHidden = false
         noResultsViewController.removeFromView()
     }
 
@@ -382,7 +381,6 @@ class AbstractPostListViewController: UIViewController,
         }
 
         postListFooterView.isHidden = true
-        rightBarButtonView.isHidden = true
         refreshNoResultsViewController(noResultsViewController)
 
         // Only add no results view if it isn't already in the table view
@@ -559,7 +557,7 @@ class AbstractPostListViewController: UIViewController,
         WPAnalytics.track(.postListPullToRefresh, withProperties: propertiesForAnalytics())
     }
 
-    @IBAction func handleAddButtonTapped(_ sender: AnyObject) {
+    @objc func handleAddButtonTapped() {
         createPost()
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -160,11 +160,11 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         configureFilterBarTopConstraint()
         configureGhost()
 
-        configurePostViewButtonItem()
+        configureNavigationButtons()
     }
 
-    func configurePostViewButtonItem() {
-        navigationItem.rightBarButtonItems = [postsViewButtonItem]
+    func configureNavigationButtons() {
+        navigationItem.rightBarButtonItems = [addButton, postsViewButtonItem]
     }
 
     @objc func togglePostsView() {

--- a/WordPress/Classes/ViewRelated/Post/Posts.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Posts.storyboard
@@ -60,40 +60,15 @@
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <nil key="simulatedBottomBarMetrics"/>
                     <connections>
-                        <outlet property="addButton" destination="9Az-zB-Hwe" id="r4s-oX-gyT"/>
                         <outlet property="filterTabBar" destination="Nmf-Iz-jkG" id="Ydz-ff-EUy"/>
                         <outlet property="filterTabBarBottomConstraint" destination="Hb8-6N-iSm" id="GsJ-Hc-dE5"/>
                         <outlet property="filterTabBarTopConstraint" destination="ZFh-Do-F2v" id="hq3-Iz-dZu"/>
                         <outlet property="filterTabBariOS10TopConstraint" destination="fGy-cf-WIB" id="2s9-pa-9Ee"/>
-                        <outlet property="rightBarButtonView" destination="8Ph-e4-iOe" id="V4F-lw-glT"/>
                         <outlet property="searchWrapperView" destination="sFK-WP-z2Z" id="CJ1-ul-bLt"/>
                         <outlet property="tableViewTopConstraint" destination="UwE-7o-GHb" id="4mJ-Ry-6Xa"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="mrN-zD-yTr" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Ph-e4-iOe">
-                    <rect key="frame" x="0.0" y="0.0" width="80" height="44"/>
-                    <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9Az-zB-Hwe">
-                            <rect key="frame" x="40" y="0.0" width="40" height="44"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="40" id="Moj-01-1lI"/>
-                            </constraints>
-                            <state key="normal" image="icon-post-add">
-                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            </state>
-                            <state key="highlighted" image="icon-post-add-highlight"/>
-                            <connections>
-                                <action selector="handleAddButtonTapped:" destination="VTO-0U-HpP" eventType="touchUpInside" id="fEv-yc-HXV"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <constraints>
-                        <constraint firstItem="9Az-zB-Hwe" firstAttribute="top" secondItem="8Ph-e4-iOe" secondAttribute="top" id="Hjj-Ra-6M9"/>
-                        <constraint firstAttribute="trailing" secondItem="9Az-zB-Hwe" secondAttribute="trailing" id="STW-Iw-FBG"/>
-                        <constraint firstAttribute="bottom" secondItem="9Az-zB-Hwe" secondAttribute="bottom" id="Usu-ZA-zoK"/>
-                    </constraints>
-                </view>
                 <view contentMode="scaleToFill" id="sFK-WP-z2Z" customClass="SearchWrapperView" customModule="WordPress" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="0.0" width="600" height="88"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -126,8 +101,4 @@
             <point key="canvasLocation" x="1202" y="318"/>
         </scene>
     </scenes>
-    <resources>
-        <image name="icon-post-add" width="22" height="22"/>
-        <image name="icon-post-add-highlight" width="22" height="22"/>
-    </resources>
 </document>


### PR DESCRIPTION
Fixes #12219. This PR reintroduces the + button to the Posts list. I also switched both Pages and Posts to use a gridicon icon for consistency, and just use the system spacing instead of doing our own thing.

<img width="413" alt="Screenshot 2019-07-29 at 14 04 13" src="https://user-images.githubusercontent.com/4780/62050731-c4efa400-b209-11e9-8f2d-4dc4e53e8cab.png">

**To test:**

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

I haven't updated the release notes yet. If we can get this into 12.9 too then a release note won't be necessary as nobody will ever notice the button was gone.