### PR TITLE
[Dark Mode] Fix Reader Detail and WebKit colors

### DIFF
--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -194,7 +194,7 @@ class WebKitViewController: UIViewController {
 
     private func setupNavBarTitleView() {
         titleView.titleLabel.text = NSLocalizedString("Loading...", comment: "Loading. Verb")
-        titleView.titleLabel.textColor = .neutral(.shade70)
+        titleView.titleLabel.textColor = UIColor(light: .white, dark: .neutral(.shade70))
         titleView.subtitleLabel.textColor = .neutral(.shade30)
 
         if let title = customTitle {
@@ -254,12 +254,12 @@ class WebKitViewController: UIViewController {
         guard let toolBar = navigationController?.toolbar else {
             return
         }
-        toolBar.barTintColor = .appBar
+        toolBar.barTintColor = UIColor(light: .white, dark: .appBar)
         fixBarButtonsColorForBoldText(on: toolBar)
     }
 
     private func styleToolBarButtons() {
-        navigationController?.toolbar.items?.forEach(styleBarButton)
+        navigationController?.toolbar.items?.forEach(styleToolBarButton)
     }
 
     // MARK: Helpers
@@ -271,6 +271,10 @@ class WebKitViewController: UIViewController {
     }
 
     private func styleBarButton(_ button: UIBarButtonItem) {
+        button.tintColor = UIColor(light: .white, dark: .neutral(.shade70))
+    }
+
+    private func styleToolBarButton(_ button: UIBarButtonItem) {
         button.tintColor = .listIcon
     }
 

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -194,7 +194,11 @@ class WebKitViewController: UIViewController {
 
     private func setupNavBarTitleView() {
         titleView.titleLabel.text = NSLocalizedString("Loading...", comment: "Loading. Verb")
-        titleView.titleLabel.textColor = UIColor(light: .white, dark: .neutral(.shade70))
+        if #available(iOS 13.0, *) {
+            titleView.titleLabel.textColor = UIColor(light: .white, dark: .neutral(.shade70))
+        } else {
+            titleView.titleLabel.textColor = .neutral(.shade70)
+        }
         titleView.subtitleLabel.textColor = .neutral(.shade30)
 
         if let title = customTitle {
@@ -271,7 +275,11 @@ class WebKitViewController: UIViewController {
     }
 
     private func styleBarButton(_ button: UIBarButtonItem) {
-        button.tintColor = UIColor(light: .white, dark: .neutral(.shade70))
+        if #available(iOS 13.0, *) {
+            button.tintColor = UIColor(light: .white, dark: .neutral(.shade70))
+        } else {
+            button.tintColor = .listIcon
+        }
     }
 
     private func styleToolBarButton(_ button: UIBarButtonItem) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderDetailViewController.swift
@@ -299,6 +299,15 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         // This is something we do to help with the resizing that can occur with
         // split screen multitasking on the iPad.
         view.layoutIfNeeded()
+
+        #if XCODE11
+        if #available(iOS 13.0, *) {
+            if previousTraitCollection?.hasDifferentColorAppearance(comparedTo: traitCollection) == true {
+                reloadGradientColors()
+                configureRichText()
+            }
+        }
+        #endif
     }
 
 
@@ -519,6 +528,12 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         WPStyleGuide.applyReaderCardActionButtonStyle(saveForLaterButton)
 
         view.backgroundColor = .listBackground
+
+        titleLabel.backgroundColor = .basicBackground
+        titleBottomPaddingView.backgroundColor = .basicBackground
+        bylineView.backgroundColor = .basicBackground
+        bylineBottomPaddingView.backgroundColor = .basicBackground
+
         headerView.backgroundColor = .listForeground
         footerView.backgroundColor = .listForeground
         footerDivider.backgroundColor = .divider
@@ -531,9 +546,13 @@ open class ReaderDetailViewController: UIViewController, UIViewControllerRestora
         }
         #endif
 
+        reloadGradientColors()
+    }
+
+    fileprivate func reloadGradientColors() {
         bylineGradientViews.forEach({ view in
-            view.fromColor = .listBackground
-            view.toColor = UIColor.listBackground.withAlphaComponent(0.0)
+            view.fromColor = .basicBackground
+            view.toColor = UIColor.basicBackground.withAlphaComponent(0.0)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -440,7 +440,7 @@ class ContentInformation: ImageSourceInformation {
 @objc fileprivate class BlockquoteBackgroundLayoutManager: NSLayoutManager {
     /// Blockquote's Left Border Color
     ///
-    let blockquoteBorderColor = UIColor.textSubtle
+    let blockquoteBorderColor = UIColor.listIcon
 
     /// Blockquote's Left Border width
     ///


### PR DESCRIPTION
Refs. #12320
Fixes #12457
Fixes #12456 
![reader-details-dark-mode](https://user-images.githubusercontent.com/912252/64362176-f5471100-d005-11e9-82af-ae315a870fc2.jpg)
![webkit-dark-mode](https://user-images.githubusercontent.com/912252/64362177-f5dfa780-d005-11e9-8c6b-6f54a9bfe673.jpg)

This PR fixes some wrong colors and behaviour in Dark Mode. The visible Gradient has been fixed along with the Quote border. This PR also contains a fix with the tab bar in the WebKit view controller.

**Note**:
This doesn't fix #12441 . Switching the interface mode while the app is running doesn't update the RichView background color.

## To test:
• Run the branch with Xcode 11 and iOS 13
• To test the reader, open a post with a quote in the Reader to check the gradient and the quote border
• To test the WebKit view select _View Site_ from the Site dashboard.

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
