### PR TITLE
Dark Mode: Fix colors for pending comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsTableViewCell.swift
@@ -86,9 +86,18 @@ open class CommentsTableViewCell: WPTableViewCell {
     }
 
     fileprivate func refreshTimestampLabel() {
+        guard let timestamp = timestamp else {
+            return
+        }
         let style               = Style.timestampStyle(isApproved: approved)
-        let unwrappedTimestamp  = timestamp ?? String()
-        timestampLabel?.attributedText = NSAttributedString(string: unwrappedTimestamp, attributes: style)
+        let formattedTimestamp: String
+        if approved {
+            formattedTimestamp = timestamp
+        } else {
+            let pendingLabel = NSLocalizedString("Pending", comment: "Status name for a comment that hasn't yet been approved.")
+            formattedTimestamp = "\(timestamp) · \(pendingLabel)"
+        }
+        timestampLabel?.attributedText = NSAttributedString(string: formattedTimestamp, attributes: style)
     }
 
     fileprivate func refreshBackground() {

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+Comments.swift
@@ -13,50 +13,40 @@ extension WPStyleGuide {
         }
 
         public static func separatorsColor(isApproved approved: Bool) -> UIColor {
-            return approved ? .divider : UIColor(light: .warning(.shade90), dark: .warning(.shade40))
+            return .divider
         }
 
         public static func detailsRegularStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            let color = approved ? .textSubtle : UIColor(light: .warning(.shade90), dark: .warning(.shade40))
-
             return  [.paragraphStyle: titleParagraph,
                      .font: titleRegularFont,
-                     .foregroundColor: color ]
+                     .foregroundColor: UIColor.textSubtle ]
         }
 
         public static func detailsRegularRedStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            let color = approved ? .text : UIColor(light: .error(.shade90), dark: .error(.shade40))
-
             return  [.paragraphStyle: titleParagraph,
                      .font: titleRegularFont,
-                     .foregroundColor: color ]
+                     .foregroundColor: UIColor.text ]
         }
 
         public static func detailsItalicsStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            let color = approved ? .text : UIColor(light: .error(.shade90), dark: .error(.shade40))
-
             return  [.paragraphStyle: titleParagraph,
                      .font: titleItalicsFont,
-                     .foregroundColor: color ]
+                     .foregroundColor: UIColor.text ]
         }
 
         public static func detailsBoldStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            let color = approved ? .text : UIColor(light: .error(.shade90), dark: .error(.shade40))
-
             return  [.paragraphStyle: titleParagraph,
                      .font: titleBoldFont,
-                     .foregroundColor: color ]
+                     .foregroundColor: UIColor.text ]
         }
 
         public static func timestampStyle(isApproved approved: Bool) -> [NSAttributedString.Key: Any] {
-            let color = approved ? .textSubtle : UIColor(light: .warning(.shade90), dark: .warning(.shade40))
-
             return  [.font: timestampFont,
-                     .foregroundColor: color ]
+                     .foregroundColor: UIColor.textSubtle ]
         }
 
         public static func backgroundColor(isApproved approved: Bool) -> UIColor {
-            return approved ? .listForeground : UIColor(light: .warning(.shade0), dark: .warning(.shade100))
+            return approved ? .listForeground : UIColor(light: .warning(.shade0), dark: .warning(.shade90))
         }
 
         public static func timestampImage(isApproved approved: Bool) -> UIImage {


### PR DESCRIPTION
Refs #12320

This improves the look of pending comments in both light and dark modes:

<img width="416" alt="image" src="https://user-images.githubusercontent.com/517257/64043831-40e74f80-cb1a-11e9-99aa-7b99a6be85a8.png">
<img width="417" alt="image" src="https://user-images.githubusercontent.com/517257/64043853-4a70b780-cb1a-11e9-95cc-c12fed87a051.png">


To test:
- View some pending comments
- Ensure the colors match the image above

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
