### PR TITLE
Only publish a post after all media has been uploaded

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -36,7 +36,7 @@ class PostCoordinator: NSObject {
 
         change(post: post, status: .pushing)
 
-        if mediaCoordinator.isUploadingMedia(for: post) {
+        if mediaCoordinator.isUploadingMedia(for: post) || post.hasFailedMedia {
             change(post: post, status: .pushingMedia)
             // Only observe if we're not already
             guard !isObserving(post: post) else {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -44,6 +44,7 @@ extension PostEditor where Self: UIViewController {
             displayHasFailedMediaAlert(then: {
                 // Failed media is removed, try again.
                 // Note: Intentionally not tracking another analytics stat here (no appropriate one exists yet)
+                self.removeFailedMedia()
                 self.publishPost(action: action, dismissWhenDone: dismissWhenDone, analyticsStat: analyticsStat)
             })
             return
@@ -133,7 +134,6 @@ extension PostEditor where Self: UIViewController {
     fileprivate func displayHasFailedMediaAlert(then: @escaping () -> ()) {
         let alertController = UIAlertController(title: FailedMediaRemovalAlert.title, message: FailedMediaRemovalAlert.message, preferredStyle: .alert)
         alertController.addDefaultActionWithTitle(FailedMediaRemovalAlert.acceptTitle) { [weak self] alertAction in
-            self?.removeFailedMedia()
             then()
         }
 


### PR DESCRIPTION
Fixes #12408

To test:

#### Bad connection

1. Use a bad connection (you can use the throttle in Charles proxy or some tool like Network Conditioner)
2. Create a post with some text and publish it
3. Add some images to the post you just published
4. Tap "Update"
5. Close the app before the images were uploaded
6. Open the app
7. Go to the post and tap to edit it
8. Restore your connection and tap "Update"
9. Check that `data-wp_upload_id` is still present or if the path of the images were all replaced for its remote URL

#### Offline

1. Open the app and publish a post
2. Close the app and go offline
3. Edit the post and add an image
4. Go back online and tap "Update"
5. Check that `data-wp_upload_id` is still present or if the path of the images were all replaced for its remote URL

### Additional information

The issue was happening if the posts had all images in a failed state PLUS not being uploaded. If those conditions were satisfied the post was published right away and all core data identifiers were removed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
