### PR TITLE
Add missing editor (Aztec) tracks events

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -13,14 +13,14 @@ plugin 'cocoapods-repo-update'
 ##
 def wordpress_shared
     ## for production:
-    # pod 'WordPressShared', '~> 1.8.6'
+    pod 'WordPressShared', '~> 1.8.7-beta.1'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
     # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'feature/change-username-events'
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> 'fcbe3ce78f66b7dfabba230137ff509ec330d0d9'
+    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> ''
 end
 
 def aztec

--- a/Podfile
+++ b/Podfile
@@ -13,14 +13,14 @@ plugin 'cocoapods-repo-update'
 ##
 def wordpress_shared
     ## for production:
-    pod 'WordPressShared', '~> 1.8.6'
+    # pod 'WordPressShared', '~> 1.8.6'
 
     ## for development:
     # pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 
     ## while PR is in review:
-#     pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'feature/change-username-events'
-    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> ''
+    # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared', :branch => 'feature/change-username-events'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit	=> 'fcbe3ce78f66b7dfabba230137ff509ec330d0d9'
 end
 
 def aztec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -301,7 +301,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.8.0-beta.1)
   - WordPressKit (~> 4.4.0)
   - WordPressMocks (~> 0.0.5)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `fcbe3ce78f66b7dfabba230137ff509ec330d0d9`)
