### PR TITLE
Dark mode: Activity, support activity log, plans

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/Activity.storyboard
+++ b/WordPress/Classes/ViewRelated/Activity/Activity.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,10 +17,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2EY-TD-6V1" userLabel="container view">
-                                <rect key="frame" x="0.0" y="20" width="375" height="357.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="331"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="mSI-6P-kcW">
-                                        <rect key="frame" x="16" y="16" width="343" height="325.5"/>
+                                        <rect key="frame" x="16" y="16" width="343" height="299"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="DDN-1Y-KHk" userLabel="header">
                                                 <rect key="frame" x="0.0" y="0.0" width="343" height="38.5"/>
@@ -72,7 +70,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="jlr-kR-xzq" userLabel="content">
-                                                <rect key="frame" x="0.0" y="68.5" width="343" height="257"/>
+                                                <rect key="frame" x="0.0" y="68.5" width="343" height="230.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZGb-bM-Y2p" customClass="RichTextVIew">
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="20.5"/>
@@ -81,22 +79,22 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3sW-BH-Aq9">
-                                                        <rect key="frame" x="0.0" y="28.5" width="343" height="200"/>
-                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <rect key="frame" x="0.0" y="28.5" width="343" height="176"/>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                     </textView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ASx-wD-w08">
-                                                        <rect key="frame" x="0.0" y="236.5" width="343" height="20.5"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                        <rect key="frame" x="0.0" y="212.5" width="343" height="18"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <color key="textColor" red="0.40000000000000002" green="0.55686274509803924" blue="0.66666666666666663" alpha="1" colorSpace="calibratedRGB"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
                                             </stackView>
                                             <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Ouv-sN-axZ" userLabel="rewind">
-                                                <rect key="frame" x="0.0" y="325.5" width="343" height="44.5"/>
+                                                <rect key="frame" x="0.0" y="299" width="343" height="44.5"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yPg-ua-Eim">
                                                         <rect key="frame" x="0.0" y="0.0" width="343" height="0.5"/>
@@ -123,9 +121,10 @@
                                                 </subviews>
                                             </stackView>
                                         </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     </stackView>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="mSI-6P-kcW" secondAttribute="bottom" constant="16" id="Fha-kb-hYl"/>
                                     <constraint firstAttribute="trailing" secondItem="mSI-6P-kcW" secondAttribute="trailing" constant="16" id="kcr-xl-FGY"/>
@@ -143,6 +142,7 @@
                     </view>
                     <connections>
                         <outlet property="bottomConstaint" destination="Fha-kb-hYl" id="vUN-uA-iaq"/>
