### PR TITLE
Updating new post status *after* setting its created date

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+BlogPicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+BlogPicker.swift
@@ -73,9 +73,9 @@ extension PostEditor where Self: UIViewController {
         newPost.content = contentByStrippingMediaAttachments()
         newPost.postTitle = post.postTitle
         newPost.password = post.password
-        newPost.status = post.status
         newPost.dateCreated = post.dateCreated
         newPost.dateModified = post.dateModified
+        newPost.status = post.status
 
         if let source = post as? Post, let target = newPost as? Post {
             target.tags = source.tags


### PR DESCRIPTION
Fixes #12300 
The issue here is that when switching a site while in the editor, we are calling recreatePostRevision to create the post in the selected site.

When we are setting the new post createDate by doing:
`newPost.dateCreated = post.dateCreated`
The setCreatedDate method in AbstractPost is getting called. There we check if the date created is nil or equal to the modified date and if so we update the status to publish:
``` 
if ([self dateCreatedIsNilOrEqualToDateModified]) {
        // A nil date means publish immediately.
        self.status = PostStatusPublish;

    } 
```
This PR sets the status of the new post, after setting it's createdDate so the original post status will remain and will be set back to draft.

To test:
1. Open the editor in the app.
2. Tap the site name at the top of the editor. In the site picker, select a different site.
3. Open the Post Settings and note that the status is Draft.
4. Add a title/content to the post.
5. Tap the X to close the editor.
In the action sheet that appears make sure you see the following options:
"Save Draft"
"Discard"
"Keep Editing"

Update release notes:

- [ ] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
