### PR TITLE
Fix for media overlay disappears on action sheet dismissal in Classic editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2928,12 +2928,17 @@ extension AztecPostViewController {
     }
 
     fileprivate func resetMediaAttachmentOverlayIfNoError(_ mediaAttachment: MediaAttachment) {
+        // having an uploadID means we are uploading or just finished uplading (successfully or not). In this case, we remove the overlay only if no error
         if let uploadID = mediaAttachment.uploadID,
-        let media = self.mediaFor(uploadID: uploadID),
-        media.error == nil {
-            mediaAttachment.overlayImage = nil
+            let media = self.mediaFor(uploadID: uploadID) {
+            if media.error == nil {
+                mediaAttachment.overlayImage = nil
+                mediaAttachment.message = nil
+                mediaAttachment.shouldHideBorder = false
+            }
+        // For an existing media we set it's message to nil so the glyphImage will be removed.
+        } else {
             mediaAttachment.message = nil
-            mediaAttachment.shouldHideBorder = false
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2628,7 +2628,7 @@ extension AztecPostViewController {
     }
 
     fileprivate func retryFailedMediaUpload(media: Media, attachment: MediaAttachment) {
-        resetMediaAttachmentOverlayIfNoError(attachment)
+        resetMediaAttachmentOverlay(attachment)
         attachment.progress = 0
         richTextView.refresh(attachment)
 
@@ -2702,7 +2702,7 @@ extension AztecPostViewController {
         let dismissAction = UIAlertAction(title: MediaAttachmentActionSheet.dismissActionTitle, style: .cancel) { (action) in
             if attachment == self.currentSelectedAttachment {
                 self.currentSelectedAttachment = nil
-                self.resetMediaAttachmentOverlayIfNoError(attachment)
+                self.resetMediaAttachmentOverlay(attachment)
                 self.richTextView.refresh(attachment)
             }
         }
@@ -2828,7 +2828,7 @@ extension AztecPostViewController {
         controller.onCancel = { [weak self] in
             if attachment == self?.currentSelectedAttachment {
                 self?.currentSelectedAttachment = nil
-                self?.resetMediaAttachmentOverlayIfNoError(attachment)
+                self?.resetMediaAttachmentOverlay(attachment)
                 self?.richTextView.refresh(attachment)
             }
         }
@@ -2927,7 +2927,7 @@ extension AztecPostViewController {
         restoreInputAssistantItems()
     }
 
-    fileprivate func resetMediaAttachmentOverlayIfNoError(_ mediaAttachment: MediaAttachment) {
+    fileprivate func resetMediaAttachmentOverlay(_ mediaAttachment: MediaAttachment) {
         // having an uploadID means we are uploading or just finished uplading (successfully or not). In this case, we remove the overlay only if no error
         if let uploadID = mediaAttachment.uploadID,
             let media = self.mediaFor(uploadID: uploadID) {
@@ -2975,7 +2975,7 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
         if !errorAssociatedToAttachment {
             // If it's a new attachment tapped let's unmark the previous one...
             if let selectedAttachment = currentSelectedAttachment {
-                resetMediaAttachmentOverlayIfNoError(selectedAttachment)
+                resetMediaAttachmentOverlay(selectedAttachment)
                 richTextView.refresh(selectedAttachment)
             }
 
@@ -2997,7 +2997,7 @@ extension AztecPostViewController: TextViewAttachmentDelegate {
     func deselected(textAttachment attachment: NSTextAttachment, atPosition position: CGPoint) {
         currentSelectedAttachment = nil
         if let mediaAttachment = attachment as? MediaAttachment {
-            self.resetMediaAttachmentOverlayIfNoError(mediaAttachment)
+            self.resetMediaAttachmentOverlay(mediaAttachment)
             richTextView.refresh(mediaAttachment)
             processMediaAttachments()
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2486,7 +2486,9 @@ extension AztecPostViewController {
     }
 
     private func handleUploadStarted(attachment: MediaAttachment) {
-        resetMediaAttachmentOverlayIfNoError(attachment)
+        attachment.overlayImage = nil
+        attachment.message = nil
+        attachment.shouldHideBorder = false
         attachment.progress = 0
         richTextView.refresh(attachment, overlayUpdateOnly: true)
     }
@@ -2503,7 +2505,6 @@ extension AztecPostViewController {
             guard let attachment = self.findAttachment(withUploadID: mediaUploadID) else {
                 return
             }
-            resetMediaAttachmentOverlayIfNoError(attachment)
             attachment.uploadID = nil
             attachment.progress = nil
             if let imageAttachment = attachment as? ImageAttachment {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -973,7 +973,7 @@ extension AztecPostViewController {
 
         toolbar.selectItemsMatchingIdentifiers(identifiers.map({ $0.rawValue }))
     }
-    
+
     private func mediaFor(uploadID: String) -> Media? {
         for media in post.media {
             if media.uploadID == uploadID {


### PR DESCRIPTION
- Added a mediaFor(uploadID: String) which searches for the media by upload id within the post object since the mediaCoordinator keeps returning nil for the media that failed to upload

- updated overlay reset method to reset only if the media doesn't have an error. 

- updated the reset overlay method name to communicate that it will only be reset if there is no error

Fixes #11937 

To test:
1. Open the editor on an existing post or start a new post in the classic editor
2. Be offline
3.  Add media to the post
4. See the failure overlay 
5. Tap on overlay
6. Choose discard or tap on title (or other content in the post)
7. See that the overlay is still there
8. Become online
9. Wait till the media is auto uploaded
10. See that the overlay disappears 

![20190814_181526](https://user-images.githubusercontent.com/1335657/63066879-275eca80-bec1-11e9-8349-98aac21d6844.gif)

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
