### PR TITLE
[Dark Mode] Fix colors in Share Extension

### DIFF
--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -36,11 +36,10 @@ class MainShareViewController: UIViewController {
 private extension MainShareViewController {
     func setupAppearance() {
         let navigationBarAppearace = UINavigationBar.appearance()
-        navigationBarAppearace.barTintColor = .listBackground
-        navigationBarAppearace.barStyle = .default
-        navigationBarAppearace.tintColor = .primary
-        navigationBarAppearace.titleTextAttributes = [.foregroundColor: UIColor.primary]
         navigationBarAppearace.isTranslucent = false
+        navigationBarAppearace.tintColor = .white
+        navigationBarAppearace.barTintColor = .appBar
+        navigationBarAppearace.barStyle = .default
     }
 
     func loadAndPresentNavigationVC() {

--- a/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
@@ -56,7 +56,10 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
         textView.formattingDelegate = self
         textView.textAttachmentDelegate = self
         textView.backgroundColor = ShareColors.aztecBackground
+        textView.textColor = .text
         textView.tintColor = ShareColors.aztecCursorColor
+        textView.blockquoteBackgroundColor = UIColor(light: textView.blockquoteBackgroundColor, dark: .neutral(.shade5))
+        textView.blockquoteBorderColor = .listIcon
         textView.linkTextAttributes = linkAttributes
         textView.textAlignment = .natural
 
@@ -86,7 +89,7 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
         let titleParagraphStyle = NSMutableParagraphStyle()
         titleParagraphStyle.alignment = .natural
 
-        let attributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.darkText,
+        let attributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.text,
                                                         .font: ShareFonts.title,
                                                         .paragraphStyle: titleParagraphStyle]
 
@@ -96,7 +99,7 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
         textView.delegate = self
         textView.font = ShareFonts.title
         textView.returnKeyType = .next
-        textView.textColor = UIColor.darkText
+        textView.textColor = .text
         textView.typingAttributes = attributes
         textView.translatesAutoresizingMaskIntoConstraints = false
         textView.textAlignment = .natural
@@ -356,7 +359,7 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
 
     func configureView() {
         edgesForExtendedLayout = UIRectEdge()
-        view.backgroundColor = .white
+        view.backgroundColor = .basicBackground
     }
 
     func configureSubviews() {
@@ -460,6 +463,7 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
     func createToolbar() -> Aztec.FormatBar {
         let toolbar = Aztec.FormatBar()
 
+        toolbar.backgroundColor = .filterBarBackground
         toolbar.tintColor = ShareColors.aztecFormatBarInactiveColor
         toolbar.highlightedTintColor = ShareColors.aztecFormatBarActiveColor
         toolbar.selectedTintColor = ShareColors.aztecFormatBarActiveColor
@@ -1276,19 +1280,19 @@ fileprivate extension ShareExtensionEditorViewController {
     }
 
     struct ShareColors {
-        static let title                          = UIColor.neutral(.shade30)
-        static let separator                      = UIColor.neutral(.shade5)
-        static let placeholder                    = UIColor.neutral(.shade30)
+        static let title                          = UIColor.text
+        static let separator                      = UIColor.divider
+        static let placeholder                    = UIColor.textPlaceholder
         static let mediaProgressOverlay           = UIColor.neutral(.shade70).withAlphaComponent(CGFloat(0.6))
         static let mediaOverlayBorderColor        = UIColor.primary
-        static let aztecBackground                = UIColor.clear
-        static let aztecLinkColor                 = UIColor.primary(.shade40)
+        static let aztecBackground                = UIColor.basicBackground
+        static let aztecLinkColor                 = UIColor.primary
         static let aztecFormatBarDisabledColor    = UIColor.neutral(.shade10)
-        static let aztecFormatBarDividerColor     = UIColor.neutral(.shade5)
+        static let aztecFormatBarDividerColor     = UIColor.divider
         static let aztecCursorColor               = UIColor.primary
-        static let aztecFormatBarBackgroundColor  = UIColor.white
-        static let aztecFormatBarInactiveColor    = UIColor(hexString: "7B9AB1")
-        static let aztecFormatBarActiveColor      = UIColor(hexString: "11181D")
+        static let aztecFormatBarBackgroundColor  = UIColor.basicBackground
+        static let aztecFormatBarInactiveColor    = UIColor.toolbarInactive
+        static let aztecFormatBarActiveColor      = UIColor.primary
 
         static var aztecFormatPickerSelectedCellBackgroundColor: UIColor {
             get {

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -197,6 +197,8 @@ class ShareModularViewController: ShareExtensionAbstractViewController {
         // Style!
         WPStyleGuide.configureColors(view: view, tableView: sitesTableView)
         WPStyleGuide.configureAutomaticHeightRows(for: sitesTableView)
+
+        sitesTableView.separatorColor = .divider
     }
 
     override func updateViewConstraints() {

--- a/WordPress/WordPressShareExtension/ShareTagsPickerViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareTagsPickerViewController.swift
@@ -117,7 +117,7 @@ class ShareTagsPickerViewController: UIViewController {
         textView.isScrollEnabled = false
         textView.textContainer.lineFragmentPadding = 0
         textView.textContainerInset = UIEdgeInsets(top: Constants.textViewTopBottomInset, left: 0, bottom: Constants.textViewTopBottomInset, right: 0)
-        textViewContainer.backgroundColor = UIColor.white
+        textViewContainer.backgroundColor = UIColor(light: .white, dark: .listBackground)
         textViewContainer.layer.masksToBounds = false
     }
 

--- a/WordPress/WordPressShareExtension/WPStyleGuide+Share.swift
+++ b/WordPress/WordPressShareExtension/WPStyleGuide+Share.swift
@@ -17,7 +17,7 @@ extension WPStyleGuide {
             cell.detailTextLabel?.sizeToFit()
             cell.detailTextLabel?.textColor = .textSubtle
 
-            cell.backgroundColor = UIColor.white
+            cell.backgroundColor = .listForeground
             cell.separatorInset = UIEdgeInsets.zero
         }
 
@@ -27,7 +27,7 @@ extension WPStyleGuide {
             cell.textLabel?.textColor = .text
             cell.textLabel?.numberOfLines = 0
 
-            cell.backgroundColor = UIColor.white
+            cell.backgroundColor = .listForeground
             cell.separatorInset = UIEdgeInsets.zero
             cell.tintColor = .primary
         }
@@ -37,7 +37,7 @@ extension WPStyleGuide {
             cell.textLabel?.sizeToFit()
             cell.textLabel?.textColor = .text
 
-            cell.backgroundColor = UIColor.white
+            cell.backgroundColor = .listForeground
             cell.separatorInset = UIEdgeInsets.zero
         }
 
@@ -67,14 +67,14 @@ extension WPStyleGuide {
 
             cell.detailTextLabel?.font = subtitleFont()
             cell.detailTextLabel?.sizeToFit()
-            cell.detailTextLabel?.textColor = greyDarken10()
+            cell.detailTextLabel?.textColor = .textSubtle
             cell.detailTextLabel?.numberOfLines = 0
 
             cell.imageView?.layer.borderColor = UIColor.white.cgColor
             cell.imageView?.layer.borderWidth = 1
-            cell.imageView?.tintColor = greyLighten10()
+            cell.imageView?.tintColor = .neutral(.shade30)
 
-            cell.backgroundColor = UIColor.white
+            cell.backgroundColor = .listForeground
             cell.tintColor = .primary
         }
     }


### PR DESCRIPTION
Refs. #12320 

This PR fixes the colors in the Share Extension. 

![share-extension-dark-mode-01](https://user-images.githubusercontent.com/912252/64271524-5d79f200-cf35-11e9-9878-78068e391266.jpg)
![share-extension-dark-mode-02](https://user-images.githubusercontent.com/912252/64271525-5e128880-cf35-11e9-87a2-6f323fd4bc12.jpg)
![share-extension-dark-mode-03](https://user-images.githubusercontent.com/912252/64271526-5e128880-cf35-11e9-98f5-a8e3c6f9e325.jpg)

## To test:
• Run the branch with Xcode 11 and iOS 13
• Open a Post preview and try to share it selecting WordPress as option
• Check the colors in Light/Dark mode
• Run it on iOS 12 to check everything works fine

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
