### PR TITLE
Fix logout not stopping notifications

### DIFF
--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -125,6 +125,13 @@ final public class PushNotificationsManager: NSObject {
     /// Unregister the device from WordPress.com notifications
     ///
     @objc func unregisterDeviceToken() {
+
+        // It's possible for the unregister server call to fail, so always unregister the device locally
+        // to fix https://github.com/wordpress-mobile/WordPress-iOS/issues/11779.
+        if UIApplication.shared.isRegisteredForRemoteNotifications {
+            UIApplication.shared.unregisterForRemoteNotifications()
+        }
+
         guard let knownDeviceId = deviceId else {
             return
         }


### PR DESCRIPTION
Fixes #11779. Kudos to @jtreanor for the suggested fix!

**To test:**
You can replicate the issue by following the steps in #11779.

To test that this fixes the issue, follow the same steps:
- Sign in
- Ensure Push Notifications are working (take some action to cause one to be sent – posting a comment as another user is a good candidate)
- Turn on Airplane Mode
- Log Out
- Turn Airplane Mode off
- Take some action that causes a push notification to be sent – it shouldn't appear on-device. Ideally, you could test this with a signed-in device next to your testing device – that'll help ensure the push notification was actually sent.

**Update release notes:**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.