### PR TITLE
Fixes an issue that causing our previews to cancel loading.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -95,7 +95,6 @@
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
-    [self stopLoading];
     [self stopWaitingForConnectionRestored];
 }
 
@@ -112,20 +111,21 @@
     [self.view addSubview:self.webView];
 }
 
-#pragma mark - Loading
+#pragma mark - Loading Animations
 
-- (void)startLoading
+- (void)startLoadAnimation
 {
     [self.navigationItem setLeftBarButtonItem:[self statusButtonItem] animated:YES];
     self.navigationItem.title = nil;
 }
 
-- (void)stopLoading
+- (void)stopLoadAnimation
 {
     self.navigationItem.leftBarButtonItem = self.navigationItem.backBarButtonItem;
     self.navigationItem.title  = NSLocalizedString(@"Preview", @"Post Editor / Preview screen title.");
-    [self.webView stopLoading];
 }
+
+#pragma mark - Reachability
 
 - (void)reloadWhenConnectionRestored
 {
@@ -154,6 +154,7 @@
 - (void)webViewDidFinishLoad:(UIWebView *)awebView
 {
     DDLogMethod();
+    [self stopLoadAnimation];
 }
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
@@ -178,6 +179,8 @@
         return;
     }
 
+    [self stopLoadAnimation];
+    
     [self.generator previewRequestFailedWithReason:[NSString stringWithFormat:@"Generic web view error Error. Error code: %d, Error domain: %@", error.code, error.domain]];
 }
 
@@ -224,7 +227,7 @@
 }
 
 - (void)preview:(PostPreviewGenerator *)generator attemptRequest:(NSURLRequest *)request {
-    [self startLoading];
+    [self startLoadAnimation];
     [self.webView loadRequest:request];
     [self.noResultsViewController removeFromView];
 }

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -154,7 +154,6 @@
 - (void)webViewDidFinishLoad:(UIWebView *)awebView
 {
     DDLogMethod();
-    [self stopLoading];
 }
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
@@ -179,7 +178,6 @@
         return;
     }
 
-    [self stopLoading];
     [self.generator previewRequestFailedWithReason:[NSString stringWithFormat:@"Generic web view error Error. Error code: %d, Error domain: %@", error.code, error.domain]];
 }
 
@@ -212,26 +210,6 @@
     }
     
     if (navigationType == UIWebViewNavigationTypeFormSubmitted) {
-        return NO;
-    }
-    
-    // Something is causing our web view to try and load a different URL after the initial URL is already loading.
-    //
-    // Example of first URL: https://diegotest4.wordpress.com/?p=748
-    // Example of second URL: https://public-api.wordpress.com/wp-admin/rest-proxy/#https://diegotest4.wordpress.com
-    //
-    // The second URL is probably loaded by Javascript code or is part of a frame, as it's also loaded by Safari
-    // according to Charles.app (not just in our app in WPiOS).
-    //
-    // The problem is that our code is failing to filter this second URL, and allowing it to load.  This fix
-    // implements a final safeguard in the logic of this method, after all other checks are above pass.
-    //
-    // We won't allow a URL that's not the base document to load at this point.
-    // It could be worth our effort to try removing this check once we migrate our web view to WKWebView.
-    //
-    // More information and context on this issue can be found here: https://git.io/fj5Px
-    //
-    if (![request.URL isEqual:request.mainDocumentURL]) {
         return NO;
     }
     

--- a/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostPreviewViewController.m
@@ -214,6 +214,27 @@
     if (navigationType == UIWebViewNavigationTypeFormSubmitted) {
         return NO;
     }
+    
+    // Something is causing our web view to try and load a different URL after the initial URL is already loading.
+    //
+    // Example of first URL: https://diegotest4.wordpress.com/?p=748
+    // Example of second URL: https://public-api.wordpress.com/wp-admin/rest-proxy/#https://diegotest4.wordpress.com
+    //
+    // The second URL is probably loaded by Javascript code or is part of a frame, as it's also loaded by Safari
+    // according to Charles.app (not just in our app in WPiOS).
+    //
+    // The problem is that our code is failing to filter this second URL, and allowing it to load.  This fix
+    // implements a final safeguard in the logic of this method, after all other checks are above pass.
+    //
+    // We won't allow a URL that's not the base document to load at this point.
+    // It could be worth our effort to try removing this check once we migrate our web view to WKWebView.
+    //
+    // More information and context on this issue can be found here: https://git.io/fj5Px
+    //
+    if (![request.URL isEqual:request.mainDocumentURL]) {
+        return NO;
+    }
+    
     return YES;
 }
 


### PR DESCRIPTION
Fixes #10677 

The issue seems to be that our `UIWebView` delegate methods call `stopLoading`.  This would be fine if the delegate methods were called once for the web view, but they can be called multiple times for any resources (like embeds) that the page loads.

## Testing requirements / suggestions

@shiki hasn't been able to reproduce this reliably, while I've managed to reproduce it every single time.  When testing this I suggest to use the network link conditioner and try to make sure it's set to have a very slow connection.

The reason for this is that the bug relies on the second request being started BEFORE the first one completes.  On a very fast connection, the first request could complete really fast, and make it look like everything's fine.

## To test:

@rachelmcr - Can I ask you to test this fix on several different site types with and without custom domains?

It should be enough to:

1. Have a slow connection.
2. Preview any post with an image, to make the post loading interruption more apparent (as crazy as it sounds, this bug isn't really specific to images though - but they do make it easy to test the bug).

## Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.