### PR TITLE
[Insights Management] Add 'Add New Stats Card' view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -229,6 +229,15 @@
         }
     }
 
+    var insightManagementTitle: String {
+        switch self {
+        case .insightsTodaysStats:
+            return InsightManagementTitles.todaysStats
+        default:
+            return title
+        }
+    }
+
     // MARK: - Image Size Accessor
 
     static let defaultImageSize = CGFloat(24)
@@ -266,6 +275,10 @@
 
     struct DetailsTitles {
         static let annualSiteStats = NSLocalizedString("Annual Site Stats", comment: "Insights 'This Year' details view header")
+    }
+
+    struct InsightManagementTitles {
+        static let todaysStats = NSLocalizedString("Today's Stats", comment: "Insights Management 'Today's Stats' title")
     }
 
     struct PeriodHeaders {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
@@ -4,6 +4,8 @@ class AddInsightTableViewController: UITableViewController {
 
     // MARK: - Properties
 
+    weak var insightsDelegate: SiteStatsInsightsDelegate?
+
     private lazy var tableHandler: ImmuTableViewHandler = {
         return ImmuTableViewHandler(takeOver: self)
     }()
@@ -54,10 +56,27 @@ private extension AddInsightTableViewController {
     }
 
     func tableViewModel() -> ImmuTable {
-        return ImmuTable(sections: [ InsightsCategories.general.tableSection(),
-                                     InsightsCategories.postsAndPages.tableSection(),
-                                     InsightsCategories.activity.tableSection() ]
+        return ImmuTable(sections: [ sectionForCategory(.general),
+                                     sectionForCategory(.postsAndPages),
+                                     sectionForCategory(.activity) ]
         )
+    }
+
+    // MARK: - Table Sections
+
+    func sectionForCategory(_ category: InsightsCategories) -> ImmuTableSection {
+        return ImmuTableSection(headerText: category.title,
+                                rows: category.insights.map { AddInsightStatRow(title: $0.insightManagementTitle,
+                                                                                enabled: true,
+                                                                                action: rowActionFor($0)) }
+        )
+    }
+
+    func rowActionFor(_ statSection: StatSection) -> ImmuTableAction {
+        return { [unowned self] row in
+            self.insightsDelegate?.addInsightSelected?(statSection)
+            self.navigationController?.popViewController(animated: true)
+        }
     }
 
     // MARK: - Insights Categories
@@ -87,13 +106,6 @@ private extension AddInsightTableViewController {
             case .activity:
                 return [.insightsCommentsPosts, .insightsFollowersEmail, .insightsFollowerTotals, .insightsPublicize]
             }
-        }
-
-        func tableSection() -> ImmuTableSection {
-            return ImmuTableSection(
-                headerText: title,
-                rows: insights.map { AddInsightStatRow(title: $0.insightManagementTitle, enabled: true, action: nil) }
-            )
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
@@ -1,0 +1,100 @@
+import UIKit
+
+class AddInsightTableViewController: UITableViewController {
+
+    // MARK: - Properties
+
+    private lazy var tableHandler: ImmuTableViewHandler = {
+        return ImmuTableViewHandler(takeOver: self)
+    }()
+
+    // MARK: - Init
+
+    override init(style: UITableView.Style) {
+        super.init(style: style)
+        navigationItem.title = NSLocalizedString("Add New Stats Card", comment: "Add New Stats Card view title")
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    required convenience init() {
+        self.init(style: .grouped)
+    }
+
+    // MARK: - View
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        ImmuTable.registerRows([AddInsightStatRow.self], tableView: tableView)
+        reloadViewModel()
+        WPStyleGuide.configureColors(view: view, tableView: tableView)
+        WPStyleGuide.configureAutomaticHeightRows(for: tableView)
+        tableView.accessibilityIdentifier = "Add Insight Table"
+    }
+
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return 38
+    }
+
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 0
+    }
+
+}
+
+private extension AddInsightTableViewController {
+
+    // MARK: - Table Model
+
+    func reloadViewModel() {
+        tableHandler.viewModel = tableViewModel()
+    }
+
+    func tableViewModel() -> ImmuTable {
+        return ImmuTable(sections: [ InsightsCategories.general.tableSection(),
+                                     InsightsCategories.postsAndPages.tableSection(),
+                                     InsightsCategories.activity.tableSection() ]
+        )
+    }
+
+    // MARK: - Insights Categories
+
+    enum InsightsCategories {
+        case general
+        case postsAndPages
+        case activity
+
+        var title: String {
+            switch self {
+            case .general:
+                return NSLocalizedString("General", comment: "Add New Stats Card category title")
+            case .postsAndPages:
+                return NSLocalizedString("Posts and Pages", comment: "Add New Stats Card category title")
+            case .activity:
+                return NSLocalizedString("Activity", comment: "Add New Stats Card category title")
+            }
+        }
+
+        var insights: [StatSection] {
+            switch self {
+            case .general:
+                return [.insightsAllTime, .insightsMostPopularTime, .insightsAnnualSiteStats, .insightsTodaysStats]
+            case .postsAndPages:
+                return [.insightsLatestPostSummary, .insightsPostingActivity, .insightsTagsAndCategories]
+            case .activity:
+                return [.insightsCommentsPosts, .insightsFollowersEmail, .insightsFollowerTotals, .insightsPublicize]
+            }
+        }
+
+        func tableSection() -> ImmuTableSection {
+            return ImmuTableSection(
+                headerText: title,
+                rows: insights.map { AddInsightStatRow(title: $0.title, enabled: true, action: nil) }
+            )
+        }
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
@@ -92,7 +92,7 @@ private extension AddInsightTableViewController {
         func tableSection() -> ImmuTableSection {
             return ImmuTableSection(
                 headerText: title,
-                rows: insights.map { AddInsightStatRow(title: $0.title, enabled: true, action: nil) }
+                rows: insights.map { AddInsightStatRow(title: $0.insightManagementTitle, enabled: true, action: nil) }
             )
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
@@ -65,10 +65,14 @@ private extension AddInsightTableViewController {
     // MARK: - Table Sections
 
     func sectionForCategory(_ category: InsightsCategories) -> ImmuTableSection {
+        // TODO: set 'enabled' indicating whether the row can be selected or not
+        // depending on if it's already displayed in Insights.
+        let enabled = true
+
         return ImmuTableSection(headerText: category.title,
                                 rows: category.insights.map { AddInsightStatRow(title: $0.insightManagementTitle,
-                                                                                enabled: true,
-                                                                                action: rowActionFor($0)) }
+                                                                                enabled: enabled,
+                                                                                action: enabled ? rowActionFor($0) : nil) }
         )
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -42,6 +42,7 @@ enum InsightType: Int {
     @objc optional func customizeDismissButtonTapped()
     @objc optional func customizeTryButtonTapped()
     @objc optional func showAddInsight()
+    @objc optional func addInsightSelected(_ insight: StatSection)
 
 }
 
@@ -219,7 +220,9 @@ private extension SiteStatsInsightsTableViewController {
     // MARK: - Insights Management
 
     func showAddInsightView() {
-        navigationController?.pushViewController(AddInsightTableViewController(), animated: true)
+        let controller = AddInsightTableViewController()
+        controller.insightsDelegate = self
+        navigationController?.pushViewController(controller, animated: true)
     }
 
 }
@@ -359,6 +362,10 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
 
     func showAddInsight() {
         showAddInsightView()
+    }
+
+    func addInsightSelected(_ insight: StatSection) {
+        NSLog("Add Insight selected: \(insight.insightManagementTitle)")
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -215,6 +215,13 @@ private extension SiteStatsInsightsTableViewController {
 
         UserDefaults.standard.set(hideCustomizeCard, forKey: userDefaultsHideCustomizeKey)
     }
+
+    // MARK: - Insights Management
+
+    func showAddInsightView() {
+        navigationController?.pushViewController(AddInsightTableViewController(), animated: true)
+    }
+
 }
 
 extension SiteStatsInsightsTableViewController: NoResultsViewHost {
@@ -347,22 +354,11 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
     }
 
     func customizeTryButtonTapped() {
-        // TODO: remove when Insights Management view added.
-        showTemporaryAlert()
+        showAddInsightView()
     }
 
     func showAddInsight() {
-        // TODO: remove when Insights Management view added.
-        showTemporaryAlert()
-    }
-
-    // TODO: remove when Insights Management view added.
-    private func showTemporaryAlert() {
-        let alertController = UIAlertController(title: "Under Construction",
-                                                message: "This will show the Insights Management view.",
-                                                preferredStyle: .alert)
-        alertController.addActionWithTitle("OK", style: .default)
-        present(alertController, animated: true, completion: nil)
+        showAddInsightView()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -212,6 +212,8 @@ struct TwoColumnStatsRow: ImmuTableRow {
     }
 }
 
+// MARK: - Insights Management
+
 struct AddInsightRow: ImmuTableRow {
 
     typealias CellType = TopTotalsCell
@@ -232,7 +234,24 @@ struct AddInsightRow: ImmuTableRow {
 
         cell.configure(dataRows: [dataRow], siteStatsInsightsDelegate: siteStatsInsightsDelegate)
     }
+}
 
+struct AddInsightStatRow: ImmuTableRow {
+    static let cell = ImmuTableCell.class(WPTableViewCellDefault.self)
+
+    let title: String
+    let enabled: Bool
+    let action: ImmuTableAction?
+
+    func configureCell(_ cell: UITableViewCell) {
+        WPStyleGuide.configureTableViewCell(cell)
+
+        cell.textLabel?.text = title
+        cell.textLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
+        cell.textLabel?.adjustsFontForContentSizeCategory = true
+        cell.textLabel?.textColor = enabled ? .text : .textPlaceholder
+        cell.selectionStyle = .none
+    }
 }
 
 // MARK: - Period Rows

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1083,6 +1083,7 @@
 		9826AE9121B5D3CD00C851FA /* PostingActivityCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9826AE8F21B5D3CD00C851FA /* PostingActivityCell.xib */; };
 		9829162F2224BC1C008736C0 /* SiteStatsDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9829162E2224BC1C008736C0 /* SiteStatsDetailsViewModel.swift */; };
 		982A4C3520227D6700B5518E /* NoResultsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 982A4C3420227D6700B5518E /* NoResultsViewController.swift */; };
+		983002A822FA05D600F03DBB /* AddInsightTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983002A722FA05D600F03DBB /* AddInsightTableViewController.swift */; };
 		983DBBAA22125DD500753988 /* StatsTableFooter.xib in Resources */ = {isa = PBXBuildFile; fileRef = 983DBBA822125DD300753988 /* StatsTableFooter.xib */; };
 		983DBBAB22125DD500753988 /* StatsTableFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 983DBBA922125DD300753988 /* StatsTableFooter.swift */; };
 		98458CB821A39D350025D232 /* StatsNoDataRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98458CB721A39D350025D232 /* StatsNoDataRow.swift */; };
