### PR TITLE
Auto-upload local published posts

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -254,7 +254,7 @@ extension PostCoordinator: Uploader {
                 return
             }
 
-            posts.forEach({ self.retrySave(of: $0) })
+            posts.forEach { self.retrySave(of: $0) }
         }
     }
 }
@@ -276,13 +276,13 @@ extension PostCoordinator {
             let allowedStatuses: [BasePost.Status] = [.draft, .publish]
 
             postService.getFailedPosts { posts in
-                let postsToRetry = posts.filter({ post -> Bool in
+                let postsToRetry = posts.filter { post -> Bool in
                     guard let status = post.status else {
                         return false
                     }
 
                     return allowedStatuses.contains(status) && !post.hasRemote()
-                })
+                }
 
                 result(postsToRetry)
             }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -273,9 +273,15 @@ extension PostCoordinator {
         }
 
         func getPostsToRetry(result: @escaping ([AbstractPost]) -> Void) {
+            let allowedStatuses: [BasePost.Status] = [.draft, .publish]
+
             postService.getFailedPosts { posts in
                 let postsToRetry = posts.filter({ post -> Bool in
-                    return post.status == .draft && !post.hasRemote()
+                    guard let status = post.status else {
+                        return false
+                    }
+
+                    return allowedStatuses.contains(status) && !post.hasRemote()
                 })
 
                 result(postsToRetry)

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -259,11 +259,6 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
             Post *postInContext = (Post *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
                 postInContext.remoteStatus = AbstractPostRemoteStatusFailed;
-                // If the post was not created on the server yet we convert the post to a local draft post with the current date.
-                if (!postInContext.hasRemote) {
-                    postInContext.status = PostStatusDraft;
-                    postInContext.dateModified = [NSDate date];
-                }
                 [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
             }
             if (failure) {

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -259,12 +259,14 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
             Post *postInContext = (Post *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
                 postInContext.remoteStatus = AbstractPostRemoteStatusFailed;
-                // If the post was not created on the server yet we convert the post to a local
-                // draft post with the current date. However, if it's PUBLISHED or DRAFT, we will
-                // not reset the status so that when retrying the upload, the post will have the
-                // status that the user originally intended.
+                // If the post was not created on the server yet we convert the post to a local draft
+                // with the current date. This post upload will be automatically retried later as a draft.
                 //
-                // When we support auto-uploading of all statuses, we will fully remove this block.
+                // However, if the post was supposed to be published or draft, we will leave it as is.
+                // This is intentional because we currently want to automatically retry posts that
+                // are either published or drafts. In the future, we will automatically retry all statuses.
+                //
+                // Automatic uploads happen in `PostCoordinator.resume()`.
                 if (!postInContext.hasRemote && ![postInContext.status isEqualToString:PostStatusPublish]) {
                     postInContext.status = PostStatusDraft;
                     postInContext.dateModified = [NSDate date];

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -68,7 +68,7 @@ import Foundation
         let filterType: Status = .published
         let statuses: [BasePost.Status] = [.publish, .publishPrivate]
 
-        let predicate = NSPredicate(format: "status IN %@", statuses.strings)
+        let predicate = NSPredicate(format: "postID > 0 AND status IN %@", statuses.strings)
 
         let title = NSLocalizedString("Published", comment: "Title of the published filter. This filter shows a list of posts that the user has published.")
 
@@ -83,7 +83,10 @@ import Foundation
         let statuses: [BasePost.Status] = [.draft, .pending]
         let statusesExcluded: [BasePost.Status] = [.publish, .publishPrivate, .scheduled, .trash]
 
-        let predicate = NSPredicate(format: "NOT status IN %@", statusesExcluded.strings)
+        // The postID = -1 condition is intentionally a reverse of publishedFilter() so that
+        // local published posts will show in the Drafts list instead of the Published list.
+        let statusesForLocalDrafts: [BasePost.Status] = [.publish, .publishPrivate]
+        let predicate = NSPredicate(format: "(postID = -1 AND status IN %@) OR NOT status IN %@", statusesForLocalDrafts.strings, statusesExcluded.strings)
 
         let title = NSLocalizedString("Drafts", comment: "Title of the drafts filter.  This filter shows a list of draft posts.")
 

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -85,8 +85,8 @@ import Foundation
 
         // The postID = -1 condition is intentionally a reverse of publishedFilter() so that
         // local published posts will show in the Drafts list instead of the Published list.
-        let statusesForLocalDrafts: [BasePost.Status] = [.publish, .publishPrivate]
-        let predicate = NSPredicate(format: "(postID = -1 AND status IN %@) OR NOT status IN %@", statusesForLocalDrafts.strings, statusesExcluded.strings)
+        let predicate = NSPredicate(format: "(postID = -1 AND status = %@) OR NOT status IN %@",
+                                    BasePost.Status.publish.rawValue, statusesExcluded.strings)
 
         let title = NSLocalizedString("Drafts", comment: "Title of the drafts filter.  This filter shows a list of draft posts.")
 

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -68,7 +68,11 @@ import Foundation
         let filterType: Status = .published
         let statuses: [BasePost.Status] = [.publish, .publishPrivate]
 
-        let predicate = NSPredicate(format: "postID > 0 AND status IN %@", statuses.strings)
+        // The postID > 0 condition is a reverse of draftFilter(). In the Published List, we only
+        // want to show private and previously uploaded published posts. Local published posts
+        // will be shown in Drafts. See draftFilter().
+        let predicate = NSPredicate(format: "(postID > 0 AND status = %@) OR status = %@",
+                                    BasePost.Status.publish.rawValue, BasePost.Status.publishPrivate.rawValue)
 
         let title = NSLocalizedString("Published", comment: "Title of the published filter. This filter shows a list of posts that the user has published.")
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -531,6 +531,7 @@
 		570265172298960B00F2214C /* PostListTableViewHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570265162298960B00F2214C /* PostListTableViewHandlerTests.swift */; };
 		5703A4C622C003DC0028A343 /* WPStyleGuide+Posts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5703A4C522C003DC0028A343 /* WPStyleGuide+Posts.swift */; };
 		57047A4F22A961BC00B461DF /* PostSearchHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57047A4E22A961BC00B461DF /* PostSearchHeader.swift */; };
+		570B037722F1FFF6009D8411 /* PostCoordinatorFailedPostsFetcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570B037622F1FFF6009D8411 /* PostCoordinatorFailedPostsFetcherTests.swift */; };
 		570BFD8B22823D7B007859A8 /* PostActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570BFD8A22823D7B007859A8 /* PostActionSheet.swift */; };
 		570BFD8D22823DE5007859A8 /* PostActionSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570BFD8C22823DE5007859A8 /* PostActionSheetTests.swift */; };
 		570BFD902282418A007859A8 /* PostBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570BFD8F2282418A007859A8 /* PostBuilder.swift */; };
