### PR TITLE
Issue/11555 Site Creation: Space in the title/tagline doesn't appear

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -60,6 +60,7 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
     }
 
     @objc func textFieldDidChange(textField: UITextField) {
+        textField.text = textField.text?.replacingOccurrences(of: " ", with: "\u{00a0}")
         delegate?.inlineEditableNameValueCell?(self, valueTextFieldDidChange: textField)
     }
 

--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -65,6 +65,7 @@ class InlineEditableNameValueCell: WPTableViewCell, NibReusable {
     }
 
     @objc func textEditingDidEnd(textField: UITextField) {
+        textField.text = textField.text?.replacingOccurrences(of: "\u{00a0}", with: " ")
         delegate?.inlineEditableNameValueCell?(self, valueTextFieldEditingDidEnd: textField)
     }
 


### PR DESCRIPTION
Fixes #11555 
- added a workaround for the text fiel to be able to show the spaces (spaces need to be replaced by unicode space)

To test:
1. Start creating a new site
2. When entering the title, enter some name with spaces, spaces are now normally visible during typing

Update release notes:
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
