### PR TITLE
[Gutenberg] Implement new single request to bulk update user's mobile editor preference

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -45,7 +45,7 @@ end
 def wordpress_kit
     #pod 'WordPressKit', '~> 4.3.0'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/9705-update-username'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '723fe9bb709b61e7520ffdf10ccd1bd1cfb10b02'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'bcd579af5dde7b3b61c5270dcb4139b609df0bf7'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -43,9 +43,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.3.0'
+    #pod 'WordPressKit', '~> 4.3.0'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/9705-update-username'
-    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'cbacefca353ffea31448bc26e75641f95555e730'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '723fe9bb709b61e7520ffdf10ccd1bd1cfb10b02'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -43,9 +43,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    #pod 'WordPressKit', '~> 4.3.0'
+    pod 'WordPressKit', '~> 4.3.1'
     #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/9705-update-username'
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'bcd579af5dde7b3b61c5270dcb4139b609df0bf7'
+    #pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'bcd579af5dde7b3b61c5270dcb4139b609df0bf7'
     #pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -299,7 +299,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.8.0)
   - WordPressAuthenticator (~> 1.7.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `723fe9bb709b61e7520ffdf10ccd1bd1cfb10b02`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `bcd579af5dde7b3b61c5270dcb4139b609df0bf7`)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.5)
   - WordPressUI (~> 1.3.4)
@@ -408,7 +408,7 @@ EXTERNAL SOURCES:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.0
   WordPressKit:
-    :commit: 723fe9bb709b61e7520ffdf10ccd1bd1cfb10b02
+    :commit: bcd579af5dde7b3b61c5270dcb4139b609df0bf7
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.10.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
@@ -424,7 +424,7 @@ CHECKOUT OPTIONS:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.0
   WordPressKit:
-    :commit: 723fe9bb709b61e7520ffdf10ccd1bd1cfb10b02
+    :commit: bcd579af5dde7b3b61c5270dcb4139b609df0bf7
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
@@ -497,6 +497,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 74d6de91ecf1a1315be6266affb229a4e585a58f
+PODFILE CHECKSUM: c50f5cff41f19480c55d2609b58dc075661c12df
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -299,7 +299,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.8.0)
   - WordPressAuthenticator (~> 1.7.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `bcd579af5dde7b3b61c5270dcb4139b609df0bf7`)
+  - WordPressKit (~> 4.3.1)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.5)
   - WordPressUI (~> 1.3.4)
@@ -343,6 +343,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -407,9 +408,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.0
-  WordPressKit:
-    :commit: bcd579af5dde7b3b61c5270dcb4139b609df0bf7
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.10.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -423,9 +421,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.0
-  WordPressKit:
-    :commit: bcd579af5dde7b3b61c5270dcb4139b609df0bf7
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -497,6 +492,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: c50f5cff41f19480c55d2609b58dc075661c12df
+PODFILE CHECKSUM: ab4d90934ff0b10f7cc16be4385cdc5971826497
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -221,7 +221,7 @@ PODS:
     - WordPressKit (~> 4.1)
     - WordPressShared (~> 1.8)
     - WordPressUI (~> 1.3)
-  - WordPressKit (4.3.0):
+  - WordPressKit (4.3.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -299,7 +299,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.8.0)
   - WordPressAuthenticator (~> 1.7.0)
-  - WordPressKit (~> 4.3.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `723fe9bb709b61e7520ffdf10ccd1bd1cfb10b02`)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.5)
   - WordPressUI (~> 1.3.4)
@@ -343,7 +343,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -408,6 +407,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.0
+  WordPressKit:
+    :commit: 723fe9bb709b61e7520ffdf10ccd1bd1cfb10b02
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.10.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -421,6 +423,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.0
+  WordPressKit:
+    :commit: 723fe9bb709b61e7520ffdf10ccd1bd1cfb10b02
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -482,7 +487,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 5022d76e7c4cd2a492f670944e24b9dd05639763
   WordPress-Editor-iOS: e0116fe2c4d3e0d2c325f053d9becdf637bfd708
   WordPressAuthenticator: 485679ba24ceefb15acb8e0bd18f3856cf52e8f4
-  WordPressKit: b746095e0734e25ca240d1da68bd22d365b3d832
+  WordPressKit: 47be0fd68e031dffc8eebf52da0e58a1eed2ca86
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
   WordPressShared: 18f7bce275fb88e269906eef1b16efab8b7c1bc3
   WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
