### PR TITLE
Merge Duplicate Sites Fix into 13.2.xx Part 2

### DIFF
--- a/WordPress/Classes/Services/AccountService+MergeDuplicates.swift
+++ b/WordPress/Classes/Services/AccountService+MergeDuplicates.swift
@@ -9,10 +9,7 @@ extension AccountService {
         }
 
         let accountGroups = Dictionary(grouping: accounts) { $0.userID }
-        for key in accountGroups.keys {
-            guard let group = accountGroups[key], group.count > 1 else {
-                continue
-            }
+        for group in accountGroups.values where group.count > 1 {
             mergeDuplicateAccounts(accounts: group)
         }
 
@@ -34,10 +31,7 @@ extension AccountService {
             destination = defaultAccount
         }
 
-        for account in accounts {
-            if account == destination {
-                continue
-            }
+        for account in accounts where account != destination {
             mergeAccount(account: account, into: destination)
         }
 
@@ -48,7 +42,6 @@ extension AccountService {
     private func mergeAccount(account: WPAccount, into destination: WPAccount) {
         // Move all blogs to the destination account
         destination.addBlogs(account.blogs)
-        account.removeBlogs(account.blogs)
         managedObjectContext.delete(account)
     }
 

--- a/WordPress/Classes/Services/AccountService+MergeDuplicates.swift
+++ b/WordPress/Classes/Services/AccountService+MergeDuplicates.swift
@@ -3,11 +3,11 @@ import Foundation
 extension AccountService {
 
     func mergeDuplicatesIfNecessary() {
-        let accounts = allAccounts()
-        guard accounts.count > 1 else {
+        guard numberOfAccounts() > 1 else {
             return
         }
 
+        let accounts = allAccounts()
         let accountGroups = Dictionary(grouping: accounts) { $0.userID }
         for group in accountGroups.values where group.count > 1 {
             mergeDuplicateAccounts(accounts: group)

--- a/WordPress/Classes/Services/AccountService+MergeDuplicates.swift
+++ b/WordPress/Classes/Services/AccountService+MergeDuplicates.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+extension AccountService {
+
+    func mergeDuplicatesIfNecessary() {
+        let accounts = allAccounts()
+        guard accounts.count > 1 else {
+            return
+        }
+
+        let accountGroups = Dictionary(grouping: accounts) { $0.userID }
+        for key in accountGroups.keys {
+            guard let group = accountGroups[key], group.count > 1 else {
+                continue
+            }
+            mergeDuplicateAccounts(accounts: group)
+        }
+
+        if managedObjectContext.hasChanges {
+            ContextManager.sharedInstance().save(managedObjectContext)
+        }
+    }
+
+    private func mergeDuplicateAccounts(accounts: [WPAccount]) {
+        // For paranoia
+        guard accounts.count > 1 else {
+            return
+        }
+
+        // If one of the accounts is the default account, merge the rest into it.
+        // Otherwise just use the first account.
+        var destination = accounts.first!
+        if let defaultAccount = defaultWordPressComAccount(), accounts.contains(defaultAccount) {
+            destination = defaultAccount
+        }
+
+        for account in accounts {
+            if account == destination {
+                continue
+            }
+            mergeAccount(account: account, into: destination)
+        }
+
+        let service = BlogService(managedObjectContext: managedObjectContext)
+        service.deduplicateBlogs(for: destination)
+    }
+
+    private func mergeAccount(account: WPAccount, into destination: WPAccount) {
+        // Move all blogs to the destination account
+        destination.addBlogs(account.blogs)
+        account.removeBlogs(account.blogs)
+        managedObjectContext.delete(account)
+    }
+
+}

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -112,6 +112,13 @@ extern NSNotificationName const WPAccountEmailAndDefaultBlogUpdatedNotification;
 - (NSUInteger)numberOfAccounts;
 
 /**
+ Returns all accounts currently existing in core data.
+
+ @return An array of WPAccounts.
+ */
+- (NSArray<WPAccount *> *)allAccounts;
+
+/**
  Returns a WordPress.com account with the specified username, if it exists
 
  @param username the account's username

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -243,11 +243,6 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     return count;
 }
 
-/**
- Returns all accounts currently existing in core data.
-
- @return An array of WPAccounts.
- */
 - (NSArray<WPAccount *> *)allAccounts
 {
     NSFetchRequest *fetchRequest = [NSFetchRequest fetchRequestWithEntityName:@"Account"];

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -56,7 +56,6 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
 
-        AccountService(managedObjectContext: ContextManager.shared.mainContext).mergeDuplicatesIfNecessary()
         // Configure WPCom API overrides
         configureWordPressComApi()
 
@@ -235,6 +234,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         // Deferred tasks to speed up app launch
         DispatchQueue.global(qos: .background).async { [weak self] in
+            AccountService(managedObjectContext: ContextManager.shared.mainContext).mergeDuplicatesIfNecessary()
             MediaCoordinator.shared.refreshMediaStatus()
             PostCoordinator.shared.refreshPostStatus()
             MediaFileManager.clearUnusedMediaUploadFiles(onCompletion: nil, onError: nil)

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -234,7 +234,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         // Deferred tasks to speed up app launch
         DispatchQueue.global(qos: .background).async { [weak self] in
-            AccountService(managedObjectContext: ContextManager.shared.mainContext).mergeDuplicatesIfNecessary()
+            self?.mergeDuplicateAccountsIfNeeded()
             MediaCoordinator.shared.refreshMediaStatus()
             PostCoordinator.shared.refreshPostStatus()
             MediaFileManager.clearUnusedMediaUploadFiles(onCompletion: nil, onError: nil)
@@ -248,6 +248,13 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         window?.rootViewController = WPTabBarController.sharedInstance()
 
         setupNoticePresenter()
+    }
+
+    private func mergeDuplicateAccountsIfNeeded() {
+        let context = ContextManager.shared.mainContext
+        context.perform {
+            AccountService(managedObjectContext: ContextManager.shared.mainContext).mergeDuplicatesIfNecessary()
+        }
     }
 
     private func setupPingHub() {

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -56,7 +56,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
 
-        AccountService.init(managedObjectContext: ContextManager.shared.mainContext).mergeDuplicatesIfNecessary()
+        AccountService(managedObjectContext: ContextManager.shared.mainContext).mergeDuplicatesIfNecessary()
         // Configure WPCom API overrides
         configureWordPressComApi()
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -56,6 +56,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
 
+        AccountService.init(managedObjectContext: ContextManager.shared.mainContext).mergeDuplicatesIfNecessary()
         // Configure WPCom API overrides
         configureWordPressComApi()
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1841,6 +1841,7 @@
 		E6B9B8AF1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6B9B8AE1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift */; };
 		E6BDEA731CE4824300682885 /* ReaderSearchTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6BDEA721CE4824300682885 /* ReaderSearchTopic.swift */; };
 		E6C09B3E1BF0FDEB003074CB /* ReaderCrossPostMeta.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C09B3D1BF0FDEB003074CB /* ReaderCrossPostMeta.swift */; };
+		E6C0ED3B231DA23400A08B57 /* AccountService+MergeDuplicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C0ED3A231DA23400A08B57 /* AccountService+MergeDuplicates.swift */; };
 		E6C892D61C601D55007AD612 /* SharingButtonsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C892D51C601D55007AD612 /* SharingButtonsViewController.swift */; };
 		E6D170371EF9D8D10046D433 /* SiteInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6D170361EF9D8D10046D433 /* SiteInfo.swift */; };
 		E6D2E15F1B8A9C830000ED14 /* ReaderSiteStreamHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = E6D2E15E1B8A9C830000ED14 /* ReaderSiteStreamHeader.xib */; };
@@ -4182,6 +4183,7 @@
 		E6B9B8AE1B94FA1C0001B92F /* ReaderStreamViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderStreamViewControllerTests.swift; sourceTree = "<group>"; };
 		E6BDEA721CE4824300682885 /* ReaderSearchTopic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderSearchTopic.swift; sourceTree = "<group>"; };
 		E6C09B3D1BF0FDEB003074CB /* ReaderCrossPostMeta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReaderCrossPostMeta.swift; path = Classes/Models/ReaderCrossPostMeta.swift; sourceTree = SOURCE_ROOT; };
+		E6C0ED3A231DA23400A08B57 /* AccountService+MergeDuplicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AccountService+MergeDuplicates.swift"; sourceTree = "<group>"; };
 		E6C892D51C601D55007AD612 /* SharingButtonsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharingButtonsViewController.swift; sourceTree = "<group>"; };
 		E6D170361EF9D8D10046D433 /* SiteInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteInfo.swift; sourceTree = "<group>"; };
 		E6D2E15E1B8A9C830000ED14 /* ReaderSiteStreamHeader.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReaderSiteStreamHeader.xib; sourceTree = "<group>"; };
@@ -6872,6 +6874,7 @@
 				B5EFB1C31B31B99D007608A3 /* Facades */,
 				93C1147D18EC5DD500DAC95C /* AccountService.h */,
 				93C1147E18EC5DD500DAC95C /* AccountService.m */,
+				E6C0ED3A231DA23400A08B57 /* AccountService+MergeDuplicates.swift */,
 				E1FD45DF1C030B3800750F4C /* AccountSettingsService.swift */,
 				822D60B81F4CCC7A0016C46D /* BlogJetpackSettingsService.swift */,
 				93C1148318EDF6E100DAC95C /* BlogService.h */,
@@ -10878,6 +10881,7 @@
 				E6E27D621C6144DB0063F821 /* SharingButton.swift in Sources */,
 				570BFD8B22823D7B007859A8 /* PostActionSheet.swift in Sources */,
 				E6374DC01C444D8B00F24720 /* PublicizeConnection.swift in Sources */,
+				E6C0ED3B231DA23400A08B57 /* AccountService+MergeDuplicates.swift in Sources */,
 				0845B8C61E833C56001BA771 /* URL+Helpers.swift in Sources */,
 				17D975AF1EF7F6F100303D63 /* WPStyleGuide+Aztec.swift in Sources */,
 				5D17F0BE1A1D4C5F0087CCB8 /* PrivateSiteURLProtocol.m in Sources */,

--- a/WordPress/WordPressTest/AccountServiceTests.swift
+++ b/WordPress/WordPressTest/AccountServiceTests.swift
@@ -210,7 +210,7 @@ class AccountServiceTests: XCTestCase {
         XCTAssertFalse(account3.isDeleted)
     }
 
-    func createMockBlogs(withIDs IDs:[Int], in context: NSManagedObjectContext) -> Set<Blog> {
+    func createMockBlogs(withIDs IDs: [Int], in context: NSManagedObjectContext) -> Set<Blog> {
         var blogs = Set<Blog>()
         for id in IDs {
             let blog = Blog(context: context)

--- a/WordPress/WordPressTest/AccountServiceTests.swift
+++ b/WordPress/WordPressTest/AccountServiceTests.swift
@@ -159,9 +159,9 @@ class AccountServiceTests: XCTestCase {
         account3.uuid = UUID().uuidString
 
         let context = contextManager.mainContext
-        account1.addBlogs(createMockBlogs(withIDs: [1,2,3,4,5,6], in: context))
-        account2.addBlogs(createMockBlogs(withIDs: [1,2,3], in: context))
-        account3.addBlogs(createMockBlogs(withIDs: [4,5,6], in: context))
+        account1.addBlogs(createMockBlogs(withIDs: [1, 2, 3, 4, 5, 6], in: context))
+        account2.addBlogs(createMockBlogs(withIDs: [1, 2, 3], in: context))
+        account3.addBlogs(createMockBlogs(withIDs: [4, 5, 6], in: context))
         contextManager.save(context)
 
         accountService.mergeDuplicatesIfNecessary()

--- a/WordPress/WordPressTest/AccountServiceTests.swift
+++ b/WordPress/WordPressTest/AccountServiceTests.swift
@@ -197,9 +197,9 @@ class AccountServiceTests: XCTestCase {
         account3.uuid = UUID().uuidString
 
         let context = contextManager.mainContext
-        account1.addBlogs(createMockBlogs(withIDs: [1,2,3,4,5,6], in: context))
-        account2.addBlogs(createMockBlogs(withIDs: [1,2,3], in: context))
-        account3.addBlogs(createMockBlogs(withIDs: [4,5,6], in: context))
+        account1.addBlogs(createMockBlogs(withIDs: [1, 2, 3, 4, 5, 6], in: context))
+        account2.addBlogs(createMockBlogs(withIDs: [1, 2, 3], in: context))
+        account3.addBlogs(createMockBlogs(withIDs: [4, 5, 6], in: context))
         contextManager.save(context)
 
         accountService.mergeDuplicatesIfNecessary()

--- a/WordPress/WordPressTest/AccountServiceTests.swift
+++ b/WordPress/WordPressTest/AccountServiceTests.swift
@@ -139,4 +139,89 @@ class AccountServiceTests: XCTestCase {
         XCTAssertNil(accountService.defaultWordPressComAccount())
     }
 
+    func testMergeMultipleDuplicateAccounts() {
+        let account1 = WPAccount(context: contextManager.mainContext)
+        account1.userID = 1
+        account1.username = "username"
+        account1.authToken = "authToken"
+        account1.uuid = UUID().uuidString
+
+        let account2 = WPAccount(context: contextManager.mainContext)
+        account2.userID = 1
+        account2.username = "username"
+        account2.authToken = "authToken"
+        account2.uuid = UUID().uuidString
+
+        let account3 = WPAccount(context: contextManager.mainContext)
+        account3.userID = 1
+        account3.username = "username"
+        account3.authToken = "authToken"
+        account3.uuid = UUID().uuidString
+
+        let context = contextManager.mainContext
+        account1.addBlogs(createMockBlogs(withIDs: [1,2,3,4,5,6], in: context))
+        account2.addBlogs(createMockBlogs(withIDs: [1,2,3], in: context))
+        account3.addBlogs(createMockBlogs(withIDs: [4,5,6], in: context))
+        contextManager.save(context)
+
+        accountService.mergeDuplicatesIfNecessary()
+        contextManager.save(context)
+
+        XCTAssertFalse(account1.isDeleted)
+        XCTAssertTrue(account2.isDeleted)
+        XCTAssertTrue(account3.isDeleted)
+
+        let service = BlogService(managedObjectContext: contextManager.mainContext)
+        let blogs = service.blogsForAllAccounts()
+        XCTAssertTrue(blogs.count == 6)
+        XCTAssertTrue(account1.blogs.count == 6)
+    }
+
+    func testMergeDuplicateAccountsKeepingNonDups() {
+        let account1 = WPAccount(context: contextManager.mainContext)
+        account1.userID = 1
+        account1.username = "username"
+        account1.authToken = "authToken"
+        account1.uuid = UUID().uuidString
+
+        let account2 = WPAccount(context: contextManager.mainContext)
+        account2.userID = 1
+        account2.username = "username"
+        account2.authToken = "authToken"
+        account2.uuid = UUID().uuidString
+
+        let account3 = WPAccount(context: contextManager.mainContext)
+        account3.userID = 3
+        account3.username = "username3"
+        account3.authToken = "authToken3"
+        account3.uuid = UUID().uuidString
+
+        let context = contextManager.mainContext
+        account1.addBlogs(createMockBlogs(withIDs: [1,2,3,4,5,6], in: context))
+        account2.addBlogs(createMockBlogs(withIDs: [1,2,3], in: context))
+        account3.addBlogs(createMockBlogs(withIDs: [4,5,6], in: context))
+        contextManager.save(context)
+
+        accountService.mergeDuplicatesIfNecessary()
+        contextManager.save(context)
+
+        XCTAssertFalse(account1.isDeleted)
+        XCTAssertTrue(account2.isDeleted)
+        XCTAssertFalse(account3.isDeleted)
+    }
+
+    func createMockBlogs(withIDs IDs:[Int], in context: NSManagedObjectContext) -> Set<Blog> {
+        var blogs = Set<Blog>()
+        for id in IDs {
+            let blog = Blog(context: context)
+            blog.dotComID = NSNumber(integerLiteral: id)
+            blog.xmlrpc = "http://test.blog/\(id)/xmlrpc.php"
+            blog.username = "admin"
+            blog.url = "http://test.blog/\(id)"
+            blog.isHostedAtWPcom = true
+            blogs.insert(blog)
+        }
+        return blogs
+    }
+
 }


### PR DESCRIPTION
This is a copy of #12451 that ports the fix into our forthcoming 13.2.xx release.

This PR cannot be merged until #12484 has been.

This PR consists of commits that were artisanally plucked from the other branch and brought into this one. The code moving over should be identical. 