### PR TITLE
Improved logging of core data save errors

### DIFF
--- a/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
+++ b/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
@@ -60,7 +60,9 @@ extension ContextManager {
         let reason = reasonForError(error)
         DDLogError("Unresolved Core Data save error: \(error)")
         DDLogError("Generating exception with reason:\n\(reason)")
-        let exception = NSException(name: .coreDataSaveException, reason: reason, userInfo: error.userInfo)
+        // Sentry is choking when userInfo is too big and not sending crash reports
+        // For debugging we can still see the userInfo details since we're logging the full error above
+        let exception = NSException(name: .coreDataSaveException, reason: reason, userInfo: nil)
         exception.raise()
     }
 

--- a/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
+++ b/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
@@ -68,7 +68,9 @@ extension ContextManager {
         let exception = NSException(name: exceptionName, reason: reason, userInfo: nil)
         exception.raise()
     }
+}
 
+private extension ContextManager {
     func reasonForError(_ error: NSError) -> String {
         if error.code == NSValidationMultipleErrorsError {
             guard let errors = error.userInfo[NSDetailedErrorsKey] as? [NSError] else {

--- a/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
+++ b/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
@@ -1,0 +1,102 @@
+import CoreData
+
+// Imported from CoreData.CoreDataErrors
+private let coreDataKnownErrorCodes = [
+    NSCoreDataError: "General Core Data error",
+    NSEntityMigrationPolicyError: "Migration failed during processing of the entity migration policy ",
+    NSExternalRecordImportError: "General error encountered while importing external records",
+    NSInferredMappingModelError: "Inferred mapping model creation error",
+    NSManagedObjectConstraintMergeError: "Merge policy failed - unable to complete merging due to multiple conflicting constraint violations",
+    NSManagedObjectConstraintValidationError: "One or more uniqueness constraints were violated",
+    NSManagedObjectContextLockingError: "Can't acquire a lock in a managed object context",
+    NSManagedObjectExternalRelationshipError: "An object being saved has a relationship containing an object from another store",
+    NSManagedObjectMergeError: "Merge policy failed - unable to complete merging",
+    NSManagedObjectReferentialIntegrityError: "Attempt to fire a fault pointing to an object that does not exist (we can see the store, we can't see the object)",
+    NSManagedObjectValidationError: "Generic validation error",
+    NSMigrationCancelledError: "Migration failed due to manual cancellation",
+    NSMigrationConstraintViolationError: "Migration failed due to a violated uniqueness constraint",
+    NSMigrationError: "General migration error",
+    NSMigrationManagerDestinationStoreError: "Migration failed due to a problem with the destination data store",
+    NSMigrationManagerSourceStoreError: "Migration failed due to a problem with the source data store",
+    NSMigrationMissingMappingModelError: "Migration failed due to missing mapping model",
+    NSMigrationMissingSourceModelError: "Migration failed due to missing source data model",
+    NSPersistentHistoryTokenExpiredError: "The history token passed to NSPersistentChangeRequest was invalid",
+    NSPersistentStoreCoordinatorLockingError: "Can't acquire a lock in a persistent store coordinator",
+    NSPersistentStoreIncompatibleSchemaError: "Store returned an error for save operation (database level errors ie missing table, no permissions)",
+    NSPersistentStoreIncompatibleVersionHashError: "Entity version hashes incompatible with data model",
+    NSPersistentStoreIncompleteSaveError: "One or more of the stores returned an error during save (stores/objects that failed will be in userInfo)",
+    NSPersistentStoreInvalidTypeError: "Unknown persistent store type/format/version",
+    NSPersistentStoreOpenError: "An error occurred while attempting to open the persistent store",
+    NSPersistentStoreOperationError: "The persistent store operation failed",
+    NSPersistentStoreSaveConflictsError: "An unresolved merge conflict was encountered during a save.  userInfo has NSPersistentStoreSaveConflictsErrorKey",
+    NSPersistentStoreSaveError: "Unclassified save error - something we depend on returned an error",
+    NSPersistentStoreTimeoutError: "Failed to connect to the persistent store within the specified timeout (see NSPersistentStoreTimeoutOption)",
+    NSPersistentStoreTypeMismatchError: "Returned by persistent store coordinator if a store is accessed that does not match the specified type",
+    NSPersistentStoreUnsupportedRequestTypeError: "An NSPersistentStore subclass was passed an NSPersistentStoreRequest that it did not understand",
+    NSSQLiteError: "General SQLite error ",
+    NSValidationDateTooLateError: "Some date value is too late",
+    NSValidationDateTooSoonError: "Some date value is too soon",
+    NSValidationInvalidDateError: "Some date value fails to match date pattern",
+    NSValidationInvalidURIError: "Some URI value cannot be represented as a string",
+    NSValidationMissingMandatoryPropertyError: "Non-optional property with a nil value",
+    NSValidationMultipleErrorsError: "Generic message for error containing multiple validation errors",
+    NSValidationNumberTooLargeError: "Some numerical value is too large",
+    NSValidationNumberTooSmallError: "Some numerical value is too small",
+    NSValidationRelationshipDeniedDeleteError: "Some relationship with NSDeleteRuleDeny is non-empty",
+    NSValidationRelationshipExceedsMaximumCountError: "Bounded, to-many relationship with too many destination objects",
+    NSValidationRelationshipLacksMinimumCountError: "To-many relationship with too few destination objects",
+    NSValidationStringPatternMatchingError: "Some string value fails to match some pattern",
+    NSValidationStringTooLongError: "Some string value is too long",
+    NSValidationStringTooShortError: "Some string value is too short",
+]
+
+private extension NSExceptionName {
+    static let coreDataSaveException = NSExceptionName("Unresolved Core Data save error")
+}
+
+extension ContextManager {
+    @objc
+    func handleSaveError(_ error: NSError) {
+        let reason = reasonForError(error)
+        DDLogError("Unresolved Core Data save error: \(error)")
+        DDLogError("Generating exception with reason:\n\(reason)")
+        let exception = NSException(name: .coreDataSaveException, reason: reason, userInfo: error.userInfo)
+        exception.raise()
+    }
+
+    func reasonForError(_ error: NSError) -> String {
+        if error.code == NSValidationMultipleErrorsError {
+            guard let errors = error.userInfo[NSDetailedErrorsKey] as? [NSError] else {
+                return "Multiple errors without details"
+            }
+            return reasonForMultipleErrors(errors)
+        } else {
+            return reasonForIndividualError(error)
+        }
+    }
+
+    func reasonForMultipleErrors(_ errors: [NSError]) -> String {
+        return "Multiple errors:\n" + errors.enumerated().map({ (index, error) in
+            return "  \(index + 1): " + reasonForIndividualError(error)
+        }).joined(separator: "\n")
+    }
+
+    func reasonForIndividualError(_ error: NSError) -> String {
+        let entity = entityName(for: error) ?? "null"
+        let property = propertyName(for: error) ?? "null"
+        let message = coreDataKnownErrorCodes[error.code] ?? "Unknown error (domain: \(error.domain) code: \(error.code), \(error.localizedDescription)"
+        return "\(message) on \(entity).\(property)"
+    }
+
+    func entityName(for error: NSError) -> String? {
+        guard let managedObject = error.userInfo[NSValidationObjectErrorKey] as? NSManagedObject else {
+            return nil
+        }
+        return managedObject.entity.name
+    }
+
+    func propertyName(for error: NSError) -> String? {
+        return error.userInfo[NSValidationKeyErrorKey] as? String
+    }
+
+}

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -117,7 +117,7 @@ static ContextManager *_override;
         }
 
         if (![context save:&error]) {
-            [self handleSaveError:error];
+            [self handleSaveError:error inContext:context];
         }
 
         if (completionBlock) {
@@ -302,7 +302,7 @@ static ContextManager *_override;
     }
     
     if ([context hasChanges] && ![context save:&error]) {
-        [self handleSaveError:error];
+        [self handleSaveError:error inContext:context];
     }
 }
 

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -1,6 +1,7 @@
 #import "ContextManager.h"
 #import "ContextManager-Internals.h"
 #import "ALIterativeMigrator.h"
+#import "WordPress-Swift.h"
 @import WordPressShared.WPAnalytics;
 
 // MARK: - Static Variables
@@ -116,10 +117,7 @@ static ContextManager *_override;
         }
 
         if (![context save:&error]) {
-            DDLogError(@"Fatal Core Data Error encountered — throwing an exception. Underlying error is:\n %@", error);
-            @throw [NSException exceptionWithName:@"Unresolved Core Data save error"
-                                           reason:[NSString stringWithFormat:@"Unresolved Core Data save error - derived context. Core Data Error Domain: %@, code: %i", error.domain, error.code]
-                                         userInfo:error.userInfo];
+            [self handleSaveError:error];
         }
 
         if (completionBlock) {
@@ -304,144 +302,7 @@ static ContextManager *_override;
     }
     
     if ([context hasChanges] && ![context save:&error]) {
-        DDLogError(@"Unresolved core data error\n%@:", error);
-
-        // error handling based on https://stackoverflow.com/a/3510918
-        NSArray *errors = nil;
-        NSString *errorName = nil;
-        NSString *reasons = @"Reasons: ";
-        if ([error code] == NSValidationMultipleErrorsError) {
-            errors = [[error userInfo] objectForKey:NSDetailedErrorsKey];
-        } else {
-            errors = [NSArray arrayWithObject:error];
-        }
-
-        if (errors && [errors count] > 0) {
-            for (NSError * error in errors) {
-                NSString *entityName = [[[[error userInfo] objectForKey:@"NSValidationErrorObject"] entity] name];
-                NSString *attributeName = [[error userInfo] objectForKey:@"NSValidationErrorKey"];
-                NSString *msg;
-                switch ([error code]) {
-                        // MARK: general errors
-                    case NSCoreDataError:
-                        msg = @"General Core Data error";
-                        break;
-                    case NSSQLiteError:
-                        msg = @"General SQLite error";
-                        break;
-                    case NSInferredMappingModelError:
-                        msg = @"Inferred mapping model creation error";
-                        break;
-                    case NSExternalRecordImportError:
-                        msg = @"General error encountered while importing external records";
-                        break;
-                    case NSPersistentHistoryTokenExpiredError:
-                        msg = @"The history token passed to NSPersistentChangeRequest was invalid";
-                        break;
-
-                        // MARK: managed object errors
-                    case NSManagedObjectValidationError:
-                        // Note: there are several specific validation errors not handled here since we don't use much (or any) CD validation
-                        msg = @"Generic validation error.";
-                        break;
-                    case NSManagedObjectContextLockingError:
-                        msg = @"Couldn't acquire a lock in a managed object context";
-                        break;
-                    case NSPersistentStoreCoordinatorLockingError:
-                        msg = @"Couldn't acquire a lock in a persistent store coordinator";
-                        break;
-                    case NSManagedObjectReferentialIntegrityError:
-                        msg = @"Attempt to fire a fault pointing to an object that does not exist: %@";
-                        break;
-                    case NSManagedObjectExternalRelationshipError:
-                        msg = @"An object being saved has a relationship containing an object from another store";
-                        break;
-                    case NSManagedObjectMergeError:
-                        msg = @"Unable to complete merging";
-                        break;
-                    case NSManagedObjectConstraintMergeError:
-                        msg = @"Unable to complete merging due to multiple conflicting constraint violations";
-                        break;
-
-                        // MARK: persistent store errors
-                    case NSPersistentStoreInvalidTypeError:
-                        msg = @"Unknown persistent store type/format/version";
-                        break;
-                    case NSPersistentStoreTypeMismatchError:
-                        msg = @"Store was accessed that does not match the specified type";
-                        break;
-                    case NSPersistentStoreIncompatibleSchemaError:
-                        msg = @"Store returned an error for save operation";
-                        break;
-                    case NSPersistentStoreSaveError:
-                        msg = @"Unclassified save error";
-                        break;
-                    case NSPersistentStoreIncompleteSaveError:
-                        msg = @"One or more of the stores returned an error during save";
-                        break;
-                    case NSPersistentStoreSaveConflictsError:
-                        attributeName = [[error userInfo] objectForKey:@"NSPersistentStoreSaveConflictsErrorKey"];
-                        msg = [NSString stringWithFormat:@"An unresolved merge conflict was encountered on '%@'", attributeName];
-                        break;
-                    case NSPersistentStoreOperationError:
-                        msg = @"The persistent store operation failed";
-                        break;
-                    case NSPersistentStoreOpenError:
-                        msg = @"An error occurred while attempting to open the persistent store";
-                        break;
-                    case NSPersistentStoreTimeoutError:
-                        msg = @"Failed to connect to the persistent store within the specified timeout";
-                        break;
-                    case NSPersistentStoreUnsupportedRequestTypeError:
-                        msg = @"An NSPersistentStore subclass was passed an NSPersistentStoreRequest that it did not understand";
-                        break;
-                    case NSPersistentStoreIncompatibleVersionHashError:
-                        msg = @"Entity version hashes incompatible with data model";
-                        break;
-
-                        // MARK: migration errors
-                    case NSMigrationError:
-                        msg = @"General migration error";
-                        break;
-                    case NSMigrationConstraintViolationError:
-                        msg = @"Migration failed due to a violated uniqueness constraint";
-                        break;
-                    case NSMigrationCancelledError:
-                        msg = @"Migration failed due to manual cancellation";
-                        break;
-                    case NSMigrationMissingSourceModelError:
-                        msg = @"Migration failed due to missing source data model";
-                        break;
-                    case NSMigrationMissingMappingModelError:
-                        msg = @"Migration failed due to missing mapping model";
-                        break;
-                    case NSMigrationManagerSourceStoreError:
-                        msg = @"Migration failed due to a problem with the source data store";
-                        break;
-                    case NSMigrationManagerDestinationStoreError:
-                        msg = @"Migration failed due to a problem with the destination data store";
-                        break;
-                    case NSEntityMigrationPolicyError:
-                        msg = @"Migration failed during processing of the entity migration policy";
-                        break;
-
-                    default:
-                        msg = [NSString stringWithFormat:@"Unknown error (code %i).", [error code]];
-                        break;
-                }
-
-                if (errorName == nil) {
-                    errorName = [NSString stringWithFormat:@"Unresolved Core Data save error: %@", msg];
-                    reasons = [reasons stringByAppendingFormat:@"%@\n", (entityName? : @"no entity name provided")];
-                } else {
-                    reasons = [reasons stringByAppendingFormat:@"%@%@%@\n", (entityName?:@""),(entityName?@": ":@""),msg];
-                }
-            }
-        }
-
-        @throw [NSException exceptionWithName:errorName
-                                       reason:reasons
-                                     userInfo:error.userInfo];
+        [self handleSaveError:error];
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1761,6 +1761,7 @@
 		E1E4CE0B1773C59B00430844 /* WPAvatarSource.m in Sources */ = {isa = PBXBuildFile; fileRef = E1E4CE0A1773C59B00430844 /* WPAvatarSource.m */; };
 		E1E4CE0D177439D100430844 /* WPAvatarSourceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = E1E4CE0C177439D100430844 /* WPAvatarSourceTest.m */; };
 		E1E4CE0F1774563F00430844 /* misteryman.jpg in Resources */ = {isa = PBXBuildFile; fileRef = E1E4CE0E1774531500430844 /* misteryman.jpg */; };
+		E1E5EE37231E47A80018E9E3 /* ContextManager+ErrorHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E5EE36231E47A80018E9E3 /* ContextManager+ErrorHandling.swift */; };
 		E1E89C6C1FD80E74006E7A33 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E89C6B1FD80E74006E7A33 /* Plugin.swift */; };
 		E1EBC36F1C118EA500F638E0 /* ImmuTable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EBC36E1C118EA500F638E0 /* ImmuTable.swift */; };
 		E1EBC3731C118ED200F638E0 /* ImmuTableTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EBC3721C118ED200F638E0 /* ImmuTableTest.swift */; };
