### PR TITLE
Towards fixing a flaky test

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -14,9 +14,7 @@ class PostCoordinator: NSObject {
 
     private var observerUUIDs: [AbstractPost: UUID] = [:]
 
-    private lazy var mediaCoordinator: MediaCoordinator = {
-        return MediaCoordinator.shared
-    }()
+    private var mediaCoordinator: MediaCoordinator
 
     private let backgroundService: PostService
 
@@ -24,7 +22,7 @@ class PostCoordinator: NSObject {
 
     // MARK: - Initializers
 
-    init(mainService: PostService? = nil, backgroundService: PostService? = nil) {
+    init(mainService: PostService? = nil, backgroundService: PostService? = nil, mediaCoordinator: MediaCoordinator? = nil) {
         let contextManager = ContextManager.sharedInstance()
 
         let mainContext = contextManager.mainContext
@@ -36,6 +34,7 @@ class PostCoordinator: NSObject {
 
         self.mainService = mainService ?? PostService(managedObjectContext: mainContext)
         self.backgroundService = backgroundService ?? PostService(managedObjectContext: backgroundContext)
+        self.mediaCoordinator = mediaCoordinator ?? MediaCoordinator.shared
     }
 
     // MARK: - Uploading Media

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -14,7 +14,7 @@ class PostCoordinator: NSObject {
 
     private var observerUUIDs: [AbstractPost: UUID] = [:]
 
-    private var mediaCoordinator: MediaCoordinator
+    private let mediaCoordinator: MediaCoordinator
 
     private let backgroundService: PostService
 

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -88,4 +88,8 @@ private class MediaCoordinatorMock: MediaCoordinator {
         onUpdate(self.media, mediaState)
         return UUID()
     }
+
+    override func retryMedia(_ media: Media, automatedRetry: Bool = false, analyticsInfo: MediaAnalyticsInfo? = nil) {
+        // noop
+    }
 }

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -28,7 +28,7 @@ class PostCoordinatorTests: XCTestCase {
 
         postCoordinator.save(post)
 
-        expect(post.remoteStatus).toEventually(equal(.failed))
+        expect(post.remoteStatus).to(equal(.failed))
         expect(postServiceMock.didCallUploadPost).to(beFalse())
     }
 


### PR DESCRIPTION
This one has been failing here and there for a while.

Thanks @aerych for the ping to look at it.  IMHO calling `postCoordinator.save` ought to either:
- Have persisted its changes by the time it returns _or_
- Provide a callback that lets the caller know exactly when the save operation is complete.

Personally, I'd prefer the first approach, but right now it seems like the timing in this save behaviour is non-deterministic, which makes me wonder if it's part of / related to some of the Core Data instability we've seen recently.

Assuming this should be synchronous, I think we should refactor the tests not to use `toEventually(equal()) ` and instead should just use `to(equal())`.

**To test:** (not ready yet)
- Ensure tests are green in GitHub
- Erase Content + Settings in the Simulator then run the test suite
- Run the test suite a second time
- Re-run the tests a few times in CircleCI to ensure they're not flaky there 

**Update release notes:**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

[Edit by @leandroalonso: The fix was made in a different way, explained here: https://github.com/wordpress-mobile/WordPress-iOS/pull/12514#issuecomment-533641629]