### PR TITLE
Dark mode: Reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.swift
@@ -84,7 +84,7 @@ final class NewsCard: UIViewController {
     }
 
     private func styleBackground() {
-        view.backgroundColor = .clear
+        view.backgroundColor = .listForeground
     }
 
     private func styleBorderedView() {

--- a/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
+++ b/WordPress/Classes/ViewRelated/Reader/NewsCard.xib
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -29,28 +26,28 @@
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7Cb-NM-WoN" userLabel="BorderedView">
                     <rect key="frame" x="-1" y="0.0" width="375" height="193"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" alignment="top" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Ewo-7I-oMB">
                     <rect key="frame" x="0.0" y="8" width="375" height="184"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="275" verticalHuggingPriority="270" verticalCompressionResistancePriority="760" axis="vertical" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="9hi-UA-p04">
-                            <rect key="frame" x="16" y="20" width="149" height="156"/>
+                            <rect key="frame" x="16" y="8" width="149" height="168"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aSK-uI-6js" userLabel="NewsTitle">
-                                    <rect key="frame" x="0.0" y="0.0" width="149" height="89.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="149" height="101.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gf2-Wv-Ozo" userLabel="NewsSubtitle">
-                                    <rect key="frame" x="0.0" y="97.5" width="149" height="20.5"/>
+                                    <rect key="frame" x="0.0" y="109.5" width="149" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WFs-AW-Uc0">
-                                    <rect key="frame" x="0.0" y="126" width="149" height="30"/>
+                                    <rect key="frame" x="0.0" y="138" width="149" height="30"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="30" id="m6f-Pp-yMs"/>
                                     </constraints>
@@ -59,14 +56,14 @@
                             </subviews>
                         </stackView>
                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="58s-bz-Teb">
-                            <rect key="frame" x="175" y="20" width="130" height="130"/>
+                            <rect key="frame" x="175" y="8" width="130" height="130"/>
                             <constraints>
                                 <constraint firstAttribute="width" secondItem="58s-bz-Teb" secondAttribute="height" multiplier="1:1" id="Hdv-k8-lBE"/>
                                 <constraint firstAttribute="width" constant="130" id="mBb-U9-zfe"/>
                             </constraints>
                         </imageView>
                         <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalCompressionResistancePriority="900" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0k3-KZ-dKQ">
-                            <rect key="frame" x="315" y="20" width="44" height="44"/>
+                            <rect key="frame" x="315" y="8" width="44" height="44"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="44" id="3Uq-t0-qSi"/>
                                 <constraint firstAttribute="width" constant="44" id="wEy-Hh-F2m"/>

--- a/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Reader.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,7 +16,7 @@
                         <viewControllerLayoutGuide type="bottom" id="icf-FG-h6u"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="nFH-eq-cvg">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="437"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="477"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
@@ -41,7 +39,7 @@
                         <viewControllerLayoutGuide type="bottom" id="zkd-Io-waS"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="dbo-c9-92a">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="250" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="LMp-cd-vT3">
@@ -60,7 +58,7 @@
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="www.blogname.com" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RfN-yk-yXb">
                                                 <rect key="frame" x="58" y="32" width="281" height="14.5"/>
-                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -94,7 +92,7 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <gestureRecognizers/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="66" id="8xE-9V-O9N"/>
@@ -118,21 +116,21 @@
                                     </imageView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="H39-2a-c92" customClass="ReaderSpacerView" customModule="WordPress">
                                         <rect key="frame" x="0.0" y="116" width="383" height="8"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="8" placeholder="YES" id="bGU-WI-BPq"/>
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Title Jj" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="ut9-jn-WNM">
                                         <rect key="frame" x="16" y="124" width="351" height="24"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MYy-Lu-AaC">
                                         <rect key="frame" x="0.0" y="148" width="383" height="4"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="4" id="Iqd-8s-Xhu"/>
                                         </constraints>
@@ -155,7 +153,7 @@
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UR6-eY-gQg" userLabel="Padding View">
                                                                 <rect key="frame" x="0.0" y="0.0" width="0.0" height="44"/>
-                                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" id="NeN-dw-2V8"/>
                                                                 </constraints>
@@ -179,7 +177,7 @@
                                                             </button>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AEL-5F-FbO" userLabel="Padding View">
                                                                 <rect key="frame" x="79" y="0.0" width="0.0" height="44"/>
-                                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" id="5rq-de-u3C"/>
                                                                 </constraints>
@@ -228,7 +226,7 @@
                                                 </userDefinedRuntimeAttributes>
                                             </view>
                                         </subviews>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="bottom" secondItem="BGT-ob-j9p" secondAttribute="bottom" id="1YW-Ox-VHk"/>
                                             <constraint firstItem="BGT-ob-j9p" firstAttribute="top" secondItem="JFE-Nr-imf" secondAttribute="top" id="MQn-FA-Rps"/>
@@ -247,7 +245,7 @@
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aER-Yk-oAm">
                                         <rect key="frame" x="0.0" y="196" width="383" height="4"/>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="4" id="hgy-5R-zg1"/>
                                         </constraints>
@@ -290,19 +288,19 @@
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" text="Attribution" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I5s-ci-UB0">
                                                         <rect key="frame" x="28" y="0.0" width="80.5" height="20.5"/>
-                                                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <view alpha="0.0" contentMode="scaleToFill" horizontalHuggingPriority="1" verticalHuggingPriority="1" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="YBQ-xA-5CN" userLabel="View (spacer)">
                                                         <rect key="frame" x="116.5" y="0.0" width="228.5" height="0.0"/>
-                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </view>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
-                                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="trailing" secondItem="lUA-Mu-a4u" secondAttribute="trailing" id="29T-ZN-CUn"/>
                                             <constraint firstItem="lUA-Mu-a4u" firstAttribute="top" secondItem="UJH-3y-QkU" secondAttribute="top" id="Jbh-tW-3mu"/>
@@ -317,7 +315,7 @@
                                 </subviews>
                             </stackView>
                             <view clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vSH-j9-J3c">
-                                <rect key="frame" x="-4" y="553" width="383" height="50"/>
+                                <rect key="frame" x="-4" y="573" width="383" height="50"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="utM-eb-n7b">
                                         <rect key="frame" x="0.0" y="0.0" width="383" height="1"/>
@@ -380,7 +378,7 @@
                                         </subviews>
                                     </stackView>
                                 </subviews>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="utM-eb-n7b" firstAttribute="leading" secondItem="vSH-j9-J3c" secondAttribute="leading" id="AGa-qi-Ch2"/>
                                     <constraint firstAttribute="height" constant="50" id="DZ4-kQ-gyy"/>
@@ -419,6 +417,7 @@
                         <outlet property="commentButton" destination="XmB-eN-d59" id="nAO-lB-cA3"/>
                         <outlet property="featuredImageBottomPaddingView" destination="H39-2a-c92" id="T3d-Hz-kcK"/>
                         <outlet property="featuredImageView" destination="cAC-kN-MLi" id="cgd-fT-E3R"/>
+                        <outlet property="footerDivider" destination="utM-eb-n7b" id="Fjv-Nt-526"/>
                         <outlet property="footerView" destination="vSH-j9-J3c" id="tRl-Z2-Oo1"/>
                         <outlet property="footerViewHeightConstraint" destination="DZ4-kQ-gyy" id="w37-fs-Xni"/>
                         <outlet property="headerView" destination="A1K-ZI-1wr" id="yu0-A1-s21"/>
@@ -451,14 +450,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="B6J-Lg-PdX">
-                                <rect key="frame" x="0.0" y="20" width="375" height="56"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
                                 <connections>
                                     <outlet property="delegate" destination="e0f-8T-Sz8" id="8aD-d4-C9q"/>
                                 </connections>
                             </searchBar>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="49S-3J-OMN">
-                                <rect key="frame" x="0.0" y="76" width="375" height="591"/>
+                                <rect key="frame" x="0.0" y="56" width="375" height="611"/>
                                 <connections>
                                     <segue destination="FBk-BW-Oyk" kind="embed" id="BIm-m7-JCp"/>
                                 </connections>
@@ -509,7 +508,7 @@
                         <viewControllerLayoutGuide type="bottom" id="4Hq-9j-ssQ"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="3Jv-hf-pib">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="UQY-Uf-csX">
@@ -527,13 +526,13 @@
                                 </constraints>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PuG-YC-OIC">
-                                <rect key="frame" x="0.0" y="102" width="375" height="501"/>
+                                <rect key="frame" x="0.0" y="102" width="375" height="521"/>
                                 <connections>
                                     <segue destination="His-O5-Cy6" kind="embed" id="xfh-l2-pdU"/>
                                 </connections>
                             </containerView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="What would you like to find?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="afc-5c-5tF">
-                                <rect key="frame" x="16" y="339" width="343" height="27"/>
+                                <rect key="frame" x="16" y="349" width="343" height="27"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="22"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -643,7 +642,7 @@
             <objects>
                 <tableViewController id="FBk-BW-Oyk" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="54" sectionHeaderHeight="18" sectionFooterHeight="18" id="q5P-P8-r6d">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="591"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="611"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <connections>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardDiscoverAttributionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardDiscoverAttributionView.swift
@@ -31,6 +31,11 @@ private enum ReaderCardDiscoverAttribution: Int {
 
     @objc weak var delegate: ReaderCardDiscoverAttributionViewDelegate?
 
+    override open var backgroundColor: UIColor? {
+        didSet {
+            applyOpaqueBackgroundColors()
+        }
+    }
 
     // MARK: - Lifecycle Methods
 
@@ -57,6 +62,7 @@ private enum ReaderCardDiscoverAttribution: Int {
         textLabel.isUserInteractionEnabled = true
         imageView.isUserInteractionEnabled = true
 
+        backgroundColor = .listForeground
         applyOpaqueBackgroundColors()
     }
 
@@ -67,9 +73,8 @@ private enum ReaderCardDiscoverAttribution: Int {
      Applies opaque backgroundColors to all subViews to avoid blending, for optimized drawing.
      */
     fileprivate func applyOpaqueBackgroundColors() {
-        backgroundColor = .listForeground
-        imageView.backgroundColor = .listForeground
-        textLabel.backgroundColor = .listForeground
+        imageView?.backgroundColor = backgroundColor
+        textLabel?.backgroundColor = backgroundColor
     }
 
     @objc open func configureView(_ contentProvider: ReaderPostContentProvider?) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -57,6 +57,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
 
     // Header realated Views
     @IBOutlet fileprivate weak var headerView: UIView!
+    @IBOutlet fileprivate weak var headerViewBackground: UIView!
     @IBOutlet fileprivate weak var blavatarImageView: UIImageView!
     @IBOutlet fileprivate weak var blogNameButton: UIButton!
     @IBOutlet fileprivate weak var blogURLLabel: UILabel!
@@ -84,6 +85,7 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
     @IBOutlet fileprivate weak var featuredImageBottomPaddingView: UIView!
     @IBOutlet fileprivate weak var titleBottomPaddingView: UIView!
     @IBOutlet fileprivate weak var bylineBottomPaddingView: UIView!
+    @IBOutlet fileprivate weak var footerDivider: UIView!
 
     @objc open var shouldHideComments = false
     fileprivate var didBumpStats = false
@@ -515,6 +517,24 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         WPStyleGuide.applyReaderCardActionButtonStyle(commentButton)
         WPStyleGuide.applyReaderCardActionButtonStyle(likeButton)
         WPStyleGuide.applyReaderCardActionButtonStyle(saveForLaterButton)
+
+        view.backgroundColor = .listBackground
+        headerView.backgroundColor = .listForeground
+        footerView.backgroundColor = .listForeground
+        footerDivider.backgroundColor = .divider
+
+        #if XCODE11
+        if #available(iOS 13.0, *) {
+            if traitCollection.userInterfaceStyle == .dark {
+                attributionView.backgroundColor = .listBackground
+            }
+        }
+        #endif
+
+        bylineGradientViews.forEach({ view in
+            view.fromColor = .listBackground
+            view.toColor = UIColor.listBackground.withAlphaComponent(0.0)
+        })
     }
 
 

--- a/WordPress/WordPressTest/NewsCardTests.swift
+++ b/WordPress/WordPressTest/NewsCardTests.swift
@@ -60,10 +60,6 @@ final class NewsCardTests: XCTestCase {
         super.tearDown()
     }
 
-    func testViewHasTheExpectedBackgroundColor() {
-        XCTAssertEqual(subject?.view.backgroundColor, .clear)
-    }
-
     func testTitleHasTheExpectedColor() {
         XCTAssertEqual(subject?.newsTitle.textColor, .text)
     }

--- a/WordPress/WordPressTest/SiteCreation/SiteSegmentsCellTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteSegmentsCellTests.swift
@@ -52,10 +52,6 @@ final class SiteSegmentsCellTests: XCTestCase {
         XCTAssertEqual(cell?.title.font, WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold))
     }
 
