### PR TITLE
Allow clearing of unused media uploads

### DIFF
--- a/WordPress/Classes/Utility/Media/MediaFileManager.swift
+++ b/WordPress/Classes/Utility/Media/MediaFileManager.swift
@@ -200,7 +200,9 @@ class MediaFileManager: NSObject {
     ///
     @objc class func clearAllMediaCacheFiles(onCompletion: (() -> Void)?, onError: ((Error) -> Void)?) {
         let cacheManager = MediaFileManager(directory: .cache)
-        cacheManager.clearFilesFromDirectory(onCompletion: onCompletion, onError: onError)
+        cacheManager.clearFilesFromDirectory(onCompletion: {
+            MediaFileManager.clearUnusedMediaUploadFiles(onCompletion: onCompletion, onError: onError)
+        }, onError: onError)
     }
 
     /// Helper method for getting the default upload directory URL.

--- a/WordPress/Classes/Utility/Media/MediaFileManager.swift
+++ b/WordPress/Classes/Utility/Media/MediaFileManager.swift
@@ -165,7 +165,7 @@ class MediaFileManager: NSObject {
     ///   was being created or when a CoreData migration fails and the database is recreated.
     ///
     @objc func clearUnusedFilesFromDirectory(onCompletion: (() -> Void)?, onError: ((Error) -> Void)?) {
-        purgeMediaFiles(exceptMedia: NSPredicate(format: "blog != NULL || remoteURL == NULL"),
+        purgeMediaFiles(exceptMedia: NSPredicate(format: "blog != NULL && remoteURL == NULL"),
                         onCompletion: onCompletion,
                         onError: onError)
     }


### PR DESCRIPTION
Refs #12218.

@etoledom, I wasn't sure who to ask to review this – ideally I'd ask @SergioEstevao, but he's still AFK for a while. I know you've worked on some media code in the past, but let me know if you'd rather I pass it to somebody else.

The issue referenced mentions reports of user device storage being used up and never cleared when we clear the media cache. I noticed two issues that I think contribute to this:

### Automatic upload clearing

We have code to clear the media uploads folder (in Documents) on app launch, but in my testing this is never actually happening. The predicate to find media that should be excluded from the deletion was:

`purgeMediaFiles(exceptMedia: NSPredicate(format: "blog != NULL || remoteURL == NULL")`

along with the comment:

```
/// Clear the local Media directory of any files that are no longer in use or can be fetched again,
/// such as Media without a blog or with a remote URL
```

The issue is that unless something has gone very wrong, media should never have a nil `blog`. Because practically every Media has a blog, this predicate was matching all media, and thus preventing any media from being deleted.

I've updated the predicate to only exclude items which **have** a blog AND don't have a remote URL – this should indicate that they haven't been uploaded yet:

`"blog != NULL && remoteURL == NULL"`

This should allow all uploaded media with a remoteURL to be cleared, and keep anything that hasn't been uploaded yet. Media without a blog will now be cleared, which makes sense to me as we can never do anything with it. I think this is more in line with the intention of the comment I quoted above.

### Clear uploads on manual cache clear

The second issue was that the "Clear Device Media Cache" button in App Settings only clears the temporary downloaded image cache and not the uploads directory. I've updated that call to run the same upload clearing that happens on startup.

In the screenshot below, the top folder is the uploads directory which has 3 successful uploaded images and one failed image. The bottom folder is the normal image caches directory. After tapping the clear cache button, everything is cleared except for the failed upload.

![media-cache](https://user-images.githubusercontent.com/4780/62218288-0caa3300-b3a4-11e9-9f0e-ded7103dd57f.png)

**To test:**

* Build and run on the simulator (easiest to access the caches directories)
* Pause the app and `po NSHomeDirectory()`. Open this folder in Finder, and navigate into Documents > Media. This is the uploads store.
* Upload a few images in the media library and see that they get copied into the uploads folder.
* Upload another image but cause it to fail. You could use Network Link Conditioner set to 100% packet loss, or kill your network connection before the upload completes. The image for this should also be present in the uploads folder.
* Relaunch the app, and verify that all images except for the failed image are removed from the uploads directory. The failed image should automatically attempt to re-upload thanks to the work by Ravenclaw.
* Repeat the above steps, but instead of restarting the app, use the Me > App Settings > Clear Device Media Cache button. It should have the same effect.

cc @charliescheer 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.