### PR TITLE
Reader: Adjust guard statement to check for nil date.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -979,14 +979,18 @@ import WordPressFlux
             return
         }
 
-        guard let post = content.content?.last as? ReaderPost else {
+        guard
+            let posts = content.content,
+            let post = posts.last as? ReaderPost,
+            let sortDate = post.sortDate
+        else {
             DDLogError("Error: Unable to retrieve an existing reader gap marker.")
             return
         }
 
         footerView.showSpinner(true)
 
-        let earlierThan = post.sortDate
+        let earlierThan = sortDate
         let syncContext = ContextManager.sharedInstance().newDerivedContext()
         let service =  ReaderPostService(managedObjectContext: syncContext)
         let offset = content.contentCount


### PR DESCRIPTION
Refs #11389 

This PR is an attempt at resolving #11389 by adjusting a guard statement to check for a nil date--a possible cause of the crash based on the stack trace.

To test:
- Go to the Reader. 
- Scroll to load more. 
- Ensure more posts load (assuming there were more), and there are no regressions in this feature.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

@ctarda could I trouble you for a quick review? 