@@ -3239,6 +3240,7 @@
 		9826AE8F21B5D3CD00C851FA /* PostingActivityCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PostingActivityCell.xib; sourceTree = "<group>"; };
 		9829162E2224BC1C008736C0 /* SiteStatsDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStatsDetailsViewModel.swift; sourceTree = "<group>"; };
 		982A4C3420227D6700B5518E /* NoResultsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoResultsViewController.swift; sourceTree = "<group>"; };
+		983002A722FA05D600F03DBB /* AddInsightTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddInsightTableViewController.swift; sourceTree = "<group>"; };
 		983DBBA822125DD300753988 /* StatsTableFooter.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StatsTableFooter.xib; sourceTree = "<group>"; };
 		983DBBA922125DD300753988 /* StatsTableFooter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsTableFooter.swift; sourceTree = "<group>"; };
 		98458CB721A39D350025D232 /* StatsNoDataRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsNoDataRow.swift; sourceTree = "<group>"; };
@@ -4935,7 +4937,7 @@
 			path = Networking;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				F14B5F6F208E648200439554 /* config */,
@@ -6988,6 +6990,7 @@
 			children = (
 				985793C622F23D7000643DBF /* CustomizeInsightsCell.swift */,
 				985793C722F23D7000643DBF /* CustomizeInsightsCell.xib */,
+				983002A722FA05D600F03DBB /* AddInsightTableViewController.swift */,
 			);
 			path = "Insights Management";
 			sourceTree = "<group>";
