### PR TITLE
[Account Settings] Change Username analytics

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,13 +13,13 @@ plugin 'cocoapods-repo-update'
 ##
 def wordpress_shared
     ## for production:
-#    pod 'WordPressShared', '~> 1.8.6-beta.2'
+    pod 'WordPressShared', '~> 1.8.6-beta.2'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-     pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'feature/change-username-events'
+#     pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'feature/change-username-events'
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> ''
 end
 

--- a/Podfile
+++ b/Podfile
@@ -13,13 +13,13 @@ plugin 'cocoapods-repo-update'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.8.6-beta.1'
+#    pod 'WordPressShared', '~> 1.8.6-beta.2'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'feature/customize_insights_events'
+     pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'feature/change-username-events'
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> ''
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -301,7 +301,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.7.0)
   - WordPressKit (~> 4.4.0-beta.2)
   - WordPressMocks (~> 0.0.5)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared`, branch `feature/change-username-events`)
+  - WordPressShared (~> 1.8.6-beta.2)
   - WordPressUI (~> 1.3.4)
   - WPMediaPicker (~> 1.4.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.10.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -345,6 +345,7 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -407,9 +408,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.0
-  WordPressShared:
-    :branch: feature/change-username-events
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.10.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -423,9 +421,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.0
-  WordPressShared:
-    :commit: d105fc35672fd97cfbb761c582ce4b83d6a89363
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -489,7 +484,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: 485679ba24ceefb15acb8e0bd18f3856cf52e8f4
   WordPressKit: 91237a0adcb2db19595114833f76efa2e3da9e55
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
-  WordPressShared: ed85d3cbeac9b67cffdcb903fdfae266b0b698e9
+  WordPressShared: e5dd3839eced389a56809164fc47e4cf24c833a3
   WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
   WPMediaPicker: 1897f312c7b41114ffd239fb782431ae602134a1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -497,6 +492,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 6debeeb2a241294e8666e31f0061b92a0bfce6cd
+PODFILE CHECKSUM: dab7a04e7001e81156f27292138f45e206f8700b
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -229,7 +229,7 @@ PODS:
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
   - WordPressMocks (0.0.5)
-  - WordPressShared (1.8.6-beta.1):
+  - WordPressShared (1.8.6-beta.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.3.4)
@@ -301,7 +301,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.7.0)
   - WordPressKit (~> 4.4.0-beta.2)
   - WordPressMocks (~> 0.0.5)
-  - WordPressShared (~> 1.8.6-beta.1)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared`, branch `feature/change-username-events`)
   - WordPressUI (~> 1.3.4)
   - WPMediaPicker (~> 1.4.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.10.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -345,7 +345,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -408,6 +407,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.0
+  WordPressShared:
+    :branch: feature/change-username-events
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.10.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -421,6 +423,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.0
+  WordPressShared:
+    :commit: d105fc35672fd97cfbb761c582ce4b83d6a89363
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -484,7 +489,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: 485679ba24ceefb15acb8e0bd18f3856cf52e8f4
   WordPressKit: 91237a0adcb2db19595114833f76efa2e3da9e55
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
-  WordPressShared: 88ad200b8259c08fc97b25822b8896660ebcf7f9
+  WordPressShared: ed85d3cbeac9b67cffdcb903fdfae266b0b698e9
   WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
   WPMediaPicker: 1897f312c7b41114ffd239fb782431ae602134a1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -492,6 +497,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 5d0330fe9247cb8271a5b40a9c08e0ca40d50005
+PODFILE CHECKSUM: 6debeeb2a241294e8666e31f0061b92a0bfce6cd
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1872,6 +1872,15 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatOpenedAccountSettings:
             eventName = @"account_settings_opened";
             break;
+        case WPAnalyticsStatAccountSettingsChangeUsernameSucceeded:
+            eventName = @"account_settings_change_username_succeeded";
+            break;
+        case WPAnalyticsStatAccountSettingsChangeUsernameFailed:
+            eventName = @"account_settings_change_username_failed";
+            break;
+        case WPAnalyticsStatAccountSettingsChangeUsernameSuggestionsFailed:
+            eventName = @"account_settings_change_username_suggestions_failed";
+            break;
         case WPAnalyticsStatOpenedAppSettings:
             eventName = @"app_settings_opened";
             break;

--- a/WordPress/Classes/ViewRelated/Me/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Change Username/ChangeUsernameViewController.swift
@@ -55,6 +55,9 @@ private extension ChangeUsernameViewController {
             case .loading:
                 SVProgressHUD.show(withStatus: Constants.Alert.loading)
             case .success:
+                if suggestions.isEmpty {
+                    WPAppAnalytics.track(.accountSettingsChangeUsernameSuggestionsFailed)
+                }
                 SVProgressHUD.dismiss()
                 self?.suggestions = suggestions
                 self?.reloadSections(includingAllSections: reloadAllSections)
@@ -99,10 +102,12 @@ private extension ChangeUsernameViewController {
         viewModel.save() { [weak self] (state, error) in
             switch state {
             case .success:
+                WPAppAnalytics.track(.accountSettingsChangeUsernameSucceeded)
                 SVProgressHUD.dismiss()
                 self?.completionBlock()
                 self?.navigationController?.popViewController(animated: true)
             case .failure:
+                WPAppAnalytics.track(.accountSettingsChangeUsernameFailed)
                 SVProgressHUD.showError(withStatus: error)
             default:
                 break


### PR DESCRIPTION
Fixes #9705 

This PR adds 3 new analytics events:
- _account_settings_change_username_succeeded_
- _account_settings_change_username_failed_
- _account_settings_change_username_suggestions_failed_

WP Shared updated [here](https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/214). I'll create a tag version and update here the pod file as soon this PR will be approved.

## To test:
* Select the Tab Me -> Account Settings
* Tap on the username to open the new screen and change the username

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
