### PR TITLE
[Fix] Author filter issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
@@ -62,6 +62,8 @@ class AuthorFilterViewController: UITableViewController {
         get {
             let height = CGFloat(tableView(self.tableView, numberOfRowsInSection: 0)) * Metrics.rowHeight
             if #available(iOS 13, *) {
+                // Popovers in iOS 13 use safe area. This means the safe area is over the last row.
+                // I need to add the safe area bottom inset to the height.
                 let bottomSafeInset = UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0.0
                 return CGSize(width: Metrics.preferredWidth, height: height + bottomSafeInset)
             }

--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
@@ -45,13 +45,13 @@ class AuthorFilterViewController: UITableViewController {
 
         tableView.rowHeight = Metrics.rowHeight
         tableView.separatorInset = .zero
-        tableView.separatorColor = .neutral(.shade10)
+        tableView.separatorColor = .clear
         tableView.isScrollEnabled = false
         tableView.showsVerticalScrollIndicator = false
         if #available(iOS 13, *) {
             tableView.contentInset = .zero
         } else {
-            tableView.contentInset = UIEdgeInsets(top: -13.0, left: 0, bottom: 0, right: 0)
+            tableView.contentInset = UIEdgeInsets(top: -Metrics.topinset, left: 0, bottom: 0, right: 0)
         }
     }
 
@@ -93,6 +93,7 @@ class AuthorFilterViewController: UITableViewController {
             cell.accessoryType = (filter == currentSelection) ? .checkmark : .none
 
             cell.title = filter.stringValue
+            cell.separatorIsHidden = indexPath.row != 0
         }
 
         return cell
@@ -180,9 +181,22 @@ private class AuthorFilterCell: UITableViewCell {
         return stackView
     }()
 
+    private let separator: UIView = {
+        let separator = UIView()
+        separator.backgroundColor = .divider
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        return separator
+    }()
+
     var title: String = "" {
         didSet {
             titleLabel.text = title
+        }
+    }
+
+    var separatorIsHidden: Bool = false {
+        didSet {
+            separator.isHidden = separatorIsHidden
         }
     }
 
@@ -190,6 +204,7 @@ private class AuthorFilterCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
         addSubview(stackView)
+        addSubview(separator)
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.horizontalPadding),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metrics.horizontalPadding),
@@ -201,6 +216,13 @@ private class AuthorFilterCell: UITableViewCell {
 
         stackView.addArrangedSubview(gravatarImageView)
         stackView.addArrangedSubview(titleLabel)
+
+        NSLayoutConstraint.activate([
+            separator.leadingAnchor.constraint(equalTo: leadingAnchor),
+            separator.trailingAnchor.constraint(equalTo: trailingAnchor),
+            separator.bottomAnchor.constraint(equalTo: bottomAnchor),
+            separator.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth)
+            ])
 
         tintColor = .primary(.shade40)
     }

--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
@@ -39,12 +39,7 @@ class AuthorFilterViewController: UITableViewController {
         self.onSelectionChanged = onSelectionChanged
         self.currentSelection = initialSelection
 
-        var style: UITableView.Style = .plain
-        if #available(iOS 13, *) {
-            style = .grouped
-        }
-
-        super.init(style: style)
+        super.init(style: .grouped)
 
         tableView.register(AuthorFilterCell.self, forCellReuseIdentifier: Identifiers.authorFilterCell)
 
@@ -53,6 +48,11 @@ class AuthorFilterViewController: UITableViewController {
         tableView.separatorColor = .neutral(.shade10)
         tableView.isScrollEnabled = false
         tableView.showsVerticalScrollIndicator = false
+        if #available(iOS 13, *) {
+            tableView.contentInset = .zero
+        } else {
+            tableView.contentInset = UIEdgeInsets(top: -13.0, left: 0, bottom: 0, right: 0)
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -126,21 +126,13 @@ class AuthorFilterViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if #available(iOS 13, *) {
-            return Metrics.topinset
-        }
-        return 0
+        return Metrics.topinset
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        #if XCODE11
-            if #available(iOS 13, *) {
-                let view = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: Metrics.topinset))
-                view.backgroundColor = .listForeground
-                return view
-            }
-        #endif
-        return nil
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: Metrics.topinset))
+        view.backgroundColor = .listForeground
+        return view
     }
 
     // MARK: - Constants