@@ -2573,6 +2574,7 @@
 		570265162298960B00F2214C /* PostListTableViewHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListTableViewHandlerTests.swift; sourceTree = "<group>"; };
 		5703A4C522C003DC0028A343 /* WPStyleGuide+Posts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Posts.swift"; sourceTree = "<group>"; };
 		57047A4E22A961BC00B461DF /* PostSearchHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostSearchHeader.swift; sourceTree = "<group>"; };
+		570B037622F1FFF6009D8411 /* PostCoordinatorFailedPostsFetcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PostCoordinatorFailedPostsFetcherTests.swift; path = Services/PostCoordinatorFailedPostsFetcherTests.swift; sourceTree = "<group>"; };
 		570BFD8A22823D7B007859A8 /* PostActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostActionSheet.swift; sourceTree = "<group>"; };
 		570BFD8C22823DE5007859A8 /* PostActionSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostActionSheetTests.swift; sourceTree = "<group>"; };
 		570BFD8F2282418A007859A8 /* PostBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostBuilder.swift; sourceTree = "<group>"; };
@@ -7837,6 +7839,7 @@
 				59FBD5611B5684F300734466 /* ThemeServiceTests.m */,
 				40E4698E2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift */,
 				7E8980B822E73F4000C567B0 /* EditorSettingsServiceTests.swift */,
+				570B037622F1FFF6009D8411 /* PostCoordinatorFailedPostsFetcherTests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -11641,6 +11644,7 @@
 				570265172298960B00F2214C /* PostListTableViewHandlerTests.swift in Sources */,
 				E1EBC3731C118ED200F638E0 /* ImmuTableTest.swift in Sources */,
 				E1AB5A091E0BF31E00574B4E /* ArrayTests.swift in Sources */,
+				570B037722F1FFF6009D8411 /* PostCoordinatorFailedPostsFetcherTests.swift in Sources */,
 				4054F4592214E6FE00D261AB /* TagsCategoriesStatsRecordValueTests.swift in Sources */,
 				4054F43E221357B600D261AB /* TopCommentedPostStatsRecordValueTests.swift in Sources */,
 				93B853231B4416A30064FE72 /* WPAnalyticsTrackerAutomatticTracksTests.m in Sources */,

