### PR TITLE
[Dark Mode] Fix colors in rich notifications

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * Block editor: Blocks that would be replaced are now hidden when add block bottom sheet displays
 * Block editor: Tapping on empty editor area now always inserts new block at end of post
 * Block editor: Fixed a performance issue that caused a freeze in the editor with long text content.
+* Dark Mode: Fixed colors in rich notifications
 
 13.2
 -----

--- a/WordPress/WordPressNotificationContentExtension/Sources/NotificationViewController.swift
+++ b/WordPress/WordPressNotificationContentExtension/Sources/NotificationViewController.swift
@@ -45,6 +45,13 @@ class NotificationViewController: UIViewController {
         contentView = nil
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        DispatchQueue.main.async {
+            self.contentView?.reloadContent()
+        }
+    }
+
     // MARK: Private behavior
 
     /// Responsible for instantiation, installation & configuration of the content view

--- a/WordPress/WordPressNotificationContentExtension/Sources/Views/NotificationContentView.swift
+++ b/WordPress/WordPressNotificationContentExtension/Sources/Views/NotificationContentView.swift
@@ -108,6 +108,7 @@ class NotificationContentView: UIView {
         label.numberOfLines = 0
 
         label.attributedText = viewModel.attributedSubject
+        label.textColor = .text
         label.sizeToFit()
 
         return label
@@ -121,6 +122,7 @@ class NotificationContentView: UIView {
         label.numberOfLines = 0
 
         label.attributedText = viewModel.attributedBody
+        label.textColor = .textSubtle
         label.sizeToFit()
 
         return label
@@ -138,6 +140,15 @@ class NotificationContentView: UIView {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Reload the content when the trait did change
+    func reloadContent() {
+        subjectLabel.attributedText = viewModel.attributedSubject
+        subjectLabel.textColor = .text
+
+        bodyLabel.attributedText = viewModel.attributedBody
+        bodyLabel.textColor = .textSubtle
     }
 
     // MARK: Private behavior


### PR DESCRIPTION
Refs. #12320 

This PR fixes the colors used in the rich notifications title and body.
**Title** -> `.text`
**Body** -> `. textSubtle`
![dark-mode-rich-notifications](https://user-images.githubusercontent.com/912252/65517294-60d02000-deda-11e9-833a-c98632b6ab42.jpg)

## To test:
- Run this branch with iOS 13
- Generate a push notification from another account
- Expand the notification to see its content
- Switch between light/dark style to verify the colors are ok
- Run it with iOS 12 and verify everything works as always

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
