### PR TITLE
[Fix] Stats TimeZone delta

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -125,10 +125,15 @@ class StatsDataHelper {
 
     class func currentDateForSite() -> Date {
         let siteTimeZone = SiteStatsInformation.sharedInstance.siteTimeZone ?? .autoupdatingCurrent
-        let delta = TimeInterval(siteTimeZone.secondsFromGMT())
-        return Date().addingTimeInterval(delta)
+        return Date().convert(from: siteTimeZone)
     }
+}
 
+fileprivate extension Date {
+    func convert(from timeZone: TimeZone, to target: TimeZone = TimeZone.current) -> Date {
+        let delta = TimeInterval(timeZone.secondsFromGMT(for: self) - target.secondsFromGMT(for: self))
+        return addingTimeInterval(delta)
+    }
 }
 
 private extension StatsDataHelper {

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -130,7 +130,7 @@ class StatsDataHelper {
 }
 
 fileprivate extension Date {
-    func convert(from timeZone: TimeZone, to target: TimeZone = TimeZone.current) -> Date {
+    func convert(from timeZone: TimeZone, comparedWith target: TimeZone = TimeZone.current) -> Date {
         let delta = TimeInterval(timeZone.secondsFromGMT(for: self) - target.secondsFromGMT(for: self))
         return addingTimeInterval(delta)
     }


### PR DESCRIPTION
Fixes #12348

This PR fixes the delta generated when the site TimeZone is applied to the current date.
The delta represents a Time Interval generated by the difference between the Site and the Local TimeZones. 

**An example:** (The site is 8hrs ahead)
**Device**: UTC-8 (6:30am): current date printed is _2019-08-29 14:18:12 +0000_ (GMT)
**Site**: UTC+0
**Results**: _2019-08-29 22:18:17 +0000_ (GMT)

## To test:
- Run the app and open Stats -> DWMY (Day is fine and quick to load)
- Play with the Site TimeZone and your device TimeZone (I found the bug testing with Site and Device UTC+2)

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
