### PR TITLE
[SIWA] - Add Continue with Apple to Sign Up

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -176,9 +176,9 @@ target 'WordPress' do
     
     pod 'Gridicons', '~> 0.16'
 
-#    pod 'WordPressAuthenticator', '~> 1.8.0-beta.14'
+    pod 'WordPressAuthenticator', '~> 1.8.0-beta.14'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issues/12398-signup-siwa-button'
+#    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issues/12398-signup-siwa-button'
 
     aztec
     wordpress_ui

--- a/Podfile
+++ b/Podfile
@@ -176,9 +176,9 @@ target 'WordPress' do
     
     pod 'Gridicons', '~> 0.16'
 
-    pod 'WordPressAuthenticator', '~> 1.8.0-beta.13'
+#    pod 'WordPressAuthenticator', '~> 1.8.0-beta.14'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'fix/more-dark-mode'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => 'issues/12398-signup-siwa-button'
 
     aztec
     wordpress_ui

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -211,7 +211,7 @@ PODS:
   - WordPress-Aztec-iOS (1.8.1)
   - WordPress-Editor-iOS (1.8.1):
     - WordPress-Aztec-iOS (= 1.8.1)
-  - WordPressAuthenticator (1.8.0-beta.13):
+  - WordPressAuthenticator (1.8.0-beta.14):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
     - CocoaLumberjack (~> 3.5)
@@ -301,7 +301,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.8.1)
-  - WordPressAuthenticator (~> 1.8.0-beta.13)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issues/12398-signup-siwa-button`)
   - WordPressKit (~> 4.5.0-beta.2)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.7-beta.1)
@@ -345,7 +345,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -413,6 +412,9 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
+  WordPressAuthenticator:
+    :branch: issues/12398-signup-siwa-button
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.11.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -426,6 +428,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
+  WordPressAuthenticator:
+    :commit: 34122fa5b31177d20ce3203331355dc2486dd157
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -487,7 +492,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-Aztec-iOS: 898336652f474b4bf940a80dc0f0172ace39f0c0
   WordPress-Editor-iOS: ca06c5868d1ac68144a4626465b9c1eef1c53e40
-  WordPressAuthenticator: c3098c453bce76106bc818124b98d5e5299d7fe0
+  WordPressAuthenticator: b5b65c194489810ff668217a51ea2101ae7bbb2f
   WordPressKit: 6fb3101e9542398c895517d64ac435d3a4e83e25
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
   WordPressShared: fc1ef47c3dc91237ef225706bb21ea10c9e4388f
@@ -498,6 +503,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 1b9332269f379da0ccd4c9b4a047f2aaaaa4c057
+PODFILE CHECKSUM: 2dc3f624e69d1531655db1c443e544ca0d4d5d23
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -301,7 +301,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.8.1)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `issues/12398-signup-siwa-button`)
+  - WordPressAuthenticator (~> 1.8.0-beta.14)
   - WordPressKit (~> 4.5.0-beta.2)
   - WordPressMocks (~> 0.0.5)
   - WordPressShared (~> 1.8.7-beta.1)
@@ -345,6 +345,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
     - WordPressShared
@@ -412,9 +413,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
-  WordPressAuthenticator:
-    :branch: issues/12398-signup-siwa-button
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.11.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -428,9 +426,6 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
-  WordPressAuthenticator:
-    :commit: 34122fa5b31177d20ce3203331355dc2486dd157
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -492,7 +487,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
   WordPress-Aztec-iOS: 898336652f474b4bf940a80dc0f0172ace39f0c0
   WordPress-Editor-iOS: ca06c5868d1ac68144a4626465b9c1eef1c53e40
-  WordPressAuthenticator: b5b65c194489810ff668217a51ea2101ae7bbb2f
+  WordPressAuthenticator: a8c93e9ccc4be4b3593c1319caf0c9e759c489d9
   WordPressKit: 6fb3101e9542398c895517d64ac435d3a4e83e25
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
   WordPressShared: fc1ef47c3dc91237ef225706bb21ea10c9e4388f
@@ -503,6 +498,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 2dc3f624e69d1531655db1c443e544ca0d4d5d23
+PODFILE CHECKSUM: e46aa359e870db2fbc7889998432a0b29c4c8718
 
 COCOAPODS: 1.6.1


### PR DESCRIPTION
Fixes #12398 

This PR implements the changes added in [WordPressAuthenticator-iOS PR](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/125).

The _Continue with Apple_ button is now available in the Sign Up .

![Simulator Screen Shot - iPhone Xs - 2019-09-02 at 11 34 24](https://user-images.githubusercontent.com/912252/64108840-dcc0c780-cd75-11e9-809f-cd7fd37ae31c.png)

I will update the _Podfile_ as soon the WordPressAuthenticator PR will be approved.

## To test:
• Run the App on iOS 13 with Xcode 11
• Logout if you are signed in
• Tap _Sign up for WordPress.com_
• You should see the _Continue with Apple_ button
• Complete the flow testing everything works fine


Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
