### PR TITLE
Universal links: If we don't match a URL, pop back to Safari

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 * Sign In With Apple: if the Apple ID has been disconnected from the WordPress app, log out the account.
 * Sign In With Apple: if the Apple ID has been disconnected from the WordPress app, log out the account on app launch.
 * Dark Mode: General improvements
-
+* Universal links: Pass back to Safari if we can't handle a URL.
  
 13.3
 -----

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -116,6 +116,12 @@ struct UniversalLinkRouter {
             trackDeepLink(matchCount: matches.count, url: url)
         }
 
+        if matches.isEmpty {
+            UIApplication.shared.open(url,
+                                      options: [:],
+                                      completionHandler: nil)
+        }
+
         for matchedRoute in matches {
             matchedRoute.action.perform(matchedRoute.values, source: source)
         }


### PR DESCRIPTION
Fixes #12388.

Some of our universal links rules for WordPress.com capture URLs that we currently don't handle in the app. For example:

`/post/*` is used to open the editor for new posts for URLs like `wordpress.com/post/mycoolsite.wordpress.com`

Unfortunately, this also captures URLs we don't handle in the app, such as editing a specific post:

`wordpress.com/post/mycoolsite.wordpress.com/123`

We didn't implement handling for these URLs because we felt we couldn't be confident that the post exists in the app and that we have the latest version (the user could've already done some editing in Safari, potentially). However, our `/post/*` route matches this URL, so the app launches but we just silently do nothing.

This PR is a small tweak so if we launch due to a URL but it doesn't match any of our routes, we'll pop back out to Safari.

**To test:**

* Build and run in the simulator
* Launch the app / login
* Background the app
* In terminal, run:

```
xcrun simctl openurl booted https://wordpress.com/post/your-test-site-domain
```

and ensure that the editor opens for the correct site.
* Background the app again, and now run:

```
xcrun simctl openurl booted https://wordpress.com/post/your-test-site-domain/123
```

* The app should launch momentarily, and then jump back out to Safari. Before this PR, the app would launch and then just do nothing.

Update release notes:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