@@ -4075,6 +4076,7 @@
 		E1E4CE0A1773C59B00430844 /* WPAvatarSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAvatarSource.m; sourceTree = "<group>"; };
 		E1E4CE0C177439D100430844 /* WPAvatarSourceTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPAvatarSourceTest.m; sourceTree = "<group>"; };
 		E1E4CE0E1774531500430844 /* misteryman.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = misteryman.jpg; sourceTree = "<group>"; };
+		E1E5EE36231E47A80018E9E3 /* ContextManager+ErrorHandling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContextManager+ErrorHandling.swift"; sourceTree = "<group>"; };
 		E1E89C6B1FD80E74006E7A33 /* Plugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plugin.swift; sourceTree = "<group>"; };
 		E1E977BC17B0FA9A00AFB867 /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Localizable.strings; sourceTree = "<group>"; };
 		E1EBC36E1C118EA500F638E0 /* ImmuTable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImmuTable.swift; sourceTree = "<group>"; };
@@ -8003,6 +8005,7 @@
 				C545E0A01811B9880020844C /* ContextManager.h */,
 				93EF094B19ED4F1100C89770 /* ContextManager-Internals.h */,
 				C545E0A11811B9880020844C /* ContextManager.m */,
+				E1E5EE36231E47A80018E9E3 /* ContextManager+ErrorHandling.swift */,
 				B5ECA6C91DBAA0020062D7E0 /* CoreDataHelper.swift */,
 			);
 			name = CoreData;