+                        <outlet property="containerView" destination="2EY-TD-6V1" id="pkP-dO-mdo"/>
                         <outlet property="contentStackView" destination="jlr-kR-xzq" id="bkc-3M-MDt"/>
                         <outlet property="dateLabel" destination="YIh-B5-5mX" id="k3s-5c-AXy"/>
                         <outlet property="headerStackView" destination="DDN-1Y-KHk" id="FTi-Sr-BFK"/>

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -35,6 +35,7 @@ class ActivityDetailViewController: UIViewController {
     @IBOutlet private var headerStackView: UIStackView!
     @IBOutlet private var rewindStackView: UIStackView!
     @IBOutlet private var contentStackView: UIStackView!
+    @IBOutlet private var containerView: UIView!
 
     @IBOutlet private var bottomConstaint: NSLayoutConstraint!
 
@@ -63,6 +64,10 @@ class ActivityDetailViewController: UIViewController {
         textLabel.textColor = .text
         summaryLabel.textColor = .textSubtle
 
+        roleLabel.textColor = .textSubtle
+        dateLabel.textColor = .textSubtle
+        timeLabel.textColor = .textSubtle
+
         rewindButton.setTitleColor(.primary, for: .normal)
         rewindButton.setTitleColor(.primaryDark, for: .highlighted)
     }
@@ -73,6 +78,7 @@ class ActivityDetailViewController: UIViewController {
         }
 
         view.backgroundColor = .listBackground
+        containerView.backgroundColor = .listForeground
 
         textLabel.isHidden = true
         textView.textContainerInset = .zero

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListSectionHeaderView.swift
@@ -3,6 +3,7 @@ import Foundation
 class ActivityListSectionHeaderView: UITableViewHeaderFooterView {
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var separator: UIView!
+    @IBOutlet weak var backgroundColorView: UIView!
 
     static let height: CGFloat = 40
     static let identifier = "ActivityListSectionHeaderView"
@@ -10,5 +11,8 @@ class ActivityListSectionHeaderView: UITableViewHeaderFooterView {
     override func awakeFromNib() {
         super.awakeFromNib()
         WPStyleGuide.applyBorderStyle(separator)
+        separator.backgroundColor = .divider
+
+        backgroundColorView.backgroundColor = .listBackground
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListSectionHeaderView.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -51,9 +49,11 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <connections>
+                <outlet property="backgroundColorView" destination="L4V-t8-P4G" id="nHv-za-Dom"/>
                 <outlet property="separator" destination="XJm-Vt-ZYG" id="8dL-Hf-kh6"/>
                 <outlet property="titleLabel" destination="rTR-ms-4m0" id="vUB-uB-DAt"/>
             </connections>
+            <point key="canvasLocation" x="139" y="154"/>
         </view>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -26,6 +26,9 @@ open class ActivityTableViewCell: WPTableViewCell {
         summaryLabel.text = activity.summary
         contentLabel.text = activity.text
 
+        summaryLabel.textColor = .text
+        contentLabel.textColor = .textSubtle
+
         iconBackgroundImageView.backgroundColor = Style.getColorByActivityStatus(activity)
         if let iconImage = Style.getIconForActivity(activity) {
             iconImageView.image = iconImage.imageFlippedForRightToLeftLayoutDirection()

--- a/WordPress/Classes/ViewRelated/Activity/WPStyleGuide+Activity.swift
+++ b/WordPress/Classes/ViewRelated/Activity/WPStyleGuide+Activity.swift
@@ -46,7 +46,7 @@ extension WPStyleGuide {
         }
 
         public static func backgroundColor() -> UIColor {
-            return UIColor.white
+            return .listForeground
         }
 
         public static func backgroundDiscardedColor() -> UIColor {

--- a/WordPress/Classes/ViewRelated/Me/ActivityLogDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Me/ActivityLogDetailViewController.m
@@ -33,7 +33,8 @@
     textView.editable = NO;
     textView.text = self.logText;
     textView.font = [WPStyleGuide subtitleFont];
-    textView.backgroundColor = [UIColor whiteColor];
+    textView.textColor = [UIColor murielText];
+    textView.backgroundColor = [UIColor murielListBackground];
     textView.textAlignment = NSTextAlignmentLeft; // Logs aren't RTL friendly
     [self.view addSubview:textView];
     textView.translatesAutoresizingMaskIntoConstraints = NO;

--- a/WordPress/Classes/ViewRelated/Plans/FeatureItemCell.swift
+++ b/WordPress/Classes/ViewRelated/Plans/FeatureItemCell.swift
@@ -26,7 +26,15 @@ class FeatureItemCell: WPTableViewCell {
 
         layoutMargins = UIEdgeInsets.zero
 
-        separator.backgroundColor = .neutral(.shade5)
+        configureAppearance()
+    }
+
+    private func configureAppearance() {
+        separator.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth).isActive = true
+        separator.backgroundColor = .divider
+
+        featureTitleLabel.textColor = .primary
+        featureDescriptionLabel.textColor = .text
     }
 
     override func prepareForReuse() {

--- a/WordPress/Classes/ViewRelated/Plans/FeatureItemRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/FeatureItemRow.swift
@@ -18,8 +18,6 @@ struct FeatureItemRow: ImmuTableRow {
             cell.featureDescriptionLabel?.attributedText = attributedDescriptionText(description, font: featureDescriptionLabel.font)
         }
 
-        cell.featureTitleLabel.textColor = .neutral(.shade70)
-        cell.featureDescriptionLabel.textColor = .neutral(.shade30)
         WPStyleGuide.configureTableViewCell(cell)
     }
 

--- a/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanDetailViewController.swift
@@ -34,6 +34,7 @@ class PlanDetailViewController: UIViewController {
     @IBOutlet weak var planTitleLabel: UILabel!
     @IBOutlet weak var planDescriptionLabel: UILabel!
     @IBOutlet weak var separator: UIView!
+    @IBOutlet weak var headerContainerView: UIView!
 
     fileprivate lazy var currentPlanLabel: UIView = {
         let label = UILabel()
@@ -73,12 +74,19 @@ class PlanDetailViewController: UIViewController {
     }
 
     fileprivate func configureAppearance() {
-        planTitleLabel.textColor = .neutral(.shade70)
-        planDescriptionLabel.textColor = .neutral(.shade30)
+        view.backgroundColor = .basicBackground
+        tableView.backgroundColor = .basicBackground
+
+        planTitleLabel.textColor = .primary
+        planDescriptionLabel.textColor = .text
         dropshadowImageView.backgroundColor = UIColor.white
         configurePlanImageDropshadow()
 
-        separator.backgroundColor = .neutral(.shade5)
+        separator.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth).isActive = true
+        separator.backgroundColor = .divider
+
+        headerView.backgroundColor = .listBackground
+        headerContainerView.backgroundColor = .listBackground
     }
 
     fileprivate func configureTableView() {
@@ -184,6 +192,8 @@ extension PlanDetailViewController: UITableViewDataSource, UITableViewDelegate {
         } else {
             cell.separatorInset = UIEdgeInsets(top: 0, left: separatorInset, bottom: 0, right: separatorInset)
         }
+
+        cell.contentView.backgroundColor = .listForeground
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {

--- a/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
@@ -25,6 +25,7 @@ struct PlanListRow: ImmuTableRow {
         cell.detailTextLabel?.textColor = .neutral(.shade30)
         cell.detailTextLabel?.font = WPFontManager.systemRegularFont(ofSize: 14.0)
         cell.separatorInset = UIEdgeInsets.zero
+        cell.backgroundColor = .listForeground
     }
 
     fileprivate var attributedTitle: NSAttributedString {

--- a/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
+++ b/WordPress/Classes/ViewRelated/Plans/Plans.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina5_5" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,7 +20,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="751" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="DH7-9o-kVF">
-                                <rect key="frame" x="0.0" y="20" width="414" height="716"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <color key="sectionIndexBackgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="rNB-K6-2G7" userLabel="Header View">
@@ -33,7 +31,7 @@
                                             <rect key="frame" x="0.0" y="259" width="414" height="1"/>
                                             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <constraints>
-                                                <constraint firstAttribute="height" constant="1" id="hg2-4K-vsh"/>
+                                                <constraint firstAttribute="height" constant="1" placeholder="YES" id="hg2-4K-vsh"/>
                                             </constraints>
                                         </view>
                                         <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nps-70-EDE" userLabel="Dropshadow Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
@@ -52,7 +50,7 @@
                                                     </constraints>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="WordPress.com Premium" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="isU-1g-ArF" userLabel="Plan Title Label">
-                                                    <rect key="frame" x="0.0" y="72" width="350" height="21"/>
+                                                    <rect key="frame" x="0.0" y="72" width="350" height="20.333333333333329"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                     <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
@@ -91,17 +89,17 @@
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="WordPress.FeatureItemCell" id="zaq-fe-bpz" customClass="FeatureItemCell" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="315.33333333333331" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="315.33333206176758" width="414" height="69"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="zaq-fe-bpz" id="dGV-Jz-XSf">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="69"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="nuR-h6-384">
-                                                    <rect key="frame" x="16" y="16" width="362" height="12"/>
+                                                    <rect key="frame" x="16" y="16" width="362" height="37"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kr8-eT-Qom">
-                                                            <rect key="frame" x="0.0" y="0.0" width="362" height="12"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kr8-eT-Qom">
+                                                            <rect key="frame" x="0.0" y="0.0" width="362" height="20"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="20" placeholder="YES" id="RYI-iO-uJJ"/>
                                                                 <constraint firstAttribute="width" priority="999" constant="505" placeholder="YES" id="TXd-ry-W0z"/>
@@ -110,8 +108,8 @@
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="1000" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3WW-WL-C4o">
-                                                            <rect key="frame" x="0.0" y="12" width="362" height="0.0"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="1000" text="Label" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3WW-WL-C4o">
+                                                            <rect key="frame" x="0.0" y="20" width="362" height="17"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -119,10 +117,10 @@
                                                     </subviews>
                                                 </stackView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4OK-zA-asu" userLabel="Separator">
-                                                    <rect key="frame" x="15" y="43" width="384" height="1"/>
+                                                    <rect key="frame" x="15" y="68" width="384" height="1"/>
                                                     <color key="backgroundColor" red="0.66666668653488159" green="0.66666668653488159" blue="0.66666668653488159" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" constant="1" id="Zq4-kP-be6"/>
+                                                        <constraint firstAttribute="height" constant="1" placeholder="YES" id="Zq4-kP-be6"/>
                                                     </constraints>
                                                 </view>
                                             </subviews>
@@ -164,6 +162,7 @@
                     </view>
                     <connections>
                         <outlet property="dropshadowImageView" destination="nps-70-EDE" id="fyT-av-Rh8"/>
+                        <outlet property="headerContainerView" destination="sWC-Ef-Tro" id="ppF-oW-4IG"/>
                         <outlet property="headerView" destination="rNB-K6-2G7" id="Y7e-0Y-RBY"/>
                         <outlet property="planDescriptionLabel" destination="edq-hC-GnQ" id="8Cy-Z5-E3i"/>
                         <outlet property="planImageView" destination="f6b-b4-ZgP" id="6nb-u6-9DE"/>

--- a/WordPress/Classes/ViewRelated/System/PagedViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/PagedViewController.swift
@@ -6,6 +6,7 @@ class PagedViewController: UIViewController {
     @IBOutlet weak var divider: UIView!
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var pageControl: UIPageControl!
+    @IBOutlet weak var pageControlContainer: UIView!
 
     @objc let viewControllers: [UIViewController]
     @objc var currentIndex: Int = 0 {
@@ -55,10 +56,14 @@ class PagedViewController: UIViewController {
     }
 
     fileprivate func applyWPStyles() {
-        view.backgroundColor = .neutral(.shade5)
-        divider.backgroundColor = .neutral(.shade5)
-        pageControl.currentPageIndicatorTintColor = .neutral(.shade30)
-        pageControl.pageIndicatorTintColor = UIColor.neutral(.shade30).withAlphaComponent(0.5)
+        view.backgroundColor = .listBackground
+        pageControlContainer.backgroundColor = .listBackground
+
+        divider.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth).isActive = true
+        divider.backgroundColor = .divider
+
+        pageControl.currentPageIndicatorTintColor = .listSmallIcon
+        pageControl.pageIndicatorTintColor = UIColor.listSmallIcon.withAlphaComponent(0.5)
     }
 
     fileprivate func addViewControllers() {

--- a/WordPress/Classes/ViewRelated/System/PagedViewController.xib
+++ b/WordPress/Classes/ViewRelated/System/PagedViewController.xib
@@ -1,14 +1,17 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PagedViewController" customModule="WordPress" customModuleProvider="target">
             <connections>
                 <outlet property="divider" destination="DfB-RW-b4e" id="ZGU-T8-tPg"/>
                 <outlet property="pageControl" destination="OD7-ow-FrX" id="LKd-e1-wpI"/>
+                <outlet property="pageControlContainer" destination="BGa-Zn-NkJ" id="VoM-zd-JB5"/>
                 <outlet property="pagedStackView" destination="F8R-PU-KTv" id="ISp-Vo-PkW"/>
                 <outlet property="scrollView" destination="u97-ah-1GZ" id="hbv-B8-wZD"/>
                 <outlet property="view" destination="738-EE-kwR" id="fJz-KN-nQW"/>
@@ -16,17 +19,17 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="738-EE-kwR">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="zq7-WR-Khc">
-                    <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                     <subviews>
                         <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u97-ah-1GZ">
-                            <rect key="frame" x="0.0" y="0.0" width="600" height="540"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="836"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="F8R-PU-KTv">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="540"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="836"/>
                                 </stackView>
                             </subviews>
                             <constraints>
@@ -41,25 +44,25 @@
                             </connections>
                         </scrollView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DfB-RW-b4e">
-                            <rect key="frame" x="0.0" y="540" width="600" height="1"/>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <rect key="frame" x="0.0" y="836" width="414" height="1"/>
+                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="1" id="F6Q-x3-V3d"/>
+                                <constraint firstAttribute="height" constant="1" placeholder="YES" id="F6Q-x3-V3d"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BGa-Zn-NkJ">
-                            <rect key="frame" x="0.0" y="541" width="600" height="59"/>
+                            <rect key="frame" x="0.0" y="837" width="414" height="59"/>
                             <subviews>
                                 <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="3" translatesAutoresizingMaskIntoConstraints="NO" id="OD7-ow-FrX">
-                                    <rect key="frame" x="8" y="8" width="584" height="43"/>
-                                    <color key="pageIndicatorTintColor" red="0.72326811719999995" green="0.869224102" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                    <color key="currentPageIndicatorTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    <rect key="frame" x="8" y="8" width="398" height="9"/>
+                                    <color key="pageIndicatorTintColor" red="0.72326811719999995" green="0.869224102" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    <color key="currentPageIndicatorTintColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                     <connections>
                                         <action selector="pageControlChanged" destination="-1" eventType="valueChanged" id="6G1-q1-JEg"/>
                                     </connections>
                                 </pageControl>
                             </subviews>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstItem="OD7-ow-FrX" firstAttribute="leading" secondItem="BGa-Zn-NkJ" secondAttribute="leadingMargin" id="EaK-83-v6o"/>
                                 <constraint firstAttribute="bottomMargin" secondItem="OD7-ow-FrX" secondAttribute="bottom" id="FOz-Rh-EHk"/>
@@ -71,7 +74,7 @@
                     </subviews>
                 </stackView>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="zq7-WR-Khc" firstAttribute="top" secondItem="738-EE-kwR" secondAttribute="top" id="4UH-Rl-iNO"/>
                 <constraint firstItem="zq7-WR-Khc" firstAttribute="leading" secondItem="738-EE-kwR" secondAttribute="leading" id="EBW-CO-mV7"/>
@@ -79,6 +82,7 @@
                 <constraint firstAttribute="trailing" secondItem="zq7-WR-Khc" secondAttribute="trailing" id="hgv-Jp-E0H"/>
                 <constraint firstItem="F8R-PU-KTv" firstAttribute="width" secondItem="738-EE-kwR" secondAttribute="width" priority="250" placeholder="YES" id="xkT-Vs-oM2"/>
             </constraints>
+            <point key="canvasLocation" x="34" y="54"/>
         </view>
     </objects>
 </document>


### PR DESCRIPTION
Refs #12320. This PR adds fixes for a number of areas:

**My Site > Activity**

Cells and headers now support dark mode

![Simulator Screen Shot - iPhone Xs - 2019-08-30 at 16 29 09](https://user-images.githubusercontent.com/4780/64034439-920d3880-cb46-11e9-8980-66fff3cc56e7.png)

**Help and Support > Activity Logs**

These are now readable.

![Simulator Screen Shot - iPhone Xs - 2019-08-30 at 16 51 52](https://user-images.githubusercontent.com/4780/64034427-8ae62a80-cb46-11e9-95d8-63463cc62164.png)

**Plans**

Plans list and detail now support dark mode

![plans-dark](https://user-images.githubusercontent.com/4780/64034451-9a657380-cb46-11e9-8087-f8596baae9e3.png)

**To test:**

* Build and run on iOS 13 light and dark mode, and iOS 12
* Check the styles of each section listed above.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.