### PR TITLE
Accounts: Ensure authtoken is updated for existing account.

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -190,11 +190,8 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 
 - (WPAccount *)createOrUpdateAccountWithUserDetails:(RemoteUser *)remoteUser authToken:(NSString *)authToken
 {
-    WPAccount *account = [self findAccountWithUserID:remoteUser.userID];
-    if (!account) {
-        NSString *username = remoteUser.username;
-        account = [self createOrUpdateAccountWithUsername:username authToken:authToken];
-    }
+    NSString *username = remoteUser.username;
+    WPAccount *account = [self createOrUpdateAccountWithUsername:username authToken:authToken];
     [self updateAccount:account withUserDetails:remoteUser];
     return account;
 }

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -190,8 +190,16 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 
 - (WPAccount *)createOrUpdateAccountWithUserDetails:(RemoteUser *)remoteUser authToken:(NSString *)authToken
 {
-    NSString *username = remoteUser.username;
-    WPAccount *account = [self createOrUpdateAccountWithUsername:username authToken:authToken];
+    WPAccount *account = [self findAccountWithUserID:remoteUser.userID];
+    if (account) {
+        // Even if we find an account via its userID we should still update
+        // its authtoken, otherwise the Authenticator's authtoken fixer won't
+        // work.
+        account.authToken = authToken;
+    } else {
+        NSString *username = remoteUser.username;
+        account = [self createOrUpdateAccountWithUsername:username authToken:authToken];
+    }
     [self updateAccount:account withUserDetails:remoteUser];
     return account;
 }


### PR DESCRIPTION
Refs #12537

While testing #12537 I noticed that auth tokens were not updating as expected.  This PR restores the expected behavior. 

To test:
- Apply the patch
- Start logged into the app
- You want to clear your existing auth token.  One way to do this is set a break point in the `[BlogListViewController setEditing:]`, go to the My Sites tab and view the blog list.  Tap the Edit button. Then run `po [WordPressAuthenticationManager showSigninForWPComFixingAuthToken];`. 
- If you use the above method, you can pull to refresh to invoke the authenticator to fix the auth toekn.  Otherwise you can close and relaunch the app. 
- Enter your password to login when prompted by the auth flow. 
- Confirm you are properly logged in and an NSAssert is not tripped due to the account not having an auth token. 

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
