### PR TITLE
Offline Posting: Expire AutoUploads after 48h

### DIFF
--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -5,7 +5,7 @@ data model as well as any custom migrations.
 
 ## WordPress 90
 @jklausa 2019-08-19
-- `AbstractPost`: Addded a  `confirmedChangesHash` property. 
+- `AbstractPost`: Addded a  `confirmedChangesHash`  and  `confirmedChangesTimestamp`  properties. 
 
 ## WordPress 89
 

--- a/WordPress/Classes/Models/AbstractPost+HashHelpers.h
+++ b/WordPress/Classes/Models/AbstractPost+HashHelpers.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 // This value is used in Offline Posting — to calculate whether the post that the user _wanted_ to publish,
 // hasn't changed in the meantime and still is the same post.
 // It works by calculating a SHA256 hash for a subset of properties of a Post and then combining them together (including the hashes returned by the `additionalContentHashes` method, to let subclasses provide additional sources of truthfulness).
-- (NSString *)changesConfirmedContentHashValue;
+- (NSString *)calculateConfirmedChangesContentHash;
 
 // This is an extension point for the subclasses to add additional sources of truthfulness.
 - (NSArray<NSData *> *)additionalContentHashes;

--- a/WordPress/Classes/Models/AbstractPost+HashHelpers.m
+++ b/WordPress/Classes/Models/AbstractPost+HashHelpers.m
@@ -4,7 +4,7 @@
 
 @implementation AbstractPost (HashHelpers)
 
