### PR TITLE
Update colors on plugin screens

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/PluginDetailViewHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDetailViewHeaderCell.swift
@@ -10,7 +10,7 @@ class PluginDetailViewHeaderCell: UITableViewCell {
     }
 
     open func configureCell(_ directoryEntry: PluginDirectoryEntry) {
-        contentView.backgroundColor = .primary(shade: .shade0)
+        contentView.backgroundColor = .neutral(shade: .shade0)
 
         if let banner = directoryEntry.banner {
             headerImageView?.isHidden = false

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDetailViewHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDetailViewHeaderCell.swift
@@ -10,6 +10,8 @@ class PluginDetailViewHeaderCell: UITableViewCell {
     }
 
     open func configureCell(_ directoryEntry: PluginDirectoryEntry) {
+        contentView.backgroundColor = .primary(shade: .shade0)
+
         if let banner = directoryEntry.banner {
             headerImageView?.isHidden = false
             headerImageView?.downloadImage(from: banner)
@@ -19,6 +21,8 @@ class PluginDetailViewHeaderCell: UITableViewCell {
 
         let iconPlaceholder = Gridicon.iconOfType(.plugins, withSize: CGSize(width: 40, height: 40))
         iconImageView?.downloadImage(from: directoryEntry.icon, placeholderImage: iconPlaceholder)
+        iconImageView?.backgroundColor = .neutral(shade: .shade0)
+        iconImageView?.tintColor = .neutral
 
         nameLabel?.text = directoryEntry.name
 

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDetailViewHeaderCell.xib
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDetailViewHeaderCell.xib
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -29,15 +28,13 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="center" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="Mru-gt-rZz">
-                                <rect key="frame" x="0.0" y="240" width="741" height="162.5"/>
+                                <rect key="frame" x="0.0" y="240" width="148" height="162.5"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="xnc-Ub-bwQ">
-                                        <rect key="frame" x="0.0" y="59" width="44" height="44"/>
+                                        <rect key="frame" x="14" y="59" width="44" height="44"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="j3r-BA-ohO">
-                                                <rect key="frame" x="0.0" y="2" width="40" height="40"/>
-                                                <color key="backgroundColor" red="0.9137254901960784" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="deviceRGB"/>
-                                                <color key="tintColor" red="0.6588235294117647" green="0.74901960784313726" blue="0.81176470588235294" alpha="1" colorSpace="calibratedRGB"/>
+                                                <rect key="frame" x="2" y="2" width="40" height="40"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="40" id="V6c-02-jRC"/>
                                                     <constraint firstAttribute="height" priority="999" constant="40" id="bDE-cw-nZF"/>
@@ -55,20 +52,20 @@
                                         </constraints>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="-5" translatesAutoresizingMaskIntoConstraints="NO" id="ELc-B1-A79">
-                                        <rect key="frame" x="0.0" y="61" width="0.0" height="40"/>
+                                        <rect key="frame" x="72" y="15.5" width="76" height="131"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="1" translatesAutoresizingMaskIntoConstraints="NO" id="9vT-Of-2n7">
-                                                <rect key="frame" x="0.0" y="10.5" width="0.0" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="10" width="76" height="91"/>
                                                 <string key="text">This is 
 a 
 mutliline
 label</string>
                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="19"/>
-                                                <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="fill" contentVerticalAlignment="fill" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fTl-o8-Hoz">
-                                                <rect key="frame" x="0.0" y="10" width="46" height="30"/>
+                                                <rect key="frame" x="0.0" y="101" width="46" height="30"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <inset key="titleEdgeInsets" minX="0.0" minY="-10" maxX="0.0" maxY="0.0"/>
                                                 <state key="normal" title="Button"/>
@@ -90,7 +87,6 @@ label</string>
                         </constraints>
                     </stackView>
                 </subviews>
-                <color key="backgroundColor" red="0.91372549020000005" green="0.93725490199999995" blue="0.95294117649999999" alpha="1" colorSpace="deviceRGB"/>
                 <constraints>
                     <constraint firstItem="CPT-b8-8Kc" firstAttribute="leading" secondItem="ico-oq-JhH" secondAttribute="leading" id="6DP-nG-T7c"/>
                     <constraint firstAttribute="bottom" secondItem="CPT-b8-8Kc" secondAttribute="bottom" id="PGv-yt-Lwi"/>

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryAccessoryItem.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryAccessoryItem.swift
@@ -76,7 +76,7 @@ struct PluginDirectoryAccessoryItem {
         let label = UILabel(frame: .zero)
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = WPStyleGuide.subtitleFont()
-        label.textColor = tintColor
+        label.textColor = .textSubtle
         label.text = text
 
         container.axis = .horizontal

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryCollectionViewCell.swift
@@ -56,8 +56,11 @@ class PluginDirectoryCollectionViewCell: UICollectionViewCell {
             logoImageView.image = iconPlaceholder
         }
 
-        authorLabel?.text = author
         nameLabel?.text = name
+        authorLabel?.text = author
+
+        nameLabel?.textColor = .text
+        authorLabel?.textColor = .textSubtle
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryCollectionViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryCollectionViewCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,13 +27,13 @@
                     <string key="text">Gutenberg
 with long title</string>
                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
-                    <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="calibratedRGB"/>
+                    <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Gutenberg Team" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4tb-ga-CSc">
                     <rect key="frame" x="0.0" y="149.5" width="98" height="14.5"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
-                    <color key="textColor" red="0.30980392156862746" green="0.45490196078431372" blue="0.55686274509803924" alpha="1" colorSpace="calibratedRGB"/>
+                    <nil key="textColor"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListCell.swift
@@ -24,8 +24,8 @@ class PluginListCell: UITableViewCell {
         }
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
+    override func awakeFromNib() {
+        super.awakeFromNib()
 
         nameLabel.textColor = .text
         authorLabel.textColor = .textSubtle

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListCell.swift
@@ -23,6 +23,14 @@ class PluginListCell: UITableViewCell {
             view.leadingAnchor.constraint(greaterThanOrEqualTo: accessoryViewContainer.leadingAnchor).isActive = true
         }
     }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        nameLabel.textColor = .text
+        authorLabel.textColor = .textSubtle
+    }
+
     override func prepareForReuse() {
         super.prepareForReuse()
 


### PR DESCRIPTION
Refs #11683

This updates colors on the plugin screens:

Directory | List | Detail
--- | --- | ---
![Simulator Screen Shot - iPhone Xʀ - 2019-08-05 at 22 55 42](https://user-images.githubusercontent.com/517257/62514473-2ef0e600-b7d4-11e9-93e3-87808beb6025.png)|![Simulator Screen Shot - iPhone Xʀ - 2019-08-05 at 22 52 07](https://user-images.githubusercontent.com/517257/62514416-f8b36680-b7d3-11e9-90cc-723f773362a6.png)|![Simulator Screen Shot - iPhone Xʀ - 2019-08-05 at 22 52 00](https://user-images.githubusercontent.com/517257/62514399-e9341d80-b7d3-11e9-9ac0-cbe65d8f88c6.png)


To test:
- On a Jetpack site, tap Plugins 
- Ensure the colors in this section have been updated

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
