### PR TITLE
[Dark Mode] Fix Plugins colors

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
@@ -57,7 +57,7 @@ class ExpandableCell: WPReusableTableViewCell {
         chevronImageView?.image = Gridicon.iconOfType(.chevronDown)
         chevronImageView?.tintColor = WPStyleGuide.cellGridiconAccessoryColor()
 
-        titleTextLabel?.textColor = .neutral(.shade70)
+        titleTextLabel?.textColor = .text
 
         let linkAttributes: [NSAttributedString.Key: Any] = [.foregroundColor: UIColor.primary,
                                                              .underlineStyle: 0,
@@ -67,6 +67,8 @@ class ExpandableCell: WPReusableTableViewCell {
         expandableTextView?.delegate = self
         expandableTextView?.textContainerInset = .zero
         expandableTextView?.textContainer.lineFragmentPadding = 0
+        expandableTextView?.textColor = .text
+        expandableTextView?.backgroundColor = .clear
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
@@ -67,7 +67,6 @@ class ExpandableCell: WPReusableTableViewCell {
         expandableTextView?.delegate = self
         expandableTextView?.textContainerInset = .zero
         expandableTextView?.textContainer.lineFragmentPadding = 0
-        expandableTextView?.textColor = .text
         expandableTextView?.backgroundColor = .clear
     }
 

--- a/WordPress/Classes/ViewRelated/Cells/TextWithAccessoryButtonCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/TextWithAccessoryButtonCell.swift
@@ -13,7 +13,11 @@ class TextWithAccessoryButtonCell: WPReusableTableViewCell {
         }
     }
 
-    @IBOutlet private var mainLabel: UILabel?
+    @IBOutlet private var mainLabel: UILabel? {
+        didSet {
+            mainLabel?.textColor = .textSubtle
+        }
+    }
     @IBOutlet private var secondaryLabel: UILabel?
     @IBOutlet public private(set) var button: NUXButton?
 

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDetailViewHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDetailViewHeaderCell.swift
@@ -10,7 +10,7 @@ class PluginDetailViewHeaderCell: UITableViewCell {
     }
 
     open func configureCell(_ directoryEntry: PluginDirectoryEntry) {
-        contentView.backgroundColor = .neutral(.shade0)
+        contentView.backgroundColor = .listForeground
 
         if let banner = directoryEntry.banner {
             headerImageView?.isHidden = false
@@ -21,7 +21,7 @@ class PluginDetailViewHeaderCell: UITableViewCell {
 
         let iconPlaceholder = Gridicon.iconOfType(.plugins, withSize: CGSize(width: 40, height: 40))
         iconImageView?.downloadImage(from: directoryEntry.icon, placeholderImage: iconPlaceholder)
-        iconImageView?.backgroundColor = .neutral(.shade0)
+        iconImageView?.backgroundColor = .listForeground
         iconImageView?.tintColor = .neutral
 
         nameLabel?.text = directoryEntry.name

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryCollectionViewCell.swift
@@ -26,7 +26,6 @@ class PluginDirectoryCollectionViewCell: UICollectionViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-
         nameLabel.font = WPStyleGuide.subtitleFontBold()
         logoImageView.tintColor = WPStyleGuide.cellGridiconAccessoryColor()
     }

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryCollectionViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryCollectionViewCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -37,7 +35,7 @@ with long title</string>
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="huw-bc-DnN" secondAttribute="trailing" id="Mhr-k4-l9t"/>
                 <constraint firstItem="kDU-L0-NYI" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Rrv-tf-Udl"/>

--- a/WordPress/Classes/ViewRelated/Plugins/PluginListCell.xib
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginListCell.xib
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14865.1" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14819.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,7 +13,7 @@
             <rect key="frame" x="0.0" y="0.0" width="643" height="72"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="9JL-Ab-5ka" id="Zhb-0F-wJw">
-                <rect key="frame" x="0.0" y="0.0" width="643" height="71.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="643" height="72"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="RK4-vT-k2f">
@@ -28,7 +24,7 @@
                         </constraints>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Jetpack" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F0c-Qp-f0w">
-                        <rect key="frame" x="72" y="15" width="535" height="20.5"/>
+                        <rect key="frame" x="72" y="15" width="540" height="20.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <color key="textColor" red="0.18039215689999999" green="0.2666666667" blue="0.32549019610000002" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
@@ -40,8 +36,8 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fKA-Hi-YBp" userLabel="accessoryViewContainer">
-                        <rect key="frame" x="151.5" y="41.5" width="475.5" height="14"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <rect key="frame" x="151.5" y="42" width="475.5" height="14"/>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="14" id="Oog-o2-yXz"/>
                         </constraints>

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -562,7 +562,7 @@ class PluginViewModel: Observable {
             guard let font = value as? UIFont, font.familyName == "Times New Roman" else { return }
 
             copy.addAttribute(.font, value: WPStyleGuide.subtitleFont(), range: range)
-            copy.addAttribute(.foregroundColor, value: UIColor.neutral(.shade70), range: range)
+            copy.addAttribute(.foregroundColor, value: UIColor.text, range: range)
         }
 
 


### PR DESCRIPTION
Refs #12320 

This PR fixes some white background and colors in the Plugins section.
![plugins-dark-mode-dark](https://user-images.githubusercontent.com/912252/64448683-2d1d8980-d0d6-11e9-94a8-622088db0450.jpg)
![plugins-dark-mode-light](https://user-images.githubusercontent.com/912252/64448684-2d1d8980-d0d6-11e9-8a82-e00b71c13dcf.jpg)
## To test:
- Run this branch with Xcode 11 and iOS 13
- Use a site where you can install plugins
- Open the Plugins list and check the colors
- Open on Plugins category and check the colors
- Open a Plugin detail (specially one not installed) and check the colors
- Test everything works on iOS 12

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