@@ -9490,7 +9493,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -10867,6 +10870,7 @@
 				749197EE209B9A2E006F5E66 /* ReaderCardContent+PostInformation.swift in Sources */,
 				FF355D981FB492DD00244E6D /* ExportableAsset.swift in Sources */,
 				E15644EF1CE0E53B00D96E64 /* PlanListViewModel.swift in Sources */,
+				983002A822FA05D600F03DBB /* AddInsightTableViewController.swift in Sources */,
 				98CAD296221B4ED2003E8F45 /* StatSection.swift in Sources */,
 				93C1147F18EC5DD500DAC95C /* AccountService.m in Sources */,
 				FF945F701B28242300FB8AC4 /* MediaLibraryPickerDataSource.m in Sources */,


### PR DESCRIPTION
Ref #12246 

This adds the 'Add New Stats Card' table view.
- Lists all Insights by category.
  - Currently, the view is not aware of shown Insights, so all rows are enabled.
- Selecting a stat will:
  - Dismiss the view.
  - Log to the console which stat was selected. Ex: `Add Insight selected: Posting Activity`

The view can be accessed via:
- 'Try it now' on the Customize card.
- Tapping the 'Add new stats card'.

Tips:
- To force the Customize card to show without reinstalling the app:
  - In `SiteStatsInsightsTableViewController:loadInsightsFromUserDefaults`, set `hideCustomizeCard = false`.
- To disable the rows:  
  - In `AddInsightTableViewController:sectionForCategory`, set `enabled = false`.

To test:
- Access 'Add New Stats Card' via the two ways listed above.
  - Verify the Insights are shown by category.
- Select a row.
  - Verify the view is dismissed.
  - Verify a log message appears noting which stat was selected.
- Disable the rows via the tip noted above & return to 'Add New Stats Card'.
  - Verify the text is now light grey.
  - Verify selecting a row does nothing.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
