### PR TITLE
[Dark Mode] Fix colors in Domain redemption flow

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -110,7 +110,7 @@ extension WPStyleGuide {
     @objc
     class func configureTableViewActionCell(_ cell: UITableViewCell?) {
         configureTableViewCell(cell)
-        cell?.textLabel?.textColor = .primary
+        cell?.textLabel?.textColor = .text
     }
 
     @objc

--- a/WordPress/Classes/ViewRelated/Blog/DomainCredit/DomainCreditRedemptionSuccessViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/DomainCredit/DomainCreditRedemptionSuccessViewController.swift
@@ -47,7 +47,7 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
             return nil
         }
         let font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
-        newAttributedString.setAttributes([.font: font, .foregroundColor: UIColor.neutral(.shade70)],
+        newAttributedString.setAttributes([.font: font, .foregroundColor: UIColor.text],
                                           range: range)
         return newAttributedString
     }

--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -12,8 +12,8 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
 
     enum Const {
         enum Color {
-            static let nameText = UIColor.neutral(.shade70)
-            static let valueText = UIColor.neutral(.shade40)
+            static let nameText = UIColor.text
+            static let valueText = UIColor.textSubtle
         }
     }
 
@@ -39,6 +39,7 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
         nameLabel.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(setValueTextFieldAsFirstResponder(_:))))
 
         valueTextField.textColor = Const.Color.valueText
