### PR TITLE
Existing the editor to posts list / pages list will remain in the same tab.

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -466,15 +466,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     private func show(_ editorViewController: EditorViewController) {
         let filterIndex = filterSettings.currentFilterIndex()
 
-        editorViewController.onClose = { [weak self, weak editorViewController] changesSaved, _ in
-            if changesSaved {
-                if let postStatus = editorViewController?.post.status {
-                    self?.updateFilterWithPostStatus(postStatus)
-                }
-            } else {
-                self?.updateFilter(index: filterIndex)
-            }
-
+        editorViewController.onClose = { [weak self, weak editorViewController] _, _ in
+            self?.updateFilter(index: filterIndex)
             self?._tableViewHandler.isSearching = false
             editorViewController?.dismiss(animated: true)
         }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -464,10 +464,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     private func show(_ editorViewController: EditorViewController) {
-        let filterIndex = filterSettings.currentFilterIndex()
-
         editorViewController.onClose = { [weak self, weak editorViewController] _, _ in
-            self?.updateFilter(index: filterIndex)
             self?._tableViewHandler.isSearching = false
             editorViewController?.dismiss(animated: true)
         }
@@ -476,9 +473,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         navController.restorationIdentifier = Restorer.Identifier.navigationController.rawValue
         navController.modalPresentationStyle = .fullScreen
 
-        present(navController, animated: true, completion: { [weak self] in
-            self?.updateFilterWithPostStatus(.draft)
-        })
+        present(navController, animated: true, completion: nil)
     }
 
     func replaceEditor(editor: EditorViewController, replacement: EditorViewController) {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -483,15 +483,9 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     // MARK: - Post Actions
 
     override func createPost() {
-        let filterIndex = filterSettings.currentFilterIndex()
         let editor = EditPostViewController(blog: blog)
-        editor.onClose = { [weak self] _ in
-             self?.updateFilter(index: filterIndex)
-        }
         editor.modalPresentationStyle = .fullScreen
-        present(editor, animated: false, completion: { [weak self] in
-            self?.updateFilterWithPostStatus(.draft)
-        })
+        present(editor, animated: false, completion: nil)
         WPAppAnalytics.track(.editorCreatedPost, withProperties: ["tap_source": "posts_view"], with: blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -485,14 +485,8 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     override func createPost() {
         let filterIndex = filterSettings.currentFilterIndex()
         let editor = EditPostViewController(blog: blog)
-        editor.onClose = { [weak self] changesSaved in
-            if changesSaved {
-                if let postStatus = editor.post?.status {
-                    self?.updateFilterWithPostStatus(postStatus)
-                }
-            } else {
-                self?.updateFilter(index: filterIndex)
-            }
+        editor.onClose = { [weak self] _ in
+             self?.updateFilter(index: filterIndex)
         }
         editor.modalPresentationStyle = .fullScreen
         present(editor, animated: false, completion: { [weak self] in


### PR DESCRIPTION
Fixes #12284 

To test:
1. Be on drafts / scheduled tab
2. Create a post / page
3. publish the post / page
4. The editor is removed from view
* Notice that the post lists / pages list remains on the same tab you started in.


Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
