### PR TITLE
[Auto-upload Published] Update Notice and Post List messages for failed local published posts

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
@@ -112,7 +112,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="Qxw-fl-tZF">
                                         <rect key="frame" x="0.0" y="333.5" width="326" height="40"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbu-l3-L8G">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Status" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbu-l3-L8G">
                                                 <rect key="frame" x="16" y="0.0" width="294" height="40"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
@@ -310,7 +310,7 @@
         <image name="icon-post-actionbar-restore" width="18" height="18"/>
         <image name="icon-post-actionbar-view" width="18" height="18"/>
         <namedColor name="Gray10">
-            <color red="0.80784313725490198" green="0.78823529411764703" blue="0.80784313725490198" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.80392156862745101" green="0.78823529411764703" blue="0.80392156862745101" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -33,6 +33,10 @@ class PostCardStatusViewModel: NSObject {
         if MediaCoordinator.shared.isUploadingMedia(for: post) {
             return NSLocalizedString("Uploading media...", comment: "Message displayed on a post's card while the post is uploading media")
         } else if post.isFailed {
+            if post.status == .publish {
+                return NSLocalizedString("Post will be published next time your device is online", comment: "Message shown in the posts list when a post is scheduled for publishing")
+            }
+
             return NSLocalizedString("Upload failed", comment: "Message displayed on a post's card when the post has failed to upload")
         } else if post.remoteStatus == .pushing {
             return NSLocalizedString("Uploading post...", comment: "Message displayed on a post's card when the post has failed to upload")
@@ -104,7 +108,7 @@ class PostCardStatusViewModel: NSObject {
         }
 
         if post.isFailed {
-            return .error
+            return status == .publish ? .warning : .error
         }
 
         switch status {

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -30,11 +30,12 @@ class PostCardStatusViewModel: NSObject {
 
     @objc
     var status: String? {
+        // TODO Move these string constants to the StatusMessages enum
         if MediaCoordinator.shared.isUploadingMedia(for: post) {
             return NSLocalizedString("Uploading media...", comment: "Message displayed on a post's card while the post is uploading media")
         } else if post.isFailed {
             if post.status == .publish {
-                return NSLocalizedString("Post will be published next time your device is online", comment: "Message shown in the posts list when a post is scheduled for publishing")
+                return StatusMessages.postWillBePublished
             }
 
             return NSLocalizedString("Upload failed", comment: "Message displayed on a post's card when the post has failed to upload")
@@ -146,5 +147,10 @@ class PostCardStatusViewModel: NSObject {
 
     private enum Constants {
         static let stickyLabel = NSLocalizedString("Sticky", comment: "Label text that defines a post marked as sticky")
+    }
+
+    enum StatusMessages {
+        static let postWillBePublished = NSLocalizedString("Post will be published next time your device is online",
+                                                           comment: "Message shown in the posts list when a post is scheduled for publishing")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -6,7 +6,8 @@ import Gridicons
 class PostCardStatusViewModel: NSObject {
     private let post: Post
     private var progressObserverUUID: UUID? = nil
-    @objc var progressBlock: ((Float) -> Void)? = nil {
+
+    var progressBlock: ((Float) -> Void)? = nil {
         didSet {
             if let _ = oldValue, let uuid = progressObserverUUID {
                 MediaCoordinator.shared.removeObserver(withUUID: uuid)
@@ -22,14 +23,12 @@ class PostCardStatusViewModel: NSObject {
         }
     }
 
-    @objc
     init(post: Post) {
         self.post = post
         super.init()
     }
 
-    @objc
-    var status: String? {
+    private var status: String? {
         // TODO Move these string constants to the StatusMessages enum
         if MediaCoordinator.shared.isUploadingMedia(for: post) {
             return NSLocalizedString("Uploading media...", comment: "Message displayed on a post's card while the post is uploading media")
@@ -98,7 +97,6 @@ class PostCardStatusViewModel: NSObject {
         }
     }
 
-    @objc
     var statusColor: UIColor {
         guard let status = postStatus else {
             return .neutral(shade: .shade70)
@@ -124,12 +122,10 @@ class PostCardStatusViewModel: NSObject {
         }
     }
 
-    @objc
     var shouldHideProgressView: Bool {
         return !(MediaCoordinator.shared.isUploadingMedia(for: post) || post.remoteStatus == .pushing)
     }
 
-    @objc
     var progress: Float {
         if post.remoteStatus == .pushing {
             return 1.0

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -61,42 +61,6 @@ class PostCardStatusViewModel: NSObject {
         return post.status
     }
 
-    @objc
-    var shouldHideStatusView: Bool {
-        guard let status = status else {
-            return !post.isStickyPost
-        }
-
-        return status.isEmpty && !post.isStickyPost
-    }
-
-    @objc
-    var statusImage: UIImage? {
-        guard let status = postStatus else {
-            return nil
-        }
-
-        // In progress uploads
-        if MediaCoordinator.shared.isUploadingMedia(for: post) || post.remoteStatus == .pushing {
-            return Gridicon.iconOfType(.cloudUpload)
-        }
-
-        if post.isFailed {
-            return Gridicon.iconOfType(.cloudUpload)
-        }
-
-        switch status {
-        case .pending:
-            return Gridicon.iconOfType(.chat)
-        case .scheduled:
-            return Gridicon.iconOfType(.scheduled)
-        case .trash:
-            return Gridicon.iconOfType(.trash)
-        default:
-            return UIDevice.isPad() ? Gridicon.iconOfType(.tablet) : Gridicon.iconOfType(.phone)
-        }
-    }
-
     var statusColor: UIColor {
         guard let status = postStatus else {
             return .neutral(shade: .shade70)

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -131,6 +131,7 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
 
         badgesLabel.textColor = viewModel.statusColor
         badgesLabel.text = viewModel.statusAndBadges(separatedBy: Constants.separator)
+        badgesLabel.numberOfLines = viewModel.isUploadingOrFailed ? 0 : 1
     }
 
     private func configureProgressView() {

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
@@ -134,11 +134,13 @@
                             <constraint firstAttribute="trailingMargin" secondItem="Zh4-Mc-AK7" secondAttribute="trailing" constant="-8" id="6OK-8s-Dxs"/>
                             <constraint firstAttribute="trailing" secondItem="06O-B0-y3k" secondAttribute="trailing" id="8ib-ER-7zy"/>
                             <constraint firstItem="XTx-r8-hUF" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" id="DSl-Iw-NhL"/>
+                            <constraint firstItem="UrU-r4-hAL" firstAttribute="top" secondItem="HJK-1N-bmY" secondAttribute="top" constant="6" id="JL4-zc-5bz"/>
                             <constraint firstAttribute="bottom" secondItem="XTx-r8-hUF" secondAttribute="bottom" id="Psp-EO-ZSL"/>
+                            <constraint firstAttribute="bottom" secondItem="UrU-r4-hAL" secondAttribute="bottom" constant="10" id="QLd-8e-C0k"/>
                             <constraint firstItem="XTx-r8-hUF" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="leading" id="Sn7-OG-k7S"/>
                             <constraint firstItem="tne-qn-oAS" firstAttribute="centerY" secondItem="HJK-1N-bmY" secondAttribute="centerY" id="UEo-T2-kHC"/>
                             <constraint firstItem="UrU-r4-hAL" firstAttribute="trailing" secondItem="Zh4-Mc-AK7" secondAttribute="leading" priority="750" id="VgY-3y-Xq1"/>
-                            <constraint firstAttribute="height" priority="999" constant="60" id="XwZ-7a-9Cd"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="999" constant="60" id="XwZ-7a-9Cd"/>
                             <constraint firstItem="tne-qn-oAS" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="trailing" constant="16" id="YXw-VS-KHH"/>
                             <constraint firstItem="Zh4-Mc-AK7" firstAttribute="leading" secondItem="XTx-r8-hUF" secondAttribute="trailing" id="ex5-gp-3zr"/>
                             <constraint firstItem="06O-B0-y3k" firstAttribute="leading" secondItem="HJK-1N-bmY" secondAttribute="leading" id="g6x-y3-fZX"/>

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -90,10 +90,10 @@ struct PostNoticeViewModel {
         }
     }
 
+    // TODO Move strings to FailureTitles enum
     private var failureTitle: String {
         if post.status == .publish {
-            return NSLocalizedString("Post will be published the next time your device is online",
-                                     comment: "Text displayed in notice after a post if published while offline.")
+            return FailureTitles.postWillBePublished
         }
 
         if post is Page {
@@ -205,5 +205,10 @@ struct PostNoticeViewModel {
         let postInContext = objectInContext as? AbstractPost
 
         return postInContext
+    }
+
+    enum FailureTitles {
+        static let postWillBePublished = NSLocalizedString("Post will be published the next time your device is online",
+                                                           comment: "Text displayed in notice after a post if published while offline.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -91,6 +91,11 @@ struct PostNoticeViewModel {
     }
 
     private var failureTitle: String {
+        if post.status == .publish {
+            return NSLocalizedString("Post will be published the next time your device is online",
+                                     comment: "Text displayed in notice after a post if published while offline.")
+        }
+
         if post is Page {
             return NSLocalizedString("Page failed to upload", comment: "Title of notification displayed when a page has failed to upload.")
         } else {

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -130,7 +130,9 @@ class NoticeView: UIView {
         titleLabel.textColor = notice.style.titleColor
         messageLabel.textColor = notice.style.messageColor
 
+        titleLabel.numberOfLines = 0
         messageLabel.numberOfLines = 0
+
         if notice.cancelTitle != nil {
             messageLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: Appearance.minMessageHeight).isActive = true
         }
@@ -266,8 +268,6 @@ class NoticeView: UIView {
             titleLabel.isHidden = true
         } else if let message = notice.message {
             messageLabel.text = message
-        } else {
-            titleLabel.numberOfLines = 2
         }
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -537,6 +537,7 @@
 		570BFD902282418A007859A8 /* PostBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570BFD8F2282418A007859A8 /* PostBuilder.swift */; };
 		5727EAF82284F5AC00822104 /* InteractivePostViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5727EAF72284F5AC00822104 /* InteractivePostViewDelegate.swift */; };
 		572FB401223A806000933C76 /* NoticeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 572FB400223A806000933C76 /* NoticeStoreTests.swift */; };
+		5749984722FA0F2E00CE86ED /* PostNoticeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5749984622FA0F2E00CE86ED /* PostNoticeViewModelTests.swift */; };
 		575E126322973EBB0041B3EB /* PostCompactCellGhostableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575E126222973EBB0041B3EB /* PostCompactCellGhostableTests.swift */; };
 		575E126F229779E70041B3EB /* RestorePostTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575E126E229779E70041B3EB /* RestorePostTableViewCell.swift */; };
 		577C2AAB22936DCB00AD1F03 /* PostCardCellGhostableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 577C2AAA22936DCB00AD1F03 /* PostCardCellGhostableTests.swift */; };
@@ -2580,6 +2581,7 @@
 		570BFD8F2282418A007859A8 /* PostBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostBuilder.swift; sourceTree = "<group>"; };
 		5727EAF72284F5AC00822104 /* InteractivePostViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InteractivePostViewDelegate.swift; sourceTree = "<group>"; };
 		572FB400223A806000933C76 /* NoticeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeStoreTests.swift; sourceTree = "<group>"; };
+		5749984622FA0F2E00CE86ED /* PostNoticeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostNoticeViewModelTests.swift; sourceTree = "<group>"; };
 		575E126222973EBB0041B3EB /* PostCompactCellGhostableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCompactCellGhostableTests.swift; sourceTree = "<group>"; };
 		575E126E229779E70041B3EB /* RestorePostTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorePostTableViewCell.swift; sourceTree = "<group>"; };
 		577C2AAA22936DCB00AD1F03 /* PostCardCellGhostableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardCellGhostableTests.swift; sourceTree = "<group>"; };
@@ -5490,6 +5492,15 @@
 			path = Stores;
 			sourceTree = "<group>";
 		};
+		5749984522FA0EB900CE86ED /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				5749984622FA0F2E00CE86ED /* PostNoticeViewModelTests.swift */,
+			);
+			name = Utils;
+			path = ViewRelated/Post/Utils;
+			sourceTree = "<group>";
+		};
 		59B48B601B99E0B0008EBB84 /* TestUtilities */ = {
 			isa = PBXGroup;
 			children = (
@@ -6753,6 +6764,7 @@
 		937E3AB41E3EBDC900CDA01A /* Post */ = {
 			isa = PBXGroup;
 			children = (
+				5749984522FA0EB900CE86ED /* Utils */,
 				937E3AB51E3EBE1600CDA01A /* PostEditorStateTests.swift */,
 				E10F3DA01E5C2CE0008FAADA /* PostListFilterTests.swift */,
 				E684383F221F5A2200752258 /* PostListExcessiveLoadMoreTests.swift */,
@@ -11616,6 +11628,7 @@
 				D81C2F6020F891C4002AE1F1 /* TrashCommentActionTests.swift in Sources */,
 				570BFD8D22823DE5007859A8 /* PostActionSheetTests.swift in Sources */,
 				FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */,
+				5749984722FA0F2E00CE86ED /* PostNoticeViewModelTests.swift in Sources */,
 				08B6E51C1F037ADD00268F57 /* MediaFileManagerTests.swift in Sources */,
 				5981FE051AB8A89A0009E080 /* WPUserAgentTests.m in Sources */,
 				73178C2C21BEE09300E37C9A /* SiteCreationHeaderDataTests.swift in Sources */,

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -4,7 +4,7 @@ import Foundation
 
 class PostBuilder {
 
-    private(set) var post: Post!
+    private var post: Post!
 
     init() {
         post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: setUpInMemoryManagedObjectContext()) as? Post

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -4,10 +4,14 @@ import Foundation
 
 class PostBuilder {
 
-    var post: Post!
+    private(set) var post: Post!
 
     init() {
         post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: setUpInMemoryManagedObjectContext()) as? Post
+    }
+
+    init(_ context: NSManagedObjectContext) {
+        post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: context) as? Post
     }
 
     func published() -> PostBuilder {

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 @testable import WordPress
 
+private typealias StatusMessages = PostCardStatusViewModel.StatusMessages
+
 class PostCardCellTests: XCTestCase {
 
     var postCell: PostCardCell!
@@ -107,7 +109,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        XCTAssertEqual(postCell.statusLabel?.text, PostCardStatusViewModel.StatusMessages.postWillBePublished)
+        XCTAssertEqual(postCell.statusLabel?.text, StatusMessages.postWillBePublished)
     }
 
 
@@ -249,6 +251,18 @@ class PostCardCellTests: XCTestCase {
 
         XCTAssertFalse(postCell.authorLabel.isHidden)
         XCTAssertFalse(postCell.separatorLabel.isHidden)
+    }
+
+    func testShowsWarningMessageForFailedPublishedPosts() {
+        // Given
+        let post = PostBuilder().published().with(remoteStatus: .failed).build()
+
+        // When
+        postCell.configure(with: post)
+
+        // Then
+        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.postWillBePublished)
+        XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
     private func postCellFromNib() -> PostCardCell {

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -107,7 +107,7 @@ class PostCardCellTests: XCTestCase {
 
         postCell.configure(with: post)
 
-        XCTAssertEqual(postCell.statusLabel?.text, "Upload failed")
+        XCTAssertEqual(postCell.statusLabel?.text, PostCardStatusViewModel.StatusMessages.postWillBePublished)
     }
 
 

--- a/WordPress/WordPressTest/PostCompactCellTests.swift
+++ b/WordPress/WordPressTest/PostCompactCellTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 @testable import WordPress
 
+private typealias StatusMessages = PostCardStatusViewModel.StatusMessages
+
 class PostCompactCellTests: XCTestCase {
 
     var postCell: PostCompactCell!
@@ -107,6 +109,18 @@ class PostCompactCellTests: XCTestCase {
         postCell.configure(with: post)
 
         XCTAssertTrue(postCell.progressView.isHidden)
+    }
+
+    func testShowsWarningMessageForFailedPublishedPosts() {
+        // Given
+        let post = PostBuilder().published().with(remoteStatus: .failed).build()
+
+        // When
+        postCell.configure(with: post)
+
+        // Then
+        XCTAssertEqual(postCell.badgesLabel.text, StatusMessages.postWillBePublished)
+        XCTAssertEqual(postCell.badgesLabel.textColor, UIColor.warning)
     }
 
     private func postCellFromNib() -> PostCompactCell {

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import XCTest
+import Nimble
+
+@testable import WordPress
+
+class PostNoticeViewModelTests: XCTestCase {
+    private var contextManager: TestContextManager!
+    private var context: NSManagedObjectContext!
+
+    override func setUp() {
+        super.setUp()
+
+        contextManager = TestContextManager()
+        context = contextManager.newDerivedContext()
+    }
+
+    override func tearDown() {
+        context = nil
+        contextManager = nil
+
+        super.tearDown()
+    }
+
+    func testCreatesNoticeWithFailureMessageForFailedPublishedPosts() {
+        // Given
+        let post = PostBuilder(context).published().with(title: "Darby Ritchie").with(remoteStatus: .failed).build()
+
+        // When
+        let notice = PostNoticeViewModel(post: post).notice
+
+        // Then
+        expect(notice.title).to(equal(PostNoticeViewModel.FailureTitles.postWillBePublished))
+        expect(notice.message).to(equal(post.postTitle))
+    }
+}


### PR DESCRIPTION
Part of #12240. 

In #12252, we added auto-uploads for locally published posts. This PR updates the Notice and Post List messages to reflect the design described in #12240. 

Most of the commits were cherry-picked from @diegoreymendez's work in #12178.  

|What| Before | After |
--------|-------|----
Notice | <img src="https://user-images.githubusercontent.com/198826/62576719-a406fe80-b85a-11e9-9bf8-fb1f736e123c.PNG" width="320"> | <img src="https://user-images.githubusercontent.com/198826/62576723-a49f9500-b85a-11e9-841d-ee79ba48e715.PNG" width="320">
Post List | <img src="https://user-images.githubusercontent.com/198826/62576718-a406fe80-b85a-11e9-843c-6e7b5b5ed270.PNG" width="320"> | <img src="https://user-images.githubusercontent.com/198826/62576722-a49f9500-b85a-11e9-9552-c43c2a97cc0b.PNG" width="320">
Post List (compact) | <img src="https://user-images.githubusercontent.com/198826/62576717-a406fe80-b85a-11e9-962f-07c883a45642.PNG" width="320"> | <img src="https://user-images.githubusercontent.com/198826/62576720-a49f9500-b85a-11e9-851c-340297f58137.PNG" width="320">

Support for pages is out of the scope of this PR and will be tackled later. 

## Testing

1. Go offline.
2. Create a post and publish it. 
3. Confirm the new messages shown in the Notice and the Post List. 

## Code Review 

Only 1 reviewer is needed but anyone can review. 

## Release Notes

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
