### PR TITLE
Stats: Add File Download details

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -189,6 +189,8 @@ private extension SiteStatsDetailTableViewController {
             return periodStore.isFetchingCountries
         case .periodPublished:
             return periodStore.isFetchingPublished
+        case .periodFileDownloads:
+            return periodStore.isFetchingFileDownloads
         case .postStatsMonthsYears, .postStatsAverageViews:
             return periodStore.isFetchingPostStats(for: postID)
         default:
@@ -246,6 +248,8 @@ private extension SiteStatsDetailTableViewController {
             viewModel?.refreshCountries()
         case .periodPublished:
             viewModel?.refreshPublished()
+        case .periodFileDownloads:
+            viewModel?.refreshFileDownloads()
         case .postStatsMonthsYears, .postStatsAverageViews:
             viewModel?.refreshPostStats()
         default:

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -188,6 +188,10 @@ class SiteStatsDetailsViewModel: Observable {
         case .periodPublished:
             tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: "", dataSubtitle: ""))
             tableRows.append(contentsOf: publishedRows())
+        case .periodFileDownloads:
+            tableRows.append(DetailSubtitlesHeaderRow(itemSubtitle: StatSection.periodFileDownloads.itemSubtitle,
+                                                      dataSubtitle: StatSection.periodFileDownloads.dataSubtitle))
+            tableRows.append(contentsOf: fileDownloadsRows())
         case .postStatsMonthsYears:
             tableRows.append(DetailSubtitlesCountriesHeaderRow(itemSubtitle: StatSection.postStatsMonthsYears.itemSubtitle,
                                                                dataSubtitle: StatSection.postStatsMonthsYears.dataSubtitle))
@@ -289,6 +293,14 @@ class SiteStatsDetailsViewModel: Observable {
         ActionDispatcher.dispatch(PeriodAction.refreshPublished(date: selectedDate, period: selectedPeriod))
     }
 
+    func refreshFileDownloads() {
+        guard let selectedDate = selectedDate,
+            let selectedPeriod = selectedPeriod else {
+                return
+        }
+        ActionDispatcher.dispatch(PeriodAction.refreshFileDownloads(date: selectedDate, period: selectedPeriod))
+    }
+
     func refreshPostStats() {
         guard let postID = postID else {
             return
@@ -344,6 +356,8 @@ private extension SiteStatsDetailsViewModel {
             return .allCountries(date: selectedDate, period: selectedPeriod)
         case .periodPublished:
             return .allPublished(date: selectedDate, period: selectedPeriod)
+        case .periodFileDownloads:
+            return .allFileDownloads(date: selectedDate, period: selectedPeriod)
         default:
             return nil
         }
@@ -677,6 +691,19 @@ private extension SiteStatsDetailsViewModel {
                                                                                      showDisclosure: true,
                                                                                      disclosureURL: $0.postURL,
                                                                                      statSection: .periodPublished) }
+            ?? []
+    }
+
+    // MARK: - File Downloads
+
+    func fileDownloadsRows() -> [DetailDataRow] {
+        return dataRowsFor(fileDownloadsRowData())
+    }
+
+    func fileDownloadsRowData() -> [StatsTotalRowData] {
+        return periodStore.getTopFileDownloads()?.fileDownloads.map { StatsTotalRowData(name: $0.file,
+                                                                                        data: $0.downloadCount.abbreviatedString(),
+                                                                                        statSection: .periodFileDownloads) }
             ?? []
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
@@ -94,6 +94,8 @@ private extension StatSection {
             return .statsViewMoreTappedTagsAndCategories
         case .periodVideos:
             return .statsViewMoreTappedVideoPlays
+        case .periodFileDownloads:
+            return .statsViewMoreTappedFileDownloads
         default:
             return nil
         }


### PR DESCRIPTION
Ref #11963 

This adds _File Downloads_ detail view.

Since the endpoint isn't returning data yet, use the temporary method `stubFileDownloads` to simulate displaying data.

To test:
- In `StatsPeriodStore:getTopFileDownloads`, enable `return stubFileDownloads()`.
- Go to Period > _File Downloads_ and select `View more`.
- Verify `🔵 Tracked: stats_file_downloads_view_more_tapped <blog_id: xxxxxx>` appears in the logs.
- Verify the 10 rows created with `stubFileDownloads` are displayed.

<img width="400" alt="download_details" src="https://user-images.githubusercontent.com/1816888/62166084-19b01f00-b2dd-11e9-9ddd-ae7e4c4d9911.png">


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
