### PR TITLE
Issues/7886 bug 3

### DIFF
--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -85,17 +85,6 @@ extern NSNotificationName const WPAccountEmailAndDefaultBlogUpdatedNotification;
 ///-----------------------
 
 /**
- A convenience method for creating an Account from an auth token and remote user.
-
- This method makes a pass through call to `createOrUpdateAccountWithUsername:authToken:`, see it for details.
-
- @param remoteUser a RemoteUser instance.
- @param authToken the OAuth2 token returned by signIntoWordPressDotComWithUsername:authToken:
- @return a WordPress.com `WPAccount` object
- */
-- (WPAccount *)createOrUpdateAccountWithUserDetails:(RemoteUser *)remoteUser authToken:(NSString *)authToken;
-
-/**
  Creates a new WordPress.com account or updates the password if there is a matching account
  
  There can only be one WordPress.com account per username, so if one already exists for the given `username` its password is updated
@@ -145,7 +134,7 @@ extern NSNotificationName const WPAccountEmailAndDefaultBlogUpdatedNotification;
  @param success A success block.
  @param failure A failure block.
  */
-- (void)syncAccountDetailsAndCreateAccount:(NSString *)authToken
+- (void)createOrUpdateAccountWithAuthToken:(NSString *)authToken
                                    success:(void (^)(WPAccount * _Nonnull))success
                                    failure:(void (^)(NSError * _Nonnull))failure;
 

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -136,6 +136,11 @@ extern NSNotificationName const WPAccountEmailAndDefaultBlogUpdatedNotification;
                             success:(nullable void (^)(void))success
                             failure:(nullable void (^)(NSError *error))failure;
 
+
+- (void)syncAccountDetailsAndCreateAccount:(NSString *)authToken
+                                   success:(void (^)(WPAccount * _Nonnull))success
+                                   failure:(void (^)(NSError * _Nonnull))failure;
+
 /**
  Initializes the WordPress iOS Extensions with the WordPress.com Default Account.
  */

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -137,6 +137,14 @@ extern NSNotificationName const WPAccountEmailAndDefaultBlogUpdatedNotification;
                             failure:(nullable void (^)(NSError *error))failure;
 
 
+/**
+ Syncs the details for the account associated with the provided auth token, then
+ creates or updates a WPAccount with the synced information.
+
+ @param authToken The auth token associated with the account being created/updated.
+ @param success A success block.
+ @param failure A failure block.
+ */
 - (void)syncAccountDetailsAndCreateAccount:(NSString *)authToken
                                    success:(void (^)(WPAccount * _Nonnull))success
                                    failure:(void (^)(NSError * _Nonnull))failure;

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -4,6 +4,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class WPAccount;
+@class RemoteUser;
 
 extern NSString *const WPAccountDefaultWordPressComAccountChangedNotification;
 extern NSNotificationName const WPAccountEmailAndDefaultBlogUpdatedNotification;
@@ -84,16 +85,15 @@ extern NSNotificationName const WPAccountEmailAndDefaultBlogUpdatedNotification;
 ///-----------------------
 
 /**
- A convenience method for creating an Account just from an auth token.
- A temporary username is assigned and is expected to be updated as soon as
- the account is synced from the server.
+ A convenience method for creating an Account from an auth token and remote user.
 
  This method makes a pass through call to `createOrUpdateAccountWithUsername:authToken:`, see it for details.
 
+ @param remoteUser a RemoteUser instance.
  @param authToken the OAuth2 token returned by signIntoWordPressDotComWithUsername:authToken:
  @return a WordPress.com `WPAccount` object
  */
