### PR TITLE
Fix incorrect color references for map view

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
@@ -27,7 +27,7 @@ class CountriesMapView: UIView, NibLoadable {
 
     @IBOutlet private var mapContainer: UIView! {
         didSet {
-            map.strokeColor = .tableForeground
+            map.strokeColor = .listForeground
             map.fillColor = WPStyleGuide.Stats.mapBackground
             map.loadMap("world-map", withData: [:], colorAxis: colors)
             mapContainer.addSubview(map)
@@ -36,8 +36,8 @@ class CountriesMapView: UIView, NibLoadable {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        backgroundColor = .tableForeground
-        map.backgroundColor = .tableForeground
+        backgroundColor = .listForeground
+        map.backgroundColor = .listForeground
         colors = mapColors()
     }
 


### PR DESCRIPTION
Fixes a build error on `develop` where the stats map view references old color names.

**To test**

* Check the app builds with no errors

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
