### PR TITLE
[Dark Mode] Multiple Fixes

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -158,7 +158,14 @@ extension UIColor {
     }
 
     static var textInverted = UIColor(light: .white, dark: .gray(.shade100))
-    static var textPlaceholder = neutral(.shade30)
+    static var textPlaceholder: UIColor {
+        #if XCODE11
+            if #available(iOS 13, *) {
+                return .tertiaryLabel
+            }
+        #endif
+        return neutral(.shade30)
+    }
     static var placeholderElement: UIColor {
         #if XCODE11
             if #available(iOS 13, *) {

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.swift
@@ -6,7 +6,7 @@ class BlogDetailsSectionHeaderView: UITableViewHeaderFooterView {
 
     @objc @IBOutlet private(set) var ellipsisButton: UIButton? {
         didSet {
-            ellipsisButton?.setImage(Gridicon.iconOfType(.ellipsis).imageWithTintColor(.neutral(.shade30)), for: .normal)
+            ellipsisButton?.setImage(Gridicon.iconOfType(.ellipsis).imageWithTintColor(.listIcon), for: .normal)
         }
     }
 
@@ -17,6 +17,11 @@ class BlogDetailsSectionHeaderView: UITableViewHeaderFooterView {
     }
 
     @objc var ellipsisButtonDidTouch: EllipsisCallback?
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        titleLabel?.textColor = .textSubtle
+    }
 
     @IBAction func ellipsisTapped() {
         ellipsisButtonDidTouch?(self)

--- a/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Blog/BlogDetailsSectionHeaderView.xib
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,9 +26,9 @@
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DATE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eUE-Sb-m3L">
                     <rect key="frame" x="16" y="0.0" width="32.5" height="36"/>
-                    <color key="backgroundColor" red="0.91372549020000005" green="0.93725490199999995" blue="0.95294117649999999" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                    <color key="textColor" red="0.30980392159999998" green="0.4549019608" blue="0.5568627451" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <color key="textColor" name="Gray50"/>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
@@ -52,4 +51,9 @@
             <point key="canvasLocation" x="233.59999999999999" y="186.20689655172416"/>
         </view>
     </objects>
+    <resources>
+        <namedColor name="Gray50">
+            <color red="0.40392156862745099" green="0.41568627450980394" blue="0.45490196078431372" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistCell.swift
@@ -12,8 +12,16 @@ class QuickStartChecklistCell: UITableViewCell {
         }
     }
     @IBOutlet private var iconView: UIImageView?
-    @IBOutlet private var stroke: UIView?
-    @IBOutlet private var topSeparator: UIView?
+    @IBOutlet private var stroke: UIView? {
+        didSet {
+            stroke?.backgroundColor = .divider
+        }
+    }
+    @IBOutlet private var topSeparator: UIView? {
+        didSet {
+            topSeparator?.backgroundColor = .divider
+        }
+    }
 
     private var bottomStrokeLeading: NSLayoutConstraint?
     private var contentViewLeadingAnchor: NSLayoutXAxisAnchor {
@@ -34,9 +42,11 @@ class QuickStartChecklistCell: UITableViewCell {
                                                                attributes: [.strikethroughStyle: 1,
                                                                             .foregroundColor: UIColor.neutral(.shade30)])
                 descriptionLabel.textColor = .neutral(.shade30)
+                iconView?.tintColor = .neutral(.shade30)
             } else {
-                titleLabel.textColor = .neutral(.shade70)
-                descriptionLabel.textColor = .neutral(.shade70)
+                titleLabel.textColor = .text
+                descriptionLabel.textColor = .textSubtle
+                iconView?.tintColor = .listIcon
             }
         }
     }
