### PR TITLE
[Insights Management] Add 'Add new stats card' card

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -25,6 +25,7 @@
     case insightsTodaysStats
     case insightsPostingActivity
     case insightsPublicize
+    case insightsAddInsight
     case postStatsGraph
     case postStatsMonthsYears
     case postStatsAverageViews
@@ -92,6 +93,8 @@
             return InsightsHeaders.postingActivity
         case .insightsPublicize:
             return InsightsHeaders.publicize
+        case .insightsAddInsight:
+            return InsightsHeaders.addCard
         case .periodPostsAndPages:
             return PeriodHeaders.postsAndPages
         case .periodReferrers:
@@ -258,6 +261,7 @@
         static let followers = NSLocalizedString("Followers", comment: "Insights 'Followers' header")
         static let tagsAndCategories = NSLocalizedString("Tags and Categories", comment: "Insights 'Tags and Categories' header")
         static let annualSiteStats = NSLocalizedString("This Year", comment: "Insights 'This Year' header")
+        static let addCard = NSLocalizedString("Add new stats card", comment: "Label for action to add a new Insight.")
     }
 
     struct DetailsTitles {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -41,6 +41,8 @@ enum InsightType: Int {
     @objc optional func showPostStats(postID: Int, postTitle: String?, postURL: URL?)
     @objc optional func customizeDismissButtonTapped()
     @objc optional func customizeTryButtonTapped()
+    @objc optional func showAddInsight()
+
 }
 
 class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoadable {
@@ -267,7 +269,6 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
     }
 
     func showShareForPost(postID: NSNumber, fromView: UIView) {
-
         guard let blogId = SiteStatsInformation.sharedInstance.siteID,
         let blog = blogService.blog(byBlogId: blogId) else {
             DDLogInfo("Failed to get blog with id \(String(describing: SiteStatsInformation.sharedInstance.siteID))")
@@ -347,6 +348,16 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
 
     func customizeTryButtonTapped() {
         // TODO: remove when Insights Management view added.
+        showTemporaryAlert()
+    }
+
+    func showAddInsight() {
+        // TODO: remove when Insights Management view added.
+        showTemporaryAlert()
+    }
+
+    // TODO: remove when Insights Management view added.
+    private func showTemporaryAlert() {
         let alertController = UIAlertController(title: "Under Construction",
                                                 message: "This will show the Insights Management view.",
                                                 preferredStyle: .alert)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -115,6 +115,11 @@ class SiteStatsInsightsViewModel: Observable {
             }
         }
 
+        if FeatureFlag.statsInsightsManagement.enabled {
+            tableRows.append(TableFooterRow())
+            tableRows.append(AddInsightRow(dataRow: createAddInsightRow(), siteStatsInsightsDelegate: siteStatsInsightsDelegate))
+        }
+
         tableRows.append(TableFooterRow())
 
         return ImmuTable(sections: [
@@ -463,4 +468,12 @@ private extension SiteStatsInsightsViewModel {
                        totalCount: totalCount,
                        dataRows: followersData ?? [])
     }
+
+    func createAddInsightRow() -> StatsTotalRowData {
+        return StatsTotalRowData(name: StatSection.insightsAddInsight.title,
+                                 data: "",
+                                 icon: Style.imageForGridiconType(.plus, withTint: .darkGrey),
+                                 statSection: .insightsAddInsight)
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -187,6 +187,12 @@ class StatsTotalRow: UIView, NibLoadable, Accessible {
         let dataTitle = dataLabel.text ?? ""
         accessibilityLabel = [itemTitle, dataTitle].joined(separator: ", ")
 
+        if let statSection = rowData?.statSection, statSection == .insightsAddInsight {
+            accessibilityTraits = .button
+            accessibilityHint = NSLocalizedString("Tap to customize insights", comment: "Accessibility hint")
+            return
+        }
+
         let showDisclosure = rowData?.showDisclosure ?? false
         accessibilityTraits = (showDisclosure) ? .button : .staticText
         accessibilityHint = (showDisclosure) ? NSLocalizedString("Tap for more detail.", comment: "Accessibility hint") : ""

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -304,6 +304,10 @@ extension TopTotalsCell: StatsTotalRowDelegate {
         siteStatsDetailsDelegate?.showPostStats?(postID: postID, postTitle: postTitle, postURL: postURL)
     }
 
+    func showAddInsight() {
+        siteStatsInsightsDelegate?.showAddInsight?()
+    }
+
 }
 
 // MARK: - ViewMoreRowDelegate

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -212,6 +212,29 @@ struct TwoColumnStatsRow: ImmuTableRow {
     }
 }
 
+struct AddInsightRow: ImmuTableRow {
+
+    typealias CellType = TopTotalsCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.nib(CellType.defaultNib, CellType.self)
+    }()
+
+    let dataRow: StatsTotalRowData
+    weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(dataRows: [dataRow], siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+    }
+
+}
+
 // MARK: - Period Rows
 
 struct TopTotalsPeriodStatsRow: ImmuTableRow {


### PR DESCRIPTION
Fixes #12245 

To test:
- Go to Insights.
- Verify the 'Add new' card appears at the bottom.

<img width="400" alt="add_new" src="https://user-images.githubusercontent.com/1816888/62400841-ec15e080-b53d-11e9-97f3-5114944f3843.png">

- Tapping the row will display an alert (it's temporary, since the IM view doesn't exist yet).

<img width="300" alt="alert" src="https://user-images.githubusercontent.com/1816888/62400901-241d2380-b53e-11e9-98cf-6299b0b6048b.png">

- Enable VoiceOver.
  - Go to the 'Add new' card & select it.
  - Verify the label and hint are accurate.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
