### PR TITLE
Remote auto-save unconfirmed published posts

### DIFF
--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -284,7 +284,7 @@ class Post: AbstractPost {
         }
 
         if isRevision() {
-            let localOnly = NSLocalizedString("Local", comment: "A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog.")
+            let localOnly = NSLocalizedString("Local changes", comment: "A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog.")
 
             if let tempStatusString = statusString, !tempStatusString.isEmpty {
                 statusString = String(format: "%@, %@", tempStatusString, localOnly)

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -220,22 +220,6 @@ class PostCoordinator: NSObject {
         backgroundService.refreshPostStatus()
     }
 
-    /// Cancel active and pending automatic uploads of the post.
-    func cancelAutoUploadOf(_ post: AbstractPost) {
-        cancelAnyPendingSaveOf(post: post)
-
-        post.shouldAttemptAutoUpload = false
-
-        let moc = post.managedObjectContext
-
-        moc?.perform {
-            try? moc?.save()
-        }
-
-        let notice = Notice(title: NSLocalizedString("Changes will not be published", comment: "title for notice displayed on cancel auto-upload"), message: "")
-        ActionDispatcher.dispatch(NoticeAction.post(notice))
-    }
-
     private func upload(post: AbstractPost) {
         mainService.uploadPost(post, success: { uploadedPost in
             print("Post Coordinator -> upload succesfull: \(String(describing: uploadedPost.content))")
@@ -329,6 +313,22 @@ class PostCoordinator: NSObject {
 
             try? post.managedObjectContext?.save()
         }
+    }
+
+    /// Cancel active and pending automatic uploads of the post.
+    func cancelAutoUploadOf(_ post: AbstractPost) {
+        cancelAnyPendingSaveOf(post: post)
+
+        post.shouldAttemptAutoUpload = false
+
+        let moc = post.managedObjectContext
+
+        moc?.perform {
+            try? moc?.save()
+        }
+
+        let notice = Notice(title: NSLocalizedString("Changes will not be published", comment: "title for notice displayed on cancel auto-upload"), message: "")
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 }
 

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -41,6 +41,37 @@ class PostCoordinator: NSObject {
         self.failedPostsFetcher = failedPostsFetcher ?? FailedPostsFetcher(mainContext)
     }
 
+    // MARK: - Uploading Media
+
+    /// Uploads all local media for the post, and returns `true` if it was possible to start uploads for all
+    /// of the existing media for the post.
+    ///
+    /// - Parameters:
+    ///     - post: the post to get the media to upload from.
+    ///     - automatedRetry: true if this call is the result of an automated upload-retry attempt.
+    ///
+    /// - Returns: `true` if all media in the post is uploading or was uploaded, `false` otherwise.
+    ///
+    private func uploadMedia(for post: AbstractPost, automatedRetry: Bool = false) -> Bool {
+        let mediaService = MediaService(managedObjectContext: backgroundContext)
+        let media: [Media]
+        let isPushingAllMedia: Bool
+
+        if automatedRetry {
+            media = mediaService.failedMediaForUpload(in: post, automatedRetry: automatedRetry)
+            isPushingAllMedia = media.count == post.media.count
+        } else {
+            media = post.media.filter({ $0.remoteStatus == .failed })
+            isPushingAllMedia = true
+        }
+
+        media.forEach { mediaObject in
+            mediaCoordinator.retryMedia(mediaObject, automatedRetry: automatedRetry)
+        }
+
+        return isPushingAllMedia
+    }
+
     func save(_ postToSave: AbstractPost, automatedRetry: Bool = false) {
         prepareToSave(postToSave, automatedRetry: automatedRetry) { post in
             self.upload(post: post)
@@ -51,6 +82,77 @@ class PostCoordinator: NSObject {
         prepareToSave(postToSave, automatedRetry: automatedRetry) { post in
             self.uploadRevision(post: post)
         }
+    }
+
+    /// Saves the post to both the local database and the server if available.
+    /// If media is still uploading it keeps track of the ongoing media operations and updates the post content when they finish
+    ///
+    /// - Parameter post: the post to save
+    /// - Parameter automatedRetry: if this is an automated retry, without user intervenction
+    /// - Parameter then: a block to perform after post is ready to be saved
+    ///
+    private func prepareToSave(_ postToSave: AbstractPost, automatedRetry: Bool = false, then completion: @escaping (AbstractPost) -> ()) {
+        var post = postToSave
+
+        if postToSave.isRevision() && !postToSave.hasRemote(), let originalPost = postToSave.original {
+            post = originalPost
+            post.applyRevision()
+            post.deleteRevision()
+        }
+
+        guard uploadMedia(for: post, automatedRetry: automatedRetry) else {
+            change(post: post, status: .failed)
+            return
+        }
+
+        change(post: post, status: .pushing)
+
+        if mediaCoordinator.isUploadingMedia(for: post) || post.hasFailedMedia {
+            change(post: post, status: .pushingMedia)
+            // Only observe if we're not already
+            guard !isObserving(post: post) else {
+                return
+            }
+
+            let uuid = mediaCoordinator.addObserver({ [weak self](media, state) in
+                guard let `self` = self else {
+                    return
+                }
+                switch state {
+                case .ended:
+                    let successHandler = {
+                        self.updateReferences(to: media, in: post)
+                        // Let's check if media uploading is still going, if all finished with success then we can upload the post
+                        if !self.mediaCoordinator.isUploadingMedia(for: post) && !post.hasFailedMedia {
+                            self.removeObserver(for: post)
+                            completion(post)
+                        }
+                    }
+                    switch media.mediaType {
+                    case .video:
+                        EditorMediaUtility.fetchRemoteVideoURL(for: media, in: post) { [weak self] (result) in
+                            switch result {
+                            case .error:
+                                self?.change(post: post, status: .failed)
+                            case .success(let value):
+                                media.remoteURL = value.videoURL.absoluteString
+                                successHandler()
+                            }
+                        }
+                    default:
+                        successHandler()
+                    }
+                case .failed:
+                    self.change(post: post, status: .failed)
+                default:
+                    DDLogInfo("Post Coordinator -> Media state: \(state)")
+                }
+            }, forMediaFor: post)
+            trackObserver(receipt: uuid, for: post)
+            return
+        }
+
+        completion(post)
     }
 
     func cancelAnyPendingSaveOf(post: AbstractPost) {
@@ -132,77 +234,6 @@ class PostCoordinator: NSObject {
 
         let notice = Notice(title: NSLocalizedString("Changes will not be published", comment: "title for notice displayed on cancel auto-upload"), message: "")
         ActionDispatcher.dispatch(NoticeAction.post(notice))
-    }
-
-    /// Saves the post to both the local database and the server if available.
-    /// If media is still uploading it keeps track of the ongoing media operations and updates the post content when they finish
-    ///
-    /// - Parameter post: the post to save
-    /// - Parameter automatedRetry: if this is an automated retry, without user intervenction
-    /// - Parameter then: a block to perform after post is ready to be saved
-    ///
-    private func prepareToSave(_ postToSave: AbstractPost, automatedRetry: Bool = false, then completion: @escaping (AbstractPost) -> ()) {
-        var post = postToSave
-
-        if postToSave.isRevision() && !postToSave.hasRemote(), let originalPost = postToSave.original {
-            post = originalPost
-            post.applyRevision()
-            post.deleteRevision()
-        }
-
-        guard uploadMedia(for: post, automatedRetry: automatedRetry) else {
-            change(post: post, status: .failed)
-            return
-        }
-
-        change(post: post, status: .pushing)
-
-        if mediaCoordinator.isUploadingMedia(for: post) || post.hasFailedMedia {
-            change(post: post, status: .pushingMedia)
-            // Only observe if we're not already
-            guard !isObserving(post: post) else {
-                return
-            }
-
-            let uuid = mediaCoordinator.addObserver({ [weak self](media, state) in
-                guard let `self` = self else {
-                    return
-                }
-                switch state {
-                case .ended:
-                    let successHandler = {
-                        self.updateReferences(to: media, in: post)
-                        // Let's check if media uploading is still going, if all finished with success then we can upload the post
-                        if !self.mediaCoordinator.isUploadingMedia(for: post) && !post.hasFailedMedia {
-                            self.removeObserver(for: post)
-                            completion(post)
-                        }
-                    }
-                    switch media.mediaType {
-                    case .video:
-                        EditorMediaUtility.fetchRemoteVideoURL(for: media, in: post) { [weak self] (result) in
-                            switch result {
-                            case .error:
-                                self?.change(post: post, status: .failed)
-                            case .success(let value):
-                                media.remoteURL = value.videoURL.absoluteString
-                                successHandler()
-                            }
-                        }
-                    default:
-                        successHandler()
-                    }
-                case .failed:
-                    self.change(post: post, status: .failed)
-                default:
-                    DDLogInfo("Post Coordinator -> Media state: \(state)")
-                }
-            }, forMediaFor: post)
-            trackObserver(receipt: uuid, for: post)
-            return
-        }
-
-        completion(post)
     }
 
     private func upload(post: AbstractPost) {
@@ -298,37 +329,6 @@ class PostCoordinator: NSObject {
 
             try? post.managedObjectContext?.save()
         }
-    }
-
-    // MARK: - Uploading Media
-
-    /// Uploads all local media for the post, and returns `true` if it was possible to start uploads for all
-    /// of the existing media for the post.
-    ///
-    /// - Parameters:
-    ///     - post: the post to get the media to upload from.
-    ///     - automatedRetry: true if this call is the result of an automated upload-retry attempt.
-    ///
-    /// - Returns: `true` if all media in the post is uploading or was uploaded, `false` otherwise.
-    ///
-    private func uploadMedia(for post: AbstractPost, automatedRetry: Bool = false) -> Bool {
-        let mediaService = MediaService(managedObjectContext: backgroundContext)
-        let media: [Media]
-        let isPushingAllMedia: Bool
-
-        if automatedRetry {
-            media = mediaService.failedMediaForUpload(in: post, automatedRetry: automatedRetry)
-            isPushingAllMedia = media.count == post.media.count
-        } else {
-            media = post.media.filter({ $0.remoteStatus == .failed })
-            isPushingAllMedia = true
-        }
-
-        media.forEach { mediaObject in
-            mediaCoordinator.retryMedia(mediaObject, automatedRetry: automatedRetry)
-        }
-
-        return isPushingAllMedia
     }
 }
 

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -228,11 +228,7 @@ class PostCoordinator: NSObject {
             return
         }
 
-        mainService.autoSave(post, success: { uploadedPost, _ in
-
-        }, failure: { _ in
-
-        })
+        mainService.autoSave(post, success: { uploadedPost, _ in }, failure: { _ in })
     }
 
     private func updateReferences(to media: Media, in post: AbstractPost) {

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -79,7 +79,6 @@ class PostCoordinator: NSObject {
 
     func autoSave(_ postToSave: AbstractPost, automatedRetry: Bool = false) {
         prepareToSave(postToSave, automatedRetry: automatedRetry) { post in
-            post.status = .draft
             self.mainService.autoSave(post, success: { uploadedPost, _ in }, failure: { _ in })
         }
     }
@@ -310,6 +309,10 @@ class PostCoordinator: NSObject {
         cancelAnyPendingSaveOf(post: post)
 
         post.shouldAttemptAutoUpload = false
+
+        if !post.hasRemote() {
+            post.status = .draft
+        }
 
         let moc = post.managedObjectContext
 

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -237,12 +237,7 @@ class PostCoordinator: NSObject {
     }
 
     private func uploadRevision(post: AbstractPost) {
-        guard post.hasRemote() else {
-            post.status = .draft
-            upload(post: post)
-            return
-        }
-
+        post.status = .draft
         mainService.autoSave(post, success: { uploadedPost, _ in }, failure: { _ in })
     }
 

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -80,7 +80,8 @@ class PostCoordinator: NSObject {
 
     func autoSave(_ postToSave: AbstractPost, automatedRetry: Bool = false) {
         prepareToSave(postToSave, automatedRetry: automatedRetry) { post in
-            self.uploadRevision(post: post)
+            post.status = .draft
+            self.mainService.autoSave(post, success: { uploadedPost, _ in }, failure: { _ in })
         }
     }
 
@@ -234,11 +235,6 @@ class PostCoordinator: NSObject {
 
             print("Post Coordinator -> upload error: \(String(describing: error))")
         })
-    }
-
-    private func uploadRevision(post: AbstractPost) {
-        post.status = .draft
-        mainService.autoSave(post, success: { uploadedPost, _ in }, failure: { _ in })
     }
 
     private func updateReferences(to media: Media, in post: AbstractPost) {

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -84,8 +84,8 @@ class PostCoordinator: NSObject {
         }
     }
 
-    /// Saves the post to both the local database and the server if available.
-    /// If media is still uploading it keeps track of the ongoing media operations and updates the post content when they finish
+    /// If media is still uploading it keeps track of the ongoing media operations and updates the post content when they finish.
+    /// Then, it calls the completion block with the post ready to be saved/uploaded.
     ///
     /// - Parameter post: the post to save
     /// - Parameter automatedRetry: if this is an automated retry, without user intervenction

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -89,6 +89,10 @@ class PostCardStatusViewModel: NSObject {
             return .neutral(.shade30)
         }
 
+        if post.isRevision() {
+            return .warning
+        }
+
         if post.isFailed {
             let autoUploadAction = autoUploadInteractor.autoUploadAction(for: post)
             return (autoUploadAction == .upload || post.wasAutoUploadCancelled) ? .warning : .error

--- a/WordPress/WordPressTest/PostBuilder.swift
+++ b/WordPress/WordPressTest/PostBuilder.swift
@@ -37,6 +37,11 @@ class PostBuilder {
         return self
     }
 
+    func revision() -> PostBuilder {
+        post.setPrimitiveValue(post, forKey: "original")
+        return self
+    }
+
     func withImage() -> PostBuilder {
         post.pathForDisplayImage = "https://localhost/image.png"
         return self

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -1,5 +1,6 @@
 import UIKit
 import XCTest
+import Nimble
 
 @testable import WordPress
 
@@ -361,6 +362,15 @@ class PostCardCellTests: XCTestCase {
         // Then
         XCTAssertEqual(postCell.statusLabel.text, StatusMessages.draftWillBeUploaded)
         XCTAssertEqual(postCell.statusLabel.textColor, UIColor.warning)
+    }
+
+    func testMessageWhenPostIsArevision() {
+        let post = PostBuilder(context).revision().with(remoteStatus: .failed).with(remoteStatus: .local).build()
+
+        postCell.configure(with: post)
+
+        expect(self.postCell.statusLabel.text).to(equal("Local changes"))
+        expect(self.postCell.statusLabel.textColor).to(equal(UIColor.warning))
     }
 
     private func postCellFromNib() -> PostCardCell {

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -57,11 +57,12 @@ class PostCoordinatorTests: XCTestCase {
         expect(post.remoteStatus).toEventually(equal(.pushing))
     }
 
-    func testAutoSavePost() {
+    func testAutoSavePostThatHasRemote() {
         let postServiceMock = PostServiceMock()
         let failedPostsFetcherMock = FailedPostsFetcherMock(context)
         let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock, failedPostsFetcher: failedPostsFetcherMock)
         let post = PostBuilder(context)
+            .withRemote()
             .with(status: .draft)
             .build()
         failedPostsFetcherMock.postsAndActions = [post: .autoSave]
@@ -69,6 +70,20 @@ class PostCoordinatorTests: XCTestCase {
         postCoordinator.resume()
 
         expect(postServiceMock.didCallAutoSave).to(beTrue())
+    }
+
+    func testDraftAndUploadPostWithoutRemote() {
+        let postServiceMock = PostServiceMock()
+        let failedPostsFetcherMock = FailedPostsFetcherMock(context)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock, failedPostsFetcher: failedPostsFetcherMock)
+        let post = PostBuilder(context)
+            .build()
+        failedPostsFetcherMock.postsAndActions = [post: .autoSave]
+
+        postCoordinator.resume()
+
+        expect(postServiceMock.didCallUploadPost).to(beTrue())
+        expect(post.status).to(equal(.draft))
     }
 }
 

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -129,9 +129,9 @@ private class MediaCoordinatorMock: MediaCoordinator {
 }
 
 private class FailedPostsFetcherMock: PostCoordinator.FailedPostsFetcher {
-    var postsAndActions: [AbstractPost : PostAutoUploadInteractor.AutoUploadAction] = [:]
+    var postsAndActions: [AbstractPost: PostAutoUploadInteractor.AutoUploadAction] = [:]
 
-    override func postsAndRetryActions(result: @escaping ([AbstractPost : PostAutoUploadInteractor.AutoUploadAction]) -> Void) {
+    override func postsAndRetryActions(result: @escaping ([AbstractPost: PostAutoUploadInteractor.AutoUploadAction]) -> Void) {
         result(postsAndActions)
     }
 }

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -71,6 +71,33 @@ class PostCoordinatorTests: XCTestCase {
 
         expect(postServiceMock.didCallAutoSave).toEventually(beTrue())
     }
+
+    func testCancelAutoUploadChangePostStatusToDraftWhenPostDoesntHasRemote() {
+        let post = PostBuilder(context)
+            .with(status: .pending)
+            .with(remoteStatus: .failed)
+            .build()
+        let postServiceMock = PostServiceMock(managedObjectContext: context)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+
+        postCoordinator.cancelAutoUploadOf(post)
+
+        expect(post.status).to(equal(.draft))
+    }
+
+    func testCancelAutoUploadDoNotChangePostStatusToDraftWhenPostHasRemote() {
+        let post = PostBuilder(context)
+            .withRemote()
+            .with(status: .publish)
+            .with(remoteStatus: .failed)
+            .build()
+        let postServiceMock = PostServiceMock(managedObjectContext: context)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+
+        postCoordinator.cancelAutoUploadOf(post)
+
+        expect(post.status).to(equal(.publish))
+    }
 }
 
 private class PostServiceMock: PostService {

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -57,7 +57,7 @@ class PostCoordinatorTests: XCTestCase {
         expect(post.remoteStatus).toEventually(equal(.pushing))
     }
 
-    func testAutoSavePostThatHasRemote() {
+    func testResumeWillAutoSaveUnconfirmedExistingPosts() {
         let postServiceMock = PostServiceMock()
         let failedPostsFetcherMock = FailedPostsFetcherMock(context)
         let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock, failedPostsFetcher: failedPostsFetcherMock)
@@ -70,20 +70,6 @@ class PostCoordinatorTests: XCTestCase {
         postCoordinator.resume()
 
         expect(postServiceMock.didCallAutoSave).to(beTrue())
-    }
-
-    func testDraftAndUploadPostWithoutRemote() {
-        let postServiceMock = PostServiceMock()
-        let failedPostsFetcherMock = FailedPostsFetcherMock(context)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock, failedPostsFetcher: failedPostsFetcherMock)
-        let post = PostBuilder(context)
-            .build()
-        failedPostsFetcherMock.postsAndActions = [post: .autoSave]
-
-        postCoordinator.resume()
-
-        expect(postServiceMock.didCallUploadPost).to(beTrue())
-        expect(post.status).to(equal(.draft))
     }
 }
 

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -72,6 +72,16 @@ class PostCoordinatorTests: XCTestCase {
         expect(postServiceMock.didCallAutoSave).toEventually(beTrue())
     }
 
+    func testCancelAutoUploadOfAPost() {
+        let post = PostBuilder(context).build()
+        let postServiceMock = PostServiceMock(managedObjectContext: context)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+
+        postCoordinator.cancelAutoUploadOf(post)
+
+        expect(post.shouldAttemptAutoUpload).to(beFalse())
+    }
+
     func testCancelAutoUploadChangePostStatusToDraftWhenPostDoesntHasRemote() {
         let post = PostBuilder(context)
             .with(status: .pending)

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -285,7 +285,7 @@ class PostTests: XCTestCase {
     func testThatStatusForDisplayWorksForRevisionPost() {
         let original = newTestPost()
         let revision = original.createRevision()
-        let local = NSLocalizedString("Local", comment: "Local")
+        let local = NSLocalizedString("Local changes", comment: "Local")
         revision.status = .draft
         XCTAssertEqual(revision.statusForDisplay(), local)
 
@@ -298,7 +298,7 @@ class PostTests: XCTestCase {
         XCTAssertEqual(revision.statusForDisplay(), String(format: NSLocalizedString("%@, %@", comment: ""), publishPrivateStatusDisplay, local))
 
         revision.status = .publish
-        XCTAssertEqual(revision.statusForDisplay(), NSLocalizedString("Local", comment: "Local"))
+        XCTAssertEqual(revision.statusForDisplay(), NSLocalizedString("Local changes", comment: "Local"))
 
         revision.status = .scheduled
         let scheduledStatusDisplay = "\(Post.title(for: .scheduled))"

--- a/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
+++ b/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
@@ -74,7 +74,7 @@ private extension PostCoordinator.FailedPostsFetcher {
     func getPostsToRetrySync() -> [AbstractPost] {
         var result = [AbstractPost]()
         waitUntil(timeout: 5) { done in
-            self.getFailedPostsAndRetryActions { postsAndActions in
+            self.postsAndRetryActions { postsAndActions in
                 result = Array(postsAndActions.filter { $1 != .nothing }.keys)
                 done()
             }


### PR DESCRIPTION
Fixes #12322

## To test

While offline:
- Create a post
- Tap publish
- Tap cancel
- Go back online and check that a revision was created (aka the post was autosaved)

## Additional information

Issue #12322 mentioned that an editor crash was another way to trigger an `.autoSave` state. Currently, this *does not happen* since no post upload attempt is made.

Anyway, in the case of a crash, the content will be locally saved.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] If it's feasible, I have added unit tests. 