### PR TITLE
Enable zendesk in 13.2.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -155,7 +155,7 @@ target 'WordPress' do
     pod 'MRProgress', '0.8.3'
     pod 'Starscream', '3.0.6'
     pod 'SVProgressHUD', '2.2.5'
-    pod 'ZendeskSDK', '3.0.1'
+    pod 'ZendeskSDK', :git => 'https://github.com/zendesk/zendesk_sdk_ios', :tag => '3.0.1-swift5.1-GM'
     pod 'AlamofireNetworkActivityIndicator', '~> 2.3'
     pod 'FSInteractiveMap', :git => 'https://github.com/wordpress-mobile/FSInteractiveMap.git', :tag => '0.1.1'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -308,7 +308,7 @@ DEPENDENCIES:
   - WordPressUI (~> 1.3.5)
   - WPMediaPicker (~> 1.4.2)
   - yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.11.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json`)
-  - ZendeskSDK (= 3.0.1)
+  - ZendeskSDK (from `https://github.com/zendesk/zendesk_sdk_ios`, tag `3.0.1-swift5.1-GM`)
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
@@ -352,7 +352,6 @@ SPEC REPOS:
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
-    - ZendeskSDK
     - ZIPFoundation
 
 EXTERNAL SOURCES:
@@ -415,6 +414,9 @@ EXTERNAL SOURCES:
     :tag: v1.11.0
   yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.11.0/react-native-gutenberg-bridge/third-party-podspecs/yoga.podspec.json
+  ZendeskSDK:
+    :git: https://github.com/zendesk/zendesk_sdk_ios
+    :tag: 3.0.1-swift5.1-GM
 
 CHECKOUT OPTIONS:
   FSInteractiveMap:
@@ -426,6 +428,9 @@ CHECKOUT OPTIONS:
   RNTAztecView:
     :git: http://github.com/wordpress-mobile/gutenberg-mobile/
     :tag: v1.11.0
+  ZendeskSDK:
+    :git: https://github.com/zendesk/zendesk_sdk_ios
+    :tag: 3.0.1-swift5.1-GM
 
 SPEC CHECKSUMS:
   1PasswordExtension: 0e95bdea64ec8ff2f4f693be5467a09fac42a83d
@@ -495,9 +500,9 @@ SPEC CHECKSUMS:
   WPMediaPicker: 1897f312c7b41114ffd239fb782431ae602134a1
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
   yoga: 4e71c9a33abf45ba55af55ae9cbc86f4234bb2a9
-  ZendeskSDK: c2e49fd16a73e43e490f777cea67dd852b819ace
+  ZendeskSDK: ce880e75f12ae5dacaa3658f49e545f3c8471030
   ZIPFoundation: 89df685c971926b0323087952320bdfee9f0b6ef
 
-PODFILE CHECKSUM: eb2662b2d1884c3526e73b23c2e5a9304da88f1d
+PODFILE CHECKSUM: 5b13fe8dfd51d742f27e91fbc2cf2ecb41643867
 
 COCOAPODS: 1.6.1

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -2,10 +2,8 @@ import Foundation
 import CoreTelephony
 import WordPressAuthenticator
 
-#if !XCODE11
 import ZendeskSDK
 import ZendeskCoreSDK
-#endif
 
 extension NSNotification.Name {
     static let ZendeskPushNotificationReceivedNotification = NSNotification.Name(rawValue: "ZendeskPushNotificationReceivedNotification")
@@ -16,8 +14,6 @@ extension NSNotification.Name {
     public static let ZendeskPushNotificationReceivedNotification = NSNotification.Name.ZendeskPushNotificationReceivedNotification
     public static let ZendeskPushNotificationClearedNotification = NSNotification.Name.ZendeskPushNotificationClearedNotification
 }
-
-#if !XCODE11
 
 /// This class provides the functionality to communicate with Zendesk for Help Center and support ticket interaction,
 /// as well as displaying views for the Help Center, new tickets, and ticket list.
@@ -979,84 +975,3 @@ extension ZendeskUtils: UITextFieldDelegate {
     }
 
 }
