### PR TITLE
[Stats Refresh] Update Activity Posting colors name

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -202,12 +202,12 @@ extension WPStyleGuide {
         static let gridiconSize = CGSize(width: 24, height: 24)
 
         struct PostingActivityColors {
-            static let lightGrey = UIColor.neutral(shade: .shade10)
-            static let lightBlue = UIColor.primary(shade: .shade5)
-            static let mediumBlue = UIColor.primaryLight
-            static let blue = UIColor.primary
-            static let darkBlue = UIColor.primaryDark
-            static let pink = UIColor.accent
+            static let range1 = UIColor.neutral(shade: .shade10)
+            static let range2 = UIColor.primary(shade: .shade5)
+            static let range3 = UIColor.primaryLight
+            static let range4 = UIColor.primary
+            static let range5 = UIColor.primaryDark
+            static let selectedDay = UIColor.accent
         }
 
         // MARK: - Posting Activity Collection View Styles

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
@@ -48,7 +48,7 @@ private extension PostingActivityDay {
     }
 
     @IBAction func dayButtonPressed(_ sender: UIButton) {
-        dayButton.backgroundColor = WPStyleGuide.Stats.PostingActivityColors.pink
+        dayButton.backgroundColor = WPStyleGuide.Stats.PostingActivityColors.selectedDay
         delegate?.daySelected(self)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityLegend.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityLegend.swift
@@ -23,15 +23,15 @@ class PostingActivityLegend: UIView, NibLoadable {
     static func colorForCount(_ count: Int) -> UIColor? {
         switch count {
         case 0:
-            return Style.PostingActivityColors.lightGrey
+            return Style.PostingActivityColors.range1
         case 1...2:
-            return Style.PostingActivityColors.lightBlue
+            return Style.PostingActivityColors.range2
         case 3...5:
-            return Style.PostingActivityColors.mediumBlue
+            return Style.PostingActivityColors.range3
         case 6...7:
-            return Style.PostingActivityColors.blue
+            return Style.PostingActivityColors.range4
         default:
-            return Style.PostingActivityColors.darkBlue
+            return Style.PostingActivityColors.range5
         }
     }
 


### PR DESCRIPTION
This quick PR updates the colors names used for the PostingActivityColors struct. It uses semantic names based on the what @ScoutHarris suggested [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/12070/files#r301276239)

## To test:
• Select a site with some Posting activity
• Open Stats -> Insights and scroll until Posting activity is displayed

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
