### PR TITLE
Update News card for Stats

### DIFF
--- a/WordPress/News.strings
+++ b/WordPress/News.strings
@@ -1,11 +1,11 @@
 /* News Card title. */
-"Title" = "Sharing made easier.";
+"Title" = "Clearer Stats";
 
 /* News Card content. */
-"Content" = "We rolled up our sleeves and rethought the entire sharing workflow for both iPhones and iPads.";
+"Content" = "The stats experience just vastly improved, with a broad range of innovations in both the UI and backend.";
 
 /* News Card link. */
-"URL" = "https://en.blog.wordpress.com/2018/03/28/new-and-improved-ios-sharing-extensions/";
+"URL" = "https://en.blog.wordpress.com/2019/07/16/more-stats-better-stats-faster-stats-a-whole-new-mobile-experience/";
 
 /* Build version this card applies to. */
-"version" = "10.8";
+"version" = "12.6";


### PR DESCRIPTION
Fixes #n/a

This updates the News card to show info about Stats.

To test:
- Go to the Reader.
- Verify the News card now references Stats.
- Verify `Read more` opens the Stats en.blog post. 

<img width="400" alt="news_card" src="https://user-images.githubusercontent.com/1816888/62252317-bc38d280-b3af-11e9-9c88-096b132cf6b9.png">


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
