### PR TITLE
Notifications: Add support for `providesAppNotificationSettings`

### DIFF
--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -52,8 +52,14 @@ final class InteractiveNotificationsManager: NSObject {
         defer {
             WPAnalytics.track(.pushNotificationOSAlertShown)
         }
+
+        var options: UNAuthorizationOptions = [.badge, .sound, .alert]
+        if #available(iOS 12.0, *) {
+            options.insert(.providesAppNotificationSettings)
+        }
+
         let notificationCenter = UNUserNotificationCenter.current()
-        notificationCenter.requestAuthorization(options: [.badge, .sound, .alert]) { (allowed, _)  in
+        notificationCenter.requestAuthorization(options: options) { (allowed, _)  in
             DispatchQueue.main.async {
                 if allowed {
                     WPAnalytics.track(.pushNotificationOSAlertAllowed)
@@ -501,5 +507,9 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
         PushNotificationsManager.shared.handleNotification(userInfo) { _ in
             completionHandler()
         }
+    }
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter, openSettingsFor notification: UNNotification?) {
+        MeNavigationAction.notificationSettings.perform([:])
     }
 }

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -510,6 +510,6 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
     }
 
     func userNotificationCenter(_ center: UNUserNotificationCenter, openSettingsFor notification: UNNotification?) {
-        MeNavigationAction.notificationSettings.perform([:])
+        MeNavigationAction.notificationSettings.perform()
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Me.swift
@@ -20,7 +20,7 @@ enum MeNavigationAction: NavigationAction {
     case accountSettings
     case notificationSettings
 
-    func perform(_ values: [String: String], source: UIViewController? = nil) {
+    func perform(_ values: [String: String] = [:], source: UIViewController? = nil) {
         switch self {
         case .root:
             WPTabBarController.sharedInstance().showMeTab()


### PR DESCRIPTION
I just discovered a Notifications API that I figured we should probably implement. It allows us to hook into system notifications settings UI, providing a way for users to jump into Notification Settings in our app. There are two places it surfaces:

1. In system **Settings > WordPress > Notifications**, there's now a **WordPress Notification Settings** item:

![s](https://user-images.githubusercontent.com/4780/62779792-14588e80-baac-11e9-9769-8e649f774721.png)

2. When you receive a notification, if you either expand it and tap the `...` button or swipe it and tap Manage, you're shown a system menu for Deliver Quietly, Turn Off... or Settings. Now, if you tap Turn Off... you'll be presented with a new option to jump into the app to manage your settings:

![Slice](https://user-images.githubusercontent.com/4780/62779885-42d66980-baac-11e9-9a28-7e96aac52fe0.png)

**To test:**

* Build and run
* Navigate to system settings and check that item 1 above exists and works.
* Receive a notification, and bring up the menu shown in item 2. Tap Turn Off... and then choose Configure in WordPress... Check you're taken to notification settings in the app.

Note, you may need the debug notification server running to receive notifications – please let me know if you need help with this!

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.