### PR TITLE
Blogs: Do not sync while syncing.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -353,6 +353,9 @@ static NSInteger HideSearchMinSites = 3;
         return;
     }
 
+    if (![self.tableView.refreshControl isRefreshing]) {
+        [self.tableView.refreshControl beginRefreshing];
+    }
     self.isSyncing = YES;
     __weak __typeof(self) weakSelf = self;
     void (^completionBlock)(void) = ^() {

--- a/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/BlogListViewController.m
@@ -7,7 +7,6 @@ static NSInteger HideAllMinSites = 10;
 static NSInteger HideAllSitesThreshold = 6;
 static NSTimeInterval HideAllSitesInterval = 2.0;
 static NSInteger HideSearchMinSites = 3;
-static NSTimeInterval AutoSyncInterval = 300;
 
 @interface BlogListViewController () <UIViewControllerRestoration,
                                         UIDataSourceModelAssociation,
@@ -32,7 +31,6 @@ static NSTimeInterval AutoSyncInterval = 300;
 @property (nonatomic) NSInteger hideCount;
 @property (nonatomic) BOOL visible;
 @property (nonatomic) BOOL isSyncing;
-@property (nonatomic, strong) NSDate *lastSyncDate;
 @end
 
 @implementation BlogListViewController
@@ -148,7 +146,7 @@ static NSTimeInterval AutoSyncInterval = 300;
     [self maybeShowNUX];
     [self updateViewsForCurrentSiteCount];
     [self validateBlogDetailsViewController];
-    [self autoSyncBlogs];
+    [self syncBlogs];
     [self setAddSiteBarButtonItem];
     [self updateCurrentBlogSelection];
 }
@@ -340,13 +338,6 @@ static NSTimeInterval AutoSyncInterval = 300;
     }
 }
 
-- (void)autoSyncBlogs
-{
-    if (!self.lastSyncDate || fabs([self.lastSyncDate timeIntervalSinceNow]) > AutoSyncInterval) {
-        [self syncBlogs];
-    }
-}
-
 - (void)syncBlogs
 {
     if (self.isSyncing) {
@@ -385,7 +376,6 @@ static NSTimeInterval AutoSyncInterval = 300;
 - (void)handleSyncEnded
 {
     self.isSyncing = NO;
-    self.lastSyncDate = [NSDate date];
     [self.tableView.refreshControl endRefreshing];
 }
 


### PR DESCRIPTION
Refs #7886 

This PR introduces some new state flags to track when the blog list is syncing, ~and the last time it was synced~.  This addresses Bugs 5 and 7 in #7886 where multiple syncs (and multiple derived contexts) could occur simultaneously, leading to duplicated blogs. 

It would be nice if only a single derived context could exist but I'm not too keen on keeping a reference to a context while syncing (and beyond).  Our pattern thus far is that contexts, like services, would be ephemeral. Open to other ideas tho.

Test Prep: 
- Use Network Link Conditioner to slow requests. 
- Optionally, edit [BlogListViewController viewWillAppear:] to call `autoSyncBlogs` multiple times. 
- ~Optionally adjust the time interval for auto syncs to avoid waiting a full 5 minutes between auto syncs.~
- Add break points where isSyncing is set.

To Test:
Scenario 1:
- Visit the blog list. ~Confirm it auto syncs blogs the first time.~
- Tap to view a blog detail.
- Tap back to the blog list.  ~Confirm that it does not sync blogs when tapping back.~
- ~Wait the time interval for auto syncs.~
- Tap to view a blog detail, then tap back to the blog list. Confirm that blogs are synced.

Scenario 2:
- On the blog list view controller, pull to refresh.  Confirm that blogs sync. 
- Repeat the pull to refresh.  Confirm that a sync occurs and you didn't have to wait for the autosave time interval.

Scenario 3:
- This one is a little tricky.  Confirm that you can not trigger two simultaneous syncs:
- Launch the app and view the blog list. 
- While blogs are syncing try to pull to refresh. 
- Confirm a second sync does not start. 
- Alternatively, you can add a `syncBlogs` call in `viewWillAppear` after the auto sync call, and confirm that a second sync does not start.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Needs Review: @koke, would you mind taking a peek? 