### PR TITLE
Fix issue with gap in NotificationsController

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1293,7 +1293,6 @@ internal extension NotificationsViewController {
     }
 }
 
-
 // MARK: - Sync'ing Helpers
 //
 private extension NotificationsViewController {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -42,6 +42,10 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     /// NoResults View
     ///
     private let noResultsViewController = NoResultsViewController.controller()
+    
+    /// Will be used in viewWillLayoutSubviews to ensure layout is only preformed once
+    ///
+    private var layoutForTheFirstTIme = true
 
     /// All of the data will be fetched during the FetchedResultsController init. Prevent overfetching
     ///
@@ -180,6 +184,19 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         // If we're not onscreen, don't use row animations. Otherwise the fade animation might get animated incrementally
         tableViewHandler.updateRowAnimation = .none
     }
+    
+    override func viewWillLayoutSubviews() {
+           // in iOS 13, traitCollectionDidChange gets called when the view is created as oppose to
+           // previous versions where it was called when added to the view hierarchy
+           // which created this bug: https://github.com/wordpress-mobile/WordPress-iOS/issues/12495.
+           // Apple suggests to perform any work involving traits in one of the layout methods
+           // and then rely on traitCollectionDidChange for any future size class changes.
+           if layoutForTheFirstTIme {
+               layoutForTheFirstTIme = false
+               setupTableHeaderView()
+               setupNoResultsView()
+           }
+       }
 
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         return true

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -42,7 +42,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     /// NoResults View
     ///
     private let noResultsViewController = NoResultsViewController.controller()
-    
+
     /// Will be used in viewWillLayoutSubviews to ensure layout is only preformed once
     ///
     private var layoutForTheFirstTIme = true
@@ -184,7 +184,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         // If we're not onscreen, don't use row animations. Otherwise the fade animation might get animated incrementally
         tableViewHandler.updateRowAnimation = .none
     }
-    
+
     override func viewWillLayoutSubviews() {
            // in iOS 13, traitCollectionDidChange gets called when the view is created as oppose to
            // previous versions where it was called when added to the view hierarchy

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -180,7 +180,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         // If we're not onscreen, don't use row animations. Otherwise the fade animation might get animated incrementally
         tableViewHandler.updateRowAnimation = .none
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         layoutHeaderIfNeeded()

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -189,7 +189,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
         super.viewDidLayoutSubviews()
         layoutHeaderIfNeeded()
     }
-    
+
     private func layoutHeaderIfNeeded() {
         precondition(tableHeaderView != nil)
         // Fix: Update the Frame manually: Autolayout doesn't really help us, when it comes to Table Headers

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -43,10 +43,6 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     ///
     private let noResultsViewController = NoResultsViewController.controller()
 
-    /// Will be used in viewWillLayoutSubviews to ensure layout is only preformed once
-    ///
-    private var layoutForTheFirstTIme = true
-
     /// All of the data will be fetched during the FetchedResultsController init. Prevent overfetching
     ///
     fileprivate var lastReloadDate = Date()


### PR DESCRIPTION
Fixes #12495 

in iOS 13, traitCollectionDidChange gets called when the view is created as oppose to previous versions where it was called when added to the view hierarchy. The different timing of the call created this issue.
Apple suggestion is to perform any work involving traits in one of the layout methods
and then rely on traitCollectionDidChange for any future size class changes.

> Trait environments, such as views and view controllers, now have their traitCollection property populated with traits during initialization. These initial traits represent a prediction of the ultimate traits that the trait environment will receive when it gets added to the hierarchy. Because the traits that are populated during initialization are just a prediction, they might differ from the traits that are received once actually in the hierarchy. Therefore, when possible you should wait to perform work that uses the traitCollection until the view, or view controller’s view, has moved into the hierarchy — meaning window returns a non-nil value — so that you don’t have to throw away any work done using the predicted traits if the actual traits are different. The best time to use the traitCollection is during layout, such as inside layoutSubviews(), viewWillLayoutSubviews(), or viewDidLayoutSubviews().

For further read: https://developer.apple.com/documentation/ios_ipados_release_notes/ios_13_release_notes


To test:
Go to notifications tab and notice no gap. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
