### PR TITLE
[Dark Mode] Fix text color in Aztec - HTML text view

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -31,7 +31,9 @@ def aztec
     ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'b8c53761b89a092ac690a90f1d33bd800a9025a6'
     ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag => '1.5.0.beta.1'
     ## pod 'WordPress-Aztec-iOS', :path => '../AztecEditor-iOS'
-    pod 'WordPress-Editor-iOS', '~> 1.8.1'
+#    pod 'WordPress-Editor-iOS', '~> 1.8.1'
+  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :branch => 'feature/expose-editor-html-storage'
+  pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :branch => 'feature/expose-editor-html-storage'
 end
 
 def wordpress_ui

--- a/Podfile
+++ b/Podfile
@@ -31,9 +31,7 @@ def aztec
     ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :commit => 'b8c53761b89a092ac690a90f1d33bd800a9025a6'
     ## pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :tag => '1.5.0.beta.1'
     ## pod 'WordPress-Aztec-iOS', :path => '../AztecEditor-iOS'
-#    pod 'WordPress-Editor-iOS', '~> 1.8.1'
-  pod 'WordPress-Aztec-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :branch => 'feature/expose-editor-html-storage'
-  pod 'WordPress-Editor-iOS', :git => 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', :branch => 'feature/expose-editor-html-storage'
+    pod 'WordPress-Editor-iOS', '~> 1.9.0-beta.1'
 end
 
 def wordpress_ui

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - Alamofire (4.7.3)
   - AlamofireNetworkActivityIndicator (2.3.0):
     - Alamofire (~> 4.7)
-  - Automattic-Tracks-iOS (0.4.0):
+  - Automattic-Tracks-iOS (0.4.1):
     - CocoaLumberjack (~> 3.5.2)
     - Reachability (~> 3.1)
     - Sentry (~> 4)
@@ -31,7 +31,7 @@ PODS:
     - FormatterKit/Resources
   - FSInteractiveMap (0.1.0)
   - Gifu (3.2.0)
-  - GiphyCoreSDK (1.4.2)
+  - GiphyCoreSDK (1.4.3)
   - glog (0.3.5)
   - GoogleSignIn (4.4.0):
     - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
@@ -45,7 +45,7 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.2.1)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.1)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.1)"
-  - Gridicons (0.18)
+  - Gridicons (0.19)
   - GTMSessionFetcher/Core (1.2.2)
   - Gutenberg (1.11.0):
     - React (= 0.60.0-patched)
@@ -208,9 +208,9 @@ PODS:
   - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPress-Aztec-iOS (1.8.1)
-  - WordPress-Editor-iOS (1.8.1):
-    - WordPress-Aztec-iOS (= 1.8.1)
+  - WordPress-Aztec-iOS (1.9.0)
+  - WordPress-Editor-iOS (1.9.0):
+    - WordPress-Aztec-iOS (= 1.9.0)
   - WordPressAuthenticator (1.8.0-beta.14):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
@@ -300,7 +300,8 @@ DEPENDENCIES:
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
-  - WordPress-Editor-iOS (~> 1.8.1)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, branch `feature/expose-editor-html-storage`)
+  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, branch `feature/expose-editor-html-storage`)
   - WordPressAuthenticator (~> 1.8.0-beta.14)
   - WordPressKit (~> 4.5.0-beta.2)
   - WordPressMocks (~> 0.0.5)
@@ -343,8 +344,6 @@ SPEC REPOS:
     - Starscream
     - SVProgressHUD
     - UIDeviceIdentifier
-    - WordPress-Aztec-iOS
-    - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
@@ -413,6 +412,12 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
+  WordPress-Aztec-iOS:
+    :branch: feature/expose-editor-html-storage
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPress-Editor-iOS:
+    :branch: feature/expose-editor-html-storage
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.11.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -426,12 +431,18 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
+  WordPress-Aztec-iOS:
+    :commit: 23ec5ed57dfe9e98f238eccc2f8bde1cfabf21f4
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPress-Editor-iOS:
+    :commit: 23ec5ed57dfe9e98f238eccc2f8bde1cfabf21f4
+    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
   AlamofireNetworkActivityIndicator: 18346ff6d770d9513d0ac6f2d99706f40f93dbaa
