### PR TITLE
RichContent: Tweaks deinit logic.

### DIFF
--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -298,13 +298,17 @@ extension WPRichContentView: WPTextAttachmentManagerDelegate {
         let contentInformation = ContentInformation(isPrivateOnWPCom: isPrivate, isSelfHostedWithCredentials: false)
         let index = mediaArray.count
         let indexPath = IndexPath(row: index, section: 1)
+        weak var weakImage = image
 
         image.loadImage(from: contentInformation, preferedSize: finalSize, indexPath: indexPath, onSuccess: { [weak self] indexPath in
-            guard let richMedia = self?.mediaArray[indexPath.row] else {
+            guard
+                let richMedia = self?.mediaArray[indexPath.row],
+                let img = weakImage
+            else {
                 return
             }
 
-            richMedia.attachment.maxSize = image.contentSize()
+            richMedia.attachment.maxSize = img.contentSize()
 
             if isUsingTemporaryLayoutDimensions {
                 self?.layoutAttachmentViews()

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -111,10 +111,6 @@ class WPRichContentView: UITextView {
         setupView()
     }
 
-    deinit {
-        mediaArray.forEach { $0.image.clean() }
-    }
-
     /// A convenience method for one-time, common setup that should be done in init.
     ///
     @objc func setupView() {

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextImage.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextImage.swift
@@ -28,6 +28,10 @@ open class WPRichTextImage: UIControl, WPRichTextMediaAttachment {
 
     // MARK: Lifecycle
 
+    deinit {
+        imageView.clean()
+    }
+
     override init(frame: CGRect) {
         imageView = CachedAnimatedImageView(frame: CGRect(x: 0, y: 0, width: frame.width, height: frame.height))
         imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]


### PR DESCRIPTION
Refs #11398 

This PR is an attempt to address the crash in #11398. 

Rather than call `WPRichTextImage.clean` during `WPRichContentView.deinit`, let's call `CachedAnimatedImageView.clean` from `WPRichTextImage.deinit`.  This will avoid the call to `CachedAnimatedImageView.prepareForReuse`, which doesn't make sense during `deinit` and still cancel any inflight session tasks. 

You can see from the comments in the issue that its not clear how the deinit call could be related to the crash, but we might at least be able to rule out a suspect.

To test:
Launch the app and view the Reader. 
Find posts or comments with animated images. 
Confirm there are no regressions and that WPRichTextImage.deinit is called.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

@jleandroperez Would you be game for a quick review of this one? 