### PR TITLE
Now showing loading status in navigation bar when preview is loading 

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -7,7 +7,6 @@
 #import "WordPress-Swift.h"
 
 @import Gridicons;
-@import SVProgressHUD;
 @import WordPressUI;
 
 
@@ -19,6 +18,7 @@
 @property (nonatomic, strong) AbstractPost *apost;
 @property (nonatomic, strong) UIBarButtonItem *shareBarButtonItem;
 @property (nonatomic, strong) UIBarButtonItem *doneBarButtonItem;
+@property (nonatomic, strong) UIBarButtonItem *statusButtonItem;
 @property (nonatomic, strong) PostPreviewGenerator *generator;
 @property (nonatomic, strong) NoResultsViewController *noResultsViewController;
 @property (nonatomic, strong) id reachabilityObserver;
@@ -85,6 +85,7 @@
         [rightButtons addObject:[self shareBarButtonItem]];
     }
     [self.navigationItem setRightBarButtonItems:rightButtons animated:YES];
+    self.navigationItem.leftItemsSupplementBackButton = YES;
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -117,12 +118,12 @@
 
 - (void)startLoading
 {
-    [SVProgressHUD show];
+    [self.navigationItem setLeftBarButtonItem:[self statusButtonItem] animated:YES];
 }
 
 - (void)stopLoading
 {
-    [SVProgressHUD dismiss];
+    self.navigationItem.leftBarButtonItem = nil;
     [self.webView stopLoading];
 }
 
@@ -287,6 +288,17 @@
     }
 
     return _doneBarButtonItem;
+}
+
+- (UIBarButtonItem *)statusButtonItem
+{
+    if (!_statusButtonItem) {
+        LoadingStatusView *statusView = [[LoadingStatusView alloc] initWithTitle: NSLocalizedString(@"Loading Preview", @"Label for button to present loading preview status")];
+        _statusButtonItem = [[UIBarButtonItem alloc] initWithCustomView:statusView];
+        _statusButtonItem.accessibilityIdentifier = @"Preview Status";
+    }
+    
+    return _statusButtonItem;
 }
 
 - (void)sharePost

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -122,7 +122,7 @@
 
 - (void)stopLoading
 {
-    self.navigationItem.leftBarButtonItem = nil;
+    self.navigationItem.leftBarButtonItem = self.navigationItem.backBarButtonItem;
     self.navigationItem.title  = NSLocalizedString(@"Preview", @"Post Editor / Preview screen title.");
     [self.webView stopLoading];
 }
@@ -293,7 +293,7 @@
 - (UIBarButtonItem *)statusButtonItem
 {
     if (!_statusButtonItem) {
-        LoadingStatusView *statusView = [[LoadingStatusView alloc] initWithTitle: NSLocalizedString(@"Loading Preview", @"Label for button to present loading preview status")];
+        LoadingStatusView *statusView = [[LoadingStatusView alloc] initWithTitle: NSLocalizedString(@"Loading", @"Label for button to present loading preview status")];
         _statusButtonItem = [[UIBarButtonItem alloc] initWithCustomView:statusView];
         _statusButtonItem.accessibilityIdentifier = @"Preview Status";
     }

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -43,7 +43,6 @@
         self.apost = aPost;
         self.generator = [[PostPreviewGenerator alloc] initWithPost:aPost];
         self.generator.delegate = self;
-        self.navigationItem.title = NSLocalizedString(@"Preview", @"Post Editor / Preview screen title.");
     }
     return self;
 }
@@ -55,7 +54,6 @@
         self.apost = aPost;
         self.generator = [[PostPreviewGenerator alloc] initWithPost:aPost previewURL:previewURL];
         self.generator.delegate = self;
-        self.navigationItem.title = NSLocalizedString(@"Preview", @"Post Editor / Preview screen title.");
     }
     return self;
 }
@@ -119,11 +117,13 @@
 - (void)startLoading
 {
     [self.navigationItem setLeftBarButtonItem:[self statusButtonItem] animated:YES];
+    self.navigationItem.title = nil;
 }
 
 - (void)stopLoading
 {
     self.navigationItem.leftBarButtonItem = nil;
+    self.navigationItem.title  = NSLocalizedString(@"Preview", @"Post Editor / Preview screen title.");
     [self.webView stopLoading];
 }
 

--- a/WordPress/Classes/ViewRelated/Views/LoadingStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Views/LoadingStatusView.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class LoadingStatusView: UIView {
-    init(title: String) {
+    @objc init(title: String) {
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
         backgroundColor = .clear


### PR DESCRIPTION
This replaces the UI blocking HUD. Prominent in low connectivity. 
Fixes #12032 

To test:
1. Enable Network Link Conditioner for bad network
2. Update a post or a draft
3. Choose preview
4. See the loading status in the navigation bar instead of a blocking HUD
5. Make sure you can navigate back while the spinner is loading 

![20190731_171606](https://user-images.githubusercontent.com/1335657/62256646-f22d8500-b3b6-11e9-90f3-11fe2d596772.gif)


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
