### PR TITLE
Stats: Add File Downloads to Period view

### DIFF
--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -1083,12 +1083,12 @@ extension StatsPeriodStore {
         guard let downloads = state.topFileDownloads else {
             return nil
         }
-        
+
         var fileDownloads = [StatsFileDownload]()
         for num in 1...10 {
             fileDownloads.append(StatsFileDownload(file: "file\(num).ext", downloadCount: 666999))
         }
-        
+
         return StatsFileDownloadsTimeIntervalData(period: downloads.period,
                                                   periodEndDate: downloads.periodEndDate,
                                                   fileDownloads: fileDownloads,

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -1071,7 +1071,29 @@ extension StatsPeriodStore {
     }
 
     func getTopFileDownloads() -> StatsFileDownloadsTimeIntervalData? {
+
+        // Enable this to see File Downloads with stub data.
+        // return stubFileDownloads()
+
         return state.topFileDownloads
+    }
+
+    // TODO: remove when File Downloads endpoint is live.
+    func stubFileDownloads() -> StatsFileDownloadsTimeIntervalData? {
+        guard let downloads = state.topFileDownloads else {
+            return nil
+        }
+        
+        var fileDownloads = [StatsFileDownload]()
+        for num in 1...10 {
+            fileDownloads.append(StatsFileDownload(file: "file\(num).ext", downloadCount: 666999))
+        }
+        
+        return StatsFileDownloadsTimeIntervalData(period: downloads.period,
+                                                  periodEndDate: downloads.periodEndDate,
+                                                  fileDownloads: fileDownloads,
+                                                  totalDownloadsCount: downloads.totalDownloadsCount,
+                                                  otherDownloadsCount: downloads.otherDownloadsCount)
     }
 
     func getPostStats(for postId: Int?) -> StatsPostDetails? {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -5,6 +5,7 @@ enum FeatureFlag: Int {
     case exampleFeature
     case jetpackDisconnect
     case statsRefresh
+    case statsFileDownloads
     case domainCredit
     case murielColors
 
@@ -17,6 +18,8 @@ enum FeatureFlag: Int {
             return BuildConfiguration.current == .localDeveloper
         case .statsRefresh:
             return true
+        case .statsFileDownloads:
+            return BuildConfiguration.current == .localDeveloper
         case .domainCredit:
             return true
         case .murielColors:

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -11,6 +11,7 @@
     case periodSearchTerms
     case periodPublished
     case periodVideos
+    case periodFileDownloads
     case insightsLatestPostSummary
     case insightsAllTime
     case insightsFollowerTotals
@@ -55,7 +56,8 @@
                              .periodCountries,
                              .periodSearchTerms,
                              .periodPublished,
-                             .periodVideos
+                             .periodVideos,
+                             .periodFileDownloads
     ]
 
     static let allPostStats = [StatSection.postStatsGraph,
@@ -106,6 +108,8 @@
             return PeriodHeaders.published
         case .periodVideos:
             return PeriodHeaders.videos
+        case .periodFileDownloads:
+            return PeriodHeaders.fileDownloads
         case .postStatsMonthsYears:
             return PostStatsHeaders.monthsAndYears
         case .postStatsAverageViews:
@@ -142,6 +146,8 @@
             return ItemSubtitles.searchTerm
         case .postStatsMonthsYears, .postStatsAverageViews, .postStatsRecentWeeks:
             return ItemSubtitles.period
+        case .periodFileDownloads:
+            return ItemSubtitles.file
         default:
             return ""
         }
@@ -170,6 +176,8 @@
             return DataSubtitles.since
         case .periodClicks:
             return DataSubtitles.clicks
+        case .periodFileDownloads:
+            return DataSubtitles.downloads
         default:
             return ""
         }
@@ -265,6 +273,7 @@
         static let searchTerms = NSLocalizedString("Search Terms", comment: "Period Stats 'Search Terms' header")
         static let published = NSLocalizedString("Published", comment: "Period Stats 'Published' header")
         static let videos = NSLocalizedString("Videos", comment: "Period Stats 'Videos' header")
+        static let fileDownloads = NSLocalizedString("File Downloads", comment: "Period Stats 'File Downloads' header")
     }
 
     struct PostStatsHeaders {
@@ -283,6 +292,7 @@
         static let country = NSLocalizedString("Country", comment: "Label for list of countries.")
         static let searchTerm = NSLocalizedString("Search Term", comment: "Label for list of search term")
         static let period = NSLocalizedString("Period", comment: "Label for date periods.")
+        static let file = NSLocalizedString("File", comment: "Label for list of file downloads.")
     }
 
     struct DataSubtitles {
@@ -291,6 +301,7 @@
         static let followers = NSLocalizedString("Followers", comment: "Label for number of followers.")
         static let since = NSLocalizedString("Since", comment: "Label for time period in list of followers.")
         static let clicks = NSLocalizedString("Clicks", comment: "Label for number of clicks.")
+        static let downloads = NSLocalizedString("Downloads", comment: "Label for number of file downloads.")
     }
 
     struct TabTitles {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -89,6 +89,11 @@ class SiteStatsPeriodViewModel: Observable {
         tableRows.append(contentsOf: searchTermsTableRows())
         tableRows.append(contentsOf: publishedTableRows())
         tableRows.append(contentsOf: videosTableRows())
+
+        if FeatureFlag.statsFileDownloads.enabled {
+            tableRows.append(contentsOf: fileDownloadsTableRows())
+        }
+
         tableRows.append(TableFooterRow())
 
         return ImmuTable(sections: [
@@ -490,6 +495,24 @@ private extension SiteStatsPeriodViewModel {
                                                                                icon: Style.imageForGridiconType(.video),
                                                                                showDisclosure: true,
                                                                                statSection: .periodVideos) }
+            ?? []
+    }
+
+    func fileDownloadsTableRows() -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+        tableRows.append(CellHeaderRow(title: StatSection.periodFileDownloads.title))
+        tableRows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodFileDownloads.itemSubtitle,
+                                                 dataSubtitle: StatSection.periodFileDownloads.dataSubtitle,
+                                                 dataRows: fileDownloadsDataRows(),
+                                                 siteStatsPeriodDelegate: periodDelegate))
+        
+        return tableRows
+    }
+    
+    func fileDownloadsDataRows() -> [StatsTotalRowData] {
+        return store.getTopFileDownloads()?.fileDownloads.prefix(10).map { StatsTotalRowData(name: $0.file,
+                                                                                             data: $0.downloadCount.abbreviatedString(),
+                                                                                             statSection: .periodFileDownloads) }
             ?? []
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -505,10 +505,10 @@ private extension SiteStatsPeriodViewModel {
                                                  dataSubtitle: StatSection.periodFileDownloads.dataSubtitle,
                                                  dataRows: fileDownloadsDataRows(),
                                                  siteStatsPeriodDelegate: periodDelegate))
-        
+
         return tableRows
     }
