### PR TITLE
[Dark Mode] Fix History/Revisions colors

### DIFF
--- a/WordPress/Classes/Models/DiffAbstractValue+Attributes.swift
+++ b/WordPress/Classes/Models/DiffAbstractValue+Attributes.swift
@@ -2,15 +2,17 @@ extension DiffAbstractValue {
     var attributes: [NSAttributedString.Key: Any]? {
         switch operation {
         case .add:
-            return [.backgroundColor: UIColor.muriel(color: MurielColor(name: .blue, shade: .shade5)),
+            return [.backgroundColor: UIColor(light: .muriel(color: MurielColor(name: .blue, shade: .shade5)),
+                                              dark: .primary(.shade80)),
                     .underlineStyle: NSNumber(value: 2),
-                    .underlineColor: UIColor.primary]
+                    .underlineColor: UIColor(light: .primary, dark: .primary(.shade20))]
         case .del:
-            return [.backgroundColor: UIColor.muriel(color: MurielColor(name: .red, shade: .shade5)),
+            return [.backgroundColor: UIColor(light: .muriel(color: MurielColor(name: .red, shade: .shade5)),
+                                              dark: .muriel(color: MurielColor(name: .red, shade: .shade80))),
                     .underlineStyle: NSNumber(value: 2),
-                    .underlineColor: UIColor.error,
+                    .underlineColor: UIColor(light: .error, dark: .muriel(color: MurielColor(name: .red, shade: .shade20))),
                     .strikethroughStyle: NSNumber(value: 1),
-                    .strikethroughColor: UIColor.black]
+                    .strikethroughColor: UIColor.text]
         default:
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListSectionHeaderView.swift
@@ -11,6 +11,9 @@ class PageListSectionHeaderView: UIView {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+
+        backgroundColor = .listBackground
+        titleLabel.backgroundColor = .listBackground
         WPStyleGuide.applyBorderStyle(separator)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Diffs/RevisionDiffViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Diffs/RevisionDiffViewController.swift
@@ -5,15 +5,14 @@ class RevisionDiffViewController: UIViewController, StoryboardLoadable {
 
     @IBOutlet private var titleLabel: UILabel!
     @IBOutlet private var contentLabel: UILabel!
+    @IBOutlet private var scrollView: UIScrollView!
 
     var revision: Revision?
 
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        titleLabel.font = WPFontManager.notoBoldFont(ofSize: 24.0)
-        contentLabel.font = WPFontManager.notoRegularFont(ofSize: 16)
+        setupUI()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -22,8 +21,17 @@ class RevisionDiffViewController: UIViewController, StoryboardLoadable {
     }
 }
 
-
 private extension RevisionDiffViewController {
+    private func setupUI() {
+        view.backgroundColor = .basicBackground
+        scrollView.backgroundColor = .basicBackground
+
+        titleLabel.font = WPFontManager.notoBoldFont(ofSize: 24.0)
+        contentLabel.font = WPFontManager.notoRegularFont(ofSize: 16)
+        titleLabel.textColor = .text
+        contentLabel.textColor = .text
+    }
+
     private func showRevision() {
         guard let revision = revision else {
             return

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewViewController.swift
@@ -96,6 +96,7 @@ private extension RevisionPreviewViewController {
 //
 private extension RevisionPreviewViewController {
     private func addSubviews() {
+        view.backgroundColor = .basicBackground
         view.addSubview(textView)
         textView.addSubview(titleLabel)
     }

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/RevisionDiffsBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/RevisionDiffsBrowserViewController.swift
@@ -12,6 +12,8 @@ class RevisionDiffsBrowserViewController: UIViewController {
     private var contentPreviewState: ContentPreviewState = .html
 
     @IBOutlet private var containerView: UIView!
+    @IBOutlet private var strokeView: UIView!
+    @IBOutlet private var revisionContainer: UIView!
     @IBOutlet private var revisionTitle: UILabel!
     @IBOutlet private var previousButton: UIButton!
     @IBOutlet private var nextButton: UIButton!
@@ -143,6 +145,8 @@ private extension RevisionDiffsBrowserViewController {
         navigationItem.leftBarButtonItems = [doneBarButtonItem]
         navigationItem.rightBarButtonItems = [moreBarButtonItem, loadBarButtonItem]
         navigationItem.title = NSLocalizedString("Revision", comment: "Title of the screen that shows the revisions.")
+        strokeView.backgroundColor = .divider
+        revisionContainer.backgroundColor = .listForeground
     }
 
     private func updateNextPreviousButtons() {

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Revisions.storyboard
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Revisions.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9BX-ta-eQr">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="9BX-ta-eQr">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -16,7 +14,7 @@
             <objects>
                 <navigationController id="9BX-ta-eQr" customClass="RevisionsNavigationController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translucent="NO" id="XL2-Md-hno">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -32,11 +30,11 @@
             <objects>
                 <viewController id="aEY-1G-H9o" customClass="RevisionDiffsBrowserViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="cG0-G3-XU5">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rsS-xc-ge8">
-                                <rect key="frame" x="0.0" y="539" width="375" height="64"/>
+                                <rect key="frame" x="0.0" y="559" width="375" height="64"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rSD-aC-9V4">
                                         <rect key="frame" x="0.0" y="7" width="50" height="50"/>
@@ -81,7 +79,7 @@
                                                 </connections>
                                             </containerView>
                                         </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstItem="T2k-GK-3TX" firstAttribute="top" secondItem="1Hg-z8-YVh" secondAttribute="bottom" constant="4" id="C5J-9t-sd9"/>
                                             <constraint firstItem="1Hg-z8-YVh" firstAttribute="top" secondItem="0zh-of-VUW" secondAttribute="top" id="Isk-s9-MoC"/>
@@ -109,7 +107,7 @@
                                 </constraints>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uhq-mq-TeO">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="539"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="559"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <connections>
                                     <segue destination="1re-Hq-Vps" kind="embed" id="UdL-Ti-ban"/>
@@ -133,7 +131,9 @@
                         <outlet property="containerView" destination="uhq-mq-TeO" id="Ehy-69-qmb"/>
                         <outlet property="nextButton" destination="Und-hy-I90" id="Q6I-kh-y5d"/>
                         <outlet property="previousButton" destination="rSD-aC-9V4" id="s8K-96-nXk"/>
+                        <outlet property="revisionContainer" destination="rsS-xc-ge8" id="HyU-B2-o8q"/>
                         <outlet property="revisionTitle" destination="1Hg-z8-YVh" id="cXY-5C-yT6"/>
+                        <outlet property="strokeView" destination="7EM-Lu-3t1" id="d3c-cB-4j5"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tS6-Ip-YDF" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -201,6 +201,7 @@ Nulla sodales mauris ullamcorper massa tincidunt, eu pretium erat fringilla. Sed
                     </view>
                     <connections>
                         <outlet property="contentLabel" destination="GYn-QL-8hI" id="1e4-Xp-22g"/>
+                        <outlet property="scrollView" destination="mb8-Xb-lI6" id="yWZ-vF-8Fg"/>
                         <outlet property="titleLabel" destination="GAe-1S-aM6" id="5uM-RT-M7h"/>
                     </connections>
                 </viewController>
@@ -215,7 +216,7 @@ Nulla sodales mauris ullamcorper massa tincidunt, eu pretium erat fringilla. Sed
                     <view key="view" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" id="GfE-RI-5IB">
                         <rect key="frame" x="0.0" y="0.0" width="160" height="18"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <viewLayoutGuide key="safeArea" id="Ha8-OF-10N"/>
                     </view>
                 </viewController>
@@ -249,7 +250,7 @@ Nulla sodales mauris ullamcorper massa tincidunt, eu pretium erat fringilla. Sed
     </scenes>
     <resources>
         <namedColor name="Gray40">
-            <color red="0.50196078431372548" green="0.50196078431372548" blue="0.5490196078431373" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.49803921568627452" green="0.50196078431372548" blue="0.54117647058823526" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
@@ -79,6 +79,7 @@ private extension RevisionsTableViewController {
 
         tableView.tableFooterView = tableViewFooter
 
+        tableView.separatorColor = .divider
         WPStyleGuide.configureColors(view: view, tableView: tableView)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Views/Cell/RevisionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Views/Cell/RevisionsTableViewCell.swift
@@ -80,9 +80,9 @@ private extension RevisionsTableViewCell {
 
         // Setup labels
         titleLabel.backgroundColor = .listForeground
-        titleLabel.textColor = .neutral(.shade70)
+        titleLabel.textColor = .text
         subTitleLabel.backgroundColor = .listForeground
-        subTitleLabel.textColor = .neutral(.shade40)
+        subTitleLabel.textColor = .textSubtle
 
         // Setup del operations
         delOperation = RevisionOperation(.del)

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Views/Cell/RevisionsTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Views/Cell/RevisionsTableViewCell.swift
@@ -76,9 +76,12 @@ private extension RevisionsTableViewCell {
     private func setupStyles() {
         // Setup cell style
         WPStyleGuide.configureTableViewCell(self)
+        contentView.backgroundColor = .listForeground
 
         // Setup labels
+        titleLabel.backgroundColor = .listForeground
         titleLabel.textColor = .neutral(.shade70)
+        subTitleLabel.backgroundColor = .listForeground
         subTitleLabel.textColor = .neutral(.shade40)
 
         // Setup del operations

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Views/Footer/RevisionsTableViewFooter.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Views/Footer/RevisionsTableViewFooter.swift
@@ -29,7 +29,7 @@ class RevisionsTableViewFooter: UIView {
 
 private extension RevisionsTableViewFooter {
     private func setupUI() {
-        backgroundColor = .neutral(.shade5)
+        backgroundColor = .listBackground
 
         autoresizingMask = .flexibleWidth
 

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Views/Operation/RevisionOperationViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Views/Operation/RevisionOperationViewController.swift
@@ -15,6 +15,8 @@ class RevisionOperationViewController: UIViewController {
     }
 
     private func setupViews() {
+        view.backgroundColor = .listForeground
+
         addView = RevisionOperation(.add).internalView
         delView = RevisionOperation(.del).internalView
 


### PR DESCRIPTION
Refs. #12320 

This PR fixes the colors in _History/Revisions_.

![revisions-dark-mode-dark](https://user-images.githubusercontent.com/912252/64370258-03049280-d016-11e9-92ff-ac3cd8be570d.jpg)
![revisions-dark-mode-light](https://user-images.githubusercontent.com/912252/64370259-039d2900-d016-11e9-9418-d6f943c21a98.jpg)

## To test:
- Run the branch with Xcode 11 and iOS 13
- Select a Post with a History
- Open its History and switch between dark and light mode
- Check everything is ok with the 3 screens: _List_, _Diffs_ and _Preview_
- Test everything is ok on iOS 12

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
