### PR TITLE
Update comments swipe actions to UISwipeActions

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -251,57 +251,50 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    return NO;
+    return YES;
 }
 
-- (UITableViewCellEditingStyle)tableView:(UITableView *)tableView editingStyleForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    return UITableViewCellEditingStyleDelete;
-}
-
-- (NSArray *)tableView:(UITableView *)tableView editActionsForRowAtIndexPath:(NSIndexPath *)indexPath
-{
+- (UISwipeActionsConfiguration *)tableView:(UITableView *)tableView trailingSwipeActionsConfigurationForRowAtIndexPath:(NSIndexPath *)indexPath {
+    
     Comment *comment = [self.tableViewHandler.resultsController objectAtIndexPath:indexPath];
-    NSMutableArray *actions = [NSMutableArray array];
     __typeof(self) __weak weakSelf = self;
+    NSMutableArray *actions = [NSMutableArray array];
     
-    NSParameterAssert(comment);
+    // TODO: Fix handlers
     
-    UITableViewRowAction *trash = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleDestructive
-                                                                     title:NSLocalizedString(@"Trash", @"Trashes a comment")
-                                                                   handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
-                                                                       [ReachabilityUtils onAvailableInternetConnectionDo:^{
-                                                                           [weakSelf deleteComment:comment];
-                                                                       }];
-                                                                   }];
+    // Trash Action
+    UIContextualAction *trash = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive title:NSLocalizedString(@"Trash", @"Trashes a comment") handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
+        [ReachabilityUtils onAvailableInternetConnectionDo:^{
+            [weakSelf deleteComment:comment];
+        }];
+    }];
     trash.backgroundColor = [UIColor murielError];
     [actions addObject:trash];
     
     if (comment.isApproved) {
-        UITableViewRowAction *unapprove = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal
-                                                                             title:NSLocalizedString(@"Unapprove", @"Unapproves a Comment")
-                                                                           handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
-                                                                               [ReachabilityUtils onAvailableInternetConnectionDo:^{
-                                                                                   [weakSelf unapproveComment:comment];
-                                                                               }];
-                                                                           }];
-        
-        unapprove.backgroundColor = [UIColor murielNeutral30];
-        [actions addObject:unapprove];
+    
+    // Unapprove Action
+        UIContextualAction *unapprove = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleNormal title:NSLocalizedString(@"Unapprove", @"Unapproves a Comment") handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
+            [ReachabilityUtils onAvailableInternetConnectionDo:^{
+                [weakSelf unapproveComment:comment];
+            }];
+        }];
+        trash.backgroundColor = [UIColor murielNeutral30];
+    [actions addObject:unapprove];
     } else {
-        UITableViewRowAction *approve = [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleNormal
-                                                                           title:NSLocalizedString(@"Approve", @"Approves a Comment")
-                                                                         handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
-                                                                             [ReachabilityUtils onAvailableInternetConnectionDo:^{
-                                                                                 [weakSelf approveComment:comment];
-                                                                             }];
-                                                                         }];
-        
-        approve.backgroundColor = [UIColor murielPrimary];
-        [actions addObject:approve];
+    // Approve Action
+        UIContextualAction *approve = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleNormal title:NSLocalizedString(@"Approve", @"Approves a Comment") handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
+            [ReachabilityUtils onAvailableInternetConnectionDo:^{
+                [weakSelf approveComment:comment];
+            }];
+        }];
+        trash.backgroundColor = [UIColor murielPrimary];
+    [actions addObject:approve];
     }
     
-    return actions;
+    UISwipeActionsConfiguration *swipeActions = [UISwipeActionsConfiguration configurationWithActions:actions];
+    
+    return swipeActions;
 }
 
 - (void)approveComment:(Comment *)comment

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -297,6 +297,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     }
     
     UISwipeActionsConfiguration *swipeActions = [UISwipeActionsConfiguration configurationWithActions:actions];
+    swipeActions.performsFirstActionWithFullSwipe = FALSE;
     return swipeActions;
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -260,40 +260,43 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     __typeof(self) __weak weakSelf = self;
     NSMutableArray *actions = [NSMutableArray array];
     
-    // TODO: Fix handlers
-    
     // Trash Action
-    UIContextualAction *trash = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive title:NSLocalizedString(@"Trash", @"Trashes a comment") handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
+    UIContextualAction *trash = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleDestructive title:NSLocalizedString(@"Trash", @"Trashes a comment") handler:^(UIContextualAction * _Nonnull action, __kindof UIView * _Nonnull sourceView, void (^ _Nonnull completionHandler)(BOOL)) {
         [ReachabilityUtils onAvailableInternetConnectionDo:^{
             [weakSelf deleteComment:comment];
         }];
+        completionHandler(YES);
     }];
+    
     trash.backgroundColor = [UIColor murielError];
     [actions addObject:trash];
     
     if (comment.isApproved) {
-    
-    // Unapprove Action
-        UIContextualAction *unapprove = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleNormal title:NSLocalizedString(@"Unapprove", @"Unapproves a Comment") handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
+
+        // Unapprove Action
+        UIContextualAction *unapprove = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleNormal title:NSLocalizedString(@"Unapprove", @"Unapproves a Comment") handler:^(UIContextualAction * _Nonnull action, __kindof UIView * _Nonnull sourceView, void (^ _Nonnull completionHandler)(BOOL)) {
             [ReachabilityUtils onAvailableInternetConnectionDo:^{
                 [weakSelf unapproveComment:comment];
             }];
+            completionHandler(YES);
         }];
-        trash.backgroundColor = [UIColor murielNeutral30];
-    [actions addObject:unapprove];
+        
+        unapprove.backgroundColor = [UIColor murielNeutral30];
+        [actions addObject:unapprove];
     } else {
-    // Approve Action
-        UIContextualAction *approve = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleNormal title:NSLocalizedString(@"Approve", @"Approves a Comment") handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath) {
+        // Approve Action
+        UIContextualAction *approve = [UIContextualAction contextualActionWithStyle:UIContextualActionStyleNormal title:NSLocalizedString(@"Approve", @"Approves a Comment") handler:^(UIContextualAction * _Nonnull action, __kindof UIView * _Nonnull sourceView, void (^ _Nonnull completionHandler)(BOOL)) {
             [ReachabilityUtils onAvailableInternetConnectionDo:^{
                 [weakSelf approveComment:comment];
             }];
+            completionHandler(YES);
         }];
-        trash.backgroundColor = [UIColor murielPrimary];
-    [actions addObject:approve];
+        
+        approve.backgroundColor = [UIColor murielPrimary];
+        [actions addObject:approve];
     }
     
     UISwipeActionsConfiguration *swipeActions = [UISwipeActionsConfiguration configurationWithActions:actions];
-    
     return swipeActions;
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -297,7 +297,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
     }
     
     UISwipeActionsConfiguration *swipeActions = [UISwipeActionsConfiguration configurationWithActions:actions];
-    swipeActions.performsFirstActionWithFullSwipe = FALSE;
+    swipeActions.performsFirstActionWithFullSwipe = NO;
     return swipeActions;
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -251,7 +251,7 @@ static NSString *CommentsLayoutIdentifier                       = @"CommentsLayo
 
 - (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    return YES;
+    return NO;
 }
 
 - (UITableViewCellEditingStyle)tableView:(UITableView *)tableView editingStyleForRowAtIndexPath:(NSIndexPath *)indexPath


### PR DESCRIPTION
Fixes #12212 

It looks like there are swipe actions in the code but the swipe option wasn't working correctly (tested against iOS 12.4 and 11.4).

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.