-    
+
     func fileDownloadsDataRows() -> [StatsTotalRowData] {
         return store.getTopFileDownloads()?.fileDownloads.prefix(10).map { StatsTotalRowData(name: $0.file,
                                                                                              data: $0.downloadCount.abbreviatedString(),


### PR DESCRIPTION
Ref #11963 

This adds _File Downloads_ to the period views. 

Since the endpoint isn't returning data yet:
- There is a `statsFileDownloads` FeatureFlag, just in case.
- There is a temporary method (`stubFileDownloads`) that can be used to simulate displaying data.

To test:

---
- Go to any period.
- Verify _File Downloads_ appears at the bottom, with the `No data` message.

<img width="400" alt="no_data" src="https://user-images.githubusercontent.com/1816888/62091756-c46a0400-b22f-11e9-86ae-5a197d1a9736.png">

---
- Disable the `statsFileDownloads` FeatureFlag.
- Verify _File Downloads_ does not appear.

---
To test with stub data:
- In `StatsPeriodStore:getTopFileDownloads`, enable `return stubFileDownloads()`.
- Verify _File Downloads_ appears.
- NOTE: `View more` does not work just yet. That will be in a future PR.

<img width="400" alt="with_data" src="https://user-images.githubusercontent.com/1816888/62091896-5bcf5700-b230-11e9-9d98-522e3076220f.png">

---
Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