--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
@@ -136,7 +136,7 @@ class AuthorFilterViewController: UITableViewController {
         #if XCODE11
             if #available(iOS 13, *) {
                 let view = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: Metrics.topinset))
-                view.backgroundColor = .secondarySystemGroupedBackground
+                view.backgroundColor = .listForeground
                 return view
             }
         #endif

--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
@@ -48,6 +48,9 @@ class AuthorFilterViewController: UITableViewController {
         tableView.separatorColor = .neutral(.shade10)
         tableView.isScrollEnabled = false
         tableView.showsVerticalScrollIndicator = false
+        if #available(iOS 13, *) {
+            tableView.contentInsetAdjustmentBehavior = .always
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -58,6 +61,10 @@ class AuthorFilterViewController: UITableViewController {
         set {}
         get {
             let height = CGFloat(tableView(self.tableView, numberOfRowsInSection: 0)) * Metrics.rowHeight
+            if #available(iOS 13, *) {
+                let bottomSafeInset = UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0.0
+                return CGSize(width: Metrics.preferredWidth, height: height + bottomSafeInset)
+            }
             return CGSize(width: Metrics.preferredWidth, height: height)
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
@@ -39,7 +39,12 @@ class AuthorFilterViewController: UITableViewController {
         self.onSelectionChanged = onSelectionChanged
         self.currentSelection = initialSelection
 
-        super.init(style: .plain)
+        var style: UITableView.Style = .plain
+        if #available(iOS 13, *) {
+            style = .grouped
+        }
+
+        super.init(style: style)
 
         tableView.register(AuthorFilterCell.self, forCellReuseIdentifier: Identifiers.authorFilterCell)
 
@@ -48,9 +53,6 @@ class AuthorFilterViewController: UITableViewController {
         tableView.separatorColor = .neutral(.shade10)
         tableView.isScrollEnabled = false
         tableView.showsVerticalScrollIndicator = false
-        if #available(iOS 13, *) {
-            tableView.contentInsetAdjustmentBehavior = .always
-        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -61,12 +63,6 @@ class AuthorFilterViewController: UITableViewController {
         set {}
         get {
             let height = CGFloat(tableView(self.tableView, numberOfRowsInSection: 0)) * Metrics.rowHeight
-            if #available(iOS 13, *) {
-                // Popovers in iOS 13 use safe area. This means the safe area is over the last row.
-                // I need to add the safe area bottom inset to the height.
-                let bottomSafeInset = UIApplication.shared.keyWindow?.safeAreaInsets.bottom ?? 0.0
-                return CGSize(width: Metrics.preferredWidth, height: height + bottomSafeInset)
-            }
             return CGSize(width: Metrics.preferredWidth, height: height)
         }
     }
@@ -129,6 +125,24 @@ class AuthorFilterViewController: UITableViewController {
         return UIView()
     }
 
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if #available(iOS 13, *) {
+            return Metrics.topinset
+        }
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        #if XCODE11
+            if #available(iOS 13, *) {
+                let view = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: Metrics.topinset))
+                view.backgroundColor = .secondarySystemGroupedBackground
+                return view
+            }
+        #endif
+        return nil
+    }
+
     // MARK: - Constants
 
     private enum Identifiers {
@@ -138,6 +152,7 @@ class AuthorFilterViewController: UITableViewController {
     private enum Metrics {
         static let rowHeight: CGFloat = 44.0
         static let preferredWidth: CGFloat = 220.0
+        static let topinset: CGFloat = 13.0
     }
 }
 


### PR DESCRIPTION
Fixes #12330 

This PR wants to fix the popover tableview inset while the app is running on iOS 13.
Investigating the problem I found here ([1](https://forums.developer.apple.com/thread/121729) | [2](https://twitter.com/steipete/status/1157666057424912384)) that 
popovers in iOS 13 use safe area. This implies I had to fix the top inset and avoid the bottom safe area over the last row.


## To test:
- Run the App on iOS 13
- Open the Post list and tap on the Author filter
- Make the same test with iOS 12

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
