### PR TITLE
Fix localize.py for Xcode 11 and string issues

### DIFF
--- a/Scripts/localize.py
+++ b/Scripts/localize.py
@@ -137,7 +137,7 @@ def localize(path, language, include_pods_and_frameworks):
         find_cmd = 'find . ../Pods/WordPress* ../Pods/WPMediaPicker ../WordPressComStatsiOS/WordPressComStatsiOS ../WordPressShared/WordPressShared -name "*.m" -o -name "*.swift" | grep -v Vendor'
     else:
         find_cmd = 'find . -name "*.m" -o -name "*.swift" | grep -v Vendor'
-    filelist = os.popen(find_cmd).read().split('\n')
+    filelist = os.popen(find_cmd).read().strip().split('\n')
     filelist = '"{0}"'.format('" "'.join(filelist))
 
     if os.path.isfile(original):

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -199,8 +199,9 @@ class StatsTotalRow: UIView, NibLoadable, Accessible {
 
         switch (showDisclosure, hasChildRows) {
         case (true, true):
-            let hint = expanded ? "Expanded. Tap to collapse." : "Collapsed. Tap to expand."
-            accessibilityHint = NSLocalizedString(hint, comment: "Accessibility hint")
+            accessibilityHint = expanded
+                                    ? NSLocalizedString("Expanded. Tap to collapse.", comment: "Accessibility hint")
+                                    : NSLocalizedString("Collapsed. Tap to expand.", comment: "Accessibility hint")
         case (true, false):
             accessibilityHint = NSLocalizedString("Tap for more detail.", comment: "Accessibility hint")
         default:

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -336,12 +336,12 @@ extension TopTotalsCell: Accessible {
         let dataTitle = dataSubtitleLabel.text
 
         if let itemTitle = itemTitle, let dataTitle = dataTitle {
-            let description = String(format: "Table showing %@ and %@", itemTitle, dataTitle)
-            accessibilityLabel = NSLocalizedString(description, comment: "Accessibility of stats table. Placeholders will be populated with names of data shown in table.")
+            let descriptionFormat = NSLocalizedString("Table showing %@ and %@", comment: "Accessibility of stats table. Placeholders will be populated with names of data shown in table.")
+            accessibilityLabel = String(format: descriptionFormat, itemTitle, dataTitle)
         } else {
             if let title = (itemTitle ?? dataTitle) {
-                let description = String(format: "Table showing %@", title)
-                accessibilityLabel = NSLocalizedString(description, comment: "Accessibility of stats table. Placeholder will be populated with name of data shown in table.")
+                let descriptionFormat = NSLocalizedString("Table showing %@", comment: "Accessibility of stats table. Placeholder will be populated with name of data shown in table.")
+                accessibilityLabel = String(format: descriptionFormat, title)
             }
         }
     }


### PR DESCRIPTION
Localisation failed for the 13.3 code freeze for two reasons:

- There were some new strings that were not literals.
- Something changed in the behaviour of the command line tools for Xcode 11, causing `find` to have a trailing newline and therefore `genstrings` was looking for a file called `""`, and failing.

I have fixed both of these issues so we can proceed with the code freeze.

To test:

- Run `./Scripts/localize.py` from the root of the repo. If should succeed.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