-  Automattic-Tracks-iOS: f7a8284999a5ce2f4e768717d86a640a32f43b7c
+  Automattic-Tracks-iOS: a176848be4c95aa208184fe96d0322594ce230eb
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   Charts: f69cf0518b6d1d62608ca504248f1bbe0b6ae77e
   CocoaLumberjack: 118bf4a820efc641f79fa487b75ed928dccfae23
@@ -441,11 +452,11 @@ SPEC CHECKSUMS:
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 7bcb6427457d85e0b4dff5a84ec5947ac19a93ea
-  GiphyCoreSDK: 1a89e03e55dc6b636b9d40fde76107867dbb9da5
+  GiphyCoreSDK: 354d60d3e1ea11050fb4fed272e0e4dd7d1eb48d
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   GoogleSignIn: 7ff245e1a7b26d379099d3243a562f5747e23d39
   GoogleToolboxForMac: b3553629623a3b1bff17f555e736cd5a6d95ad55
-  Gridicons: 04261236382e9c62c62c9a104f2f532c1bdf6a78
+  Gridicons: dc92efbe5fd60111d2e8ea051d84a60cca552abc
   GTMSessionFetcher: 61bb0f61a4cb560030f1222021178008a5727a23
   Gutenberg: ae0fd5394c3de8677b5d8e9517237600962d0d63
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
@@ -485,8 +496,8 @@ SPEC CHECKSUMS:
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPress-Aztec-iOS: 898336652f474b4bf940a80dc0f0172ace39f0c0
-  WordPress-Editor-iOS: ca06c5868d1ac68144a4626465b9c1eef1c53e40
+  WordPress-Aztec-iOS: e58c7ab55b0bae53418a705876093fed314b6586
+  WordPress-Editor-iOS: 36114a1e155b0696939dba80989652c185e91e01
   WordPressAuthenticator: a8c93e9ccc4be4b3593c1319caf0c9e759c489d9
   WordPressKit: 6fb3101e9542398c895517d64ac435d3a4e83e25
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
@@ -498,6 +509,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: 481a2429d49ca44dea18b73c06e42432827c6b43
+PODFILE CHECKSUM: f15e344d3dd4265fa087cf0c021d38b960664b4a
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - Alamofire (4.7.3)
   - AlamofireNetworkActivityIndicator (2.3.0):
     - Alamofire (~> 4.7)
-  - Automattic-Tracks-iOS (0.4.1):
+  - Automattic-Tracks-iOS (0.4.0):
     - CocoaLumberjack (~> 3.5.2)
     - Reachability (~> 3.1)
     - Sentry (~> 4)
@@ -31,7 +31,7 @@ PODS:
     - FormatterKit/Resources
   - FSInteractiveMap (0.1.0)
   - Gifu (3.2.0)
-  - GiphyCoreSDK (1.4.3)
+  - GiphyCoreSDK (1.4.2)
   - glog (0.3.5)
   - GoogleSignIn (4.4.0):
     - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
@@ -45,7 +45,7 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.2.1)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.1)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.1)"
-  - Gridicons (0.19)
+  - Gridicons (0.18)
   - GTMSessionFetcher/Core (1.2.2)
   - Gutenberg (1.11.0):
     - React (= 0.60.0-patched)
@@ -208,9 +208,9 @@ PODS:
   - Starscream (3.0.6)
   - SVProgressHUD (2.2.5)
   - UIDeviceIdentifier (1.1.4)
