### PR TITLE
Core Data Threading fixes

### DIFF
--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -139,18 +139,20 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
                              forBlog:blog
                        purgeExisting:YES
                    completionHandler:^{
-                       [[self class] stopSyncingCommentsForBlog:blogID];
-                       
-                       blogInContext.lastCommentsSync = [NSDate date];
-                       [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-                       
-                       if (success) {
-                           // Note:
-                           // We'll assume that if the requested page size couldn't be filled, there are no
-                           // more comments left to retrieve.
-                           BOOL hasMore = comments.count >= WPNumberOfCommentsToSync;
-                           success(hasMore);
-                       }
+                     [[self class] stopSyncingCommentsForBlog:blogID];
+
+                     [self.managedObjectContext performBlock:^{
+                         blogInContext.lastCommentsSync = [NSDate date];
+                         [[ContextManager sharedInstance] saveContext:self.managedObjectContext withCompletionBlock:^{
+                             if (success) {
+                                 // Note:
+                                 // We'll assume that if the requested page size couldn't be filled, there are no
+                                 // more comments left to retrieve.
+                                 BOOL hasMore = comments.count >= WPNumberOfCommentsToSync;
+                                 success(hasMore);
+                             }
+                         }];
+                     }];
                    }];
              }
          }];

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -574,11 +574,11 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
                         success:(void (^)(void))success
                         failure:(void (^)(NSError *error))failure
 {
-    id<MediaServiceRemote> remote = [self remoteForBlog:blog];
     NSManagedObjectID *blogObjectID = [blog objectID];
     [self.managedObjectContext performBlock:^{
         Blog *blogInContext = (Blog *)[self.managedObjectContext objectWithID:blogObjectID];
         NSSet *originalLocalMedia = blogInContext.media;
+        id<MediaServiceRemote> remote = [self remoteForBlog:blogInContext];
         [remote getMediaLibraryWithSuccess:^(NSArray *media) {
                                    [self.managedObjectContext performBlock:^{
                                        [self mergeMedia:media forBlog:blogInContext baseMedia:originalLocalMedia completionHandler:success];
@@ -597,12 +597,16 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 - (NSInteger)getMediaLibraryCountForBlog:(Blog *)blog
                            forMediaTypes:(NSSet *)mediaTypes
 {
-    NSString *entityName = NSStringFromClass([Media class]);
-    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
-    request.predicate = [self predicateForMediaTypes:mediaTypes blog:blog];
-    NSError *error;
-    NSArray *mediaAssets = [self.managedObjectContext executeFetchRequest:request error:&error];
-    return mediaAssets.count;
+    __block NSInteger assetsCount;
+    [self.managedObjectContext performBlockAndWait:^{
+        NSString *entityName = NSStringFromClass([Media class]);
+        NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
+        request.predicate = [self predicateForMediaTypes:mediaTypes blog:blog];
+        NSError *error;
+        NSArray *mediaAssets = [self.managedObjectContext executeFetchRequest:request error:&error];
+        assetsCount = mediaAssets.count;
+    }];
+    return assetsCount;
 }
 
 - (void)getMediaLibraryServerCountForBlog:(Blog *)blog

--- a/WordPress/Classes/Services/MediaThumbnailService.swift
+++ b/WordPress/Classes/Services/MediaThumbnailService.swift
@@ -70,7 +70,7 @@ class MediaThumbnailService: LocalCoreDataService {
             // Configure a handler for any thumbnail exports
             let onThumbnailExport: MediaThumbnailExporter.OnThumbnailExport = { (identifier, export) in
                 self.managedObjectContext.perform {
-                    self.handleThumbnailExport(media: media,
+                    self.handleThumbnailExport(media: mediaInContext,
                                                identifier: identifier,
                                                export: export,
                                                onCompletion: onCompletion)

--- a/WordPress/Classes/Services/MediaThumbnailService.swift
+++ b/WordPress/Classes/Services/MediaThumbnailService.swift
@@ -118,7 +118,9 @@ class MediaThumbnailService: LocalCoreDataService {
                                              onError: { (error) in
                                                 // If an error occurred with the remote video URL, try and download the Media's
                                                 // remote thumbnail instead.
-                                                attemptDownloadingThumbnail()
+                                                self.managedObjectContext.perform {
+                                                    attemptDownloadingThumbnail()
+                                                }
                     })
                 }
                 return

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -94,11 +94,13 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
 
 - (void)updateTopic:(NSManagedObjectID *)topicObjectID withAlgorithm:(NSString *)algorithm
 {
-    NSError *error;
-    ReaderAbstractTopic *topic = (ReaderAbstractTopic *)[self.managedObjectContext existingObjectWithID:topicObjectID error:&error];
-    topic.algorithm = algorithm;
+    [self.managedObjectContext performBlock:^{
+            NSError *error;
+        ReaderAbstractTopic *topic = (ReaderAbstractTopic *)[self.managedObjectContext existingObjectWithID:topicObjectID error:&error];
+        topic.algorithm = algorithm;
 
-    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+    }];
 }
 
 
@@ -120,11 +122,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
                                     count:[self numberToSyncForTopic:topic]
                                    before:date
                                   success:^(NSArray *posts, NSString *algorithm) {
-
-                                      // Save any returned algorithm on the topic for use when requesting more posts.
-                                      NSError *error;
-                                      ReaderAbstractTopic *readerTopic = (ReaderAbstractTopic *)[self.managedObjectContext existingObjectWithID:topicObjectID error:&error];
-                                      readerTopic.algorithm = algorithm;
+                                      [self updateTopic:topicObjectID withAlgorithm:algorithm];
 
                                       // Construct a rank from the date provided
                                       NSNumber *rank = @([date timeIntervalSinceReferenceDate]);

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -200,11 +200,13 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     // Do all of this work on a background thread.
     NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
     ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:context];
-    ReaderAbstractTopic *topic = [topicService topicForFollowedSites];
-    if (topic) {
-        ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:context];
-        [service fetchPostsForTopic:topic earlierThan:[NSDate date] deletingEarlier:YES success:nil failure:nil];
-    }
+    [context performBlock:^{
+        ReaderAbstractTopic *topic = [topicService topicForFollowedSites];
+        if (topic) {
+            ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:context];
+            [service fetchPostsForTopic:topic earlierThan:[NSDate date] deletingEarlier:YES success:nil failure:nil];
+        }
+    }];
 }
 
 

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -95,7 +95,7 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
 - (void)updateTopic:(NSManagedObjectID *)topicObjectID withAlgorithm:(NSString *)algorithm
 {
     [self.managedObjectContext performBlock:^{
-            NSError *error;
+        NSError *error;
         ReaderAbstractTopic *topic = (ReaderAbstractTopic *)[self.managedObjectContext existingObjectWithID:topicObjectID error:&error];
         topic.algorithm = algorithm;
 

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -41,6 +41,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
+            BuildableName = "WordPress.app"
+            BlueprintName = "WordPress"
+            ReferencedContainer = "container:WordPress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -113,17 +122,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1D6058900D05DD3D006BFB54"
-            BuildableName = "WordPress.app"
-            BlueprintName = "WordPress"
-            ReferencedContainer = "container:WordPress.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -151,6 +149,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-wpcom-api-base-url http://localhost:8282/"
             isEnabled = "NO">
          </CommandLineArgument>
@@ -166,8 +168,6 @@
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -150,7 +150,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-com.apple.CoreData.ConcurrencyDebug 1"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-wpcom-api-base-url http://localhost:8282/"


### PR DESCRIPTION
In https://github.com/wordpress-mobile/WordPress-iOS/issues/11384#issuecomment-526758270, @aerych suggests the root cause for the crash #11384 is some implementation error when using derived contexts and multiple threads.

To mitigate this, I've enabled [Core Data's concurrency debug mode](https://oleb.net/blog/2014/06/core-data-concurrency-debugging/) (`-com.apple.CoreData.ConcurrencyDebug 1`). I've left that enabled in this PR, like we have the Main Thread Checker, so other developers can catch more threading issues I might have missed.

To find issues, I looked at every usage of `newDerivedContext` and tried to use the app hitting those code paths. When Xcode crashed on bad threading, I made sure we were using the right context for each managed object.

To test:

Code paths I have tested (and fixed):

* Sync reader posts
* Sync reader comments for a post
* Sync comments for a site
* Follow a site and wait for posts to sync
* Add an image from the media library (Gutenberg)
* Add an image on Aztec, switch to media library
* Set featured image on a post

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
