### PR TITLE
Sign in with Apple: Enable SIWA for all non-enterprise builds

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -31,7 +31,7 @@ enum FeatureFlag: Int {
             if BuildConfiguration.current == .a8cBranchTest || BuildConfiguration.current == .a8cPrereleaseTesting {
                 return false
             }
-            return BuildConfiguration.current == .localDeveloper
+            return true
         }
     }
 }


### PR DESCRIPTION
To test:

1. Archive build for release.
2. Verify SIWA is enabled.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