-  - WordPress-Aztec-iOS (1.9.0)
-  - WordPress-Editor-iOS (1.9.0):
-    - WordPress-Aztec-iOS (= 1.9.0)
+  - WordPress-Aztec-iOS (1.9.0-beta.1)
+  - WordPress-Editor-iOS (1.9.0-beta.1):
+    - WordPress-Aztec-iOS (= 1.9.0-beta.1)
   - WordPressAuthenticator (1.8.0-beta.14):
     - 1PasswordExtension (= 1.8.5)
     - Alamofire (= 4.7.3)
@@ -300,8 +300,7 @@ DEPENDENCIES:
   - SimulatorStatusMagic
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, branch `feature/expose-editor-html-storage`)
-  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, branch `feature/expose-editor-html-storage`)
+  - WordPress-Editor-iOS (~> 1.9.0-beta.1)
   - WordPressAuthenticator (~> 1.8.0-beta.14)
   - WordPressKit (~> 4.5.0-beta.2)
   - WordPressMocks (~> 0.0.5)
@@ -344,6 +343,8 @@ SPEC REPOS:
     - Starscream
     - SVProgressHUD
     - UIDeviceIdentifier
+    - WordPress-Aztec-iOS
+    - WordPress-Editor-iOS
     - WordPressAuthenticator
     - WordPressKit
     - WordPressMocks
@@ -412,12 +413,6 @@ EXTERNAL SOURCES:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
-  WordPress-Aztec-iOS:
-    :branch: feature/expose-editor-html-storage
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WordPress-Editor-iOS:
-    :branch: feature/expose-editor-html-storage
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.11.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
 
@@ -431,18 +426,12 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
-  WordPress-Aztec-iOS:
-    :commit: 23ec5ed57dfe9e98f238eccc2f8bde1cfabf21f4
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
-  WordPress-Editor-iOS:
-    :commit: 23ec5ed57dfe9e98f238eccc2f8bde1cfabf21f4
-    :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
   AlamofireNetworkActivityIndicator: 18346ff6d770d9513d0ac6f2d99706f40f93dbaa
-  Automattic-Tracks-iOS: a176848be4c95aa208184fe96d0322594ce230eb
+  Automattic-Tracks-iOS: f7a8284999a5ce2f4e768717d86a640a32f43b7c
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   Charts: f69cf0518b6d1d62608ca504248f1bbe0b6ae77e
   CocoaLumberjack: 118bf4a820efc641f79fa487b75ed928dccfae23
@@ -452,11 +441,11 @@ SPEC CHECKSUMS:
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 7bcb6427457d85e0b4dff5a84ec5947ac19a93ea
-  GiphyCoreSDK: 354d60d3e1ea11050fb4fed272e0e4dd7d1eb48d
+  GiphyCoreSDK: 1a89e03e55dc6b636b9d40fde76107867dbb9da5
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   GoogleSignIn: 7ff245e1a7b26d379099d3243a562f5747e23d39
   GoogleToolboxForMac: b3553629623a3b1bff17f555e736cd5a6d95ad55
-  Gridicons: dc92efbe5fd60111d2e8ea051d84a60cca552abc
+  Gridicons: 04261236382e9c62c62c9a104f2f532c1bdf6a78
   GTMSessionFetcher: 61bb0f61a4cb560030f1222021178008a5727a23
   Gutenberg: ae0fd5394c3de8677b5d8e9517237600962d0d63
   HockeySDK: 15afe6bc0a5bfe3a531fd73dbf082095f37dac3b
@@ -496,8 +485,8 @@ SPEC CHECKSUMS:
   Starscream: ef3ece99d765eeccb67de105bfa143f929026cf5
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPress-Aztec-iOS: e58c7ab55b0bae53418a705876093fed314b6586
-  WordPress-Editor-iOS: 36114a1e155b0696939dba80989652c185e91e01
+  WordPress-Aztec-iOS: eda39d0091d3d51ccdec439385d836d44d823dfe
+  WordPress-Editor-iOS: 3d91fdba72fb0461bb77607618ad189456766ccd
   WordPressAuthenticator: a8c93e9ccc4be4b3593c1319caf0c9e759c489d9
   WordPressKit: 6fb3101e9542398c895517d64ac435d3a4e83e25
   WordPressMocks: d8088f718439556ff3856d5881aef581740cd26a