-- (NSString *)changesConfirmedContentHashValue {
+- (NSString *)calculateConfirmedChangesContentHash {
     // The list of the properties we're taking into account here broadly mirrors: https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/f9e7fbae2479ad71bd2d1c7039f6f2bbbcc9444d/fluxc/src/main/java/org/wordpress/android/fluxc/model/PostModel.java#L443-L473
     // Note that some of the properties aren't found on `AbstractPost`, but rather on `Post` and/or `Page` —
     // that's the purpose of the `-additionalContentHashes` extension point.

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -45,12 +45,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
  */
 @property (nonatomic, strong, nullable) NSArray *revisions;
 
-/**
- This property is used to confirm that the post we'll be trying to automatically retry uploading,
- hasn't changed since user has tapped on "confirm". The hash value is calculated using `-changesConfirmedContentHashValue` method.
- */
-@property (nonatomic, strong, nullable) NSString *confirmedChangesHash;
-
 // Revision management
 - (AbstractPost *)createRevision;
 - (void)deleteRevision;
@@ -85,9 +79,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 #pragma mark - Conveniece Methods
 - (void)publishImmediately;
 - (BOOL)shouldPublishImmediately;
-
-- (BOOL)shouldAttemptAutoUpload;
-
 - (NSString *)authorNameForDisplay;
 - (NSString *)blavatarForDisplay;
 - (NSString *)dateStringForDisplay;
@@ -187,6 +178,10 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 - (void)remove;
 // Save changes to disk
 - (void)save;
+
+// This property is used to indicate whether an app should attempt to automatically retry upload this post
+// the next time a internet connection is available.
+@property (nonatomic, assign) BOOL shouldAttemptAutoUpload;
 
 /**
  * Updates the path for the display image by looking at the post content and trying to find an good image to use.

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -5,6 +5,21 @@
 #import "BasePost.h"
 @import WordPressKit;
 
+@interface AbstractPost ()
+
+/**
+ The following pair of properties is used to confirm that the post we'll be trying to automatically retry uploading,
+ hasn't changed since user has tapped on "confirm", and that we're not suddenly trying to auto-upload a post that the user
+ might have already forgotten about.
+
+ The public-facing counterparts of those is the `shouldAttemptAutoUpload` property.
+ */
+
+@property (nonatomic, strong, nullable) NSString *confirmedChangesHash;
+@property (nonatomic, strong, nullable) NSDate *confirmedChangesTimestamp;
+
+@end
+
 @implementation AbstractPost
 
 @dynamic blog;
@@ -16,6 +31,7 @@
 @dynamic featuredImage;
 @dynamic revisions;
 @dynamic confirmedChangesHash;
+@dynamic confirmedChangesTimestamp;
 
 @synthesize restorableStatus;
 
@@ -412,13 +428,6 @@
     return [self originalIsDraft] && [self dateCreatedIsNilOrEqualToDateModified];
 }
 
-- (BOOL)shouldAttemptAutoUpload {
-    BOOL hashesEqual = self.confirmedChangesHash != nil && ([self.confirmedChangesHash isEqualToString:self.changesConfirmedContentHashValue]);
-
-    return hashesEqual;
-}
-
-
 - (NSString *)authorNameForDisplay
 {
     return [NSString makePlainText:self.author];
@@ -581,6 +590,32 @@
 {
     self.remoteStatus = AbstractPostRemoteStatusFailed;
     [self save];
+}
+
+- (BOOL)shouldAttemptAutoUpload {
+    if (!self.confirmedChangesTimestamp || !self.confirmedChangesHash) {
+        return NO;
+    }
+
+    NSTimeInterval timeDifference = [self.confirmedChangesTimestamp timeIntervalSinceDate:[NSDate date]];
+
+    BOOL timeDifferenceWithinRange = timeDifference <= (60 * 60 * 24 * 2); //
+    // I know, I know. This isn't how a date comparison _should_ be done!
+    // However, going thru NSCalendar can get really expensive and this method can potentially be called a lot during
+    // scrolling of a Post List — and for our specific use-case, being slightly innacurate here in terms of
+    // leap seconds or other calendrical oddities doesn't actually matter.
+
+    BOOL hashesEqual = [self.confirmedChangesHash isEqualToString:[self calculateConfirmedChangesContentHash]];
+
+    return hashesEqual && timeDifferenceWithinRange;
+}
+
+- (void)setShouldAttemptAutoUpload:(BOOL)shouldAttemptAutoUpload {
+    NSString *currentHash = [self calculateConfirmedChangesContentHash];
+    NSDate *now = [NSDate date];
+
+    self.confirmedChangesHash = currentHash;
+    self.confirmedChangesTimestamp = now;
 }
 
 - (void)updatePathForDisplayImageBasedOnContent

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -597,9 +597,9 @@
         return NO;
     }
 
-    NSTimeInterval timeDifference = [self.confirmedChangesTimestamp timeIntervalSinceDate:[NSDate date]];
+    NSTimeInterval timeDifference = [[NSDate date] timeIntervalSinceDate:self.confirmedChangesTimestamp];
 
-    BOOL timeDifferenceWithinRange = timeDifference <= (60 * 60 * 24 * 2); //
+    BOOL timeDifferenceWithinRange = timeDifference <= (60 * 60 * 24 * 2);
     // I know, I know. This isn't how a date comparison _should_ be done!
     // However, going thru NSCalendar can get really expensive and this method can potentially be called a lot during
     // scrolling of a Post List — and for our specific use-case, being slightly innacurate here in terms of

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -600,8 +600,9 @@
     NSTimeInterval timeDifference = [[NSDate date] timeIntervalSinceDate:self.confirmedChangesTimestamp];
 
     BOOL timeDifferenceWithinRange = timeDifference <= (60 * 60 * 24 * 2);
-    // I know, I know. This isn't how a date comparison _should_ be done!
-    // However, going thru NSCalendar can get really expensive and this method can potentially be called a lot during
+    // We want the user's confirmation to upload a thing to expire after 48h.
+    // This probably should be calculated using NSCalendar APIs — but those
+    // can get really expensive. This method can potentially be called a lot during
     // scrolling of a Post List — and for our specific use-case, being slightly innacurate here in terms of
     // leap seconds or other calendrical oddities doesn't actually matter.
 

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -611,11 +611,16 @@
 }
 
 - (void)setShouldAttemptAutoUpload:(BOOL)shouldAttemptAutoUpload {
-    NSString *currentHash = [self calculateConfirmedChangesContentHash];
-    NSDate *now = [NSDate date];
+    if (shouldAttemptAutoUpload) {
+        NSString *currentHash = [self calculateConfirmedChangesContentHash];
+        NSDate *now = [NSDate date];
 
-    self.confirmedChangesHash = currentHash;
-    self.confirmedChangesTimestamp = now;
+        self.confirmedChangesHash = currentHash;
+        self.confirmedChangesTimestamp = now;
+    } else {
+        self.confirmedChangesHash = nil;
+        self.confirmedChangesTimestamp = nil;
+    }
 }
 
 - (void)updatePathForDisplayImageBasedOnContent

--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -31,7 +31,7 @@ final class PostAutoUploadInteractor {
                 return .nothing
         }
 
