### PR TITLE
[Stats Refresh] Fix title link from post stats

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 * Account Settings: added the ability to change the username.
 * Stats: added File Downloads to period stats.
+* Stats Periods: Fixed an issue that made the Post stats title button unable.
 * Adds a Publish Now action to posts in the posts list. 
  
 13.0

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.xib
@@ -52,9 +52,8 @@
                             </mask>
                         </variation>
                     </view>
-                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q7F-mg-QOb" userLabel="Post Title Button">
-                        <rect key="frame" x="16" y="33" width="374" height="20.5"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q7F-mg-QOb" userLabel="Post Title Button">
+                        <rect key="frame" x="16" y="31" width="374" height="22.5"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <connections>
                             <action selector="didTapPostTitle:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="DVU-yE-MhC"/>
@@ -71,10 +70,14 @@
                 <constraints>
                     <constraint firstItem="kmu-MC-d7s" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="0m8-gH-SnY"/>
                     <constraint firstAttribute="trailing" secondItem="kmu-MC-d7s" secondAttribute="trailing" constant="16" id="1KZ-6V-3Bg"/>
+                    <constraint firstItem="q7F-mg-QOb" firstAttribute="width" secondItem="IAo-11-r7k" secondAttribute="width" id="2XF-P5-GKT"/>
+                    <constraint firstItem="q7F-mg-QOb" firstAttribute="centerX" secondItem="IAo-11-r7k" secondAttribute="centerX" id="8aY-Wo-TjT"/>
+                    <constraint firstItem="q7F-mg-QOb" firstAttribute="centerY" secondItem="IAo-11-r7k" secondAttribute="centerY" id="Byk-hQ-anf"/>
                     <constraint firstAttribute="bottom" secondItem="dJu-H6-3qo" secondAttribute="bottom" id="MKS-QE-IDd"/>
                     <constraint firstAttribute="trailing" secondItem="dJu-H6-3qo" secondAttribute="trailing" id="QCn-b6-3ob"/>
                     <constraint firstAttribute="bottom" secondItem="kmu-MC-d7s" secondAttribute="bottom" constant="16" id="YEv-TF-quq"/>
                     <constraint firstItem="kmu-MC-d7s" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="ZCZ-Mb-8ya"/>
+                    <constraint firstItem="q7F-mg-QOb" firstAttribute="height" secondItem="IAo-11-r7k" secondAttribute="height" id="s3s-89-orz"/>
                     <constraint firstItem="dJu-H6-3qo" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="t4N-kv-EoQ"/>
                 </constraints>
             </tableViewCellContentView>


### PR DESCRIPTION
Fixes #12339 

This PR fixes a bug with the Post stats title.

@loremattei this needs to be merged in _13.1_

## To test:
• Go to _My Site > Stats > DWMY_ and find a time period with views.
• Scroll down to _Posts and Pages_, and tap one of the _Posts or Pages_ that has views.
• Try tapping the site title under _Showing stats for_

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