+  - WordPressShared (~> 1.8.7-beta.1)
   - WordPressUI (~> 1.3.4)
   - WPMediaPicker (~> 1.4.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.10.3/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -345,6 +345,7 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -407,9 +408,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.3
-  WordPressShared:
-    :commit: fcbe3ce78f66b7dfabba230137ff509ec330d0d9
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.10.3/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -423,9 +421,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.3
-  WordPressShared:
-    :commit: fcbe3ce78f66b7dfabba230137ff509ec330d0d9
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -497,6 +492,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 3a50821ab0aa79a51085da937bc768d7327c26e8
+PODFILE CHECKSUM: 9b5d8c2aec940634a0565572e4438ad609114151
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -229,7 +229,7 @@ PODS:
     - WordPressShared (~> 1.8.0)
     - wpxmlrpc (= 0.8.4)
   - WordPressMocks (0.0.5)
-  - WordPressShared (1.8.6):
+  - WordPressShared (1.8.7-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - WordPressUI (1.3.4)
@@ -301,7 +301,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.8.0-beta.1)
   - WordPressKit (~> 4.4.0)
   - WordPressMocks (~> 0.0.5)
-  - WordPressShared (~> 1.8.6)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, commit `fcbe3ce78f66b7dfabba230137ff509ec330d0d9`)
   - WordPressUI (~> 1.3.4)
   - WPMediaPicker (~> 1.4.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.10.2/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
@@ -345,7 +345,6 @@ SPEC REPOS:
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -408,6 +407,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.2
+  WordPressShared:
+    :commit: fcbe3ce78f66b7dfabba230137ff509ec330d0d9
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.10.2/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -421,6 +423,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.10.2
+  WordPressShared:
+    :commit: fcbe3ce78f66b7dfabba230137ff509ec330d0d9
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -484,7 +489,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: 0bf13c318d198c59f8cbe0a5ad955214abc1bcc8
   WordPressKit: 9e6f4ffbec47aea18ce9f7a4cec7a785df9935db
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
-  WordPressShared: 8cb6984e8c62f4341cd48d11ed04e2076d581a74
+  WordPressShared: fc1ef47c3dc91237ef225706bb21ea10c9e4388f
   WordPressUI: 065de4c33212b9ca3ae458d43c73f2ce2738d3d4
   WPMediaPicker: 1897f312c7b41114ffd239fb782431ae602134a1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
@@ -492,6 +497,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 660090e11344c775bd79083a21920f3f135faf99
+PODFILE CHECKSUM: 996e1bde0083066f1e01b2c6aa5e3c18ca2e2fbc
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -615,6 +615,14 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             eventName = @"editor_button_tapped";
             eventProperties = @{ TracksEventPropertyButtonKey : @"list" };
             break;
+        case WPAnalyticsStatEditorTappedUndo:
+            eventName = @"editor_button_tapped";
+            eventProperties = @{ TracksEventPropertyButtonKey : @"undo" };
+            break;
+        case WPAnalyticsStatEditorTappedRedo:
+            eventName = @"editor_button_tapped";
+            eventProperties = @{ TracksEventPropertyButtonKey : @"redo" };
+            break;
         case WPAnalyticsStatEditorToggledOff:
             eventName = @"editor_toggled_off";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -611,6 +611,10 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             eventName = @"editor_button_tapped";
             eventProperties = @{ TracksEventPropertyButtonKey : @"unordered_list" };
             break;
+        case WPAnalyticsStatEditorTappedList:
+            eventName = @"editor_button_tapped";
+            eventProperties = @{ TracksEventPropertyButtonKey : @"list" };
+            break;
         case WPAnalyticsStatEditorToggledOff:
             eventName = @"editor_toggled_off";
             break;

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1521,6 +1521,7 @@ extension AztecPostViewController {
     }
 
     func toggleList(fromItem item: FormatBarItem) {
+        trackFormatBarAnalytics(stat: .editorTappedList)
         let listOptions = Constants.lists.map { listType -> OptionsTableViewOption in
             let title = NSAttributedString(string: listType.description, attributes: [:])
             return OptionsTableViewOption(image: listType.iconImage,

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -728,6 +728,8 @@ class AztecPostViewController: UIViewController, PostEditor {
         nc.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
         nc.addObserver(self, selector: #selector(keyboardDidHide), name: UIResponder.keyboardDidHideNotification, object: nil)
         nc.addObserver(self, selector: #selector(applicationWillResignActive(_:)), name: UIApplication.willResignActiveNotification, object: nil)
+        nc.addObserver(self, selector: #selector(didUndoRedo), name: .NSUndoManagerDidUndoChange, object: nil)
+        nc.addObserver(self, selector: #selector(didUndoRedo), name: .NSUndoManagerDidRedoChange, object: nil)
     }
 
     func stopListeningToNotifications() {
@@ -735,6 +737,8 @@ class AztecPostViewController: UIViewController, PostEditor {
         nc.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
         nc.removeObserver(self, name: UIResponder.keyboardDidHideNotification, object: nil)
         nc.removeObserver(self, name: UIApplication.willResignActiveNotification, object: nil)
+        nc.removeObserver(self, name: .NSUndoManagerDidUndoChange, object: nil)
+        nc.removeObserver(self, name: .NSUndoManagerDidRedoChange, object: nil)
     }
 
     func rememberFirstResponder() {
@@ -925,6 +929,23 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     @objc func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
         return presentationController(forPresented: presented, presenting: presenting)
+    }
+
+    @objc func didUndoRedo(_ notification: Foundation.Notification) {
+        guard
+            let undoManager = notification.object as? UndoManager,
+            undoManager === richTextView.undoManager || undoManager === htmlTextView.undoManager
+        else {
+            return
+        }
+
+        switch notification.name {
+        case .NSUndoManagerDidUndoChange:
+            trackFormatBarAnalytics(stat: .editorTappedUndo)
+        case .NSUndoManagerDidRedoChange:
+            trackFormatBarAnalytics(stat: .editorTappedRedo)
+        default: break
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds a few missing editor events to tracks:
- List button tapped
- Undo button tapped
- Redo button tapped

WordPress-Shared PR: https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/217
This is homologue to the WPAndroid PR: https://github.com/wordpress-mobile/WordPress-Android/pull/10389

Aztec iOS doesn't have paragraph alignment options, and I did not find the options for `EDITOR_TAPPED_NEXT_PAGE` and `EDITOR_TAPPED_PREFORMAT`. @daniloercoli maybe you could clarify that?

- All other `editor button tapped` events tracked on android are being tracked already on iOS.
- I did not find any event on iOS that is not being tracked on Android ✅ 
- Also checked the names and they are consistent

cc @hypest 

To test:
- run `rake dependencies`
- Run the app (preferably on an iPad device)
- Create a new post using Aztec
- Press the list button in the tool bar to add a list
  - Check that the event `editor_button_tapped` with the prop `button: list` is tracked
- Write some content and press the undo button at the top-left of the keyboard (on iPad)
  - Check that the event `editor_button_tapped` with the prop `button: undo` is tracked
- Press the redo button next to the undo button
  - Check that the event `editor_button_tapped` with the prop `button: redo` is tracked

On an iPhone device, you can try shake to undo. But for some reason it didn't work for me on the dev build.


Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.