@@ -44,7 +54,7 @@ class QuickStartChecklistCell: UITableViewCell {
         didSet {
             titleLabel.text = tour?.title
             descriptionLabel.text = tour?.description
-            iconView?.image = tour?.icon.imageWithTintColor(.neutral(.shade20))
+            iconView?.image = tour?.icon.withRenderingMode(.alwaysTemplate)
 
             if let hint = tour?.accessibilityHintText, !hint.isEmpty {
                 accessibilityHint = hint
@@ -67,6 +77,7 @@ class QuickStartChecklistCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        contentView.backgroundColor = .listForeground
         setupConstraints()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.swift
@@ -34,10 +34,19 @@ class QuickStartChecklistHeader: UIView {
     @IBOutlet private var chevronView: UIImageView! {
         didSet {
             chevronView.image = Gridicon.iconOfType(.chevronDown)
-            chevronView.tintColor = WPStyleGuide.cellGridiconAccessoryColor()
+            chevronView.tintColor = .textTertiary
         }
     }
-    @IBOutlet private var bottomStroke: UIView!
+    @IBOutlet var topStroke: UIView! {
+        didSet {
+            topStroke.backgroundColor = .divider
+        }
+    }
+    @IBOutlet private var bottomStroke: UIView! {
+        didSet {
+            bottomStroke.backgroundColor = .divider
+        }
+    }
     @IBOutlet private var contentView: UIView! {
         didSet {
             contentView.leadingAnchor.constraint(equalTo: contentViewLeadingAnchor).isActive = true
@@ -59,6 +68,7 @@ class QuickStartChecklistHeader: UIView {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        contentView.backgroundColor = .listForeground
         prepareForVoiceOver()
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -97,6 +95,7 @@
                 <outlet property="chevronView" destination="2ag-iN-nJf" id="fe5-yH-BhN"/>
                 <outlet property="contentView" destination="rkz-KZ-Ayy" id="NET-gR-3xr"/>
                 <outlet property="titleLabel" destination="xiK-ca-ccq" id="HrR-PQ-Mtc"/>
+                <outlet property="topStroke" destination="QaU-FW-PcA" id="X0k-sy-5Eo"/>
             </connections>
             <point key="canvasLocation" x="53.600000000000001" y="48.575712143928037"/>
         </view>

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -51,7 +51,7 @@ class QuickStartChecklistViewController: UITableViewController {
     private lazy var successScreen: NoResultsViewController = {
         let successScreen = NoResultsViewController.controller()
         successScreen.view.frame = tableView.bounds
-        successScreen.view.backgroundColor = .white
+        successScreen.view.backgroundColor = .listBackground
         successScreen.configure(title: tasksCompleteScreen.title,
                                 subtitle: tasksCompleteScreen.subtitle,
                                 image: tasksCompleteScreen.imageName)
@@ -151,6 +151,7 @@ private extension QuickStartChecklistViewController {
 
         tableView.backgroundView = successScreen.view
         self.tableView = tableView
+        WPStyleGuide.configureTableViewColors(view: self.tableView)
     }
 
     func startObservingForQuickStart() {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartCongratulationsCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartCongratulationsCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,11 +13,11 @@
             <rect key="frame" x="0.0" y="0.0" width="428" height="88"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ZK2-Xw-LEM" id="HIE-6E-scc">
-                <rect key="frame" x="0.0" y="0.0" width="428" height="87.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="428" height="88"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tmx-Sd-E9i">
-                        <rect key="frame" x="16" y="16" width="396" height="35.5"/>
+                        <rect key="frame" x="16" y="16" width="396" height="36"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="18" id="719-qw-JbX"/>
                         </constraints>
@@ -28,7 +26,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lKH-i8-Ftz">
-                        <rect key="frame" x="16" y="53.5" width="396" height="18"/>
+                        <rect key="frame" x="16" y="54" width="396" height="18"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="18" id="Mq1-m6-Bag"/>
                         </constraints>

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartListTitleCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartListTitleCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,18 +13,18 @@
             <rect key="frame" x="0.0" y="0.0" width="387" height="59"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yxe-JV-A3j" id="bAc-r5-9Gc">
-                <rect key="frame" x="0.0" y="0.0" width="387" height="58.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="387" height="59"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="0G7-da-TFG" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="16" y="11.5" width="38" height="38"/>
+                        <rect key="frame" x="16" y="11" width="38" height="38"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="38" id="fAA-Kg-A8Z"/>
                             <constraint firstAttribute="height" constant="38" id="vXF-aG-DCz"/>
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="74y-RA-tA4">
-                        <rect key="frame" x="70" y="9.5" width="297" height="22"/>
+                        <rect key="frame" x="70" y="9" width="297" height="22"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="22" id="Sfz-hK-WdF"/>
                         </constraints>
@@ -35,7 +33,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4zs-C7-CtU">
-                        <rect key="frame" x="70" y="32.5" width="297" height="20"/>
+                        <rect key="frame" x="70" y="32" width="297" height="20"/>
                         <constraints>
                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="aeZ-6J-P0C"/>
                         </constraints>
@@ -44,7 +42,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="2gT-Ue-Edc">
-                        <rect key="frame" x="23" y="18.5" width="24" height="24"/>
+                        <rect key="frame" x="23" y="18" width="24" height="24"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="24" id="D3x-JW-Pwt"/>
                             <constraint firstAttribute="height" constant="24" id="E8H-Nu-AhZ"/>

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSite.storyboard
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSite.storyboard
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina5_5" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -24,7 +21,7 @@
                             <tableViewSection id="n0H-ts-xAM">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="7Uo-T8-SBI">
-                                        <rect key="frame" x="0.0" y="35" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="1" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="7Uo-T8-SBI" id="4NR-59-7vR">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -67,7 +64,7 @@
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="lvO-X5-lOQ">
-                                        <rect key="frame" x="0.0" y="79" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="45" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="lvO-X5-lOQ" id="ukM-xS-jFg">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -86,22 +83,22 @@
                                                             <rect key="frame" x="0.0" y="15.333333333333332" width="374" height="8.6666666666666679"/>
                                                             <subviews>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="J5f-IF-gpF">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="0.0" height="8.6666666666666661"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="76.666666666666671" height="8.6666666666666661"/>
                                                                     <subviews>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="• Posts" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KxO-Is-bhY">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="0.0" height="3"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="76.666666666666671" height="3"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="• Pages" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="peC-dR-nRG">
-                                                                            <rect key="frame" x="0.0" y="3" width="0.0" height="2.6666666666666661"/>
+                                                                            <rect key="frame" x="0.0" y="3" width="76.666666666666671" height="2.6666666666666661"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="• Media" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N4f-Sa-CVH">
-                                                                            <rect key="frame" x="0.0" y="5.6666666666666679" width="0.0" height="3"/>
+                                                                            <rect key="frame" x="0.0" y="5.6666666666666679" width="76.666666666666671" height="3"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
@@ -109,22 +106,22 @@
                                                                     </subviews>
                                                                 </stackView>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="Cmc-uu-9J9">
-                                                                    <rect key="frame" x="-20" y="0.0" width="0.0" height="8.6666666666666661"/>
+                                                                    <rect key="frame" x="126.66666666666663" y="0.0" width="247.33333333333337" height="8.6666666666666661"/>
                                                                     <subviews>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="• Users &amp; Authors" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FcP-ti-s9r">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="0.0" height="3"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="247.33333333333334" height="3"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="• Domains" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="760-77-2gC">
-                                                                            <rect key="frame" x="0.0" y="3" width="0.0" height="2.6666666666666661"/>
+                                                                            <rect key="frame" x="0.0" y="3" width="247.33333333333334" height="2.6666666666666661"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="• Purchased Upgrades" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q3t-nv-OBS">
-                                                                            <rect key="frame" x="0.0" y="5.6666666666666679" width="0.0" height="3"/>
+                                                                            <rect key="frame" x="0.0" y="5.6666666666666679" width="247.33333333333334" height="3"/>
                                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
@@ -146,7 +143,7 @@
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="top" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="HNw-3J-5iO">
-                                        <rect key="frame" x="0.0" y="123" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="89" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="HNw-3J-5iO" id="8rN-Pf-TUc">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
@@ -185,19 +182,20 @@ If you're unsure about what will be deleted or need any help, not to worry, our 
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="ppe-IO-Pij">
-                                        <rect key="frame" x="0.0" y="167" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="133" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="ppe-IO-Pij" id="JAd-hU-JNQ">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Efz-S9-pOZ">
+                                                <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Efz-S9-pOZ">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="o8x-CR-hFe"/>
                                                     </constraints>
-                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                    <state key="normal" title="Delete Site"/>
+                                                    <state key="normal" title="Delete Site">
+                                                        <color key="titleColor" name="Red50"/>
+                                                    </state>
                                                     <connections>
                                                         <action selector="deleteSite:" destination="aKn-1R-Ofg" eventType="touchUpInside" id="4eh-Wd-NzS"/>
                                                     </connections>
@@ -221,6 +219,7 @@ If you're unsure about what will be deleted or need any help, not to worry, our 
                         </connections>
                     </tableView>
                     <connections>
+                        <outlet property="deleteButtonContainerView" destination="JAd-hU-JNQ" id="gRj-Mz-DSm"/>
                         <outlet property="deleteSiteButton" destination="Efz-S9-pOZ" id="u1F-wG-5U7"/>
                         <outlet property="sectionThreeBody" destination="r5O-oO-teR" id="QI6-ly-kD4"/>
                         <outlet property="sectionTwoColumnOneItem" destination="KxO-Is-bhY" id="sFW-4A-a2R"/>
@@ -249,5 +248,8 @@ If you're unsure about what will be deleted or need any help, not to worry, our 
     </scenes>
     <resources>
         <image name="icon-alert" width="62" height="52"/>
+        <namedColor name="Red50">
+            <color red="0.83921568627450982" green="0.21176470588235294" blue="0.2196078431372549" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SiteManagement/DeleteSiteViewController.swift
@@ -37,6 +37,7 @@ open class DeleteSiteViewController: UITableViewController {
     @IBOutlet fileprivate weak var sectionThreeBody: UILabel!
     @IBOutlet fileprivate weak var supportButton: UIButton!
     @IBOutlet fileprivate weak var deleteSiteButton: UIButton!
+    @IBOutlet private var deleteButtonContainerView: UIView!
 
     // MARK: - View Lifecycle
 
@@ -151,10 +152,15 @@ open class DeleteSiteViewController: UITableViewController {
     /// One time setup of fourth section (delete button)
     ///
     fileprivate func setupDeleteButton() {
+        deleteButtonContainerView.backgroundColor = .listForeground
+
         let trashIcon = Gridicon.iconOfType(.trash)
         deleteSiteButton.setTitle(NSLocalizedString("Delete Site", comment: "Button label for deleting the current site"), for: .normal)
         deleteSiteButton.tintColor = .error
-        deleteSiteButton.setImage(trashIcon, for: .normal)
+        deleteSiteButton.setImage(trashIcon.imageWithTintColor(.error), for: .normal)
+        deleteSiteButton.setImage(trashIcon.imageWithTintColor(.error(.shade70)), for: .highlighted)
+        deleteSiteButton.setTitleColor(.error, for: .normal)
+        deleteSiteButton.setTitleColor(.error(.shade70), for: .highlighted)
         deleteSiteButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
     }
 

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -109,8 +109,8 @@ static CGFloat const FeaturedImageSize = 120.0;
     self.titleLabel.font = [WPStyleGuide notoBoldFontForTextStyle:UIFontTextStyleHeadline];
     self.titleLabel.adjustsFontForContentSizeCategory = YES;
     
-    self.titleLabel.textColor = [UIColor murielNeutral70];
-    self.badgesLabel.textColor = [UIColor murielNeutral];
+    self.titleLabel.textColor = [UIColor murielText];
+    self.badgesLabel.textColor = [UIColor murielTextSubtle];
     self.menuButton.tintColor = [UIColor murielTextSubtle];
     [self.menuButton setImage:[Gridicon iconOfType:GridiconTypeEllipsis] forState:UIControlStateNormal];
 

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/AssembledSiteView.swift
@@ -83,11 +83,11 @@ final class AssembledSiteView: UIView {
 
             textField.translatesAutoresizingMaskIntoConstraints = false
 
-            textField.backgroundColor = .neutral(.shade5)
+            textField.backgroundColor = .listBackground
             textField.font = WPStyleGuide.fontForTextStyle(.footnote)
             textField.isEnabled = false
             textField.textAlignment = .center
-            textField.textColor = .neutral(.shade70)
+            textField.textColor = .textSubtle
             textField.text = domainName
 
             textField.layer.cornerRadius = Parameters.textFieldCornerRadius
@@ -102,7 +102,7 @@ final class AssembledSiteView: UIView {
 
             activityIndicator.translatesAutoresizingMaskIntoConstraints = false
             activityIndicator.hidesWhenStopped = true
-            activityIndicator.color = .neutral(.shade40)
+            activityIndicator.color = .textSubtle
             activityIndicator.startAnimating()
 
             return activityIndicator

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
@@ -244,10 +244,12 @@ final class SiteAssemblyContentView: UIView {
             return
         }
 
+        buttonContainerView.backgroundColor = .basicBackground
+
         // This wrapper view provides underlap for Home indicator
         let buttonContainerContainer = UIView(frame: .zero)
         buttonContainerContainer.translatesAutoresizingMaskIntoConstraints = false
-        buttonContainerContainer.backgroundColor = .white
+        buttonContainerContainer.backgroundColor = .basicBackground
         buttonContainerContainer.addSubview(buttonContainerView)
         addSubview(buttonContainerContainer)
         self.buttonContainerContainer = buttonContainerContainer

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyContentView.swift
@@ -90,7 +90,7 @@ final class SiteAssemblyContentView: UIView {
             label.numberOfLines = 0
 
             label.font = WPStyleGuide.fontForTextStyle(.title1, fontWeight: .bold)
-            label.textColor = .neutral(.shade70)
+            label.textColor = .text
             label.textAlignment = .center
 
             let createdText = NSLocalizedString("Your site has been created!",
@@ -108,7 +108,7 @@ final class SiteAssemblyContentView: UIView {
             label.numberOfLines = 0
 
             label.font = WPStyleGuide.fontForTextStyle(.title2)
-            label.textColor = .neutral(.shade40)
+            label.textColor = .textSubtle
             label.textAlignment = .center
 
             let statusText = NSLocalizedString("We’re creating your new site.",
@@ -124,7 +124,7 @@ final class SiteAssemblyContentView: UIView {
 
             activityIndicator.translatesAutoresizingMaskIntoConstraints = false
             activityIndicator.hidesWhenStopped = true
-            activityIndicator.color = .neutral(.shade40)
+            activityIndicator.color = .textSubtle
             activityIndicator.startAnimating()
 
             return activityIndicator
@@ -185,7 +185,7 @@ final class SiteAssemblyContentView: UIView {
         translatesAutoresizingMaskIntoConstraints = true
         autoresizingMask = [ .flexibleWidth, .flexibleHeight ]
 
-        backgroundColor = .neutral(.shade5)
+        backgroundColor = .listBackground
 
         statusStackView.addArrangedSubviews([ statusLabel, activityIndicator ])
         addSubviews([ completionLabel, statusStackView ])

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
@@ -71,7 +71,7 @@ final class TitleSubtitleHeader: UIView {
     }
 
     private func styleBackground() {
-        backgroundColor = .neutral(.shade5)
+        backgroundColor = .listBackground
     }
 
     private func styleTitle() {

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
@@ -76,12 +76,12 @@ final class TitleSubtitleHeader: UIView {
 
     private func styleTitle() {
         titleLabel.font = WPStyleGuide.fontForTextStyle(.title1, fontWeight: .bold)
-        titleLabel.textColor = .neutral(.shade70)
+        titleLabel.textColor = .text
     }
 
     private func styleSubtitle() {
         subtitleLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
-        subtitleLabel.textColor = .neutral(.shade40)
+        subtitleLabel.textColor = .textSubtle
     }
 
     func setTitle(_ text: String) {

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -68,17 +68,28 @@ final class SearchTextField: UITextField {
     private func initialize() {
         translatesAutoresizingMaskIntoConstraints = false
 
-        backgroundColor = .white
+        backgroundColor = .listForeground
         clearButtonMode = .whileEditing
         font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
-        textColor = .neutral(.shade70)
+        textColor = .text
 
         autocapitalizationType = .none
         autocorrectionType = .no
         adjustsFontForContentSizeCategory = true
 
+        setIconImage()
+
+        NSLayoutConstraint.activate([
+            heightAnchor.constraint(equalToConstant: Constants.searchHeight),
+            ])
+
+        addTopBorder(withColor: .divider)
+        addBottomBorder(withColor: .divider)
+    }
+
+    private func setIconImage() {
         let iconSize = CGSize(width: Constants.iconDimension, height: Constants.iconDimension)
-        let loupeIcon = Gridicon.iconOfType(.search, withSize: iconSize).imageWithTintColor(WPStyleGuide.readerCardCellHighlightedBorderColor())?.imageFlippedForRightToLeftLayoutDirection()
+        let loupeIcon = Gridicon.iconOfType(.search, withSize: iconSize).imageWithTintColor(.listIcon)?.imageFlippedForRightToLeftLayoutDirection()
         let imageView = UIImageView(image: loupeIcon)
 
         if traitCollection.layoutDirection == .rightToLeft {
@@ -88,13 +99,16 @@ final class SearchTextField: UITextField {
             leftView = imageView
             leftViewMode = .always
         }
+    }
 
-        NSLayoutConstraint.activate([
-            heightAnchor.constraint(equalToConstant: Constants.searchHeight),
-            ])
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
 
-        addTopBorder(withColor: .neutral(.shade10))
-        addBottomBorder(withColor: .neutral(.shade10))
+        #if XCODE11
+            if #available(iOS 13, *) {
+                setIconImage()
+            }
+        #endif
     }
 }
 
@@ -162,7 +176,7 @@ final class TitleSubtitleTextfieldHeader: UIView {
     }
 
     private func setStyles() {
-        backgroundColor = .neutral(.shade5)
+        backgroundColor = .clear
     }
 
     func setTitle(_ text: String) {

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteInfo/SiteInformationWizardContent.swift
@@ -81,7 +81,7 @@ final class SiteInformationWizardContent: UIViewController {
     }
 
     private func setupBackground() {
-        view.backgroundColor = .neutral(.shade5)
+        view.backgroundColor = .listBackground
     }
 
     private func setupTable() {
@@ -97,11 +97,11 @@ final class SiteInformationWizardContent: UIViewController {
     }
 
     private func setupTableBackground() {
-        table.backgroundColor = .neutral(.shade5)
+        table.backgroundColor = .listBackground
     }
 
     private func setupTableSeparator() {
-        table.separatorColor = .neutral(.shade10)
+        table.separatorColor = .divider
     }
 
     private func registerCell() {
@@ -117,7 +117,7 @@ final class SiteInformationWizardContent: UIViewController {
     }
 
     private func setupButtonWrapper() {
-        buttonWrapper.backgroundColor = .neutral(.shade5)
+        buttonWrapper.backgroundColor = .listBackground
     }
 
     private func setupNextButton() {
@@ -287,11 +287,15 @@ extension SiteInformationWizardContent: UITableViewDataSource {
             cell.addBottomBorder(withColor: .neutral(.shade10))
         }
 
+        cell.contentView.backgroundColor = .listForeground
+
         cell.nameLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
-        cell.nameLabel.textColor = .neutral(.shade70)
+        cell.nameLabel.textColor = .text
+        cell.nameLabel.backgroundColor = .listForeground
 
         cell.valueTextField.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
-        cell.valueTextField.textColor = .neutral(.shade60)
+        cell.valueTextField.textColor = .text
+        cell.valueTextField.backgroundColor = .listForeground
 
         if cell.delegate == nil {
             cell.delegate = self
@@ -300,7 +304,7 @@ extension SiteInformationWizardContent: UITableViewDataSource {
 
     private func attributedPlaceholder(text: String) -> NSAttributedString {
         let attributes: [NSAttributedString.Key: Any] = [
-            .foregroundColor: UIColor.neutral(.shade30),
+            .foregroundColor: UIColor.textPlaceholder,
             .font: WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
         ]
 

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsCell.swift
@@ -28,9 +28,7 @@ final class SiteSegmentsCell: UITableViewCell, ModelSettableCell {
             if let modelIcon = model?.icon {
                 icon.downloadImage(from: modelIcon, placeholderImage: nil, success: { [weak self] downloadedImage in
                     let tintedImage = downloadedImage.withRenderingMode(.alwaysTemplate)
-                    if let tintColor = self?.model?.iconTintColor {
-                        self?.icon.tintColor = tintColor
-                    }
+                    self?.icon.tintColor = .listIcon
                     self?.icon.image = tintedImage
                 }, failure: nil)
             }
@@ -61,18 +59,18 @@ final class SiteSegmentsCell: UITableViewCell, ModelSettableCell {
     }
 
     private func styleBackground() {
-        backgroundColor = .white
+        backgroundColor = .listForeground
     }
 
     private func styleTitle() {
         title.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
-        title.textColor = .neutral(.shade70)
+        title.textColor = .text
         title.adjustsFontForContentSizeCategory = true
     }
 
     private func styleSubtitle() {
         subtitle.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .regular)
-        subtitle.textColor = .neutral(.shade70)
+        subtitle.textColor = .textSubtle
         subtitle.adjustsFontForContentSizeCategory = true
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
@@ -81,11 +81,11 @@ final class SiteSegmentsWizardContent: UIViewController {
     }
 
     private func setupTableBackground() {
-        table.backgroundColor = .neutral(.shade5)
+        table.backgroundColor = .listBackground
     }
 
     private func setupTableSeparator() {
-        table.separatorColor = .neutral(.shade10)
+        table.separatorColor = .divider
     }
 
     private func hideSeparators() {

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsWizardContent.swift
@@ -63,7 +63,7 @@ final class SiteSegmentsWizardContent: UIViewController {
     }
 
     private func setupBackground() {
-        view.backgroundColor = .neutral(.shade5)
+        view.backgroundColor = .listBackground
     }
 
     override func viewDidLayoutSubviews() {

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/NewVerticalCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/NewVerticalCell.swift
@@ -30,11 +30,11 @@ final class NewVerticalCell: UITableViewCell, SiteVerticalPresenter {
 
     private func styleTitle() {
         WPStyleGuide.configureLabel(title, textStyle: .body, symbolicTraits: .traitItalic)
-        title.textColor = .neutral(.shade70)
+        title.textColor = .text
     }
 
     private func styleSubtitle() {
         subtitle.font = WPFontManager.systemRegularFont(ofSize: 15.0)
-        subtitle.textColor = .neutral(.shade30)
+        subtitle.textColor = .textSubtle
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsCell.swift
@@ -23,7 +23,7 @@ final class VerticalsCell: UITableViewCell, SiteVerticalPresenter {
 
     private func styleTitle() {
         title.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
-        title.textColor = .neutral(.shade70)
+        title.textColor = .text
         title.adjustsFontForContentSizeCategory = true
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Verticals/VerticalsWizardContent.swift
@@ -291,7 +291,7 @@ final class VerticalsWizardContent: UIViewController {
     }
 
     private func setupBackground() {
-        view.backgroundColor = .neutral(.shade5)
+        view.backgroundColor = .listBackground
     }
 
     private func setupCellHeight() {
@@ -333,7 +333,7 @@ final class VerticalsWizardContent: UIViewController {
     }
 
     private func setupButtonWrapper() {
-        buttonWrapper.backgroundColor = .neutral(.shade5)
+        buttonWrapper.backgroundColor = .listBackground
     }
 
     private func setupNextButton() {
@@ -362,7 +362,7 @@ final class VerticalsWizardContent: UIViewController {
     }
 
     private func setupTableBackground() {
-        table.backgroundColor = .neutral(.shade5)
+        table.backgroundColor = .listBackground
     }
 
     private func setupTableHeaderWithPrompt(_ prompt: SiteVerticalsPrompt) {
@@ -380,7 +380,7 @@ final class VerticalsWizardContent: UIViewController {
         header.accessibilityTraits = .header
 
         let placeholderText = prompt.hint
-        let attributes = WPStyleGuide.defaultSearchBarTextAttributesSwifted(.neutral(.shade30))
+        let attributes = WPStyleGuide.defaultSearchBarTextAttributesSwifted(.textPlaceholder)
         let attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: attributes)
         header.textField.attributedPlaceholder = attributedPlaceholder
         header.textField.returnKeyType = .done
@@ -408,7 +408,7 @@ final class VerticalsWizardContent: UIViewController {
     }
 
     private func setupTableSeparator() {
-        table.separatorColor = .neutral(.shade10)
+        table.separatorColor = .divider
     }
 
     private func trackVerticalSelection(_ vertical: SiteVertical) {

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/AddressCell.swift
@@ -3,8 +3,10 @@ import WordPressKit
 
 final class AddressCell: UITableViewCell, ModelSettableCell {
     private struct TextStyleAttributes {
-        static let defaults: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular), .foregroundColor: UIColor.neutral(.shade30)]
-        static let customName: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular), .foregroundColor: UIColor.neutral(.shade70)]
+        static let defaults: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular),
+                                                              .foregroundColor: UIColor.textSubtle]
+        static let customName: [NSAttributedString.Key: Any] = [.font: WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular),
+                                                                .foregroundColor: UIColor.text]
     }
 
     @IBOutlet weak var title: UILabel!

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -78,7 +78,7 @@ final class WebAddressWizardContent: UIViewController {
 
             label.font = WPStyleGuide.fontForTextStyle(.title2)
             label.textAlignment = .center
-            label.textColor = .neutral(.shade40)
+            label.textColor = .text
 
             let noResultsMessage = NSLocalizedString("No available addresses matching your search", comment: "Advises the user that no Domain suggestions could be found for the search query.")
             label.text = noResultsMessage
@@ -254,11 +254,11 @@ final class WebAddressWizardContent: UIViewController {
     }
 
     private func setupBackground() {
-        view.backgroundColor = .neutral(.shade5)
+        view.backgroundColor = .listBackground
     }
 
     private func setupButtonWrapper() {
-        buttonWrapper.backgroundColor = .neutral(.shade5)
+        buttonWrapper.backgroundColor = .listBackground
     }
 
     private func setupCreateSiteButton() {
@@ -347,7 +347,7 @@ final class WebAddressWizardContent: UIViewController {
         header.accessibilityTraits = .header
 
         let placeholderText = NSLocalizedString("Search Domains", comment: "Site creation. Seelect a domain, search field placeholder")
-        let attributes = WPStyleGuide.defaultSearchBarTextAttributesSwifted(.neutral(.shade30))
+        let attributes = WPStyleGuide.defaultSearchBarTextAttributesSwifted(.textPlaceholder)
         let attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: attributes)
         header.textField.attributedPlaceholder = attributedPlaceholder
 
@@ -378,11 +378,11 @@ final class WebAddressWizardContent: UIViewController {
     }
 
     private func setupTableBackground() {
-        table.backgroundColor = .neutral(.shade5)
+        table.backgroundColor = .listBackground
     }
 
     private func setupTableSeparator() {
-        table.separatorColor = .neutral(.shade10)
+        table.separatorColor = .divider
     }
 
     private func setupConstraints() {

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -142,7 +142,7 @@ private extension SiteStatsDashboardViewController {
                                                        animated: false)
             }
 
-            periodTableViewController.selectedDate = periodDate ?? StatsDataHelper.currentDateForSite().normalizedForSite()
+            periodTableViewController.selectedDate = periodDate ?? StatsDataHelper.currentDateForSite()
             let selectedPeriod = StatsPeriodUnit(rawValue: currentSelectedPeriod.rawValue - 1) ?? .day
             periodTableViewController.selectedPeriod = selectedPeriod
         }


### PR DESCRIPTION
Refs. #12320 

This PR fixes:
- Muriel placeholder color: [bd29ac8](https://github.com/wordpress-mobile/WordPress-iOS/commit/bd29ac834e1ace71c5838c02ee47bc71df49ec24)

- Page List cell labels colors & Delete Button in Site Settings
![dark-mode-mix](https://user-images.githubusercontent.com/912252/64436471-52050300-d0bc-11e9-8fdf-d3b3e2e2c510.jpg)
- Site creation flow
![site-creation-dark-mode-dark-01](https://user-images.githubusercontent.com/912252/64437926-13bd1300-d0bf-11e9-9a68-d6073afa48ee.jpg)
![site-creation-dark-mode-dark-02](https://user-images.githubusercontent.com/912252/64437927-13bd1300-d0bf-11e9-9947-c436bbdad3f4.jpg)
![site-creation-dark-mode-dark-03](https://user-images.githubusercontent.com/912252/64437928-13bd1300-d0bf-11e9-9178-dcc3e0c6e866.jpg)
![site-creation-dark-mode-dark-04](https://user-images.githubusercontent.com/912252/64437929-13bd1300-d0bf-11e9-947e-75f6577f2c81.jpg)
![site-creation-dark-mode-light-01](https://user-images.githubusercontent.com/912252/64438847-b7f38980-d0c0-11e9-9732-cac849da339b.jpg)
![site-creation-dark-mode-light-02](https://user-images.githubusercontent.com/912252/64438848-b88c2000-d0c0-11e9-87ef-ebeef7cb7eba.jpg)
![site-creation-dark-mode-light-03](https://user-images.githubusercontent.com/912252/64438849-b88c2000-d0c0-11e9-858c-17922d5adfef.jpg)
![site-creation-dark-mode-light-04](https://user-images.githubusercontent.com/912252/64438852-b88c2000-d0c0-11e9-9bc2-fe847abf5187.jpg)
- Fix Quick Start
![quick-start-dark-mode-dark](https://user-images.githubusercontent.com/912252/64437193-c42a1780-d0bd-11e9-9000-e27d4cde84e5.jpg)
![quick-start-dark-mode-light](https://user-images.githubusercontent.com/912252/64437210-ce4c1600-d0bd-11e9-8440-fc10f56c7bcb.jpg)

## To test:
• Run this branch with Xcode 11 and iOS 13
• Create a new WordPress.com site and check everything works fine in dark and light mode
• Then activate QuickStart and check the site dashboard header has the right color.
• Check the 2 QuickStart checklist have the right colors
• Go to the site settings and try to cancel it. Check the cancel button has the right color.
• Do the same thing building for iOS 12

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
