### PR TITLE
Turn error initializing Core Data into proper exception

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -263,8 +263,9 @@ static ContextManager *_override;
                                                                  URL:storeURL
                                                              options:nil
                                                                error:&error]) {
-            DDLogError(@"Unresolved error %@, %@", error, [error userInfo]);
-            abort();
+            @throw [NSException exceptionWithName:@"Can't initialize Core Data stack"
+                                           reason:[error localizedDescription]
+                                         userInfo:[error userInfo]];
         }
     }
 


### PR DESCRIPTION
This would at least allow us to capture the message and context of the error

For #12338

I'm wondering if we should ship this in a 13.2 hot fix instead, since 13.3 is still a week away (cc @jtreanor)

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
