### PR TITLE
[Stats Refresh] Fix formatted date when timezone is different

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,8 @@
 * Account Settings: added the ability to change the username.
 * Stats: added File Downloads to period stats.
 * Stats Periods: Fixed an issue that made the Post stats title button unable.
-* Adds a Publish Now action to posts in the posts list. 
+* Adds a Publish Now action to posts in the posts list.
+* Stats Periods: Fixed a bug that affected the header date when the site and the device timezones were different.
  
 13.0
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -166,18 +166,9 @@ private extension StatsDataHelper {
 extension Date {
 
     func normalizedForSite() -> Date {
-        var calendar = StatsDataHelper.calendarForSite
-
-        let flags: NSCalendar.Unit = [.day, .month, .year]
-        let components = (calendar as NSCalendar).components(flags, from: self)
-
-        var normalized = DateComponents()
-        normalized.day = components.day
-        normalized.month = components.month
-        normalized.year = components.year
-
-        calendar.timeZone = .autoupdatingCurrent
-        return calendar.date(from: normalized) ?? self
+        let calendar = StatsDataHelper.calendar
+        let components = calendar.dateComponents([.day, .month, .year], from: self)
+        return calendar.date(from: components) ?? self
     }
 
     func relativeStringInPast() -> String {

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
@@ -47,7 +47,7 @@ class StatsPeriodHelper {
 
         switch period {
         case .day:
-            return date < currentDate
+            return date < currentDate.normalizedDate()
         case .week:
             let week = weekIncludingDate(date)
             guard let weekEnd = week?.weekEnd,

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -142,7 +142,7 @@ private extension SiteStatsDashboardViewController {
                                                        animated: false)
             }
 
-            periodTableViewController.selectedDate = periodDate ?? StatsDataHelper.currentDateForSite().normalizedForSite()
+            periodTableViewController.selectedDate = periodDate ?? StatsDataHelper.currentDateForSite()
             let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
             periodTableViewController.selectedPeriod = selectedPeriod
         }


### PR DESCRIPTION
Fixes #12348

This PR fixes the problem with the formatted date when the Site timezone is different from the device timezone.

CC. @rachelmcr @elibud @jkmassel 

## To test:
- Set your site timezone to a timezone other than UTC. Choose a timezone that, if you add your device timezone to it, the date will be different.
- Check your stats in the app. Note that it now shows the right date for your site timezone setting.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
