### PR TITLE
[Dark Mode]Fix/stats insights white space

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -228,7 +228,7 @@ extension WPStyleGuide {
         static let gridiconSize = CGSize(width: 24, height: 24)
 
         struct PostingActivityColors {
-            static let range1 = UIColor.neutral(.shade5)
+            static let range1 = UIColor(light: .neutral(.shade5), dark: .neutral(.shade10))
             static let range2 = UIColor.primary(.shade5)
             static let range3 = UIColor.primaryLight
             static let range4 = UIColor.primary

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -228,7 +228,7 @@ extension WPStyleGuide {
         static let gridiconSize = CGSize(width: 24, height: 24)
 
         struct PostingActivityColors {
-            static let range1 = UIColor.neutral(.shade10)
+            static let range1 = UIColor.neutral(.shade5)
             static let range2 = UIColor.primary(.shade5)
             static let range3 = UIColor.primaryLight
             static let range4 = UIColor.primary

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
@@ -11,6 +11,8 @@ class PostingActivityCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var topSeparatorLine: UIView!
     @IBOutlet weak var bottomSeparatorLine: UIView!
 
+    @IBOutlet private var viewMoreView: UIView!
+
     private typealias Style = WPStyleGuide.Stats
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
 
@@ -38,6 +40,7 @@ class PostingActivityCell: UITableViewCell, NibLoadable {
 private extension PostingActivityCell {
 
     func applyStyles() {
+        viewMoreView.backgroundColor = .listForeground
         viewMoreLabel.text = NSLocalizedString("View more", comment: "Label for viewing more posting activity.")
         viewMoreLabel.textColor = Style.actionTextColor
         Style.configureCell(self)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,7 +14,7 @@
             <rect key="frame" x="0.0" y="0.0" width="342" height="242"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="342" height="241.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="342" height="242"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="BVC-pc-qhM" userLabel="Months Stack View">
@@ -114,6 +112,7 @@
                 <outlet property="monthsStackView" destination="BVC-pc-qhM" id="IlC-oK-tm8"/>
                 <outlet property="topSeparatorLine" destination="SrM-6z-hC1" id="AGS-zl-lmo"/>
                 <outlet property="viewMoreLabel" destination="D7G-gg-9QM" id="6DH-YF-5A5"/>
+                <outlet property="viewMoreView" destination="A6f-g5-v7s" id="ISO-67-aVn"/>
             </connections>
             <point key="canvasLocation" x="-502.39999999999998" y="63.868065967016499"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
@@ -22,6 +22,7 @@ class PostingActivityDay: UIView, NibLoadable {
         visible = dayData != nil
         active = delegate != nil
         self.delegate = delegate
+        backgroundColor = .clear
         configureButton()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityViewController.swift
@@ -98,10 +98,13 @@ private extension PostingActivityViewController {
 
     func addLegend() {
         let legend = PostingActivityLegend.loadFromNib()
+        legend.backgroundColor = .listBackground
         legendView.addSubview(legend)
     }
 
     func applyStyles() {
+        view.backgroundColor = .listBackground
+        collectionView.backgroundColor = .listBackground
         Style.configureLabelAsPostingDate(dateLabel)
         Style.configureLabelAsPostingCount(postCountLabel)
         Style.configureViewAsSeparator(separatorLine)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityViewController.swift
@@ -98,7 +98,7 @@ private extension PostingActivityViewController {
 
     func addLegend() {
         let legend = PostingActivityLegend.loadFromNib()
-        legend.backgroundColor = .listBackground
+        legend.backgroundColor = .listForeground
         legendView.addSubview(legend)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityViewController.swift
@@ -103,8 +103,8 @@ private extension PostingActivityViewController {
     }
 
     func applyStyles() {
-        view.backgroundColor = .listBackground
-        collectionView.backgroundColor = .listBackground
+        view.backgroundColor = .listForeground
+        collectionView.backgroundColor = .listForeground
         Style.configureLabelAsPostingDate(dateLabel)
         Style.configureLabelAsPostingCount(postCountLabel)
         Style.configureViewAsSeparator(separatorLine)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -40,6 +40,8 @@ class TabbedTotalsCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var itemSubtitleLabel: UILabel!
     @IBOutlet weak var dataSubtitleLabel: UILabel!
 
+    @IBOutlet private var labelsContainer: UIView!
+
     @IBOutlet weak var rowsStackView: UIStackView!
     @IBOutlet weak var bottomSeparatorLine: UIView!
     @IBOutlet weak var noResultsView: UIView!
@@ -155,6 +157,8 @@ private extension TabbedTotalsCell {
 private extension TabbedTotalsCell {
 
     func applyStyles() {
+        totalCountView.backgroundColor = .listForeground
+        labelsContainer.backgroundColor = .listForeground
         Style.configureCell(self)
         Style.configureLabelAsTotalCount(totalCountLabel)
         Style.configureViewAsSeparator(topSeparatorLine)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,11 +14,11 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="199"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="198.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="199"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="BCs-rZ-yvc" userLabel="Content Stack View">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="198.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="199"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0D1-nR-ode" customClass="FilterTabBar" customModule="WordPress">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="46"/>
@@ -30,7 +28,7 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="lNV-f4-WuQ" userLabel="Labels Stack View">
-                                <rect key="frame" x="0.0" y="46" width="320" height="102.5"/>
+                                <rect key="frame" x="0.0" y="46" width="320" height="103"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rbk-YO-aQi" userLabel="Count View">
                                         <rect key="frame" x="0.0" y="0.0" width="320" height="56"/>
@@ -51,16 +49,16 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="10R-ih-Pr7">
-                                        <rect key="frame" x="0.0" y="56" width="320" height="46.5"/>
+                                        <rect key="frame" x="0.0" y="56" width="320" height="47"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ABk-vW-HsC">
-                                                <rect key="frame" x="16" y="7" width="33" height="32.5"/>
+                                                <rect key="frame" x="16" y="7" width="33" height="33"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A1z-Hh-le1">
-                                                <rect key="frame" x="271" y="7" width="33" height="32.5"/>
+                                                <rect key="frame" x="271" y="7" width="33" height="33"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
@@ -79,10 +77,10 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="EG5-87-rU0">
-                                <rect key="frame" x="0.0" y="148.5" width="320" height="50"/>
+                                <rect key="frame" x="0.0" y="149" width="320" height="50"/>
                             </stackView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rq8-nV-ybk">
-                                <rect key="frame" x="0.0" y="198.5" width="320" height="0.0"/>
+                                <rect key="frame" x="0.0" y="199" width="320" height="0.0"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                         </subviews>
@@ -95,7 +93,7 @@
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mrX-mq-7oM" userLabel="Bottom Seperator Line">
-                        <rect key="frame" x="0.0" y="198" width="320" height="0.5"/>
+                        <rect key="frame" x="0.0" y="198.5" width="320" height="0.5"/>
                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0.5" id="QHX-ho-GbS"/>
@@ -121,6 +119,7 @@
                 <outlet property="dataSubtitleLabel" destination="A1z-Hh-le1" id="X6f-Pa-GFA"/>
                 <outlet property="filterTabBar" destination="0D1-nR-ode" id="vHL-h2-cY0"/>
                 <outlet property="itemSubtitleLabel" destination="ABk-vW-HsC" id="BRR-gC-H8q"/>
+                <outlet property="labelsContainer" destination="10R-ih-Pr7" id="wKp-hW-ViQ"/>
                 <outlet property="labelsStackView" destination="lNV-f4-WuQ" id="4Gk-Jp-fLW"/>
                 <outlet property="noResultsView" destination="Rq8-nV-ybk" id="h9y-ph-Bba"/>
                 <outlet property="rowsStackView" destination="EG5-87-rU0" id="pEz-Ra-CwP"/>

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
@@ -43,6 +43,7 @@ class TwoColumnCell: UITableViewCell, NibLoadable {
 private extension TwoColumnCell {
 
     func applyStyles() {
+        viewMoreView.backgroundColor = .listForeground
         viewMoreLabel.text = NSLocalizedString("View more", comment: "Label for viewing more stats.")
         viewMoreLabel.textColor = Style.actionTextColor
         Style.configureCell(self)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
@@ -7,6 +7,7 @@ class PostStatsTitleCell: UITableViewCell, NibLoadable {
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var postTitleLabel: UILabel!
     @IBOutlet weak var bottomSeparatorLine: UIView!
+    @IBOutlet private var labelsView: UIView!
 
     private typealias Style = WPStyleGuide.Stats
     private var postURL: URL?
@@ -26,6 +27,8 @@ private extension PostStatsTitleCell {
 
     func applyStyles() {
         titleLabel.text = NSLocalizedString("Showing stats for:", comment: "Label on Post Stats view indicating which post the stats are for.")
+
+        labelsView.backgroundColor = .listForeground
 
         Style.configureCell(self)
         Style.configureLabelAsPostStatsTitle(titleLabel)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,11 +14,11 @@
             <rect key="frame" x="0.0" y="0.0" width="406" height="70"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="406" height="69.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="406" height="70"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kmu-MC-d7s" userLabel="Labels View">
-                        <rect key="frame" x="16" y="16" width="374" height="37.5"/>
+                        <rect key="frame" x="16" y="16" width="374" height="38"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Showing stats for:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VQc-hL-Bbc">
                                 <rect key="frame" x="0.0" y="0.0" width="374" height="16"/>
@@ -29,7 +27,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="Site Name" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IAo-11-r7k">
-                                <rect key="frame" x="0.0" y="15" width="374" height="22.5"/>
+                                <rect key="frame" x="0.0" y="15" width="374" height="23"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -61,7 +59,7 @@
                         </connections>
                     </button>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dJu-H6-3qo" userLabel="Bottom Separator Line">
-                        <rect key="frame" x="0.0" y="69" width="406" height="0.5"/>
+                        <rect key="frame" x="0.0" y="69.5" width="406" height="0.5"/>
                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0.5" id="y0D-Z6-7PP"/>
@@ -81,6 +79,7 @@
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
                 <outlet property="bottomSeparatorLine" destination="dJu-H6-3qo" id="9aa-at-qTn"/>
+                <outlet property="labelsView" destination="kmu-MC-d7s" id="B8g-Tc-y8R"/>
                 <outlet property="postTitleLabel" destination="IAo-11-r7k" id="Vq3-Qu-ku2"/>
                 <outlet property="titleLabel" destination="VQc-hL-Bbc" id="4KO-Om-16S"/>
             </connections>


### PR DESCRIPTION
Refs. #12320 

This PR fixes some white background in Stats, mostly in Insights Overview and some detail.

![stats-dark-mode-01](https://user-images.githubusercontent.com/912252/63979906-f29e6600-cab1-11e9-991d-dc9173ef6c2d.jpg)
![stats-dark-mode-02](https://user-images.githubusercontent.com/912252/63979907-f29e6600-cab1-11e9-9feb-23b0aff6976f.jpg)

## To test:
- Run the App with Xcode 11 and iOS 13 with Dark Mode enabled
- Select a site with data like `en.blog` site
- Open Stats -> Insights and scroll the whole overview to check if there are still white backgrounds
- Click on View More from the Insights Posting Activities section and check the detail
- From the LPS (or select a post in the Post and Pages section in DWMY) select view more and check the detail.

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
