### PR TITLE
Validate strings before committing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -224,6 +224,7 @@ namespace :git do
   task :pre_commit => %[dependencies:lint:check] do
     begin
       swiftlint %w[lint --quiet --strict]
+      sh('find WordPress -name *.strings -exec plutil -lint {} +')
     rescue
       exit $?.exitstatus
     end


### PR DESCRIPTION
This PR adds a check to ensure that `.strings` files are not malformed before committing.

**To test:**
- Check out this branch
- Deliberately break a `.strings` file (deleting the trailing quote on a line is a good way to do it) 
- Ensure that you're not able to commit this change

**Please note**
This PR is an example of a possible direction for localization validation, and may be discarded as inadvisable.

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
