### PR TITLE
Dark mode: today widget

### DIFF
--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -74,10 +74,12 @@ class TodayViewController: UIViewController {
     }
 
     func changeTextColor() {
-        configureMeLabel.textColor = UIColor.black
-        siteNameLabel.textColor = UIColor.black
-        visitorsCountLabel.textColor = UIColor.black
-        viewsCountLabel.textColor = UIColor.black
+        configureMeLabel.textColor = .text
+        siteNameLabel.textColor = .text
+        visitorsCountLabel.textColor = .text
+        viewsCountLabel.textColor = .text
+        visitorsLabel.textColor = .textSubtle
+        viewsLabel.textColor = .textSubtle
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
Refs #12320. This PR updates the text label colors in the today widget for dark mode.

![widgets-dark-mode](https://user-images.githubusercontent.com/4780/64043857-5b8ee800-cb5d-11e9-8b56-b7103b7ffbc7.png)

**To test:**

* Build and run in iOS 13 light and dark mode, and iOS 12
* Check the labels in the today widget are readable

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.