-
-
-
-#else
-
-/// This class provides the functionality to communicate with Zendesk for Help Center and support ticket interaction,
-/// as well as displaying views for the Help Center, new tickets, and ticket list.
-///
-@objc class ZendeskUtils: NSObject {
-
-    // MARK: - Public Properties
-
-    static var sharedInstance: ZendeskUtils = ZendeskUtils()
-    static var zendeskEnabled = false
-    @objc static var unreadNotificationsCount = 0
-
-    @objc static var showSupportNotificationIndicator: Bool {
-        return false
-    }
-
-    struct PushNotificationIdentifiers {
-        static let key = "type"
-        static let type = "zendesk"
-    }
-
-    // MARK: - Private Properties
-
-    private override init() {}
-    private var sourceTag: WordPressSupportSourceTag?
-
-    private var userName: String?
-    private var userEmail: String?
-    private var deviceID: String?
-    private var haveUserIdentity = false
-    private var alertNameField: UITextField?
-    private var sitePlansCache = [Int: RemotePlanSimpleDescription]()
-
-    private static var zdAppID: String?
-    private static var zdUrl: String?
-    private static var zdClientId: String?
-    private static var presentInController: UIViewController?
-
-    private static var appVersion: String {
-        return Bundle.main.shortVersionString() ?? ""
-    }
-
-    private static var appLanguage: String {
-        return Locale.preferredLanguages[0]
-    }
-
-    // MARK: - Public Methods
-
-    @objc static func setup() {}
-
-    // MARK: - Show Zendesk Views
-
-    func showHelpCenterIfPossible(from controller: UIViewController, with sourceTag: WordPressSupportSourceTag? = nil) {}
-    func showNewRequestIfPossible(from controller: UIViewController, with sourceTag: WordPressSupportSourceTag? = nil) {}
-    func showTicketListIfPossible(from controller: UIViewController, with sourceTag: WordPressSupportSourceTag? = nil) {}
-    func showSupportEmailPrompt(from controller: UIViewController, completion: @escaping (Bool) -> Void) {}
-
-    func cacheUnlocalizedSitePlans() {}
-
-    // MARK: - Device Registration
-    static func setNeedToRegisterDevice(_ identifier: String) {}
-    static func unregisterDevice() {}
-
-    // MARK: - Push Notifications
-
-    static func handlePushNotification(_ userInfo: NSDictionary) {}
-    static func pushNotificationReceived() {}
-    static func pushNotificationRead() {}
-
-    // MARK: - Helpers
-
-    static func userSupportEmail() -> String? {
-        return nil
-    }
-}
-
-#endif

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -10029,10 +10029,10 @@
 				"${BUILT_PRODUCTS_DIR}/WordPressKit/WordPressKit.framework",
 				"${BUILT_PRODUCTS_DIR}/WordPressShared/WordPressShared.framework",
 				"${BUILT_PRODUCTS_DIR}/WordPressUI/WordPressUI.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0.1/ZendeskCoreSDK.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0.1/ZendeskProviderSDK.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0.1/ZendeskSDK.framework",
-				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.0.1/CommonUISDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.1.0/ZendeskCoreSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.1.0/ZendeskProviderSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.1.0/ZendeskSDK.framework",
+				"${PODS_ROOT}/ZendeskSDK/ZendeskSDK/5.1.0/CommonUISDK.framework",
 				"${BUILT_PRODUCTS_DIR}/wpxmlrpc/wpxmlrpc.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";


### PR DESCRIPTION
Re-enables ZenDesk and updates the ZenDesk pod to the iOS 13 version.

**To test:**
1) Ensure the PR is green
2) Run on-device, and ensure that tickets can be sent.

Known issue: 
- If you change the email address for the user in ZenDesk, sending tickets may fail
- Sending tickets from a WordPress.com admin account may fail.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.