### PR TITLE
Dark mode: semantic color names v2

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/MurielColor.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/MurielColor.swift
@@ -34,6 +34,7 @@ enum MurielColorShade: Int, CustomStringConvertible {
     case shade70 = 70
     case shade80 = 80
     case shade90 = 90
+    case shade100 = 100
 
     var description: String {
         return "\(rawValue)"

--- a/WordPress/Classes/Extensions/Colors and Styles/MurielColor.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/MurielColor.swift
@@ -68,9 +68,6 @@ struct MurielColor {
     static let textSubtle = MurielColor(name: .gray, shade: .shade50)
     static let warning = MurielColor(name: .yellow)
 
-    // MARK: - Additional iOS semantic colors
-    static let tableBackground = MurielColor(name: .gray, shade: .shade0)
-
     /// The full name of the color, with required shade value
     func assetName() -> String {
         return "\(name)\(shade)"

--- a/WordPress/Classes/Extensions/Colors and Styles/MurielColor.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/MurielColor.swift
@@ -60,7 +60,7 @@ struct MurielColor {
     static let brand = MurielColor(name: .wordPressBlue)
     static let divider = MurielColor(name: .gray, shade: .shade10)
     static let error = MurielColor(name: .red)
-    static let neutral = MurielColor(name: .gray)
+    static let gray = MurielColor(name: .gray)
     static let primary = MurielColor(name: .blue)
     static let success = MurielColor(name: .green)
     static let text = MurielColor(name: .gray, shade: .shade80)

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -78,27 +78,29 @@ extension UIColor {
     class func neutral(_ shade: MurielColorShade) -> UIColor {
         switch shade {
         case .shade0:
-            return UIColor(light: muriel(color: .gray, .shade0), dark: muriel(color: .gray, .shade90))
+            return UIColor(light: muriel(color: .gray, .shade0), dark: muriel(color: .gray, .shade100))
             case .shade5:
-            return UIColor(light: muriel(color: .gray, .shade5), dark: muriel(color: .gray, .shade80))
+            return UIColor(light: muriel(color: .gray, .shade5), dark: muriel(color: .gray, .shade90))
             case .shade10:
-            return UIColor(light: muriel(color: .gray, .shade10), dark: muriel(color: .gray, .shade70))
+            return UIColor(light: muriel(color: .gray, .shade10), dark: muriel(color: .gray, .shade80))
             case .shade20:
-            return UIColor(light: muriel(color: .gray, .shade20), dark: muriel(color: .gray, .shade60))
+            return UIColor(light: muriel(color: .gray, .shade20), dark: muriel(color: .gray, .shade70))
             case .shade30:
-            return UIColor(light: muriel(color: .gray, .shade30), dark: muriel(color: .gray, .shade50))
+            return UIColor(light: muriel(color: .gray, .shade30), dark: muriel(color: .gray, .shade60))
             case .shade40:
-            return UIColor(light: muriel(color: .gray, .shade40), dark: muriel(color: .gray, .shade40))
+            return UIColor(light: muriel(color: .gray, .shade40), dark: muriel(color: .gray, .shade50))
             case .shade50:
-            return UIColor(light: muriel(color: .gray, .shade50), dark: muriel(color: .gray, .shade30))
+            return UIColor(light: muriel(color: .gray, .shade50), dark: muriel(color: .gray, .shade40))
             case .shade60:
-            return UIColor(light: muriel(color: .gray, .shade60), dark: muriel(color: .gray, .shade20))
+            return UIColor(light: muriel(color: .gray, .shade60), dark: muriel(color: .gray, .shade30))
             case .shade70:
-            return UIColor(light: muriel(color: .gray, .shade70), dark: muriel(color: .gray, .shade10))
+            return UIColor(light: muriel(color: .gray, .shade70), dark: muriel(color: .gray, .shade20))
             case .shade80:
-            return UIColor(light: muriel(color: .gray, .shade80), dark: muriel(color: .gray, .shade5))
+            return UIColor(light: muriel(color: .gray, .shade80), dark: muriel(color: .gray, .shade10))
             case .shade90:
-            return UIColor(light: muriel(color: .gray, .shade90), dark: muriel(color: .gray, .shade0))
+            return UIColor(light: muriel(color: .gray, .shade90), dark: muriel(color: .gray, .shade5))
+            case .shade100:
+            return UIColor(light: muriel(color: .gray, .shade100), dark: muriel(color: .gray, .shade0))
         }
     }
 }

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -157,11 +157,11 @@ extension UIColor {
         return UIColor.neutral(.shade10)
     }
 
-    static var textInverted = UIColor(light: .white, dark: .gray(.shade90))
+    static var textInverted = UIColor(light: .white, dark: .gray(.shade100))
     static var textPlaceholder = neutral(.shade30)
 
     /// Muriel/iOS navigation color
-    static var appBar = UIColor(light: .brand, dark: .gray(.shade90))
+    static var appBar = UIColor(light: .brand, dark: .gray(.shade100))
 
     // MARK: - Table Views
 
@@ -225,7 +225,7 @@ extension UIColor {
     static var filterBarBackground: UIColor {
         #if XCODE11
             if #available(iOS 13, *) {
-                return UIColor(light: white, dark: .gray(.shade90))
+                return UIColor(light: white, dark: .gray(.shade100))
             }
         #endif
         return white
@@ -241,7 +241,7 @@ extension UIColor {
     }
 
     /// Tab bar unselected color
-    static var tabUnselected: UIColor =  UIColor(light: .gray(.shade20), dark: .gray(.shade50))
+    static var tabUnselected: UIColor =  UIColor(light: .gray(.shade20), dark: .gray(.shade40))
 
 // MARK: - WP Fancy Buttons
     static var primaryButtonBackground = accent

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -11,47 +11,54 @@ extension UIColor {
         }
         return color
     }
+    /// Get a UIColor from the Muriel color palette, adjusted to a given shade
+    /// - Parameter color: an instance of a MurielColor
+    /// - Parameter shade: a MurielColorShade
+    class func muriel(color: MurielColor, _ shade: MurielColorShade) -> UIColor {
+        let newColor = MurielColor(from: color, shade: shade)
+        return muriel(color: newColor)
+    }
 }
 // MARK: - Basic Colors
 extension UIColor {
     /// Muriel accent color
     static var accent = muriel(color: .accent)
-    static var accentDark = muriel(color: MurielColor(from: .accent, shade: .shade70))
+    static var accentDark = muriel(color: .accent, .shade70)
     class func accent(_ shade: MurielColorShade) -> UIColor {
-        return muriel(color: MurielColor(from: .accent, shade: shade))
+        return muriel(color: .accent, shade)
     }
 
     /// Muriel brand color
     static var brand = muriel(color: .brand)
     class func brand(_ shade: MurielColorShade) -> UIColor {
-        return muriel(color: MurielColor(from: .brand, shade: shade))
+        return muriel(color: .brand, shade)
     }
 
     /// Muriel error color
     static var error = muriel(color: .error)
-    static var errorDark = muriel(color: MurielColor(from: .error, shade: .shade70))
+    static var errorDark = muriel(color: .error, .shade70)
     class func error(_ shade: MurielColorShade) -> UIColor {
-        return muriel(color: MurielColor(from: .error, shade: shade))
+        return muriel(color: .error, shade)
     }
 
     /// Muriel primary color
     static var primary = muriel(color: .primary)
-    static var primaryLight = muriel(color: MurielColor(from: .primary, shade: .shade30))
-    static var primaryDark = muriel(color: MurielColor(from: .primary, shade: .shade70))
+    static var primaryLight = muriel(color: .primary, .shade30)
+    static var primaryDark = muriel(color: .primary, .shade70)
     class func primary(_ shade: MurielColorShade) -> UIColor {
-        return muriel(color: MurielColor(from: .primary, shade: shade))
+        return muriel(color: .primary, shade)
     }
 
     /// Muriel success color
     static var success = muriel(color: .success)
     class func success(_ shade: MurielColorShade) -> UIColor {
-        return muriel(color: MurielColor(from: .success, shade: shade))
+        return muriel(color: .success, shade)
     }
 
     /// Muriel warning color
     static var warning = muriel(color: .warning)
     class func warning(_ shade: MurielColorShade) -> UIColor {
-        return muriel(color: MurielColor(from: .warning, shade: shade))
+        return muriel(color: .warning, shade)
     }
 }
 
@@ -60,7 +67,7 @@ extension UIColor {
     /// Muriel gray palette
     /// - Parameter shade: a MurielColorShade of the desired shade of gray
     class func gray(_ shade: MurielColorShade) -> UIColor {
-        return muriel(color: MurielColor(from: .gray, shade: shade))
+        return muriel(color: .gray, shade)
     }
 
     /// Muriel neutral colors, which invert in dark mode
@@ -71,38 +78,38 @@ extension UIColor {
     class func neutral(_ shade: MurielColorShade) -> UIColor {
         switch shade {
         case .shade0:
-            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade0)),
-                           dark: muriel(color: MurielColor(name: .gray, shade: .shade90)))
+            return UIColor(light: muriel(color: .gray, .shade0),
+                           dark: muriel(color: .gray, .shade90))
             case .shade5:
-            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade5)),
-                           dark: muriel(color: MurielColor(name: .gray, shade: .shade80)))
+            return UIColor(light: muriel(color: .gray, .shade5),
+                           dark: muriel(color: .gray, .shade80))
             case .shade10:
-            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade10)),
-                           dark: muriel(color: MurielColor(name: .gray, shade: .shade70)))
+            return UIColor(light: muriel(color: .gray, .shade10),
+                           dark: muriel(color: .gray, .shade70))
             case .shade20:
-            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade20)),
-                           dark: muriel(color: MurielColor(name: .gray, shade: .shade60)))
+            return UIColor(light: muriel(color: .gray, .shade20),
+                           dark: muriel(color: .gray, .shade60))
             case .shade30:
-            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade30)),
-                           dark: muriel(color: MurielColor(name: .gray, shade: .shade50)))
+            return UIColor(light: muriel(color: .gray, .shade30),
+                           dark: muriel(color: .gray, .shade50))
             case .shade40:
-            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade40)),
-                           dark: muriel(color: MurielColor(name: .gray, shade: .shade40)))
+            return UIColor(light: muriel(color: .gray, .shade40),
+                           dark: muriel(color: .gray, .shade40))
             case .shade50:
-            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade50)),
-                           dark: muriel(color: MurielColor(name: .gray, shade: .shade30)))
+            return UIColor(light: muriel(color: .gray, .shade50),
+                           dark: muriel(color: .gray, .shade30))
             case .shade60:
-            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade60)),
-                           dark: muriel(color: MurielColor(name: .gray, shade: .shade20)))
+            return UIColor(light: muriel(color: .gray, .shade60),
+                           dark: muriel(color: .gray, .shade20))
             case .shade70:
-            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade70)),
-                           dark: muriel(color: MurielColor(name: .gray, shade: .shade10)))
+            return UIColor(light: muriel(color: .gray, .shade70),
+                           dark: muriel(color: .gray, .shade10))
             case .shade80:
-            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade80)),
-                           dark: muriel(color: MurielColor(name: .gray, shade: .shade5)))
+            return UIColor(light: muriel(color: .gray, .shade80),
+                           dark: muriel(color: .gray, .shade5))
             case .shade90:
-            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade90)),
-                           dark: muriel(color: MurielColor(name: .gray, shade: .shade0)))
+            return UIColor(light: muriel(color: .gray, .shade90),
+                           dark: muriel(color: .gray, .shade0))
         }
     }
 }
@@ -248,8 +255,8 @@ extension UIColor {
 // MARK: - WP Fancy Buttons
     static var primaryButtonBackground = accent
     static var primaryButtonBorder = accentDark
-    static var primaryButtonDownBackground = muriel(color: MurielColor(name: .pink, shade: .shade80))
-    static var primaryButtonDownBorder = muriel(color: MurielColor(name: .pink, shade: .shade90))
+    static var primaryButtonDownBackground = muriel(color: .accent, .shade80)
+    static var primaryButtonDownBorder = muriel(color: .accent, .shade90)
 }
 
 extension UIColor {

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -144,7 +144,7 @@ extension UIColor {
                 return .tertiaryLabel
             }
         #endif
-        return UIColor.neutral(.shade10)
+        return UIColor.neutral(.shade20)
     }
 
     /// Very, very low contrast text

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -2,7 +2,7 @@ extension UIColor {
     /// Get a UIColor from the Muriel color palette
     ///
     /// - Parameters:
-    ///   - color: an instance of a MurielColorIdentifier
+    ///   - color: an instance of a MurielColor
     /// - Returns: UIColor. Red in cases of error
     class func muriel(color murielColor: MurielColor) -> UIColor {
         let assetName = murielColor.assetName()
@@ -34,12 +34,6 @@ extension UIColor {
         return muriel(color: MurielColor(from: .error, shade: shade))
     }
 
-    /// Muriel neutral color
-    static var neutral = muriel(color: .neutral)
-    class func neutral(_ shade: MurielColorShade) -> UIColor {
-        return muriel(color: MurielColor(from: .neutral, shade: shade))
-    }
-
     /// Muriel primary color
     static var primary = muriel(color: .primary)
     static var primaryLight = muriel(color: MurielColor(from: .primary, shade: .shade30))
@@ -58,6 +52,58 @@ extension UIColor {
     static var warning = muriel(color: .warning)
     class func warning(_ shade: MurielColorShade) -> UIColor {
         return muriel(color: MurielColor(from: .warning, shade: shade))
+    }
+}
+
+// MARK: - Grays
+extension UIColor {
+    /// Muriel gray palette
+    /// - Parameter shade: a MurielColorShade of the desired shade of gray
+    class func gray(_ shade: MurielColorShade) -> UIColor {
+        return muriel(color: MurielColor(from: .gray, shade: shade))
+    }
+
+    /// Muriel neutral colors, which invert in dark mode
+    /// - Parameter shade: a MurielColorShade of the desired neutral shade
+    static var neutral: UIColor {
+        return neutral(.shade50)
+    }
+    class func neutral(_ shade: MurielColorShade) -> UIColor {
+        switch shade {
+        case .shade0:
+            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade0)),
+                           dark: muriel(color: MurielColor(name: .gray, shade: .shade90)))
+            case .shade5:
+            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade5)),
+                           dark: muriel(color: MurielColor(name: .gray, shade: .shade80)))
+            case .shade10:
+            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade10)),
+                           dark: muriel(color: MurielColor(name: .gray, shade: .shade70)))
+            case .shade20:
+            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade20)),
+                           dark: muriel(color: MurielColor(name: .gray, shade: .shade60)))
+            case .shade30:
+            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade30)),
+                           dark: muriel(color: MurielColor(name: .gray, shade: .shade50)))
+            case .shade40:
+            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade40)),
+                           dark: muriel(color: MurielColor(name: .gray, shade: .shade40)))
+            case .shade50:
+            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade50)),
+                           dark: muriel(color: MurielColor(name: .gray, shade: .shade30)))
+            case .shade60:
+            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade60)),
+                           dark: muriel(color: MurielColor(name: .gray, shade: .shade20)))
+            case .shade70:
+            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade70)),
+                           dark: muriel(color: MurielColor(name: .gray, shade: .shade10)))
+            case .shade80:
+            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade80)),
+                           dark: muriel(color: MurielColor(name: .gray, shade: .shade5)))
+            case .shade90:
+            return UIColor(light: muriel(color: MurielColor(name: .gray, shade: .shade90)),
+                           dark: muriel(color: MurielColor(name: .gray, shade: .shade0)))
+        }
     }
 }
 
@@ -90,7 +136,7 @@ extension UIColor {
                 return .secondaryLabel
             }
         #endif
