### PR TITLE
CircleCI: Run UI tests on every PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2.1
 
 orbs:
   ios: wordpress-mobile/ios@0.0.29
-  slack: circleci/slack@2.5.0
 
 jobs:
   build-ui-tests:
@@ -44,16 +43,6 @@ jobs:
           command: test-without-building
           arguments: -xctestrun DerivedData/Build/Products/WordPressUITests_iphonesimulator12.2-x86_64.xctestrun -destination "platform=iOS Simulator,id=$SIMULATOR_UDID"
       - ios/save-xcodebuild-artifacts
-      - run:
-          name: Prepare Slack message
-          when: always
-          command: |
-            # Get the name of the device that is running. Using "<< parameters.device >>" can cause slack formatting errors.
-            DEVICE_NAME=$(xcrun simctl list -j | jq -r --arg UDID $SIMULATOR_UDID '.devices[] | .[] | select(.udid == "\($UDID)") | .name')
-            echo "export SLACK_FAILURE_MESSAGE=':red_circle: WordPress iOS UI tests have failed on ${DEVICE_NAME}!'" >> $BASH_ENV
-      - slack/status:
-          fail_only: 'true'
-          failure_message: '${SLACK_FAILURE_MESSAGE}'
 
 workflows:
   wordpress_ios:
@@ -65,13 +54,6 @@ workflows:
           scheme: WordPress
           device: iPhone XS
   ui_tests:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - develop
     jobs:
       - build-ui-tests:
           name: Build UI Tests


### PR DESCRIPTION
The UI tests have now been running nightly for several weeks and have proved to be reliable. This enables running them on every PR. It means that PRs will take a little longer to go green, but should only be a few minutes longer than now.

There is potential to improve run time by parallelizing the unit tests and UI tests building but that can be an improvement for later.

To test:

- UI tests for iPhone XS and iPad 6th gen are green on this PR.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
