### PR TITLE
Issues/7886 bug 2

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -282,13 +282,18 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
  */
 - (BOOL)isJetpackAccount:(WPAccount *)account
 {
-    // If an account has multiple blogs, or zero blogs, then it is not an account
-    // that was connected via Jetpack login while another default wpcom account existed.
-    if ([account.blogs count] != 1 ) {
+    if ([account.blogs count] == 0) {
+        // Most likly, this is a blogless account used for the reader or commenting and not Jetpack.
         return NO;
     }
-    Blog *blog = [account.blogs anyObject];
-    return !blog.isHostedAtWPcom;
+
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"SELF.isHostedAtWPcom = true"];
+    NSSet *wpcomBlogs = [account.blogs filteredSetUsingPredicate:predicate];
+    if ([wpcomBlogs count] > 0) {
+        return NO;
+    }
+
+    return YES;
 }
 
 - (WPAccount *)findAccountWithUsername:(NSString *)username

--- a/WordPress/WordPressTest/AccountServiceTests.swift
+++ b/WordPress/WordPressTest/AccountServiceTests.swift
@@ -105,4 +105,38 @@ class AccountServiceTests: XCTestCase {
         XCTAssertEqual(accountService.defaultWordPressComAccount(), account)
     }
 
+    func testRestoreDefaultAccount() {
+        XCTAssertNil(accountService.defaultWordPressComAccount())
+
+        let account = accountService.createOrUpdateAccount(withUsername: "username", authToken: "authtoken")
+        XCTAssertEqual(accountService.defaultWordPressComAccount(), account)
+
+        UserDefaults.standard.removeObject(forKey: "AccountDefaultDotcomUUID")
+
+        XCTAssertEqual(accountService.defaultWordPressComAccount(), account)
+    }
+
+    func testAccountUsedForJetpackIsNotRestored() {
+        XCTAssertNil(accountService.defaultWordPressComAccount())
+
+        let account = accountService.createOrUpdateAccount(withUsername: "username", authToken: "authtoken")
+        XCTAssertEqual(accountService.defaultWordPressComAccount(), account)
+
+        let context = contextManager.mainContext
+        let jetpackAccount = accountService.createOrUpdateAccount(withUsername: "jetpack", authToken: "jetpack")
+        let blog = Blog(context: context)
+        blog.xmlrpc = "http://test.blog/xmlrpc.php"
+        blog.username = "admin"
+        blog.url = "http://test.blog/"
+        blog.isHostedAtWPcom = false
+        blog.account = jetpackAccount
+        contextManager.save(context)
+
+        UserDefaults.standard.removeObject(forKey: "AccountDefaultDotcomUUID")
+        XCTAssertEqual(accountService.defaultWordPressComAccount(), account)
+
+        accountService.removeDefaultWordPressComAccount()
+        XCTAssertNil(accountService.defaultWordPressComAccount())
+    }
+
 }


### PR DESCRIPTION
Refs #7886 

This PR attempts to address Bug 2 as @koke described [here](https://github.com/wordpress-mobile/WordPress-iOS/issues/7886#issuecomment-524221031). Incidentally it should also sort out bug 1.

With these changes, when a call is made to retrieve the default account and the default can not be retrieved, the remaining accounts in the app are examined to find one that is a likely candidate to be the default. Accounts that were added strictly to connect a self-hosed blog to Jetpack, but were not default accounts themselves, are ignored to avoid surprising the user.

These changes leave the edge case where a user was logged in with a Jetpack connected account with a self-hosted site but no wpcom blogs of its own, but this seems pretty fringe (I think?).

To test:
Run AccountServiceTests.  Ensure all pass. 

Scenario 1:
Confirm you can log in to an account, and log back out without errors. No regressions!

Scenario 2:
Be logged in to a WordPress.com account.
Put a break point at the beginning of the app delegate's `willFinishLaunchingWithOptions` method. 
Start the simulator, and when the break point is reached, clear the default account key from user defaults by running the following in the debugger:
`po UserDefaults.standard.removeObject(forKey: "AccountDefaultDotcomUUID")`
Continue execution.  Confirm you are still logged in. 

Scenario 3:
Log in to a WordPress.com account
Add a self-hosted site that is connected to a different WordPress.com account. 
Sign in to Jetpack on that WordPress.com account. 
Switch to the Me tab and log out. 
Confirm that you are actually logged out of the first WP com account and you are not logged in to the Jetpack connected account. 

Scenario 4:
Log in to a WordPress.com account
Add a self-hosted site that is connected to a different WordPress.com account. 
Sign in to Jetpack on that WordPress.com account. 
Repeat the steps in Scenario 2 to clear the key from user defaults. 
Confirm the initial WordPress.com account is restored and not the Jetpack connected account. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

@koke Can I trouble you with another? 