### PR TITLE
Hide the "upload failed" message if the user has manually cancelled

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -183,6 +183,10 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 // the next time a internet connection is available.
 @property (nonatomic, assign) BOOL shouldAttemptAutoUpload;
 
+// This property tracks whether a file's attempt to auto-upload was manually cancelled by the user.
+@property (nonatomic, assign, readonly) BOOL wasAutoUploadCancelled;
+
+
 /**
  * Updates the path for the display image by looking at the post content and trying to find an good image to use.
  * If no appropiated image is found the path is set to nil.

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -619,15 +619,14 @@
         self.confirmedChangesHash = currentHash;
         self.confirmedChangesTimestamp = now;
     } else {
-        self.confirmedChangesHash = nil;
-        self.confirmedChangesTimestamp = nil;
+        self.confirmedChangesHash = @"";
+        self.confirmedChangesTimestamp = [NSDate dateWithTimeIntervalSinceReferenceDate:0];
     }
 }
 
 - (BOOL)wasAutoUploadCancelled {
-    return self.confirmedChangesHash == nil
-        && self.confirmedChangesTimestamp == nil
-        && self.isFailed;
+    return [self.confirmedChangesHash isEqualToString:@""]
+    && [self.confirmedChangesTimestamp isEqualToDate:[NSDate dateWithTimeIntervalSinceReferenceDate:0]];
 }
 
 - (void)updatePathForDisplayImageBasedOnContent

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -624,6 +624,12 @@
     }
 }
 
+- (BOOL)wasAutoUploadCancelled {
+    return self.confirmedChangesHash == nil
+        && self.confirmedChangesTimestamp == nil
+        && self.isFailed;
+}
+
 - (void)updatePathForDisplayImageBasedOnContent
 {
     // First lets check the post content for a suitable image

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -39,7 +39,7 @@ class PostCardStatusViewModel: NSObject {
                 return StatusMessages.postWillBePublished
             }
 
-            if didCancelAutoUpload {
+            if post.wasAutoUploadCancelled {
                 return StatusMessages.localChanges
             }
 
@@ -77,7 +77,7 @@ class PostCardStatusViewModel: NSObject {
         }
 
         if post.isFailed {
-            return (canCancelAutoUpload || didCancelAutoUpload) ? .warning : .error
+            return (canCancelAutoUpload || post.wasAutoUploadCancelled) ? .warning : .error
         }
 
         switch status {
@@ -110,10 +110,6 @@ class PostCardStatusViewModel: NSObject {
 
     var canCancelAutoUpload: Bool {
         return autoUploadInteractor.canCancelAutoUpload(of: post)
-    }
-
-    var didCancelAutoUpload: Bool {
-        return post.isFailed && post.wasAutoUploadCancelled
     }
 
     var canPreview: Bool {

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -39,6 +39,10 @@ class PostCardStatusViewModel: NSObject {
                 return StatusMessages.postWillBePublished
             }
 
+            if didCancelAutoUpload {
+                return StatusMessages.localChanges
+            }
+
             return StatusMessages.uploadFailed
         } else if post.remoteStatus == .pushing {
             return NSLocalizedString("Uploading post...", comment: "Message displayed on a post's card when the post has failed to upload")
@@ -73,7 +77,7 @@ class PostCardStatusViewModel: NSObject {
         }
 
         if post.isFailed {
-            return canCancelAutoUpload ? .warning : .error
+            return (canCancelAutoUpload || didCancelAutoUpload) ? .warning : .error
         }
 
         switch status {
@@ -108,6 +112,10 @@ class PostCardStatusViewModel: NSObject {
         return autoUploadInteractor.canCancelAutoUpload(of: post)
     }
 
+    var didCancelAutoUpload: Bool {
+        return post.isFailed && post.wasAutoUploadCancelled
+    }
+
     var canPreview: Bool {
         return !post.isFailed
     }
@@ -127,5 +135,6 @@ class PostCardStatusViewModel: NSObject {
         static let uploadFailed = NSLocalizedString("Upload failed", comment: "Message displayed on a post's card when the post has failed to upload")
         static let postWillBePublished = NSLocalizedString("Post will be published next time your device is online",
                                                            comment: "Message shown in the posts list when a post is scheduled for publishing")
+        static let localChanges = NSLocalizedString("Local changes", comment: "A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog.")
     }
 }

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -82,6 +82,11 @@ class PostBuilder {
         return self
     }
 
+    func cancelledAutoUpload() -> PostBuilder {
+        post.shouldAttemptAutoUpload = false
+        return self
+    }
+
     func build() -> Post {
         return post
     }

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -309,6 +309,23 @@ class PostCardCellTests: XCTestCase {
         }
     }
 
+    func testDoesntShowFailedForCancelledAutoUploads() {
+        // Given
+        let post = PostBuilder()
+            .published()
+            .with(remoteStatus: .failed)
+            .confirmedAutoUpload()
+            .cancelledAutoUpload()
+            .build()
+
+        // When
+        postCell.configure(with: post)
+
+        // Then
+        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.localChanges)
+        XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
+    }
+
     private func postCellFromNib() -> PostCardCell {
         let bundle = Bundle(for: PostCardCell.self)
         guard let postCell = bundle.loadNibNamed("PostCardCell", owner: nil)?.first as? PostCardCell else {

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -454,6 +454,10 @@ class PostTests: XCTestCase {
 
         XCTAssertEqual(post.wasAutoUploadCancelled, false)
 
+        post.shouldAttemptAutoUpload = true
+
+        XCTAssertEqual(post.wasAutoUploadCancelled, false)
+
         post.shouldAttemptAutoUpload = false
 
         XCTAssertEqual(post.wasAutoUploadCancelled, true)

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -448,4 +448,14 @@ class PostTests: XCTestCase {
 
         XCTAssertEqual(post.shouldAttemptAutoUpload, true)
     }
+
+    func testAutoUploadCancellationProperty() {
+        let post = newTestPost()
+
+        XCTAssertEqual(post.wasAutoUploadCancelled, false)
+
+        post.shouldAttemptAutoUpload = false
+
+        XCTAssertEqual(post.wasAutoUploadCancelled, true)
+    }
 }


### PR DESCRIPTION
Fixes #12328
Part of #12240.

We don't to show a "Upload failed" message for those posts, for which users have manually cancelled the auto-retries. This does that!

To test:
1. Go offline
2. Try to publish a post
3. Tap on "Cancel" in the post list
4. Verify it no longer says "Upload failed" in red, but "Local changes" 


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