@@ -492,6 +497,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: cbd49d65efb2f2cdbdcaac84e618896ae87b861e
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 49c7763eb074a55355c1acb04b60a3538f5133ca
+PODFILE CHECKSUM: 74d6de91ecf1a1315be6266affb229a4e585a58f
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
+++ b/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
@@ -21,7 +21,9 @@ class BlogToBlogMigration87to88: NSEntityMigrationPolicy {
         NotificationCenter.default.observeOnce(forName: .applicationLaunchCompleted, object: nil, queue: .main, using: { (_) in
             let context = ContextManager.shared.mainContext
             let service = EditorSettingsService(managedObjectContext: context)
-            service.postAppWideEditorSettingToRemoteForAllBlogsAfterMigration()
+            let isGutenbergEnabled = UserDefaults.standard.object(forKey: "kUserDefaultsGutenbergEditorEnabled") as? Bool ?? false
+
+            service.migrateGlobalSettingToRemote(isGutenbergEnabled: isGutenbergEnabled)
         })
     }
 }

--- a/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
+++ b/WordPress/Classes/Utility/Migrations/87-88/BlogToBlogMigration87to88.swift
@@ -21,7 +21,7 @@ class BlogToBlogMigration87to88: NSEntityMigrationPolicy {
         NotificationCenter.default.observeOnce(forName: .applicationLaunchCompleted, object: nil, queue: .main, using: { (_) in
             let context = ContextManager.shared.mainContext
             let service = EditorSettingsService(managedObjectContext: context)
-            service.syncEditorSettingsForAllBlogs()
+            service.postAppWideEditorSettingToRemoteForAllBlogsAfterMigration()
         })
     }
 }

--- a/WordPress/WordPressTest/EditorSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/EditorSettingsServiceTests.swift
@@ -78,9 +78,7 @@ class EditorSettingsServiceTest: XCTestCase {
     }
 
     func testAppWideGutenbergSyncWithServer() {
-        database.set(true, forKey: GutenbergSettings.Key.appWideEnabled)
-
-        service.postAppWideEditorSettingToRemoteForAllBlogsAfterMigration(database: database)
+        service.migrateGlobalSettingToRemote(isGutenbergEnabled: true)
 
         XCTAssertTrue(remoteApi.postMethodCalled)
         XCTAssertTrue(remoteApi.URLStringPassedIn?.contains("me/gutenberg") ?? false)
@@ -91,18 +89,7 @@ class EditorSettingsServiceTest: XCTestCase {
     func testAppWideAztecSyncWithServer() {
         database.set(false, forKey: GutenbergSettings.Key.appWideEnabled)
 
-        service.postAppWideEditorSettingToRemoteForAllBlogsAfterMigration(database: database)
-
-        XCTAssertTrue(remoteApi.postMethodCalled)
-        XCTAssertTrue(remoteApi.URLStringPassedIn?.contains("me/gutenberg") ?? false)
-        let parameters = remoteApi.parametersPassedIn as? [String: Any]
-        XCTAssertEqual(parameters?["editor"] as? String, MobileEditor.aztec.rawValue)
-    }
-
-    func testAppWideNilSyncAztecWithServer() {
-        database.set(nil, forKey: GutenbergSettings.Key.appWideEnabled)
-
-        service.postAppWideEditorSettingToRemoteForAllBlogsAfterMigration(database: database)
+        service.migrateGlobalSettingToRemote(isGutenbergEnabled: false)
 
         XCTAssertTrue(remoteApi.postMethodCalled)
         XCTAssertTrue(remoteApi.URLStringPassedIn?.contains("me/gutenberg") ?? false)
@@ -115,7 +102,7 @@ class EditorSettingsServiceTest: XCTestCase {
         let blogs = addBlogsToAccount(count: numberOfBlogs)
         let response = bulkResponse(with: .gutenberg, count: numberOfBlogs)
 
-        service.postAppWideEditorSettingToRemoteForAllBlogsAfterMigration(database: database)
+        service.migrateGlobalSettingToRemote(isGutenbergEnabled: true)
         remoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
 
         blogs.forEach {
@@ -133,7 +120,7 @@ class EditorSettingsServiceTest: XCTestCase {
             $0.mobileEditor = .gutenberg
         }
 
-        service.postAppWideEditorSettingToRemoteForAllBlogsAfterMigration(database: database)
+        service.migrateGlobalSettingToRemote(isGutenbergEnabled: false)
         remoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
 
         blogs.forEach {


### PR DESCRIPTION
This PR implements the new request from https://github.com/wordpress-mobile/WordPressKit-iOS/pull/176

To test:
- Run the migration from 12.9 to 13.0
- Check that the settings on server corresponds with the expectation:
  - All blogs without mobile editor set, should be set to the new value given
  - All blogs with a mobile editor set, should remain unchanged
  - The local settings for all blogs should map the final state of mobile editor settings on server

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