-    func testCellTitleIsTheCorrectColor() {
-        XCTAssertEqual(cell?.title.textColor, .neutral(.shade70))
-    }
-
     func testCellSubtitleIsTheCorrectFont() {
         // This approach fails both locally and on CI
         //XCTAssertEqual(cell?.subtitle.font, WPStyleGuide.fontForTextStyle(.callout, fontWeight: .regular))
@@ -72,9 +68,5 @@ final class SiteSegmentsCellTests: XCTestCase {
 
         XCTAssertEqual(expectedFont.fontName, actualFont!.fontName)
         XCTAssertEqual(expectedFont.pointSize, actualFont!.pointSize, accuracy: 0.01)
-    }
-
-    func testCellSubtitleIsTheCorrectColor() {
-        XCTAssertEqual(cell?.subtitle.textColor, .neutral(.shade70))
     }
 }

--- a/WordPress/WordPressTest/SiteCreation/TitleSubtitleHeaderTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/TitleSubtitleHeaderTests.swift
@@ -41,15 +41,7 @@ final class TitleSubtitleHeaderTests: XCTestCase {
         XCTAssertEqual(header?.titleLabel.font, WPStyleGuide.fontForTextStyle(.title1, fontWeight: .bold))
     }
 
-    func testTitleFontColor() {
-        XCTAssertEqual(header?.titleLabel.textColor, .neutral(.shade70))
-    }
-
     func testSubtitleFont() {
         XCTAssertEqual(header?.subtitleLabel.font, WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular))
-    }
-
-    func testSubtitleFontColor() {
-        XCTAssertEqual(header?.subtitleLabel.textColor, .neutral(.shade40))
     }
 }


### PR DESCRIPTION
Refs #12320. This PR implements dark mode improvements for the Reader.

![reader-dark](https://user-images.githubusercontent.com/4780/63680769-50019100-c7ec-11e9-9d1f-f86645ccac6f.png)

I think there are still probably a few loose ends, but on the whole it's better than what was there before!

**To test:**

* Build and run on iOS 13 light and dark mode and iOS 12
* Check nothing looks unexpected

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
