### PR TITLE
Dark Mode: Webkit view controller

### DIFF
--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -254,7 +254,7 @@ class WebKitViewController: UIViewController {
         guard let toolBar = navigationController?.toolbar else {
             return
         }
-        toolBar.barTintColor = UIColor.white
+        toolBar.barTintColor = .appBar
         fixBarButtonsColorForBoldText(on: toolBar)
     }
 
@@ -266,12 +266,12 @@ class WebKitViewController: UIViewController {
 
     private func fixBarButtonsColorForBoldText(on bar: UIView) {
         if UIAccessibility.isBoldTextEnabled {
-            bar.tintColor = .neutral(.shade20)
+            bar.tintColor = .listIcon
         }
     }
 
     private func styleBarButton(_ button: UIBarButtonItem) {
-        button.tintColor = .neutral(.shade20)
+        button.tintColor = .listIcon
     }
 
     // MARK: Reachability Helpers

--- a/WordPress/Classes/Utility/WebProgressView.swift
+++ b/WordPress/Classes/Utility/WebProgressView.swift
@@ -55,6 +55,7 @@ class WebProgressView: UIProgressView {
 
     private func configure() {
         progressTintColor = .primary
+        backgroundColor = .listBackground
     }
 
     private enum Progress {


### PR DESCRIPTION
Refs #12320. Quick PR to improve the appearance of WebKitViewController in dark mode.

![webkit-1](https://user-images.githubusercontent.com/4780/63767228-f15c1600-c8c4-11e9-85f3-bf114b8f1de2.png)


**To test:**

* You know the drill. Build and run on iOS 13 light and dark mode and iOS 12.
* Check it looks 😎

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
