### PR TITLE
Remove unused InteractivePostViewDelegate.schedule

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -915,14 +915,6 @@ class AbstractPostListViewController: UIViewController,
         present(alertController, animated: true)
     }
 
-    @objc func schedulePost(_ apost: AbstractPost) {
-        WPAnalytics.track(.postListScheduleAction, withProperties: propertiesForAnalytics())
-
-        apost.status = .scheduled
-        uploadPost(apost)
-        updateFilterWithPostStatus(.scheduled)
-    }
-
     @objc func moveToDraft(_ apost: AbstractPost) {
         WPAnalytics.track(.postListDraftAction, withProperties: propertiesForAnalytics())
 

--- a/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
@@ -5,7 +5,6 @@ import Foundation
     func view(_ post: AbstractPost)
     func stats(for post: AbstractPost)
     func publish(_ post: AbstractPost)
-    func schedule(_ post: AbstractPost)
     func trash(_ post: AbstractPost)
     func restore(_ post: AbstractPost)
     func draft(_ post: AbstractPost)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -629,12 +629,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         }
     }
 
-    func schedule(_ post: AbstractPost) {
-        ReachabilityUtils.onAvailableInternetConnectionDo {
-            schedulePost(post)
-        }
-    }
-
     func trash(_ post: AbstractPost) {
         guard ReachabilityUtils.isInternetReachable() else {
             let offlineMessage = NSLocalizedString("Unable to trash posts while offline. Please try again later.", comment: "Message that appears when a user tries to trash a post while their device is offline.")

--- a/WordPress/WordPressTest/PostActionSheetTests.swift
+++ b/WordPress/WordPressTest/PostActionSheetTests.swift
@@ -163,10 +163,6 @@ class InteractivePostViewDelegateMock: InteractivePostViewDelegate {
 
     }
 
-    func schedule(_ post: AbstractPost) {
-
-    }
-
     func restore(_ post: AbstractPost) {
 
     }


### PR DESCRIPTION
I found this while doing additional scoping for #12240. It does not look like we use this at all.

## Testing

I believe compiling and the tests passing should be enough. 😬 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 
