### PR TITLE
Dark mode: Fix NUX sign up epilogue colors

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -176,9 +176,9 @@ target 'WordPress' do
     
     pod 'Gridicons', '~> 0.16'
 
-    pod 'WordPressAuthenticator', '~> 1.8.0-beta.12'
+    # pod 'WordPressAuthenticator', '~> 1.8.0-beta.12'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'nux-dark-mode'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/more-dark-mode'
 
     aztec
     wordpress_ui

--- a/Podfile
+++ b/Podfile
@@ -176,9 +176,9 @@ target 'WordPress' do
     
     pod 'Gridicons', '~> 0.16'
 
-    # pod 'WordPressAuthenticator', '~> 1.8.0-beta.12'
+    pod 'WordPressAuthenticator', '~> 1.8.0-beta.13'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/more-dark-mode'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/more-dark-mode'
 
     aztec
     wordpress_ui

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -301,7 +301,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.8.1)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/more-dark-mode`)
+  - WordPressAuthenticator (~> 1.8.0-beta.13)
   - WordPressKit (~> 4.5.0-beta.2)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.7-beta.1)
@@ -345,6 +345,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -412,9 +413,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
-  WordPressAuthenticator:
-    :branch: fix/more-dark-mode
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.11.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -428,9 +426,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
-  WordPressAuthenticator:
-    :commit: 80d1cd0a0755240aa0d36712c286eb4db0e96963
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -492,7 +487,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-Aztec-iOS: 898336652f474b4bf940a80dc0f0172ace39f0c0
   WordPress-Editor-iOS: ca06c5868d1ac68144a4626465b9c1eef1c53e40
-  WordPressAuthenticator: 6ba8d3ee1de9a6fafb0d11f78bec0b68cd89a8c8
+  WordPressAuthenticator: c3098c453bce76106bc818124b98d5e5299d7fe0
   WordPressKit: 6fb3101e9542398c895517d64ac435d3a4e83e25
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
   WordPressShared: fc1ef47c3dc91237ef225706bb21ea10c9e4388f
@@ -503,6 +498,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 278807e3ebf10b9769416ba8dd5591831273ab45
+PODFILE CHECKSUM: 1b9332269f379da0ccd4c9b4a047f2aaaaa4c057
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -211,7 +211,7 @@ PODS:
   - WordPress-Aztec-iOS (1.8.1)
   - WordPress-Editor-iOS (1.8.1):
     - WordPress-Aztec-iOS (= 1.8.1)
-  - WordPressAuthenticator (1.8.0-beta.12):
+  - WordPressAuthenticator (1.8.0-beta.13):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (~> 3.5)
@@ -301,7 +301,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.8.1)
-  - WordPressAuthenticator (~> 1.8.0-beta.12)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `fix/more-dark-mode`)
   - WordPressKit (~> 4.5.0-beta.2)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.7-beta.1)
@@ -345,7 +345,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -413,6 +412,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
+  WordPressAuthenticator:
+    :branch: fix/more-dark-mode
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.11.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -426,6 +428,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
+  WordPressAuthenticator:
+    :commit: 80d1cd0a0755240aa0d36712c286eb4db0e96963
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -487,7 +492,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-Aztec-iOS: 898336652f474b4bf940a80dc0f0172ace39f0c0
   WordPress-Editor-iOS: ca06c5868d1ac68144a4626465b9c1eef1c53e40
-  WordPressAuthenticator: 0ac3268a4aec56c36e276869915c6f27c7693032
+  WordPressAuthenticator: 6ba8d3ee1de9a6fafb0d11f78bec0b68cd89a8c8
   WordPressKit: 6fb3101e9542398c895517d64ac435d3a4e83e25
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
   WordPressShared: fc1ef47c3dc91237ef225706bb21ea10c9e4388f
@@ -498,6 +503,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 2814ff5279597bbe34c23871d7d5ec3e424756e0
+PODFILE CHECKSUM: 278807e3ebf10b9769416ba8dd5591831273ab45
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -58,6 +58,12 @@ class SignupEpilogueTableViewController: NUXTableViewController, EpilogueUserInf
 
     // MARK: - View
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .listBackground
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
@@ -142,6 +148,14 @@ class SignupEpilogueTableViewController: NUXTableViewController, EpilogueUserInf
         }
 
         return super.tableView(tableView, cellForRowAt: indexPath)
+    }
+
+    override func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        guard cell is EpilogueUserInfoCell else {
+            return
+        }
+
+        cell.contentView.backgroundColor = .listForeground
     }
 
     override func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -32,6 +32,7 @@ class SignupEpilogueViewController: NUXViewController {
         let buttonViewController = NUXButtonViewController.instance()
         buttonViewController.delegate = self
         buttonViewController.setButtonTitles(primary: ButtonTitles.primary, primaryAccessibilityId: ButtonTitles.primaryAccessibilityId)
+        buttonViewController.backgroundColor = WordPressAuthenticator.shared.style.viewControllerBackgroundColor
         return buttonViewController
     }()
 


### PR DESCRIPTION
Fixes #12320. This PR can also be used to verify the changes in https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/124

This PR updates the sign up epilogue to remove white backgrounds:

![Simulator Screen Shot - iPhone Xs - 2019-08-30 at 10 38 26](https://user-images.githubusercontent.com/4780/64014231-8eaf8800-cb19-11e9-969e-0e947e6b4065.png)

**To test:**

* See the WPAuthenticator PR for full testing instructions.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.