@@ -509,6 +498,6 @@ SPEC CHECKSUMS:
   ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: f15e344d3dd4265fa087cf0c021d38b960664b4a
+PODFILE CHECKSUM: a8ce6f84860d973073a04237d88cf98ed4633136
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -111,6 +111,7 @@ class AztecPostViewController: UIViewController, PostEditor {
             defaultMissingImage: Assets.defaultMissingImage)
 
         editorView.clipsToBounds = false
+        editorView.htmlStorage.textColor = .text
         setupHTMLTextView(editorView.htmlTextView)
         setupRichTextView(editorView.richTextView)
 
@@ -542,18 +543,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         configureMediaProgressView(in: navigationController.navigationBar)
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        #if XCODE11
-            if #available(iOS 13, *) {
-                if previousTraitCollection?.hasDifferentColorAppearance(comparedTo: traitCollection) == true {
-                    refreshTextViewTextColor()
-                }
-            }
-        #endif
-    }
-
 
     // MARK: - Title and Title placeholder position methods
 
@@ -781,10 +770,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         } else {
             navigationItem.leftBarButtonItems = navigationBarManager.leftBarButtonItems
         }
-    }
-
-    func refreshTextViewTextColor() {
-        htmlTextView.textColor = .text
     }
 
     func setHTML(_ html: String) {
@@ -1903,12 +1888,6 @@ extension AztecPostViewController {
         if editorView.editingMode == .richText {
             processMediaAttachments()
         }
-
-        #if XCODE11
-        if #available(iOS 13, *) {
-            refreshTextViewTextColor()
-        }
-        #endif
     }
 
     func toggleHeader(fromItem item: FormatBarItem) {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1904,7 +1904,11 @@ extension AztecPostViewController {
             processMediaAttachments()
         }
 
-        refreshTextViewTextColor()
+        #if XCODE11
+        if #available(iOS 13, *) {
+            refreshTextViewTextColor()
+        }
+        #endif
     }
 
     func toggleHeader(fromItem item: FormatBarItem) {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -542,6 +542,18 @@ class AztecPostViewController: UIViewController, PostEditor {
         configureMediaProgressView(in: navigationController.navigationBar)
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        #if XCODE11
+            if #available(iOS 13, *) {
+                if previousTraitCollection?.hasDifferentColorAppearance(comparedTo: traitCollection) == true {
+                    refreshTextViewTextColor()
+                }
+            }
+        #endif
+    }
+
 
     // MARK: - Title and Title placeholder position methods
 
@@ -769,6 +781,10 @@ class AztecPostViewController: UIViewController, PostEditor {
         } else {
             navigationItem.leftBarButtonItems = navigationBarManager.leftBarButtonItems
         }
+    }
+
+    func refreshTextViewTextColor() {
+        htmlTextView.textColor = .text
     }
 
     func setHTML(_ html: String) {
@@ -1887,6 +1903,8 @@ extension AztecPostViewController {
         if editorView.editingMode == .richText {
             processMediaAttachments()
         }
+
+        refreshTextViewTextColor()
     }
 
     func toggleHeader(fromItem item: FormatBarItem) {


### PR DESCRIPTION
Refs. #12320 

This PR set the color to the HTML textView in the Aztec editor.

![aztec-editor-dark-mode](https://user-images.githubusercontent.com/912252/64260139-4382e400-cf22-11e9-8153-b3b37b9e0e1d.jpg)

I'll update the Podfile as soon [Aztec #1209](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1209) will be merged

Adding also @mattmiklic to set the right colors used for the comments and the tags.

## To test:
• Run the branch with Xcode 11 and iOS 13
• Edit a post and switch between _visual_ and _HTML_ mode
• Check the html text color is not black in Dark Mode
• Run it on iOS 12 to check everything works fine

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
