### PR TITLE
Makes the remoteStatus change synchronous for media uploads.

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -242,12 +242,12 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
         return;
     }
 
-    [self.managedObjectContext performBlock:^{
+    [self.managedObjectContext performBlockAndWait:^{
         Media *mediaInContext = (Media *)[self.managedObjectContext existingObjectWithID:mediaObjectID error:nil];
         if (mediaInContext) {
             mediaInContext.remoteStatus = MediaRemoteStatusPushing;
             mediaInContext.error = nil;
-            [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+            [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
         }
     }];
     void (^successBlock)(RemoteMedia *media) = ^(RemoteMedia *media) {

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -135,6 +135,23 @@ static ContextManager *_override;
 
 - (void)saveContextAndWait:(NSManagedObjectContext *)context
 {
+    __block NSManagedObjectContext *currentContext = context;
+    
+    while (currentContext.parentContext != nil) {
+        [currentContext performBlockAndWait:^{
+            NSError *error;
+            
+            if (![currentContext save:&error]) {
+                DDLogError(@"Fatal Core Data Error encountered — throwing an exception. Underlying error is:\n %@", error);
+                @throw [NSException exceptionWithName:@"Unresolved Core Data save error"
+                                               reason:[NSString stringWithFormat:@"Unresolved Core Data save error - derived context. Core Data Error Domain: %@, code: %i", error.domain, error.code]
+                                             userInfo:error.userInfo];
+            }
+            
+            currentContext = currentContext.parentContext;
+        }];
+    }
+    
     [context performBlockAndWait:^{
         [self internalSaveContext:context];
     }];


### PR DESCRIPTION
While trying to resolve #12416, I realized that media being uploaded wasn't properly marked as having `remoteStatus == .pushing`.  Upon debugging this issue I realized the problem was that we are setting this status asyncrhonously here:

https://github.com/wordpress-mobile/WordPress-iOS/blob/534556756a7d11efb3e10000aad6860493bc7d6b/WordPress/Classes/Services/MediaService.m#L245-L252

In this PR I change that block to be executed synchronously, as well as the save operation at the end of the block.

## Testing:

Place breakpoint A [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/534556756a7d11efb3e10000aad6860493bc7d6b/WordPress/Classes/Services/MediaService.m#L248).
Place breakpoint B [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/534556756a7d11efb3e10000aad6860493bc7d6b/WordPress/Classes/Services/MediaService.m#L253)

### Test:

1. Launch the editor and insert an image in a post.
2. Breakpoint A should be hit.
3. Do `po mediaInContext.remoteStatus` and make sure the remote status is `MediaRemoteStatusLocal`.
4. Step once, `po mediaInContext.remoteStatus` and make sure it's now `MediaRemoteStatusPushing`.
5. Tap play, breakpoint B should hit.
6. Do `po mediaInContext.remoteStatus` and make sure the remote status is still `MediaRemoteStatusPushing`. - ie: it was synchronously saved

## Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.