### PR TITLE
Show notice on cancel auto upload

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -273,7 +273,7 @@ extension PostCoordinator: Uploader {
     /// Cancel active and pending automatic uploads of the post.
     func cancelAutoUploadOf(_ post: AbstractPost) {
         cancelAnyPendingSaveOf(post: post)
-        
+
         #warning("stub")
         post.managedObjectContext?.perform {
             post.confirmedAutoUpload = false

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -273,11 +273,14 @@ extension PostCoordinator: Uploader {
     /// Cancel active and pending automatic uploads of the post.
     func cancelAutoUploadOf(_ post: AbstractPost) {
         cancelAnyPendingSaveOf(post: post)
-
+        
         #warning("stub")
         post.managedObjectContext?.perform {
             post.confirmedAutoUpload = false
         }
+
+        let notice = Notice(title: NSLocalizedString("Changes will not be published", comment: "title for notice displayed on cancel auto-upload"), message: "")
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 }
 


### PR DESCRIPTION
Fixes #12325 

To test:
1. Be offline 
2. Create new post 
3. Publish post
4. See the option to cancel
5. Tap cancel
6. See the notice 

![cancel_notice](https://user-images.githubusercontent.com/1335657/63538917-bffed700-c4cd-11e9-8bd4-49974b1d9c6e.gif)


Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
