### PR TITLE
Dark Mode: My Sites section fixes part 1

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
@@ -98,7 +98,7 @@ class MediaItemImageTableViewCell: WPTableViewCell {
     }
 
     private func resetBackgroundColors() {
-        contentView.backgroundColor = .white
+        contentView.backgroundColor = .listForeground
     }
 
     override func layoutSubviews() {

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
@@ -13,11 +13,11 @@ extension WPStyleGuide {
         }
 
         public static func separatorsColor(isApproved approved: Bool) -> UIColor {
-            return approved ? WPStyleGuide.readGrey() : WPStyleGuide.alertYellowDark()
+            return approved ? .divider : UIColor(light: .warning(.shade90), dark: .warning(.shade40))
         }
 
         public static func detailsRegularStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            let color = approved ? WPStyleGuide.littleEddieGrey() : WPStyleGuide.alertYellowDark()
+            let color = approved ? .textSubtle : UIColor(light: .warning(.shade90), dark: .warning(.shade40))
 
             return  [.paragraphStyle: titleParagraph,
                      .font: titleRegularFont,
@@ -25,7 +25,7 @@ extension WPStyleGuide {
         }
 
         public static func detailsRegularRedStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            let color = approved ? WPStyleGuide.littleEddieGrey() : .errorDark
+            let color = approved ? .text : UIColor(light: .error(.shade90), dark: .error(.shade40))
 
             return  [.paragraphStyle: titleParagraph,
                      .font: titleRegularFont,
@@ -33,7 +33,7 @@ extension WPStyleGuide {
         }
 
         public static func detailsItalicsStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            let color = approved ? WPStyleGuide.littleEddieGrey() : .errorDark
+            let color = approved ? .text : UIColor(light: .error(.shade90), dark: .error(.shade40))
 
             return  [.paragraphStyle: titleParagraph,
                      .font: titleItalicsFont,
@@ -41,7 +41,7 @@ extension WPStyleGuide {
         }
 
         public static func detailsBoldStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            let color = approved ? WPStyleGuide.littleEddieGrey() : .errorDark
+            let color = approved ? .text : UIColor(light: .error(.shade90), dark: .error(.shade40))
 
             return  [.paragraphStyle: titleParagraph,
                      .font: titleBoldFont,
@@ -49,14 +49,14 @@ extension WPStyleGuide {
         }
 
         public static func timestampStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            let color = approved ? WPStyleGuide.allTAllShadeGrey() : WPStyleGuide.alertYellowDark()
+            let color = approved ? .textSubtle : UIColor(light: .warning(.shade90), dark: .warning(.shade40))
 
             return  [.font: timestampFont,
                      .foregroundColor: color ]
         }
 
         public static func backgroundColor(isApproved approved: Bool) -> UIColor {
-            return approved ? UIColor.white : WPStyleGuide.alertYellowLighter()
+            return approved ? .listForeground : UIColor(light: .warning(.shade5), dark: .warning(.shade100))
         }
 
         public static func timestampImage(isApproved approved: Bool) -> UIImage {

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -20,14 +18,14 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="59.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Um-2J-DCT">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="59.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6l3-mv-Tbu" userLabel="Labels">
-                                <rect key="frame" x="16" y="7" width="185" height="43.5"/>
+                                <rect key="frame" x="16" y="7.5" width="185" height="43.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S9J-0t-GbV">
                                         <rect key="frame" x="0.0" y="0.0" width="185" height="23.5"/>
@@ -41,7 +39,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="s9t-JC-dzu" firstAttribute="top" secondItem="S9J-0t-GbV" secondAttribute="bottom" constant="2" id="0iK-yR-Vxs"/>
                                     <constraint firstAttribute="trailing" secondItem="S9J-0t-GbV" secondAttribute="trailing" id="1zk-Kl-c5k"/>
@@ -74,7 +72,7 @@
                                 </constraints>
                             </imageView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="VPZ-yr-cJj" firstAttribute="leading" secondItem="8cG-SG-iYd" secondAttribute="trailing" id="B58-5v-Mt7"/>
                             <constraint firstItem="6l3-mv-Tbu" firstAttribute="leading" secondItem="6Um-2J-DCT" secondAttribute="leadingMargin" constant="8" id="Qas-h4-x8w"/>

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -411,6 +411,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             }
         }
 
+        cell.contentView.backgroundColor = UIColor.listForeground
+
         cell.configureCell(page)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
@@ -137,6 +137,7 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
         setupActionBar()
         setupFeaturedImage()
         setupBorders()
+        setupBackgrounds()
         setupLabels()
         setupSeparatorLabel()
         setupSelectedBackgroundView()
@@ -265,6 +266,15 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
         WPStyleGuide.applyBorderStyle(upperBorder)
         WPStyleGuide.applyBorderStyle(bottomBorder)
         WPStyleGuide.applyBorderStyle(actionBarSeparator)
+    }
+
+    private func setupBackgrounds() {
+        containerView.backgroundColor = .listForeground
+        titleLabel.backgroundColor = .listForeground
+        snippetLabel.backgroundColor = .listForeground
+        dateLabel.backgroundColor = .listForeground
+        authorLabel.backgroundColor = .listForeground
+        separatorLabel.backgroundColor = .listForeground
     }
 
     private func setupActionBar() {

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,11 +14,11 @@
             <rect key="frame" x="0.0" y="0.0" width="326" height="466"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="sqZ-hd-ibO" id="MWK-lj-FaS">
-                <rect key="frame" x="0.0" y="0.0" width="326" height="465.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="326" height="466"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lk7-nZ-b0t">
-                        <rect key="frame" x="0.0" y="16" width="326" height="449.5"/>
+                        <rect key="frame" x="0.0" y="16" width="326" height="450"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sev-PH-HG8">
                                 <rect key="frame" x="0.0" y="0.0" width="326" height="1"/>
@@ -30,7 +28,7 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="JqA-of-VBn">
-                                <rect key="frame" x="0.0" y="16" width="326" height="433.5"/>
+                                <rect key="frame" x="0.0" y="16" width="326" height="434"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="qax-CV-9QZ">
                                         <rect key="frame" x="0.0" y="0.0" width="326" height="100"/>
@@ -45,17 +43,17 @@
                                         <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="8a8-4i-YeE">
-                                        <rect key="frame" x="0.0" y="108" width="326" height="169.5"/>
+                                        <rect key="frame" x="0.0" y="108" width="326" height="170"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Post Title" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="xIT-FJ-g43">
-                                                <rect key="frame" x="16" y="2" width="294" height="147.5"/>
+                                                <rect key="frame" x="16" y="2" width="294" height="148"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Snippet" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="POV-pe-wu8">
-                                                <rect key="frame" x="16" y="152.5" width="294" height="17"/>
+                                                <rect key="frame" x="16" y="153" width="294" height="17"/>
                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -65,7 +63,7 @@
                                         <edgeInsets key="layoutMargins" top="2" left="16" bottom="0.0" right="16"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="lQh-4z-2Tt">
-                                        <rect key="frame" x="0.0" y="285.5" width="326" height="40"/>
+                                        <rect key="frame" x="0.0" y="286" width="326" height="40"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="c55-4m-uvT">
                                                 <rect key="frame" x="16" y="0.0" width="294" height="40"/>
@@ -110,7 +108,7 @@
                                         <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="Qxw-fl-tZF">
-                                        <rect key="frame" x="0.0" y="333.5" width="326" height="40"/>
+                                        <rect key="frame" x="0.0" y="334" width="326" height="40"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dbu-l3-L8G">
                                                 <rect key="frame" x="16" y="0.0" width="294" height="40"/>
@@ -126,7 +124,7 @@
                                         <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                                     </stackView>
                                     <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="O86-Za-gd3">
-                                        <rect key="frame" x="0.0" y="377.5" width="326" height="24"/>
+                                        <rect key="frame" x="0.0" y="378" width="326" height="24"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pUW-s6-y3t">
                                                 <rect key="frame" x="16" y="0.0" width="294" height="24"/>
@@ -168,7 +166,7 @@
                                         <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="6Zz-tH-1DC">
-                                        <rect key="frame" x="0.0" y="381.5" width="326" height="52"/>
+                                        <rect key="frame" x="0.0" y="382" width="326" height="52"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="A8f-pJ-oKt">
                                                 <rect key="frame" x="0.0" y="8" width="81.5" height="44"/>
@@ -223,14 +221,14 @@
                                 </subviews>
                             </stackView>
                             <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progressViewStyle="bar" progress="0.90000000000000002" translatesAutoresizingMaskIntoConstraints="NO" id="33v-Uz-9S6">
-                                <rect key="frame" x="0.0" y="445.5" width="326" height="5"/>
+                                <rect key="frame" x="0.0" y="446" width="326" height="5"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="4" id="gFE-it-kOj"/>
                                 </constraints>
                                 <color key="trackTintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </progressView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kcO-mG-FcD">
-                                <rect key="frame" x="0.0" y="404.5" width="326" height="1"/>
+                                <rect key="frame" x="0.0" y="405" width="326" height="1"/>
                                 <color key="backgroundColor" name="Gray10"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="Nuu-dr-YF0"/>
@@ -238,7 +236,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9eW-ex-CSu">
-                                <rect key="frame" x="0.0" y="448.5" width="326" height="1"/>
+                                <rect key="frame" x="0.0" y="449" width="326" height="1"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" placeholder="YES" id="FoL-Rc-HfI"/>
@@ -310,7 +308,7 @@
         <image name="icon-post-actionbar-restore" width="18" height="18"/>
         <image name="icon-post-actionbar-view" width="18" height="18"/>
         <namedColor name="Gray10">
-            <color red="0.80784313725490198" green="0.78823529411764703" blue="0.80784313725490198" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.80392156862745101" green="0.78823529411764703" blue="0.80392156862745101" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -81,8 +81,9 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
 
         featuredImageView.layer.cornerRadius = Constants.imageRadius
 
-        backgroundColor = innerView.backgroundColor
-        contentView.backgroundColor = innerView.backgroundColor
+        innerView.backgroundColor = .listForeground
+        backgroundColor = .listForeground
+        contentView.backgroundColor = .listForeground
     }
 
     private func setupSeparator() {
@@ -184,6 +185,7 @@ extension PostCompactCell: GhostableView {
         menuButton.isGhostableDisabled = true
         separator.isGhostableDisabled = true
         ghostView.isHidden = !visible
+        ghostView.backgroundColor = .listForeground
         featuredImageView.isHidden = true
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -20,14 +18,14 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="Bfq-Ne-g8g" id="9ZV-7I-syI">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="59.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="HJK-1N-bmY">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="59.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UrU-r4-hAL" userLabel="Labels">
-                                <rect key="frame" x="16" y="6" width="192" height="43.5"/>
+                                <rect key="frame" x="16" y="6.5" width="192" height="43.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZUq-Dg-elW">
                                         <rect key="frame" x="0.0" y="0.0" width="192" height="23.5"/>
@@ -47,7 +45,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="fEo-hS-PK1" firstAttribute="leading" secondItem="UrU-r4-hAL" secondAttribute="leading" id="Ar0-bF-oL3"/>
                                     <constraint firstAttribute="trailing" secondItem="ZUq-Dg-elW" secondAttribute="trailing" id="K78-Nm-WTO"/>
@@ -83,13 +81,13 @@
                                 </constraints>
                             </imageView>
                             <progressView hidden="YES" opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progress="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="06O-B0-y3k">
-                                <rect key="frame" x="0.0" y="55.5" width="320" height="4"/>
+                                <rect key="frame" x="0.0" y="56" width="320" height="4"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="4" id="j1t-t8-KFy"/>
                                 </constraints>
                             </progressView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XTx-r8-hUF">
-                                <rect key="frame" x="16" y="0.0" width="248" height="59.5"/>
+                                <rect key="frame" x="16" y="0.0" width="248" height="60"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ESK-bT-Bix">
                                         <rect key="frame" x="0.0" y="11.5" width="248" height="37"/>
@@ -107,7 +105,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                         </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="6QQ-XY-q2l" secondAttribute="trailing" constant="40" id="Bc6-rp-y5l"/>
                                             <constraint firstAttribute="bottom" secondItem="yxn-r2-waJ" secondAttribute="bottom" id="E5o-DB-eDv"/>
@@ -119,7 +117,7 @@
                                         </constraints>
                                     </view>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="ESK-bT-Bix" secondAttribute="trailing" id="h96-7a-N0h"/>
                                     <constraint firstItem="ESK-bT-Bix" firstAttribute="leading" secondItem="XTx-r8-hUF" secondAttribute="leading" id="mJJ-sj-Om2"/>
@@ -148,7 +146,7 @@
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y9d-AS-bhE">
-                        <rect key="frame" x="0.0" y="58.5" width="320" height="1"/>
+                        <rect key="frame" x="0.0" y="59" width="320" height="1"/>
                         <color key="backgroundColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" placeholder="YES" id="Yov-Gm-bZ6"/>

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowser.storyboard
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowser.storyboard
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="CnL-S6-q9U">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="CnL-S6-q9U">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -55,7 +51,7 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="INFO" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UTC-JU-oQg">
-                                                            <rect key="frame" x="77.5" y="21.5" width="29.5" height="14.5"/>
+                                                            <rect key="frame" x="77.5" y="21" width="29.5" height="14.5"/>
                                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="12"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -136,20 +132,20 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="4cE-G3-dPY">
-                                            <rect key="frame" x="0.0" y="0.0" width="600" height="163"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="163"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1gq-o6-8td">
-                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="109"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="109"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mll-1k-nOP" userLabel="Header Divider Line">
-                                                            <rect key="frame" x="16" y="8" width="568" height="93"/>
+                                                            <rect key="frame" x="16" y="1" width="343" height="54"/>
                                                             <color key="backgroundColor" red="0.84705883260000003" green="0.88627451660000001" blue="0.91372549530000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         </view>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="U27-29-c8Q">
-                                                            <rect key="frame" x="0.0" y="0.0" width="600" height="109"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="375" height="109"/>
                                                             <subviews>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jwo-3t-dLB">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="600" height="54"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
                                                                     <subviews>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QqI-lf-7WU">
                                                                             <rect key="frame" x="15" y="29" width="39.5" height="17"/>
@@ -173,16 +169,13 @@
                                                                     </constraints>
                                                                 </view>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="AFz-WC-4n8">
-                                                                    <rect key="frame" x="0.0" y="55" width="600" height="54"/>
+                                                                    <rect key="frame" x="0.0" y="55" width="375" height="54"/>
                                                                     <subviews>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IWG-BN-4Em">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="200" height="54"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="125" height="54"/>
                                                                             <subviews>
-                                                                                <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="theme-customize" translatesAutoresizingMaskIntoConstraints="NO" id="1xR-MV-xJj">
-                                                                                    <rect key="frame" x="91" y="8" width="18" height="18"/>
-                                                                                </imageView>
                                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="u2z-nw-Vyc">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="200" height="54"/>
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="125" height="54"/>
                                                                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                     <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="-20"/>
                                                                                     <state key="normal" title="Customize">
@@ -192,8 +185,11 @@
                                                                                         <action selector="didTapCustomizeButton:" destination="47y-8d-jwn" eventType="touchUpInside" id="S4h-dy-zTy"/>
                                                                                     </connections>
                                                                                 </button>
+                                                                                <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="theme-customize" translatesAutoresizingMaskIntoConstraints="NO" id="1xR-MV-xJj">
+                                                                                    <rect key="frame" x="53.5" y="8" width="18" height="18"/>
+                                                                                </imageView>
                                                                             </subviews>
-                                                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                             <constraints>
                                                                                 <constraint firstItem="u2z-nw-Vyc" firstAttribute="top" secondItem="IWG-BN-4Em" secondAttribute="top" id="0sg-8V-agt"/>
                                                                                 <constraint firstAttribute="trailing" secondItem="u2z-nw-Vyc" secondAttribute="trailing" id="QbH-tI-ldb"/>
@@ -204,13 +200,10 @@
                                                                             </constraints>
                                                                         </view>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JzW-Fm-uZ0">
-                                                                            <rect key="frame" x="200" y="0.0" width="200" height="54"/>
+                                                                            <rect key="frame" x="125" y="0.0" width="125" height="54"/>
                                                                             <subviews>
-                                                                                <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="theme-details" translatesAutoresizingMaskIntoConstraints="NO" id="ujm-Fw-DZX">
-                                                                                    <rect key="frame" x="91" y="8" width="18" height="18"/>
-                                                                                </imageView>
                                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6BA-aY-mOt">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="200" height="54"/>
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="125" height="54"/>
                                                                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                     <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="-20"/>
                                                                                     <state key="normal" title="Details">
@@ -220,8 +213,11 @@
                                                                                         <action selector="didTapDetailsButton:" destination="47y-8d-jwn" eventType="touchUpInside" id="xQO-1t-CBD"/>
                                                                                     </connections>
                                                                                 </button>
+                                                                                <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="theme-details" translatesAutoresizingMaskIntoConstraints="NO" id="ujm-Fw-DZX">
+                                                                                    <rect key="frame" x="53.5" y="8" width="18" height="18"/>
+                                                                                </imageView>
                                                                             </subviews>
-                                                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                             <constraints>
                                                                                 <constraint firstItem="ujm-Fw-DZX" firstAttribute="centerY" secondItem="JzW-Fm-uZ0" secondAttribute="centerY" constant="-10" id="axm-UY-nnC"/>
                                                                                 <constraint firstItem="6BA-aY-mOt" firstAttribute="leading" secondItem="JzW-Fm-uZ0" secondAttribute="leading" id="bMT-Fw-OFI"/>
@@ -232,13 +228,10 @@
                                                                             </constraints>
                                                                         </view>
                                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ufe-0H-S8G">
-                                                                            <rect key="frame" x="400" y="0.0" width="200" height="54"/>
+                                                                            <rect key="frame" x="250" y="0.0" width="125" height="54"/>
                                                                             <subviews>
-                                                                                <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="theme-support" translatesAutoresizingMaskIntoConstraints="NO" id="xKH-00-3XD">
-                                                                                    <rect key="frame" x="91" y="8" width="18" height="18"/>
-                                                                                </imageView>
                                                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iix-Pu-kKG">
-                                                                                    <rect key="frame" x="0.0" y="0.0" width="200" height="54"/>
+                                                                                    <rect key="frame" x="0.0" y="0.0" width="125" height="54"/>
                                                                                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                                     <inset key="titleEdgeInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="-20"/>
                                                                                     <state key="normal" title="Support">
@@ -248,8 +241,11 @@
                                                                                         <action selector="didTapSupportButton:" destination="47y-8d-jwn" eventType="touchUpInside" id="ELI-lH-PCS"/>
                                                                                     </connections>
                                                                                 </button>
+                                                                                <imageView opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" image="theme-support" translatesAutoresizingMaskIntoConstraints="NO" id="xKH-00-3XD">
+                                                                                    <rect key="frame" x="53.5" y="8" width="18" height="18"/>
+                                                                                </imageView>
                                                                             </subviews>
-                                                                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="trailing" secondItem="iix-Pu-kKG" secondAttribute="trailing" id="3hB-fX-74c"/>
                                                                                 <constraint firstItem="iix-Pu-kKG" firstAttribute="top" secondItem="ufe-0H-S8G" secondAttribute="top" id="EK4-c0-7vq"/>
@@ -268,12 +264,12 @@
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstItem="U27-29-c8Q" firstAttribute="top" secondItem="1gq-o6-8td" secondAttribute="top" id="1aQ-1h-Oit"/>
-                                                        <constraint firstAttribute="bottom" secondItem="mll-1k-nOP" secondAttribute="bottom" constant="8" id="3AB-Qx-5uD"/>
                                                         <constraint firstItem="U27-29-c8Q" firstAttribute="leading" secondItem="1gq-o6-8td" secondAttribute="leading" id="4Ra-TZ-NW3"/>
                                                         <constraint firstItem="mll-1k-nOP" firstAttribute="leading" secondItem="1gq-o6-8td" secondAttribute="leading" constant="16" id="JxL-ZU-wgP"/>
-                                                        <constraint firstItem="mll-1k-nOP" firstAttribute="top" secondItem="1gq-o6-8td" secondAttribute="top" constant="8" id="NCb-mV-xyg"/>
+                                                        <constraint firstItem="mll-1k-nOP" firstAttribute="top" secondItem="1gq-o6-8td" secondAttribute="top" constant="1" id="NCb-mV-xyg"/>
                                                         <constraint firstAttribute="height" constant="107" id="OUk-xU-hEP"/>
                                                         <constraint firstAttribute="trailing" secondItem="mll-1k-nOP" secondAttribute="trailing" constant="16" id="pje-H6-V8j"/>
+                                                        <constraint firstItem="mll-1k-nOP" firstAttribute="height" secondItem="Jwo-3t-dLB" secondAttribute="height" id="rgs-tt-VB2"/>
                                                         <constraint firstAttribute="bottom" secondItem="U27-29-c8Q" secondAttribute="bottom" id="sir-s1-gxb"/>
                                                         <constraint firstAttribute="trailing" secondItem="U27-29-c8Q" secondAttribute="trailing" id="vGi-Hm-wD0"/>
                                                     </constraints>
@@ -284,10 +280,10 @@
                                                     </variation>
                                                 </view>
                                                 <view contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QcA-Am-6I5">
-                                                    <rect key="frame" x="0.0" y="109" width="600" height="53"/>
+                                                    <rect key="frame" x="0.0" y="109" width="375" height="53"/>
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vOP-ZF-qi0" userLabel="Above Search Line">
-                                                            <rect key="frame" x="0.0" y="0.0" width="600" height="1"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
                                                             <color key="backgroundColor" red="0.84705883264541626" green="0.88627451658248901" blue="0.91372549533843994" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="1" id="Cy1-Ly-r0w" userLabel="height = 5"/>
@@ -314,7 +310,7 @@
                                                     </constraints>
                                                 </view>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mCK-BA-lBb" userLabel="Below Search Line">
-                                                    <rect key="frame" x="0.0" y="162" width="600" height="1"/>
+                                                    <rect key="frame" x="0.0" y="162" width="375" height="1"/>
                                                     <color key="backgroundColor" red="0.84705883264541626" green="0.88627451658248901" blue="0.91372549533843994" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="1" id="4dN-RY-rvY" userLabel="height = 5"/>
@@ -337,6 +333,7 @@
                                         <outlet property="currentThemeLabel" destination="dxt-YX-Xef" id="N7E-LR-C7h"/>
                                         <outlet property="currentThemeName" destination="QqI-lf-7WU" id="qGX-CK-8ey"/>
                                         <outlet property="customizeButton" destination="u2z-nw-Vyc" id="1gk-tM-uLp"/>
+                                        <outlet property="customizeIcon" destination="1xR-MV-xJj" id="eU7-1o-VQf"/>
                                         <outlet property="detailsButton" destination="6BA-aY-mOt" id="LAT-yo-MX8"/>
                                         <outlet property="detailsIcon" destination="ujm-Fw-DZX" id="Jze-Vq-1Zx"/>
                                         <outlet property="filterBar" destination="QcA-Am-6I5" id="ULL-Kt-Bh8"/>
@@ -352,7 +349,7 @@
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Va9-Te-cqS">
-                                            <rect key="frame" x="290" y="15" width="20" height="20"/>
+                                            <rect key="frame" x="177.5" y="15" width="20" height="20"/>
                                         </activityIndicatorView>
                                     </subviews>
                                     <constraints>

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserCell.swift
@@ -142,6 +142,7 @@ open class ThemeBrowserCell: UICollectionViewCell {
             nameLabel.text = theme.name
             if theme.isCurrentTheme() {
                 backgroundColor = Styles.activeCellBackgroundColor
+                infoBar.backgroundColor = Styles.activeCellBackgroundColor
                 layer.borderColor = Styles.activeCellBorderColor.cgColor
                 infoBar.layer.borderColor = Styles.activeCellDividerColor.cgColor
                 actionButton.layer.borderColor = Styles.activeCellDividerColor.cgColor
@@ -152,6 +153,7 @@ open class ThemeBrowserCell: UICollectionViewCell {
                 infoLabel.text = NSLocalizedString("ACTIVE", comment: "Label for active Theme browser cell")
             } else {
                 backgroundColor = Styles.inactiveCellBackgroundColor
+                infoBar.backgroundColor = Styles.inactiveCellBackgroundColor
                 layer.borderColor = Styles.inactiveCellBorderColor.cgColor
                 infoBar.layer.borderColor = Styles.inactiveCellDividerColor.cgColor
                 actionButton.layer.borderColor = Styles.inactiveCellDividerColor.cgColor

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserHeaderView.swift
@@ -18,6 +18,7 @@ open class ThemeBrowserHeaderView: UICollectionReusableView {
     @IBOutlet weak var currentThemeContainer: UIView!
     @IBOutlet weak var currentThemeName: UILabel!
     @IBOutlet weak var customizeButton: UIButton!
+    @IBOutlet weak var customizeIcon: UIImageView!
     @IBOutlet weak var detailsButton: UIButton!
     @IBOutlet weak var detailsIcon: UIImageView!
     @IBOutlet weak var supportButton: UIButton!
@@ -85,6 +86,7 @@ open class ThemeBrowserHeaderView: UICollectionReusableView {
 
     fileprivate func applyStyles() {
         currentThemeBar.backgroundColor = Styles.currentThemeBackgroundColor
+        currentThemeContainer.backgroundColor = Styles.currentThemeBackgroundColor
         currentThemeDivider.backgroundColor = Styles.currentThemeDividerColor
 
         currentThemeLabel.font = Styles.currentThemeLabelFont
@@ -95,6 +97,8 @@ open class ThemeBrowserHeaderView: UICollectionReusableView {
 
         let currentThemeButtons = [customizeButton, detailsButton, supportButton]
         currentThemeButtons.forEach { Styles.styleCurrentThemeButton($0!) }
+
+        [customizeIcon, detailsIcon, supportIcon].forEach { $0?.tintColor = .listIcon }
 
         spotlightCustomizeButtonIfTourIsActive()
 

--- a/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
+++ b/WordPress/Classes/ViewRelated/Themes/WPStyleGuide+Themes.swift
@@ -7,8 +7,8 @@ extension WPStyleGuide {
     public struct Themes {
         // MARK: - Current Theme Styles
 
-        public static let currentThemeBackgroundColor: UIColor = .white
-        public static let currentThemeDividerColor: UIColor = .neutral(.shade5)
+        public static let currentThemeBackgroundColor: UIColor = .listForeground
+        public static let currentThemeDividerColor: UIColor = .divider
 
         public static let currentThemeLabelFont = WPFontManager.systemRegularFont(ofSize: 11)
         public static let currentThemeLabelColor: UIColor = .textSubtle
@@ -22,6 +22,7 @@ extension WPStyleGuide {
         public static func styleCurrentThemeButton(_ button: UIButton) {
             button.titleLabel?.font = currentThemeButtonFont
             button.setTitleColor(currentThemeButtonColor, for: UIControl.State())
+            button.backgroundColor = currentThemeBackgroundColor
         }
 
         // MARK: - Search Styles
@@ -52,10 +53,10 @@ extension WPStyleGuide {
         public static let activeCellBackgroundColor: UIColor = .neutral(.shade40)
         public static let activeCellBorderColor: UIColor = .neutral(.shade40)
         public static let activeCellDividerColor: UIColor = .neutral(.shade20)
-        public static let activeCellNameColor: UIColor = .white
+        public static let activeCellNameColor: UIColor = .textInverted
         public static let activeCellInfoColor: UIColor = .primaryLight
 
-        public static let inactiveCellBackgroundColor: UIColor = .white
+        public static let inactiveCellBackgroundColor: UIColor = .listForeground
         public static let inactiveCellBorderColor: UIColor = .neutral(.shade10)
         public static let inactiveCellDividerColor: UIColor = .neutral(.shade5)
         public static let inactiveCellNameColor: UIColor = .neutral(.shade70)

--- a/WordPress/Resources/AppImages.xcassets/theme-support.imageset/Contents.json
+++ b/WordPress/Resources/AppImages.xcassets/theme-support.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/theme-customize.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/theme-customize.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }

--- a/WordPress/Resources/MurielImages.xcassets/theme-details.imageset/Contents.json
+++ b/WordPress/Resources/MurielImages.xcassets/theme-details.imageset/Contents.json
@@ -8,5 +8,8 @@
   "info" : {
     "version" : 1,
     "author" : "xcode"
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
   }
 }


### PR DESCRIPTION
Refs #12320

This PR fixes dark mode colors for several subsections within My Sites:
- Site Pages
- Blog Posts
- Media
- Comments
- Themes

![my sites p1](https://user-images.githubusercontent.com/517257/63627775-016eaf80-c5be-11e9-9149-d24cab1f00ce.png)

To test:
- visit these subsections in both light and dark mode
- look for wrong colors

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