+        valueTextField.tintColor = .textPlaceholder
         valueTextField.font = WPStyleGuide.tableviewTextFont()
         valueTextField.borderStyle = .none
         valueTextField.addTarget(self,

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+HeaderFooter.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+HeaderFooter.swift
@@ -57,10 +57,11 @@ extension RegisterDomainDetailsViewController {
                 return nil
         }
         view.titleLabel?.attributedText = termsAndConditionsFooterTitle
+        view.titleLabel?.textColor = .textSubtle
         view.titleLabel?.numberOfLines = 0
         view.titleLabel?.lineBreakMode = .byWordWrapping
         view.topConstraint.constant = Constant.privacyProtectionSectionTitleTopDistance
-        view.contentView.backgroundColor = .neutral(.shade5)
+        view.contentView.backgroundColor = .listBackground
         let tap = UITapGestureRecognizer(target: self, action: #selector(handleTermsAndConditionsTap(_:)))
         view.addGestureRecognizer(tap)
         return view
@@ -77,8 +78,8 @@ extension RegisterDomainDetailsViewController {
     }
 
     var termsAndConditionsFooterTitle: NSAttributedString {
-        let bodyColor = UIColor.neutral(.shade50)
-        let linkColor = UIColor.neutral(.shade70)
+        let bodyColor = UIColor.textSubtle
+        let linkColor = UIColor.textSubtle
         let font = UIFont.preferredFont(forTextStyle: .footnote)
 
         let attributes: StyledHTMLAttributes = [

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -280,7 +280,7 @@ extension RegisterDomainDetailsViewController {
             let attributedItem = NSAttributedString.init(
                 string: item,
                 attributes: [.font: WPStyleGuide.tableviewTextFont(),
-                             .foregroundColor: UIColor.neutral(.shade70)]
+                             .foregroundColor: UIColor.text]
             )
             let option = OptionsTableViewOption(
                 image: nil,
@@ -289,6 +289,7 @@ extension RegisterDomainDetailsViewController {
             options.append(option)
         }
         let viewController = OptionsTableViewController(options: options)
+        viewController.cellBackgroundColor = .listForeground
         if let selectedIndex = selectedItemIndex[indexPath] {
             viewController.selectRow(at: selectedIndex)
         }

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/Views/RegisterDomainDetailsFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainDetails/Views/RegisterDomainDetailsFooterView.swift
@@ -9,5 +9,6 @@ class RegisterDomainDetailsFooterView: UIView, NibLoadable {
         super.awakeFromNib()
         clipsToBounds = false
         submitButton.isPrimary = true
+        backgroundColor = .basicBackground
     }
 }

--- a/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Register/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -31,6 +31,7 @@ class RegisterDomainSuggestionsViewController: NUXViewController, DomainSuggesti
 
     private lazy var buttonViewController: NUXButtonViewController = {
         let buttonViewController = NUXButtonViewController.instance()
+        buttonViewController.view.backgroundColor = .basicBackground
         buttonViewController.delegate = self
         buttonViewController.setButtonTitles(
             primary: NSLocalizedString("Choose domain",

--- a/WordPress/Classes/ViewRelated/Domains/Views/RegisterDomainSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/RegisterDomainSectionHeaderView.swift
@@ -10,13 +10,13 @@ class RegisterDomainSectionHeaderView: UITableViewHeaderFooterView {
         super.awakeFromNib()
         titleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline,
                                                         fontWeight: .semibold)
-        titleLabel.textColor = .neutral(.shade70)
+        titleLabel.textColor = .textSubtle
         titleLabel.numberOfLines = 0
 
         descriptionLabel.font = WPStyleGuide.fontForTextStyle(.footnote)
-        descriptionLabel.textColor = .neutral(.shade70)
+        descriptionLabel.textColor = .textSubtle
         descriptionLabel.numberOfLines = 0
-        contentView.backgroundColor = .neutral(.shade5)
+        contentView.backgroundColor = .listBackground
     }
 
     func setTitle(_ title: String?) {

--- a/WordPress/Classes/ViewRelated/NUX/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/DomainSuggestionsTableViewController.swift
@@ -265,7 +265,7 @@ extension DomainSuggestionsTableViewController {
         }
 
         cell.placeholder = searchFieldPlaceholder
-        cell.reloadTextFieldIcon()
+        cell.reloadTextfieldStyle()
         cell.delegate = self
         cell.selectionStyle = .none
         cell.backgroundColor = .clear
@@ -392,7 +392,8 @@ extension DomainSuggestionsTableViewController: SearchTableViewCellDelegate {
 }
 
 extension SearchTableViewCell {
-    fileprivate func reloadTextFieldIcon() {
+    fileprivate func reloadTextfieldStyle() {
+        textField.textColor = .text
         textField.leftViewImage = UIImage(named: "icon-post-search")
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/DomainSuggestionsTableViewController.swift
@@ -96,6 +96,18 @@ class DomainSuggestionsTableViewController: NUXTableViewController {
         SVProgressHUD.dismiss()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        #if XCODE11
+            if #available(iOS 13, *) {
+                if traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+                    tableView.reloadData()
+                }
+            }
+        #endif
+    }
+
     /// Fetches new domain suggestions based on the provided string
     ///
     /// - Parameters:
@@ -253,10 +265,10 @@ extension DomainSuggestionsTableViewController {
         }
 
         cell.placeholder = searchFieldPlaceholder
+        cell.reloadTextFieldIcon()
         cell.delegate = self
         cell.selectionStyle = .none
         cell.backgroundColor = .clear
-
         return cell
     }
 
@@ -376,5 +388,11 @@ extension DomainSuggestionsTableViewController: SearchTableViewCellDelegate {
             self?.searchSuggestions = suggestions
             self?.tableView.reloadSections(IndexSet(integer: Sections.suggestions.rawValue), with: .automatic)
         }
+    }
+}
+
+extension SearchTableViewCell {
+    fileprivate func reloadTextFieldIcon() {
+        textField.leftViewImage = UIImage(named: "icon-post-search")
     }
 }

--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -277,11 +277,12 @@ private extension NoResultsViewController {
         titleLabel.text = titleText
         titleLabel.textColor = .text
 
+        subtitleTextView.textColor = .textSubtle
+
         if let subtitleText = subtitleText {
             subtitleTextView.attributedText = nil
             subtitleTextView.text = subtitleText
             subtitleTextView.isSelectable = false
-            subtitleTextView.textColor = .textSubtle
         }
 
         if let attributedSubtitleText = attributedSubtitleText {


### PR DESCRIPTION
Refs. #12320 

This PR fixes some colors and white background in the Domain Redemption flow.

![domain-redeem-dark-mode-01](https://user-images.githubusercontent.com/912252/64894014-a1ac7700-d646-11e9-8cbf-5a4feb8989f6.jpg)
![domain-redeem-dark-mode-02](https://user-images.githubusercontent.com/912252/64894654-4da29200-d648-11e9-81d4-47dec2351195.jpg)
![domain-redeem-dark-mode-03](https://user-images.githubusercontent.com/912252/64894336-6a8a9580-d647-11e9-918c-579ec2d5752b.jpg)

## To test:
- Run this branch with Xcode 11 and an iOS 13 device
- Buy a plan in order to obtain the possibility to register a domain
- Register the domain using the app. Follow the flow form the site dashboard and check the colors.
- Run it with iOS 11/12 to check everything works fine.

Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
