### PR TITLE
Add Cancel button in notice shown after failing to publish a post

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -244,6 +244,20 @@ class PostCoordinator: NSObject {
             try? post.managedObjectContext?.save()
         }
     }
+
+    /// Cancel active and pending automatic uploads of the post.
+    func cancelAutoUploadOf(_ post: AbstractPost) {
+        cancelAnyPendingSaveOf(post: post)
+
+        // nil-ing this out will make the `shouldAttemptAutoUpload` property to return false.
+        post.confirmedChangesHash = nil
+
+        let moc = post.managedObjectContext
+
+        moc?.perform {
+            try? moc?.save()
+        }
+    }
 }
 
 // MARK: - Automatic Uploads
@@ -267,20 +281,6 @@ extension PostCoordinator: Uploader {
                     return
                 }
             }
-        }
-    }
-
-    /// Cancel active and pending automatic uploads of the post.
-    func cancelAutoUploadOf(_ post: AbstractPost) {
-        cancelAnyPendingSaveOf(post: post)
-
-        // nil-ing this out will make the `shouldAttemptAutoUpload` property to return false.
-        post.confirmedChangesHash = nil
-
-        let moc = post.managedObjectContext
-
-        moc?.perform {
-            try? moc?.save()
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -5,7 +5,13 @@ enum PostNoticeUserInfoKey {
 }
 
 struct PostNoticeViewModel {
-    let post: AbstractPost
+    private let post: AbstractPost
+    private let postCoordinator: PostCoordinator
+
+    init(post: AbstractPost, postCoordinator: PostCoordinator = PostCoordinator.shared) {
+        self.post = post
+        self.postCoordinator = postCoordinator
+    }
 
     /// Returns the Notice represented by this view model.
     ///
@@ -192,7 +198,7 @@ struct PostNoticeViewModel {
         }
 
         post.status = .publish
-        PostCoordinator.shared.save(post: post)
+        postCoordinator.save(post: post)
     }
 
     private func retryUpload() {
@@ -200,7 +206,7 @@ struct PostNoticeViewModel {
             return
         }
 
-        PostCoordinator.shared.save(post: post)
+        postCoordinator.save(post: post)
     }
 
     private var postInContext: AbstractPost? {

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -174,7 +174,11 @@ struct PostNoticeViewModel {
     }
 
     private var failureActionTitle: String {
-        return NSLocalizedString("Retry", comment: "Button title. Retries uploading a post.")
+        if post.status == .publish {
+            return FailureActionTitles.cancel
+        } else {
+            return FailureActionTitles.retry
+        }
     }
 
     private func viewPost() {
@@ -210,5 +214,10 @@ struct PostNoticeViewModel {
     enum FailureTitles {
         static let postWillBePublished = NSLocalizedString("Post will be published the next time your device is online",
                                                            comment: "Text displayed in notice after a post if published while offline.")
+    }
+
+    enum FailureActionTitles {
+        static let retry = NSLocalizedString("Retry", comment: "Button title. Retries uploading a post.")
+        static let cancel = NSLocalizedString("Cancel", comment: "Button title. Cancels automatic uploading of the post when the device is back online.")
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -549,6 +549,7 @@
 		57AA848F228715DA00D3C2A2 /* PostCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AA848E228715DA00D3C2A2 /* PostCardCell.swift */; };
 		57AA8491228715E700D3C2A2 /* PostCardCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 57AA8490228715E700D3C2A2 /* PostCardCell.xib */; };
 		57AA8493228790AA00D3C2A2 /* PostCardCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AA8492228790AA00D3C2A2 /* PostCardCellTests.swift */; };
+		57B71D4E230DB5F200789A68 /* BlogBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B71D4D230DB5F200789A68 /* BlogBuilder.swift */; };
 		57BAD50C225CCE1A006139EC /* WPTabBarController+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BAD50B225CCE1A006139EC /* WPTabBarController+Swift.swift */; };
 		57C2331822FE0EC900A3863B /* PostAutoUploadInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C2331722FE0EC900A3863B /* PostAutoUploadInteractor.swift */; };
 		57D5812D2228526C002BAAD7 /* WPError+Swift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57D5812C2228526C002BAAD7 /* WPError+Swift.swift */; };
@@ -2609,6 +2610,7 @@
 		57AA848E228715DA00D3C2A2 /* PostCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardCell.swift; sourceTree = "<group>"; };
 		57AA8490228715E700D3C2A2 /* PostCardCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = PostCardCell.xib; sourceTree = "<group>"; };
 		57AA8492228790AA00D3C2A2 /* PostCardCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCardCellTests.swift; sourceTree = "<group>"; };
+		57B71D4D230DB5F200789A68 /* BlogBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogBuilder.swift; sourceTree = "<group>"; };
 		57BAD50B225CCE1A006139EC /* WPTabBarController+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPTabBarController+Swift.swift"; sourceTree = "<group>"; };
 		57C2331722FE0EC900A3863B /* PostAutoUploadInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostAutoUploadInteractor.swift; sourceTree = "<group>"; };
 		57D5812C2228526C002BAAD7 /* WPError+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPError+Swift.swift"; sourceTree = "<group>"; };
@@ -5543,6 +5545,7 @@
 				59B48B611B99E132008EBB84 /* JSONLoader.swift */,
 				E157D5DF1C690A6C00F04FB9 /* ImmuTableTestUtils.swift */,
 				570BFD8F2282418A007859A8 /* PostBuilder.swift */,
+				57B71D4D230DB5F200789A68 /* BlogBuilder.swift */,
 			);
 			name = TestUtilities;
 			sourceTree = "<group>";
