### PR TITLE
Fix the issue with persistent failure upload notices, hopefully for realsies this time.

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -622,7 +622,6 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
 extension MediaCoordinator: Uploader {
     func resume() {
         let service = MediaService(managedObjectContext: mainContext)
-        addObserverForDeletedFiles()
 
         service.getFailedMedia { [weak self] media in
             guard let self = self else {

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -698,6 +698,15 @@ extension Media {
             nsError.code == multipartEncodingFailedSampleError.code {
             // and if we only have the NSError-level of data, let's just fall back on best-effort guess.
             return true
+        } else if let nsError = error as NSError?,
+            nsError.domain == MediaServiceErrorDomain,
+            nsError.code == MediaServiceError.fileDoesNotExist.rawValue {
+            // if for some reason, the app crashed when trying to create a media object (like, for example, in this crash):
+            // https://github.com/wordpress-mobile/gutenberg-mobile/issues/1190
+            // the Media objects ends up in a malformed state, and we acutally handle that on the
+            // MediaService level. We need to also handle it here!
+
+            return true
         }
 
         return false

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -675,7 +675,7 @@ extension Media {
 
         // I don't want to hand-encode the Alamofire.AFError domain and/or code — they're both subject to change
         // in the future, so I'm hand-creating an error here to get the domain/code out of.
-        let multipartEncodingFailedSampleError = AFError.multipartEncodingFailed(reason:.bodyPartFileNotReachable(at: URL(string: "https://wordpress.com")!)) as NSError
+        let multipartEncodingFailedSampleError = AFError.multipartEncodingFailed(reason: .bodyPartFileNotReachable(at: URL(string: "https://wordpress.com")!)) as NSError
         // (yes, yes, I know, unwrapped optional. but if creating a URL from this string fails, then something is probably REALLY wrong and we should bail anyway.)
 
         // If we still have enough data to know this is a Swift Error, let's do the actual right thing here:

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -11,6 +11,11 @@ import enum Alamofire.AFError
 class MediaCoordinator: NSObject {
     @objc static let shared = MediaCoordinator()
 
+    override init() {
+        super.init()
+        addObserverForDeletedFiles()
+    }
+
     private(set) var backgroundContext: NSManagedObjectContext = {
         let context = ContextManager.sharedInstance().newDerivedContext()
         context.automaticallyMergesChangesFromParent = true
@@ -617,6 +622,7 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
 extension MediaCoordinator: Uploader {
     func resume() {
         let service = MediaService(managedObjectContext: mainContext)
+        addObserverForDeletedFiles()
 
         service.getFailedMedia { [weak self] media in
             guard let self = self else {
@@ -624,7 +630,6 @@ extension MediaCoordinator: Uploader {
             }
 
             media.forEach() {
-                self.addObserverForDeletedFiles(for: $0)
                 self.retryMedia($0)
             }
         }
@@ -637,18 +642,18 @@ extension MediaCoordinator {
     // `Documents` folder.
     // We want to collect more data about that, so we're going to log that info to Sentry,
     // and also delete the `Media` object, since there isn't really a reasonable way to recover from that failure.
-    func addObserverForDeletedFiles(for media: Media) {
-        addObserver({ [weak self] (media, _) in
+    func addObserverForDeletedFiles() {
+        addObserver({ (media, _) in
             guard let mediaError = media.error,
                 media.hasMissingFileError else {
                 return
             }
 
+            self.cancelUploadAndDeleteMedia(media)
             CrashLogging.logError(mediaError,
                                   userInfo: ["description": "Deleting a media object that's failed to upload because of a missing local file."])
-            self?.cancelUploadAndDeleteMedia(media)
 
-        }, for: media)
+        }, for: nil)
     }
 }
 
@@ -658,19 +663,43 @@ extension Media {
     }
 
     fileprivate var hasMissingFileError: Bool {
-        guard
-            let afError = error as? AFError,
-            case .multipartEncodingFailed = afError,
-            case .multipartEncodingFailed(let encodingFailure) = afError else {
+        // So this is weirdly complicated for a weird reason.
+        // Turns out, Core Data and Swift-y `Error`s do not play super well together, but there's some magic here involved.
+        // If you assing an `Error` property to a Core Data's object field, it will retain all it's Swifty-ish magic properties,
+        // it'll have all the enum values you expect, etc.
+        // However.
+        // Persisting the data to disk and/or reading it from a different MOC using methods like `existingObjectWithID(:_)`
+        // or similar, loses all that data, and the resulting error is "simplified" down to a "dumb"
+        // `NSError` with just a `domain` and `code` set.
+        // This was _not_ a fun one to track down.
+
+        // I don't want to hand-encode the Alamofire.AFError domain and/or code — they're both subject to change
+        // in the future, so I'm hand-creating an error here to get the domain/code out of.
+        let multipartEncodingFailedSampleError = AFError.multipartEncodingFailed(reason:.bodyPartFileNotReachable(at: URL(string: "https://wordpress.com")!)) as NSError
+        // (yes, yes, I know, unwrapped optional. but if creating a URL from this string fails, then something is probably REALLY wrong and we should bail anyway.)
+
+        // If we still have enough data to know this is a Swift Error, let's do the actual right thing here:
+        if let afError = error as? AFError {
+            guard
+                case .multipartEncodingFailed = afError,
+                case .multipartEncodingFailed(let encodingFailure) = afError else {
+                    return false
+            }
+
+            switch encodingFailure {
+            case .bodyPartFileNotReachableWithError,
+                 .bodyPartFileNotReachable:
+                return true
+            default:
                 return false
+            }
+        } else if let nsError = error as NSError?,
+            nsError.domain == multipartEncodingFailedSampleError.domain,
+            nsError.code == multipartEncodingFailedSampleError.code {
+            // and if we only have the NSError-level of data, let's just fall back on best-effort guess.
+            return true
         }
 
-        switch encodingFailure {
-        case .bodyPartFileNotReachableWithError,
-             .bodyPartFileNotReachable:
-            return true
-        default:
-            return false
-        }
+        return false
     }
 }


### PR DESCRIPTION
Fixes (hopefully for realsies this time?????) #12213.

After staring at the code for 6h today, I had a eureka moment — I realized my fix from #12214 worked for images uploaded added straight to media library, but could (potentially) fail for images added directly to the posts.

I _thought_ my fix would cover both of those cases (and in my local testing it seemed to have done so), but I now realize there was a subtle (I THINK) race condition involved.

My (pretty educated, but also, desperate) guess at what was happening is as follows:

1. There's a race between `resume()` methods of `MediaCoordinator` and `PostCoordinator` (or, more specifically, between `-[PostService getFailedPosts:]` and the `MediaService` counterpart.

2. I think that in cases where MediaCoordinator/Service won that race, my old fix worked.
3. However, in cases where the PostService/Coordinator won that race, my workaround wasn't triggered, because: 

* the observer for deleted files was added on a per-file basis, inside the `resume()` method of `MediaCoordinator`
* *but*,  PostCoordinator _also_ checks for failed media uploads related to post it's trying to upload and [manually retries them](https://github.com/wordpress-mobile/WordPress-iOS/blob/b71fc07ee9a9345ec24dbaa08b931a618402f021/WordPress/Classes/Services/PostCoordinator.swift#L149-L157). this method doesn't call thru to `resume()` at any point, and therefore no observers for deleted files are ever created.
* the `resume()` on `MediaCoordinator` filters for media objects that have '.failed' status, and at this precise moment, the specific media object is `.pushing`, because the other class is trying to upload it now.
4) even then, the suppressing of the image error should have kicked in. turns out, not so much!
it also only worked if it an image was directly retried from the MediaCoordinator. otherwise, it would have been saved to Core Data in the meantime, which caused...
5) fun Swift.Error / NSError incompatibilities!!! Look at the patch and the comment to find out more.

<hr / >
again, testing for this is pretty nigthmarish, so bear with me:

## Bug reproduction (*must* be done on Simulator):
1. Comment-out line 43 (comment out the `MediaCoordinator`) in `WordPressAppDelegate` to simulate the race outcome 
1. Enable Network Link Conditioner on your Mac, with a `Very Bad Network` or `100% Packet Loss` Presets
1. Build latest `develop`
2. Create a new post _with Aztec_
3. Add a new picture from your device (using the "Choose from My Device") option
4. Verify it fails to upload (wait for the notice to pop-up)
5. Save the post as draft (using the three dots -> save as draft option)
5. This should fail, so now exit the editor clicking on X->save as draft
5. Locate the media file on disk (I usually just do `po NSHomeDirectory()` and `cd` to `Documents/Media` in iTerm) and delete it.
5. Turn off Network Link Conditioner
6. Relaunch the app
7. Verify that the "1 post, 1 file not uploaded" Notice shows up.

## Now, for the actual fix
1. Checkout this branch
2. Make sure that the `MediaCoordinator` in `AppDelegate` is still commented out
2. Verify that the notices no longer pop-up
3. For extra credit, open up the database in `sqlite3` (or your preferred SQLite browser of choice), and verify that the Media object gets deleted


###  **REMEMBER TO TURN OFF YOUR NETWORK LINK CONDITIONER**
