### PR TITLE
New colors: turn off feature flag

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -1,6 +1,3 @@
-/// Only necessary until the .murielColors feature flag is removed
-import WordPressShared
-
 extension UIColor {
     /// Get a UIColor from the Muriel color palette
     ///
@@ -18,24 +15,10 @@ extension UIColor {
 // MARK: - Basic Colors
 extension UIColor {
     /// Muriel accent color
-    static var accent: UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return muriel(color: .accent)
-        } else {
-            return WPStyleGuide.jazzyOrange()
-        }
-    }
-
+    static var accent = muriel(color: .accent)
+    static var accentDark = muriel(color: MurielColor(from: .accent, shade: .shade70))
     class func accent(shade: MurielColorShade) -> UIColor {
         return muriel(color: MurielColor(from: .accent, shade: shade))
-    }
-
-    static var accentDark: UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return muriel(color: MurielColor(from: .accent, shade: .shade70))
-        } else {
-            return WPStyleGuide.fireOrange()
-        }
     }
 
     /// Muriel brand color
@@ -45,22 +28,8 @@ extension UIColor {
     }
 
     /// Muriel error color
-    static var error: UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return muriel(color: .error)
-        } else {
-            return WPStyleGuide.errorRed()
-        }
-    }
-
-    static var errorDark: UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return muriel(color: MurielColor(from: .error, shade: .shade70))
-        } else {
-            return WPStyleGuide.alertRedDarker()
-        }
-    }
-
+    static var error = muriel(color: .error)
+    static var errorDark = muriel(color: MurielColor(from: .error, shade: .shade70))
     class func error(shade: MurielColorShade) -> UIColor {
         return muriel(color: MurielColor(from: .error, shade: shade))
     }
@@ -68,85 +37,19 @@ extension UIColor {
     /// Muriel neutral color
     static var neutral = muriel(color: .neutral)
     class func neutral(shade: MurielColorShade) -> UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return muriel(color: MurielColor(from: .neutral, shade: shade))
-        } else {
-            // here's compatibility with the old colors
-            switch shade {
-            case .shade70, .shade80, .shade90:
-                return WPStyleGuide.darkGrey()
-            case .shade60:
-                return WPStyleGuide.greyDarken30()
-            case .shade50:
-                return WPStyleGuide.greyDarken20()
-            case .shade40:
-                return WPStyleGuide.greyDarken10()
-            case .shade30:
-                return WPStyleGuide.grey()
-            case .shade20:
-                return WPStyleGuide.greyLighten10()
-            case .shade10:
-                return WPStyleGuide.greyLighten20()
-            case .shade5:
-                return WPStyleGuide.greyLighten30()
-            case .shade0:
-                return WPStyleGuide.lightGrey()
-            }
-        }
+        return muriel(color: MurielColor(from: .neutral, shade: shade))
     }
 
     /// Muriel primary color
-    static var primary: UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return muriel(color: .primary)
-        } else {
-            return WPStyleGuide.wordPressBlue()
-        }
-    }
-
-    static var primaryLight: UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return muriel(color: MurielColor(from: .primary, shade: .shade30))
-        } else {
-            return WPStyleGuide.lightBlue()
-        }
-    }
-
-    static var primaryDark: UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return muriel(color: MurielColor(from: .primary, shade: .shade70))
-        } else {
-            return WPStyleGuide.darkBlue()
-        }
-    }
-
+    static var primary = muriel(color: .primary)
+    static var primaryLight = muriel(color: MurielColor(from: .primary, shade: .shade30))
+    static var primaryDark = muriel(color: MurielColor(from: .primary, shade: .shade70))
     class func primary(shade: MurielColorShade) -> UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return muriel(color: MurielColor(from: .primary, shade: shade))