@@ -11783,6 +11786,7 @@
 				D816B8D72112D75C0052CE4D /* NewsCardTests.swift in Sources */,
 				D809E686203F0215001AA0DE /* ReaderPostCardCellTests.swift in Sources */,
 				40E4698F2017E0700030DB5F /* PluginDirectoryEntryStateTests.swift in Sources */,
+				57B71D4E230DB5F200789A68 /* BlogBuilder.swift in Sources */,
 				D848CC1920FF3A2400A9038F /* FormattableNotIconTests.swift in Sources */,
 				E1AB5A3A1E0C464700574B4E /* DelayTests.swift in Sources */,
 				D848CC0320FF04FA00A9038F /* FormattableUserContentTests.swift in Sources */,

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+@testable import WordPress
+
+final class BlogBuilder {
+    private let blog: Blog!
+
+    init(_ context: NSManagedObjectContext) {
+        blog = Blog(context: context)
+
+        // Non-null properties in Core Data
+        blog.dotComID = NSNumber(value: arc4random_uniform(UInt32.max))
+        blog.url = "https://example.com"
+        blog.xmlrpc = "https://example.com/xmlrpc.php"
+    }
+
+    func build() -> Blog {
+        return blog
+    }
+}

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -7,6 +7,9 @@ class PostBuilder {
 
     init(_ context: NSManagedObjectContext = PostBuilder.setUpInMemoryManagedObjectContext()) {
         post = Post(context: context)
+
+        // Non-null Core Data properties
+        post.blog = BlogBuilder(context).build()
     }
 
     func published() -> PostBuilder {

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -3,15 +3,10 @@ import Foundation
 @testable import WordPress
 
 class PostBuilder {
+    private let post: Post
 
-    private var post: Post!
-
-    init() {
-        post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: setUpInMemoryManagedObjectContext()) as? Post
-    }
-
-    init(_ context: NSManagedObjectContext) {
-        post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: context) as? Post
+    init(_ context: NSManagedObjectContext = PostBuilder.setUpInMemoryManagedObjectContext()) {
+        post = Post(context: context)
     }
 
     func published() -> PostBuilder {
@@ -88,7 +83,7 @@ class PostBuilder {
         return post
     }
 
-    private func setUpInMemoryManagedObjectContext() -> NSManagedObjectContext {
+    private static func setUpInMemoryManagedObjectContext() -> NSManagedObjectContext {
         let managedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
 
         let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -32,5 +32,6 @@ class PostNoticeViewModelTests: XCTestCase {
         // Then
         expect(notice.title).to(equal(PostNoticeViewModel.FailureTitles.postWillBePublished))
         expect(notice.message).to(equal(post.postTitle))
+        expect(notice.actionTitle).to(equal(PostNoticeViewModel.FailureActionTitles.cancel))
     }
 }

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -24,7 +24,12 @@ class PostNoticeViewModelTests: XCTestCase {
 
     func testCreatesNoticeWithFailureMessageForFailedPublishedPosts() {
         // Given
-        let post = PostBuilder(context).published().with(title: "Darby Ritchie").with(remoteStatus: .failed).build()
+        let post = PostBuilder(context)
+            .published()
+            .with(title: "Darby Ritchie")
+            .with(remoteStatus: .failed)
+            .confirmedAutoUpload()
+            .build()
 
         // When
         let notice = PostNoticeViewModel(post: post).notice
@@ -33,5 +38,33 @@ class PostNoticeViewModelTests: XCTestCase {
         expect(notice.title).to(equal(PostNoticeViewModel.FailureTitles.postWillBePublished))
         expect(notice.message).to(equal(post.postTitle))
         expect(notice.actionTitle).to(equal(PostNoticeViewModel.FailureActionTitles.cancel))
+    }
+
+    func testFailedPublishedPostsCancelButtonWillCancelAutoUpload() {
+        // Given
+        let post = PostBuilder(context)
+            .published()
+            .with(title: "Dr. Ed Simonis")
+            .with(remoteStatus: .failed)
+            .confirmedAutoUpload()
+            .build()
+        try! context.save()
+
+        let postCoordinator = MockPostCoordinator()
+        let notice = PostNoticeViewModel(post: post, postCoordinator: postCoordinator).notice
+
+        // When
+        notice.actionHandler?(true)
+
+        // Then
+        expect(postCoordinator.cancelAutoUploadOfInvocations).to(equal(1))
+    }
+
+    private final class MockPostCoordinator: PostCoordinator {
+        private(set) var cancelAutoUploadOfInvocations: Int = 0
+
+        override func cancelAutoUploadOf(_ post: AbstractPost) {
+            cancelAutoUploadOfInvocations += 1
+        }
     }
 }


### PR DESCRIPTION
Closes #12319.

⚠️ This is targeting the branch of #12136. That has to be merged first.  

This adds the _Cancel_ button for the notice that is shown after publishing while offline. 

Before | After 
--------|-------
<img width="320" alt="retry" src="https://user-images.githubusercontent.com/198826/63469787-495bce00-c428-11e9-893f-ceeab7d12a49.png">     |   <img width="320" alt="cancel button" src="https://user-images.githubusercontent.com/198826/63469785-48c33780-c428-11e9-89df-863026df2194.png">
    
## Testing

1. Go offline.
2. Create a post and publish it.
3. A notice should be shown with a _Cancel_ button.

Confirm that tapping on the _Cancel_ button will prevent the app from auto-uploading the post. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] If there are user-facing changes, I have added an item to `RELEASE-NOTES.txt`.
- [x] If it's feasible, I have added unit tests. 

## Tasks

- [ ] #12136 Must be merged first. After that, change the target branch to `issue/12240-master-branch`