-- (WPAccount *)createOrUpdateAccountWithAuthToken:(NSString *)authToken;
+- (WPAccount *)createOrUpdateAccountWithUserDetails:(RemoteUser *)remoteUser authToken:(NSString *)authToken;
 
 /**
  Creates a new WordPress.com account or updates the password if there is a matching account

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -187,10 +187,12 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 /// @name Account creation
 ///-----------------------
 
-- (WPAccount *)createOrUpdateAccountWithAuthToken:(NSString *)authToken
+- (WPAccount *)createOrUpdateAccountWithUserDetails:(RemoteUser *)remoteUser authToken:(NSString *)authToken
 {
-    NSString *tempUsername = [[NSUUID UUID] UUIDString];
-    return [self createOrUpdateAccountWithUsername:tempUsername authToken:authToken];
+    NSString *username = remoteUser.username;
+    WPAccount *account = [self createOrUpdateAccountWithUsername:username authToken:authToken];
+    [self updateAccount:account withUserDetails:remoteUser];
+    return account;
 }
 
 /**

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -264,7 +264,6 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     return [results firstObject];
 }
 
-
 - (void)syncAccountDetailsAndCreateAccount:(NSString *)authToken
                                    success:(void (^)(WPAccount * _Nonnull))success
                                    failure:(void (^)(NSError * _Nonnull))failure

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -267,11 +267,11 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     return [results firstObject];
 }
 
-- (void)syncAccountDetailsAndCreateAccount:(NSString *)authToken
+- (void)createOrUpdateAccountWithAuthToken:(NSString *)authToken
                                    success:(void (^)(WPAccount * _Nonnull))success
                                    failure:(void (^)(NSError * _Nonnull))failure
 {
-    WordPressComRestApi *api = [[WordPressComRestApi alloc] initWithOAuthToken:authToken userAgent:[WPUserAgent defaultUserAgent]];
+    WordPressComRestApi *api = [WordPressComRestApi defaultApiWithOAuthToken:authToken userAgent:[WPUserAgent defaultUserAgent] localeKey:[WordPressComRestApi LocaleKeyDefault]];
     AccountServiceRemoteREST *remote = [[AccountServiceRemoteREST alloc] initWithWordPressComRestApi:api];
     [remote getAccountDetailsWithSuccess:^(RemoteUser *remoteUser) {
         WPAccount *account = [self createOrUpdateAccountWithUserDetails:remoteUser authToken:authToken];

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -264,6 +264,21 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     return [results firstObject];
 }
 
+
+- (void)syncAccountDetailsAndCreateAccount:(NSString *)authToken
+                                   success:(void (^)(WPAccount * _Nonnull))success
+                                   failure:(void (^)(NSError * _Nonnull))failure
+{
+    WordPressComRestApi *api = [[WordPressComRestApi alloc] initWithOAuthToken:authToken userAgent:[WPUserAgent defaultUserAgent]];
+    AccountServiceRemoteREST *remote = [[AccountServiceRemoteREST alloc] initWithWordPressComRestApi:api];
+    [remote getAccountDetailsWithSuccess:^(RemoteUser *remoteUser) {
+        WPAccount *account = [self createOrUpdateAccountWithUserDetails:remoteUser authToken:authToken];
+        success(account);
+    } failure:^(NSError *error) {
+        failure(error);
+    }];
+}
+
 - (void)updateUserDetailsForAccount:(WPAccount *)account
                            success:(nullable void (^)(void))success
                            failure:(nullable void (^)(NSError * _Nonnull))failure

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -189,8 +189,11 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 
 - (WPAccount *)createOrUpdateAccountWithUserDetails:(RemoteUser *)remoteUser authToken:(NSString *)authToken
 {
-    NSString *username = remoteUser.username;
-    WPAccount *account = [self createOrUpdateAccountWithUsername:username authToken:authToken];
+    WPAccount *account = [self findAccountWithUserID:remoteUser.userID];
+    if (!account) {
+        NSString *username = remoteUser.username;
+        account = [self createOrUpdateAccountWithUsername:username authToken:authToken];
+    }
     [self updateAccount:account withUserDetails:remoteUser];
     return account;
 }

--- a/WordPress/Classes/Services/WordPressComSyncService.swift
+++ b/WordPress/Classes/Services/WordPressComSyncService.swift
@@ -17,7 +17,7 @@ class WordPressComSyncService {
     func syncWPCom(authToken: String, isJetpackLogin: Bool, onSuccess: @escaping (WPAccount) -> Void, onFailure: @escaping (Error) -> Void) {
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)
-        accountService.syncAccountDetailsAndCreateAccount(authToken, success: { account in
+        accountService.createOrUpdateAccount(withAuthToken: authToken, success: { account in
             self.syncOrAssociateBlogs(account: account, isJetpackLogin: isJetpackLogin, onSuccess: onSuccess, onFailure: onFailure)
         }, failure: { error in
             onFailure(error)

--- a/WordPress/Classes/Services/WordPressComSyncService.swift
+++ b/WordPress/Classes/Services/WordPressComSyncService.swift
@@ -24,6 +24,14 @@ class WordPressComSyncService {
         })
     }
 
+    /// Syncs or associates blogs for the specified account.
+    ///
+    /// - Parameters:
+    ///   - account: The WPAccount for which to sync/associate blogs.
+    ///   - isJetpackLogin: Whether a Jetpack connected account is being logged into.
+    ///   - onSuccess: Success block
+    ///   - onFailure: Failure block
+    ///
     func syncOrAssociateBlogs(account: WPAccount, isJetpackLogin: Bool, onSuccess: @escaping (WPAccount) -> Void, onFailure: @escaping (Error) -> Void) {
         let context = ContextManager.sharedInstance().mainContext
         let accountService = AccountService(managedObjectContext: context)

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -59,8 +59,7 @@ class EpilogueUserInfoCell: UITableViewCell {
         fullNameLabel.text = userInfo.fullName
         fullNameLabel.fadeInAnimation()
 
-        let username = userInfo.username.characterCount > 0 ? "@\(userInfo.username)" : ""
-        usernameLabel.text = showEmail ? userInfo.email : username
+        usernameLabel.text = showEmail ? userInfo.email : "@\(userInfo.username)"
         usernameLabel.fadeInAnimation()
 
         gravatarAddIcon.isHidden = !allowGravatarUploads

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
@@ -14,7 +14,7 @@ public struct LoginEpilogueUserInfo {
     /// Initializes the EpilogueUserInfo with all of the metadata contained within WPAccount.
     ///
     init(account: WPAccount) {
-        if let name = account.username, UUID(uuidString: name) == nil {
+        if let name = account.username {
             username = name
         }
         if let accountEmail = account.email {


### PR DESCRIPTION
Refs #7886 

This PR addresses "Bug 3" as mentioned by @koke [here](https://github.com/wordpress-mobile/WordPress-iOS/issues/7886#issuecomment-524221031). 

I've reworked the sync logic to sync account details before creating an account and syncing blogs, removing the use-case for the temp user id.  With this change any existing blog should be detected by its username when calling `[AccountService createOrUpdateAccountWithUsername:authToken:]`.

To test:

Scenario A 
- Start logged out. 
- Log in to a wpcom account via magic link or password
- Confirm the log in is successful. 
- Confirm the epilogue shows the correct username and blogs. 
- After logging in confirm that the sites are not duplicated. 

Scenario B
- Start logged out
- Use the self-hosted flow to log in to a self-hosted account that is connected Jetpack connected.
- Go to Stats
- Log in to the connected WPcom account. 
- Confirm the log in is successful. 
- Confirm the epilogue shows the correct username and blogs. 
- After logging in confirm that the sites are not duplicated. 

Scenario C
- Start logged out
- Log into a wpcom account that is NOT connected to Jetpack.
- Add a self-hosted account that is connected to Jetpack via a different wpcom account. 
- Go to Stats for the self-hosted account.
- Log in to the connected WPcom account. 
- Confirm the log in is successful. 
- Confirm the epilogue shows the correct username and blogs. 
- After logging in confirm that the sites are not duplicated. 
- Confirm that the only wpcom blogs shown are the ones belonging to the account that was added first.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

@jklausa could I trouble you with this one?