### PR TITLE
Fix Scroll Indicator in login epilogue screen

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -123,9 +123,9 @@ extension LoginEpilogueTableViewController {
         return Settings.headerHeight
     }
 
-    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
-    }
+//    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+//        return UITableView.automaticDimension
+//    }
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return UITableView.automaticDimension


### PR DESCRIPTION
Fixes #12162 

I traced this back to heighForRowAt in the LoginEpilogueTableViewController. If that is disabled, the scrollbar works as expected. This causes the side affect of the rows not being the proper height (screenshot below)

Not really sure where to go from here, if this would be setting a different heighForRowAt value, or adjusting the constrains in the storyboard. 

![B87AD15C-E12E-4CB5-97D9-AFDCAA902857](https://user-images.githubusercontent.com/15347255/63988202-a7c82280-caa0-11e9-82a3-ab6083ddbba1.png)