### PR TITLE
Revert "Makes the remoteStatus change synchronous for media uploads."

### DIFF
--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -242,12 +242,12 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
         return;
     }
 
-    [self.managedObjectContext performBlockAndWait:^{
+    [self.managedObjectContext performBlock:^{
         Media *mediaInContext = (Media *)[self.managedObjectContext existingObjectWithID:mediaObjectID error:nil];
         if (mediaInContext) {
             mediaInContext.remoteStatus = MediaRemoteStatusPushing;
             mediaInContext.error = nil;
-            [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
+            [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
         }
     }];
     void (^successBlock)(RemoteMedia *media) = ^(RemoteMedia *media) {

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -135,23 +135,6 @@ static ContextManager *_override;
 
 - (void)saveContextAndWait:(NSManagedObjectContext *)context
 {
-    __block NSManagedObjectContext *currentContext = context;
-    
-    while (currentContext.parentContext != nil) {
-        [currentContext performBlockAndWait:^{
-            NSError *error;
-            
-            if (![currentContext save:&error]) {
-                DDLogError(@"Fatal Core Data Error encountered — throwing an exception. Underlying error is:\n %@", error);
-                @throw [NSException exceptionWithName:@"Unresolved Core Data save error"
-                                               reason:[NSString stringWithFormat:@"Unresolved Core Data save error - derived context. Core Data Error Domain: %@, code: %i", error.domain, error.code]
-                                             userInfo:error.userInfo];
-            }
-            
-            currentContext = currentContext.parentContext;
-        }];
-    }
-    
     [context performBlockAndWait:^{
         [self internalSaveContext:context];
     }];


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-iOS#12450 for the time being due to a deadlock found by @leandroalonso.

I'll investigate this further in the original branch.