--- a/WordPress/WordPressTest/PostListFilterTests.swift
+++ b/WordPress/WordPressTest/PostListFilterTests.swift
@@ -95,7 +95,8 @@ class PostListFilterTests: XCTestCase {
         let predicate = PostListFilter.publishedFilter().predicateForFetchRequest
         let matchingPosts = [
             createPost(.publish, hasRemote: true),
-            createPost(.publishPrivate, hasRemote: true)
+            createPost(.publishPrivate),
+            createPost(.publishPrivate, hasRemote: true),
         ]
         let nonMatchingPosts = [
             createPost(.draft),

--- a/WordPress/WordPressTest/PostListFilterTests.swift
+++ b/WordPress/WordPressTest/PostListFilterTests.swift
@@ -1,7 +1,23 @@
 import XCTest
 @testable import WordPress
+import Nimble
 
 class PostListFilterTests: XCTestCase {
+    private var contextManager: TestContextManager!
+    private var context: NSManagedObjectContext!
+
+    override func setUp() {
+        super.setUp()
+
+        contextManager = TestContextManager()
+        context = contextManager.newDerivedContext()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        context = nil
+        contextManager = nil
+    }
 
     func testSortDescriptorForPublished() {
         let filter = PostListFilter.publishedFilter()
@@ -10,7 +26,6 @@ class PostListFilterTests: XCTestCase {
         XCTAssertEqual(descriptors[0].key, "date_created_gmt")
         XCTAssertFalse(descriptors[0].ascending)
     }
-
 
     func testSortDescriptorForDrafs() {
         let filter = PostListFilter.draftFilter()
@@ -50,5 +65,63 @@ class PostListFilterTests: XCTestCase {
             XCTAssertEqual(descriptors.count, 1)
             XCTAssertEqual(descriptors[0].key, filter.sortField.keyPath)
         }
+    }
+
+    func testDraftFilterOnlyIncludesDraftsAndLocalPublishedPosts() {
+        // Arrange
+        let predicate = PostListFilter.draftFilter().predicateForFetchRequest
+        let matchingPosts = [
+            createPost(.draft),
+            createPost(.draft, hasRemote: true),
+            createPost(.publish),
+        ]
+        let nonMatchingPosts = [
+            createPost(.publish, hasRemote: true),
+            createPost(.publishPrivate),
+            createPost(.publishPrivate, hasRemote: true),
+            createPost(.scheduled),
+            createPost(.scheduled, hasRemote: true),
+            createPost(.trash),
+            createPost(.trash, hasRemote: true)
+        ]
+
+        // Assert
+        expect(matchingPosts).to(allPass { predicate.evaluate(with: $0!) == true })
+        expect(nonMatchingPosts).to(allPass { predicate.evaluate(with: $0!) == false })
+    }
+
+    func testPublishedFilterOnlyIncludesPrivateAndRemotePublishedPosts() {
+        // Arrange
+        let predicate = PostListFilter.publishedFilter().predicateForFetchRequest
+        let matchingPosts = [
+            createPost(.publish, hasRemote: true),
+            createPost(.publishPrivate, hasRemote: true)
+        ]
+        let nonMatchingPosts = [
+            createPost(.draft),
+            createPost(.draft, hasRemote: true),
+            createPost(.publish),
+            createPost(.scheduled),
+            createPost(.scheduled, hasRemote: true),
+            createPost(.trash),
+            createPost(.trash, hasRemote: true)
+        ]
+
+        // Assert
+        expect(matchingPosts).to(allPass { predicate.evaluate(with: $0!) == true })
+        expect(nonMatchingPosts).to(allPass { predicate.evaluate(with: $0!) == false })
+    }
+}
+
+private extension PostListFilterTests {
+    func createPost(_ status: BasePost.Status, hasRemote: Bool = false) -> Post {
+        let post = Post(context: context)
+        post.status = status
+
+        if hasRemote {
+            post.postID = NSNumber(value: Int.random(in: 1...Int.max))
+        }
+
+        return post
     }
 }

--- a/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
+++ b/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
@@ -25,30 +25,37 @@ class PostCoordinatorFailedPostsFetcherTests: XCTestCase {
 
     func testItOnlyReturnsLocalDrafts() {
         // Arrange
-        let localDrafts = [createPost(), createPost(), createPost()]
+        let expectedPosts = [
+            createPost(status: .draft),
+            createPost(status: .draft),
+            createPost(status: .draft),
+            createPost(status: .publish)
+        ]
         let unexpectedPosts = [
-            // Draft from remote
-            createPost(hasRemote: true),
-            createPost(status: .publish),
+            createPost(status: .draft, hasRemote: true),
+            createPost(status: .publish, hasRemote: true),
             createPost(status: .publishPrivate),
+            createPost(status: .publishPrivate, hasRemote: true),
             createPost(status: .scheduled),
+            createPost(status: .scheduled, hasRemote: true),
             createPost(status: .trash),
-            // Local draft that we never attempted to upload
-            createPost(remoteStatus: .local)
+            createPost(status: .trash, hasRemote: true),
+            // Local draft that we never attempted to upload so it never failed
+            createPost(status: .draft, remoteStatus: .local)
         ]
 
         // Act
         let posts = fetcher.getPostsToRetrySync()
 
         // Assert
-        expect(posts).to(haveCount(localDrafts.count))
-        expect(posts).to(contain(localDrafts))
+        expect(posts).to(haveCount(expectedPosts.count))
+        expect(posts).to(contain(expectedPosts))
         expect(posts).notTo(contain(unexpectedPosts))
     }
 }
 
 private extension PostCoordinatorFailedPostsFetcherTests {
-    func createPost(status: BasePost.Status = .draft,
+    func createPost(status: BasePost.Status,
                     remoteStatus: AbstractPostRemoteStatus = .failed,
                     hasRemote: Bool = false) -> Post {
         let post = Post(context: context)

--- a/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
+++ b/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
@@ -1,0 +1,78 @@
+
+@testable import WordPress
+import Nimble
+
+class PostCoordinatorFailedPostsFetcherTests: XCTestCase {
+    private var contextManager: TestContextManager!
+    private var context: NSManagedObjectContext!
+
+    private var fetcher: PostCoordinator.FailedPostsFetcher!
+
+    override func setUp() {
+        super.setUp()
+
+        contextManager = TestContextManager()
+        context = contextManager.newDerivedContext()
+        fetcher = PostCoordinator.FailedPostsFetcher(context)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        fetcher = nil
+        context = nil
+        contextManager = nil
+    }
+
+    func testItOnlyReturnsLocalDrafts() {
+        // Arrange
+        let localDrafts = [createPost(), createPost(), createPost()]
+        let unexpectedPosts = [
+            // Draft from remote
+            createPost(hasRemote: true),
+            createPost(status: .publish),
+            createPost(status: .publishPrivate),
+            createPost(status: .scheduled),
+            createPost(status: .trash),
+            // Local draft that we never attempted to upload
+            createPost(remoteStatus: .local)
+        ]
+
+        // Act
+        let posts = fetcher.getPostsToRetrySync()
+
+        // Assert
+        expect(posts).to(haveCount(localDrafts.count))
+        expect(posts).to(contain(localDrafts))
+        expect(posts).notTo(contain(unexpectedPosts))
+    }
+}
+
+private extension PostCoordinatorFailedPostsFetcherTests {
+    func createPost(status: BasePost.Status = .draft,
+                    remoteStatus: AbstractPostRemoteStatus = .failed,
+                    hasRemote: Bool = false) -> Post {
+        let post = Post(context: context)
+        post.status = status
+        post.remoteStatus = remoteStatus
+
+        if hasRemote {
+            post.postID = NSNumber(value: Int.random(in: 1...Int.max))
+        }
+
+        return post
+    }
+}
+
+private extension PostCoordinator.FailedPostsFetcher {
+    func getPostsToRetrySync() -> [AbstractPost] {
+        var result = [AbstractPost]()
+        waitUntil(timeout: 5) { done in
+            self.getPostsToRetry { posts in
+                result = posts
+                done()
+            }
+        }
+        return result
+    }
+}
+

--- a/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
+++ b/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
@@ -82,4 +82,3 @@ private extension PostCoordinator.FailedPostsFetcher {
         return result
     }
 }
-


### PR DESCRIPTION
Part of #12240. This is targeting the master branch `issue/12240-master-branch`. 

## Changes

![Flow@2x](https://user-images.githubusercontent.com/198826/62250916-724ded80-b3ab-11e9-886d-d03ba0de50dd.png)

### Auto-uploading local `published` posts

Local drafts that the user set to `published` will now be automatically uploaded and **published** when the device is online. Previously, local `published` posts were changed to `DRAFT` and were automatically uploaded as `draft`.

This change was based on @diegoreymendez's work in #12178. 

This deliberately targets `published` only. Scheduled, private, and other statuses' behaviors are left unchanged. I believe this lowers the risk of regression. After everything is done, we can also test the whole publishing flow before fully committing with all statuses.

Please see #12240 for the current plan. 

### Post stays in Draft

This change also completes the _"Post stays in draft"_ requirement. This is a missing portion of #12178, as described in https://github.com/wordpress-mobile/WordPress-iOS/pull/12178#issuecomment-514307641.

- Local drafts that failed to upload will be shown in the Drafts list.
- Existing Published posts that were edited but failed in uploads will remain in the Published list. Please see https://github.com/wordpress-mobile/WordPress-iOS/issues/12240#issuecomment-516878607.

## Reviewing

Since this involves auto-uploading, it would probably be better if at least two developers can review this. 

## Testing

1. Go offline.
2. Create a post and publish it. Verify that the post will stay in Drafts.
3. Go online.
4. The post should be automatically published and will be moved to the Published list.

Please also test with other statuses like `scheduled/future`, `private`, and `pending`. Their behavior should not change.