### PR TITLE
[iOS 13] Editor modals

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 13.2
 -----
 * When Log In is selected, all available options are displayed.
-
+* Updated presentation style of settings, media, previews, and the blog picker in the editor for iOS 13.
  
 13.1
 -----

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1813,7 +1813,12 @@ extension AztecPostViewController {
         picker.selectionActionTitle = Constants.mediaPickerInsertText
         picker.mediaPicker.options = options
         picker.delegate = self
-        picker.modalPresentationStyle = .currentContext
+        if #available(iOS 13.0, *) {
+            picker.modalPresentationStyle = .automatic
+        } else {
+            picker.modalPresentationStyle = .overCurrentContext
+        }
+
         if let previousPicker = mediaPickerInputViewController?.mediaPicker {
             picker.mediaPicker.selectedAssets = previousPicker.selectedAssets
         }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1814,7 +1814,9 @@ extension AztecPostViewController {
         picker.mediaPicker.options = options
         picker.delegate = self
         if #available(iOS 13.0, *) {
+#if XCODE11
             picker.modalPresentationStyle = .automatic
+#endif
         } else {
             picker.modalPresentationStyle = .overCurrentContext
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -11,7 +11,13 @@ extension PostEditor where Self: UIViewController {
             settingsViewController = PostSettingsViewController(post: post)
         }
         settingsViewController.hidesBottomBarWhenPushed = true
-        self.navigationController?.pushViewController(settingsViewController, animated: true)
+
+        if #available(iOS 13.0, *) {
+            let navigationController = UINavigationController(rootViewController: settingsViewController)
+            present(navigationController, animated: true)
+        } else {
+            self.navigationController?.pushViewController(settingsViewController, animated: true)
+        }
     }
 
     private func createPostRevisionBeforePreview(completion: @escaping (() -> Void)) {
@@ -61,7 +67,15 @@ extension PostEditor where Self: UIViewController {
     private func displayPreviewNotAvailable(title: String, subtitle: String? = nil) {
         let noResultsController = NoResultsViewController.controllerWith(title: title, subtitle: subtitle)
         noResultsController.hidesBottomBarWhenPushed = true
-        navigationController?.pushViewController(noResultsController, animated: true)
+
+        if #available(iOS 13.0, *) {
+            noResultsController.showDismissButton()
+
+            let navigationController = UINavigationController(rootViewController: noResultsController)
+            self.present(navigationController, animated: true)
+        } else {
+            navigationController?.pushViewController(noResultsController, animated: true)
+        }
     }
 
     func displayPreview() {
@@ -88,7 +102,13 @@ extension PostEditor where Self: UIViewController {
                 previewController = PostPreviewViewController(post: self.post)
             }
             previewController.hidesBottomBarWhenPushed = true
-            self.navigationController?.pushViewController(previewController, animated: true)
+
+            if #available(iOS 13.0, *) {
+                let navigationController = UINavigationController(rootViewController: previewController)
+                self.present(navigationController, animated: true)
+            } else {
+                self.navigationController?.pushViewController(previewController, animated: true)
+            }
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -166,6 +166,12 @@ FeaturedImageViewControllerDelegate>
     // reachability callbacks to trigger before such initial setup completes.
     //
     [self setupReachability];
+    
+    if ([self isModal]) {
+        self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
+                                                                                               target:self
+                                                                                               action:@selector(dismiss)];
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -361,6 +367,10 @@ FeaturedImageViewControllerDelegate>
     [self.tableView reloadData];
 }
 
+- (void)dismiss
+{
+    [self.presentingViewController dismissViewControllerAnimated:YES completion:nil];
+}
 
 #pragma mark - TextField Delegate Methods
 

--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -194,7 +194,7 @@ import Reachability
         removeFromParent()
     }
 
-    /// Public method to show a 'Dismiss' button in the navigation bar in place of the 'Back' button.
+    /// Public method to show a 'Dismiss' button in the navigation bar
     ///
     func showDismissButton() {
         navigationItem.hidesBackButton = true
@@ -204,7 +204,7 @@ import Reachability
                                             target: self,
                                             action: #selector(self.dismissButtonPressed))
         dismissButton.accessibilityLabel = NSLocalizedString("Dismiss", comment: "Dismiss button title.")
-        navigationItem.leftBarButtonItem = dismissButton
+        navigationItem.rightBarButtonItem = dismissButton
     }
 
     /// Public method to get the view height when adding the No Results View to a table cell.

--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -462,7 +462,11 @@ private extension NoResultsViewController {
     }
 
     @objc func dismissButtonPressed() {
-        delegate?.dismissButtonPressed?()
+        if let dismiss = delegate?.dismissButtonPressed {
+            dismiss()
+        } else {
+            presentingViewController?.dismiss(animated: true, completion: nil)
+        }
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
This PR updates the classic editor so that the blog picker, post settings, post preview, and media picker are displayed using iOS 13's new dismissable modal sheet style.

![editor-modals](https://user-images.githubusercontent.com/4780/63583044-1e8d8900-c592-11e9-983c-660091fa8c6a.gif)

I had to update one or two of the presented views to add a dismiss / done button. I also moved NoResultsViewController's dismiss button to the right side of the navigation bar for consistency.

**To test:**

* Build and run on iOS 13
* Start a new post in the classic editor (Aztec)
* Check each of the following are displayed in a modal sheet and can be dismissed:
    * Tap the blog picker in the navigation bar.
    * Tap `...` > Preview with no post content (no results view)
    * Tap `...` > Preview with post content
    * Tap `...` > Post Settings
    * Tap + in the formatting toolbar and open the media picker
* Also verify these are still presented 'normally' on iOS 12.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
