### PR TITLE
Reader: Initialize attachments with default image data.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -4,6 +4,18 @@ import WordPressShared
 import WordPressUI
 import QuartzCore
 import Gridicons
+import MobileCoreServices
+
+class ReaderPlaceholderAttachment: NSTextAttachment {
+    init() {
+        // Initialize with default image data to prevent placeholder graphics appearing on iOS 13.
+        super.init(data: UIImage.init(color: .basicBackground).pngData(), ofType: kUTTypePNG as String)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
 
 open class ReaderDetailViewController: UIViewController, UIViewControllerRestoration {
     @objc static let restorablePostObjectURLhKey: String = "RestorablePostObjectURLKey"
@@ -84,9 +96,9 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     private let readerLinkRouter = UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes)
 
-    private let topMarginAttachment = NSTextAttachment()
+    private let topMarginAttachment = ReaderPlaceholderAttachment()
 
-    private let bottomMarginAttachment = NSTextAttachment()
+    private let bottomMarginAttachment = ReaderPlaceholderAttachment()
 
     @objc var currentPreferredStatusBarStyle = UIStatusBarStyle.lightContent {
         didSet {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -9,7 +9,7 @@ import MobileCoreServices
 class ReaderPlaceholderAttachment: NSTextAttachment {
     init() {
         // Initialize with default image data to prevent placeholder graphics appearing on iOS 13.
-        super.init(data: UIImage.init(color: .basicBackground).pngData(), ofType: kUTTypePNG as String)
+        super.init(data: UIImage(color: .basicBackground).pngData(), ofType: kUTTypePNG as String)
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachment.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachment.swift
@@ -38,8 +38,9 @@ open class WPTextAttachment: NSTextAttachment {
         self.identifier = identifier
         self.tagName = tagName
         self.src = src
-        let img = UIImage.init(color: UIColor.white)
-        super.init(data: img!.pngData(), ofType: kUTTypePNG as String)
+
+        // Initialize with default image data to prevent placeholder graphics appearing on iOS 13.
+        super.init(data: UIImage.init(color: .basicBackground).pngData(), ofType: kUTTypePNG as String)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachment.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachment.swift
@@ -40,7 +40,7 @@ open class WPTextAttachment: NSTextAttachment {
         self.src = src
 
         // Initialize with default image data to prevent placeholder graphics appearing on iOS 13.
-        super.init(data: UIImage.init(color: .basicBackground).pngData(), ofType: kUTTypePNG as String)
+        super.init(data: UIImage(color: .basicBackground).pngData(), ofType: kUTTypePNG as String)
     }
 
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachment.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPTextAttachment.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
-
+import WordPressUI
+import MobileCoreServices
 
 /// An NSTextAttachment for representing remote HTML content such as images, iframes and video.
 ///
@@ -37,8 +38,8 @@ open class WPTextAttachment: NSTextAttachment {
         self.identifier = identifier
         self.tagName = tagName
         self.src = src
-
-        super.init(data: nil, ofType: nil)
+        let img = UIImage.init(color: UIColor.white)
+        super.init(data: img!.pngData(), ofType: kUTTypePNG as String)
     }
 
 


### PR DESCRIPTION
Refs #12211 

This is a first pass at resolving some artifacting be hind images in the Reader on iOS 13.  It looks like NSTextAttachments that are initialized without default data, file reference, or image will show a placeholder graphic.  Adding a 1px x 1px white image as starting data seems to hide the placeholder. 

This is the first thing I thought of, and there might be a more elegant solution. Other ideas welcome. 

To test:
Confirm the artifacting by viewing the reader post detail with an iOS 13 development build. Look for any post with an attachment--image or media.
Switch to this branch and confirm that the artifacting no longer appear.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
