### PR TITLE
[Stats] Remove file downloads feature flag.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -5,7 +5,6 @@ enum FeatureFlag: Int {
     case exampleFeature
     case jetpackDisconnect
     case statsRefresh
-    case statsFileDownloads
     case statsInsightsManagement
     case domainCredit
     case signInWithApple
@@ -19,8 +18,6 @@ enum FeatureFlag: Int {
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .statsRefresh:
-            return true
-        case .statsFileDownloads:
             return true
         case .statsInsightsManagement:
             return BuildConfiguration.current == .localDeveloper

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -89,10 +89,7 @@ class SiteStatsPeriodViewModel: Observable {
         tableRows.append(contentsOf: searchTermsTableRows())
         tableRows.append(contentsOf: publishedTableRows())
         tableRows.append(contentsOf: videosTableRows())
-
-        if FeatureFlag.statsFileDownloads.enabled {
-            tableRows.append(contentsOf: fileDownloadsTableRows())
-        }
+        tableRows.append(contentsOf: fileDownloadsTableRows())
 
         tableRows.append(TableFooterRow())
 


### PR DESCRIPTION
Fixes #n/a

To test:
- Go to Stats > any Period.
- Verify File Downloads card still appears at the bottom of the table.

<img width="350" alt="file_downloads" src="https://user-images.githubusercontent.com/1816888/65453455-74a75380-de00-11e9-9d04-816f6b0b7c3d.png">

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