-        return muriel(color: .neutral)
+        return muriel(color: .gray)
     }
 
     /// Very low contrast text

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -78,38 +78,27 @@ extension UIColor {
     class func neutral(_ shade: MurielColorShade) -> UIColor {
         switch shade {
         case .shade0:
-            return UIColor(light: muriel(color: .gray, .shade0),
-                           dark: muriel(color: .gray, .shade90))
+            return UIColor(light: muriel(color: .gray, .shade0), dark: muriel(color: .gray, .shade90))
             case .shade5:
-            return UIColor(light: muriel(color: .gray, .shade5),
-                           dark: muriel(color: .gray, .shade80))
+            return UIColor(light: muriel(color: .gray, .shade5), dark: muriel(color: .gray, .shade80))
             case .shade10:
-            return UIColor(light: muriel(color: .gray, .shade10),
-                           dark: muriel(color: .gray, .shade70))
+            return UIColor(light: muriel(color: .gray, .shade10), dark: muriel(color: .gray, .shade70))
             case .shade20:
-            return UIColor(light: muriel(color: .gray, .shade20),
-                           dark: muriel(color: .gray, .shade60))
+            return UIColor(light: muriel(color: .gray, .shade20), dark: muriel(color: .gray, .shade60))
             case .shade30:
-            return UIColor(light: muriel(color: .gray, .shade30),
-                           dark: muriel(color: .gray, .shade50))
+            return UIColor(light: muriel(color: .gray, .shade30), dark: muriel(color: .gray, .shade50))
             case .shade40:
-            return UIColor(light: muriel(color: .gray, .shade40),
-                           dark: muriel(color: .gray, .shade40))
+            return UIColor(light: muriel(color: .gray, .shade40), dark: muriel(color: .gray, .shade40))
             case .shade50:
-            return UIColor(light: muriel(color: .gray, .shade50),
-                           dark: muriel(color: .gray, .shade30))
+            return UIColor(light: muriel(color: .gray, .shade50), dark: muriel(color: .gray, .shade30))
             case .shade60:
-            return UIColor(light: muriel(color: .gray, .shade60),
-                           dark: muriel(color: .gray, .shade20))
+            return UIColor(light: muriel(color: .gray, .shade60), dark: muriel(color: .gray, .shade20))
             case .shade70:
-            return UIColor(light: muriel(color: .gray, .shade70),
-                           dark: muriel(color: .gray, .shade10))
+            return UIColor(light: muriel(color: .gray, .shade70), dark: muriel(color: .gray, .shade10))
             case .shade80:
-            return UIColor(light: muriel(color: .gray, .shade80),
-                           dark: muriel(color: .gray, .shade5))
+            return UIColor(light: muriel(color: .gray, .shade80), dark: muriel(color: .gray, .shade5))
             case .shade90:
-            return UIColor(light: muriel(color: .gray, .shade90),
-                           dark: muriel(color: .gray, .shade0))
+            return UIColor(light: muriel(color: .gray, .shade90), dark: muriel(color: .gray, .shade0))
         }
     }
 }
@@ -166,11 +155,11 @@ extension UIColor {
         return UIColor.neutral(.shade10)
     }
 
-    static var textInverted = UIColor(light: .white, dark: .neutral(.shade0))
+    static var textInverted = UIColor(light: .white, dark: .gray(.shade90))
     static var textPlaceholder = neutral(.shade30)
 
     /// Muriel/iOS navigation color
-    static var navigationBar = UIColor(light: .brand, dark: .neutral(.shade0))
+    static var navigationBar = UIColor(light: .brand, dark: .gray(.shade90))
 
     // MARK: - Table Views
 
