### PR TITLE
[Gutenberg] Adding Tracks properties to gutenberg enable/disable event

### DIFF
--- a/WordPress/Classes/Utility/Editor/EditorFactory.swift
+++ b/WordPress/Classes/Utility/Editor/EditorFactory.swift
@@ -24,7 +24,7 @@ class EditorFactory {
         let gutenbergVC = GutenbergViewController(post: post, replaceEditor: replaceEditor)
 
         if gutenbergSettings.shouldAutoenableGutenberg(for: post) {
-            gutenbergSettings.setGutenbergEnabled(true, for: post.blog)
+            gutenbergSettings.setGutenbergEnabled(true, for: post.blog, source: .onBlockPostOpening)
             gutenbergSettings.postSettingsToRemote(for: post.blog)
             gutenbergVC.shouldPresentInformativeDialog = true
         }

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -12,6 +12,12 @@ class GutenbergSettings {
         }
     }
 
+    enum TracksSwitchSource: String {
+        case viaSiteSettings = "via-site-settings"
+        case onSiteCreation = "on-site-creation"
+        case onBlockPostOpening = "on-block-post-opening"
+    }
+
     // MARK: - Internal variables
     fileprivate let database: KeyValueDatabase
 
@@ -33,12 +39,12 @@ class GutenbergSettings {
     /// - Parameters:
     ///   - isEnabled: Enabled state to set
     ///   - blog: The site to set the gutenberg enabled state
-    func setGutenbergEnabled(_ isEnabled: Bool, for blog: Blog) {
+    func setGutenbergEnabled(_ isEnabled: Bool, for blog: Blog, source: TracksSwitchSource? = nil) {
         guard shouldUpdateSettings(enabling: isEnabled, for: blog) else {
             return
         }
 
-        softSetGutenbergEnabled(isEnabled, for: blog)
+        softSetGutenbergEnabled(isEnabled, for: blog, source: source)
 
         if isEnabled {
             database.set(true, forKey: Key.enabledOnce(for: blog))
@@ -49,13 +55,13 @@ class GutenbergSettings {
     /// Use this to set gutenberg and still show the auto-enabled dialog.
     ///
     /// - Parameter blog: The site to set the
-    func softSetGutenbergEnabled(_ isEnabled: Bool, for blog: Blog) {
+    func softSetGutenbergEnabled(_ isEnabled: Bool, for blog: Blog, source: TracksSwitchSource?) {
         guard shouldUpdateSettings(enabling: isEnabled, for: blog) else {
             return
         }
 
-        if blog.isGutenbergEnabled != isEnabled {
-            trackSettingChange(to: isEnabled)
+        if let source = source, blog.isGutenbergEnabled != isEnabled {
+            trackSettingChange(to: isEnabled, from: source)
         }
 
         blog.mobileEditor = isEnabled ? .gutenberg : .aztec
@@ -69,9 +75,12 @@ class GutenbergSettings {
         return blog.mobileEditor != selectedEditor
     }
 
-    private func trackSettingChange(to isEnabled: Bool) {
+    private func trackSettingChange(to isEnabled: Bool, from source: TracksSwitchSource) {
         let stat: WPAnalyticsStat = isEnabled ? .appSettingsGutenbergEnabled : .appSettingsGutenbergDisabled
-        WPAppAnalytics.track(stat)
+        let props: [String: Any] = [
+            "source": source.rawValue
+        ]
+        WPAppAnalytics.track(stat, withProperties: props)
     }
 
 
@@ -124,7 +133,7 @@ class GutenbergSettings {
 class GutenbergSettingsBridge: NSObject {
     @objc(setGutenbergEnabled:forBlog:)
     static func setGutenbergEnabled(_ isEnabled: Bool, for blog: Blog) {
-        GutenbergSettings().setGutenbergEnabled(isEnabled, for: blog)
+        GutenbergSettings().setGutenbergEnabled(isEnabled, for: blog, source: .viaSiteSettings)
     }
 
     @objc(postSettingsToRemoteForBlog:)

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -114,7 +114,7 @@ final class SiteAssemblyWizardContent: UIViewController {
                     // Default all new blogs to use Gutenberg
                     if let createdBlog = blog {
                         let gutenbergSettings = GutenbergSettings()
-                        gutenbergSettings.softSetGutenbergEnabled(true, for: createdBlog)
+                        gutenbergSettings.softSetGutenbergEnabled(true, for: createdBlog, source: .onSiteCreation)
                         gutenbergSettings.postSettingsToRemote(for: createdBlog)
                     }
 


### PR DESCRIPTION
This PR is the WPiOS side of: https://github.com/wordpress-mobile/WordPress-Android/pull/10300

Add additional properties to gutenberg_enabled , and gutenberg_disabled analytics events:
The property source can now have the following values:

- via-site-settings
- on-block-post-open
- on-site-creation


**Disclosure:**
With this changes, are **not** tracking the switch event in cases where:
- We are setting Gutenberg/Aztec as part of a migration
- We are setting Gutenberg/Aztec as part of sync with remote
- We are setting Aztec as the default value

Is this the proper behavior? cc @daniloercoli @hypest 

**To test:**

Test 1:
- Flip the block editor setting in Site settings and make sure the property is added correctly

Test 2:
- Create a new site, and make sure the property is added with the correct value
- Tap on new post, and make sure nothing is tracked

Test 3:
- Clear your editor settings on the web
- Re-install the app
- open a block based post
- the popup should appear, and the correct property value bumped with analytics

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
