### PR TITLE
Update several screen's background colors

### DIFF
--- a/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/WPStyleGuide+ApplicationStyles.swift
@@ -98,7 +98,7 @@ extension WPStyleGuide {
     class func configureColors(view: UIView, collectionView: UICollectionView) {
         configureTableViewColors(view: view)
         collectionView.backgroundView = nil
-        collectionView.backgroundColor = greyLighten30()
+        collectionView.backgroundColor = .tableBackground
     }
 
     @objc

--- a/WordPress/Classes/ViewRelated/Activity/Activity.storyboard
+++ b/WordPress/Classes/ViewRelated/Activity/Activity.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14295.6" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14270.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -134,7 +134,6 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" red="0.91372549020000005" green="0.93725490199999995" blue="0.95294117649999999" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstItem="fnA-qw-vPe" firstAttribute="trailing" secondItem="2EY-TD-6V1" secondAttribute="trailing" id="36M-yw-daV"/>
                             <constraint firstItem="2EY-TD-6V1" firstAttribute="top" secondItem="fnA-qw-vPe" secondAttribute="top" id="KcE-uG-uhl"/>

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -45,7 +45,7 @@ class ActivityDetailViewController: UIViewController {
     var router: ActivityContentRouter?
 
     override func viewDidLoad() {
-        setupFonts()
+        setupLabelStyles()
         setupViews()
         setupText()
         setupAccesibility()
@@ -56,9 +56,15 @@ class ActivityDetailViewController: UIViewController {
         rewindPresenter?.presentRewindFor(activity: activity!)
     }
 
-    private func setupFonts() {
+    private func setupLabelStyles() {
+        nameLabel.textColor = .text
         nameLabel.font = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize,
                                            weight: .semibold)
+        textLabel.textColor = .text
+        summaryLabel.textColor = .textSubtle
+
+        rewindButton.setTitleColor(.primary, for: .normal)
+        rewindButton.setTitleColor(.primaryDark, for: .highlighted)
     }
 
     private func setupViews() {
@@ -66,9 +72,9 @@ class ActivityDetailViewController: UIViewController {
             return
         }
 
+        view.backgroundColor = .tableBackground
 
         textLabel.isHidden = true
-
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
 
@@ -170,7 +176,7 @@ class ActivityDetailViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
-            setupFonts()
+            setupLabelStyles()
             setupAccesibility()
         }
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -90,6 +90,10 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         noResultsView.delegate = self
 
         updateViewState(for: pickerDataSource.totalAssetCount)
+
+        if let collectionView = collectionView {
+            WPStyleGuide.configureColors(view: view, collectionView: collectionView)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Menus/MenuHeaderViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuHeaderViewController.m
@@ -26,7 +26,7 @@ static CGFloat ViewExpansionAnimationDelay = 0.15;
     [super viewDidLoad];
 
     self.view.translatesAutoresizingMaskIntoConstraints = NO;
-    self.view.backgroundColor = [UIColor murielNeutral5];
+    self.view.backgroundColor = [UIColor murielNeutral0];
 
     self.stackView.spacing = MenusDesignDefaultContentSpacing / 2.0;
 

--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -81,7 +81,7 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
     [super viewDidLoad];
 
     self.navigationItem.title = NSLocalizedString(@"Menus", @"Title for screen that allows configuration of your site's menus");
-    self.view.backgroundColor = [UIColor murielNeutral5];
+    self.view.backgroundColor = [UIColor murielNeutral0];
 
     self.scrollView.backgroundColor = self.view.backgroundColor;
     self.scrollView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
@@ -119,7 +119,7 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
 {
     UILabel *label = [[UILabel alloc] init];
     label.font = [WPFontManager systemLightFontOfSize:14];
-    label.textColor = [UIColor murielPrimaryDark];
+    label.textColor = [UIColor murielText];
     label.numberOfLines = 0;
     [self.stackView addArrangedSubview:label];
     [label.leadingAnchor constraintEqualToAnchor:self.stackView.leadingAnchor constant:MenusDesignDefaultContentSpacing].active = YES;


### PR DESCRIPTION
Refs #11683

This fixes the background colors for: Activity, Menu, Themes, and Media screens. It also includes some text color fixes for activity details view.

<img width="419" alt="image" src="https://user-images.githubusercontent.com/517257/62335098-469c3780-b47f-11e9-9775-0a1733c776f0.png">
<img width="412" alt="image" src="https://user-images.githubusercontent.com/517257/62335109-4f8d0900-b47f-11e9-9a72-f8f32df4469f.png">
<img width="413" alt="image" src="https://user-images.githubusercontent.com/517257/62335117-57e54400-b47f-11e9-9067-58d8644a084e.png">


To test:
- Check out the screens mentioned above
- Verify that they all have the same background color, which is the same as the blog details view (and hopefully, by now, most of the rest of the app)

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
