### PR TITLE
Fix threading crash on iOS 13

### DIFF
--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -148,7 +148,9 @@ static NSString * const WordPressComOAuthKeychainServiceName = @"public-api.word
                 }
             }];
         } else {
-            [WordPressAuthenticationManager showSigninForWPComFixingAuthToken];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [WordPressAuthenticationManager showSigninForWPComFixingAuthToken];
+            });
         }
     }
     return _wordPressComRestApi;


### PR DESCRIPTION
It seems iOS 13 introduces a new check to ensure we don't try to present a controller from a background thread, or the app will crash. This would happen when syncing blogs (in a derived context), if the token for the account was missing it would present the sign in flow.

Fixes #12520 

To test:

I haven't been able to reproduce the issue, but if you can make the account token go away, then pull to refresh in the blogs list it should happen?

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
