### PR TITLE
Updates auth pod to 1.8.0-beta.12 for SIWA fixes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -176,7 +176,7 @@ target 'WordPress' do
     
     pod 'Gridicons', '~> 0.16'
 
-    pod 'WordPressAuthenticator', '~> 1.8.0-beta.10'
+    pod 'WordPressAuthenticator', '~> 1.8.0-beta.12'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'nux-dark-mode'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -211,7 +211,7 @@ PODS:
   - WordPress-Aztec-iOS (1.8.1)
   - WordPress-Editor-iOS (1.8.1):
     - WordPress-Aztec-iOS (= 1.8.1)
-  - WordPressAuthenticator (1.8.0-beta.10):
+  - WordPressAuthenticator (1.8.0-beta.12):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (~> 3.5)
@@ -301,7 +301,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.8.1)
-  - WordPressAuthenticator (~> 1.8.0-beta.10)
+  - WordPressAuthenticator (~> 1.8.0-beta.12)
   - WordPressKit (~> 4.5.0-beta.2)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.7-beta.1)
@@ -487,7 +487,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-Aztec-iOS: 898336652f474b4bf940a80dc0f0172ace39f0c0
   WordPress-Editor-iOS: ca06c5868d1ac68144a4626465b9c1eef1c53e40
-  WordPressAuthenticator: bb13b6c7da6b3b2cdbf76a71ff6dc68cd60dd051
+  WordPressAuthenticator: 0ac3268a4aec56c36e276869915c6f27c7693032
   WordPressKit: 6fb3101e9542398c895517d64ac435d3a4e83e25
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
   WordPressShared: fc1ef47c3dc91237ef225706bb21ea10c9e4388f
@@ -498,6 +498,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: e87e7edfe4bfc8f41fb952404bfe30f0c89a25c4
+PODFILE CHECKSUM: 2814ff5279597bbe34c23871d7d5ec3e424756e0
 
 COCOAPODS: 1.6.1


### PR DESCRIPTION
Fixes #12397 

To test:

Pod has been tested functionally in the source repo; make sure compilation works in Xcode 11 beta 6.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
