### PR TITLE
Marks an uploaded draft to be auto uploaded.

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift
@@ -232,6 +232,7 @@ struct PostNoticeViewModel {
         }
 
         post.status = .publish
+        post.shouldAttemptAutoUpload = true
         postCoordinator.save(post: post)
     }
 

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -71,6 +71,16 @@ class PostBuilder {
         post.author = author
         return self
     }
+    
+    func with(userName: String) -> PostBuilder {
+        post.blog.username = userName
+        return self
+    }
+    
+    func with(password: String) -> PostBuilder {
+        post.blog.password = password
+        return self
+    }
 
     func with(remoteStatus: AbstractPostRemoteStatus) -> PostBuilder {
         post.remoteStatus = remoteStatus

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -71,12 +71,12 @@ class PostBuilder {
         post.author = author
         return self
     }
-    
+
     func with(userName: String) -> PostBuilder {
         post.blog.username = userName
         return self
     }
-    
+
     func with(password: String) -> PostBuilder {
         post.blog.password = password
         return self

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -157,6 +157,7 @@ class PostNoticeViewModelTests: XCTestCase {
         override func cancelAutoUploadOf(_ post: AbstractPost) {
             cancelAutoUploadOfInvocations += 1
         }
+
         override func save(post postToSave: AbstractPost) {
 
         }

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -113,7 +113,7 @@ class PostNoticeViewModelTests: XCTestCase {
         // Then
         expect(postCoordinator.cancelAutoUploadOfInvocations).to(equal(1))
     }
-    
+
     func testFailedPublishedUploadedDraftPostsPublishButtonWillMarkForAutoUpload() {
         // Given
         let context = ContextManager.shared.mainContext
@@ -126,13 +126,13 @@ class PostNoticeViewModelTests: XCTestCase {
             .with(password: "ThisIsABadPassword")
             .build()
         try! context.save()
-        
+
         let postCoordinator = MockPostCoordinator()
         let notice = PostNoticeViewModel(post: post, postCoordinator: postCoordinator).notice
-        
+
         // When
         notice.actionHandler?(true)
- 
+
         // Then
         expect(post.shouldAttemptAutoUpload).to(beTrue())
     }

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -113,6 +113,30 @@ class PostNoticeViewModelTests: XCTestCase {
         // Then
         expect(postCoordinator.cancelAutoUploadOfInvocations).to(equal(1))
     }
+    
+    func testFailedPublishedUploadedDraftPostsPublishButtonWillMarkForAutoUpload() {
+        // Given
+        let context = ContextManager.shared.mainContext
+        let post = PostBuilder(context)
+            .drafted()
+            .with(title: "I've been drafted!")
+            .withRemote()
+            .with(remoteStatus: .sync)
+            .with(userName: "Meee")
+            .with(password: "ThisIsABadPassword")
+            .build()
+        try! context.save()
+        
+        let postCoordinator = MockPostCoordinator()
+        let notice = PostNoticeViewModel(post: post, postCoordinator: postCoordinator).notice
+        
+        // When
+        notice.actionHandler?(true)
+ 
+        // Then
+        expect(post.shouldAttemptAutoUpload).to(beTrue())
+    }
+
 
     private func createPost(_ status: BasePost.Status, hasRemote: Bool = false) -> Post {
         var builder = PostBuilder(context)

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -122,8 +122,6 @@ class PostNoticeViewModelTests: XCTestCase {
             .with(title: "I've been drafted!")
             .withRemote()
             .with(remoteStatus: .sync)
-            .with(userName: "Meee")
-            .with(password: "ThisIsABadPassword")
             .build()
         try! context.save()
 
@@ -158,6 +156,9 @@ class PostNoticeViewModelTests: XCTestCase {
 
         override func cancelAutoUploadOf(_ post: AbstractPost) {
             cancelAutoUploadOfInvocations += 1
+        }
+        override func save(post postToSave: AbstractPost) {
+
         }
     }
 }


### PR DESCRIPTION
Fixes #12362 

To test:

1. Be online
2. Create a post with title
3. Exit editor
4. Save as draft
5. Put a break point here: https://github.com/wordpress-mobile/WordPress-iOS/blob/fb953e49825704046034ee1aba673e7c682fc83b/WordPress/Classes/ViewRelated/Post/PostNoticeViewModel.swift#L30
6. Go offline
7. Continue run 
8. See notice "Post was uploaded" and tap publish in notice
9. Go online
10. See that the post is auto uploaded.

![20190919_140606](https://user-images.githubusercontent.com/1335657/65288332-550be480-dafb-11e9-9792-8f899f9806d7.gif)



Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
