### PR TITLE
Fix Jetpack install presentation for iOS 13

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
@@ -224,6 +224,7 @@ class JetpackLoginViewController: UIViewController {
                                                             delegate: self,
                                                             promptType: promptType)
         let navController = UINavigationController(rootViewController: controller)
+        navController.modalPresentationStyle = .fullScreen
         present(navController, animated: true)
     }
 


### PR DESCRIPTION
Just a quick one for the iOS 13 release – setting the Jetpack install flow to explicitly use fullscreen modal presentation. Without this change, on iOS 13 it was displaying a dismissable modal sheet, which would allow the user to swipe out of the flow partway through.

**To test:**

* Build and run, and add a self-hosted non-Jetpack site.
* Go to Stats and tap Install Jetpack, and insure the Jetpack flow is presented as a fullscreen modal.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
