### PR TITLE
[iOS 13] Fix for WPAnimatedBox 100% CPU usage

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPAnimatedBox.m
+++ b/WordPress/Classes/ViewRelated/Views/WPAnimatedBox.m
@@ -113,7 +113,7 @@ static CGFloat const WPAnimatedBoxYPosPage3 = WPAnimatedBoxAnimationTolerance + 
         [UIView animateWithDuration:0.8 delay:2.0 usingSpringWithDamping:0.8 initialSpringVelocity:0.0 options:UIViewAnimationOptionCurveEaseOut animations:^{
             [weakSelf moveAnimationToFirstFrame];
         } completion:^(BOOL finished) {
-            if (weakSelf.isAnimating) {
+            if (weakSelf.isAnimating && weakSelf.window != nil) {
                 [weakSelf playAnimation];
             }
         }];


### PR DESCRIPTION
This is a quick / hacky fix to prevent an issue where the WPAnimatedBox loading animation was using 100% CPU when not on screen. I _think_ this is only affecting iOS 13.

From my testing it only seemed to occur for StatsInsightsViewController – I think one is created on app launch and hangs around in the background. We need to fix the underlying issue, but this PR should prevent the animation from looping and using CPU.

**To test**

* Build and run on iOS 13
* In the Debug navigator, you should see CPU at ~100%
* Pause the app in the debugger and you should see a stack trace containing WPAnimatedBox. If not, try resuming and pausing again.

<img width="311" alt="Screenshot 2019-08-27 at 13 05 29" src="https://user-images.githubusercontent.com/4780/63769779-86faa400-c8cb-11e9-8e0d-6fbab8d75e78.png">

<img width="306" alt="Screenshot 2019-08-27 at 13 05 20" src="https://user-images.githubusercontent.com/4780/63769769-83671d00-c8cb-11e9-8403-d17a003db8ac.png">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
