### PR TITLE
[Dark mode] Fix iPad split view appearance

### DIFF
--- a/WordPress/Classes/Extensions/UINavigationController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+Helpers.swift
@@ -1,6 +1,17 @@
 import UIKit
 
 extension UINavigationController {
+    override open var preferredStatusBarStyle: UIStatusBarStyle {
+        return .lightContent
+    }
+
+    override open var childForStatusBarStyle: UIViewController? {
+        if let _ = topViewController as? DefinesVariableStatusBarStyle {
+            return topViewController
+        }
+        return nil
+    }
+
     @objc func scrollContentToTopAnimated(_ animated: Bool) {
         guard viewControllers.count == 1 else { return }
 

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -127,15 +127,25 @@ class WPSplitViewController: UISplitViewController {
     override func overrideTraitCollection(forChild childViewController: UIViewController) -> UITraitCollection? {
         guard let collection = super.overrideTraitCollection(forChild: childViewController) else { return nil }
 
+        var traits = [collection]
+
         // By default, the detail view controller of a split view is passed the same size class as the split view itself.
         // However, if the splitview is smaller than full screen (i.e. multitasking is active), a number of our
         // view controllers will display better if we tell them they're compact even though the split view is regular.
         if childViewController == viewControllers.last && shouldOverrideDetailViewControllerHorizontalSizeClass {
-            return UITraitCollection(traitsFrom: [collection, UITraitCollection(horizontalSizeClass: .compact)])
+            traits.append(UITraitCollection(horizontalSizeClass: .compact))
+        } else {
+            traits.append(UITraitCollection(horizontalSizeClass: traitCollection.horizontalSizeClass))
         }
 
-        let overrideCollection = UITraitCollection(horizontalSizeClass: self.traitCollection.horizontalSizeClass)
-        return UITraitCollection(traitsFrom: [collection, overrideCollection])
+        // This is to work around an apparent bug in iOS 13 where the detail view is assuming the system is in dark
+        // mode when switching out of the app and then back in. Here we ensure the overridden user interface style
+        // traits are replaced with the correct current traits before we use them.
+        if #available(iOS 12.0, *) {
+            traits.append(UITraitCollection(userInterfaceStyle: traitCollection.userInterfaceStyle))
+        }
+
+        return UITraitCollection(traitsFrom: traits)
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Fixes an issue that @rachelmcr discovered with the split view on iPads in dark mode. I don't think this entirely fixes the underlying issue, but it does resolve it for now. Really, we need to re-do the splitview implementation at some point.

I also resolved an issue where the status bar text color was dark instead of light.

![ipad-dark](https://user-images.githubusercontent.com/4780/65262082-75d73880-db01-11e9-8878-7cf8f5cd7141.png)

**To test:**

* Build and run on iPad, iOS 13
* Launch the app to a view like Me
* Enter iPad multitasking (on the simulator, hold Cmd+shift and double-tap H)
* Select another app
* Enter multitasking again
* Select WordPress
* Before this patch, the detail pane would switch into dark mode.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
