### PR TITLE
[Dark Mode] Activities log, Plans, Sharing and Menu fixes

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColorsObjC.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColorsObjC.swift
@@ -62,6 +62,11 @@
     }
 
     @available(swift, obsoleted: 1.0)
+    static func murielNeutral80() -> UIColor {
+        return .neutral(.shade80)
+    }
+
+    @available(swift, obsoleted: 1.0)
     static func murielSuccess() -> UIColor {
         return .success
     }
@@ -74,6 +79,11 @@
     @available(swift, obsoleted: 1.0)
     static func murielTextSubtle() -> UIColor {
         return .textSubtle
+    }
+
+    @available(swift, obsoleted: 1.0)
+    static func murielTextTertiary() -> UIColor {
+        return .textTertiary
     }
 
     @available(swift, obsoleted: 1.0)

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewController.swift
@@ -127,6 +127,7 @@ extension ActivityListViewController {
             return nil
         }
 
+        cell.separator.isHidden = true
         cell.titleLabel.text = NSLocalizedString("Since you're on a free plan, you'll see limited events in your Activity Log.", comment: "Text displayed as a footer of a table view with Activities when user is on a free plan")
 
         return cell

--- a/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityTableViewCell.swift
@@ -26,8 +26,8 @@ open class ActivityTableViewCell: WPTableViewCell {
         summaryLabel.text = activity.summary
         contentLabel.text = activity.text
 
-        summaryLabel.textColor = .text
-        contentLabel.textColor = .textSubtle
+        summaryLabel.textColor = .textSubtle
+        contentLabel.textColor = .text
 
         iconBackgroundImageView.backgroundColor = Style.getColorByActivityStatus(activity)
         if let iconImage = Style.getIconForActivity(activity) {

--- a/WordPress/Classes/ViewRelated/Blog/SettingTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Blog/SettingTableViewCell.m
@@ -14,7 +14,7 @@
     if (self) {
         self.textLabel.text = label;
         [WPStyleGuide configureTableViewCell:self];
-        self.detailTextLabel.textColor = [UIColor murielNeutral30];
+        self.detailTextLabel.textColor = [UIColor murielTextSubtle];
         if (editable) {
             self.accessoryType = UITableViewCellAccessoryDisclosureIndicator;
             self.selectionStyle = UITableViewCellSelectionStyleDefault;

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -373,7 +373,7 @@ import WordPressShared
         cell.editingAccessoryView = cell.accessoryView
         cell.editingAccessoryType = cell.accessoryType
         cell.imageView?.image = self.iconForSharingButton(button)
-        cell.imageView?.tintColor = .neutral(.shade10)
+        cell.imageView?.tintColor = .listIcon
         cell.textLabel?.text = button.name
     }
 

--- a/WordPress/Classes/ViewRelated/Menus/MenuDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuDetailsViewController.m
@@ -52,7 +52,8 @@ static NSTimeInterval const TextfieldEditingAnimationDuration = 0.3;
 {
     UITextField *textField = self.textField;
     textField.placeholder = NSLocalizedString(@"Menu Name", @"Menus placeholder text for the name field of a menu with no name.");
-    textField.textColor = [UIColor murielNeutral70];
+    textField.textColor = [UIColor murielText];
+    textField.tintColor = [UIColor murielListIcon];
     textField.adjustsFontForContentSizeCategory = YES;
     [self updateTextFieldFont];
     [textField addTarget:self action:@selector(hideTextFieldKeyboard) forControlEvents:UIControlEventEditingDidEndOnExit];
@@ -73,7 +74,7 @@ static NSTimeInterval const TextfieldEditingAnimationDuration = 0.3;
 {
     UIButton *trashButton = self.trashButton;
     [trashButton setTitle:nil forState:UIControlStateNormal];
-    trashButton.tintColor = [UIColor murielNeutral30];
+    trashButton.tintColor = [UIColor murielListIcon];
     [trashButton setImage:[Gridicon iconOfType:GridiconTypeTrash] forState:UIControlStateNormal];
     [trashButton addTarget:self action:@selector(trashButtonPressed) forControlEvents:UIControlEventTouchUpInside];
     trashButton.backgroundColor = [UIColor clearColor];
@@ -88,7 +89,7 @@ static NSTimeInterval const TextfieldEditingAnimationDuration = 0.3;
     UIImage *image = [Gridicon iconOfType:GridiconTypePencil];
     UIImageView *imageView = [[UIImageView alloc] initWithImage:image];
     imageView.translatesAutoresizingMaskIntoConstraints = NO;
-    imageView.tintColor = [UIColor murielNeutral30];
+    imageView.tintColor = [UIColor murielListIcon];
     imageView.contentMode = UIViewContentModeScaleAspectFit;
     _textFieldDesignIcon = imageView;
 
@@ -156,7 +157,11 @@ static NSTimeInterval const TextfieldEditingAnimationDuration = 0.3;
 
         self.doneButton.alpha = 1.0;
         self.textFieldDesignIcon.hidden = YES;
-        self.textFieldDesignView.backgroundColor = [UIColor colorWithWhite:1.0 alpha:0.6];
+        if (@available(iOS 13, *)) {
+            self.textFieldDesignView.backgroundColor = [UIColor tertiarySystemBackgroundColor];
+        } else {
+            self.textFieldDesignView.backgroundColor = [UIColor murielNeutral0];
+        }
 
     } completion:nil];
 }

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemAbstractView.m
@@ -109,7 +109,7 @@ CGFloat const MenuItemsStackableViewDefaultHeight = 44.0;
     // width and height constraints are (less than or equal to) in case the view is hidden
     [iconView.widthAnchor constraintLessThanOrEqualToConstant:MenusDesignItemIconSize].active = YES;
     [iconView.heightAnchor constraintLessThanOrEqualToConstant:MenusDesignItemIconSize].active = YES;
-    iconView.tintColor = [UIColor murielNeutral30];
+    iconView.tintColor = [UIColor murielListIcon];
     _iconView = iconView;
 
     NSAssert(_stackView != nil, @"stackView is nil");
@@ -214,6 +214,7 @@ CGFloat const MenuItemsStackableViewDefaultHeight = 44.0;
     button.backgroundColor = [UIColor clearColor];
 
     [button setImage:image forState:UIControlStateNormal];
+    button.tintColor = [UIColor murielTextTertiary];
 
     CGFloat padding = 6.0;
     CGFloat width = MenusDesignItemIconSize + (padding * 2);
@@ -269,7 +270,7 @@ CGFloat const MenuItemsStackableViewDefaultHeight = 44.0;
     if (self.highlighted) {
         color = [UIColor whiteColor];
     } else  {
-        color = [UIColor murielNeutral30];
+        color = [UIColor murielListIcon];
     }
 
     return color;

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemView.m
@@ -97,7 +97,7 @@
 
         [self.cancelButton setTitleColor:[UIColor murielPrimary] forState:UIControlStateNormal];
         self.addButton.tintColor = [UIColor murielPrimary];
-        self.orderingButton.tintColor = [UIColor murielNeutral10];
+        self.orderingButton.tintColor = [UIColor murielTextTertiary];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Menus/MenusSelectionDetailView.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusSelectionDetailView.m
@@ -110,7 +110,7 @@
     UIImageView *accessoryView = [[UIImageView alloc] init];
     accessoryView.contentMode = UIViewContentModeScaleAspectFit;
     accessoryView.image = [Gridicon iconOfType:GridiconTypeChevronDown];
-    accessoryView.tintColor = [UIColor murielNeutral10];
+    accessoryView.tintColor = [UIColor murielTextTertiary];
     [accessoryView.widthAnchor constraintEqualToConstant:24].active = YES;
     [accessoryView.heightAnchor constraintEqualToConstant:24].active = YES;
     _accessoryView = accessoryView;

--- a/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListRow.swift
@@ -22,7 +22,7 @@ struct PlanListRow: ImmuTableRow {
         cell.textLabel?.attributedText = attributedTitle
         cell.textLabel?.adjustsFontSizeToFitWidth = true
         cell.detailTextLabel?.text = description
-        cell.detailTextLabel?.textColor = .neutral(.shade30)
+        cell.detailTextLabel?.textColor = .textSubtle
         cell.detailTextLabel?.font = WPFontManager.systemRegularFont(ofSize: 14.0)
         cell.separatorInset = UIEdgeInsets.zero
         cell.backgroundColor = .listForeground


### PR DESCRIPTION
Refs. #12320 

This PR fixes some colors:
- Activity log labels and footer stroke
- Plans subtitle label
![dark-mode-mix-p2-dark-01](https://user-images.githubusercontent.com/912252/64518759-b6a5a500-d2ea-11e9-9647-49e3afe266b7.jpg)
![dark-mode-mix-p2-light-01](https://user-images.githubusercontent.com/912252/64518763-b73e3b80-d2ea-11e9-8d3d-009341d07389.jpg)

- The Icons colors under Sharing 
![dark-mode-mix-p2-dark-02](https://user-images.githubusercontent.com/912252/64518761-b6a5a500-d2ea-11e9-815e-57c95f4304d4.jpg)
![dark-mode-mix-p2-light-02](https://user-images.githubusercontent.com/912252/64518764-b73e3b80-d2ea-11e9-9596-99dacf1c67ab.jpg)

- Menu icons and textfield appearance
![dark-mode-mix-p2-dark-03](https://user-images.githubusercontent.com/912252/64518762-b6a5a500-d2ea-11e9-8c41-97f16fe29f6d.jpg)
![dark-mode-mix-p2-light-03](https://user-images.githubusercontent.com/912252/64518765-b73e3b80-d2ea-11e9-9ae0-245ef622fc7e.jpg)

## To test:
- Run this branch with Xcode 11 and iOS 13
- Open the Activites log to check the labels color and the footer stroke has been removed
- Under _Sharing > Sharing Buttons / Manage > Edit sharing buttons_ check the icons color
- In Menu check the icon colors and the Menu title textfield appearance
- Run with iOS 12 to verify everything works as expected.

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