@@ -10511,6 +10514,7 @@
 				E12FE0741FA0CEE000F28710 /* ImmuTable+Optional.swift in Sources */,
 				1A433B1D2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift in Sources */,
 				7EFF208C20EADF68009C4699 /* FormattableCommentContent.swift in Sources */,
+				E1E5EE37231E47A80018E9E3 /* ContextManager+ErrorHandling.swift in Sources */,
 				D8212CBF20AA7B7F008E8AE8 /* ReaderShowAttributionAction.swift in Sources */,
 				C58349C51806F95100B64089 /* IOS7CorrectedTextView.m in Sources */,
 				FFABD800213423F1003C65B6 /* LinkSettingsViewController.swift in Sources */,


### PR DESCRIPTION
See #12338

In #12208 we added some extra information to the errors generated when saving Core Data failed. This improved things a bit but it hasn't been enough to debug the recent surge in Core Data crashes.

First, the first PR was missing some important error codes, wrongly assuming that we weren't using much of Core Data validation. Perhaps we aren't doing a good job at it, but we have plenty of [properties that are non-optional](https://gist.github.com/koke/3622bd216354030e93b5fc6abfb492f3).

Second, the new error handling was only added to the save method for the main context. Saving derived context would still generate errors without any extra detail. More than two thirds of the latest 1,000 crashes happened on a derived context.

The new error handling added information about the entity where the validation failed, but not the attribute. And it would not handle multiple validation errors too well.

## Before

Derived context:

```
Unresolved Core Data save error
Unresolved Core Data save error - derived context. Core Data Error Domain: NSCocoaErrorDomain, code: 1560
```

Main context:

```
Unresolved Core Data save error: Unknown error (code 1570).
Reasons: Post
Post: Unknown error (code 1570).
```

## After

Single error:

```
Unresolved Core Data save error
Non-optional property with a nil value on Blog.url
```

Multiple errors:

```
Unresolved Core Data save error
Multiple errors:
  1: Non-optional property with a nil value on Blog.blogID
  2: Non-optional property with a nil value on Blog.url
  3: Non-optional property with a nil value on Blog.xmlrpc
```

To test:

What I did to test this was to provoke some validation errors. In my case, at the end of `-[BlogService updateBlog:withRemoteBlog:]` I added this:

```objc
[blog setValue:nil forKey:@"url"];
[blog setValue:nil forKey:@"xmlrpc"];
[blog setValue:nil forKey:@"blogID"];
```

Keep in mind that the crashes won't get sent to Sentry on debug builds, so I had to tweak `CrashLogging.shouldSendEvent(_:)` to return `true`. And even then, the crash doesn't seem to register when the debugger is running, so you'd need to:

1. Build & run
2. Stop the app
3. Launch the app from the home screen (no debugger)
4. Make it crash
5. Launch the app again so the crash gets uploaded

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
