### PR TITLE
Upload failed medias before updating a post

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -48,6 +48,7 @@ class MediaCoordinator: NSObject {
     ///
     /// - Returns: `true` if all media in the post is uploading or was uploaded, `false` otherwise.
     ///
+    @discardableResult
     func uploadMedia(for post: AbstractPost, automatedRetry: Bool = false) -> Bool {
         let mediaService = MediaService(managedObjectContext: backgroundContext)
         let media: [Media]

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -38,37 +38,6 @@ class PostCoordinator: NSObject {
         self.backgroundService = backgroundService ?? PostService(managedObjectContext: backgroundContext)
     }
 
-    // MARK: - Uploading Media
-
-    /// Uploads all local media for the post, and returns `true` if it was possible to start uploads for all
-    /// of the existing media for the post.
-    ///
-    /// - Parameters:
-    ///     - post: the post to get the media to upload from.
-    ///     - automatedRetry: true if this call is the result of an automated upload-retry attempt.
-    ///
-    /// - Returns: `true` if all media in the post is uploading or was uploaded, `false` otherwise.
-    ///
-    private func uploadMedia(for post: AbstractPost, automatedRetry: Bool = false) -> Bool {
-        let mediaService = MediaService(managedObjectContext: backgroundContext)
-        let media: [Media]
-        let isPushingAllMedia: Bool
-
-        if automatedRetry {
-            media = mediaService.failedMediaForUpload(in: post, automatedRetry: automatedRetry)
-            isPushingAllMedia = media.count == post.media.count
-        } else {
-            media = post.media.filter({ $0.remoteStatus == .failed })
-            isPushingAllMedia = true
-        }
-
-        media.forEach { mediaObject in
-            mediaCoordinator.retryMedia(mediaObject, automatedRetry: automatedRetry)
-        }
-
-        return isPushingAllMedia
-    }
-
     // MARK: - Misc
 
     /// Saves the post to both the local database and the server if available.
@@ -85,7 +54,7 @@ class PostCoordinator: NSObject {
             post.deleteRevision()
         }
 
-        guard uploadMedia(for: post, automatedRetry: automatedRetry) else {
+        guard mediaCoordinator.uploadMedia(for: post, automatedRetry: automatedRetry) else {
             change(post: post, status: .failed)
             return
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -33,6 +33,8 @@ extension PostEditor where Self: UIViewController {
         dismissWhenDone: Bool,
         analyticsStat: WPAnalyticsStat?) {
 
+        MediaCoordinator.shared.uploadMedia(for: post)
+
         // Cancel publishing if media is currently being uploaded
         if !action.isAsync && !dismissWhenDone && isUploadingMedia {
             displayMediaIsUploadingAlert()


### PR DESCRIPTION
# To test

While online:
- Create a post
- Add 2 images
- Publish the post
- Go Offline
- Tap Edit
- Add another image and wait until it fails
- Go back Online
- Tap Update
- You should see a message and the upload should start
- After the upload is done, tap "Update" again

# Additional info

* The best solution is to change the "Update" action to use `PostCoordinator.save`. However, this is not a small change and we've decided to address it later
* We tried to add a unit test but due to coupling issues, we had to give up. It was taking too long.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
