### PR TITLE
CircleCI: Shallow clone repo to speed up builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,27 @@
 version: 2.1
 
 orbs:
-  ios: wordpress-mobile/ios@0.0.29
+  ios: wordpress-mobile/ios@0.0.31
+  git: wordpress-mobile/git@0.0.31
 
 jobs:
+  unit-tests:
+    executor:
+      name: ios/default
+      xcode-version: "10.2.0"
+    steps:
+      - git/shallow-checkout
+      - ios/test:
+          xcode-version: "10.2.0"
+          workspace: WordPress.xcworkspace
+          scheme: WordPress
+          device: iPhone XS
   build-ui-tests:
     executor:
       name: ios/default
       xcode-version: "10.2.0"
     steps:
-      - checkout
+      - git/shallow-checkout
       - ios/install-dependencies:
           bundle-install: true
           pod-install: true
@@ -47,12 +59,8 @@ jobs:
 workflows:
   wordpress_ios:
     jobs:
-      - ios/test:
+      - unit-tests:
           name: build_and_test
-          xcode-version: "10.2.0"
-          workspace: WordPress.xcworkspace
-          scheme: WordPress
-          device: iPhone XS
   ui_tests:
     jobs:
       - build-ui-tests:


### PR DESCRIPTION
This shaves >1 minute off every CircleCI job by speeding up git checkout time using https://github.com/wordpress-mobile/circleci-orbs/pull/32

To test:

- CircleCI is green, and quick!

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
