### PR TITLE
Remove awakeFromFetch from AbstractPost

### DIFF
--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -50,17 +50,6 @@
 
 #pragma mark - Life Cycle Methods
 
-- (void)awakeFromFetch
-{
-    [super awakeFromFetch];
-
-    if (!self.isDeleted && self.remoteStatus == AbstractPostRemoteStatusPushing) {
-        // If we've just been fetched and our status is AbstractPostRemoteStatusPushing then something
-        // when wrong saving -- the app crashed for instance. So change our remote status to failed.
-        [self setPrimitiveValue:@(AbstractPostRemoteStatusFailed) forKey:@"remoteStatusNumber"];
-    }
-}
-
 - (void)remove
 {
     if (self.remoteStatus == AbstractPostRemoteStatusPushing || self.remoteStatus == AbstractPostRemoteStatusLocal) {


### PR DESCRIPTION
We are preforming refreshStatus in PostService+RefreshStatus that does the exact thing so no need  for the logic in awakeFromFetch.

This solves the issue of the status not being updated to failed as expected and as a result the post was not being picked up by the auto uploader

Please see comment: https://github.com/wordpress-mobile/WordPress-iOS/issues/12420#issuecomment-535319004

Fixes #12420 

To test:
1. Be offline
2. Create a post
3. Publish post
4. See the message: "Post will be published..."
5. Quit the app
6. return to the app turn online
7. See that the post is being auto uploaded

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
