### PR TITLE
Dark Mode: Fix colors on the ghosts in posts list

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -159,6 +159,22 @@ extension UIColor {
 
     static var textInverted = UIColor(light: .white, dark: .gray(.shade100))
     static var textPlaceholder = neutral(.shade30)
+    static var placeholderElement: UIColor {
+        #if XCODE11
+            if #available(iOS 13, *) {
+                return UIColor(light: .systemGray5, dark: .systemGray4)
+            }
+        #endif
+        return .gray(.shade10)
+    }
+    static var placeholderElementFaded: UIColor {
+        #if XCODE11
+            if #available(iOS 13, *) {
+                return UIColor(light: .systemGray6, dark: .systemGray5)
+            }
+        #endif
+        return .gray(.shade5)
+    }
 
     /// Muriel/iOS navigation color
     static var appBar = UIColor(light: .brand, dark: .gray(.shade100))

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -792,7 +792,10 @@ class AbstractPostListViewController: UIViewController,
             return
         }
 
-        tableView.displayGhostContent(options: ghostOptions)
+        let style = GhostStyle(beatDuration: GhostStyle.Defaults.beatDuration,
+                               beatStartColor: .placeholderElement,
+                               beatEndColor: .placeholderElementFaded)
+        tableView.displayGhostContent(options: ghostOptions, style: style)
         tableView.isScrollEnabled = false
         noResultsViewController.view.isHidden = true
     }

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.swift
@@ -25,6 +25,7 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
     @IBOutlet weak var topPadding: NSLayoutConstraint!
     @IBOutlet weak var contentStackView: UIStackView!
     @IBOutlet weak var ghostStackView: UIStackView!
+    @IBOutlet weak var ghostHolder: UIView!
 
     lazy var imageLoader: ImageLoader = {
         return ImageLoader(imageView: featuredImage, gifStrategy: .mediumGIFs)
@@ -275,6 +276,7 @@ class PostCardCell: UITableViewCell, ConfigurablePostView {
         dateLabel.backgroundColor = .listForeground
         authorLabel.backgroundColor = .listForeground
         separatorLabel.backgroundColor = .listForeground
+        ghostHolder.backgroundColor = .listForeground
     }
 
     private func setupActionBar() {

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
@@ -286,6 +286,7 @@
                 <outlet property="featuredImage" destination="doZ-n4-W7C" id="Jd2-4a-6Zs"/>
                 <outlet property="featuredImageHeight" destination="a2g-RS-Lb9" id="hcy-Ow-AXq"/>
                 <outlet property="featuredImageStackView" destination="qax-CV-9QZ" id="DuA-CB-LTQ"/>
+                <outlet property="ghostHolder" destination="pUW-s6-y3t" id="qNT-rh-KBM"/>
                 <outlet property="ghostStackView" destination="O86-Za-gd3" id="SyQ-1N-CSA"/>
                 <outlet property="moreButton" destination="ud6-kQ-Qkb" id="gGi-Ty-OCg"/>
                 <outlet property="progressView" destination="33v-Uz-9S6" id="Ie3-MT-W3v"/>


### PR DESCRIPTION
Refs #12320

Makes the ghosts in the posts list look much better in dark mode. 

![ghosts-dark-gray-5-4](https://user-images.githubusercontent.com/517257/63894667-0ce91e80-c9a2-11e9-8049-ad7889ae461b.gif)
![ghosts-light-i2](https://user-images.githubusercontent.com/517257/63894668-0d81b500-c9a2-11e9-8755-52227b0238e9.gif)


To test:
- Pay attention to the placeholder cells/ghosts while the posts list is loading
- Check for both big and small cards

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
