### PR TITLE
Automatically upload published and draft posts

### DIFF
--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -26,8 +26,7 @@ final class PostAutoUploadInteractor {
     func autoUploadAction(for post: AbstractPost) -> AutoUploadAction {
         guard post.isFailed,
             let status = post.status,
-            PostAutoUploadInteractor.allowedStatuses.contains(status),
-            !post.hasRemote() else {
+            PostAutoUploadInteractor.allowedStatuses.contains(status) else {
                 return .nothing
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -71,9 +71,9 @@ class PostCardStatusViewModel: NSObject {
 
             switch postStatus {
             case .draft:
-                return canCancelAutoUpload ? StatusMessages.draftWillBeUploaded : StatusMessages.localChanges
+                return canCancelAutoUpload ? StatusMessages.changesWillBeUploaded : StatusMessages.draftWillBeUploaded
             case .publish:
-                return StatusMessages.postWillBePublished
+                return post.hasRemote() ? StatusMessages.changesWillBeUploaded : StatusMessages.postWillBePublished
             default:
                 return defaultFailedMessage
             }
@@ -240,5 +240,7 @@ class PostCardStatusViewModel: NSObject {
         static let localChanges = NSLocalizedString("Local changes", comment: "A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog.")
         static let draftWillBeUploaded = NSLocalizedString("Draft will be uploaded next time your device is online",
                                                            comment: "Message shown in post list when a draft is scheduled to be automatically uploaded.")
+        static let changesWillBeUploaded = NSLocalizedString("Changes will be uploaded next time your device is online",
+                                                             comment: "Message shown in post list when a post's local changes will be automatically uploaded when the device is online.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -68,12 +68,15 @@ class PostCardStatusViewModel: NSObject {
             if autoUploadInteractor.autoUploadAction(for: post) != .upload {
                 return defaultFailedMessage
             }
+            if post.hasRemote() {
+                return StatusMessages.changesWillBeUploaded
+            }
 
             switch postStatus {
             case .draft:
-                return canCancelAutoUpload ? StatusMessages.changesWillBeUploaded : StatusMessages.draftWillBeUploaded
+                return StatusMessages.draftWillBeUploaded
             case .publish:
-                return post.hasRemote() ? StatusMessages.changesWillBeUploaded : StatusMessages.postWillBePublished
+                return StatusMessages.postWillBePublished
             default:
                 return defaultFailedMessage
             }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -71,7 +71,7 @@ class PostCardStatusViewModel: NSObject {
 
             switch postStatus {
             case .draft:
-                return StatusMessages.draftWillBeUploaded
+                return canCancelAutoUpload ? StatusMessages.draftWillBeUploaded : StatusMessages.localChanges
             case .publish:
                 return StatusMessages.postWillBePublished
             default:

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -213,11 +213,9 @@ class PostCardStatusViewModel: NSObject {
     ///
     /// This is a helper method for `status`.
     private func generateFailedStatusMessage() -> String {
-        assert(post.remoteStatus == .failed, "This should only be used if the remoteStatus is .failed")
-
         let defaultFailedMessage = StatusMessages.uploadFailed
 
-        guard post.remoteStatus == .failed, let postStatus = post.status else {
+        guard post.isFailed, let postStatus = post.status else {
             return defaultFailedMessage
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -56,30 +56,7 @@ class PostCardStatusViewModel: NSObject {
         if MediaCoordinator.shared.isUploadingMedia(for: post) {
             return NSLocalizedString("Uploading media...", comment: "Message displayed on a post's card while the post is uploading media")
         } else if post.isFailed {
-            let defaultFailedMessage = StatusMessages.uploadFailed
-            guard let postStatus = post.status else {
-                return defaultFailedMessage
-            }
-
-            if post.wasAutoUploadCancelled {
-                return StatusMessages.localChanges
-            }
-
-            if autoUploadInteractor.autoUploadAction(for: post) != .upload {
-                return defaultFailedMessage
-            }
-            if post.hasRemote() {
-                return StatusMessages.changesWillBeUploaded
-            }
-
-            switch postStatus {
-            case .draft:
-                return StatusMessages.draftWillBeUploaded
-            case .publish:
-                return StatusMessages.postWillBePublished
-            default:
-                return defaultFailedMessage
-            }
+            return generateFailedStatusMessage()
         } else if post.remoteStatus == .pushing {
             return NSLocalizedString("Uploading post...", comment: "Message displayed on a post's card when the post has failed to upload")
         } else {
@@ -230,6 +207,39 @@ class PostCardStatusViewModel: NSObject {
         let status = self.status ?? ""
 
         return [status, sticky].filter { !$0.isEmpty }.joined(separator: separator)
+    }
+
+    /// Determine what the failed status message should be and return it.
+    ///
+    /// This is a helper method for `status`.
+    private func generateFailedStatusMessage() -> String {
+        assert(post.remoteStatus == .failed, "This should only be used if the remoteStatus is .failed")
+
+        let defaultFailedMessage = StatusMessages.uploadFailed
+
+        guard post.remoteStatus == .failed, let postStatus = post.status else {
+            return defaultFailedMessage
+        }
+
+        if post.wasAutoUploadCancelled {
+            return StatusMessages.localChanges
+        }
+
+        if autoUploadInteractor.autoUploadAction(for: post) != .upload {
+            return defaultFailedMessage
+        }
+        if post.hasRemote() {
+            return StatusMessages.changesWillBeUploaded
+        }
+
+        switch postStatus {
+        case .draft:
+            return StatusMessages.draftWillBeUploaded
+        case .publish:
+            return StatusMessages.postWillBePublished
+        default:
+            return defaultFailedMessage
+        }
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -105,14 +105,28 @@ struct PostNoticeViewModel {
     }
 
     private var failureTitle: String {
-        if post.status == .publish {
-            return FailureTitles.postWillBePublished
+        var defaultTitle: String {
+            if post is Page {
+                return FailureTitles.pageFailedToUpload
+            } else {
+                return FailureTitles.postFailedToUpload
+            }
         }
 
-        if post is Page {
-            return FailureTitles.pageFailedToUpload
-        } else {
-            return FailureTitles.postFailedToUpload
+        guard let postStatus = post.status,
+            autoUploadInteractor.autoUploadAction(for: post) == .upload,
+            autoUploadInteractor.canCancelAutoUpload(of: post) else {
+                
+            return defaultTitle
+        }
+
+        switch postStatus {
+        case .draft:
+            return FailureTitles.draftWillBeUploaded
+        case .publish:
+            return FailureTitles.postWillBePublished
+        default:
+            return defaultTitle
         }
     }
 
@@ -246,6 +260,8 @@ struct PostNoticeViewModel {
     enum FailureTitles {
         static let postWillBePublished = NSLocalizedString("Post will be published the next time your device is online",
                                                            comment: "Text displayed in notice after a post if published while offline.")
+        static let draftWillBeUploaded = NSLocalizedString("Draft will be uploaded next time your device is online",
+                                                           comment: "Text displayed in notice after the app fails to upload a draft.")
         static let pageFailedToUpload = NSLocalizedString("Page failed to upload",
                                                           comment: "Title of notification displayed when a page has failed to upload.")
         static let postFailedToUpload = NSLocalizedString("Post failed to upload",

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -114,10 +114,12 @@ struct PostNoticeViewModel {
         }
 
         guard let postStatus = post.status,
-            autoUploadInteractor.autoUploadAction(for: post) == .upload,
-            autoUploadInteractor.canCancelAutoUpload(of: post) else {
-                
+            autoUploadInteractor.autoUploadAction(for: post) == .upload else {
             return defaultTitle
+        }
+
+        if post.hasRemote() {
+            return FailureTitles.changesWillBeUploaded
         }
 
         switch postStatus {
@@ -266,6 +268,8 @@ struct PostNoticeViewModel {
                                                           comment: "Title of notification displayed when a page has failed to upload.")
         static let postFailedToUpload = NSLocalizedString("Post failed to upload",
                                                           comment: "Title of notification displayed when a post has failed to upload.")
+        static let changesWillBeUploaded = NSLocalizedString("Changes will be uploaded next time your device is online",
+                                                             comment: "Text displayed in notice after the app fails to upload a post.")
     }
 
     enum FailureActionTitles {

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -104,16 +104,15 @@ struct PostNoticeViewModel {
         }
     }
 
-    // TODO Move strings to FailureTitles enum
     private var failureTitle: String {
         if post.status == .publish {
             return FailureTitles.postWillBePublished
         }
 
         if post is Page {
-            return NSLocalizedString("Page failed to upload", comment: "Title of notification displayed when a page has failed to upload.")
+            return FailureTitles.pageFailedToUpload
         } else {
-            return NSLocalizedString("Post failed to upload", comment: "Title of notification displayed when a post has failed to upload.")
+            return FailureTitles.postFailedToUpload
         }
     }
 
@@ -247,6 +246,10 @@ struct PostNoticeViewModel {
     enum FailureTitles {
         static let postWillBePublished = NSLocalizedString("Post will be published the next time your device is online",
                                                            comment: "Text displayed in notice after a post if published while offline.")
+        static let pageFailedToUpload = NSLocalizedString("Page failed to upload",
+                                                          comment: "Title of notification displayed when a page has failed to upload.")
+        static let postFailedToUpload = NSLocalizedString("Post failed to upload",
+                                                          comment: "Title of notification displayed when a post has failed to upload.")
     }
 
     enum FailureActionTitles {

--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -7,6 +7,7 @@ enum PostNoticeUserInfoKey {
 struct PostNoticeViewModel {
     private let post: AbstractPost
     private let postCoordinator: PostCoordinator
+    private let autoUploadInteractor = PostAutoUploadInteractor()
 
     init(post: AbstractPost, postCoordinator: PostCoordinator = PostCoordinator.shared) {
         self.post = post
@@ -201,8 +202,7 @@ struct PostNoticeViewModel {
     }
 
     private var failureAction: FailureAction {
-        let interactor = PostAutoUploadInteractor()
-        return interactor.canCancelAutoUpload(of: post) ? .cancel : .retry
+        return autoUploadInteractor.canCancelAutoUpload(of: post) ? .cancel : .retry
     }
 
     // MARK: - Action Handlers

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -42,6 +42,11 @@ class PostBuilder {
         return self
     }
 
+    func with(status: BasePost.Status) -> PostBuilder {
+        post.status = status
+        return self
+    }
+
     func with(title: String) -> PostBuilder {
         post.postTitle = title
         return self

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -264,21 +264,28 @@ class PostCardCellTests: XCTestCase {
         XCTAssertFalse(postCell.separatorLabel.isHidden)
     }
 
-    func testShowsWarningMessageForFailedPublishedPosts() {
-        // Arrange
-        let posts = [
-            PostBuilder().published().with(remoteStatus: .failed).confirmedAutoUpload().build(),
-            PostBuilder().published().with(remoteStatus: .failed).withRemote().confirmedAutoUpload().build(),
-        ]
+    func testShowsChangesWillBeUploadedWarningForFailedPublishedPostsWithRemote() {
+        // Given
+        let post = PostBuilder(context).published().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
-        posts.forEach { post in
-            // Act
-            postCell.configure(with: post)
+        // When
+        postCell.configure(with: post)
 
-            // Assert
-            XCTAssertEqual(postCell.statusLabel.text, StatusMessages.postWillBePublished)
-            XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
-        }
+        // Then
+        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.changesWillBeUploaded)
+        XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
+    }
+
+    func testShowsPostWillBePublishedWarningForLocallyPublishedPosts() {
+        // Given
+        let post = PostBuilder(context).published().with(remoteStatus: .failed).confirmedAutoUpload().build()
+
+        // When
+        postCell.configure(with: post)
+
+        // Then
+        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.postWillBePublished)
+        XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
     func testShowsCancelButtonForUserConfirmedFailedPublishedPosts() {
@@ -332,7 +339,7 @@ class PostCardCellTests: XCTestCase {
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
-    func testShowsWillBeUploadedMessageForDraftsWithRemote() {
+    func testShowsChangesWillBeUploadedMessageForDraftsWithRemote() {
         // Given
         let post = PostBuilder(context).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
@@ -340,11 +347,11 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.draftWillBeUploaded)
+        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.changesWillBeUploaded)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
-    func testShowsLocalChangesMessageForLocalDrafts() {
+    func testShowsDraftWillBeUploadedMessageForLocalDrafts() {
         // Given
         let post = PostBuilder(context).drafted().with(remoteStatus: .failed).build()
 
@@ -352,7 +359,7 @@ class PostCardCellTests: XCTestCase {
         postCell.configure(with: post)
 
         // Then
-        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.localChanges)
+        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.draftWillBeUploaded)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -332,21 +332,28 @@ class PostCardCellTests: XCTestCase {
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
-    func testShowsWillBeUploadedMessageForDrafts() {
-        // Arrange
-        let posts = [
-            PostBuilder(context).drafted().with(remoteStatus: .failed).confirmedAutoUpload().build(),
-            PostBuilder(context).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build()
-        ]
+    func testShowsWillBeUploadedMessageForDraftsWithRemote() {
+        // Given
+        let post = PostBuilder(context).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
-        posts.forEach { post in
-            // Act
-            postCell.configure(with: post)
+        // When
+        postCell.configure(with: post)
 
-            // Assert
-            XCTAssertEqual(postCell.statusLabel.text, StatusMessages.draftWillBeUploaded)
-            XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
-        }
+        // Then
+        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.draftWillBeUploaded)
+        XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
+    }
+
+    func testShowsLocalChangesMessageForLocalDrafts() {
+        // Given
+        let post = PostBuilder(context).drafted().with(remoteStatus: .failed).build()
+
+        // When
+        postCell.configure(with: post)
+
+        // Then
+        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.localChanges)
+        XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
     }
 
     private func postCellFromNib() -> PostCardCell {

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -14,6 +14,7 @@ class PostCardCellTests: XCTestCase {
     private var postActionSheetDelegateMock: PostActionSheetDelegateMock!
 
     override func setUp() {
+        super.setUp()
         contextManager = TestContextManager()
         context = contextManager.newDerivedContext()
 
@@ -264,15 +265,20 @@ class PostCardCellTests: XCTestCase {
     }
 
     func testShowsWarningMessageForFailedPublishedPosts() {
-        // Given
-        let post = PostBuilder().published().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        // Arrange
+        let posts = [
+            PostBuilder().published().with(remoteStatus: .failed).confirmedAutoUpload().build(),
+            PostBuilder().published().with(remoteStatus: .failed).withRemote().confirmedAutoUpload().build(),
+        ]
 
-        // When
-        postCell.configure(with: post)
+        posts.forEach { post in
+            // Act
+            postCell.configure(with: post)
 
-        // Then
-        XCTAssertEqual(postCell.statusLabel.text, StatusMessages.postWillBePublished)
-        XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
+            // Assert
+            XCTAssertEqual(postCell.statusLabel.text, StatusMessages.postWillBePublished)
+            XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
+        }
     }
 
     func testShowsCancelButtonForUserConfirmedFailedPublishedPosts() {
@@ -324,6 +330,23 @@ class PostCardCellTests: XCTestCase {
         // Then
         XCTAssertEqual(postCell.statusLabel.text, StatusMessages.localChanges)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
+    }
+
+    func testShowsWillBeUploadedMessageForDrafts() {
+        // Arrange
+        let posts = [
+            PostBuilder(context).drafted().with(remoteStatus: .failed).confirmedAutoUpload().build(),
+            PostBuilder(context).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        ]
+
+        posts.forEach { post in
+            // Act
+            postCell.configure(with: post)
+
+            // Assert
+            XCTAssertEqual(postCell.statusLabel.text, StatusMessages.draftWillBeUploaded)
+            XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
+        }
     }
 
     private func postCellFromNib() -> PostCardCell {

--- a/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
+++ b/WordPress/WordPressTest/Services/PostAutoUploadInteractorTests.swift
@@ -31,10 +31,12 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
             createPost(.publish, confirmedAutoUpload: true): .upload,
             // Published local drafts with no confirmation will be remote auto-saved
             createPost(.publish): .autoSave,
-            // Draft and published posts with remote are currently unsupported. This will be
-            // fixed soon.
-            createPost(.draft, hasRemote: true): .nothing,
-            createPost(.publish, hasRemote: true): .nothing,
+            // Posts with remote that do not have confirmation will be remote auto-saved
+            createPost(.draft, hasRemote: true): .autoSave,
+            createPost(.publish, hasRemote: true): .autoSave,
+            // Posts with remote that have confirmation will be automatically uploaded
+            createPost(.draft, hasRemote: true, confirmedAutoUpload: true): .upload,
+            createPost(.publish, hasRemote: true, confirmedAutoUpload: true): .upload,
             // Other statuses are currently ignored
             createPost(.publishPrivate, confirmedAutoUpload: true): .nothing,
             createPost(.scheduled, confirmedAutoUpload: true): .nothing,
@@ -67,7 +69,7 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
     }
 
     /// Test which auto-uploaded post types can be canceled by the user
-    func testCancelAutoUploadMethodAppliesToLocalDraftsAndConfirmedUploads() {
+    func testCancelAutoUploadMethodAppliesToDraftsAndConfirmedUploads() {
         // Arrange
         let postsAndExpectedCancelableResult: [Post: Bool] = [
             // Local drafts are automatically uploaded and do not need to be canceled. We consider
@@ -79,10 +81,9 @@ class PostCoordinatorUploadActionUseCaseTests: XCTestCase {
             // auto-saved is considered safe and do not need to be canceled. It should also happen
             // in the background without any interaction from the user.
             createPost(.publish): false,
-            // Draft and published posts with remote are currently unsupported. These should
-            // allow cancelation. This will be fixed soon.
-            createPost(.draft, hasRemote: true, confirmedAutoUpload: true): false,
-            createPost(.publish, hasRemote: true, confirmedAutoUpload: true): false,
+            // Confirmed draft and published posts with remote will be automatically uploaded.
+            createPost(.draft, hasRemote: true, confirmedAutoUpload: true): true,
+            createPost(.publish, hasRemote: true, confirmedAutoUpload: true): true,
             // Posts with remote that have no confirmation will be remote auto-saved.
             createPost(.draft, hasRemote: true): false,
             createPost(.publish, hasRemote: true): false,

--- a/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
+++ b/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
@@ -29,11 +29,11 @@ class PostCoordinatorFailedPostsFetcherTests: XCTestCase {
             createPost(status: .draft),
             createPost(status: .draft),
             createPost(status: .draft),
-            createPost(status: .publish)
-        ]
-        let unexpectedPosts = [
+            createPost(status: .publish),
             createPost(status: .draft, hasRemote: true),
             createPost(status: .publish, hasRemote: true),
+        ]
+        let unexpectedPosts = [
             createPost(status: .publishPrivate),
             createPost(status: .publishPrivate, hasRemote: true),
             createPost(status: .scheduled),

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -35,6 +35,16 @@ class PostCardStatusViewModelTests: XCTestCase {
                 ButtonGroups(primary: [.edit, .publish, .trash], secondary: [])
             ),
             (
+                "Draft with remote and confirmed local changes",
+                PostBuilder(context).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build(),
+                ButtonGroups(primary: [.edit, .cancelAutoUpload, .more], secondary: [.publish, .trash])
+            ),
+            (
+                "Draft with remote and canceled local changes",
+                PostBuilder(context).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().cancelledAutoUpload().build(),
+                ButtonGroups(primary: [.edit, .publish, .trash], secondary: [])
+            ),
+            (
                 "Local published draft with confirmed auto-upload",
                 PostBuilder(context).published().with(remoteStatus: .failed).confirmedAutoUpload().build(),
                 ButtonGroups(primary: [.edit, .cancelAutoUpload, .more], secondary: [.moveToDraft, .trash])
@@ -48,7 +58,17 @@ class PostCardStatusViewModelTests: XCTestCase {
                 "Published post",
                 PostBuilder(context).published().withRemote().build(),
                 ButtonGroups(primary: [.edit, .view, .more], secondary: [.stats, .moveToDraft, .trash])
-            )
+            ),
+            (
+                "Published post with local confirmed changes",
+                PostBuilder(context).published().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build(),
+                ButtonGroups(primary: [.edit, .cancelAutoUpload, .more], secondary: [.stats, .moveToDraft, .trash])
+            ),
+            (
+                "Published post with canceled local changes",
+                PostBuilder(context).published().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build(),
+                ButtonGroups(primary: [.edit, .cancelAutoUpload, .more], secondary: [.stats, .moveToDraft, .trash])
+            ),
         ]
 
         // Act and Assert


### PR DESCRIPTION
Closes #12324. 

This adds auto-uploading support for published and draft posts that were previously uploaded to the server. The main change is the removal of [`!post.hasRemote()` in `PostAutoUploadInteractor`](https://github.com/wordpress-mobile/WordPress-iOS/commit/873bd85000c3970bc20d4c5fafe61fdbd0ceb10f#diff-ebdb8497b6444c39da3f2b426dc2a78cL29-L30). 

This also incorporates the related changes as described in the pending tasks in Android:

- https://github.com/wordpress-mobile/WordPress-Android/issues/10465 - Show “Cancel” after editing existing drafts. 
- https://github.com/wordpress-mobile/WordPress-Android/issues/10461#issuecomment-526843789 - Show “Draft will be uploaded next time your device is online” for drafts.
- https://github.com/wordpress-mobile/WordPress-Android/issues/10463 - Show “Changes will be published...” for existing posts. I needed some confirmation on this so the message is the temporary ”Changes will be upload next time your device is online”. We can update this in a separate PR.  
 
The rest of the changes are automated tests. 

## Previews and Testing Steps

### Local draft

Before | After 
--------|-------
![before local draft](https://user-images.githubusercontent.com/198826/64275553-0bb87400-cf03-11e9-95c7-2a0c94dcb32a.gif)  |  ![local draft](https://user-images.githubusercontent.com/198826/64273103-e2e1b000-cefd-11e9-8085-a39b9ab24bd0.gif)

1. Go offline. 
2. Create a post. 
3. Tap on **X** and tap _Save Draft_.
3. Confirm the Post List and the notice says “Draft will be uploaded next time your device is online”
4. Go online. Confirm the post is automatically uploaded. 

### Editing an existing draft

Before | After 
--------|-------
![before existing draft](https://user-images.githubusercontent.com/198826/64275551-0bb87400-cf03-11e9-97b8-9aa87701af33.gif)     |     ![existing draft](https://user-images.githubusercontent.com/198826/64274429-9b105800-cf00-11e9-8c3d-cdf5c58825f8.gif)

1. Go offline. 
2. Edit a draft that has been previously uploaded to the server. Make some changes.
3. Tap on **X** and tap _Update Draft_.
3. Confirm the Post List and the notice says “Changes will be uploaded next time your device is online”
4. Go online. Confirm the draft is **automatically uploaded**. 

### Publishing a local draft 

Before | After 
--------|-------
![before published draft](https://user-images.githubusercontent.com/198826/64275555-0bb87400-cf03-11e9-9d67-d8b2608739a4.gif)        |       ![published draft](https://user-images.githubusercontent.com/198826/64273501-acf0fb80-cefe-11e9-8076-2b767a4e7f94.gif)

1. Go offline.
2. Create a post. 
3. Tap on _Publish_.
4. Confirm the Post List and notice says “Post will be published next time your device is online”
5. Go online. Confirm the post is **automatically published**.

### Editing an existing published post

Before | After 
--------|-------
![before existing published post](https://user-images.githubusercontent.com/198826/64275552-0bb87400-cf03-11e9-8496-7c3d2bbf8530.gif)  |       ![existing published post](https://user-images.githubusercontent.com/198826/64274450-a82d4700-cf00-11e9-888d-ac1ff680a321.gif)

1. Go offline. 
2. Edit a published post that has been previously uploaded to the server. Make some changes.
3. Tap on **X** and tap _Update Post_.
3. Confirm the Post List and the notice says “Changes will be uploaded next time your device is online”
4. Go online. Confirm the draft is **automatically published**. 

## Reviewing 

Only 1 reviewer is needed but anyone can review. 

## Submitter Checklist

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 

## Tasks

- [ ] Fix _Update_ button marking the post as confirmed https://github.com/wordpress-mobile/WordPress-iOS/pull/12466#issuecomment-529694557