### PR TITLE
Change page list labels (private, etc) to be gray

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -111,8 +111,7 @@ static CGFloat const FeaturedImageSize = 120.0;
     self.titleLabel.adjustsFontForContentSizeCategory = YES;
     
     self.titleLabel.textColor = [UIColor murielNeutral70];
-    self.timestampLabel.textColor = [UIColor murielNeutral30];
-    self.badgesLabel.textColor = [UIColor murielWarningDark];
+    self.badgesLabel.textColor = [UIColor murielNeutral];
     self.menuButton.tintColor = [UIColor murielTextSubtle];
     [self.menuButton setImage:[Gridicon iconOfType:GridiconTypeEllipsis] forState:UIControlStateNormal];
 
@@ -145,27 +144,22 @@ static CGFloat const FeaturedImageSize = 120.0;
 {
     Page *page = (Page *)self.post;
 
-    NSString *badgesString = @"";
+    NSMutableArray<NSString *> *badges = [NSMutableArray new];
+
+    NSString *timestamp = [self.post isScheduled] ? [self.dateFormatter stringFromDate:self.post.dateCreated] : [self.post.dateCreated mediumString];
+    [badges addObject:timestamp];
     
     if (page.hasPrivateState) {
-        badgesString = NSLocalizedString(@"Private", @"Title of the Private Badge");
+        [badges addObject:NSLocalizedString(@"Private", @"Title of the Private Badge")];
     } else if (page.hasPendingReviewState) {
-        badgesString = NSLocalizedString(@"Pending review", @"Title of the Pending Review Badge");
+        [badges addObject:NSLocalizedString(@"Pending review", @"Title of the Pending Review Badge")];
     }
     
     if (page.hasLocalChanges) {
-        if (badgesString.length > 0) {
-            badgesString = [badgesString stringByAppendingString:@" · "];
-        }
-        badgesString = [badgesString stringByAppendingString:NSLocalizedString(@"Local changes", @"Title of the Local Changes Badge")];
+        [badges addObject:NSLocalizedString(@"Local changes", @"Title of the Local Changes Badge")];
     }
     
-    self.badgesLabel.text = badgesString;
-}
-
-- (void)configureTimeStamp
-{
-    self.timestampLabel.text = [self.post isScheduled] ? [self.dateFormatter stringFromDate:self.post.dateCreated] : [self.post.dateCreated mediumString];
+    self.badgesLabel.text = [badges componentsJoinedByString:@" • "];
 }
 
 - (void)configureFeaturedImage

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -158,7 +158,7 @@ static CGFloat const FeaturedImageSize = 120.0;
         [badges addObject:NSLocalizedString(@"Local changes", @"Title of the Local Changes Badge")];
     }
     
-    self.badgesLabel.text = [badges componentsJoinedByString:@" • "];
+    self.badgesLabel.text = [badges componentsJoinedByString:@" · "];
 }
 
 - (void)configureFeaturedImage

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -95,7 +95,6 @@ static CGFloat const FeaturedImageSize = 120.0;
     [self configureTitle];
     [self configureForStatus];
     [self configureBadges];
-    [self configureTimeStamp];
     [self configureFeaturedImage];
 }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -34,14 +34,8 @@
                                         <fontDescription key="fontDescription" name="NotoSerif-Bold" family="Noto Serif" pointSize="17"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2 days ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oZc-K5-966">
-                                        <rect key="frame" x="0.0" y="25.5" width="75" height="18"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Private • Local changes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="s9t-JC-dzu">
-                                        <rect key="frame" x="83" y="25.5" width="102" height="18"/>
+                                        <rect key="frame" x="0.0" y="25.5" width="185" height="18"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -51,15 +45,11 @@
                                 <constraints>
                                     <constraint firstItem="s9t-JC-dzu" firstAttribute="top" secondItem="S9J-0t-GbV" secondAttribute="bottom" constant="2" id="0iK-yR-Vxs"/>
                                     <constraint firstAttribute="trailing" secondItem="S9J-0t-GbV" secondAttribute="trailing" id="1zk-Kl-c5k"/>
+                                    <constraint firstItem="s9t-JC-dzu" firstAttribute="leading" secondItem="6l3-mv-Tbu" secondAttribute="leading" id="G0U-lY-puO"/>
                                     <constraint firstAttribute="bottom" secondItem="s9t-JC-dzu" secondAttribute="bottom" id="GJL-jP-3j6"/>
-                                    <constraint firstItem="oZc-K5-966" firstAttribute="leading" secondItem="6l3-mv-Tbu" secondAttribute="leading" id="KjI-zE-VTt"/>
-                                    <constraint firstAttribute="bottom" secondItem="oZc-K5-966" secondAttribute="bottom" id="Tnu-BT-BXA"/>
                                     <constraint firstItem="S9J-0t-GbV" firstAttribute="leading" secondItem="6l3-mv-Tbu" secondAttribute="leading" id="WD8-Px-1ST"/>
                                     <constraint firstAttribute="trailing" secondItem="s9t-JC-dzu" secondAttribute="trailing" id="pMN-9O-aLr"/>
                                     <constraint firstItem="S9J-0t-GbV" firstAttribute="top" secondItem="6l3-mv-Tbu" secondAttribute="top" id="tEH-TE-pPc"/>
-                                    <constraint firstItem="oZc-K5-966" firstAttribute="top" secondItem="S9J-0t-GbV" secondAttribute="bottom" constant="2" id="uk1-Us-sR4"/>
-                                    <constraint firstItem="s9t-JC-dzu" firstAttribute="leading" secondItem="oZc-K5-966" secondAttribute="trailing" constant="8" id="wa4-fW-WaS"/>
-                                    <constraint firstItem="oZc-K5-966" firstAttribute="top" secondItem="S9J-0t-GbV" secondAttribute="bottom" constant="2" id="y4H-aK-sGm"/>
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VPZ-yr-cJj">
@@ -113,7 +103,6 @@
                 <outlet property="labelsContainerTrailing" destination="TnQ-N0-CaM" id="BbR-qQ-JWD"/>
                 <outlet property="leadingContentConstraint" destination="El0-aj-PpS" id="LqZ-K0-Tc4"/>
                 <outlet property="menuButton" destination="VPZ-yr-cJj" id="yjZ-Su-mum"/>
-                <outlet property="timestampLabel" destination="oZc-K5-966" id="VFf-1d-m1I"/>
                 <outlet property="titleLabel" destination="S9J-0t-GbV" id="yd0-0r-RpF"/>
             </connections>
             <point key="canvasLocation" x="137.59999999999999" y="153.82308845577214"/>


### PR DESCRIPTION
Refs #11863

> Yellow "private" text should be gray, preceded by a •

Before | After
----- | -----
| <img width="378" alt="image" src="https://user-images.githubusercontent.com/517257/62313318-55fe8f00-b445-11e9-8b96-ed91b2611854.png"> | <img width="422" alt="image" src="https://user-images.githubusercontent.com/517257/62313331-6151ba80-b445-11e9-8d1e-b560ecdd7cfa.png"> |

To test:
- Open the pages list, find or create a private page
- Ensure that the new appearance matches the description

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.