### PR TITLE
[Gutenberg] Fix showing autoenable dialog after migration

### DIFF
--- a/WordPress/Classes/Utility/Editor/EditorFactory.swift
+++ b/WordPress/Classes/Utility/Editor/EditorFactory.swift
@@ -27,6 +27,7 @@ class EditorFactory {
             gutenbergSettings.setGutenbergEnabled(true, for: post.blog)
             gutenbergSettings.postSettingsToRemote(for: post.blog)
             gutenbergVC.shouldPresentInformativeDialog = true
+            gutenbergSettings.willShowDialog(for: post.blog)
         }
 
         return gutenbergVC

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -87,12 +87,16 @@ class GutenbergSettings {
 
     /// True if gutenberg editor has been enabled at least once on the given blog
     func wasGutenbergEnabledOnce(for blog: Blog) -> Bool {
-        return database.object(forKey: Key.enabledOnce(for: blog)) != nil
+        return database.object(forKey: Key.enabledOnce(for: blog)) != nil || database.object(forKey: Key.appWideEnabled) != nil
     }
 
     /// True if gutenberg should be autoenabled for the blog hosting the given post.
     func shouldAutoenableGutenberg(for post: AbstractPost) -> Bool {
         return !wasGutenbergEnabledOnce(for: post.blog)
+    }
+
+    func willShowDialog(for blog: Blog) {
+        database.set(true, forKey: Key.enabledOnce(for: blog))
     }
 
     // MARK: - Gutenberg Choice Logic

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -7,7 +7,7 @@ class GutenbergSettings {
     enum Key {
         static let appWideEnabled = "kUserDefaultsGutenbergEditorEnabled"
         static func enabledOnce(for blog: Blog) -> String {
-            let url = (blog.displayURL ?? "") as String
+            let url = (blog.url ?? "") as String
             return "com.wordpress.gutenberg-autoenabled-" + url
         }
     }
@@ -87,7 +87,7 @@ class GutenbergSettings {
 
     /// True if gutenberg editor has been enabled at least once on the given blog
     func wasGutenbergEnabledOnce(for blog: Blog) -> Bool {
-        return database.object(forKey: Key.enabledOnce(for: blog)) != nil || database.object(forKey: Key.appWideEnabled) != nil
+        return database.object(forKey: Key.enabledOnce(for: blog)) != nil
     }
 
     /// True if gutenberg should be autoenabled for the blog hosting the given post.

--- a/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
+++ b/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
@@ -4,10 +4,17 @@ class BlogToBlogMigration87to88: NSEntityMigrationPolicy {
     override func createRelationships(forDestination dInstance: NSManagedObject, in mapping: NSEntityMapping, manager: NSMigrationManager) throws {
         try super.createRelationships(forDestination: dInstance, in: mapping, manager: manager)
 
-        let isGutenbergEnabled = UserDefaults.standard.object(forKey: "kUserDefaultsGutenbergEditorEnabled") as? Bool ?? false
+        let gutenbergEnabledFlag = UserDefaults.standard.object(forKey: "kUserDefaultsGutenbergEditorEnabled") as? Bool
+        let isGutenbergEnabled = gutenbergEnabledFlag ?? false
         let editor = isGutenbergEnabled ? "gutenberg" : "aztec"
 
         dInstance.setValue(editor, forKey: "mobileEditor")
+
+        if gutenbergEnabledFlag != nil {
+            let url = dInstance.value(forKey: "url") as? String ?? ""
+            let perSiteEnabledKey = "com.wordpress.gutenberg-autoenabled-"+url
+            UserDefaults.standard.set(true, forKey: perSiteEnabledKey)
+        }
     }
 
     override func end(_ mapping: NSEntityMapping, manager: NSMigrationManager) throws {

--- a/WordPress/WordPressTest/GutenbergSettingsTests.swift
+++ b/WordPress/WordPressTest/GutenbergSettingsTests.swift
@@ -152,6 +152,7 @@ class GutenbergSettingsTests: XCTestCase {
 
     func testAutoenableOnNewPostAndNewBlogs() {
         settings.softSetGutenbergEnabled(true, for: blog)
+        settings.setGutenbergEnabled(true, for: blog) // Called after sync
 
         XCTAssertTrue(mustUseGutenberg)
         XCTAssertTrue(shouldAutoenableGutenberg)
@@ -159,6 +160,8 @@ class GutenbergSettingsTests: XCTestCase {
 
     func testAutoenableOnExistingPostAndNewBlogs() {
         settings.softSetGutenbergEnabled(true, for: blog)
+        settings.setGutenbergEnabled(true, for: blog) // Called after sync
+
         post.content = gutenbergContent
 
         XCTAssertTrue(mustUseGutenberg)
@@ -167,11 +170,12 @@ class GutenbergSettingsTests: XCTestCase {
 
     func testAutoenableOnNewBlogsOccoursOnlyOnce() {
         settings.softSetGutenbergEnabled(true, for: blog)
+        settings.setGutenbergEnabled(true, for: blog) // Called after sync
 
         XCTAssertTrue(mustUseGutenberg)
         XCTAssertTrue(shouldAutoenableGutenberg)
 
-        settings.willShowDialog(for: blog)
+        settings.willShowDialog(for: blog) // Called by EditorFactory
 
         XCTAssertFalse(shouldAutoenableGutenberg)
     }
@@ -214,7 +218,6 @@ class GutenbergSettingsTests: XCTestCase {
         blog.mobileEditor = editor
 
         if gutenbergEnabledFlag != nil {
-            let url = blog.url ?? ""
             let perSiteEnabledKey = GutenbergSettings.Key.enabledOnce(for: blog)
             database.set(true, forKey: perSiteEnabledKey)
         }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/pull/12221#issuecomment-516079036

I tried to avoid adding the change on the migration to not need to modify the key used for per-site gutenberg enabled once. But the migration alternative feels a bit more "correct" (?).

I also added a set of tests to cover our backs regarding the autoenable logic and requirements.
If you notice there are some cases not covered by the tests please let me know.

To test:
- Migrate from v12.9 with GB ON, start new post → should be Gutenberg in all sites
- Should not show the autoenable dialog on new gutenberg post.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
