### PR TITLE
Fix crash after logout

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -17,6 +17,7 @@
 #import "WordPress-Swift.h"
 #import "WPWebViewController.h"
 #import <wpxmlrpc/WPXMLRPC.h>
+#import "AccountService.h"
 @import WordPressKit;
 
 
@@ -149,6 +150,10 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
                                              selector:@selector(handleDataModelChange:)
                                                  name:NSManagedObjectContextObjectsDidChangeNotification
                                                object:self.blog.managedObjectContext];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleAccountChange:)
+                                                 name:WPAccountDefaultWordPressComAccountChangedNotification
+                                               object:nil];
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     
@@ -1347,6 +1352,11 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     if ([updatedObjects containsObject:self.blog]) {
         [self.tableView reloadData];
     }
+}
+
+- (void)handleAccountChange:(NSNotification *)notification
+{
+    [self.tableView reloadData];
 }
 
 @end


### PR DESCRIPTION
Fixes #12242 

**Reason of the crash:**

With the site settings controller loaded, after the user logs out, the blog's account becomes nil.
This makes the `tableSections` return to change, while the table still expected the old values.
For some reason the system will refresh the sections (or possibly, all visible cells) when the app goes to background, and given the state previously described, the crash will happen. 💥 

**Fix proposal:**
This PR forces to reload the table when there default account changes (i.e. user logout), updating the table's data source.

Maybe another option could be to manually remove the controller when a logout happens.

To test:
- Follow the instructions from #12242 
- Check that the app doesn't crash.
- Run UI tests locally on iPad
- Check that all UI tests pass

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.

cc @jtreanor 