### PR TITLE
Remove broken site segment cell test

### DIFF
--- a/WordPress/WordPressTest/SiteCreation/SiteSegmentsCellTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteSegmentsCellTests.swift
@@ -44,10 +44,6 @@ final class SiteSegmentsCellTests: XCTestCase {
         XCTAssertEqual(cell?.subtitle.text, MockValues.subtitle)
     }
 
-    func testBackgroundIsStyled() {
-        XCTAssertEqual(cell?.backgroundColor, UIColor.white)
-    }
-
     func testCellTitleIsTheCorrectFont() {
         XCTAssertEqual(cell?.title.font, WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold))
     }


### PR DESCRIPTION
This PR removes a failing site segment test, where we've now updated background colors to use system colors.