-        } else {
-            // here's compatibility with the old colors
-            switch shade {
-            case .shade70, .shade80, .shade90:
-                return WPStyleGuide.darkBlue()
-            case .shade50, .shade60:
-                return WPStyleGuide.wordPressBlue()
-            case .shade40:
-                return WPStyleGuide.mediumBlue()
-            case .shade30, .shade20, .shade10, .shade5, .shade0:
-                return WPStyleGuide.lightBlue()
-            }
-        }
+        return muriel(color: MurielColor(from: .primary, shade: shade))
     }
 
     /// Muriel success color
-    static var success: UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return muriel(color: .success)
-        } else {
-            return WPStyleGuide.validGreen()
-        }
-    }
-
+    static var success = muriel(color: .success)
     class func success(shade: MurielColorShade) -> UIColor {
         return muriel(color: MurielColor(from: .success, shade: shade))
     }
@@ -297,37 +200,10 @@ extension UIColor {
     static var tabUnselected: UIColor =  UIColor(light: .neutral(shade: .shade20), dark: .neutral(shade: .shade50))
 
 // MARK: - WP Fancy Buttons
-    static var primaryButtonBackground: UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return .accent
-        } else {
-            return WPStyleGuide.mediumBlue()
-        }
-    }
-
-    static var primaryButtonBorder: UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return .accentDark
-        } else {
-            return WPStyleGuide.wordPressBlue()
-        }
-    }
-
-    static var primaryButtonDownBackground: UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return muriel(color: MurielColor(name: .pink, shade: .shade80))
-        } else {
-            return WPStyleGuide.wordPressBlue()
-        }
-    }
-
-    static var primaryButtonDownBorder: UIColor {
-        if FeatureFlag.murielColors.enabled {
-            return muriel(color: MurielColor(name: .pink, shade: .shade90))
-        } else {
-            return WPStyleGuide.wordPressBlue()
-        }
-    }
+    static var primaryButtonBackground = accent
+    static var primaryButtonBorder = accentDark
+    static var primaryButtonDownBackground = muriel(color: MurielColor(name: .pink, shade: .shade80))
+    static var primaryButtonDownBorder = muriel(color: MurielColor(name: .pink, shade: .shade90))
 }
 
 extension UIColor {

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -16,21 +16,11 @@ extension WPStyleGuide {
     }
 
     class func configureDefaultTint() {
-        guard FeatureFlag.murielColors.enabled else {
-            configureNavigationBarAppearance()
-            return
-        }
-
         UIWindow.appearance().tintColor = .primary
     }
 
     /// Style the navigation appearance using Muriel colors
     class func configureNavigationAppearance() {
-        guard FeatureFlag.murielColors.enabled else {
-            configureNavigationBarAppearance()
-            return
-        }
-
         let navigationAppearance = UINavigationBar.appearance()
         navigationAppearance.isTranslucent = false
         navigationAppearance.tintColor = .white
@@ -83,14 +73,9 @@ extension WPStyleGuide {
         guard let tableView = tableView else {
             return
         }
-        if FeatureFlag.murielColors.enabled {
-            tableView.backgroundColor = .tableBackground
-            tableView.separatorColor = .neutral(shade: .shade10)
-        } else {
-            tableView.backgroundView = nil
-            tableView.backgroundColor = greyLighten30()
-            tableView.separatorColor = greyLighten20()
-        }
+
+        tableView.backgroundColor = .tableBackground
+        tableView.separatorColor = .neutral(shade: .shade10)
     }
 
     class func configureColors(view: UIView, collectionView: UICollectionView) {
@@ -111,24 +96,15 @@ extension WPStyleGuide {
         cell.detailTextLabel?.sizeToFit()
 
         // we only set the text subtle color, so that system colors are used otherwise
-        if FeatureFlag.murielColors.enabled {
-            cell.detailTextLabel?.textColor = .textSubtle
-            cell.imageView?.tintColor = .neutral(shade: .shade30)
-        } else {
-            cell.textLabel?.textColor = darkGrey()
-            cell.detailTextLabel?.textColor = grey()
-            cell.imageView?.tintColor = greyLighten10()
-        }
+        cell.detailTextLabel?.textColor = .textSubtle
+        cell.imageView?.tintColor = .neutral(shade: .shade30)
+
     }
 
     class func configureTableViewSmallSubtitleCell(_ cell: UITableViewCell) {
         configureTableViewColors(view: cell)
         cell.detailTextLabel?.font = subtitleFont()
-        if FeatureFlag.murielColors.enabled {
-            cell.detailTextLabel?.textColor = .textSubtle
-        } else {
-            cell.detailTextLabel?.textColor = darkGrey()
-        }
+        cell.detailTextLabel?.textColor = .textSubtle
     }
 
     @objc
@@ -150,18 +126,10 @@ extension WPStyleGuide {
         configureTableViewCell(cell)
 
         if cell.textField.isEnabled {
-            if FeatureFlag.murielColors.enabled {
-                cell.detailTextLabel?.textColor = .text
-            } else {
-                cell.detailTextLabel?.textColor = darkBlue()
-            }
+            cell.detailTextLabel?.textColor = .text
             cell.textField.textAlignment = .natural
         } else {
-            if FeatureFlag.murielColors.enabled {
-                cell.detailTextLabel?.textColor = .textSubtle
-            } else {
-                cell.detailTextLabel?.textColor = darkGrey()
-            }
+            cell.detailTextLabel?.textColor = .textSubtle
             if cell.effectiveUserInterfaceLayoutDirection == .leftToRight {
                 // swiftlint:disable:next inverse_text_alignment
                 cell.textField.textAlignment = .right
@@ -170,14 +138,6 @@ extension WPStyleGuide {
                 cell.textField.textAlignment = .left
             }
         }
-    }
-
-    @objc class func configureTableViewSectionHeader(_ header: UIView) {
-        guard !FeatureFlag.murielColors.enabled,
-            let header = header as? UITableViewHeaderFooterView else {
-            return
-        }
-        header.textLabel?.textColor = whisperGrey()
     }
 
     @objc

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -148,10 +148,7 @@ extension WPStyleGuide {
         }
         if textLabel.isUserInteractionEnabled {
             textLabel.textColor = .primary
-        } else if !FeatureFlag.murielColors.enabled {
-            textLabel.textColor = greyDarken10()
         }
-
     }
 
 }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -783,20 +783,6 @@ extension WordPressAppDelegate {
         WPStyleGuide.configureTabBarAppearance()
         WPStyleGuide.configureNavigationAppearance()
         WPStyleGuide.configureDefaultTint()
-        if !FeatureFlag.murielColors.enabled {
-            UITabBar.appearance().shadowImage = UIImage(color: UIColor(red: 210.0/255.0, green: 222.0/255.0, blue: 230.0/255.0, alpha: 1.0))
-
-            let navigationAppearance = UINavigationBar.appearance()
-            navigationAppearance.setBackgroundImage(WPStyleGuide.navigationBarBackgroundImage(), for: .default)
-            navigationAppearance.shadowImage = WPStyleGuide.navigationBarShadowImage()
-            navigationAppearance.barStyle = WPStyleGuide.navigationBarBarStyle()
-
-            let tabBarTextColor = WPStyleGuide.wordPressBlue()
-            let tabBarUnselectedTextColor = UIColor.neutral(shade: .shade30)
-
-            UITabBarItem.appearance().setTitleTextAttributes([NSAttributedString.Key.foregroundColor: tabBarUnselectedTextColor], for: .normal)
-            UITabBarItem.appearance().setTitleTextAttributes([NSAttributedString.Key.foregroundColor: tabBarTextColor], for: .selected)
-        }
 
         UISegmentedControl.appearance().setTitleTextAttributes( [NSAttributedString.Key.font: WPStyleGuide.regularTextFont()], for: .normal)
         UIToolbar.appearance().barTintColor = .primary

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -8,7 +8,6 @@ enum FeatureFlag: Int {
     case statsFileDownloads
     case statsInsightsManagement
     case domainCredit
-    case murielColors
     case signInWithApple
 
     /// Returns a boolean indicating if the feature is enabled
@@ -25,8 +24,6 @@ enum FeatureFlag: Int {
         case .statsInsightsManagement:
             return BuildConfiguration.current == .localDeveloper
         case .domainCredit:
-            return true
-        case .murielColors:
             return true
         case .signInWithApple:
             // SIWA can NOT be enabled for internal builds

--- a/WordPress/Classes/Utility/ImmuTable+WordPress.swift
+++ b/WordPress/Classes/Utility/ImmuTable+WordPress.swift
@@ -6,10 +6,6 @@ import WordPressShared
 ///
 extension ImmuTableViewHandler {
 
-    public func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
-
     public func tableView(_ tableView: UITableView, willDisplayFooterView view: UIView, forSection section: Int) {
         WPStyleGuide.configureTableViewSectionFooter(view)
     }

--- a/WordPress/Classes/Utility/WPTableViewHandler.m
+++ b/WordPress/Classes/Utility/WPTableViewHandler.m
@@ -502,8 +502,6 @@ static CGFloat const DefaultCellHeight = 44.0;
 {
     if ([self.delegate respondsToSelector:@selector(tableView:willDisplayHeaderView:forSection:)]) {
         [self.delegate tableView:tableView willDisplayHeaderView:view forSection:section];
-    } else {
-        [WPStyleGuide configureTableViewSectionHeader:view];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsViewController.m
@@ -1188,11 +1188,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self presentViewController:removeSheet animated:YES completion:nil];
 }
 
-- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
-{
-    [WPStyleGuide configureTableViewSectionHeader:view];
-}
-
 - (NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(nonnull NSIndexPath *)indexPath
 {
     BOOL isNewSelection = (indexPath != tableView.indexPathForSelectedRow);

--- a/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DiscussionSettingsViewController.swift
@@ -125,10 +125,6 @@ open class DiscussionSettingsViewController: UITableViewController {
         return sections[section].headerText
     }
 
-    open override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
-
     open override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return sections[section].footerText
     }

--- a/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/RelatedPostsSettingsViewController.m
@@ -106,11 +106,6 @@ typedef NS_ENUM(NSInteger, RelatedPostsSettingsOptions) {
     }
 }
 
-- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
-{
-    [WPStyleGuide configureTableViewSectionHeader:view];
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     switch (section) {

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -828,7 +828,6 @@ extension SharingButtonsViewController {
     override func tableView(_ tableView: UITableView,
                             willDisplayHeaderView view: UIView,
                             forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
     }
 
     override func tableView(_ tableView: UITableView,

--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -116,11 +116,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return title;
 }
 
-- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
-{
-    [WPStyleGuide configureTableViewSectionHeader:view];
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     if ([self hasConnectedAccounts] && section == 0) {

--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
@@ -125,11 +125,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     return nil;
 }
 
-- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
-{
-    [WPStyleGuide configureTableViewSectionHeader:view];
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     if (section == 0) {

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -90,11 +90,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     }
 }
 
-- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
-{
-    [WPStyleGuide configureTableViewSectionHeader:view];
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     if (section == SharingPublicizeServices) {

--- a/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SiteSettingsViewController.m
@@ -793,11 +793,6 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     return [self titleForHeaderInSection:settingsSection];
 }
 
-- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
-{
-    [WPStyleGuide configureTableViewSectionHeader:view];
-}
-
 - (NSString *)titleForHeaderInSection:(NSInteger)section
 {
     NSString *headingTitle = nil;

--- a/WordPress/Classes/ViewRelated/Domains/DomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/DomainsListViewController.swift
@@ -150,10 +150,6 @@ class DomainsListViewController: UITableViewController, ImmuTablePresenter {
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return viewModel.sections[section].headerText
     }
-
-    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
 }
 
 extension DomainsListViewController: NSFetchedResultsControllerDelegate {

--- a/WordPress/Classes/ViewRelated/Me/ActivityLogViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/ActivityLogViewController.m
@@ -113,11 +113,6 @@ static NSString *const ActivityLogCellIdentifier = @"ActivityLogCell";
     return nil;
 }
 
-- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
-{
-    [WPStyleGuide configureTableViewSectionHeader:view];
-}
-
 - (NSString *)tableView:(UITableView *)tableView titleForFooterInSection:(NSInteger)section
 {
     if (section == 0) {

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -431,10 +431,6 @@ extension MediaItemViewController {
         return tableView.rowHeight
     }
 
-    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
-
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let row = viewModel.rowAtIndexPath(indexPath)
         row.action?(row)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -214,10 +214,6 @@ class NotificationSettingDetailsViewController: UITableViewController {
         return siteName
     }
 
-    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
-
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return sections[section].footerText
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -207,10 +207,6 @@ open class NotificationSettingsViewController: UIViewController {
         return theSection.headerText()
     }
 
-    @objc open func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
-
     @objc open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         // Hide when the section is empty!
         if isSectionEmpty(section) {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSiteSubscriptionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSiteSubscriptionViewController.swift
@@ -226,10 +226,6 @@ class NotificationSiteSubscriptionViewController: UITableViewController {
 
     // MARK: - Table view delegate
 
-    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
-
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return sections[section].footerText
     }

--- a/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/ParentPageSettingsViewController.swift
@@ -285,10 +285,6 @@ extension ParentPageSettingsViewController: UITableViewDataSource {
 
 
 extension ParentPageSettingsViewController: UITableViewDelegate {
-    func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
-
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return sections[section].headerText
     }

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -189,10 +189,6 @@ extension PlanDetailViewController: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         return noResultsViewModel != nil ? nil : tableViewModel.sections[section].headerText
     }
-
-    func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
 }
 
 // MARK: - No Results Handling Private Extension

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -487,11 +487,6 @@ FeaturedImageViewControllerDelegate>
     return nil;
 }
 
-- (void)tableView:(UITableView *)tableView willDisplayHeaderView:(UIView *)view forSection:(NSInteger)section
-{
-    [WPStyleGuide configureTableViewSectionHeader:view];
-}
-
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
 {
     if ([self tableView:tableView numberOfRowsInSection:section] == 0) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderMenuViewController.swift
@@ -535,10 +535,6 @@ import WordPressShared
         return viewModel.titleForSection(section)
     }
 
-    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
-
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let menuItem = viewModel.menuItemAtIndexPath(indexPath)
         if menuItem?.type == .addItem {

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressTableViewProvider.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressTableViewProvider.swift
@@ -53,10 +53,6 @@ final class WebAddressTableViewProvider: NSObject, TableViewProvider {
         return data.count
     }
 
-    func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
-
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         guard isShowingImplicitSuggestions else {
             return nil

--- a/WordPress/WordPressShareExtension/ShareCategoriesPickerViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareCategoriesPickerViewController.swift
@@ -149,10 +149,6 @@ class ShareCategoriesPickerViewController: UITableViewController {
         return nil
     }
 
-    override func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
-
     override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         return nil
     }

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -352,10 +352,6 @@ extension ShareModularViewController: UITableViewDataSource {
         }
     }
 
-    func tableView(_ tableView: UITableView, willDisplayHeaderView view: UIView, forSection section: Int) {
-        WPStyleGuide.configureTableViewSectionHeader(view)
-    }
-
     func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
         if tableView == modulesTableView {
             if isModulesSectionEmpty(section) {


### PR DESCRIPTION
Refs #11683

This removes the `murielColors` feature flag. If I did everything right, you won't even notice it's gone.

To test:
- launch the app
- look at every single screen in the app
- ensure that nothing has changed since before this PR

Update release notes:

- [x] If there are user facing changes, I have added an item to `RELEASE-NOTES.txt`.