-        if post.isLocalDraft || post.shouldAttemptAutoUpload() {
+        if post.isLocalDraft || post.shouldAttemptAutoUpload {
             return .upload
         } else {
             // TODO This is currently not supported by PostCoordinator

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -274,8 +274,7 @@ extension PostCoordinator: Uploader {
     func cancelAutoUploadOf(_ post: AbstractPost) {
         cancelAnyPendingSaveOf(post: post)
 
-        // nil-ing this out will make the `shouldAttemptAutoUpload` property to return false.
-        post.confirmedChangesHash = nil
+        post.shouldAttemptAutoUpload = false
 
         let moc = post.managedObjectContext
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -84,7 +84,7 @@ extension PostEditor where Self: UIViewController {
                 }
             }
 
-            self.post.confirmedChangesHash = self.post.changesConfirmedContentHashValue()
+            self.post.shouldAttemptAutoUpload = true
 
             if let analyticsStat = analyticsStat {
                 self.trackPostSave(stat: analyticsStat)

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 90.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 90.xcdatamodel/contents
@@ -2,6 +2,7 @@
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="14490.99" systemVersion="18G87" minimumToolsVersion="Xcode 7.3" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AbstractPost" representedClassName="AbstractPost" isAbstract="YES" parentEntity="BasePost">
         <attribute name="confirmedChangesHash" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="confirmedChangesTimestamp" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="dateModified" optional="YES" attributeType="Date" usesScalarValueType="NO" indexed="YES" syncable="YES"/>
         <attribute name="metaIsLocal" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="metaPublishImmediately" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
@@ -907,7 +908,7 @@
         <attribute name="visitorsCount" attributeType="Integer 64" usesScalarValueType="YES" syncable="YES"/>
     </entity>
     <elements>
-        <element name="AbstractPost" positionX="0" positionY="0" width="128" height="195"/>
+        <element name="AbstractPost" positionX="0" positionY="0" width="128" height="210"/>
         <element name="Account" positionX="0" positionY="0" width="128" height="210"/>
         <element name="AccountSettings" positionX="18" positionY="153" width="128" height="255"/>
         <element name="AllTimeStatsRecordValue" positionX="27" positionY="162" width="128" height="120"/>

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -80,7 +80,7 @@ class PostBuilder {
     }
 
     func confirmedAutoUpload() -> PostBuilder {
-        post.confirmedChangesHash = post.changesConfirmedContentHashValue()
+        post.shouldAttemptAutoUpload = true
         return self
     }
 

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -420,10 +420,10 @@ class PostTests: XCTestCase {
 
         let correctHash = "36d7cd8138748d779453d30e8f758592b40b61af464921133c9db12cd71cf0ca"
 
-        XCTAssertEqual(post.changesConfirmedContentHashValue(), correctHash)
+        XCTAssertEqual(post.calculateConfirmedChangesContentHash(), correctHash)
 
         post.isStickyPost = false
 
-        XCTAssertNotEqual(post.confirmedChangesHash, correctHash)
+        XCTAssertNotEqual(post.calculateConfirmedChangesContentHash(), correctHash)
     }
 }

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -426,4 +426,26 @@ class PostTests: XCTestCase {
 
         XCTAssertNotEqual(post.calculateConfirmedChangesContentHash(), correctHash)
     }
+
+    func testAutoUploadExpiration() {
+        let post = newTestPost()
+
+        post.shouldAttemptAutoUpload = false
+        XCTAssertEqual(post.shouldAttemptAutoUpload, false)
+
+        post.shouldAttemptAutoUpload = true
+        XCTAssertEqual(post.shouldAttemptAutoUpload, true)
+
+        let threeDaysAgo = Calendar.autoupdatingCurrent.date(byAdding: .day, value: -3, to: Date())!
+
+        post.setValue(threeDaysAgo, forKey: "confirmedChangesTimestamp")
+        // It's not great that we're setting a private property, but it's deliberately one that's private.
+        // We still want to test it though!
+        XCTAssertEqual(post.shouldAttemptAutoUpload, false)
+
+        let aDayAgo = Calendar.autoupdatingCurrent.date(byAdding: .day, value: -1, to: Date())!
+        post.setValue(aDayAgo, forKey: "confirmedChangesTimestamp")
+
+        XCTAssertEqual(post.shouldAttemptAutoUpload, true)
+    }
 }

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -116,7 +116,7 @@ private extension PostCoordinatorUploadActionUseCaseTests {
         }
 
         if confirmedAutoUpload {
-            post.confirmedChangesHash = post.changesConfirmedContentHashValue()
+            post.shouldAttemptAutoUpload = true
         }
 
         return post


### PR DESCRIPTION
This is a second part of #12136 — adding support for expiring the scheduled autouploads after 48hs from confirmation.

Note that since this is using the same Core Data model number as #12347, it might crash on launch if you ran the #12347 branch in your simulator before. You'll need to delete and reinstall the app from the sim/device.
This is expected — I don't want this to create multiple migrations that will have to happen at runtime for our users, and all the migrations in the master branch should be coalesced into one before merging into `develop`.

To test:

Scenario 1 — making sure "young posts" are correctly autouploaded:

1. Go offline
2. Change the date on your Mac/device to yesterday 
3. Compose a post, try to post it
4. Change the date on your Mac/device back to the correct one
5. Go back online
6. Verify that the Post gets correctly uploaded / is marked in the Post list as "will be published next time your device is online

Scenario 2 — expiration

1. Go offline
2. Change the date on your Mac/device to something more than 48hrs in the past
3. Compose a post, try to post it
4. Change the date on your Mac/device back to the correct one
5. Go back online
6. Verify that the Post gets doesn't get automatically uploaded and it's displayed in the post list as "Upload failed"

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