@@ -234,7 +223,7 @@ extension UIColor {
     static var filterBarBackground: UIColor {
         #if XCODE11
             if #available(iOS 13, *) {
-                return UIColor(light: white, dark: .neutral(.shade0))
+                return UIColor(light: white, dark: .gray(.shade90))
             }
         #endif
         return white
@@ -250,7 +239,7 @@ extension UIColor {
     }
 
     /// Tab bar unselected color
-    static var tabUnselected: UIColor =  UIColor(light: .neutral(.shade20), dark: .neutral(.shade50))
+    static var tabUnselected: UIColor =  UIColor(light: .gray(.shade20), dark: .gray(.shade50))
 
 // MARK: - WP Fancy Buttons
     static var primaryButtonBackground = accent

--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -161,7 +161,7 @@ extension UIColor {
     static var textPlaceholder = neutral(.shade30)
 
     /// Muriel/iOS navigation color
-    static var navigationBar = UIColor(light: .brand, dark: .gray(.shade90))
+    static var appBar = UIColor(light: .brand, dark: .gray(.shade90))
 
     // MARK: - Table Views
 
@@ -175,7 +175,7 @@ extension UIColor {
     }
 
     /// WP color for table foregrounds (cells, etc)
-    static var tableForeground: UIColor {
+    static var listForeground: UIColor {
         #if XCODE11
             if #available(iOS 13, *) {
                 return .secondarySystemGroupedBackground
@@ -184,7 +184,7 @@ extension UIColor {
         return .white
     }
 
-    static var tableForegroundUnread: UIColor {
+    static var listForegroundUnread: UIColor {
         #if XCODE11
             if #available(iOS 13, *) {
                 return .tertiarySystemGroupedBackground
@@ -193,13 +193,13 @@ extension UIColor {
         return .primary(.shade0)
     }
 
-    static var tableBackground: UIColor {
+    static var listBackground: UIColor {
         #if XCODE11
             if #available(iOS 13, *) {
                 return .systemGroupedBackground
             }
         #endif
-        return muriel(color: .tableBackground)
+        return muriel(color: .gray, .shade0)
     }
 
     /// For icons that are present in a table view, or similar list

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -24,7 +24,7 @@ extension WPStyleGuide {
         let navigationAppearance = UINavigationBar.appearance()
         navigationAppearance.isTranslucent = false
         navigationAppearance.tintColor = .white
-        navigationAppearance.barTintColor = .navigationBar
+        navigationAppearance.barTintColor = .appBar
         navigationAppearance.barStyle = .black
 
 #if XCODE11
@@ -32,7 +32,7 @@ extension WPStyleGuide {
             // Required to fix detail navigation controller appearance due to https://stackoverflow.com/q/56615513
             let appearance = UINavigationBarAppearance()
             appearance.configureWithOpaqueBackground()
-            appearance.backgroundColor = .navigationBar
+            appearance.backgroundColor = .appBar
             appearance.titleTextAttributes = [.foregroundColor: UIColor.white]
             navigationAppearance.standardAppearance = appearance
             navigationAppearance.scrollEdgeAppearance = navigationAppearance.standardAppearance
@@ -74,14 +74,14 @@ extension WPStyleGuide {
             return
         }
 
-        tableView.backgroundColor = .tableBackground
+        tableView.backgroundColor = .listBackground
         tableView.separatorColor = .neutral(.shade10)
     }
 
     class func configureColors(view: UIView, collectionView: UICollectionView) {
         configureTableViewColors(view: view)
         collectionView.backgroundView = nil
-        collectionView.backgroundColor = .tableBackground
+        collectionView.backgroundColor = .listBackground
     }
 
     @objc

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -809,7 +809,7 @@ extension WordPressAppDelegate {
 
 
         let cellAppearance = WPMediaCollectionViewCell.appearance(whenContainedInInstancesOf: [WPMediaPickerViewController.self])
-        cellAppearance.loadingBackgroundColor = .tableBackground
+        cellAppearance.loadingBackgroundColor = .listBackground
         cellAppearance.placeholderBackgroundColor = .neutral(.shade70)
         cellAppearance.placeholderTintColor = .neutral(.shade5)
         cellAppearance.setCellTintColor(.primary)

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -72,7 +72,7 @@ class ActivityDetailViewController: UIViewController {
             return
         }
 
-        view.backgroundColor = .tableBackground
+        view.backgroundColor = .listBackground
 
         textLabel.isHidden = true
         textView.textContainerInset = .zero

--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Blog.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Blog.swift
@@ -15,7 +15,7 @@ extension WPStyleGuide {
         cell.imageView?.layer.borderWidth = 1
         cell.imageView?.tintColor = .listIcon
 
-        cell.backgroundColor = UIColor.tableForeground
+        cell.backgroundColor = UIColor.listForeground
     }
 
     @objc public class func configureCellForLogin(_ cell: WPBlogTableViewCell) {
@@ -32,7 +32,7 @@ extension WPStyleGuide {
         cell.imageView?.layer.borderWidth = 1
         cell.imageView?.tintColor = .neutral(.shade30)
 
-        cell.backgroundColor = .tableBackground
+        cell.backgroundColor = .listBackground
     }
 
  }

--- a/WordPress/Classes/ViewRelated/Media/CircularProgressView.swift
+++ b/WordPress/Classes/ViewRelated/Media/CircularProgressView.swift
@@ -39,7 +39,7 @@ class CircularProgressView: UIView {
                     progressIndicatorAppearance: ProgressIndicatorView.Appearance(lineColor: .primary(.shade40)),
                     backgroundColor: .clear,
                     accessoryViewTintColor: .neutral(.shade70),
-                    accessoryViewBackgroundColor: .tableBackground)
+                    accessoryViewBackgroundColor: .listBackground)
             case .mediaCell:
                 return Appearance(
                     progressIndicatorAppearance: ProgressIndicatorView.Appearance(lineColor: .white),

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -36,7 +36,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
     @objc init(blog: Blog) {
         WPMediaCollectionViewCell.appearance().placeholderTintColor = .neutral(.shade5)
         WPMediaCollectionViewCell.appearance().placeholderBackgroundColor = .neutral(.shade70)
-        WPMediaCollectionViewCell.appearance().loadingBackgroundColor = .tableBackground
+        WPMediaCollectionViewCell.appearance().loadingBackgroundColor = .listBackground
 
         self.blog = blog
         self.pickerDataSource = MediaLibraryPickerDataSource(blog: blog)

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -140,7 +140,7 @@ extension LoginEpilogueTableViewController {
 
         headerView.textLabel?.font = UIFont.preferredFont(forTextStyle: .footnote)
         headerView.textLabel?.textColor = .neutral(.shade50)
-        headerView.contentView.backgroundColor = .tableBackground
+        headerView.contentView.backgroundColor = .listBackground
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -149,7 +149,7 @@ private extension LoginEpilogueViewController {
             buttonPanel.backgroundColor = .white
             shadowView.isHidden = false
         } else {
-            buttonPanel.backgroundColor = .tableBackground
+            buttonPanel.backgroundColor = .listBackground
             shadowView.isHidden = true
         }
     }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -51,7 +51,7 @@ class WordPressAuthenticationManager: NSObject {
                                                 instructionColor: .text,
                                                 subheadlineColor: .textSubtle,
                                                 placeholderColor: .textPlaceholder,
-                                                viewControllerBackgroundColor: .tableBackground,
+                                                viewControllerBackgroundColor: .listBackground,
                                                 navBarImage: Gridicon.iconOfType(.mySites),
                                                 navBarBadgeColor: .accent(.shade20),
                                                 prologueBackgroundColor: .primary,

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -376,7 +376,7 @@ extension NotificationDetailsViewController {
     }
 
     func setupMainView() {
-        view.backgroundColor = .tableBackground
+        view.backgroundColor = .listBackground
     }
 
     func setupTableView() {
@@ -384,7 +384,7 @@ extension NotificationDetailsViewController {
         tableView.keyboardDismissMode       = .interactive
         tableView.backgroundColor           = .neutral(.shade5)
         tableView.accessibilityIdentifier   = NSLocalizedString("Notification Details Table", comment: "Notifications Details Accessibility Identifier")
-        tableView.backgroundColor           = .tableBackground
+        tableView.backgroundColor           = .listBackground
     }
 
     func setupTableViewCells() {

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Notifications.swift
@@ -10,7 +10,7 @@ extension WPStyleGuide {
         //
 
         // NoteTableViewHeader
-        public static let sectionHeaderBackgroundColor = UIColor.tableBackground
+        public static let sectionHeaderBackgroundColor = UIColor.listBackground
 
         public static var sectionHeaderRegularStyle: [NSAttributedString.Key: Any] {
             return  [.paragraphStyle: sectionHeaderParagraph,
@@ -25,8 +25,8 @@ extension WPStyleGuide {
         public static let noticonUnreadColor        = UIColor.primary
         public static let noticonUnmoderatedColor   = UIColor.warning
 
-        public static let noteBackgroundReadColor   = UIColor.tableForeground
-        public static let noteBackgroundUnreadColor = UIColor.tableForegroundUnread
+        public static let noteBackgroundReadColor   = UIColor.listForeground
+        public static let noteBackgroundUnreadColor = UIColor.listForegroundUnread
 
         public static let noteSeparatorColor        = blockSeparatorColor
 

--- a/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Reply.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Style/WPStyleGuide+Reply.swift
@@ -16,6 +16,6 @@ extension WPStyleGuide {
         public static let placeholderColor = UIColor.neutral(.shade20)
         public static let textColor        = UIColor.text
         public static let separatorColor   = UIColor.neutral(.shade20)
-        public static let backgroundColor  = UIColor.tableBackground
+        public static let backgroundColor  = UIColor.listBackground
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
@@ -20,8 +20,8 @@ extension WPStyleGuide {
     static let separatorHeight: CGFloat = .hairlineBorderWidth
 
     class func applyPostCardStyle(_ cell: UITableViewCell) {
-        cell.backgroundColor = .tableBackground
-        cell.contentView.backgroundColor = .tableBackground
+        cell.backgroundColor = .listBackground
+        cell.contentView.backgroundColor = .listBackground
     }
 
     class func applyPostTitleStyle(_ label: UILabel) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderBlockedSiteCell.swift
@@ -11,7 +11,7 @@ open class ReaderBlockedSiteCell: UITableViewCell {
     }
 
     fileprivate func applyStyles() {
-        contentView.backgroundColor = .tableBackground
+        contentView.backgroundColor = .listBackground
         borderedContentView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedContentView.layer.borderWidth = .hairlineBorderWidth
         label.font = WPStyleGuide.subtitleFont()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardDiscoverAttributionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardDiscoverAttributionView.swift
@@ -67,9 +67,9 @@ private enum ReaderCardDiscoverAttribution: Int {
      Applies opaque backgroundColors to all subViews to avoid blending, for optimized drawing.
      */
     fileprivate func applyOpaqueBackgroundColors() {
-        backgroundColor = .tableForeground
-        imageView.backgroundColor = .tableForeground
-        textLabel.backgroundColor = .tableForeground
+        backgroundColor = .listForeground
+        imageView.backgroundColor = .listForeground
+        textLabel.backgroundColor = .listForeground
     }
 
     @objc open func configureView(_ contentProvider: ReaderPostContentProvider?) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCrossPostCell.swift
@@ -54,8 +54,8 @@ open class ReaderCrossPostCell: UITableViewCell {
     // MARK: - Appearance
 
     fileprivate func applyStyles() {
-        contentView.backgroundColor = .tableBackground
-        label?.backgroundColor = .tableBackground
+        contentView.backgroundColor = .listBackground
+        label?.backgroundColor = .listBackground
     }
 
     fileprivate func applyHighlightedEffect(_ highlighted: Bool, animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesStreamHeader.swift
@@ -25,7 +25,7 @@ import WordPressShared.WPStyleGuide
 
     @objc func applyStyles() {
         backgroundColor = .clear
-        borderedView.backgroundColor = .tableForeground
+        borderedView.backgroundColor = .listForeground
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = .hairlineBorderWidth
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderGapMarkerCell.swift
@@ -15,11 +15,11 @@ open class ReaderGapMarkerCell: UITableViewCell {
 
     fileprivate func applyStyles() {
         // Background styles
-        contentView.backgroundColor = .tableBackground
+        contentView.backgroundColor = .listBackground
         selectedBackgroundView = UIView(frame: contentView.frame)
-        selectedBackgroundView?.backgroundColor = .tableBackground
-        contentView.backgroundColor = .tableBackground
-        tearMaskView.backgroundColor = .tableBackground
+        selectedBackgroundView?.backgroundColor = .listBackground
+        contentView.backgroundColor = .listBackground
+        tearMaskView.backgroundColor = .listBackground
 
         // Draw the tear
         drawTearBackground()
@@ -55,7 +55,7 @@ open class ReaderGapMarkerCell: UITableViewCell {
         if highlighted {
             // Redraw the backgrounds when highlighted
             drawTearBackground()
-            tearMaskView.backgroundColor = .tableBackground
+            tearMaskView.backgroundColor = .listBackground
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderListStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderListStreamHeader.swift
@@ -19,8 +19,8 @@ import WordPressShared.WPStyleGuide
     }
 
     @objc func applyStyles() {
-        backgroundColor = .tableBackground
-        borderedView.backgroundColor = .tableForeground
+        backgroundColor = .listBackground
+        borderedView.backgroundColor = .listForeground
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = .hairlineBorderWidth
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -257,8 +257,8 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     */
     fileprivate func applyStyles() {
         backgroundColor = .clear
-        contentView.backgroundColor = .tableBackground
-        borderedView.backgroundColor = .tableForeground
+        contentView.backgroundColor = .listBackground
+        borderedView.backgroundColor = .listForeground
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = .hairlineBorderWidth
 
@@ -277,12 +277,12 @@ fileprivate func < <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
         Applies opaque backgroundColors to all subViews to avoid blending, for optimized drawing.
     */
     fileprivate func applyOpaqueBackgroundColors() {
-        blogNameLabel.backgroundColor = .tableForeground
-        bylineLabel.backgroundColor = .tableForeground
-        titleLabel.backgroundColor = .tableForeground
-        summaryLabel.backgroundColor = .tableForeground
-        commentActionButton.titleLabel?.backgroundColor = .tableForeground
-        likeActionButton.titleLabel?.backgroundColor = .tableForeground
+        blogNameLabel.backgroundColor = .listForeground
+        bylineLabel.backgroundColor = .listForeground
+        titleLabel.backgroundColor = .listForeground
+        summaryLabel.backgroundColor = .listForeground
+        commentActionButton.titleLabel?.backgroundColor = .listForeground
+        likeActionButton.titleLabel?.backgroundColor = .listForeground
     }
 
     @objc open func configureCell(_ contentProvider: ReaderPostContentProvider) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
@@ -76,7 +76,7 @@ class ReaderSearchSuggestionsViewController: UIViewController {
 
         let buttonTitle = NSLocalizedString("Clear search history", comment: "Title of a button.")
         clearButton.setTitle(buttonTitle, for: UIControl.State())
-        let buttonBackgroundImage = UIImage(color: .tableBackground)
+        let buttonBackgroundImage = UIImage(color: .listBackground)
         clearButton.setBackgroundImage(buttonBackgroundImage, for: UIControl.State())
 
         borderImageView.image = UIImage(color: .neutral(.shade20), havingSize: CGSize(width: stackView.frame.width, height: 1))

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.swift
@@ -46,8 +46,8 @@ fileprivate func > <T: Comparable>(lhs: T?, rhs: T?) -> Bool {
     }
 
     @objc func applyStyles() {
-        backgroundColor = .tableBackground
-        borderedView.backgroundColor = .tableForeground
+        backgroundColor = .listBackground
+        borderedView.backgroundColor = .listForeground
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = .hairlineBorderWidth
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTagStreamHeader.swift
@@ -19,8 +19,8 @@ import WordPressShared
     }
 
     @objc func applyStyles() {
-        backgroundColor = .tableBackground
-        borderedView.backgroundColor = .tableForeground
+        backgroundColor = .listBackground
+        borderedView.backgroundColor = .listForeground
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = .hairlineBorderWidth
         WPStyleGuide.applyReaderStreamHeaderTitleStyle(titleLabel)

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -203,8 +203,8 @@ extension WPStyleGuide {
         static let summaryFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         static let substringHighlightFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
 
-        static let tableBackgroundColor = UIColor.tableBackground
-        static let cellBackgroundColor = UIColor.tableForeground
+        static let tableBackgroundColor = UIColor.listBackground
+        static let cellBackgroundColor = UIColor.listForeground
         static let separatorColor = UIColor.divider
         static let dataBarColor = UIColor.textTertiary
         static let separatorHeight: CGFloat = 1.0 / UIScreen.main.scale

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsChildRowsView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsChildRowsView.swift
@@ -17,7 +17,7 @@ class StatsChildRowsView: UIView, NibLoadable {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        backgroundColor = .tableForeground
+        backgroundColor = .listForeground
         WPStyleGuide.Stats.configureViewAsSeparator(bottomSeperatorLine)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsNoDataRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsNoDataRow.swift
@@ -15,7 +15,7 @@ class StatsNoDataRow: UIView, NibLoadable, Accessible {
     func configure(forType statType: StatType) {
         noDataLabel.text = statType == .insights ? insightsNoDataLabel : periodNoDataLabel
         WPStyleGuide.Stats.configureLabelAsNoData(noDataLabel)
-        backgroundColor = .tableForeground
+        backgroundColor = .listForeground
         prepareForVoiceOver()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -212,8 +212,8 @@ class StatsTotalRow: UIView, NibLoadable, Accessible {
 private extension StatsTotalRow {
 
     func applyStyles() {
-        backgroundColor = .tableForeground
-        contentView.backgroundColor = .tableForeground
+        backgroundColor = .listForeground
+        contentView.backgroundColor = .listForeground
         Style.configureLabelAsCellRowTitle(itemLabel)
         Style.configureLabelItemDetail(itemDetailLabel)
         Style.configureLabelAsData(dataLabel)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
@@ -36,7 +36,7 @@ class ViewMoreRow: UIView, NibLoadable, Accessible {
 private extension ViewMoreRow {
 
     func applyStyles() {
-        backgroundColor = .tableForeground
+        backgroundColor = .listForeground
         viewMoreLabel.text = NSLocalizedString("View more", comment: "Label for viewing more stats.")
         viewMoreLabel.textColor = WPStyleGuide.Stats.actionTextColor
     }

--- a/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
+++ b/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
@@ -26,7 +26,7 @@ extension WPStyleGuide {
 
         // MARK: - Search Styles
 
-        public static let searchBarBackgroundColor: UIColor = .tableBackground
+        public static let searchBarBackgroundColor: UIColor = .listBackground
         public static let searchBarBorderColor: UIColor = .neutral(.shade10)
 
         public static let searchTypeTitleFont = WPFontManager.systemSemiBoldFont(ofSize: 14)

--- a/WordPress/ColorPalette.xcassets/Gray0.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray0.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "244"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.063",
-          "alpha" : "1.000",
-          "blue" : "0.090",
-          "green" : "0.082"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray10.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray10.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "201"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.173",
-          "alpha" : "1.000",
-          "blue" : "0.220",
-          "green" : "0.200"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray100.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray100.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "21"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.969",
-          "alpha" : "1.000",
-          "blue" : "0.961",
-          "green" : "0.957"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray20.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray20.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "177"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.239",
-          "alpha" : "1.000",
-          "blue" : "0.294",
-          "green" : "0.267"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray30.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray30.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "152"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.318",
-          "alpha" : "1.000",
-          "blue" : "0.373",
-          "green" : "0.337"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray40.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray40.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "128"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.404",
-          "alpha" : "1.000",
-          "blue" : "0.455",
-          "green" : "0.416"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray5.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray5.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "223"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.114",
-          "alpha" : "1.000",
-          "blue" : "0.153",
-          "green" : "0.137"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray50.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray50.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "106"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.498",
-          "alpha" : "1.000",
-          "blue" : "0.541",
-          "green" : "0.502"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray60.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray60.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "86"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.604",
-          "alpha" : "1.000",
-          "blue" : "0.631",
-          "green" : "0.596"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray70.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray70.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "68"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.706",
-          "alpha" : "1.000",
-          "blue" : "0.722",
-          "green" : "0.694"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray80.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray80.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "51"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.804",
-          "alpha" : "1.000",
-          "blue" : "0.804",
-          "green" : "0.788"
-        }
-      }
     }
   ]
 }

--- a/WordPress/ColorPalette.xcassets/Gray90.colorset/Contents.json
+++ b/WordPress/ColorPalette.xcassets/Gray90.colorset/Contents.json
@@ -15,24 +15,6 @@
           "green" : "35"
         }
       }
-    },
-    {
-      "idiom" : "universal",
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "red" : "0.890",
-          "alpha" : "1.000",
-          "blue" : "0.886",
-          "green" : "0.875"
-        }
-      }
     }
   ]
 }

--- a/WordPress/WordPressDraftActionExtension/MainDraftActionViewController.swift
+++ b/WordPress/WordPressDraftActionExtension/MainDraftActionViewController.swift
@@ -37,7 +37,7 @@ private extension MainDraftActionViewController {
     func setupAppearance() {
         self.view.backgroundColor = .white
         let navigationBarAppearace = UINavigationBar.appearance()
-        navigationBarAppearace.barTintColor = .tableBackground
+        navigationBarAppearace.barTintColor = .listBackground
         navigationBarAppearace.barStyle = .default
         navigationBarAppearace.tintColor = .primary
         navigationBarAppearace.titleTextAttributes = [.foregroundColor: UIColor.primary]

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -36,7 +36,7 @@ class MainShareViewController: UIViewController {
 private extension MainShareViewController {
     func setupAppearance() {
         let navigationBarAppearace = UINavigationBar.appearance()
-        navigationBarAppearace.barTintColor = .tableBackground
+        navigationBarAppearace.barTintColor = .listBackground
         navigationBarAppearace.barStyle = .default
         navigationBarAppearace.tintColor = .primary
         navigationBarAppearace.titleTextAttributes = [.foregroundColor: UIColor.primary]

--- a/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
@@ -1292,13 +1292,13 @@ fileprivate extension ShareExtensionEditorViewController {
 
         static var aztecFormatPickerSelectedCellBackgroundColor: UIColor {
             get {
-                return (UIDevice.current.userInterfaceIdiom == .pad) ? .tableBackground : .neutral(.shade5)
+                return (UIDevice.current.userInterfaceIdiom == .pad) ? .listBackground : .neutral(.shade5)
             }
         }
 
         static var aztecFormatPickerBackgroundColor: UIColor {
             get {
-                return (UIDevice.current.userInterfaceIdiom == .pad) ? .white : .tableBackground
+                return (UIDevice.current.userInterfaceIdiom == .pad) ? .white : .listBackground
             }
         }
     }

--- a/WordPress/WordPressTest/ViewRelated/Blog/Style/WPStyleGuide+BlogTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Blog/Style/WPStyleGuide+BlogTests.swift
@@ -22,6 +22,6 @@ class WPStyleGuide_BlogTests: XCTestCase {
 
     func testConfigureTableViewBlogCellSetsBackgroundColor() {
         WPStyleGuide.configureTableViewBlogCell(testCell)
-        XCTAssertEqual(UIColor.tableForeground, testCell.backgroundColor)
+        XCTAssertEqual(UIColor.listForeground, testCell.backgroundColor)
     }
 }


### PR DESCRIPTION
Refs #12320 

This PR makes two main changes to the muriel color API:
- **add** method `gray(_: MurielColorShade)` to `UIColor` to explicitly pick a shade of muriel gray
- **refactor** method `neutral(…)` to be explicit that the color values ramp in the opposite way in dark mode. Previously this was done in the `xcassets` file, and I think that was misleading.

<img width="979" alt="image" src="https://user-images.githubusercontent.com/517257/63548273-c0559d00-c4e2-11e9-8221-0509361be583.png">


**Note:**
The inverted values for `neutral` in dark mode does a lot of the heavy lifting for dark mode support, though as we use more specific semantic colors, this is having less impact. Also, The xcassets file still has alternate values for `Blue` and `WordPressBlue` for dark and light modes. Ideally, at some point, color-studio will provide dark mode values for these.

To test:
- fire up the app
- make sure it still looks about right

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
