### PR TITLE
Issue/11397 Fix Zendesk presentation crash

### DIFF
--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -479,18 +479,13 @@ private extension ZendeskUtils {
             return
         }
 
-        // If the controller is a UIViewController, set the modal display for iPad.
-        if !presentInController.isKind(of: UINavigationController.self) && WPDeviceIdentification.isiPad() {
-            let navController = UINavigationController(rootViewController: zendeskView)
-            navController.modalPresentationStyle = .fullScreen
-            navController.modalTransitionStyle = .crossDissolve
-            presentInController.present(navController, animated: true)
-            return
-        }
-
-        if let navController = presentInController as? UINavigationController {
-            navController.pushViewController(zendeskView, animated: true)
-        }
+        // Presenting in a modal instead of pushing onto an existing navigation stack
+        // seems to fix this issue we were seeing when trying to add media to a ticket:
+        // https://github.com/wordpress-mobile/WordPress-iOS/issues/11397
+        let navController = UINavigationController(rootViewController: zendeskView)
+        navController.modalPresentationStyle = .formSheet
+        navController.modalTransitionStyle = .coverVertical
+        presentInController.present(navController, animated: true)
     }
 
     // MARK: - Get User Information


### PR DESCRIPTION
Fixes #11397. I think this PR should fix the crash we're seeing in #11397. It switches Zendesk to use a modal presentation style instead of pushing onto the existing navigation stack. We're using `formSheet`, which will show full screen on iPhone, and in a smaller modal on iPad.

![before-after-zendesk](https://user-images.githubusercontent.com/4780/62454794-e2be8b00-b76c-11e9-8f42-93a581c0e70f.png)

**To test:**

* Build and run
* Ensure that Zendesk views still work as expected
* Create a new ticket, and tap the attachment icon. Scroll the image picker to the left and choose Media Library or Camera and ensure the app doesn't crash.

cc @jkmassel @SylvesterWilmott 

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
