### PR TITLE
Auto-upload published posts with failed media

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -50,22 +50,21 @@ class PostCoordinator: NSObject {
     ///
     private func uploadMedia(for post: AbstractPost, automatedRetry: Bool = false) -> Bool {
         let mediaService = MediaService(managedObjectContext: backgroundContext)
-        let media: [Media]
-        let isPushingAllMedia: Bool
+        let failedMedia: [Media] = post.media.filter({ $0.remoteStatus == .failed })
+        let mediasToUpload: [Media]
 
         if automatedRetry {
-            media = mediaService.failedMediaForUpload(in: post, automatedRetry: automatedRetry)
-            isPushingAllMedia = media.count == post.media.count
+            mediasToUpload = mediaService.failedMediaForUpload(in: post, automatedRetry: automatedRetry)
         } else {
-            media = post.media.filter({ $0.remoteStatus == .failed })
-            isPushingAllMedia = true
+            mediasToUpload = failedMedia
         }
 
-        media.forEach { mediaObject in
+        mediasToUpload.forEach { mediaObject in
             mediaCoordinator.retryMedia(mediaObject, automatedRetry: automatedRetry)
         }
 
-        return isPushingAllMedia
+        let isPushingAllPendingMedia = mediasToUpload.count == failedMedia.count
+        return isPushingAllPendingMedia
     }
 
     // MARK: - Misc

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2293,7 +2293,7 @@ extension AztecPostViewController {
         case .processing:
             DDLogInfo("Creating media")
         case .thumbnailReady(let url):
-            handleThumbnailURL(url, attachment: attachment)
+            handleThumbnailURL(url, attachment: attachment, then: { self.post.content = self.getHTML() })
         case .uploading:
             handleUploadStarted(attachment: attachment)
         case .ended:
@@ -2451,7 +2451,8 @@ extension AztecPostViewController {
         return videoAttachment
     }
 
-    private func handleThumbnailURL(_ thumbnailURL: URL, attachment: MediaAttachment) {
+    private func handleThumbnailURL(_ thumbnailURL: URL, attachment: MediaAttachment,
+                                    then afterCallback: (() -> ())? = nil) {
         DispatchQueue.main.async {
             if let attachment = attachment as? ImageAttachment {
                 attachment.updateURL(thumbnailURL)
@@ -2461,6 +2462,7 @@ extension AztecPostViewController {
                 attachment.posterURL = thumbnailURL
                 self.richTextView.refresh(attachment)
             }
+            afterCallback?()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2293,7 +2293,7 @@ extension AztecPostViewController {
         case .processing:
             DDLogInfo("Creating media")
         case .thumbnailReady(let url):
-            handleThumbnailURL(url, attachment: attachment, then: { self.mapUIContentToPostAndSave(immediate: true) })
+            handleThumbnailURL(url, attachment: attachment, savePostContent: true)
         case .uploading:
             handleUploadStarted(attachment: attachment)
         case .ended:
@@ -2452,7 +2452,7 @@ extension AztecPostViewController {
     }
 
     private func handleThumbnailURL(_ thumbnailURL: URL, attachment: MediaAttachment,
-                                    then afterCallback: (() -> ())? = nil) {
+                                    savePostContent: Bool = false) {
         DispatchQueue.main.async {
             if let attachment = attachment as? ImageAttachment {
                 attachment.updateURL(thumbnailURL)
@@ -2462,7 +2462,10 @@ extension AztecPostViewController {
                 attachment.posterURL = thumbnailURL
                 self.richTextView.refresh(attachment)
             }
-            afterCallback?()
+
+            if savePostContent {
+                self.mapUIContentToPostAndSave(immediate: true)
+            }
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2293,7 +2293,7 @@ extension AztecPostViewController {
         case .processing:
             DDLogInfo("Creating media")
         case .thumbnailReady(let url):
-            handleThumbnailURL(url, attachment: attachment, then: { self.post.content = self.getHTML() })
+            handleThumbnailURL(url, attachment: attachment, then: { self.mapUIContentToPostAndSave(immediate: true) })
         case .uploading:
             handleUploadStarted(attachment: attachment)
         case .ended:

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -33,6 +33,8 @@ extension PostEditor where Self: UIViewController {
         dismissWhenDone: Bool,
         analyticsStat: WPAnalyticsStat?) {
 
+        mapUIContentToPostAndSave(immediate: true)
+
         // Cancel publishing if media is currently being uploaded
         if !action.isAsync && !dismissWhenDone && isUploadingMedia {
             displayMediaIsUploadingAlert()

--- a/WordPress/WordPressTest/Aztec/AztecPostViewControllerAttachmentTests.swift
+++ b/WordPress/WordPressTest/Aztec/AztecPostViewControllerAttachmentTests.swift
@@ -64,6 +64,19 @@ class AztecPostViewControllerAttachmentTests: XCTestCase {
         expect(attachment.progress).to(equal(0))
     }
 
+    func testUpdatePostContentAfterAMediaThumbnailUpdate() {
+        // Arrange
+        let media = Media(context: context)
+        let post = Fixtures.createPost(context: context, with: media)
+        let vc = Fixtures.createAztecPostViewController(with: post)
+
+        // Act
+        vc.mediaObserver(media: media, state: .thumbnailReady(url: URL(string: "file://path/to/image.png")!))
+
+        // Assert
+        expect(post.content).toEventually(contain("src=\"file://path/to/image.png\""))
+    }
+
     private struct Fixtures {
         static func createPost(context: NSManagedObjectContext, with media: Media) -> Post {
             let post = Post(context: context)


### PR DESCRIPTION
Fixes #12498

## To test

While offline:
- Create a new post (using Aztec)
- Add some images
- Tap publish
- Check that the message "post will be published next time..." is appearing

## Additional info

We had an issue with Aztec (the same doesn't happen with Gutenberg) that was not updating `post.content` after an image was added. This explains why sometimes we ended up with `<img src="placeholder://">` in the post. This fix also prevents this issue from happening again.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
