### PR TITLE
Issue/12267 draft publish action

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 13.1
 -----
+* Adds a Publish Now action to posts in the posts list. 
  
 13.0
 -----

--- a/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
@@ -31,7 +31,11 @@ class PostActionSheet {
             }
         }
 
-        if post.status != .draft {
+        if post.status == .draft {
+            actionSheetController.addDefaultActionWithTitle(Titles.publish) { [weak self] _ in
+                self?.interactivePostViewDelegate?.publish(post)
+            }
+        } else {
             actionSheetController.addDefaultActionWithTitle(Titles.draft) { [weak self] _ in
                 self?.interactivePostViewDelegate?.draft(post)
             }
@@ -54,6 +58,7 @@ class PostActionSheet {
     struct Titles {
         static let cancel = NSLocalizedString("Cancel", comment: "Dismiss the post action sheet")
         static let stats = NSLocalizedString("Stats", comment: "Label for post stats option. Tapping displays statistics for a post.")
+        static let publish = NSLocalizedString("Publish Now", comment: "Label for an option that moves a publishes a post immediately")
         static let draft = NSLocalizedString("Move to Draft", comment: "Label for an option that moves a post to the draft folder")
         static let delete = NSLocalizedString("Delete Permanently", comment: "Label for the delete post option. Tapping permanently deletes a post.")
         static let trash = NSLocalizedString("Move to Trash", comment: "Label for a option that moves a post to the trash folder")

--- a/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
@@ -25,7 +25,7 @@ class PostActionSheet {
             }
         }
 
-        if post.status == .publish || post.status == .draft {
+        if post.status == .publish {
             actionSheetController.addDefaultActionWithTitle(Titles.stats) { [weak self] _ in
                 self?.interactivePostViewDelegate?.stats(for: post)
             }

--- a/WordPress/WordPressTest/PostActionSheetTests.swift
+++ b/WordPress/WordPressTest/PostActionSheetTests.swift
@@ -32,7 +32,7 @@ class PostActionSheetTests: XCTestCase {
         postActionSheet.show(for: post, from: view)
 
         let options = viewControllerMock.viewControllerPresented?.actions.compactMap { $0.title }
-        XCTAssertEqual(["Cancel", "Stats", "Move to Trash"], options)
+        XCTAssertEqual(["Cancel", "Publish Now", "Move to Trash"], options)
     }
 
     func testScheduledPostOptions() {


### PR DESCRIPTION
Fixes #12267. This PR adds a 'Publish Now' action for drafts in the posts list, accessible from the `...` menu. It also removes the Stats item from that menu for drafts, as it doesn't make sense to be there.

![before-after-draft-actions](https://user-images.githubusercontent.com/4780/62464985-c7ac4500-b785-11e9-8eb4-194315172e9f.png)

**To test:**

* Build and run, navigate to the Posts list
* Choose Drafts
* Ensure that the `...` menu doesn't show a Stats item, and does show a Publish Now item.
* Try publishing a post using the Publish Now action.
* Ensure the Published, Scheduled, and Trash lists still contain the expected actions.

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.