### PR TITLE
Fix notification request crash on iOS 13

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController+FancyAlerts.swift
@@ -141,7 +141,9 @@ extension BlogDetailsViewController {
 
             let alert = FancyAlertViewController.makeNotificationPrimerAlertController { (controller) in
                 InteractiveNotificationsManager.shared.requestAuthorization {
-                    controller.dismiss(animated: true)
+                    DispatchQueue.main.async {
+                        controller.dismiss(animated: true)
+                    }
                 }
             }
             alert.modalPresentationStyle = .custom


### PR DESCRIPTION
Refs #11221

This fixes a crash after approving push notifications on iOS 13.

To test:
- Install a fresh install of WPiOS
- Login
- Re-launch (why isn't the request happening the first time? 🤔)
- Approve push notifications
- Ensure nothing crashes

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.